### PR TITLE
Improved API speed of members count cache queries

### DIFF
--- a/ghost/admin/app/services/members-count-cache.js
+++ b/ghost/admin/app/services/members-count-cache.js
@@ -93,7 +93,7 @@ export default class MembersCountCacheService extends Service {
         }
 
         try {
-            const result = yield this.store.query('member', {...query, limit: 1, page: 1});
+            const result = yield this.store.query('member', {...query, order: 'id', limit: 1, page: 1});
             return result.meta.pagination.total;
         } catch (e) {
             console.error(e); // eslint-disable-line


### PR DESCRIPTION
no issue

- the members API endpoint by default adds `order by created_at` to the SQL queries which creates unnecessary overhead when we only care about a count because MySQL sorts the table before querying the single member
- specifying an explicit `order by id` overrides the default API behaviour
- locally with 2 million members the query times drop from >5sec to ~1sec
