### PR TITLE
Replaced menu members count stats API with members count cache

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -100,15 +100,19 @@
                         <li class="relative">
                             {{#if (eq this.router.currentRouteName "members.index")}}
                                 <LinkTo @route="members" @current-when="members member member.new" @query={{reset-query-params "members.index"}} data-test-nav="members">{{svg-jar "members"}}Members
-                                    {{#unless this.memberCountLoading}}
-                                        <span class="gh-nav-member-count">{{format-number this.membersStats.memberCount}}</span>
-                                    {{/unless}}
+                                    {{#let (members-count-fetcher) as |count|}}
+                                        {{#unless count.isLoading}}
+                                            <span class="gh-nav-member-count">{{format-number count.count}}</span>
+                                        {{/unless}}
+                                    {{/let}}
                                 </LinkTo>
                             {{else}}
                                 <LinkTo @route="members" @current-when="members member member.new" data-test-nav="members">{{svg-jar "members"}}Members
-                                    {{#unless this.memberCountLoading}}
-                                        <span class="gh-nav-member-count">{{format-number this.membersStats.memberCount}}</span>
-                                    {{/unless}}
+                                    {{#let (members-count-fetcher) as |count|}}
+                                        {{#unless count.isLoading}}
+                                            <span class="gh-nav-member-count">{{format-number count.count}}</span>
+                                        {{/unless}}
+                                    {{/let}}
                                 </LinkTo>
                             {{/if}}
                         </li>

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -117,7 +117,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     @task(function* () {
         try {
             this.set('memberCountLoading', true);
-            yield this.membersStats.fetchMemberCount();
+            yield this.membersCountCache.count({});
             this.set('memberCountLoading', false);
         } catch (e) {
             return false;

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -10,7 +10,6 @@ import {htmlSafe} from '@ember/template';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 import {tagName} from '@ember-decorators/component';
-import {task} from 'ember-concurrency';
 
 @classic
 @tagName('')

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -33,7 +33,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     iconStyle = '';
     iconClass = '';
-    memberCountLoading = true;
     shortcuts = null;
 
     @match('router.currentRouteName', /^settings\.integration/)
@@ -69,10 +68,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     didReceiveAttrs() {
         super.didReceiveAttrs(...arguments);
         this._setIconStyle();
-
-        if (this.session.user && this.session.user.isAdmin) {
-            this._loadMemberCountsTask.perform();
-        }
     }
 
     didInsertElement() {
@@ -113,17 +108,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     toggleExploreWindow() {
         this.explore.openExploreWindow();
     }
-
-    @task(function* () {
-        try {
-            this.set('memberCountLoading', true);
-            yield this.membersCountCache.count({});
-            this.set('memberCountLoading', false);
-        } catch (e) {
-            return false;
-        }
-    })
-        _loadMemberCountsTask;
 
     _setIconStyle() {
         let icon = this.icon;


### PR DESCRIPTION
no issue

The members stats API is a lot more slower than the normal members count cache, and we use the members count cache in a lot more places. So we can cache it more.