### PR TITLE
Fixed loading member count stats

### DIFF
--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -524,8 +524,8 @@ export default class DashboardStatsService extends Service {
             this.memberCountStats = this.dashboardMocks.memberCountStats;
             return;
         }
-        
-        const stats = yield this.membersStats.fetchMemberCounts();
+
+        const stats = yield this.membersStats.fetchMemberCount();
         this.memberCountStats = stats.stats.map((d) => {
             return {
                 ...d,


### PR DESCRIPTION
We had a wee typo here, accidentally pluralised the fetchMemberCount method.
