### PR TITLE
Added experimental filesystem-based cache adapter

### DIFF
--- a/ghost/adapter-cache-fs/.eslintrc.js
+++ b/ghost/adapter-cache-fs/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/ts'
+    ]
+};

--- a/ghost/adapter-cache-fs/README.md
+++ b/ghost/adapter-cache-fs/README.md
@@ -1,0 +1,17 @@
+# Adapter Cache FS
+
+Cache adapter based upon filesystem persistence.
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/adapter-cache-fs/package.json
+++ b/ghost/adapter-cache-fs/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tryghost/adapter-cache-fs",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/adapter-cache-fs",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "build/AdapterCacheFS.js",
+  "types": "build/AdapterCacheFS.d.ts",
+  "scripts": {
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
+    "test:types": "tsc --noEmit",
+    "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100  --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
+    "test": "yarn test:unit && yarn test:types",
+    "lint:code": "eslint src/ --ext .ts --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "c8": "8.0.1",
+    "mocha": "10.2.0",
+    "sinon": "15.2.0"
+  },
+  "dependencies": {
+    "@tryghost/adapter-base-cache": "0.1.10",
+    "fs-extra": "11.2.0"
+  }
+}

--- a/ghost/adapter-cache-fs/src/AdapterCacheFS.ts
+++ b/ghost/adapter-cache-fs/src/AdapterCacheFS.ts
@@ -1,0 +1,107 @@
+import crypto from 'crypto';
+import fs from 'fs-extra';
+import path from 'path';
+import Base from '@tryghost/adapter-base-cache';
+
+type AdapterOptions = {
+    cachePath?: string;
+}
+
+/**
+ * Filesystem-based cache adapter for Ghost
+ *
+ * To instantly invalidate the cache, we use a timestamp in the folder name. This means that
+ * when we want to invalidate the cache, we can just change the timestamp and we drop all knowledge
+ * of the old cache.
+ *
+ * To keep the overhead low, we only create the directory structure upon initialization, and then
+ * during the reset() method. ie. we don't do this for ever set() call. If we want to do further directory
+ * partitioning, this may need to change.
+ *
+ * It is up to the host system to clean up files periodically.
+ */
+export default class AdapterCacheFS extends Base {
+    // Keep a reset count to protect against resets occuring in the same millisecond and the cache not
+    // getting reset
+    #resetCount: number = 0;
+
+    // Initalize the timestamp with the current Date in ms
+    #timestamp: number = Date.now();
+
+    #cachePath: string;
+
+    constructor(options?: AdapterOptions) {
+        super();
+
+        this.#cachePath = options?.cachePath || '/tmp';
+
+        // Set up the initial cache folder
+        fs.mkdirpSync(this._getPrefixedCacheFolder());
+    }
+
+    _generateKey(key: string): string {
+        // md5 is not secure but it's fast and we're not using it for security
+        // the probability of a collision is low enough that we don't care
+        return crypto.createHash('md5').update(key).digest('hex');
+    }
+
+    _getPrefixedCacheFolder(timestamp: number = this.#timestamp): string {
+        return path.join(this.#cachePath, `${timestamp.toString()}-${this.#resetCount.toString()}`);
+    }
+
+    async get(key: string): Promise<object | null> {
+        const prefixedCacheFolder = this._getPrefixedCacheFolder();
+        const keyCachePath = path.join(prefixedCacheFolder, this._generateKey(key));
+
+        try {
+            const value = await fs.readFile(keyCachePath, 'utf8');
+            return JSON.parse(value);
+        } catch (err) {
+            return null;
+        }
+    }
+
+    /**
+     * Stores a value in the cache
+     *
+     * To do this, we generate a temporary file with a semi-random suffix, and then rename it
+     * to the final one. This is to ensure that we don't end up with a half-written file, and
+     * it also prevents multiple cache saves from overlapping each other.
+     *
+     * If it fails, do nothing except log it out.
+     */
+    async set(key: string, value: object): Promise<void> {
+        const generatedKey = this._generateKey(key);
+        const prefixedCacheFolder = this._getPrefixedCacheFolder();
+        const keyCachePath = path.join(prefixedCacheFolder, generatedKey);
+        const keyCachePathTemp = path.join(prefixedCacheFolder, `${generatedKey}.${Math.random().toString(36).substring(5)}}`);
+
+        try {
+            await fs.writeFile(keyCachePathTemp, JSON.stringify(value));
+            await fs.rename(keyCachePathTemp, keyCachePath);
+        } catch (err) {
+            // TODO: log it out + add to Sentry but it's ok if we fail to store?
+        }
+    }
+
+    /**
+     * Resets the timestamp for this instance, which changes the cache key
+     * and drops all knowledge of the existing cache.
+     *
+     * Also sets up the new cache folder so we don't have to set to do it in the .set() method.
+     */
+    async reset() {
+        this.#resetCount += 1;
+
+        const newTimestamp = Date.now();
+        this.#timestamp = newTimestamp;
+
+        await fs.mkdirp(this._getPrefixedCacheFolder(newTimestamp));
+    }
+
+    async keys(): Promise<string[]> {
+        // TODO: what should we really do here? is fetching the filenames useful?
+        const folderFiles = await fs.readdir(this._getPrefixedCacheFolder());
+        return folderFiles;
+    }
+};

--- a/ghost/adapter-cache-fs/src/libraries.d.ts
+++ b/ghost/adapter-cache-fs/src/libraries.d.ts
@@ -1,0 +1,1 @@
+declare module '@tryghost/adapter-base-cache';

--- a/ghost/adapter-cache-fs/test/.eslintrc.js
+++ b/ghost/adapter-cache-fs/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/adapter-cache-fs/test/adapter-cache-fs.test.ts
+++ b/ghost/adapter-cache-fs/test/adapter-cache-fs.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import path from 'path';
+import sinon from 'sinon';
+
+import AdapterCacheFS from '../';
+
+const SAMPLE_KEY = 'banana';
+const SAMPLE_VALUE = {
+    posts: {
+        id: 123,
+        title: 'abc'
+    }
+};
+
+const CACHE_PATH = '/tmp/cache';
+
+describe('Cache Adapter', function () {
+    let cache: AdapterCacheFS;
+
+    beforeEach(() => {
+        sinon.restore();
+        cache = new AdapterCacheFS({
+            cachePath: CACHE_PATH
+        });
+    });
+
+    afterEach(async () => {
+        await fs.remove(CACHE_PATH);
+    });
+
+    it('can initialize a cache instance', () => {
+        assert.ok(cache);
+    });
+
+    it('can initialize with a default root path', () => {
+        const cache2 = new AdapterCacheFS();
+        const prefixedCachePath = cache2._getPrefixedCacheFolder();
+        assert.ok(prefixedCachePath.startsWith('/tmp'));
+    });
+
+    it('can initialize with a different root path', () => {
+        const newCachePath = '/tmp/banana';
+
+        const cache2 = new AdapterCacheFS({
+            cachePath: newCachePath
+        });
+
+        const prefixedCachePath = cache2._getPrefixedCacheFolder();
+        assert.ok(prefixedCachePath.startsWith(newCachePath));
+    });
+
+    it('can reset the cache path by calling reset()', async () => {
+        const existingCachePath = cache._getPrefixedCacheFolder();
+
+        await cache.reset();
+
+        const newCachePath = cache._getPrefixedCacheFolder();
+
+        assert.notEqual(newCachePath, existingCachePath);
+    });
+
+    it('can set and get a value', async () => {
+        await cache.set(SAMPLE_KEY, SAMPLE_VALUE);
+        const fetchedValue = await cache.get(SAMPLE_KEY);
+
+        assert.deepEqual(fetchedValue, SAMPLE_VALUE);
+    });
+
+    it('can set, reset and not get a value', async () => {
+        await cache.set(SAMPLE_KEY, SAMPLE_VALUE);
+        await cache.reset();
+        const fetchedValue = await cache.get(SAMPLE_KEY);
+
+        assert.deepEqual(fetchedValue, null);
+    });
+
+    it('can set, corrupt the file and not get a value', async () => {
+        const filename = path.join(cache._getPrefixedCacheFolder(), cache._generateKey(SAMPLE_KEY));
+        await fs.writeFile(filename, '{a'); // write some broken JSON to indicate a partial write that happened at some point
+
+        const fetchedValue = await cache.get(SAMPLE_KEY);
+
+        assert.deepEqual(fetchedValue, null);
+    });
+
+    it('doesn\'t set a key upon some failure', async () => {
+        sinon.stub(fs, 'rename').throws(new Error('foo'));
+
+        await cache.set(SAMPLE_KEY, SAMPLE_VALUE);
+
+        const fetchedValue = await cache.get(SAMPLE_KEY);
+        assert.deepEqual(fetchedValue, null);
+    });
+
+    it('can list keys', async () => {
+        await cache.set(SAMPLE_KEY, SAMPLE_VALUE);
+        const fetchedKeys = await cache.keys();
+
+        assert.equal(fetchedKeys.length, 1);
+    });
+});

--- a/ghost/adapter-cache-fs/tsconfig.json
+++ b/ghost/adapter-cache-fs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "build"
+  }
+}

--- a/ghost/adapter-manager/lib/AdapterManager.js
+++ b/ghost/adapter-manager/lib/AdapterManager.js
@@ -130,6 +130,10 @@ module.exports = class AdapterManager {
             });
         }
 
+        if (Adapter.default) {
+            Adapter = Adapter.default;
+        }
+
         const adapter = new Adapter(config);
 
         if (!(adapter instanceof this.baseClasses[adapterType])) {

--- a/ghost/core/core/server/adapters/cache/filesystem.js
+++ b/ghost/core/core/server/adapters/cache/filesystem.js
@@ -1,0 +1,1 @@
+module.exports = require('@tryghost/adapter-cache-fs');

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -60,6 +60,7 @@
     "@extractus/oembed-extractor": "3.2.1",
     "@sentry/node": "7.86.0",
     "@tryghost/adapter-base-cache": "0.1.10",
+    "@tryghost/adapter-cache-fs": "0.0.0",
     "@tryghost/adapter-cache-redis": "0.0.0",
     "@tryghost/adapter-manager": "0.0.0",
     "@tryghost/admin-api-schema": "4.5.3",


### PR DESCRIPTION
refs https://www.notion.so/ghost/Filesystem-based-caches-dd7d6b6fe6924cb39a10d37f16ad3e7d
refs https://github.com/TryGhost/DevOps/issues/125

- this will serialize the cache to JSON files, which means its very
  simple versus alternatives that require a lot more setup
- this is a drop-in adapter with a full test suite