### PR TITLE
Revert "Replaced menu members count stats API with members count cache"

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -100,19 +100,15 @@
                         <li class="relative">
                             {{#if (eq this.router.currentRouteName "members.index")}}
                                 <LinkTo @route="members" @current-when="members member member.new" @query={{reset-query-params "members.index"}} data-test-nav="members">{{svg-jar "members"}}Members
-                                    {{#let (members-count-fetcher) as |count|}}
-                                        {{#unless count.isLoading}}
-                                            <span class="gh-nav-member-count">{{format-number count.count}}</span>
-                                        {{/unless}}
-                                    {{/let}}
+                                    {{#unless this.memberCountLoading}}
+                                        <span class="gh-nav-member-count">{{format-number this.membersStats.memberCount}}</span>
+                                    {{/unless}}
                                 </LinkTo>
                             {{else}}
                                 <LinkTo @route="members" @current-when="members member member.new" data-test-nav="members">{{svg-jar "members"}}Members
-                                    {{#let (members-count-fetcher) as |count|}}
-                                        {{#unless count.isLoading}}
-                                            <span class="gh-nav-member-count">{{format-number count.count}}</span>
-                                        {{/unless}}
-                                    {{/let}}
+                                    {{#unless this.memberCountLoading}}
+                                        <span class="gh-nav-member-count">{{format-number this.membersStats.memberCount}}</span>
+                                    {{/unless}}
                                 </LinkTo>
                             {{/if}}
                         </li>

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -10,6 +10,7 @@ import {htmlSafe} from '@ember/template';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 import {tagName} from '@ember-decorators/component';
+import {task} from 'ember-concurrency';
 
 @classic
 @tagName('')
@@ -32,6 +33,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     iconStyle = '';
     iconClass = '';
+    memberCountLoading = true;
     shortcuts = null;
 
     @match('router.currentRouteName', /^settings\.integration/)
@@ -67,6 +69,10 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     didReceiveAttrs() {
         super.didReceiveAttrs(...arguments);
         this._setIconStyle();
+
+        if (this.session.user && this.session.user.isAdmin) {
+            this._loadMemberCountsTask.perform();
+        }
     }
 
     didInsertElement() {
@@ -107,6 +113,17 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     toggleExploreWindow() {
         this.explore.openExploreWindow();
     }
+
+    @task(function* () {
+        try {
+            this.set('memberCountLoading', true);
+            yield this.membersStats.fetchMemberCount();
+            this.set('memberCountLoading', false);
+        } catch (e) {
+            return false;
+        }
+    })
+        _loadMemberCountsTask;
 
     _setIconStyle() {
         let icon = this.icon;


### PR DESCRIPTION
Reverts TryGhost/Ghost#19476

We might need to revert this because there might be a difference in member counts between this endpoint and the one on the dashboard. Not sure, we'll need to check! 