### PR TITLE
🐛 Fixed error logging crash when email recipients count if off by 1%

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -115,6 +115,7 @@ if (sentryConfig && !sentryConfig.disabled) {
         }),
         tracingHandler: Sentry.Handlers.tracingHandler(),
         captureException: Sentry.captureException,
+        captureMessage: Sentry.captureMessage,
         beforeSend: beforeSend,
         initQueryTracing: (knex) => {
             if (sentryConfig.tracing?.enabled === true) {


### PR DESCRIPTION
no issue

When creating the batches when sending an email, we log a message to Sentry when there is an unexpected offset of 1% between creating the email and actually creating the batch recipients. We used a method that was not mapped in our Sentry proxy.

Location of error: ghost/email-service/lib/BatchSendingService.js:286