### PR TITLE
Improved portal settings PROD-275 PROD-59

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
@@ -4,6 +4,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import PortalPreview from './PortalPreview';
 import React, {useEffect, useState} from 'react';
 import SignupOptions from './SignupOptions';
+import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useQueryParams from '../../../../hooks/useQueryParams';
 import {ConfirmationModal, PreviewModalContent, Tab, TabView, showToast} from '@tryghost/admin-x-design-system';
 import {Dirtyable, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -23,7 +24,8 @@ const Sidebar: React.FC<{
     setError: (key: string, error: string | undefined) => void
 }> = ({localSettings, updateSetting, localTiers, updateTier, errors, setError}) => {
     const [selectedTab, setSelectedTab] = useState('signupOptions');
-
+    const hasPortalImprovements = useFeatureFlag('portalImprovements');
+    
     const tabs: Tab[] = [
         {
             id: 'signupOptions',
@@ -44,7 +46,7 @@ const Sidebar: React.FC<{
         },
         {
             id: 'accountPage',
-            title: 'Account page',
+            title: 'Support',
             contents: <AccountPage errors={errors} setError={setError} updateSetting={updateSetting} />
         }
     ];

--- a/apps/admin-x-settings/src/components/settings/membership/portal/SignupOptions.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/SignupOptions.tsx
@@ -1,3 +1,4 @@
+import LookAndFeel from './LookAndFeel';
 import React, {useCallback, useEffect, useMemo} from 'react';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import {CheckboxGroup, CheckboxProps, Form, HtmlField, Select, SelectOption, Toggle} from '@tryghost/admin-x-design-system';
@@ -117,46 +118,47 @@ const SignupOptions: React.FC<{
         });
     }
 
-    return <div className='mt-7'><Form>
-        <Toggle
-            checked={Boolean(portalName)}
-            disabled={isDisabled}
-            label='Display name in signup form'
-            labelStyle='heading'
-            onChange={e => updateSetting('portal_name', e.target.checked)}
-        />
+    return <div className='mt-7'>
+        <Form title={hasPortalImprovements ? 'Signup options' : undefined} >
+            <Toggle
+                checked={Boolean(portalName)}
+                disabled={isDisabled}
+                label='Display name in signup form'
+                labelStyle='heading'
+                onChange={e => updateSetting('portal_name', e.target.checked)}
+            />
 
-        <CheckboxGroup
-            checkboxes={tiersCheckboxes}
-            title='Tiers available at signup'
-        />
+            <CheckboxGroup
+                checkboxes={tiersCheckboxes}
+                title='Tiers available at signup'
+            />
 
-        {isStripeEnabled && localTiers.some(tier => tier.visibility === 'public') && (
-            <>
-                <CheckboxGroup
-                    checkboxes={[
-                        {
-                            checked: portalPlans.includes('monthly'),
-                            disabled: isDisabled,
-                            label: 'Monthly',
-                            value: 'monthly',
-                            onChange: () => {
-                                togglePlan('monthly');
+            {isStripeEnabled && localTiers.some(tier => tier.visibility === 'public') && (
+                <>
+                    <CheckboxGroup
+                        checkboxes={[
+                            {
+                                checked: portalPlans.includes('monthly'),
+                                disabled: isDisabled,
+                                label: 'Monthly',
+                                value: 'monthly',
+                                onChange: () => {
+                                    togglePlan('monthly');
+                                }
+                            },
+                            {
+                                checked: portalPlans.includes('yearly'),
+                                disabled: isDisabled,
+                                label: 'Yearly',
+                                value: 'yearly',
+                                onChange: () => {
+                                    togglePlan('yearly');
+                                }
                             }
-                        },
-                        {
-                            checked: portalPlans.includes('yearly'),
-                            disabled: isDisabled,
-                            label: 'Yearly',
-                            value: 'yearly',
-                            onChange: () => {
-                                togglePlan('yearly');
-                            }
-                        }
-                    ]}
-                    title='Prices available at signup'
-                />
-                {(hasPortalImprovements && (portalPlans.includes('yearly') && portalPlans.includes('monthly'))) &&
+                        ]}
+                        title='Prices available at signup'
+                    />
+                    {(hasPortalImprovements && (portalPlans.includes('yearly') && portalPlans.includes('monthly'))) &&
                     <Select
                         options={defaultPlanOptions}
                         selectedOption={defaultPlanOptions.find(option => option.value === portalDefaultPlan)}
@@ -165,28 +167,32 @@ const SignupOptions: React.FC<{
                             updateSetting('portal_default_plan', option?.value ?? 'yearly');
                         }}
                     />
-                }
-            </>
-        )}
+                    }
+                </>
+            )}
 
-        <HtmlField
-            error={Boolean(errors.portal_signup_terms_html)}
-            hint={errors.portal_signup_terms_html || <>Recommended: <strong>115</strong> characters. You&apos;ve used <strong className="text-green">{signupTermsLength}</strong></>}
-            nodes='MINIMAL_NODES'
-            placeholder={`By signing up, I agree to receive emails from ...`}
-            title='Display notice at signup'
-            value={portalSignupTermsHtml?.toString()}
-            onChange={html => updateSetting('portal_signup_terms_html', html)}
-        />
+            <HtmlField
+                error={Boolean(errors.portal_signup_terms_html)}
+                hint={errors.portal_signup_terms_html || <>Recommended: <strong>115</strong> characters. You&apos;ve used <strong className="text-green">{signupTermsLength}</strong></>}
+                nodes='MINIMAL_NODES'
+                placeholder={`By signing up, I agree to receive emails from ...`}
+                title='Display notice at signup'
+                value={portalSignupTermsHtml?.toString()}
+                onChange={html => updateSetting('portal_signup_terms_html', html)}
+            />
 
-        {portalSignupTermsHtml?.toString() && <Toggle
-            checked={Boolean(portalSignupCheckboxRequired)}
-            disabled={isDisabled}
-            label='Require agreement'
-            labelStyle='heading'
-            onChange={e => updateSetting('portal_signup_checkbox_required', e.target.checked)}
-        />}
-    </Form></div>;
+            {portalSignupTermsHtml?.toString() && <Toggle
+                checked={Boolean(portalSignupCheckboxRequired)}
+                disabled={isDisabled}
+                label='Require agreement'
+                labelStyle='heading'
+                onChange={e => updateSetting('portal_signup_checkbox_required', e.target.checked)}
+            />}
+        </Form>
+        {hasPortalImprovements && <Form gap='sm' margins='lg' title='Portal button'>
+            <LookAndFeel localSettings={localSettings} updateSetting={updateSetting} />
+        </Form>}
+    </div>;
 };
 
 export default SignupOptions;

--- a/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
@@ -222,7 +222,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                     />}
                     <TextField
                         autoComplete='off'
-                        autoFocus={isFreeTier}
+                        autoFocus={!hasPortalImprovements && isFreeTier}
                         placeholder={isFreeTier ? `Free preview of ${siteTitle}` : 'Full access to premium content'}
                         title='Description'
                         value={formState.description || ''}


### PR DESCRIPTION
no refs

- Changed `Account page` tab to `Support`
- Improved logic for displaying portal settings so settings that don’t make sense in that context don’t even show up