### PR TITLE
Send Ghost version to migrator tool

### DIFF
--- a/ghost/admin/app/components/gh-migrate-iframe.js
+++ b/ghost/admin/app/components/gh-migrate-iframe.js
@@ -63,7 +63,8 @@ export default class GhMigrateIframe extends Component {
                 apiUrl: this.migrate.apiUrl,
                 apiToken: theToken,
                 darkMode: this.feature.nightShift,
-                stripe: this.migrate.isStripeConnected
+                stripe: this.migrate.isStripeConnected,
+                ghostVersion: this.migrate.ghostVersion
             }
         }, new URL(this.migrate.getIframeURL()).origin);
     }

--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -1,4 +1,5 @@
 import Service, {inject as service} from '@ember/service';
+import config from 'ghost-admin/config/environment';
 import {SignJWT} from 'jose';
 import {tracked} from '@glimmer/tracking';
 
@@ -64,6 +65,10 @@ export default class MigrateService extends Service {
 
     get isStripeConnected() {
         return (this.settings.stripeConnectAccountId && this.settings.stripeConnectPublishableKey && this.settings.stripeConnectLivemode) ? true : false;
+    }
+
+    get ghostVersion() {
+        return config.APP.version;
     }
 
     constructor() {


### PR DESCRIPTION
This sends the Ghost version to the self-service migrator tool so it can change what features and functions are available.