### PR TITLE
Fixed type error when logging editor error

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor-input.js
+++ b/ghost/admin/app/components/koenig-lexical-editor-input.js
@@ -23,7 +23,7 @@ class ErrorHandler extends React.Component {
             });
         }
 
-        console.error(error, errorInfo); // eslint-disable-line
+        console.error(error); // eslint-disable-line
     }
 
     render() {

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -58,7 +58,7 @@ class ErrorHandler extends React.Component {
             });
         }
 
-        console.error(error, errorInfo); // eslint-disable-line
+        console.error(error); // eslint-disable-line
     }
 
     render() {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/19284

- previous commit had only partially rolled back usage of `errorInfo` variable but it wasn't caught because the line in question has linting disabled
