### PR TITLE
Added default string to href to Offers Portal iFrame

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
@@ -618,7 +618,7 @@ const AddOfferModal = () => {
     />;
 
     const iframe = <PortalFrame
-        href={href}
+        href={href || ''}
     />;
     return <PreviewModalContent
         afterClose={() => {

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -257,7 +257,7 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
     }, [formState, siteData]);
 
     const iframe = <PortalFrame
-        href={href}
+        href={href || ''}
     />;
 
     return offerById ? <PreviewModalContent


### PR DESCRIPTION
no issue

- potentially fixes a small performance issues to avoid the homepage of your publication from being loaded should an href from Portal not exist when loading Offers, that could cause flashing.