### PR TITLE
Used a key prefix to enable immediate cache resets

### DIFF
--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -188,6 +188,10 @@ class AdapterCacheRedis extends BaseCacheAdapter {
             lookup.then((value) => {
                 clearTimeout(timer);
                 resolve(value);
+            }, () => {
+                // redis failure during lookup - treat as MISS, same as the timeout path
+                clearTimeout(timer);
+                resolve({internalKey: null, result: null});
             });
         });
     }
@@ -241,9 +245,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {*} value
      */
     async set(key, value) {
-        const internalKey = await this._buildKey(key);
-        debug('set', internalKey);
         try {
+            const internalKey = await this._buildKey(key);
+            debug('set', internalKey);
             return await this.cache.set(internalKey, value);
         } catch (err) {
             logging.error(err);

--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -1,13 +1,16 @@
+const crypto = require('crypto');
 const BaseCacheAdapter = require('@tryghost/adapter-base-cache');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
-const metrics = require('@tryghost/metrics');
 const debug = require('@tryghost/debug')('redis-cache');
 const cacheManager = require('cache-manager');
 const redisStoreFactory = require('./redis-store-factory');
-const calculateSlot = require('cluster-key-slot');
+
+const PREFIX_HASH_KEY = 'prefix_hash';
 
 class AdapterCacheRedis extends BaseCacheAdapter {
+    #prefixHashInitInFlight = null;
+
     /**
      *
      * @param {Object} config
@@ -64,55 +67,62 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         this.refreshAheadFactor = config.refreshAheadFactor || 0;
         this.getTimeoutMilliseconds = config.getTimeoutMilliseconds || null;
         this.currentlyExecutingBackgroundRefreshes = new Set();
-        this.keyPrefix = config.keyPrefix;
-        this._keysPattern = config.keyPrefix ? `${config.keyPrefix}*` : '';
+        this._keyPrefix = config.keyPrefix || '';
         this.redisClient = this.cache.store.getClient();
         this.redisClient.on('error', this.handleRedisError);
     }
 
+    /**
+     * NOTE: this adds an extra round-trip to every cache operation. The
+     * trade-off is intentional for now (reset becomes O(1) instead of an
+     * O(n) SCAN).
+     *
+     * NOTE: the prefix_hash key is written without a TTL, but redis can
+     * still evict it under allkeys-lru / allkeys-random eviction policies.
+     * Eviction will silently invalidate the entire cache as a side effect.
+     * Operators who need stricter invalidation guarantees should configure
+     * a noeviction policy or pin this key out-of-band.
+     */
+    async prefixHash() {
+        const currentPrefixHash = await this.redisClient.get(this._keyPrefix + PREFIX_HASH_KEY);
+        if (currentPrefixHash) {
+            return currentPrefixHash;
+        }
+        return this.#initPrefixHash();
+    }
+
+    /**
+     * Lazily creates the prefix_hash. Concurrent callers in this process
+     * share one in-flight init via #prefixHashInitInFlight; SET NX ensures
+     * only one writer wins across processes.
+     */
+    #initPrefixHash() {
+        if (this.#prefixHashInitInFlight) {
+            return this.#prefixHashInitInFlight;
+        }
+        const value = crypto.randomBytes(12).toString('hex');
+        this.#prefixHashInitInFlight = this.redisClient
+            .set(this._keyPrefix + PREFIX_HASH_KEY, value, 'NX')
+            .then(async (result) => {
+                if (result === 'OK') {
+                    return value;
+                }
+                // someone else wrote it first; return their value
+                return await this.redisClient.get(this._keyPrefix + PREFIX_HASH_KEY);
+            })
+            .finally(() => {
+                this.#prefixHashInitInFlight = null;
+            });
+        return this.#prefixHashInitInFlight;
+    }
+
+    async keyPrefix() {
+        const prefixHash = await this.prefixHash();
+        return this._keyPrefix + prefixHash;
+    }
+
     handleRedisError(error) {
         logging.error(error);
-    }
-
-    #getPrimaryRedisNode() {
-        debug('getPrimaryRedisNode');
-        if (this.redisClient.constructor.name !== 'Cluster') {
-            return this.redisClient;
-        }
-        const slot = calculateSlot(this.keyPrefix);
-        const [ip, port] = this.redisClient.slots[slot][0].split(':');
-        for (const node of this.redisClient.nodes()) {
-            if (node.options.host === ip && node.options.port === parseInt(port)) {
-                return node;
-            }
-        }
-        return null;
-    }
-
-    #scanNodeForKeys(node) {
-        debug(`scanNodeForKeys matching ${this._keysPattern}`);
-        return new Promise((resolve, reject) => {
-            const stream = node.scanStream({match: this._keysPattern, count: 100});
-            let keys = [];
-            stream.on('data', (resultKeys) => {
-                keys = keys.concat(resultKeys);
-            });
-            stream.on('error', (e) => {
-                reject(e);
-            });
-            stream.on('end', () => {
-                resolve(keys);
-            });
-        });
-    }
-
-    async #getKeys() {
-        debug('#getKeys');
-        const primaryNode = this.#getPrimaryRedisNode();
-        if (primaryNode === null) {
-            return [];
-        }
-        return await this.#scanNodeForKeys(primaryNode);
     }
 
     /**
@@ -120,23 +130,11 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * the cache-manager package. Might be a good contribution to make
      * in the package itself (https://github.com/node-cache-manager/node-cache-manager/issues/158)
      * @param {string} key
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    _buildKey(key) {
-        if (this.keyPrefix) {
-            return `${this.keyPrefix}${key}`;
-        }
-
-        return key;
-    }
-
-    /**
-     * This is a method to remove the key prefix from any raw key returned from redis.
-     * @param {string} key
-     * @returns {string}
-     */
-    _removeKeyPrefix(key) {
-        return key.slice(this.keyPrefix.length);
+    async _buildKey(key) {
+        const keyPrefix = await this.keyPrefix();
+        return `${keyPrefix}${key}`;
     }
 
     /**
@@ -166,8 +164,8 @@ class AdapterCacheRedis extends BaseCacheAdapter {
     /**
      * Returns the specified key from the cache if it exists, otherwise returns null
      * - If getTimeoutMilliseconds is set, the method will return a promise that resolves with the value or null if the timeout is exceeded
-     * 
-     * @param {string} key 
+     *
+     * @param {string} key
      */
     async _get(key) {
         if (typeof this.getTimeoutMilliseconds !== 'number') {
@@ -178,7 +176,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                     debug('get', key, 'timeout');
                     resolve(null);
                 }, this.getTimeoutMilliseconds);
-    
+
                 this.cache.get(key).then((result) => {
                     clearTimeout(timer);
                     resolve(result);
@@ -193,7 +191,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {() => Promise<any>} [fetchData] An optional function to fetch the data, which will be used in the case of a cache MISS or a background refresh
      */
     async get(key, fetchData) {
-        const internalKey = this._buildKey(key);
+        const internalKey = await this._buildKey(key);
         try {
             const result = await this._get(internalKey);
             debug(`get ${internalKey}: Cache ${result ? 'HIT' : 'MISS'}`);
@@ -237,7 +235,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {*} value
      */
     async set(key, value) {
-        const internalKey = this._buildKey(key);
+        const internalKey = await this._buildKey(key);
         debug('set', internalKey);
         try {
             return await this.cache.set(internalKey, value);
@@ -246,25 +244,17 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         }
     }
 
-    /**
-     * Reset the cache by deleting everything from redis
-     */
+    async cyclePrefixHash() {
+        const value = crypto.randomBytes(12).toString('hex');
+        // Raw client: cache-manager would JSON-wrap, and reset needs an unconditional overwrite (no NX).
+        await this.redisClient.set(this._keyPrefix + PREFIX_HASH_KEY, value);
+        return value;
+    }
+
     async reset() {
         debug('reset');
         try {
-            const t0 = performance.now();
-            logging.debug(`[RedisAdapter] Clearing cache: scanning for keys matching ${this._keysPattern}`);
-            const keys = await this.#getKeys();
-            logging.debug(`[RedisAdapter] Clearing cache: found ${keys.length} keys matching ${this._keysPattern} in ${(performance.now() - t0).toFixed(1)}ms`);
-            metrics.metric('cache-reset-scan', (performance.now() - t0).toFixed(1));
-            const t1 = performance.now();
-            for (const key of keys) {
-                await this.cache.del(key);
-            }
-            logging.debug(`[RedisAdapter] Clearing cache: deleted ${keys.length} keys matching ${this._keysPattern} in ${(performance.now() - t1).toFixed(1)}ms`);
-            metrics.metric('cache-reset-delete', (performance.now() - t1).toFixed(1));
-            metrics.metric('cache-reset', (performance.now() - t0).toFixed(1));
-            metrics.metric('cache-reset-key-count', keys.length);
+            await this.cyclePrefixHash();
         } catch (err) {
             logging.error(err);
         }

--- a/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
+++ b/ghost/core/core/server/adapters/lib/redis/AdapterCacheRedis.js
@@ -162,27 +162,34 @@ class AdapterCacheRedis extends BaseCacheAdapter {
     }
 
     /**
-     * Returns the specified key from the cache if it exists, otherwise returns null
-     * - If getTimeoutMilliseconds is set, the method will return a promise that resolves with the value or null if the timeout is exceeded
+     * Performs the buildKey + cache.get sequence, bounded by
+     * getTimeoutMilliseconds if configured. On timeout resolves with
+     * {internalKey: null, result: null} so the caller treats it as a MISS.
      *
      * @param {string} key
+     * @returns {Promise<{internalKey: string|null, result: any}>}
      */
-    async _get(key) {
-        if (typeof this.getTimeoutMilliseconds !== 'number') {
-            return this.cache.get(key);
-        } else {
-            return new Promise((resolve) => {
-                const timer = setTimeout(() => {
-                    debug('get', key, 'timeout');
-                    resolve(null);
-                }, this.getTimeoutMilliseconds);
+    #lookupWithTimeout(key) {
+        const lookup = (async () => {
+            const internalKey = await this._buildKey(key);
+            const result = await this.cache.get(internalKey);
+            return {internalKey, result};
+        })();
 
-                this.cache.get(key).then((result) => {
-                    clearTimeout(timer);
-                    resolve(result);
-                });
-            });
+        if (typeof this.getTimeoutMilliseconds !== 'number') {
+            return lookup;
         }
+
+        return new Promise((resolve) => {
+            const timer = setTimeout(() => {
+                debug('get', key, 'timeout');
+                resolve({internalKey: null, result: null});
+            }, this.getTimeoutMilliseconds);
+            lookup.then((value) => {
+                clearTimeout(timer);
+                resolve(value);
+            });
+        });
     }
 
     /**
@@ -191,10 +198,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {() => Promise<any>} [fetchData] An optional function to fetch the data, which will be used in the case of a cache MISS or a background refresh
      */
     async get(key, fetchData) {
-        const internalKey = await this._buildKey(key);
         try {
-            const result = await this._get(internalKey);
-            debug(`get ${internalKey}: Cache ${result ? 'HIT' : 'MISS'}`);
+            const {internalKey, result} = await this.#lookupWithTimeout(key);
+            debug(`get ${key}: Cache ${result ? 'HIT' : 'MISS'}`);
             if (!fetchData) {
                 return result;
             }
@@ -202,10 +208,10 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 const shouldRefresh = await this.shouldRefresh(internalKey);
                 const isRefreshing = this.currentlyExecutingBackgroundRefreshes.has(internalKey);
                 if (isRefreshing) {
-                    debug(`Background refresh already happening for ${internalKey}`);
+                    debug(`Background refresh already happening for ${key}`);
                 }
                 if (!isRefreshing && shouldRefresh) {
-                    debug(`Doing background refresh for ${internalKey}`);
+                    debug(`Doing background refresh for ${key}`);
                     this.currentlyExecutingBackgroundRefreshes.add(internalKey);
                     fetchData().then(async (data) => {
                         await this.set(key, data); // We don't use `internalKey` here because `set` handles it

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -150,7 +150,7 @@ describe('Integration: AdapterCacheRedis', function () {
             assert.equal(await cache.get('fast'), 'value');
         });
 
-        it('returns null when the underlying get exceeds the timeout', async function () {
+        it('returns null when the data fetch exceeds the timeout', async function () {
             const cache = createCache({getTimeoutMilliseconds: 1});
             await cache.set('slow', 'value');
 
@@ -160,6 +160,19 @@ describe('Integration: AdapterCacheRedis', function () {
             });
 
             assert.equal(await cache.get('slow'), null);
+        });
+
+        it('returns null when the prefix_hash fetch exceeds the timeout', async function () {
+            const cache = createCache({getTimeoutMilliseconds: 1});
+            // Prime the cache so prefix_hash exists before we slow reads down.
+            await cache.set('foo', 'value');
+
+            const original = cache.redisClient.get.bind(cache.redisClient);
+            cache.redisClient.get = k => new Promise((resolve) => {
+                setTimeout(() => original(k).then(resolve), 50);
+            });
+
+            assert.equal(await cache.get('foo'), null);
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -4,6 +4,33 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const RedisCache = require('../../../../../../core/server/adapters/lib/redis/AdapterCacheRedis');
 
+const PREFIX_HASH = 'mock-prefix-hash';
+
+/**
+ * Build a stub for the cache-manager instance, including a stubbed
+ * underlying redis client. The redis client's get() returns PREFIX_HASH
+ * for the prefix_hash key by default so the prefix-rotation plumbing
+ * doesn't get in the way of the behaviour under test.
+ */
+function createCacheStub({keyPrefix = ''} = {}) {
+    const redisGet = sinon.stub();
+    redisGet.withArgs(`${keyPrefix}prefix_hash`).resolves(PREFIX_HASH);
+
+    const cacheStub = {
+        get: sinon.stub(),
+        set: sinon.stub().resolvesArg(1),
+        ttl: sinon.stub(),
+        store: {
+            getClient: sinon.stub().returns({
+                on: sinon.stub(),
+                get: redisGet,
+                set: sinon.stub().resolves('OK')
+            })
+        }
+    };
+    return cacheStub;
+}
+
 describe('Adapter Cache Redis', function () {
     beforeEach(function () {
         sinon.stub(logging, 'error');
@@ -14,17 +41,7 @@ describe('Adapter Cache Redis', function () {
     });
 
     it('can initialize Redis cache instance directly', async function () {
-        const redisCacheInstanceStub = {
-            store: {
-                getClient: sinon.stub().returns({
-                    on: sinon.stub()
-                })
-            }
-        };
-        const cache = new RedisCache({
-            cache: redisCacheInstanceStub
-        });
-
+        const cache = new RedisCache({cache: createCacheStub()});
         assert.ok(cache);
     });
 
@@ -44,17 +61,9 @@ describe('Adapter Cache Redis', function () {
 
     describe('get', function () {
         it('can get a value from the cache', async function () {
-            const redisCacheInstanceStub = {
-                get: sinon.stub().resolves('value from cache'),
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
-                }
-            };
-            const cache = new RedisCache({
-                cache: redisCacheInstanceStub
-            });
+            const cacheStub = createCacheStub();
+            cacheStub.get.resolves('value from cache');
+            const cache = new RedisCache({cache: cacheStub});
 
             const value = await cache.get('key');
 
@@ -62,22 +71,12 @@ describe('Adapter Cache Redis', function () {
         });
 
         it('returns null if getTimeoutMilliseconds is exceeded', async function () {
-            const redisCacheInstanceStub = {
-                get: sinon.stub().callsFake(async () => {
-                    return new Promise((resolve) => {
-                        setTimeout(() => {
-                            resolve('value from cache');
-                        }, 200);
-                    });
-                }),
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
-                }
-            };
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(() => new Promise((resolve) => {
+                setTimeout(() => resolve('value from cache'), 200);
+            }));
             const cache = new RedisCache({
-                cache: redisCacheInstanceStub,
+                cache: cacheStub,
                 getTimeoutMilliseconds: 100
             });
 
@@ -88,40 +87,28 @@ describe('Adapter Cache Redis', function () {
         it('can update the cache in the case of a cache miss', async function () {
             const KEY = 'update-cache-on-miss';
             let cachedValue = null;
-            const redisCacheInstanceStub = {
-                get: function (key) {
-                    assert(key === KEY);
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
                     return cachedValue;
-                },
-                set: function (key, value) {
-                    assert(key === KEY);
-                    cachedValue = value;
-                },
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
                 }
-            };
-            const cache = new RedisCache({
-                cache: redisCacheInstanceStub
             });
+            cacheStub.set.callsFake(async (key, value) => {
+                if (key === PREFIX_HASH + KEY) {
+                    cachedValue = value;
+                }
+            });
+            const cache = new RedisCache({cache: cacheStub});
 
             const fetchData = sinon.stub().resolves('Da Value');
 
-            checkFirstRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledOnce(fetchData);
-                assert.equal(value, 'Da Value');
-                break checkFirstRead;
-            }
+            const firstRead = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 1);
+            assert.equal(firstRead, 'Da Value');
 
-            checkSecondRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledOnce(fetchData);
-                assert.equal(value, 'Da Value');
-                break checkSecondRead;
-            }
+            const secondRead = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 1);
+            assert.equal(secondRead, 'Da Value');
         });
 
         it('Can do a background update of the cache', async function () {
@@ -129,27 +116,24 @@ describe('Adapter Cache Redis', function () {
             let cachedValue = null;
             let remainingTTL = 100;
 
-            const redisCacheInstanceStub = {
-                get: function (key) {
-                    assert(key === KEY);
+            const cacheStub = createCacheStub();
+            cacheStub.get.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
                     return cachedValue;
-                },
-                set: function (key, value) {
-                    assert(key === KEY);
-                    cachedValue = value;
-                },
-                ttl: function (key) {
-                    assert(key === KEY);
-                    return remainingTTL;
-                },
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
                 }
-            };
+            });
+            cacheStub.set.callsFake(async (key, value) => {
+                if (key === PREFIX_HASH + KEY) {
+                    cachedValue = value;
+                }
+            });
+            cacheStub.ttl.callsFake(async (key) => {
+                if (key === PREFIX_HASH + KEY) {
+                    return remainingTTL;
+                }
+            });
             const cache = new RedisCache({
-                cache: redisCacheInstanceStub,
+                cache: cacheStub,
                 ttl: 100,
                 refreshAheadFactor: 0.2
             });
@@ -158,114 +142,78 @@ describe('Adapter Cache Redis', function () {
             fetchData.onFirstCall().resolves('First Value');
             fetchData.onSecondCall().resolves('Second Value');
 
-            checkFirstRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledOnce(fetchData);
-                assert.equal(value, 'First Value');
-                break checkFirstRead;
-            }
+            const first = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 1);
+            assert.equal(first, 'First Value');
 
             // We simulate having been in the cache for 15 seconds
             remainingTTL = 85;
 
-            checkSecondRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledOnce(fetchData);
-                assert.equal(value, 'First Value');
-                break checkSecondRead;
-            }
+            const second = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 1);
+            assert.equal(second, 'First Value');
 
             // We simulate having been in the cache for 30 seconds
             remainingTTL = 70;
 
-            checkThirdRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledOnce(fetchData);
-                assert.equal(value, 'First Value');
-                break checkThirdRead;
-            }
+            const third = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 1);
+            assert.equal(third, 'First Value');
 
             // We simulate having been in the cache for 85 seconds
             // This should trigger a background refresh
             remainingTTL = 15;
 
-            checkFourthRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledTwice(fetchData);
-                assert.equal(value, 'First Value');
-                break checkFourthRead;
-            }
+            const fourth = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 2);
+            assert.equal(fourth, 'First Value');
 
             // We reset the TTL to 100 for the most recent write
             remainingTTL = 100;
 
-            checkFifthRead: {
-                const value = await cache.get(KEY, fetchData);
-                sinon.assert.calledTwice(fetchData);
-                assert.equal(value, 'Second Value');
-                break checkFifthRead;
-            }
+            const fifth = await cache.get(KEY, fetchData);
+            assert.equal(fetchData.callCount, 2);
+            assert.equal(fifth, 'Second Value');
         });
     });
 
     describe('set', function () {
         it('can set a value in the cache', async function () {
-            const redisCacheInstanceStub = {
-                set: sinon.stub().resolvesArg(1),
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
-                }
-            };
-            const cache = new RedisCache({
-                cache: redisCacheInstanceStub
-            });
+            const cacheStub = createCacheStub();
+            const cache = new RedisCache({cache: cacheStub});
 
             const value = await cache.set('key-here', 'new value');
 
             assert.equal(value, 'new value');
-            assert.equal(redisCacheInstanceStub.set.args[0][0], 'key-here');
+            assert.equal(cacheStub.set.args[0][0], `${PREFIX_HASH}key-here`);
         });
 
         it('sets a key based on keyPrefix', async function () {
-            const redisCacheInstanceStub = {
-                set: sinon.stub().resolvesArg(1),
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
-                }
-            };
+            const cacheStub = createCacheStub({keyPrefix: 'testing-prefix:'});
             const cache = new RedisCache({
-                cache: redisCacheInstanceStub,
+                cache: cacheStub,
                 keyPrefix: 'testing-prefix:'
             });
 
             const value = await cache.set('key-here', 'new value');
 
             assert.equal(value, 'new value');
-            assert.equal(redisCacheInstanceStub.set.args[0][0], 'testing-prefix:key-here');
+            assert.equal(cacheStub.set.args[0][0], `testing-prefix:${PREFIX_HASH}key-here`);
         });
     });
 
     describe('reset', function () {
-        it('catches an error when thrown during the reset', async function () {
-            const redisCacheInstanceStub = {
-                get: sinon.stub().resolves('value from cache'),
-                store: {
-                    getClient: sinon.stub().returns({
-                        on: sinon.stub()
-                    })
-                }
-            };
-            const cache = new RedisCache({
-                cache: redisCacheInstanceStub
-            });
+        it('writes a new prefix_hash directly via the redis client (no TTL)', async function () {
+            const cacheStub = createCacheStub();
+            const cache = new RedisCache({cache: cacheStub});
+            const redisSet = cacheStub.store.getClient().set;
 
             await cache.reset();
 
-            sinon.assert.calledOnce(logging.error);
+            const [key, value, ...extra] = redisSet.lastCall.args;
+            assert.equal(key, 'prefix_hash');
+            assert.match(value, /^[0-9a-f]{24}$/);
+            assert.deepEqual(extra, []);
         });
     });
 


### PR DESCRIPTION
## Why

The previous `reset()` scanned every matching key and DEL'd them one by one. It was O(n), slow against large caches, and needed cluster-aware routing to hit the right primary node. The slowness added load to the Redis cluster, and it meant that we had to limit the number of sites we could configure to use the cache.

This PR swaps SCAN-and-DEL for prefix rotation. Every key is stored under a random hash that's prepended at write time, so rotating the hash makes every entry unreachable in a single SET. Old entries age out via Redis's own eviction and TTL.

## Changes

- `prefix_hash` is lazily initialized on first read. Concurrent callers within a process share an in-flight promise; `SET NX` collapses the cross-process race so losers read back the winning value.
- `prefix_hash` reads and writes bypass cache-manager and go through the raw redis client. The meta-key holds a raw hex string, not JSON, so cache-manager's wrapper would choke on it; for reset we also want an unconditional overwrite.
- The SCAN-based helpers (`#getKeys`, `#scanNodeForKeys`, `#getPrimaryRedisNode`) and `_removeKeyPrefix` are deleted. They only existed to support the old SCAN-based `reset()`.
- The `cluster-key-slot` dependency is no longer used.

## Details

- `prefix_hash` is written without a TTL, and our Redis cluster uses `volatile-lru` eviction policy, so these keys won't be evicted.
- Every `get` and `set` now costs an extra round-trip to fetch the current `prefix_hash`. For cache hits that doubles the latency. We get O(1) resets in return, and we're accepting the cost for now. We are going to monitor Redis performance as we add new sites, and we might revisit this if it's an issue.


## Testing

The 12 integration tests from #27467 (already in main) continue to pass; they exercise the invalidation contract against real Redis.