### PR TITLE
🐛 Fixed embed service trying http before https for oembed providers

### DIFF
--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -26,10 +26,10 @@ const findUrlWithProvider = (url) => {
     // providers list is not always up to date with scheme or www vs non-www
     let baseUrl = url.replace(/^\/\/|^https?:\/\/(?:www\.)?/, '');
     let testUrls = [
-        `http://${baseUrl}`,
         `https://${baseUrl}`,
-        `http://www.${baseUrl}`,
-        `https://www.${baseUrl}`
+        `https://www.${baseUrl}`,
+        `http://${baseUrl}`,
+        `http://www.${baseUrl}`
     ];
 
     for (let testUrl of testUrls) {


### PR DESCRIPTION
no issue

- issue reported via the forum https://forum.ghost.org/t/video-embed-break-page-on-mobile/44172
- due to historical issues we check against http/https and non-www/www URLs to match an oembed provider in case our library's provider list is out of date. However we checked http first which could match and then update the original URL to be `http` in place of `https` leading to potentially broken oembed fetch requests as was the case with http://odysee.com URLs
