### PR TITLE
Removed onLoad from iFrame element

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalFrame.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalFrame.tsx
@@ -59,7 +59,6 @@ const PortalFrame: React.FC<PortalFrameProps> = ({href, onDestroyed, selectedTab
                 src={href}
                 title="Portal Preview"
                 width="100%"
-                onLoad={makeVisible}
             />
         </>
     );


### PR DESCRIPTION
no issue

- removed the onLoad function from the iFrame element and only rely on the listener waiting for 'portal-ready' before showing Portal
