### PR TITLE
🐛 Fixed wording when a canceled subscription has not ended yet

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -123,9 +123,9 @@
                                     <h3 class="gh-membertier-name" data-test-text="tier-name" style="align-items:center !important; justify-content:flex-start !important;">
                                         {{tier.name}}
                                         {{#if (eq sub.status "canceled")}}
-                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Cancelled</span>
+                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
                                         {{else if sub.cancel_at_period_end}}
-                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Cancelled</span>
+                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
                                         {{else if sub.compExpiry}}
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                         {{else if sub.trialUntil}}
@@ -147,9 +147,9 @@
                                             {{/if}}
                                         {{/if}}
 
-                                        {{#if (eq sub.status "canceled")}}
+                                        {{#if sub.hasEnded}}
                                             <span class="gh-cp-membertier-renewal">Ended {{sub.validUntil}}</span>
-                                        {{else if sub.cancel_at_period_end}}
+                                        {{else if sub.willEndSoon}}
                                             <span class="gh-cp-membertier-renewal">Has access until {{sub.validUntil}}</span>
                                         {{else if sub.compExpiry}}
                                             <span class="gh-cp-membertier-renewal">Expires {{sub.compExpiry}}</span>

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -63,6 +63,7 @@ export default class extends Component {
         let subscriptionData = subscriptions.filter((sub) => {
             return !!sub.price;
         }).map((sub) => {
+            const periodEnded = sub.current_period_end && new Date(sub.current_period_end) < new Date();
             const data = {
                 ...sub,
                 attribution: {
@@ -72,6 +73,8 @@ export default class extends Component {
                 },
                 startDate: sub.start_date ? moment(sub.start_date).format('D MMM YYYY') : '-',
                 validUntil: sub.current_period_end ? moment(sub.current_period_end).format('D MMM YYYY') : '-',
+                hasEnded: sub.status === 'canceled' && periodEnded,
+                willEndSoon: sub.cancel_at_period_end || (sub.status === 'canceled' && !periodEnded),
                 cancellationReason: sub.cancellation_reason,
                 price: {
                     ...sub.price,


### PR DESCRIPTION
fixes PROD-325
fixes https://github.com/TryGhost/Product/issues/3489

- a canceled subscription that is still valid till the end of the current period now correctly shows "Has access until x", instead of "Ended x"
