### PR TITLE
Added allowlist for Sentry transactions

### DIFF
--- a/ghost/core/test/unit/shared/sentry.test.js
+++ b/ghost/core/test/unit/shared/sentry.test.js
@@ -155,4 +155,26 @@ describe('UNIT: sentry', function () {
             assert.deepEqual(result, expected);
         });
     });
+
+    describe('beforeTransaction', function () {
+        it('filters transactions based on an allow list', function () {
+            sentry = require('../../../core/shared/sentry');
+
+            const beforeSendTransaction = sentry. beforeSendTransaction;
+
+            const allowedTransactions = [
+                {transaction: 'GET /ghost/api/settings'},
+                {transaction: 'PUT /members/api/member'},
+                {transaction: 'POST /ghost/api/tiers'},
+                {transaction: 'DELETE /members/api/member'}
+            ];
+
+            allowedTransactions.forEach((transaction) => {
+                assert.equal(beforeSendTransaction(transaction), transaction);
+            });
+
+            assert.equal(beforeSendTransaction({transaction: 'GET /foo/bar'}), null);
+            assert.equal(beforeSendTransaction({transaction: 'Some other transaction'}), null);
+        });
+    });
 });


### PR DESCRIPTION
refs [ARCH-41](https://linear.app/tryghost/issue/ARCH-41/add-allowlist-for-sentry-transactions)

Added allowlist for Sentry transactions so that we can better control the data we are putting into Sentry