### PR TITLE
🐛 Fixed broken access to preview of scheduled email-only posts

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -49,12 +49,13 @@ module.exports = function previewController(req, res, next) {
                 return next();
             }
 
+            // published content should only resolve to /:slug - /p/:uuid is for drafts only in lieu of an actual preview api
             if (post.status === 'published') {
                 return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
-            // published content should only resolve to /:slug or /email/:uuid - /p/:uuid is for drafts only in lieu of an actual preview api
-            if (post.status !== 'published' && post.email_only === true) {
+            // once an email-only post has been sent it shouldn't be available via /p/ to avoid leaking members-only content
+            if (post.status === 'sent') {
                 return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
             }
 


### PR DESCRIPTION
no issue

- we recently added a redirect to disable access to the preview endpoint for sent email-only posts but the condition was too broad and also disabled access to scheduled email-only posts
- adjusted so we only apply the /p/ -> /email/ redirect for sent posts
