### PR TITLE
Fixed Offers redemptions preselection

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -20,7 +20,8 @@ export type OfferType = 'percent' | 'fixed' | 'trial';
 
 export const createRedemptionFilterUrl = (id: string): string => {
     const baseHref = '/ghost/#/members';
-    return `${baseHref}?filter=${encodeURIComponent('offer_redemptions:' + id)}`;
+    const filterValue = `offer_redemptions:[${id}]`;
+    return `${baseHref}?filter=${encodeURIComponent(filterValue)}`;
 };
 
 export const getOfferCadence = (cadence: string): string => {

--- a/ghost/admin/app/templates/offers.hbs
+++ b/ghost/admin/app/templates/offers.hbs
@@ -92,7 +92,7 @@
                                     <span class="midgrey strike ml2">{{currency-symbol offer.finalCurrency}}{{gh-price-amount offer.originalPrice}}</span>
                                 {{/if}}
                             </LinkTo>
-                            <LinkTo @route="members" @query={{hash filter=(concat "offer_redemptions:" offer.id)}} class="gh-list-data" data-test-list="redemption-count">
+                            <LinkTo @route="members" @query={{hash filter=(concat "offer_redemptions:[" offer.id "]")}} class="gh-list-data" data-test-list="redemption-count">
                                 <span class="midgrey">{{offer.redemptionCount}}</span>
                             </LinkTo>
                             <div class="gh-list-data gh-list-cellwidth-10 gh-list-chevron">


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/PROD-319/offer-is-not-preselected-in-filter-dropdown-after-navigating-to

- fixes the URL builder for when Redeemed offers are selected to ensure the selected tier is preselected in the members filter
