### PR TITLE
🐛Fixed primary_name crashing Settings history

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
@@ -127,7 +127,7 @@ const HistoryActionDescription: React.FC<{action: Action}> = ({action}) => {
             {group.slice(0, 1).toUpperCase()}{group.slice(1)}
             {group !== key && <span className='text-xs'> <code className='mb-1 bg-white text-grey-800 dark:bg-grey-900 dark:text-white'>({key})</code></span>}
         </>;
-    } else if (action.resource?.title || action.resource?.name || action.context.primary_name) {
+    } else if (action.resource?.title || action.resource?.name || action.context?.primary_name) {
         const linkTarget = getLinkTarget(action);
 
         if (linkTarget) {
@@ -136,7 +136,7 @@ const HistoryActionDescription: React.FC<{action: Action}> = ({action}) => {
                 updateRoute(linkTarget);
             }}>{action.resource?.title || action.resource?.name}</a>;
         } else {
-            return <>{action.resource?.title || action.resource?.name || action.context.primary_name}</>;
+            return <>{action.resource?.title || action.resource?.name || action.context?.primary_name}</>;
         }
     } else {
         return <span className='text-grey-500'>(unknown)</span>;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/PROD-329/history-modal-crashes-the-app

- Added optional chaining operator to avoid null or undefined crashes when the condition doesn't meet and should rather just move on.
- It now aligns with the other conditions where chaining is used.