### PR TITLE
🐛 Fixed links in History

### DIFF
--- a/apps/admin-x-framework/src/api/actions.ts
+++ b/apps/admin-x-framework/src/api/actions.ts
@@ -132,7 +132,7 @@ export const getLinkTarget = (action: Action): InternalLink | ExternalLink | und
 
             return {
                 isExternal: true,
-                route: 'editor.edit',
+                route: `editor/${resourceType}/${action.resource.id}`,
                 models: [resourceType, action.resource.id]
             };
         case 'integration':
@@ -145,10 +145,10 @@ export const getLinkTarget = (action: Action): InternalLink | ExternalLink | und
             if (!action.resource || !action.resource.id) {
                 return;
             }
-
+            // replace with Settings route once Offers X GA is released
             return {
                 isExternal: true,
-                route: 'offer',
+                route: `offers/${action.resource.id}`,
                 models: [action.resource.id]
             };
         case 'tag':

--- a/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
@@ -131,7 +131,7 @@ const HistoryActionDescription: React.FC<{action: Action}> = ({action}) => {
         const linkTarget = getLinkTarget(action);
 
         if (linkTarget) {
-            return <a className='font-bold' href='#' onClick={(e) => {
+            return <a className='cursor-pointer font-bold' onClick={(e) => {
                 e.preventDefault();
                 updateRoute(linkTarget);
             }}>{action.resource?.title || action.resource?.name}</a>;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/PROD-331/post-and-offer-links-404-in-history

- Links were using Ember route instead of absolute routes, causing 404s.
