### PR TITLE
Added a `Table` prop for enabling horizontal scroll PROD-332

### DIFF
--- a/apps/admin-x-design-system/src/global/Table.tsx
+++ b/apps/admin-x-design-system/src/global/Table.tsx
@@ -28,6 +28,7 @@ export interface TableProps {
     pagination?: PaginationData;
     showMore?: ShowMoreData;
     fillContainer?: boolean;
+    horizontalScroll?: boolean;
     paddingXClassName?: string;
 }
 
@@ -65,6 +66,7 @@ const Table: React.FC<TableProps> = ({
     showMore,
     isLoading,
     fillContainer = false,
+    horizontalScroll = false,
     paddingXClassName
 }) => {
     const table = React.useRef<HTMLTableSectionElement>(null);
@@ -145,7 +147,7 @@ const Table: React.FC<TableProps> = ({
     );
 
     const mainContainerClasses = clsx(
-        'overflow-x-auto',
+        horizontalScroll ? 'overflow-x-auto' : '',
         fillContainer ? 'absolute inset-0 min-w-full' : 'w-full'
     );
 


### PR DESCRIPTION
refs PROD-332

- `Table` component now has a `horizontalScroll` prop that is `false` by default and when set to `true` adds `overflow-x-auto` to the wrapper so the horizontal scroll appears if the table can’t fit all of the columns
