### PR TITLE
🐛 Fixed in-editor style regressions

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.3",
     "@tryghost/kg-converters": "0.0.22",
-    "@tryghost/koenig-lexical": "1.0.11",
+    "@tryghost/koenig-lexical": "1.0.12",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7207,10 +7207,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.11.tgz#7cc17317e4116d0facb3add82fefd104d076d764"
-  integrity sha512-jmDYNv1jy4xUmjH/xXVZUzPNhKp7jd4rX8rAZwLxD4p+Eegh99LTBD8JMYSQmVDuWAkrILFlSCHZt7Y4O6uNuw==
+"@tryghost/koenig-lexical@1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.12.tgz#08019d4c17584f049ac04f435aadae59a8bc6e03"
+  integrity sha512-1o+FEJNC6fVCj7lSvrntWu35W+bet9/WzUpzAujAJ8NU+tKPzu016Wtr/T50A7KI1AViMvbZOIS5XbPo4jUIHA==
   dependencies:
     lodash "^4.17.21"
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/19557

- bumps `@tryghost/koenig-lexical` which includes fix for some mangled class names following a previous Tailwind update
