### PR TITLE
🐛 Fixed custom excerpts sometimes being cut off

### DIFF
--- a/ghost/core/core/frontend/helpers/excerpt.js
+++ b/ghost/core/core/frontend/helpers/excerpt.js
@@ -5,7 +5,6 @@
 //
 // Defaults to words="50"
 
-const e = require('express');
 const {SafeString} = require('../services/handlebars');
 const {metaData} = require('../services/proxy');
 const _ = require('lodash');

--- a/ghost/core/core/frontend/helpers/excerpt.js
+++ b/ghost/core/core/frontend/helpers/excerpt.js
@@ -5,6 +5,7 @@
 //
 // Defaults to words="50"
 
+const e = require('express');
 const {SafeString} = require('../services/handlebars');
 const {metaData} = require('../services/proxy');
 const _ = require('lodash');
@@ -22,7 +23,7 @@ module.exports = function excerpt(options) {
     } else {
         excerptText = '';
     }
-    
+
     excerptText = _.escape(excerptText);
 
     truncateOptions = _.reduce(truncateOptions, (_truncateOptions, value, key) => {
@@ -32,8 +33,9 @@ module.exports = function excerpt(options) {
         return _truncateOptions;
     }, {});
 
+    // For custom excerpts, make sure we truncate them only based on length
     if (!_.isEmpty(this.custom_excerpt)) {
-        truncateOptions.characters = this.custom_excerpt.length;
+        truncateOptions.characters = excerptText.length; // length is expanded by use of escaped characters
         if (truncateOptions.words) {
             delete truncateOptions.words;
         }


### PR DESCRIPTION
refs TryGhost/Ghost#19559
- custom excerpts are truncated based on character length
- escaped characters added extra length but we didn't account for this, resulting in poor truncation of excerpts