### PR TITLE
Updated portal price toggle design refs DES-24 DES-25

### DIFF
--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -51,7 +51,6 @@ export const ProductsSectionStyles = () => {
             height: 100% !important;
             width: 50%;
             border-radius: 999px;
-            color: var(--grey7);
             background: transparent;
             font-size: 1.5rem;
         }
@@ -80,13 +79,8 @@ export const ProductsSectionStyles = () => {
         }
 
         .gh-portal-maximum-discount {
-            font-size: 1.4rem;
             font-weight: 400;
             margin-left: 4px;
-            margin-bottom: -1px;
-        }
-
-        .gh-portal-btn.active .gh-portal-maximum-discount {
             opacity: 0.5;
         }
 


### PR DESCRIPTION
refs DES-24 DES-25

- “Yearly” and “Monthly” labels are now dark grey in all states for better contrast
- “(Save X%)” is now the same size like the rest of the label
