### PR TITLE
Updated docker-compose.yml to include a name for the project

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3.8'
 
+name: ghost
+
 services:
   mysql:
     image: mysql:8.0.35


### PR DESCRIPTION
no refs

Added a name for the project in `docker-compose.yml` as it was using the `scripts` directory as the name

Before:

```sh
❯ docker-compose ls
NAME                STATUS              CONFIG FILES
scripts             running(1)          /path/to/ghost/.github/scripts/docker-compose.yml
```

After:

```sh
❯ docker-compose ls
NAME                STATUS              CONFIG FILES
ghost               running(1)          /path/to/ghost/.github/scripts/docker-compose.yml
```