### PR TITLE
Reverted CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
     name: Browser tests
     timeout-minutes: 60
     runs-on:
-      labels: ubuntu-latest
+      labels: ubuntu-latest-4-cores
     needs: [job_get_metadata, job_install_deps]
     if: needs.job_get_metadata.outputs.changed_any_code == 'true' && (needs.job_get_metadata.outputs.is_main == 'true' || needs.job_get_metadata.outputs.has_browser_tests_label == 'true')
     concurrency:


### PR DESCRIPTION
refs 167a442

Attempt to resolve the browser test failures on CI by reverting the CI runners change.