### PR TITLE
Added refresh to publishing test

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -618,6 +618,11 @@ test.describe('Updating post access', () => {
             email: 'test@recipient.com'
         });
 
+        // NOTE: without the refresh, this test cannot be run in isolation because the member count (cache) isn't updated quickly enough, making the button to publish+send disabled (because there are no members)
+        //  this also means that any retries will fail
+        //  the reason is sometimes works is because the member count will carry over from previous tests via recycling the browser session, such that the cache count is >0
+        await page.reload();
+
         // go to publish a post
         await createPostDraft(page, {title: 'Published in timezones', body: 'Published in timezones'});
         await page.locator('[data-test-button="publish-flow"]').first().click();


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-599
- added refresh to publishing workflow test
- member count is cached and not updated immediately upon adding a member, but a count >0 is required in order to send a newsletter (what this test tests)
- we are looking at updating the cached count; until then, a refresh will be a performance hit but allow this test to pass