### PR TITLE
Renamed `performanceMonitoring` config to `telemetry`

### DIFF
--- a/ghost/core/core/server/data/db/ConnectionPoolInstrumentation.js
+++ b/ghost/core/core/server/data/db/ConnectionPoolInstrumentation.js
@@ -4,7 +4,7 @@ class ConnectionPoolInstrumentation {
         this.pool = this.knex.client.pool;
         this.logging = logging;
         this.metrics = metrics;
-        this.enabled = config.get('performanceMonitoring:connectionPool');
+        this.enabled = config.get('telemetry:connectionPool');
         this.requestStartTimes = {};
         this.createStartTimes = {};
     }

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -64,7 +64,7 @@ function configure(dbConfig) {
 
 if (!knexInstance && config.get('database') && config.get('database').client) {
     knexInstance = knex(configure(config.get('database')));
-    if (config.get('performanceMonitoring:connectionPool')) {
+    if (config.get('telemetry:connectionPool')) {
         const instrumentation = new ConnectionPoolInstrumentation({knex: knexInstance, logging, metrics, config});
         instrumentation.instrument();
     }

--- a/ghost/core/core/server/data/db/index.js
+++ b/ghost/core/core/server/data/db/index.js
@@ -10,7 +10,7 @@ Object.defineProperty(exports, 'knex', {
     configurable: true,
     get: function get() {
         connection = connection || require('./connection');
-        if (config.get('performanceMonitoring:connectionPool')) {
+        if (config.get('telemetry:connectionPool')) {
             const instrumentation = new ConnectionPoolInstrumentation({knex: connection, logging, metrics, config});
             instrumentation.instrument();
         }

--- a/ghost/core/test/unit/server/data/db/InstrumentConnectionPool.test.js
+++ b/ghost/core/test/unit/server/data/db/InstrumentConnectionPool.test.js
@@ -22,7 +22,7 @@ describe('ConnectionPoolInstrumentation', function () {
         const logging = {};
         const metrics = {};
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         const result = instrumentation.getPoolMetrics();
@@ -52,7 +52,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.handleCreateRequest(1);
@@ -80,7 +80,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.handleCreateRequest(1);
@@ -107,7 +107,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.handleAcquireRequest(1);
@@ -135,7 +135,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.handleAcquireRequest(1);
@@ -162,7 +162,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.handleRelease(1);
@@ -191,7 +191,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(true)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(true)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.instrument();
@@ -219,7 +219,7 @@ describe('ConnectionPoolInstrumentation', function () {
             metric: sinon.stub()
         };
         const config = {
-            get: sinon.stub().returns(false)
+            get: sinon.stub().withArgs('telemetry:connectionPool').returns(false)
         };
         const instrumentation = new ConnectionPoolInstrumentation({knex, logging, metrics, config});
         instrumentation.instrument();


### PR DESCRIPTION
no issue

- Renaming the configuration parameter created in this commit: https://github.com/TryGhost/Ghost/commit/e0dae46dfcee910e3de623b88d9d4cb8eb8c4f8a
- No functional difference, this change just makes the configuration a bit more succinct