### PR TITLE
✨ Improved sending email addresses for self-hosters

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -22,7 +22,8 @@ const GA_FEATURES = [
     'signupForm',
     'recommendations',
     'listUnsubscribeHeader',
-    'filterEmailDisabled'
+    'filterEmailDisabled',
+    'newEmailAddresses'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -47,7 +48,6 @@ const ALPHA_FEATURES = [
     // 'adminXOffers',
     'filterEmailDisabled',
     'adminXDemo',
-    'newEmailAddresses',
     'portalImprovements'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1155,7 +1155,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4507",
+  "content-length": "4534",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
@@ -240,8 +240,9 @@ test@example.com [test@example.com]"
 exports[`Authentication API Blog setup complete setup 5: [metadata 1] 1`] = `
 Object {
   "encoding": "base64",
-  "from": "noreply@127.0.0.1",
+  "from": "\\"a test blog\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "replyTo": null,
   "subject": "Your New Ghost Site",
   "to": "test@example.com",
 }
@@ -518,8 +519,9 @@ test@example.com [test@example.com]"
 exports[`Authentication API Blog setup complete setup with default theme 5: [metadata 1] 1`] = `
 Object {
   "encoding": "base64",
-  "from": "noreply@127.0.0.1",
+  "from": "\\"a test blog\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "replyTo": null,
   "subject": "Your New Ghost Site",
   "to": "test@example.com",
 }

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -192,6 +192,7 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost at 127.0.0.1\\" <noreply@example.com>",
   "generateTextFromHTML": false,
+  "replyTo": null,
   "subject": "Verify email address",
   "to": "support@example.com",
 }


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/12802
fixes DMA-27

- You can choose any support and newsletter email address in the UI without verification (as long as your SMTP-server / Mailgun can send from it)
- All emails will use the mail.from config as the from address as a default: 
    - Staff notification emails no longer use the made up ghost@domain email address 
    - Newsletters no longer default to 'noreply@domain' 
    - Member related emails (signin/signup/comment notifications...) will continue to be send from the chosen support address (Portal settings → Account page), but will now default to the mail.from config instead of noreply@domain if no support address is set.