### PR TITLE
Cleared member count cache on manual member add/delete

### DIFF
--- a/ghost/admin/app/components/gh-members-no-members.js
+++ b/ghost/admin/app/components/gh-members-no-members.js
@@ -8,6 +8,7 @@ export default class GhMembersNoMembersComponent extends Component {
     @service store;
     @service notifications;
     @service settings;
+    @service membersCountCache;
 
     @action
     addYourself() {
@@ -38,6 +39,9 @@ export default class GhMembersNoMembersComponent extends Component {
                 }
             );
 
+            // force update the member count; this otherwise only updates every minute
+            yield this.membersCountCache.count({});
+            
             return member;
         } catch (error) {
             if (error) {

--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -176,9 +176,6 @@ export default class MemberController extends Controller {
     *saveTask() {
         let {member, scratchMember} = this;
 
-        console.log(`scratch member`, scratchMember);
-        console.log(`member`, member);
-
         // if Cmd+S is pressed before the field loses focus make sure we're
         // saving the intended property values
         let scratchProps = scratchMember.getProperties(SCRATCH_PROPS);
@@ -193,8 +190,6 @@ export default class MemberController extends Controller {
 
             // replace 'member.new' route with 'member' route
             if (this.router.currentRouteName === 'member.new') {
-                console.log(`** trying to refresh count`);
-                
                 // force update the member count; this otherwise only updates every minute
                 yield this.membersCountCache.count({});
             }

--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -15,6 +15,7 @@ export default class MemberController extends Controller {
     @service session;
     @service dropdown;
     @service membersStats;
+    @service membersCountCache;
     @service modals;
     @service notifications;
     @service router;
@@ -175,6 +176,9 @@ export default class MemberController extends Controller {
     *saveTask() {
         let {member, scratchMember} = this;
 
+        console.log(`scratch member`, scratchMember);
+        console.log(`member`, member);
+
         // if Cmd+S is pressed before the field loses focus make sure we're
         // saving the intended property values
         let scratchProps = scratchMember.getProperties(SCRATCH_PROPS);
@@ -188,6 +192,13 @@ export default class MemberController extends Controller {
             this.setInitialRelationshipValues();
 
             // replace 'member.new' route with 'member' route
+            if (this.router.currentRouteName === 'member.new') {
+                console.log(`** trying to refresh count`);
+                
+                // force update the member count; this otherwise only updates every minute
+                yield this.membersCountCache.count({});
+            }
+
             this.replaceRoute('member', member);
 
             return member;

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -618,11 +618,6 @@ test.describe('Updating post access', () => {
             email: 'test@recipient.com'
         });
 
-        // NOTE: without the refresh, this test cannot be run in isolation because the member count (cache) isn't updated quickly enough, making the button to publish+send disabled (because there are no members)
-        //  this also means that any retries will fail
-        //  the reason is sometimes works is because the member count will carry over from previous tests via recycling the browser session, such that the cache count is >0
-        await page.reload();
-
         // go to publish a post
         await createPostDraft(page, {title: 'Published in timezones', body: 'Published in timezones'});
         await page.locator('[data-test-button="publish-flow"]').first().click();


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-599
- member count is based on the cache which only updates ~every minute
- forced cache clear on manual member add/delete (not import)
- tests were failing based on the assumption that a new site that adds a member has a nonzero member count, although the cache did not reflect this quickly enough for the test to pass

Previously on a new site if you tried to publish a newsletter, it would require at least one member. If you quickly added a member and tried to send a newsletter, it would stop you saying you need at least one member, requiring a browser refresh. This was a bug that is resolved with this changes, as well as odd behaviour to try to write tests around.