### PR TITLE
Fixed booting Ghost when segment config is present

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -292,11 +292,8 @@ async function initAppService() {
  * Services are components that make up part of Ghost and need initializing on boot
  * These services should all be part of core, frontend services should be loaded with the frontend
  * We are working towards this being a service loader, with the ability to make certain services optional
- *
- * @param {object} options
- * @param {object} options.config
  */
-async function initServices({config}) {
+async function initServices() {
     debug('Begin: initServices');
 
     debug('Begin: Services');

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -381,11 +381,6 @@ async function initServices({config}) {
     ]);
     debug('End: Services');
 
-    // Initialize analytics events
-    if (config.get('segment:key')) {
-        require('./server/services/segment').init();
-    }
-
     debug('End: initServices');
 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/c4912665e5d5af2c25ed76f015c47fd03bb3bde4

We removed the segment service but continued to attempt to load it when the segment config was present.
