### PR TITLE
Added check for Stripe Pass in Stripe Connect test utils

### DIFF
--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -330,6 +330,14 @@ const completeStripeSubscription = async (page) => {
     await fillInputIfExists(page, '#billingAddressLine2', 'Apt 1');
     await fillInputIfExists(page, '#billingLocality', 'Testville');
 
+    // some regions have a stripe pass checkbox that blocks the submit button
+    if (await page.isVisible('#enableStripePass')) {
+        const checkbox = await page.locator('#enableStripePass');
+        if (await checkbox.isChecked()) {
+            await checkbox.uncheck();
+        }
+    }
+
     // Wait for submit button complete
     await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
 


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-599
- Portal tests occasionally failed without clear cause on CI, possibly due to GH runner region
- Portal tests never successfully ran locally for US-based IPs because of a prompt for Stripe Pass