### PR TITLE
🐛 Fixed members events for archived newsletters

### DIFF
--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -556,7 +556,6 @@ module.exports = class MemberRepository {
         // Keep track of the newsletters that were added and removed of a member so we can generate the corresponding events
         let newslettersToAdd = [];
         let newslettersToRemove = [];
-        // let newslettersToIgnore = []; // This is used to keep track of archived newsletters where members are still subscribed to
 
         if (needsNewsletters) {
             const existingNewsletters = initialMember.related('newsletters').models;

--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -578,9 +578,9 @@ module.exports = class MemberRepository {
                     .map(newsletter => newsletter.id);
                 const incomingNewsletterIds = memberData.newsletters.map(newsletter => newsletter.id);
                 newslettersToIgnore = archivedNewsletters.map(n => n.id);
-                newslettersToAdd = _.differenceWith(incomingNewsletterIds, existingNewsletterIds);
+
                 // make sure newslettersToAdd does not contain newslettersToIgnore (archived newsletters since that creates false events)
-                newslettersToAdd = _.differenceWith(newslettersToAdd, newslettersToIgnore);
+                newslettersToAdd = _.differenceWith(_.differenceWith(incomingNewsletterIds, existingNewsletterIds), newslettersToIgnore);
                 newslettersToRemove = _.differenceWith(existingNewsletterIds, incomingNewsletterIds);
             }
 

--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -556,7 +556,7 @@ module.exports = class MemberRepository {
         // Keep track of the newsletters that were added and removed of a member so we can generate the corresponding events
         let newslettersToAdd = [];
         let newslettersToRemove = [];
-        let newslettersToIgnore = []; // This is used to keep track of archived newsletters where members are still subscribed to
+        // let newslettersToIgnore = []; // This is used to keep track of archived newsletters where members are still subscribed to
 
         if (needsNewsletters) {
             const existingNewsletters = initialMember.related('newsletters').models;
@@ -572,15 +572,13 @@ module.exports = class MemberRepository {
 
             // only ever populated with active newsletters - never archived ones
             if (memberData.newsletters) {
-                const archivedNewsletters = existingNewsletters.filter(n => n.get('status') === 'archived');
+                const archivedNewsletters = existingNewsletters.filter(n => n.get('status') === 'archived').map(n => n.id);
                 const existingNewsletterIds = existingNewsletters
                     .filter(newsletter => newsletter.attributes.status !== 'archived')
                     .map(newsletter => newsletter.id);
                 const incomingNewsletterIds = memberData.newsletters.map(newsletter => newsletter.id);
-                newslettersToIgnore = archivedNewsletters.map(n => n.id);
-
                 // make sure newslettersToAdd does not contain newslettersToIgnore (archived newsletters since that creates false events)
-                newslettersToAdd = _.differenceWith(_.differenceWith(incomingNewsletterIds, existingNewsletterIds), newslettersToIgnore);
+                newslettersToAdd = _.differenceWith(_.differenceWith(incomingNewsletterIds, existingNewsletterIds), archivedNewsletters);
                 newslettersToRemove = _.differenceWith(existingNewsletterIds, incomingNewsletterIds);
             }
 


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-604/🐛-members-events-show-member-subscribed-to-archived-newsletter

- Members Subscribe events are being created from Archived newsletters that the Member may have subscribed to in the past prior to the newsletter being archived.
- This fixes a bug where it doesn't take that into account and would create an Event for subscribing back to those newsletters even though its not the case, which causes some confusion for publishers in Member Events and wastes rows in the DB. 
