### PR TITLE
🐛 Fixed trailing slashes not handled in Settings

### DIFF
--- a/apps/admin-x-framework/src/providers/RoutingProvider.tsx
+++ b/apps/admin-x-framework/src/providers/RoutingProvider.tsx
@@ -46,7 +46,6 @@ function getHashPath(basePath: string, urlPath: string | undefined) {
     }
     const regex = new RegExp(`/${basePath}/(.*)`);
     const match = urlPath?.match(regex);
-
     if (match) {
         const afterSettingsX = match[1];
         return afterSettingsX;
@@ -84,7 +83,7 @@ const handleNavigation = (basePath: string, currentRoute: string | undefined, lo
 };
 
 const matchRoute = (pathname: string, routeDefinition: string) => {
-    const regex = new RegExp('^' + routeDefinition.replace(/:(\w+)/, '(?<$1>[^/]+)') + '$');
+    const regex = new RegExp('^' + routeDefinition.replace(/:(\w+)/g, '(?<$1>[^/]+)') + '/?$');
     const match = pathname.match(regex);
     if (match) {
         return match.groups || {};

--- a/apps/admin-x-settings/src/components/providers/SettingsRouter.tsx
+++ b/apps/admin-x-settings/src/components/providers/SettingsRouter.tsx
@@ -11,6 +11,7 @@ export const modalPaths: {[key: string]: ModalName} = {
     'navigation/edit': 'NavigationModal',
     'staff/invite': 'InviteUserModal',
     'staff/:slug': 'UserDetailModal',
+    'staff/:slug/edit': 'UserDetailModal',
     'portal/edit': 'PortalModal',
     'tiers/add': 'TierDetailModal',
     'tiers/:id': 'TierDetailModal',


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-609/staff-users-can-no-longer-be-opened-directly-with-their-url

- additionally added an `edit` route for editing staff users, which fixes a regression.
