### PR TITLE
CI/CD: Upgrade Node.js 18.x to 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
 
       - name: Nx cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache_nx
         with:
           path: .nxcache
@@ -156,7 +156,7 @@ jobs:
           restore-keys: ${{needs.job_get_metadata.outputs.is_main == 'false' && env.NX_CACHE_RESTORE_KEYS || 'nx-never-restore'}}
 
       - name: Check dependency cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache_dependencies
         with:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
@@ -164,7 +164,7 @@ jobs:
           restore-keys: ${{needs.job_get_metadata.outputs.is_main == 'false' && env.DEPENDENCY_CACHE_RESTORE_KEYS || 'dep-never-restore'}}
 
       - name: Check build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache_built_packages
         with:
           path: ${{ env.CACHED_BUILD_PATHS }}
@@ -175,7 +175,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '18.12.1'
+          node-version: '20.x'
           cache: yarn
 
       - name: Install dependencies
@@ -200,14 +200,14 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '18.12.1'
+          node-version: '20.x'
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ghost/**/.eslintcache
           key: eslint-cache
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.12.1"
+          node-version: "20.x"
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.12.1"
+          node-version: "20.x"
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -302,7 +302,7 @@ jobs:
       env:
         FORCE_COLOR: 0
       with:
-        node-version: '18.x'
+        node-version: '20.x'
         cache: yarn
 
     - name: Install Stripe-CLI
@@ -325,7 +325,7 @@ jobs:
     - name: Get Playwright version
       id: playwright-version
       run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Check if Playwright browser is cached
       id: playwright-cache
       with:
@@ -377,7 +377,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '18.12.1'
+          node-version: '20.x'
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -417,7 +417,7 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_any_code == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1' ]
+        node: [ '20.x' ]
     name: Unit tests (Node ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4
@@ -437,7 +437,7 @@ jobs:
       - run: yarn nx affected -t test:unit --base=${{ needs.job_get_metadata.outputs.BASE_COMMIT }}
 
       - uses: actions/upload-artifact@v3
-        if: startsWith(matrix.node, '18')
+        if: startsWith(matrix.node, '20')
         with:
           name: unit-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
@@ -455,12 +455,12 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_core == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1' ]
+        node: [ '20.x' ]
         env:
           - DB: mysql8
             NODE_ENV: testing-mysql
         include:
-          - node: 18.12.1
+          - node: 20.x
             env:
               DB: sqlite3
               NODE_ENV: testing
@@ -577,11 +577,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - node: 18.12.1
+          - node: 20.x
             env:
               DB: mysql8
               NODE_ENV: testing-mysql
-          - node: 18.12.1
+          - node: 20.x
             env:
               DB: sqlite3
               NODE_ENV: testing
@@ -648,7 +648,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: "18.12.1"
+          node-version: "20.x"
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -701,7 +701,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: "18.12.1"
+          node-version: "20.x"
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -754,7 +754,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: "18.12.1"
+          node-version: "20.x"
 
       - name: Restore caches
         uses: ./.github/actions/restore-cache
@@ -808,7 +808,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '16.14.0'
+          node-version: '20.x'
 
       - name: Install Ghost-CLI
         run: npm install -g ghost-cli@latest
@@ -837,7 +837,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '18.12.1'
+          node-version: '20.x'
 
       - name: Update from v4
         run: |


### PR DESCRIPTION
Upgrade Node.js 18.x to 20.x and deprecated github actions

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
