### PR TITLE
Fixed icon preview in metadata card

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/Metadata.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Metadata.tsx
@@ -35,7 +35,8 @@ const SearchEnginePreview: React.FC<SearchEnginePreviewProps> = ({
             </div>
             <div className='mt-4 flex items-center gap-2 border-t border-grey-200 pt-4 dark:border-grey-900'>
                 <div className='flex h-7 w-7 items-center justify-center rounded-full bg-grey-200 dark:bg-grey-700' style={{
-                    backgroundImage: icon ? `url(${icon})` : 'none'
+                    backgroundImage: icon ? `url(${icon})` : 'none',
+                    backgroundSize: 'contain'
                 }}>
                 </div>
                 <div className='flex flex-col text-sm'>


### PR DESCRIPTION
Closes issue: https://linear.app/tryghost/issue/DES-7/admin-x-metadata-page-shows-icon-incorrectly

Set the background image to contain.

