### PR TITLE
Added default background color to preview iframes

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/announcementBar/AnnouncementBarPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/announcementBar/AnnouncementBarPreview.tsx
@@ -71,7 +71,7 @@ const AnnouncementBarPreview: React.FC<AnnouncementBarSettings> = ({announcement
     return (
         <IframeBuffering
             addDelay={true}
-            className="absolute h-[110%] w-[110%] origin-top-left scale-[.90909] max-[1600px]:h-[130%] max-[1600px]:w-[130%] max-[1600px]:scale-[.76923]"
+            className="absolute h-[110%] w-[110%] origin-top-left scale-[.90909] bg-white max-[1600px]:h-[130%] max-[1600px]:w-[130%] max-[1600px]:scale-[.76923]"
             generateContent={injectContentIntoIframe}
             height='100%'
             parentClassName="relative h-full w-full"

--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/ThemePreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/ThemePreview.tsx
@@ -105,7 +105,7 @@ const ThemePreview: React.FC<ThemePreviewProps> = ({settings,url}) => {
     return (
         <IframeBuffering
             addDelay={false}
-            className="absolute h-[110%] w-[110%] origin-top-left scale-[.90909] max-[1600px]:h-[130%] max-[1600px]:w-[130%] max-[1600px]:scale-[.76923]"
+            className="absolute h-[110%] w-[110%] origin-top-left scale-[.90909] bg-white max-[1600px]:h-[130%] max-[1600px]:w-[130%] max-[1600px]:scale-[.76923]"
             generateContent={injectContentIntoIframe}
             height='100%'
             parentClassName="relative h-full w-full"


### PR DESCRIPTION
fixes DES-88

- preview iframes should have default background as they simulate browser windows
- transparent background causes unexpected inconsistency when themes don't have default background color set

