### PR TITLE
Updated copy

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
@@ -26,7 +26,7 @@
     <div class="gh-publish-cta">
         <GhTaskButton
             @task={{this.retryEmailTask}}
-            @buttonText="Retry sending email"
+            @buttonText="Send remaining emails"
             @runningText="Sending"
             @successText="Sent"
             @class="gh-btn gh-btn-large gh-btn-red"


### PR DESCRIPTION
Changed from "Retry sending email" to "Send remaining emails", as per the issue: https://linear.app/tryghost/issue/DES-66/copy-change-on-email-failure-retry-screen


