### PR TITLE
🐛 Fixed members importer overwriting name and note if left blank

### DIFF
--- a/ghost/members-importer/lib/MembersCSVImporter.js
+++ b/ghost/members-importer/lib/MembersCSVImporter.js
@@ -178,6 +178,14 @@ module.exports = class MembersCSVImporter {
                         memberValues.subscribed = false;
                     }
 
+                    // Don't overwrite name or note if they are blank in the file
+                    if (!row.name) {
+                        memberValues.name = existingMember.name;
+                    }
+                    if (!row.note) {
+                        memberValues.note = existingMember.note;
+                    }
+
                     member = await membersRepository.update({
                         ...memberValues,
                         labels: existingLabels.concat(memberValues.labels)

--- a/ghost/members-importer/test/MembersCSVImporter.test.js
+++ b/ghost/members-importer/test/MembersCSVImporter.test.js
@@ -610,6 +610,30 @@ describe('MembersCSVImporter', function () {
             assert.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, newsletters);
         });
 
+        it('does not overwrite name or note fields for existing members when left blank in the import file', async function () {
+            const importer = buildMockImporterInstance();
+
+            const member = {
+                name: 'John Bloggs',
+                note: 'A note',
+                related: sinon.stub()
+            };
+
+            member.related.withArgs('labels').returns(null);
+            member.related.withArgs('newsletters').returns({length: 0});
+
+            membersRepositoryStub.get = sinon.stub();
+
+            membersRepositoryStub.get
+                .withArgs({email: 'test@example.com'})
+                .resolves(member);
+
+            await importer.perform(`${csvPath}/single-column-with-header.csv`);
+
+            assert.equal(membersRepositoryStub.update.args[0][0].name, 'John Bloggs');
+            assert.equal(membersRepositoryStub.update.args[0][0].note, 'A note');
+        });
+
         it('does not add subscriptions for existing member when they do not have any subscriptions', async function () {
             const importer = buildMockImporterInstance();
 


### PR DESCRIPTION
fixes ENG-610

- Previously, when importing an existing member, if the name or note field is left blank in the CSV file, this would overwrite (re: delete) the existing name or note in the database.
- This change ensures that the name and note fields are only updated if they are not blank in the CSV file.