### PR TITLE
🐛 Fixed duplicate text when pasting URL on selection with multiple formats

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.3",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.0.15",
+    "@tryghost/koenig-lexical": "1.0.16",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,10 +7145,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.0.15":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.15.tgz#4faca60277ad91c6f676b3c28e418bd8a772670b"
-  integrity sha512-VDtrhLgy+qmCe3dKcrbi9OJaHhfcCk9hmgRbeSC9greHMYjWrKNPd4wTpoWfzHto2+3C3O4H4QJa7HN5V3z8dQ==
+"@tryghost/koenig-lexical@1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.16.tgz#fb75c32e7a6f0d21c8e97faad3701b2d24481059"
+  integrity sha512-SF8sRiCFO7sSnA/zlvC3rtOmHB7kSvDlTlrSx6iHa5aEd5vF9n+bw6/XOb2rCPZNHdPEX6t9NCVAQdjznNnihA==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
closes ENG-29

- bumped editor package to include fix for handling child nodes within a selection when pasting a URL to convert text to a link
