### PR TITLE
Added re-enable of innodb redo log once DataImporter has run

### DIFF
--- a/ghost/data-generator/lib/DataGenerator.js
+++ b/ghost/data-generator/lib/DataGenerator.js
@@ -270,6 +270,13 @@ class DataGenerator {
             });
             await tableImporter.finalise();
         }
+
+        // Re-enable the redo log because it's a persisted global
+        // Leaving it disabled can break the database in the event of an unexpected shutdown
+        // See https://dev.mysql.com/doc/refman/8.0/en/innodb-redo-log.html#innodb-disable-redo-logging
+        if (!DatabaseInfo.isSQLite(this.knex)) {
+            await transaction.raw('ALTER INSTANCE ENABLE INNODB REDO_LOG;');
+        }
     }
 }
 


### PR DESCRIPTION
no issue

- DataGenerator disables the redo log to make data imports faster but it's a persisted global config change and we were missing the re-enable query once the imports have finished
- when the redo log remains disabled an unexpected shutdown puts the database into a non-starting state with the error `Server was killed when Innodb Redo logging was disabled. Data files could be corrupt. You can try to restart the database with innodb_force_recovery=6`
