### PR TITLE
Added no-seed flag to yarn setup.

### DIFF
--- a/.github/scripts/setup.js
+++ b/.github/scripts/setup.js
@@ -119,7 +119,11 @@ async function runAndStream(command, args, options) {
 
     console.log(chalk.blue(`Running knex-migrator init`));
     await runAndStream('yarn', ['knex-migrator', 'init'], {cwd: coreFolder});
-
+    if (process.argv.includes('--no-seed')) {
+        console.log(chalk.yellow(`Skipping seed data`));
+        console.log(chalk.yellow(`Done`));
+        return;
+    }
     if (resetData) {
         const xxl = process.argv.includes('--xxl');
 

--- a/.github/scripts/setup.js
+++ b/.github/scripts/setup.js
@@ -121,21 +121,14 @@ async function runAndStream(command, args, options) {
     await runAndStream('yarn', ['knex-migrator', 'init'], {cwd: coreFolder});
 
     if (resetData) {
+        const xxl = process.argv.includes('--xxl');
 
-        const {populate} = await inquirer.prompt({name: 'populate', type:'confirm', message: 'Do you want to populate the database with test data?', default: false});
-        if (populate) {
-            // ask if we want to populate the database with XXL test data or not
-            const {xxl} = await inquirer.prompt({name: 'xxl', type:'confirm', message: 'Do you want to populate the database with XXL test data?', default: false});
-            if (xxl) {
-                console.log(chalk.blue(`Resetting all data (with xxl)`));
-                await runAndStream('yarn', ['reset:data:xxl'], {cwd: rootFolder});
-            } else {
-                console.log(chalk.blue(`Resetting all data`));
-                await runAndStream('yarn', ['reset:data'], {cwd: rootFolder});
-            }
+        if (xxl) {
+            console.log(chalk.blue(`Resetting all data (with xxl)`));
+            await runAndStream('yarn', ['reset:data:xxl'], {cwd: rootFolder});
         } else {
-            console.log(chalk.blue(`Done! . Run 'yarn dev' to start the server`));
-            return;
+            console.log(chalk.blue(`Resetting all data`));
+            await runAndStream('yarn', ['reset:data'], {cwd: rootFolder});
         }
     }
 })();

--- a/.github/scripts/setup.js
+++ b/.github/scripts/setup.js
@@ -121,14 +121,21 @@ async function runAndStream(command, args, options) {
     await runAndStream('yarn', ['knex-migrator', 'init'], {cwd: coreFolder});
 
     if (resetData) {
-        const xxl = process.argv.includes('--xxl');
 
-        if (xxl) {
-            console.log(chalk.blue(`Resetting all data (with xxl)`));
-            await runAndStream('yarn', ['reset:data:xxl'], {cwd: rootFolder});
+        const {populate} = await inquirer.prompt({name: 'populate', type:'confirm', message: 'Do you want to populate the database with test data?', default: false});
+        if (populate) {
+            // ask if we want to populate the database with XXL test data or not
+            const {xxl} = await inquirer.prompt({name: 'xxl', type:'confirm', message: 'Do you want to populate the database with XXL test data?', default: false});
+            if (xxl) {
+                console.log(chalk.blue(`Resetting all data (with xxl)`));
+                await runAndStream('yarn', ['reset:data:xxl'], {cwd: rootFolder});
+            } else {
+                console.log(chalk.blue(`Resetting all data`));
+                await runAndStream('yarn', ['reset:data'], {cwd: rootFolder});
+            }
         } else {
-            console.log(chalk.blue(`Resetting all data`));
-            await runAndStream('yarn', ['reset:data'], {cwd: rootFolder});
+            console.log(chalk.blue(`Done! . Run 'yarn dev' to start the server`));
+            return;
         }
     }
 })();


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1707994528206559

- When running Ghost development and using MySQL + Docker, you can run the command `yarn setup --no-seed` to not have the database seeded with test data.
