### PR TITLE
🐛 Fixed wide + full-width cards not displaying correctly inside the editor

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.3",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.0.18",
+    "@tryghost/koenig-lexical": "1.0.19",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,10 +7145,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.0.18":
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.18.tgz#a936657189a517146ceee47ba016eae8c353a748"
-  integrity sha512-Uplq1WrntUe20hSu8CVy/A3fbkprByMqgxPr+sTAuKb/TXfv4da09KdO9CMMXlRtH5DC4nrCSk0gHm+Y2aoxbw==
+"@tryghost/koenig-lexical@1.0.19":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.0.19.tgz#11d8f87d60f257e2c288c16a47a1eb4d777e1a28"
+  integrity sha512-6f9s5l43DFH1Cz9HdNVQ3hOmMENuNUjr2rELEe281pZoziH26byHkSeSLwtl55uD/1zCJPGUor7qzmBnVIAKqA==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
closes ENG-651

- bumps `@tryghost/koenig-lexical` to include fix for styling regression
  - https://github.com/TryGhost/Koenig/pull/1161