### PR TITLE
Added Posthog event sending to trackEvent function

### DIFF
--- a/ghost/admin/app/utils/analytics.js
+++ b/ghost/admin/app/utils/analytics.js
@@ -26,9 +26,9 @@ async function hashEmail(email) {
 }
 
 /**
- * Sends a tracking event to Plausible, if installed.
+ * Sends a tracking event to Plausible and Posthog, if installed.
  * 
- * By default, Plausible is not installed, in which case this function no-ops.
+ * By default, Plausible and Posthog are not installed, in which case this function no-ops.
  * 
  * @param {string} eventName A string name for the event being tracked
  * @param {Object} [props={}] An optional object of properties to include with the event
@@ -38,6 +38,10 @@ export function trackEvent(eventName, props = {}) {
         (window.plausible.q = window.plausible.q || []).push(arguments);
     };
     window.plausible(eventName, {props: props});
+
+    if (window.posthog) {
+        window.posthog.capture(eventName, props);
+    }
 }
 
 /**

--- a/ghost/admin/app/utils/analytics.js
+++ b/ghost/admin/app/utils/analytics.js
@@ -39,7 +39,7 @@ export function trackEvent(eventName, props = {}) {
     };
     window.plausible(eventName, {props: props});
 
-    if (window.posthog) {
+    if (isPosthogLoaded()) {
         window.posthog.capture(eventName, props);
     }
 }


### PR DESCRIPTION
refs PA-37

As we add Posthog to the stack we want to send the existing events we track to it, as well as opening up the method to teams to use in their initiatives.