### PR TITLE
Fixed issue with calling Posthog functions before it is loaded

### DIFF
--- a/ghost/admin/app/utils/analytics.js
+++ b/ghost/admin/app/utils/analytics.js
@@ -44,7 +44,7 @@ export function trackEvent(eventName, props = {}) {
  */
 export async function identifyUser(user) {
     // Return early if window.posthog doesn't exist
-    if (!window.posthog) {
+    if (!window.posthog.__loaded) {
         return;
     }
     // User the user exists and has an email address, identify them in PostHog
@@ -79,7 +79,7 @@ export async function identifyUser(user) {
  * @returns {void}
  */
 export function resetUser() {
-    if (window.posthog) {
+    if (window.posthog.__loaded) {
         window.posthog.reset();
     }
 }

--- a/ghost/admin/app/utils/analytics.js
+++ b/ghost/admin/app/utils/analytics.js
@@ -44,7 +44,7 @@ export function trackEvent(eventName, props = {}) {
  */
 export async function identifyUser(user) {
     // Return early if window.posthog doesn't exist
-    if (!window.posthog.__loaded) {
+    if (!window.posthog?.__loaded) {
         return;
     }
     // User the user exists and has an email address, identify them in PostHog
@@ -79,7 +79,7 @@ export async function identifyUser(user) {
  * @returns {void}
  */
 export function resetUser() {
-    if (window.posthog.__loaded) {
+    if (window.posthog?.__loaded) {
         window.posthog.reset();
     }
 }


### PR DESCRIPTION
refs PA-36

- Since Posthog is loaded outside of the main Admin app bundle, we need to check to make sure it exists before calling it. This way it will only run on Pro and not locally or on self-hosted instances
- Previously we were checking that `window.posthog` existed, but there are some cases where `window.posthog` may exist, but the `posthog` object is not fully loaded yet.
- This change fixes this by checking for `window.posthog.__loaded` instead, which is set to `true` once the `posthog` object is fully loaded — at this point, we should be able to call whatever functions we need to on `window.posthog`