### PR TITLE
Added ability to pass `minThreshold` for Milestone Slack notifications

### DIFF
--- a/ghost/core/core/server/services/slack-notifications/service.js
+++ b/ghost/core/core/server/services/slack-notifications/service.js
@@ -12,10 +12,11 @@ class SlackNotificationsServiceWrapper {
      * @param {string} deps.siteUrl
      * @param {boolean} deps.isEnabled
      * @param {URL} deps.webhookUrl
+     * @param {number} deps.minThreshold
      *
      * @returns {import('@tryghost/slack-notifications/lib/SlackNotificationsService')}
      */
-    static create({siteUrl, isEnabled, webhookUrl}) {
+    static create({siteUrl, isEnabled, webhookUrl, minThreshold}) {
         const {
             SlackNotificationsService,
             SlackNotifications
@@ -32,7 +33,8 @@ class SlackNotificationsServiceWrapper {
             logging,
             config: {
                 isEnabled,
-                webhookUrl
+                webhookUrl,
+                minThreshold
             },
             slackNotifications
         });
@@ -49,8 +51,9 @@ class SlackNotificationsServiceWrapper {
         const siteUrl = urlUtils.getSiteUrl();
         const isEnabled = !!(hostSettings?.milestones?.enabled && hostSettings?.milestones?.url);
         const webhookUrl = hostSettings?.milestones?.url;
+        const minThreshold = hostSettings?.milestones?.minThreshold ? parseInt(hostSettings.milestones.minThreshold) : 0;
 
-        this.#api = SlackNotificationsServiceWrapper.create({siteUrl, isEnabled, webhookUrl});
+        this.#api = SlackNotificationsServiceWrapper.create({siteUrl, isEnabled, webhookUrl, minThreshold});
 
         this.#api.subscribeEvents();
     }

--- a/ghost/core/test/unit/server/services/slack-notifications/index.test.js
+++ b/ghost/core/test/unit/server/services/slack-notifications/index.test.js
@@ -9,7 +9,7 @@ describe('Slack Notifications Service', function () {
     let scope;
 
     beforeEach(function () {
-        configUtils.set('hostSettings', {milestones: {enabled: true, url: 'https://testhooks.slack.com/'}});
+        configUtils.set('hostSettings', {milestones: {enabled: true, url: 'https://testhooks.slack.com/', minThreshold: '100'}});
 
         scope = nock('https://testhooks.slack.com/')
             .post('/')
@@ -28,13 +28,13 @@ describe('Slack Notifications Service', function () {
             milestone: {
                 type: 'arr',
                 currency: 'usd',
-                name: 'arr-100-usd',
-                value: 100,
+                name: 'arr-1000-usd',
+                value: 1000,
                 createdAt: new Date(),
                 emailSentAt: new Date()
             },
             meta: {
-                currentValue: 105
+                currentValue: 1005
             }
         }));
 

--- a/ghost/slack-notifications/lib/SlackNotificationsService.js
+++ b/ghost/slack-notifications/lib/SlackNotificationsService.js
@@ -27,6 +27,7 @@ const {MilestoneCreatedEvent} = require('@tryghost/milestones');
  * @typedef {object} config
  * @prop {boolean} isEnabled
  * @prop {URL} webhookUrl
+ * @prop {number} minThreshold
  */
 
 module.exports = class SlackNotificationsService {
@@ -71,6 +72,7 @@ module.exports = class SlackNotificationsService {
             && event.data.milestone
             && this.#config.isEnabled
             && this.#config.webhookUrl
+            && this.#config.minThreshold < event.data.milestone.value
         ) {
             try {
                 await this.#slackNotifications.notifyMilestoneReceived(event.data);


### PR DESCRIPTION
closes ENG-632

- This listens to a new property in the `milestones` config to set a minimum value of Milestones we wanna use the Slack notification service for