### PR TITLE
Fixed incorrect cache invalidation headers for slugs Admin API endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/slugs.js
+++ b/ghost/core/core/server/api/endpoints/slugs.js
@@ -16,7 +16,7 @@ module.exports = {
     docName: 'slugs',
     generate: {
         headers: {
-            cacheInvalidate: true
+            cacheInvalidate: false
         },
         options: [
             'include',

--- a/ghost/core/test/e2e-api/admin/slugs.test.js
+++ b/ghost/core/test/e2e-api/admin/slugs.test.js
@@ -20,7 +20,7 @@ describe('Slug API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(res.headers['x-cache-invalidate']);
+        should.not.exist(res.headers['x-cache-invalidate']);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.slugs);


### PR DESCRIPTION
closes ENG-666

- the Admin API `GET /slugs/{type}/{slug}/` endpoint is used by Admin to check when a potential slug needs de-duping by adding a `-{x}` suffix. Most often this occurs when setting a draft post title
- the endpoint was returning a full-site cache invalidation header meaning hosting services could be blowing away their site caches and needlessly hurting performance because this endpoint is purely a read operation and makes no changes to the site
- updated the endpoint to return no cache invalidation header