### PR TITLE
🎨 Include archived offers in members filter

### DIFF
--- a/ghost/admin/app/components/members/filter.js
+++ b/ghost/admin/app/components/members/filter.js
@@ -613,7 +613,7 @@ export default class MembersFilter extends Component {
 
     @task({drop: true})
     *fetchOffers() {
-        const response = yield this.store.query('offer', {filter: 'status:active'});
+        const response = yield this.store.query('offer', {limit: 'all'});
         this.offers = response;
         return response;
     }

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -69,7 +69,7 @@ export default class OffersSegmentSelect extends Component {
 
         // fetch all offers with count
         // TODO: add `include: 'count.members` to query once API supports
-        const offers = yield this.store.query('offer', {filter: 'status:active'});
+        const offers = yield this.store.query('offer', {limit: 'all'});
         this.offers = offers;
         if (offers.length > 0) {
             const offersGroup = {


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-19/allow-archived-offers-to-be-used-in-member-filtering

- Removed the filter to only include Active Offers so that we can also filter memebers that previously redeemed archived offers.
