### PR TITLE
Removed timestamp from initial load of comments

### DIFF
--- a/apps/comments-ui/test/e2e/auth-frame.test.ts
+++ b/apps/comments-ui/test/e2e/auth-frame.test.ts
@@ -99,12 +99,12 @@ test.describe('Auth Frame', async () => {
         // Check comment2 is replaced with a hidden message
         const secondComment = comments.nth(1);
         await expect(secondComment).toHaveText('This comment has been hidden.');
-        await expect(secondComment).not.toContainText('This is comment 4');
+        await expect(secondComment).not.toContainText('This is comment 2');
 
         // Check can show it again
         await moreButtons.nth(1).click();
         await moreButtons.nth(1).getByText('Show comment').click();
-        await expect(secondComment).toContainText('This is comment 4');
+        await expect(secondComment).toContainText('This is comment 2');
     });
 
     test('has admin options when signed in to Ghost admin and as a member', async ({page}) => {
@@ -156,12 +156,12 @@ test.describe('Auth Frame', async () => {
         // Check comment2 is replaced with a hidden message
         const secondComment = comments.nth(1);
         await expect(secondComment).toHaveText('This comment has been hidden.');
-        await expect(secondComment).not.toContainText('This is comment 4');
+        await expect(secondComment).not.toContainText('This is comment 2');
 
         // Check can show it again
         await moreButtons.nth(1).click();
         await moreButtons.nth(1).getByText('Show comment').click();
-        await expect(secondComment).toContainText('This is comment 4');
+        await expect(secondComment).toContainText('This is comment 2');
     });
 });
 

--- a/apps/comments-ui/test/e2e/pagination.test.ts
+++ b/apps/comments-ui/test/e2e/pagination.test.ts
@@ -39,12 +39,12 @@ test.describe('Pagination', async () => {
         await expect(frame.getByTestId('comment-component')).toHaveCount(5);
 
         // Check only the first 5 comments are visible
-        await expect(frame.getByText('This is comment 1')).toBeVisible();
+        await expect(frame.getByText('This is comment 1')).not.toBeVisible();
         await expect(frame.getByText('This is comment 2')).toBeVisible();
         await expect(frame.getByText('This is comment 3')).toBeVisible();
         await expect(frame.getByText('This is comment 4')).toBeVisible();
         await expect(frame.getByText('This is comment 5')).toBeVisible();
-        await expect(frame.getByText('This is comment 6')).not.toBeVisible();
+        await expect(frame.getByText('This is comment 6')).toBeVisible();
 
         // Click the pagination button
         await frame.getByTestId('pagination-component').click();
@@ -53,7 +53,7 @@ test.describe('Pagination', async () => {
         await expect(frame.getByTestId('comment-component')).toHaveCount(6);
 
         // Check comments 6 is visible
-        await expect(frame.getByText('This is comment 6')).toBeVisible();
+        await expect(frame.getByText('This is comment 1')).toBeVisible();
 
         // Check the pagination button is not visible
         await expect(frame.getByTestId('pagination-component')).not.toBeVisible();

--- a/apps/comments-ui/test/utils/MockedApi.ts
+++ b/apps/comments-ui/test/utils/MockedApi.ts
@@ -62,10 +62,10 @@ export class MockedApi {
             const bDate = new Date(b.created_at).getTime();
 
             if (aDate === bDate) {
-                return a.id > b.id ? 1 : -1;
+                return a.id > b.id ? -1 : 1;
             }
 
-            return aDate > bDate ? 1 : -1;
+            return aDate > bDate ? -1 : 1;
         });
 
         let filteredComments = this.comments;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-673

This means that the initial load of comments can be cached for everyone.

We also improve the timestamp which is used when fetching future comments, instead of using a locally generated timestamp, we use the created_at of the first comment loaded, this drastically improved the likelyhood that the timestamp will be the same, meaning that it will hit the cache.
