### PR TITLE
Invalidated post comments cache on like&unlike 

### DIFF
--- a/ghost/core/core/server/services/comments/CommentsController.js
+++ b/ghost/core/core/server/services/comments/CommentsController.js
@@ -152,11 +152,20 @@ module.exports = class CommentsController {
     async like(frame) {
         this.#checkMember(frame);
 
-        return await this.service.likeComment(
+        const result = await this.service.likeComment(
             frame.options.id,
             frame.options?.context?.member,
             frame.options
         );
+
+        const comment = await this.service.getCommentByID(frame.options.id);
+
+        const postId = comment?.get('post_id');
+        if (postId) {
+            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${postId}/`);
+        }
+
+        return result;
     }
 
     /**
@@ -165,11 +174,19 @@ module.exports = class CommentsController {
     async unlike(frame) {
         this.#checkMember(frame);
 
-        return await this.service.unlikeComment(
+        const result = await this.service.unlikeComment(
             frame.options.id,
             frame.options?.context?.member,
             frame.options
         );
+
+        const comment = await this.service.getCommentByID(frame.options.id);
+
+        const postId = comment?.get('post_id');
+        if (postId) {
+            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${postId}/`);
+        }
+        return result;
     }
 
     /**

--- a/ghost/core/core/server/services/comments/CommentsController.js
+++ b/ghost/core/core/server/services/comments/CommentsController.js
@@ -92,7 +92,7 @@ module.exports = class CommentsController {
 
         const postId = result?.get('post_id');
         if (postId) {
-            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${result.get('post_id')}/`);
+            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${postId}/`);
         }
 
         return result;
@@ -124,7 +124,7 @@ module.exports = class CommentsController {
 
         const postId = result?.get('post_id');
         if (postId) {
-            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${result.get('post_id')}/`);
+            frame.setHeader('X-Cache-Invalidate', `/api/members/comments/post/${postId}/`);
         }
 
         return result;

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -2027,6 +2027,7 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
   "x-powered-by": "Express",
 }
 `;
@@ -2094,6 +2095,7 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
   "x-powered-by": "Express",
 }
 `;
@@ -2260,6 +2262,7 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
   "x-powered-by": "Express",
 }
 `;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-676/

We want to make sure that we're not serving stale liked counts for
comments, which means we need to cache bust when they're liked/unliked

Unfortuantely this means we need to fetch the comment from the db so
that we have access to the post id.
