### PR TITLE
Released Comments-UI 0.15.0

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "MIT",
   "repository": "git@github.com:TryGhost/comments-ui.git",
   "author": "Ghost Foundation",


### PR DESCRIPTION
no issue

- switches post browse requests to `/members/api/comments/post/:post_id/` to enable better cache bucketing and invalidation
- removes `order` param from browse and replies requests