### PR TITLE
Added try/catch to iFrame buffering in Settings

### DIFF
--- a/apps/admin-x-settings/src/utils/IframeBuffering.tsx
+++ b/apps/admin-x-settings/src/utils/IframeBuffering.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import React, {useEffect, useRef, useState} from 'react';
 
 type IframeBufferingProps = {
@@ -62,7 +63,15 @@ const IframeBuffering: React.FC<IframeBufferingProps> = ({generateContent, class
         const iframe = iframes[visibleIframeIndex].current;
 
         if (iframe) {
-            iframe.contentWindow?.scrollTo(0, scrollPosition);
+            // refs https://ghost-foundation.sentry.io/issues/5024564293/
+            // Customer reported that code they injected caused Settings to crash.
+            // According to Sentry this the line that caused the crash.
+            // We are adding a try catch block to attempt to catch the error for further investigation and prevent the crash.
+            try {
+                iframe.contentWindow?.scrollTo(0, scrollPosition);
+            } catch (e) {
+                Sentry.captureException(e);
+            }
         }
     }, [scrollPosition, visibleIframeIndex, iframes]);
 


### PR DESCRIPTION
refs https://ghost.slack.com/archives/CTH5NDJMS/p1709230854358779

- Customer reported that some code they injected via the Code Injection crashed the Preview in Ghost Settings.
- This wraps the function where the crash took place (according to Sentry) to attempt to handle it gracefully.
- Added an additional Sentry log to better understand the situation should it happen again.
