### PR TITLE
🐛 Fixed 500 error for premature api token use

### DIFF
--- a/ghost/core/core/server/services/auth/api-key/admin.js
+++ b/ghost/core/core/server/services/auth/api-key/admin.js
@@ -159,7 +159,7 @@ const authenticateWithToken = async function apiKeyAuthenticateWithToken(req, re
         try {
             jwt.verify(token, secret, options);
         } catch (err) {
-            if (err.name === 'TokenExpiredError' || err.name === 'JsonWebTokenError') {
+            if (err.name === 'TokenExpiredError' || err.name === 'JsonWebTokenError' || err.name === 'NotBeforeError') {
                 return next(new errors.UnauthorizedError({
                     message: tpl(messages.invalidTokenWithMessage, {message: err.message}),
                     code: 'INVALID_JWT',

--- a/ghost/core/core/server/services/auth/api-key/admin.js
+++ b/ghost/core/core/server/services/auth/api-key/admin.js
@@ -159,16 +159,11 @@ const authenticateWithToken = async function apiKeyAuthenticateWithToken(req, re
         try {
             jwt.verify(token, secret, options);
         } catch (err) {
-            if (err.name === 'TokenExpiredError' || err.name === 'JsonWebTokenError' || err.name === 'NotBeforeError') {
-                return next(new errors.UnauthorizedError({
-                    message: tpl(messages.invalidTokenWithMessage, {message: err.message}),
-                    code: 'INVALID_JWT',
-                    err
-                }));
-            }
-
-            // unknown error
-            return next(new errors.InternalServerError({err}));
+            return next(new errors.UnauthorizedError({
+                message: tpl(messages.invalidTokenWithMessage, {message: err.message}),
+                code: 'INVALID_JWT',
+                err
+            }));
         }
 
         // authenticated OK

--- a/ghost/core/test/e2e-api/admin/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/key-authentication.test.js
@@ -40,6 +40,16 @@ describe('Admin API key authentication', function () {
         sinon.assert.calledOnce(loggingStub);
     });
 
+    it('Responds with a 401 when token is used before not before', async function () {
+        await request.get(localUtils.API.getApiQuery('posts/'))
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', 0, {
+                notBefore: '7d'
+            })}`)
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(401);
+    });
+
     it('Can access browse endpoint with correct token', async function () {
         await request.get(localUtils.API.getApiQuery('posts/'))
             .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)

--- a/ghost/core/test/e2e-api/admin/utils.js
+++ b/ghost/core/test/e2e-api/admin/utils.js
@@ -225,13 +225,14 @@ module.exports = {
         return testUtils.API.doAuth(`${API_URL}session/`, ...args);
     },
 
-    getValidAdminToken(audience, keyid = 0) {
+    getValidAdminToken(audience, keyid = 0, opts = {}) {
         const jwt = require('jsonwebtoken');
         const JWT_OPTIONS = {
             keyid: testUtils.DataGenerator.Content.api_keys[keyid].id,
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: audience
+            audience: audience,
+            ...opts
         };
 
         return jwt.sign(


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ENG-712

We weren't handling the NotBeforeError and instead responing with a 500 which
is not correct.