### PR TITLE
🐛 Fixed free tier showing in the tiers-only paywall in posts

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -62,7 +62,7 @@ module.exports = async (model, frame, options = {}) => {
             jsonModel.tiers = tiersData || [];
         }
 
-        if (jsonModel.visibility === 'paid' && jsonModel.tiers) {
+        if (['tiers', 'paid'].includes(jsonModel.visibility) && jsonModel.tiers) {
             jsonModel.tiers = tiersData ? tiersData.filter(t => t.type === 'paid') : [];
         }
 


### PR DESCRIPTION
refs INC-36

- The tiers-only paywall was incorrectly rendering "Free". Example: "This post is for subscribers of the **Free**, Silver and Gold tiers only"
- Steps to reproduce the issue:
    1. Create a post with public visibility, publish it
    2. Then swap the visibility to specific tiers. The default selects all paid tiers. Leave it like that
    3. Update the post. The paywall show Free, even though it should be showing only the paid tiers
- This fix removes the free tier from the `GET posts` (with `?include=tiers`) query, when visibility is set to `tiers`
