### PR TITLE
Improve staff empty display

### DIFF
--- a/apps/admin-x-design-system/src/global/TabView.tsx
+++ b/apps/admin-x-design-system/src/global/TabView.tsx
@@ -105,9 +105,11 @@ export interface TabViewProps<ID = string> {
     buttonBorder?: boolean;
     width?: TabWidth;
     containerClassName?: string;
+    testId?: string;
 }
 
 function TabView<ID extends string = string>({
+    testId,
     tabs,
     onTabChange,
     selectedTab,
@@ -130,7 +132,7 @@ function TabView<ID extends string = string>({
     };
 
     return (
-        <section className={containerClassName}>
+        <section className={containerClassName} data-testid={testId}>
             <TabList
                 border={border}
                 buttonBorder={buttonBorder}

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -8,6 +8,7 @@ import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
 import {useEffect, useRef, useState} from 'react';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import { APIError } from '@tryghost/admin-x-framework/errors';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor';
 
@@ -130,13 +131,20 @@ const InviteUserModal = NiceModal.create(() => {
             updateRoute('staff?tab=invited');
         } catch (e) {
             setSaveState('error');
-            let message = 'Your invitation failed to send. If the problem persists, please contact support.';
-            if (e.data?.errors?.[0]?.type === 'EmailError') {
-                message = 'Your invitation failed to send. Please check your Mailgun configuration. If the problem persists, contact support.';
+            let message = (<span><strong>Your invitation failed to send.</strong> If the problem persists, please contact support.</span>);
+            if (e instanceof APIError) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                let data = e.data as any; // we have unknown data types in the APIError/error classes
+                if (data?.errors?.[0]?.type === 'EmailError') {
+                    message = (<span><strong>Your invitation failed to send.</strong> Please check your Mailgun configuration. If the problem persists, contact support.</span>);
+                }
             }
             showToast({
                 message,
-                type: 'error'
+                type: 'neutral',
+                options: {
+                    duration: 30000
+                }
             });
             handleError(e, {withToast: false});
             return;

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -130,9 +130,12 @@ const InviteUserModal = NiceModal.create(() => {
             updateRoute('staff?tab=invited');
         } catch (e) {
             setSaveState('error');
-
+            let message = 'Your invitation failed to send. If the problem persists, please contact support.';
+            if (e.data?.errors?.[0]?.type === 'EmailError') {
+                message = 'Your invitation failed to send. Please check your Mailgun configuration. If the problem persists, contact support.';
+            }
             showToast({
-                message: `Failed to send invitation to ${email}`,
+                message,
                 type: 'error'
             });
             handleError(e, {withToast: false});

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -127,7 +127,7 @@ const InviteUserModal = NiceModal.create(() => {
             });
 
             modal.remove();
-            updateRoute('staff/invited');
+            updateRoute('staff?tab=invited');
         } catch (e) {
             setSaveState('error');
 
@@ -172,7 +172,7 @@ const InviteUserModal = NiceModal.create(() => {
     return (
         <Modal
             afterClose={() => {
-                updateRoute('staff/invited');
+                updateRoute('staff');
             }}
             cancelLabel=''
             okLabel={okLabel}

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -131,17 +131,18 @@ const InviteUserModal = NiceModal.create(() => {
             updateRoute('staff?tab=invited');
         } catch (e) {
             setSaveState('error');
-            let message = (<span><strong>Your invitation failed to send.</strong> If the problem persists, please contact support.</span>);
+            let message = (<span><strong>Your invitation failed to send.</strong><br/>If the problem persists, <a href="https://ghost.org/contact"><u>contact support</u>.</a>.</span>);
             if (e instanceof APIError) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 let data = e.data as any; // we have unknown data types in the APIError/error classes
                 if (data?.errors?.[0]?.type === 'EmailError') {
-                    message = (<span><strong>Your invitation failed to send.</strong> Please check your Mailgun configuration. If the problem persists, contact support.</span>);
+                    message = (<span><strong>Your invitation failed to send</strong><br/>Please check your Mailgun configuration. If the problem persists, <a href="https://ghost.org/contact"><u>contact support</u>.</a></span>);
                 }
             }
             showToast({
                 message,
-                type: 'neutral'
+                type: 'neutral',
+                icon: 'warning'
             });
             handleError(e, {withToast: false});
             return;

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -127,7 +127,7 @@ const InviteUserModal = NiceModal.create(() => {
             });
 
             modal.remove();
-            updateRoute('staff');
+            updateRoute('staff/invited');
         } catch (e) {
             setSaveState('error');
 
@@ -172,7 +172,7 @@ const InviteUserModal = NiceModal.create(() => {
     return (
         <Modal
             afterClose={() => {
-                updateRoute('staff');
+                updateRoute('staff/invited');
             }}
             cancelLabel=''
             okLabel={okLabel}

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -141,10 +141,7 @@ const InviteUserModal = NiceModal.create(() => {
             }
             showToast({
                 message,
-                type: 'neutral',
-                options: {
-                    duration: 30000
-                }
+                type: 'neutral'
             });
             handleError(e, {withToast: false});
             return;

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -1,5 +1,6 @@
 import NiceModal from '@ebay/nice-modal-react';
 import validator from 'validator';
+import {APIError} from '@tryghost/admin-x-framework/errors';
 import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {Modal, Radio, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {useAddInvite, useBrowseInvites} from '@tryghost/admin-x-framework/api/invites';
@@ -8,7 +9,6 @@ import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
 import {useEffect, useRef, useState} from 'react';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-import { APIError } from '@tryghost/admin-x-framework/errors';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor';
 

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -269,7 +269,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         >
             <Owner user={ownerUser} />
             {/* if there are no users besides the owner user, hide the tabs*/}
-            {(users.length > 1 || invites) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
+            {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
             {hasNextPage && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -229,27 +229,32 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         {
             id: 'users-admins',
             title: 'Administrators',
-            contents: (<UsersList groupname='administrators' users={adminUsers} />)
+            contents: (<UsersList groupname='administrators' users={adminUsers} />),
+            counter: adminUsers.length ? adminUsers.length : undefined
         },
         {
             id: 'users-editors',
             title: 'Editors',
-            contents: (<UsersList groupname='editors' users={editorUsers} />)
+            contents: (<UsersList groupname='editors' users={editorUsers} />),
+            counter: editorUsers.length ? editorUsers.length : undefined
         },
         {
             id: 'users-authors',
             title: 'Authors',
-            contents: (<UsersList groupname='authors' users={authorUsers} />)
+            contents: (<UsersList groupname='authors' users={authorUsers} />),
+            counter: authorUsers.length ? authorUsers.length : undefined
         },
         {
             id: 'users-contributors',
             title: 'Contributors',
-            contents: (<UsersList groupname='contributors' users={contributorUsers} />)
+            contents: (<UsersList groupname='contributors' users={contributorUsers} />),
+            counter: contributorUsers.length ? contributorUsers.length : undefined
         },
         {
             id: 'users-invited',
             title: 'Invited',
-            contents: (<InvitesUserList users={invites} />)
+            contents: (<InvitesUserList users={invites} />),
+            counter: invites.length ? invites.length : undefined
         }
     ];
 
@@ -263,7 +268,8 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
             title='Staff'
         >
             <Owner user={ownerUser} />
-            <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />
+            {/* if there are no users besides the owner user, hide the tabs*/}
+            {users.length > 1 && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
             {hasNextPage && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -269,7 +269,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         >
             <Owner user={ownerUser} />
             {/* if there are no users besides the owner user, hide the tabs*/}
-            {users.length > 1 && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
+            {(users.length > 1 || invites) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
             {hasNextPage && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import clsx from 'clsx';
 import useStaffUsers from '../../../hooks/useStaffUsers';
@@ -211,7 +211,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         hasNextPage,
         fetchNextPage
     } = useStaffUsers();
-    const {updateRoute} = useRouting();
+    const {route, updateRoute} = useRouting();
 
     const showInviteModal = () => {
         updateRoute('staff/invite');
@@ -223,35 +223,48 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         }} />
     );
 
-    const [selectedTab, setSelectedTab] = useState('users-admins');
+    let defaultTab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
+    defaultTab = defaultTab || 'administrators';
+    const [selectedTab, setSelectedTab] = useState(defaultTab);
+
+    useEffect(() => {
+        let tab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
+        tab = tab || 'administrators';
+        setSelectedTab(tab);
+    }, [route]);
+
+    const updateSelectedTab = (newTab: string) => {
+        updateRoute(`staff/${newTab}`);
+        setSelectedTab(newTab);
+    };
 
     const tabs = [
         {
-            id: 'users-admins',
+            id: 'administrators',
             title: 'Administrators',
             contents: (<UsersList groupname='administrators' users={adminUsers} />),
             counter: adminUsers.length ? adminUsers.length : undefined
         },
         {
-            id: 'users-editors',
+            id: 'editors',
             title: 'Editors',
             contents: (<UsersList groupname='editors' users={editorUsers} />),
             counter: editorUsers.length ? editorUsers.length : undefined
         },
         {
-            id: 'users-authors',
+            id: 'authors',
             title: 'Authors',
             contents: (<UsersList groupname='authors' users={authorUsers} />),
             counter: authorUsers.length ? authorUsers.length : undefined
         },
         {
-            id: 'users-contributors',
+            id: 'contributors',
             title: 'Contributors',
             contents: (<UsersList groupname='contributors' users={contributorUsers} />),
             counter: contributorUsers.length ? contributorUsers.length : undefined
         },
         {
-            id: 'users-invited',
+            id: 'invited',
             title: 'Invited',
             contents: (<InvitesUserList users={invites} />),
             counter: invites.length ? invites.length : undefined
@@ -269,7 +282,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         >
             <Owner user={ownerUser} />
             {/* if there are no users besides the owner user, hide the tabs*/}
-            {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />}
+            {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={updateSelectedTab} />}
             {hasNextPage && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import clsx from 'clsx';
+import useQueryParams from '../../../hooks/useQueryParams';
 import useStaffUsers from '../../../hooks/useStaffUsers';
 import {Avatar, Button, List, ListItem, NoValueLabel, TabView, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {User, hasAdminAccess, isContributorUser, isEditorUser} from '@tryghost/admin-x-framework/api/users';
@@ -211,7 +212,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         hasNextPage,
         fetchNextPage
     } = useStaffUsers();
-    const {route, updateRoute} = useRouting();
+    const {updateRoute} = useRouting();
 
     const showInviteModal = () => {
         updateRoute('staff/invite');
@@ -223,18 +224,36 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         }} />
     );
 
-    let defaultTab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
-    defaultTab = defaultTab || 'administrators';
+    // let defaultTab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
+    // defaultTab = defaultTab || 'administrators';
+    // const [selectedTab, setSelectedTab] = useState(defaultTab);
+
+    // console.log('////////// ' + selectedTab);
+
+    // useEffect(() => {
+    //     let tab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
+    //     if (tab) {
+    //         setSelectedTab(tab);
+    //     }
+    // }, [route]);
+
+    // const updateSelectedTab = (newTab: string) => {
+    //     updateRoute(`staff/${newTab}`);
+    //     setSelectedTab(newTab);
+    // };
+
+    const tabParam = useQueryParams().getParam('tab');
+    const defaultTab = tabParam || 'administrators';
     const [selectedTab, setSelectedTab] = useState(defaultTab);
 
     useEffect(() => {
-        let tab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
-        tab = tab || 'administrators';
-        setSelectedTab(tab);
-    }, [route]);
+        if (tabParam) {
+            setSelectedTab(tabParam);
+        }
+    }, [tabParam]);
 
     const updateSelectedTab = (newTab: string) => {
-        updateRoute(`staff/${newTab}`);
+        updateRoute(`staff?tab=${newTab}`);
         setSelectedTab(newTab);
     };
 
@@ -282,7 +301,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         >
             <Owner user={ownerUser} />
             {/* if there are no users besides the owner user, hide the tabs*/}
-            {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={updateSelectedTab} />}
+            {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} testId='user-tabview' onTabChange={updateSelectedTab} />}
             {hasNextPage && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -224,24 +224,6 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         }} />
     );
 
-    // let defaultTab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
-    // defaultTab = defaultTab || 'administrators';
-    // const [selectedTab, setSelectedTab] = useState(defaultTab);
-
-    // console.log('////////// ' + selectedTab);
-
-    // useEffect(() => {
-    //     let tab = route.startsWith('/') ? route.split('/')[2] : route.split('/')[1];
-    //     if (tab) {
-    //         setSelectedTab(tab);
-    //     }
-    // }, [route]);
-
-    // const updateSelectedTab = (newTab: string) => {
-    //     updateRoute(`staff/${newTab}`);
-    //     setSelectedTab(newTab);
-    // };
-
     const tabParam = useQueryParams().getParam('tab');
     const defaultTab = tabParam || 'administrators';
     const [selectedTab, setSelectedTab] = useState(defaultTab);

--- a/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
@@ -128,7 +128,7 @@ test.describe('User actions', async () => {
         await confirmation.getByRole('button', {name: 'Delete user'}).click();
 
         await expect(page.getByTestId('toast-success')).toHaveText(/User deleted/);
-        await expect(activeTab.getByTestId('user-list-item')).toHaveCount(0);
+        await expect(activeTab.getByTestId('user-tabview')).toHaveCount(0);
 
         expect(lastApiRequests.deleteUser?.url).toMatch(new RegExp(`/users/${authorUser.id}`));
     });

--- a/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
@@ -16,10 +16,10 @@ test.describe('User roles', async () => {
         await expect(section.getByTestId('owner-user')).toHaveText(/owner@test\.com/);
 
         await expect(section.getByRole('tab')).toHaveText([
-            'Administrators',
-            'Editors',
-            'Authors',
-            'Contributors',
+            'Administrators1',
+            'Editors1',
+            'Authors1',
+            'Contributors1',
             'Invited'
         ]);
 


### PR DESCRIPTION
refs. https://linear.app/tryghost/issue/DES-84/unnecessary-to-show-an-empty-list-when-the-only-staff-user-is-the

When the staff user list is empty it doesn't make sense to show empty tabs. 