### PR TITLE
🐛 Fixed HTTP 500 error when image processing fails during upload

### DIFF
--- a/ghost/core/core/server/api/endpoints/images.js
+++ b/ghost/core/core/server/api/endpoints/images.js
@@ -33,7 +33,12 @@ module.exports = {
                     width: config.get('imageOptimization:defaultMaxWidth')
                 }, imageOptimizationOptions);
 
-                await imageTransform.resizeFromPath(options);
+                try {
+                    await imageTransform.resizeFromPath(options);
+                } catch (err) {
+                    // If the image processing fails, we just want to store the original image
+                    return store.save(frame.file);
+                }
 
                 // Store the processed/optimized image
                 const processedImageUrl = await store.save({

--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -301,4 +301,14 @@ describe('Images API', function () {
         await uploadImageCheck({path: originalFilePath, filename: 'a.png', contentType: 'image/png'});
         clock.restore();
     });
+
+    it('Does not return HTTP 500 when image processing fails', async function () {
+        sinon.stub(imageTransform, 'resizeFromPath').rejects(new Error('Image processing failed'));
+
+        const originalFilePath = p.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png');
+        const fileContents = await fs.readFile(originalFilePath);
+
+        await uploadImageRequest({fileContents, filename: 'test.png', contentType: 'image/png'})
+            .expectStatus(201);
+    });
 });


### PR DESCRIPTION
fixes ENG-740
fixes https://linear.app/tryghost/issue/ENG-740/http-500-error-when-image-processing-fails

- in the event the image transform library throws (which can happen for many reasons; sharp/libvips can come across a number of errors), we currently return this as a HTTP 500 error to the user
- in this case, we should just try-catch the call and jump to the non-processing flow where it just saves the original image
- also added breaking test