### PR TITLE
🐛 Fixed Tiers API erroring when invalid filter passed

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -55,7 +55,9 @@ const initMembersCSVImporter = ({stripeAPIService}) => {
         },
         getTierByName: async (name) => {
             const tiers = await tiersService.api.browse({
-                filter: `name:'${name}'`
+                filter: {
+                    name
+                }
             });
 
             if (tiers.data.length > 0) {

--- a/ghost/core/core/server/services/tiers/TierRepository.js
+++ b/ghost/core/core/server/services/tiers/TierRepository.js
@@ -86,7 +86,8 @@ module.exports = class TierRepository {
      * @returns {Promise<import('@tryghost/tiers/lib/Tier')[]>}
      */
     async getAll(options = {}) {
-        const filter = nql(options.filter, {});
+        const filter = nql();
+        filter.filter = options.filter || {};
         return Promise.all(this.#store.slice().filter((item) => {
             return filter.queryJSON(this.toPrimitive(item));
         }).map((tier) => {

--- a/ghost/tiers/lib/InMemoryTierRepository.js
+++ b/ghost/tiers/lib/InMemoryTierRepository.js
@@ -55,7 +55,8 @@ class InMemoryTierRepository {
      * @returns {Promise<Tier[]>}
      */
     async getAll(options = {}) {
-        const filter = nql(options.filter, {});
+        const filter = nql();
+        filter.filter = options.filter || {};
         return this.#store.slice().filter((item) => {
             return filter.queryJSON(this.toPrimitive(item));
         });


### PR DESCRIPTION
closes ENG-730
closes https://linear.app/tryghost/issue/ENG-730/

We've updated the input serializer to parse the filter, and responded with an error if it cannot be parsed correctly.

Now that it's parsed, we can pass a mongo query object through the stack, which will lend itself to better typing for this code, which is a direction we want to go in anyway. We've had to update all the internal usages of the `browse` method to use mongo query objects.
