### PR TITLE
🐛 Fixed 500 errors for invalid theme layouts

### DIFF
--- a/ghost/core/core/frontend/services/rendering/renderer.js
+++ b/ghost/core/core/frontend/services/rendering/renderer.js
@@ -1,6 +1,12 @@
+const path = require('path');
 const debug = require('@tryghost/debug')('services:routing:renderer:renderer');
+const {IncorrectUsageError} = require('@tryghost/errors');
 const setContext = require('./context');
 const templates = require('./templates');
+const tpl = require('@tryghost/tpl');
+const messages = {
+    couldNotReadFile: 'Could not read file {file}'
+};
 
 /**
  * @description Helper function to finally render the data.
@@ -26,5 +32,17 @@ module.exports = function renderer(req, res, data) {
     }
 
     // Render Call
-    res.render(res._template, data);
+    res.render(res._template, data, function (err, html) {
+        if (err) {
+            if (err.code === 'ENOENT') {
+                return req.next(
+                    new IncorrectUsageError({
+                        message: tpl(messages.couldNotReadFile, {file: path.basename(err.path)})
+                    })
+                );
+            }
+            req.next(err);
+        }
+        res.send(html);
+    });
 };


### PR DESCRIPTION
ref ENG-742
ref https://linear.app/tryghost/issue/ENG-742

We don't do any parsing of layouts in gscan, which means themes can be uploaded which use non-existent files for their layout.

We can catch the error in the res.render call, and wrap it, just like we do for missing templates (e.g. the StaticRoutesRouter)
