### PR TITLE
Added cache-control header back to /auth-frame/ response

### DIFF
--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -41,6 +41,7 @@ module.exports = function setupAdminApp() {
             if (req.headers.cookie?.includes('ghost-admin-api-session')) {
                 next();
             } else {
+                res.setHeader('Cache-Control', 'public, max-age=0');
                 res.sendStatus(204);
             }
         } catch (err) {

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -54,7 +54,8 @@ describe('Admin Routing', function () {
             await request
                 .get('/ghost/auth-frame/')
                 .set('Origin', config.get('url'))
-                .expect(204);
+                .expect(204)
+                .expect('Cache-Control', 'public, max-age=0');
         });
 
         it('Renders static file with admin session cookie', async function () {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-721

- when changing the response to a `204` for requests with no cookie we'd lost the `Cache-Control: public, max-age: 0` header which meant some cache systems weren't caching as efficiently as possible