### PR TITLE
Fixed get helper cache optimizations

### DIFF
--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -11,6 +11,7 @@ const Sentry = require('@sentry/node');
 
 const _ = require('lodash');
 const jsonpath = require('jsonpath');
+const nqlLang = require('@tryghost/nql-lang');
 
 const messages = {
     mustBeCalledAsBlock: 'The {\\{{helperName}}} helper must be called as a block. E.g. {{#{helperName}}}...{{/{helperName}}}',
@@ -121,6 +122,84 @@ function parseOptions(globals, data, options) {
     return options;
 }
 
+function optimiseFilterCacheability(resource, options) {
+    const noOptimisation = {
+        options,
+        parseResult(result) {
+            return result;
+        }
+    };
+    if (resource !== 'posts') {
+        return noOptimisation;
+    }
+
+    if (!options.filter) {
+        return noOptimisation;
+    }
+
+    try {
+        if (options.filter.split('id:-').length !== 2) {
+            return noOptimisation;
+        }
+
+        const parsedFilter = nqlLang.parse(options.filter);
+        // Support either `id:blah` or `id:blah+other:stuff`
+        if (!parsedFilter.$and && !parsedFilter.id) {
+            return noOptimisation;
+        }
+        const queries = parsedFilter.$and || [parsedFilter];
+        const query = queries.find((q) => {
+            return q?.id?.$ne;
+        });
+
+        if (!query) {
+            return noOptimisation;
+        }
+
+        const idToFilter = query.id.$ne;
+
+        let limit = options.limit;
+        if (options.limit !== 'all') {
+            limit = options.limit ? 1 + parseInt(options.limit, 10) : 16;
+        }
+
+        // We replace with id:-null so we don't have to deal with leading/trailing AND operators
+        const filter = options.filter.replace(/id:-[a-f0-9A-F]{24}/, 'id:-null');
+
+        const parseResult = function parseResult(result) {
+            const filteredPosts = result?.posts?.filter((post) => {
+                return post.id !== idToFilter;
+            }) || [];
+
+            const modifiedResult = {
+                ...result,
+                posts: limit === 'all' ? filteredPosts : filteredPosts.slice(0, limit - 1)
+            };
+
+            modifiedResult.meta = modifiedResult.meta || {};
+            modifiedResult.meta.cacheabilityOptimisation = true;
+
+            if (typeof modifiedResult?.meta?.pagination?.limit === 'number') {
+                modifiedResult.meta.pagination.limit = modifiedResult.meta.pagination.limit - 1;
+            }
+
+            return modifiedResult;
+        };
+
+        return {
+            options: {
+                ...options,
+                limit,
+                filter
+            },
+            parseResult
+        };
+    } catch (err) {
+        logging.warn(err);
+        return noOptimisation;
+    }
+}
+
 /**
  *
  * @param {String} resource
@@ -131,6 +210,12 @@ function parseOptions(globals, data, options) {
  */
 async function makeAPICall(resource, controllerName, action, apiOptions) {
     const controller = api[controllerName];
+    let makeRequest = options => controller[action](options);
+
+    const {
+        options,
+        parseResult
+    } = optimiseFilterCacheability(resource, apiOptions);
 
     let timer;
 
@@ -141,7 +226,7 @@ async function makeAPICall(resource, controllerName, action, apiOptions) {
             const logLevel = config.get('optimization:getHelper:timeout:level') || 'error';
             const threshold = config.get('optimization:getHelper:timeout:threshold');
 
-            const apiResponse = controller[action](apiOptions);
+            const apiResponse = makeRequest(options).then(parseResult);
 
             const timeout = new Promise((resolve) => {
                 timer = setTimeout(() => {
@@ -161,7 +246,7 @@ async function makeAPICall(resource, controllerName, action, apiOptions) {
             response = await Promise.race([apiResponse, timeout]);
             clearTimeout(timer);
         } else {
-            response = await controller[action](apiOptions);
+            response = await makeRequest(options).then(parseResult);
         }
 
         return response;
@@ -279,3 +364,5 @@ module.exports = async function get(resource, options) {
 };
 
 module.exports.async = true;
+
+module.exports.optimiseFilterCacheability = optimiseFilterCacheability;


### PR DESCRIPTION
ref [ENG-747](https://linear.app/tryghost/issue/ENG-747/)
ref https://linear.app/tryghost/issue/ENG-747

H'okay - so what we're trying to do here is make get helper queries more
cacheable. The way we're doing that is by modifying the filter used when
we're trying to remove a single post from the query.

The idea is that we can remove that restriction on the filter, increase
the number of posts fetched by 1 and then filter the fetched posts back
down, this means that the same query, but filtering different posts,
will be updated to make _exactly_ the same query, and so share a cache!

We've been purposefully restrictive in the types of filters we
manipulate, so that we only deal with the simplest cases and the code is
easier to understand.