### PR TITLE
Stopped us rendering no-html when error occurs

### DIFF
--- a/ghost/core/core/frontend/services/rendering/renderer.js
+++ b/ghost/core/core/frontend/services/rendering/renderer.js
@@ -41,7 +41,7 @@ module.exports = function renderer(req, res, data) {
                     })
                 );
             }
-            req.next(err);
+            return req.next(err);
         }
         res.send(html);
     });


### PR DESCRIPTION
no-issue

We need to make sure that we return, otherwise we'll end up skipping the error handler middleware and trying to render.
