### PR TITLE
Removed usage of getters for api endpoints

### DIFF
--- a/ghost/core/core/server/api/endpoints/identities.js
+++ b/ghost/core/core/server/api/endpoints/identities.js
@@ -4,11 +4,16 @@ const jwt = require('jsonwebtoken');
 const jose = require('node-jose');
 const issuer = urlUtils.urlFor('admin', true);
 
-const dangerousPrivateKey = settings.get('ghost_private_key');
-const keyStore = jose.JWK.createKeyStore();
-const keyStoreReady = keyStore.add(dangerousPrivateKey, 'pem');
+let dangerousPrivateKey;
+let keyStore;
+let keyStoreReady;
 
 const getKeyID = async () => {
+    if (!keyStore) {
+        dangerousPrivateKey = settings.get('ghost_private_key');
+        keyStore = jose.JWK.createKeyStore();
+        keyStoreReady = keyStore.add(dangerousPrivateKey, 'pem');
+    }
     const key = await keyStoreReady;
     return key.kid;
 };

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -8,210 +8,108 @@ const localUtils = require('./utils');
 /* eslint-disable max-lines */
 
 module.exports = {
-    get authentication() {
-        return apiFramework.pipeline(require('./authentication'), localUtils);
-    },
+    authentication: apiFramework.pipeline(require('./authentication'), localUtils),
 
-    get collections() {
-        return apiFramework.pipeline(require('./collections'), localUtils);
-    },
+    collections: apiFramework.pipeline(require('./collections'), localUtils),
 
-    get db() {
-        return apiFramework.pipeline(require('./db'), localUtils);
-    },
+    db: apiFramework.pipeline(require('./db'), localUtils),
 
-    get identities() {
-        return apiFramework.pipeline(require('./identities'), localUtils);
-    },
+    identities: apiFramework.pipeline(require('./identities'), localUtils),
 
-    get integrations() {
-        return apiFramework.pipeline(require('./integrations'), localUtils);
-    },
+    integrations: apiFramework.pipeline(require('./integrations'), localUtils),
 
     // @TODO: transform
-    get session() {
-        return require('./session');
-    },
+    session: require('./session'),
 
-    get schedules() {
-        return apiFramework.pipeline(require('./schedules'), localUtils);
-    },
+    schedules: apiFramework.pipeline(require('./schedules'), localUtils),
 
-    get pages() {
-        return apiFramework.pipeline(require('./pages'), localUtils);
-    },
+    pages: apiFramework.pipeline(require('./pages'), localUtils),
 
-    get redirects() {
-        return apiFramework.pipeline(require('./redirects'), localUtils);
-    },
+    redirects: apiFramework.pipeline(require('./redirects'), localUtils),
 
-    get roles() {
-        return apiFramework.pipeline(require('./roles'), localUtils);
-    },
+    roles: apiFramework.pipeline(require('./roles'), localUtils),
 
-    get slugs() {
-        return apiFramework.pipeline(require('./slugs'), localUtils);
-    },
+    slugs: apiFramework.pipeline(require('./slugs'), localUtils),
 
-    get webhooks() {
-        return apiFramework.pipeline(require('./webhooks'), localUtils);
-    },
+    webhooks: apiFramework.pipeline(require('./webhooks'), localUtils),
 
-    get posts() {
-        return apiFramework.pipeline(require('./posts'), localUtils);
-    },
+    posts: apiFramework.pipeline(require('./posts'), localUtils),
 
-    get mentions() {
-        return apiFramework.pipeline(require('./mentions'), localUtils);
-    },
+    mentions: apiFramework.pipeline(require('./mentions'), localUtils),
 
-    get invites() {
-        return apiFramework.pipeline(require('./invites'), localUtils);
-    },
+    invites: apiFramework.pipeline(require('./invites'), localUtils),
 
-    get mail() {
-        return apiFramework.pipeline(require('./mail'), localUtils);
-    },
+    mail: apiFramework.pipeline(require('./mail'), localUtils),
 
-    get notifications() {
-        return apiFramework.pipeline(require('./notifications'), localUtils);
-    },
+    notifications: apiFramework.pipeline(require('./notifications'), localUtils),
 
-    get settings() {
-        return apiFramework.pipeline(require('./settings'), localUtils);
-    },
+    settings: apiFramework.pipeline(require('./settings'), localUtils),
 
-    get announcements() {
-        return apiFramework.pipeline(require('./announcements'), localUtils);
-    },
+    announcements: apiFramework.pipeline(require('./announcements'), localUtils),
 
-    get membersStripeConnect() {
-        return apiFramework.pipeline(require('./members-stripe-connect'), localUtils);
-    },
+    membersStripeConnect: apiFramework.pipeline(require('./members-stripe-connect'), localUtils),
 
-    get members() {
-        return apiFramework.pipeline(require('./members'), localUtils);
-    },
+    members: apiFramework.pipeline(require('./members'), localUtils),
 
-    get offers() {
-        return apiFramework.pipeline(require('./offers'), localUtils);
-    },
+    offers: apiFramework.pipeline(require('./offers'), localUtils),
 
-    get tiers() {
-        return apiFramework.pipeline(require('./tiers'), localUtils);
-    },
+    tiers: apiFramework.pipeline(require('./tiers'), localUtils),
 
-    get memberSigninUrls() {
-        return apiFramework.pipeline(require('./member-signin-urls.js'), localUtils);
-    },
+    memberSigninUrls: apiFramework.pipeline(require('./member-signin-urls.js'), localUtils),
 
-    get labels() {
-        return apiFramework.pipeline(require('./labels'), localUtils);
-    },
+    labels: apiFramework.pipeline(require('./labels'), localUtils),
 
-    get images() {
-        return apiFramework.pipeline(require('./images'), localUtils);
-    },
+    images: apiFramework.pipeline(require('./images'), localUtils),
 
-    get media() {
-        return apiFramework.pipeline(require('./media'), localUtils);
-    },
+    media: apiFramework.pipeline(require('./media'), localUtils),
 
-    get files() {
-        return apiFramework.pipeline(require('./files'), localUtils);
-    },
+    files: apiFramework.pipeline(require('./files'), localUtils),
 
-    get tags() {
-        return apiFramework.pipeline(require('./tags'), localUtils);
-    },
+    tags: apiFramework.pipeline(require('./tags'), localUtils),
 
-    get users() {
-        return apiFramework.pipeline(require('./users'), localUtils);
-    },
+    users: apiFramework.pipeline(require('./users'), localUtils),
 
-    get previews() {
-        return apiFramework.pipeline(require('./previews'), localUtils);
-    },
+    previews: apiFramework.pipeline(require('./previews'), localUtils),
 
-    get emailPost() {
-        return apiFramework.pipeline(require('./email-post'), localUtils);
-    },
+    emailPost: apiFramework.pipeline(require('./email-post'), localUtils),
 
-    get oembed() {
-        return apiFramework.pipeline(require('./oembed'), localUtils);
-    },
+    oembed: apiFramework.pipeline(require('./oembed'), localUtils),
 
-    get slack() {
-        return apiFramework.pipeline(require('./slack'), localUtils);
-    },
+    slack: apiFramework.pipeline(require('./slack'), localUtils),
 
-    get config() {
-        return apiFramework.pipeline(require('./config'), localUtils);
-    },
+    config: apiFramework.pipeline(require('./config'), localUtils),
 
-    get explore() {
-        return apiFramework.pipeline(require('./explore'), localUtils);
-    },
+    explore: apiFramework.pipeline(require('./explore'), localUtils),
 
-    get themes() {
-        return apiFramework.pipeline(require('./themes'), localUtils);
-    },
+    themes: apiFramework.pipeline(require('./themes'), localUtils),
 
-    get actions() {
-        return apiFramework.pipeline(require('./actions'), localUtils);
-    },
+    actions: apiFramework.pipeline(require('./actions'), localUtils),
 
-    get email_previews() {
-        return apiFramework.pipeline(require('./email-previews'), localUtils);
-    },
+    email_previews: apiFramework.pipeline(require('./email-previews'), localUtils),
 
-    get emails() {
-        return apiFramework.pipeline(require('./emails'), localUtils);
-    },
+    emails: apiFramework.pipeline(require('./emails'), localUtils),
 
-    get site() {
-        return apiFramework.pipeline(require('./site'), localUtils);
-    },
+    site: apiFramework.pipeline(require('./site'), localUtils),
 
-    get snippets() {
-        return apiFramework.pipeline(require('./snippets'), localUtils);
-    },
+    snippets: apiFramework.pipeline(require('./snippets'), localUtils),
 
-    get stats() {
-        return apiFramework.pipeline(require('./stats'), localUtils);
-    },
+    stats: apiFramework.pipeline(require('./stats'), localUtils),
 
-    get customThemeSettings() {
-        return apiFramework.pipeline(require('./custom-theme-settings'), localUtils);
-    },
+    customThemeSettings: apiFramework.pipeline(require('./custom-theme-settings'), localUtils),
 
-    get serializers() {
-        return require('./utils/serializers');
-    },
+    serializers: require('./utils/serializers'),
 
-    get newsletters() {
-        return apiFramework.pipeline(require('./newsletters'), localUtils);
-    },
+    newsletters: apiFramework.pipeline(require('./newsletters'), localUtils),
 
-    get comments() {
-        return apiFramework.pipeline(require('./comments'), localUtils);
-    },
+    comments: apiFramework.pipeline(require('./comments'), localUtils),
 
-    get links() {
-        return apiFramework.pipeline(require('./links'), localUtils);
-    },
+    links: apiFramework.pipeline(require('./links'), localUtils),
 
-    get mailEvents() {
-        return apiFramework.pipeline(require('./mail-events'), localUtils);
-    },
+    mailEvents: apiFramework.pipeline(require('./mail-events'), localUtils),
 
-    get recommendations() {
-        return apiFramework.pipeline(require('./recommendations'), localUtils);
-    },
+    recommendations: apiFramework.pipeline(require('./recommendations'), localUtils),
 
-    get incomingRecommendations() {
-        return apiFramework.pipeline(require('./incoming-recommendations'), localUtils);
-    },
+    incomingRecommendations: apiFramework.pipeline(require('./incoming-recommendations'), localUtils),
 
     /**
      * Content API Controllers
@@ -221,51 +119,27 @@ module.exports = {
      * Please create separate controllers for Content & Admin API. The goal is to expose `api.content` and
      * `api.admin` soon. Need to figure out how serializers & validation works then.
      */
-    get pagesPublic() {
-        return apiFramework.pipeline(require('./pages-public'), localUtils, 'content');
-    },
+    pagesPublic: apiFramework.pipeline(require('./pages-public'), localUtils, 'content'),
 
-    get collectionsPublic() {
-        return apiFramework.pipeline(require('./collections-public'), localUtils);
-    },
+    collectionsPublic: apiFramework.pipeline(require('./collections-public'), localUtils),
 
-    get tagsPublic() {
-        return apiFramework.pipeline(require('./tags-public'), localUtils, 'content');
-    },
+    tagsPublic: apiFramework.pipeline(require('./tags-public'), localUtils, 'content'),
 
-    get publicSettings() {
-        return apiFramework.pipeline(require('./settings-public'), localUtils, 'content');
-    },
+    publicSettings: apiFramework.pipeline(require('./settings-public'), localUtils, 'content'),
 
-    get postsPublic() {
-        return apiFramework.pipeline(require('./posts-public'), localUtils, 'content');
-    },
+    postsPublic: apiFramework.pipeline(require('./posts-public'), localUtils, 'content'),
 
-    get authorsPublic() {
-        return apiFramework.pipeline(require('./authors-public'), localUtils, 'content');
-    },
+    authorsPublic: apiFramework.pipeline(require('./authors-public'), localUtils, 'content'),
 
-    get tiersPublic() {
-        return apiFramework.pipeline(require('./tiers-public'), localUtils, 'content');
-    },
+    tiersPublic: apiFramework.pipeline(require('./tiers-public'), localUtils, 'content'),
 
-    get newslettersPublic() {
-        return apiFramework.pipeline(require('./newsletters-public'), localUtils, 'content');
-    },
+    newslettersPublic: apiFramework.pipeline(require('./newsletters-public'), localUtils, 'content'),
 
-    get offersPublic() {
-        return apiFramework.pipeline(require('./offers-public'), localUtils, 'content');
-    },
+    offersPublic: apiFramework.pipeline(require('./offers-public'), localUtils, 'content'),
 
-    get commentsMembers() {
-        return apiFramework.pipeline(require('./comments-members'), localUtils, 'members');
-    },
+    commentsMembers: apiFramework.pipeline(require('./comments-members'), localUtils, 'members'),
 
-    get feedbackMembers() {
-        return apiFramework.pipeline(require('./feedback-members'), localUtils, 'members');
-    },
+    feedbackMembers: apiFramework.pipeline(require('./feedback-members'), localUtils, 'members'),
 
-    get recommendationsPublic() {
-        return apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content');
-    }
+    recommendationsPublic: apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content')
 };


### PR DESCRIPTION
ref ENG-761
ref https://linear.app/tryghost/issue/ENG-761

By removing getters we ensure that each endpoint is only instantiated once. This _may_ have an adverse effect on boot time, so we're going to keep an eye on that, and make any necessary adjustments to the implementation.
