### PR TITLE
Updated email error button text in case of partial email errors

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.hbs
@@ -26,7 +26,7 @@
     <div class="gh-publish-cta">
         <GhTaskButton
             @task={{this.retryEmailTask}}
-            @buttonText="Retry sending email"
+            @buttonText={{if this.isPartialError "Send remaining emails" "Retry sending email"}}
             @runningText="Sending"
             @successText="Sent"
             @class="gh-btn gh-btn-large gh-btn-red"

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.js
@@ -20,6 +20,12 @@ export default class PublishFlowCompleteWithEmailError extends Component {
         return this.newEmailErrorMessage || this.args.emailErrorMessage;
     }
 
+    get isPartialError() {
+        // For now we look at the error message.
+        // This is covered in E2E tests so we'll be notified when this changes.
+        return this.emailErrorMessage && this.emailErrorMessage.includes('partially');
+    }
+
     @task({drop: true})
     *retryEmailTask() {
         this.retryErrorMessage = null;

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -761,12 +761,19 @@ describe('Batch Sending Service', function () {
                 return Promise.resolve(callCount === 12 ? false : true);
             });
             const batches = new Array(101).fill(0).map(() => createModel({}));
+
+            /**
+             * !! WARNING !!
+             * If the error message is changed that it no longer contains the word 'partially',
+             * we'll also need the frontend logic in ghost/admin/app/components/editor/modals/publish-flow/complete-with-email-error.js
+             */
             await assert.rejects(service.sendBatches({
                 email: createModel({}),
                 batches,
                 post: createModel({}),
                 newsletter: createModel({})
-            }), /was only partially sent/);
+            }), /was only partially sent/); // do not change without reading the warning above
+
             sinon.assert.callCount(sendBatch, 101);
             const sendBatches = sendBatch.getCalls().map(call => call.args[0].batch);
             assert.deepEqual(sendBatches, batches);


### PR DESCRIPTION
fixes DES-66

In case some batches succeeded sending, the button text will be different if the email sending was partially successful.

For now this uses text matching with a warning in our E2E tests because we don't have a straightforward way to check if an error is partial or not yet.