### PR TITLE
Stripe Tax: Update customer address when needed

### DIFF
--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -488,6 +488,14 @@ module.exports = class StripeAPI {
             stripeSessionOptions.customer_email = customerEmail;
         }
 
+        // Use the billing address entered during checkout to assess the
+        // customer's location for Stripe Tax. This is also needed to avoid an
+        // error if an existing customer lacks an address. It must not be used
+        // when Stripe does not already have a customer record.
+        if (customer && this._config.enableAutomaticTax) {
+            stripeSessionOptions.customer_update = {address: 'auto'};
+        }
+
         // @ts-ignore
         const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);
 
@@ -536,6 +544,14 @@ module.exports = class StripeAPI {
                 quantity: 1
             }]
         };
+
+        // Use the billing address entered during checkout to assess the
+        // customer's location for Stripe Tax. This is also needed to avoid an
+        // error if an existing customer lacks an address. It must not be used
+        // when Stripe does not already have a customer record.
+        if (customer && this._config.enableAutomaticTax) {
+            stripeSessionOptions.customer_update = {address: 'auto'};
+        }
 
         // @ts-ignore
         const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);


### PR DESCRIPTION
Use the billing address entered during checkout to assess the customer's location for Stripe Tax. This is also needed to avoid an error if an existing customer lacks an address.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change, explained below
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

We appreciate your contribution!

<hr/>

The Stripe Tax integration, when enabled, works well for new subscriptions. It does not work when an existing member tries to upgrade their subscription and Stripe’s customer record does not already have address information Stripe can use to determine a tax jurisdiction, resulting in the following error:

> **Unable to initiate checkout session**
>
> Error: Automatic tax calculation in Checkout requires a valid address on the Customer. Add a valid address to the Customer or set either `customer_update[address]` to 'auto' or `customer_update[shipping]` to 'auto' to save the address entered in Checkout to the Customer.

This change instructs Stripe to update and use the customer’s billing address entered during checkout to determine the customer’s location for Stripe Tax. It does not include the same instruction when Stripe does not already have a customer record, as that will result in a different error (Error: `customer_update` can only be used with `customer`.)