### PR TITLE
Added comments count endpoint to robots.txt disallow list

### DIFF
--- a/ghost/core/core/frontend/public/robots.txt
+++ b/ghost/core/core/frontend/public/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 Sitemap: {{blog-url}}/sitemap.xml
 Disallow: /ghost/
 Disallow: /email/
+Disallow: /members/api/comments/counts/
 Disallow: /r/
 Disallow: /webmentions/receive/

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -323,6 +323,7 @@ describe('Default Frontend routing', function () {
                 'User-agent: *\n' +
                 'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
                 'Disallow: /email/\n' +
+                'Disallow: /members/api/comments/counts/\n' +
                 'Disallow: /r/\n' +
                 'Disallow: /webmentions/receive/\n'
             );


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/ENG-771/add-comments-count-endpoint-to-robotstxt-ignorelist

- we've seen web scrapers hitting this endpoint a lot, but the value to be taken from it is minimal for SEO purposes
- adding it to robots.txt should encourage web scrapers to ignore it, and we should see less traffic as a result
