### PR TITLE
Added support for clearing all data with data generator

### DIFF
--- a/ghost/data-generator/lib/utils/event-generator.js
+++ b/ghost/data-generator/lib/utils/event-generator.js
@@ -7,6 +7,10 @@ const generateEvents = ({
     startTime = new Date(),
     endTime = new Date()
 } = {}) => {
+    if (total <= 0) {
+        return [];
+    }
+
     let alpha = 0;
     let beta = 0;
     let positiveTrend = trend === 'positive';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
     "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100000,posts:500 --seed 123",
-    "reset:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
+    "reset:data:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker:reset": "docker-compose -f .github/scripts/docker-compose.yml down -v && docker-compose -f .github/scripts/docker-compose.yml up -d --wait",
     "lint": "nx run-many -t lint",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
     "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100000,posts:500 --seed 123",
+    "reset:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker:reset": "docker-compose -f .github/scripts/docker-compose.yml down -v && docker-compose -f .github/scripts/docker-compose.yml up -d --wait",
     "lint": "nx run-many -t lint",


### PR DESCRIPTION
no issue

When testing Stripe migrations, it is useful to be able to clear the database quickly without deleting admins and tokens. This is possible with the data generator.