### PR TITLE
Added support for ignoring migrated (duplicate) subscriptions

### DIFF
--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -1032,9 +1032,11 @@ module.exports = class MemberRepository {
             logging.warn(`Subscription ${subscriptionData.subscription_id} is marked for deletion, skipping linking.`);
 
             if (model) {
+                // Delete all paid subscription events manually for this subscription
+                // This is the only related event without a foreign key constraint
                 await this._MemberPaidSubscriptionEvent.query().where('subscription_id', model.id).delete().transacting(options.transacting);
 
-                // Delete all paid subscription events for this subscription
+                // Delete the subscription in the database because we don't want to show it in the UI or in our data calculations
                 await model.destroy(options);
             }
         } else if (model) {


### PR DESCRIPTION
refs KTLO-19

When we need to migrate subscriptions from a platform with platform fees, we need to recreate the subscriptions. That can cause the same subscription to be attached multiple times to the same member in Ghost.

This is a problem because all MRR, subscriptions and cancellations stats are no longer correct. Ghost will add a MRR event for the duplicated subscription from the start time, so there is a sudden peak in MRR and a dip after the migration because all those duplicate subscriptions are suddenly cancelled 'today'.

The migrator tool adds a ghost_migrated_to metadata field to the old subscription. Ghost can use this to detect the old subscription and delete the subscription and corresponding events.