### PR TITLE
Fixed Editors being able to invite Editors

### DIFF
--- a/ghost/core/core/server/models/invite.js
+++ b/ghost/core/core/server/models/invite.js
@@ -93,8 +93,7 @@ Invite = ghostBookshelf.Model.extend({
                     } else if (_.some(loadedPermissions.user.roles, {name: 'Editor'})) {
                         allowed = ['Author', 'Contributor'];
                     }
-                }
-                if (loadedPermissions.apiKey) {
+                } else if (loadedPermissions.apiKey) {
                     allowed = ['Editor', 'Author', 'Contributor'];
                 }
 

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -153,6 +153,21 @@ describe('Unit: models/invite', function () {
                         });
                 });
 
+                it('invite editor with staff token', function () {
+                    loadedPermissions.apiKey = {
+                        roles: [{name: 'Admin Integration'}]
+                    };
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    roleModel.get.withArgs('name').returns('Editor');
+
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                        .then(Promise.reject)
+                        .catch((err) => {
+                            (err instanceof errors.NoPermissionError).should.eql(true);
+                            delete loadedPermissions.apiKey;
+                        });
+                });
+
                 it('invite author', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');


### PR DESCRIPTION
ref ENG-774
ref https://linear.app/tryghost/issue/ENG-774

Staff Tokens will have both a `user` and an `apiKey` present on the `loadedPermissions`.

The check here for `apiKey` was written when we could assume that an `apiKey` was an Admin Integration - so it completely overwrote the previous `allowed` list. When we added the concept of Staff Tokens - this resulted in a privilege escalation.

This is a good lesson in not using proxies or indicators for data, as changes elsewhere can invalidate them - if we had been specific and checked the role of the current actor we wouldn't've had this bug!

