### PR TITLE
Switched canary build to use the new faster build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -961,7 +961,7 @@ jobs:
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
           token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          workflow: .github/workflows/deploy.yml
+          workflow: .github/workflows/deploy-optimised.yml
           ref: 'refs/heads/main'
           repo: TryGhost/Ghost-Moya
           inputs: ${{ env.CANARY_BUILD_INPUTS }}


### PR DESCRIPTION
This switches our staging canary build to use a new build pipeline that is faster in a lot of cases.
