### PR TITLE
🐛 Fixed flaky offers browser test util

### DIFF
--- a/ghost/core/playwright.config.js
+++ b/ghost/core/playwright.config.js
@@ -10,8 +10,7 @@ const config = {
     workers: process.env.CI ? '100%' : (process.env.PLAYWRIGHT_SLOWMO ? 1 : undefined),
     reporter: process.env.CI ? [['list', {printSteps: true}], ['html']] : [['list', {printSteps: true}]],
     use: {
-        // trace: 'retain-on-failure',
-        trace: 'on-first-retry',
+        trace: 'retain-on-failure',
         // Use a single browser since we can't simultaneously test multiple browsers
         browserName: 'chromium',
         headless: !process.env.PLAYWRIGHT_DEBUG,

--- a/ghost/core/playwright.config.js
+++ b/ghost/core/playwright.config.js
@@ -6,12 +6,12 @@ const config = {
         timeout: 10000
     },
     // save trace on fail
-    trace: 'on-first-retry',
     retries: process.env.CI ? 2 : 0,
     workers: process.env.CI ? '100%' : (process.env.PLAYWRIGHT_SLOWMO ? 1 : undefined),
     reporter: process.env.CI ? [['list', {printSteps: true}], ['html']] : [['list', {printSteps: true}]],
     use: {
         // trace: 'retain-on-failure',
+        trace: 'on-first-retry',
         // Use a single browser since we can't simultaneously test multiple browsers
         browserName: 'chromium',
         headless: !process.env.PLAYWRIGHT_DEBUG,

--- a/ghost/core/playwright.config.js
+++ b/ghost/core/playwright.config.js
@@ -5,6 +5,8 @@ const config = {
     expect: {
         timeout: 10000
     },
+    // save trace on fail
+    trace: 'on-first-retry',
     retries: process.env.CI ? 2 : 0,
     workers: process.env.CI ? '100%' : (process.env.PLAYWRIGHT_SLOWMO ? 1 : undefined),
     reporter: process.env.CI ? [['list', {printSteps: true}], ['html']] : [['list', {printSteps: true}]],

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -314,10 +314,12 @@ test.describe('Publishing', () => {
             await adminPage.fill('[data-test-field="custom-excerpt"]', 'Short description and meta');
 
             // save
-            await adminPage.locator('[data-test-button="publish-save"]').first().click();
+            const saveButton = await adminPage.locator('[data-test-button="publish-save"]').first();
+            await expect(saveButton).toHaveText('Update');
+            await saveButton.click();
+            await expect(saveButton).toHaveText('Updated');
 
             // check front-end has new text after reloading
-            await frontendPage.waitForTimeout(300); // let save go through
             await frontendPage.reload();
             await expect(publishedBody).toContainText('This is some updated text.');
             await expect(publishedHeader).toContainText('Jan 7, 2022');

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -4,7 +4,7 @@ const {createMember, impersonateMember, completeStripeSubscription} = require('.
 
 test.describe('Portal', () => {
     test.describe('Donations', () => {
-        test.only('Can donate as an anonymous member', async ({sharedPage}) => {
+        test('Can donate as an anonymous member', async ({sharedPage}) => {
             // go to website and open portal
             await sharedPage.goto('/#/portal/support');
 
@@ -38,8 +38,8 @@ test.describe('Portal', () => {
             await completeStripeSubscription(sharedPage);
 
             // Check success message
-            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
 
@@ -67,8 +67,8 @@ test.describe('Portal', () => {
             await completeStripeSubscription(sharedPage);
 
             // Check success message
-            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
     });

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -14,8 +14,8 @@ test.describe('Portal', () => {
 
             await sharedPage.pause();
             // Check success message
-            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
 

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -4,7 +4,7 @@ const {createMember, impersonateMember, completeStripeSubscription} = require('.
 
 test.describe('Portal', () => {
     test.describe('Donations', () => {
-        test('Can donate as an anonymous member', async ({sharedPage}) => {
+        test.only('Can donate as an anonymous member', async ({sharedPage}) => {
             // go to website and open portal
             await sharedPage.goto('/#/portal/support');
 
@@ -12,8 +12,10 @@ test.describe('Portal', () => {
             await sharedPage.locator('#email').fill('member-donation-test-1@ghost.org');
             await completeStripeSubscription(sharedPage);
 
+            await sharedPage.pause();
             // Check success message
-            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
 
@@ -36,7 +38,8 @@ test.describe('Portal', () => {
             await completeStripeSubscription(sharedPage);
 
             // Check success message
-            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
 
@@ -64,7 +67,8 @@ test.describe('Portal', () => {
             await completeStripeSubscription(sharedPage);
 
             // Check success message
-            const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            // const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            const portalFrame = await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
             await expect(portalFrame.getByText('Thank you!')).toBeVisible();
         });
     });

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -261,8 +261,10 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
         // Tiers request can take time, so waiting until there is no connections before interacting with them
         await page.waitForLoadState('networkidle');
 
+        // only one of these buttons is ever available - either 'Add offer' or 'Manage offers'
         const hasExistingOffers = await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).isVisible();
         const isCTA = await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).isVisible();
+        
         // Archive other offers to keep the list tidy
         // We only need 1 offer to be active at a time
         // Either the list of active offers loads, or the CTA when no offers exist
@@ -281,12 +283,13 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
         if (isCTA) {
             await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).click();
         } else {
+            // ensure the modal is open
+            if (!page.getByTestId('offers-modal').isVisible()) {
+                await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            }
             await page.getByText('New offer').click();
         }
 
-        // const newOfferButton = await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}) || await page.getByTestId('offers').getByRole('button', {name: 'New offer'});
-        // await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).click();
-        // await newOfferButton.click();
         await page.getByLabel('Offer name').fill(offerName);
 
         if (offerType === 'freeTrial') {

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -260,6 +260,9 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
         offerName = `${name} (${new ObjectID().toHexString().slice(0, 40 - name.length - 3)})`;
         // Tiers request can take time, so waiting until there is no connections before interacting with them
         await page.waitForLoadState('networkidle');
+        // ... and even so, the component updates can take a bit to trickle down, so we should verify that the Tier is fully loaded before proceeding
+        await page.getByTestId('tiers').getByText('No active tiers found').waitFor({state: 'hidden'});
+        await page.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
 
         // only one of these buttons is ever available - either 'Add offer' or 'Manage offers'
         const hasExistingOffers = await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).isVisible();


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/CFR-13
- added some handling in case there's all offers are archived

Previously, our tests assumed that either there were offers present and would click the Manage Offers button, or there were none (even archived), and would click Add Offer. It's possible to hit the state of all archived offers, in which case no offer button is present and we still show Manage Offers. This new handling ensures the offers modal from Manage Offers is shown before looking for the appropriate button.

tldr; our logic makes assumptions about which button is available and the current state, rather than checking the current state before selecting the behaviour
