### PR TITLE
Wired onboarding checklist to saved user settings

### DIFF
--- a/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
+++ b/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
@@ -57,11 +57,15 @@
         </div>
     </div>
 
-    <a href="#" class="gh-onboarding-explore-dashboard">Explore your dashboard</a>
+    {{#if this.onboarding.allStepsCompleted}}
+        <a href="#" class="gh-onboarding-explore-dashboard" {{on "click" this.onboarding.completeChecklist}}>Explore your dashboard</a>
+    {{/if}}
 
     <p class="gh-onboarding-help">Need some more help? Check out our <a href="https://ghost.org/help?utm_source=admin&utm_campaign=onboarding" target="_blank" rel="noopener noreferrer">Help center</a></p>
 
-    <a href="#" class="gh-onboarding-skip">Skip onboarding</a>
+    {{#unless this.onboarding.allStepsCompleted}}
+        <a href="#" class="gh-onboarding-skip" {{on "click" this.onboarding.dismissChecklist}}>Skip onboarding</a>
+    {{/unless}}
 </div>
 
 {{#if this.showShareModal}}


### PR DESCRIPTION
part of https://linear.app/tryghost/issue/IPC-92/add-logic-for-completing-steps
part of https://linear.app/tryghost/issue/IPC-115/make-skip-onboarding-button-work

- updated `onboarding` service to use the `user.accessibility` (poor naming, this is an old field used for general user settings) as it's backing store
- added `onboarding.allStepsCompleted` to allow for "completion" state to be shown before the checklist is marked as completed
- added `onboarding.{complete,dismiss}Checklist()` actions and wired those up to the template

When testing, if you need to reset the checklist you can run this in DevTools console
```
Ember.Namespace.NAMESPACES_BY_ID['ghost-admin'].__container__.lookup('service:onboarding').startChecklist()
```