### PR TITLE
🐛 Fixed adding recommendations with long excerpts

### DIFF
--- a/ghost/recommendations/src/Recommendation.ts
+++ b/ghost/recommendations/src/Recommendation.ts
@@ -103,15 +103,9 @@ export class Recommendation {
             });
         }
 
-        if (properties.description && properties.description.length > 2000) {
+        if (properties.description && properties.description.length > 200) {
             throw new errors.ValidationError({
-                message: 'Description must be less than 2000 characters'
-            });
-        }
-
-        if (properties.excerpt && properties.excerpt.length > 2000) {
-            throw new errors.ValidationError({
-                message: 'Excerpt must be less than 2000 characters'
+                message: 'Description must be less than 200 characters'
             });
         }
     }
@@ -119,6 +113,14 @@ export class Recommendation {
     clean() {
         if (this.description !== null && this.description.length === 0) {
             this.description = null;
+        }
+
+        if (this.excerpt !== null && this.excerpt.length === 0) {
+            this.excerpt = null;
+        }
+
+        if (this.excerpt !== null && this.excerpt.length > 2000) {
+            this.excerpt = this.excerpt.slice(0, 1997) + '...';
         }
 
         this.createdAt.setMilliseconds(0);

--- a/ghost/recommendations/test/Recommendation.test.ts
+++ b/ghost/recommendations/test/Recommendation.test.ts
@@ -41,7 +41,7 @@ describe('Recommendation', function () {
             assert.throws(() => {
                 Recommendation.validate({
                     title: 'Test',
-                    description: 'a'.repeat(2001),
+                    description: 'a'.repeat(201),
                     excerpt: null,
                     featuredImage: null,
                     favicon: null,
@@ -50,24 +50,7 @@ describe('Recommendation', function () {
                 });
             }, {
                 name: 'ValidationError',
-                message: 'Description must be less than 2000 characters'
-            });
-        });
-
-        it('Throws for a long excerpt', function () {
-            assert.throws(() => {
-                Recommendation.validate({
-                    title: 'Test',
-                    description: null,
-                    excerpt: 'a'.repeat(2001),
-                    featuredImage: null,
-                    favicon: null,
-                    url: 'https://example.com',
-                    oneClickSubscribe: false
-                });
-            }, {
-                name: 'ValidationError',
-                message: 'Excerpt must be less than 2000 characters'
+                message: 'Description must be less than 200 characters'
             });
         });
     });
@@ -116,6 +99,36 @@ describe('Recommendation', function () {
             });
 
             assert.equal(recommendation.description, null);
+        });
+
+        it('sets empty excerpt to null', function () {
+            const recommendation = Recommendation.create({
+                title: 'Test',
+                description: null,
+                excerpt: '',
+                featuredImage: null,
+                favicon: null,
+                url: 'https://example.com',
+                oneClickSubscribe: false,
+                updatedAt: new Date('2021-01-01T00:00:05Z')
+            });
+
+            assert.equal(recommendation.excerpt, null);
+        });
+
+        it('truncates long excerpts', function () {
+            const recommendation = Recommendation.create({
+                title: 'Test',
+                description: null,
+                excerpt: 'a'.repeat(2001),
+                featuredImage: null,
+                favicon: null,
+                url: 'https://example.com',
+                oneClickSubscribe: false,
+                updatedAt: new Date('2021-01-01T00:00:05Z')
+            });
+
+            assert.equal(recommendation.excerpt?.length, 2000);
         });
 
         it('keeps search and hash params', function () {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-801/unable-to-recommend-sites-with-long-excerpts

- recommending a site with a long excerpt was being blocked by a validation error
- with this change, we truncate the excerpt to 2000 characters max. and avoid showing an error in the UI
- with this change, the description length validation is also now stricter; 200 characters max, instead of 2000, to match the UI
