### PR TITLE
Replaced setup/done screen with onboarding checklist

### DIFF
--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -2,8 +2,23 @@ import Route from '@ember/routing/route';
 import {inject as service} from '@ember/service';
 
 export default class SetupFinishingTouchesRoute extends Route {
+    @service feature;
+    @service onboarding;
+    @service router;
+    @service session;
     @service settings;
     @service themeManagement;
+
+    beforeModel() {
+        if (!this.session.user.isOwnerOnly) {
+            return;
+        }
+
+        if (this.feature.onboardingChecklist) {
+            this.onboarding.startChecklist();
+            return this.router.transitionTo('dashboard');
+        }
+    }
 
     model() {
         this.themeManagement.setPreviewType('homepage');

--- a/ghost/admin/app/services/onboarding.js
+++ b/ghost/admin/app/services/onboarding.js
@@ -26,6 +26,7 @@ export default class OnboardingService extends Service {
     get isChecklistShown() {
         return this.feature.onboardingChecklist
             && this.session.user.isOwnerOnly
+            && this.checklistStarted
             && !this.checklistCompleted
             && !this.checklistDismissed;
     }
@@ -103,6 +104,11 @@ export default class OnboardingService extends Service {
         settings.completedSteps.push(step);
 
         await this._saveSettings(settings);
+    }
+
+    @action
+    async reset() {
+        await this._saveSettings(undefined);
     }
 
     /* private */

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -27,8 +27,20 @@ describe('Acceptance: Onboarding', function () {
             return await authenticateSession();
         });
 
-        it('dashboard shows the checklist', async function () {
+        it('dashboard does not show checklist by default', async function () {
             await visit('/dashboard');
+            expect(currentURL()).to.equal('/dashboard');
+
+            // onboarding isn't shown
+            expect(find('[data-test-dashboard="onboarding-checklist"]'), 'checklist').to.not.exist;
+
+            // other default dashboard elements are visible
+            expect(find('[data-test-dashboard="header"]'), 'header').to.exist;
+            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.exist;
+        });
+
+        it('dashboard shows the checklist after accessing setup/done', async function () {
+            await visit('/setup/done');
             expect(currentURL()).to.equal('/dashboard');
 
             // main onboarding list is visible


### PR DESCRIPTION
part of https://linear.app/tryghost/issue/IPC-81/remove-setupdone-screen-from-signup-flow

- when the `onboardingChecklist` flag is enabled the `setup/done` screen shown after install or signup will initiate the onboarding checklist and redirect straight to the dashboard effectively replacing the previous onboarding flow