### PR TITLE
Updated checklist hovers in dark mode

### DIFF
--- a/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
+++ b/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
@@ -68,7 +68,7 @@
         <a href="#" class="gh-onboarding-explore-dashboard" {{on "click" this.onboarding.completeChecklist}}>Explore your dashboard</a>
     {{/if}}
 
-    <p class="gh-onboarding-help">Need some more help? Check out our <a href="https://ghost.org/help?utm_source=admin&utm_campaign=onboarding" target="_blank" rel="noopener noreferrer">Help center</a></p>
+    <p class="gh-onboarding-help">Need some more help? Check out our <a href="https://ghost.org/help?utm_source=admin&utm_campaign=onboarding" target="_blank" rel="noopener noreferrer">Help Center</a></p>
 
     {{#unless this.onboarding.allStepsCompleted}}
         <a href="#" class="gh-onboarding-skip" {{on "click" this.onboarding.dismissChecklist}}>Skip onboarding</a>

--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -1380,6 +1380,14 @@ Onboarding checklist */
     background: #1c1e21;
 }
 
+.gh-onboarding-help a:hover {
+    color: var(--black);
+}
+
+.gh-onboarding-skip {
+    color: var(--middarkgrey);
+    border: 1px solid var(--lightgrey);
+}
 
 /* ---------------------------------
 Onboarding checklist: Share publication modal */


### PR DESCRIPTION
'Skip onboarding' and 'Help Center' hover states were not legible.