### PR TITLE
Onboarding checklist design updates

### DIFF
--- a/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
+++ b/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
@@ -10,8 +10,11 @@
             </video>
         {{/if}}
         
-        <h2 class="gh-canvas-title">{{this.siteUrl}} is ready to go!</h2>
-        <p>Let's set your publication up for success.</p>
+        {{#if this.onboarding.allStepsCompleted}}
+            <h2 class="gh-canvas-title">You’re all set.</h2>
+        {{else}}
+            <h2 class="gh-canvas-title">Let’s get started.</h2>
+        {{/if}}
     </div>
 
     <div class="gh-onboarding-items">
@@ -37,8 +40,8 @@
             <LinkTo @route="lexical-editor.new" @model="post" class="gh-onboarding-item {{onboarding-step-class "first-post"}}" {{on "click" (fn this.onboarding.markStepCompleted "first-post")}}>
                 <Dashboard::Onboarding::Step
                     @icon="writing"
-                    @title="Create your first post"
-                    @description="Explore the editor and tell your story."
+                    @title="Explore the editor"
+                    @description="Get to know a writing experience you’ll love."
                     @complete={{is-onboarding-step-completed "first-post"}}
                 />
             </LinkTo>

--- a/ghost/admin/app/components/dashboard/onboarding/share-modal.hbs
+++ b/ghost/admin/app/components/dashboard/onboarding/share-modal.hbs
@@ -24,7 +24,7 @@
     </div>
 
 
-    <span class="tip">Set your publication's cover image and description in <a href="settings/design/edit/?ref=share-modal" title="Adjust settings">Settings</a>.</span>
+    <span class="tip">Set your publication's cover image and description in <LinkTo @route="settings-x.settings-x" @model="design/edit?ref=setup">Design settings</LinkTo>.</span>
 
     <div class="copy-publication-link">
         <span>{{this.config.blogUrl}}</span>

--- a/ghost/admin/app/styles/layouts/dashboard.css
+++ b/ghost/admin/app/styles/layouts/dashboard.css
@@ -2770,6 +2770,7 @@ Onboarding checklist */
     align-items: center;
     flex-direction: column;
     min-height: 100vh;
+    margin-bottom: -48px;
     position: relative;
     /* background: url(img/gradient-bg.png) no-repeat; */
     background-size: contain;
@@ -2952,8 +2953,12 @@ Onboarding checklist */
     font-size: 1.5rem;
 }
 
+.gh-onboarding-help a {
+    color: #30cf43
+}
+
 .gh-onboarding-help a:hover {
-    color: var(--darkgrey);
+    color: #2bba3c;
 }
 
 .gh-onboarding-skip {

--- a/ghost/admin/app/templates/dashboard.hbs
+++ b/ghost/admin/app/templates/dashboard.hbs
@@ -91,11 +91,10 @@
                         <Dashboard::OnboardingChecklist />
                     {{/if}}
 
-                    {{#if this.hasPaidTiers}}
-                        <Dashboard::Charts::Overview />
-                    {{/if}}
-
                     {{#unless this.onboarding.isChecklistShown}}
+                        {{#if this.hasPaidTiers}}
+                            <Dashboard::Charts::Overview />
+                        {{/if}}
                         <div class="gh-dashboard-group {{if this.isTotalMembersZero 'is-zero'}}" data-test-dashboard="attribution">
                             <Dashboard::Charts::AnchorAttribution />
                             {{#if this.hasPaidTiers}}
@@ -120,21 +119,23 @@
                     {{/unless}}
                 {{/if}}
 
-                <div class="gh-dashboard-recents-mentions">
-                    <Dashboard::Charts::Recents />
-                </div>
+                {{#unless this.onboarding.isChecklistShown}}
+                    <div class="gh-dashboard-recents-mentions">
+                        <Dashboard::Charts::Recents />
+                    </div>
 
-                <div class="gh-dashboard-split gh-dashboard-box is-secondary">
-                    <Dashboard::Resources::Resources />
-                    <Dashboard::Resources::Newsletter />
-                </div>
+                    <div class="gh-dashboard-split gh-dashboard-box is-secondary">
+                        <Dashboard::Resources::Resources />
+                        <Dashboard::Resources::Newsletter />
+                    </div>
 
-                <Dashboard::Resources::ExploreFeed />
+                    <Dashboard::Resources::ExploreFeed />
 
-                <div class="gh-dashboard-split gh-dashboard-box no-boarder">
-                    <Dashboard::Resources::Community />
-                    <Dashboard::Resources::WhatsNew />
-                </div>
+                    <div class="gh-dashboard-split gh-dashboard-box no-boarder">
+                        <Dashboard::Resources::Community />
+                        <Dashboard::Resources::WhatsNew />
+                    </div>
+                {{/unless}}
             {{/if}}
         </section>
 


### PR DESCRIPTION
- Removed dashboard widgets when onboarding checklist is active for full focus
- Changed the link in Share modal to lead to Design settings modal, instead of just scrolling you to that part of Settings