### PR TITLE
Fixed setup/done screen showing 500 when not authenticated

### DIFF
--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject as service} from '@ember/service';
 
-export default class SetupFinishingTouchesRoute extends Route {
+export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
     @service feature;
     @service onboarding;
     @service router;
@@ -10,6 +10,8 @@ export default class SetupFinishingTouchesRoute extends Route {
     @service themeManagement;
 
     beforeModel() {
+        super.beforeModel(...arguments);
+
         if (!this.session.user.isOwnerOnly) {
             return;
         }

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -1,4 +1,4 @@
-import {authenticateSession} from 'ember-simple-auth/test-support';
+import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {currentURL, find, visit} from '@ember/test-helpers';
 import {describe, it} from 'mocha';
 import {enableLabsFlag} from '../helpers/labs-flag';
@@ -69,6 +69,18 @@ describe('Acceptance: Onboarding', function () {
             // other default dashboard elements are visible
             expect(find('[data-test-dashboard="header"]'), 'header').to.exist;
             expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.exist;
+        });
+    });
+
+    describe('unauthenticated', function () {
+        beforeEach(async function () {
+            this.server.db.users.remove();
+            await invalidateSession();
+        });
+
+        it('setup is redirected to signin', async function () {
+            await visit('/setup/done');
+            expect(currentURL()).to.equal('/signin');
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/IPC-136/setupdone-route-500s-if-you-hit-it-from-a-logged-out-state-instead-of

- the setup/done route was not set up as an authenticated route so no redirect occurred when accessing it directly before logging in which in turn caused an error because the route tries to read from the session user
