### PR TITLE
Updated onboarding copy and line-height

### DIFF
--- a/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
+++ b/ghost/admin/app/components/dashboard/onboarding-checklist.hbs
@@ -32,8 +32,8 @@
             <LinkTo @route="settings-x.settings-x" @model="design/edit?ref=setup" class="gh-onboarding-item {{onboarding-step-class "customize-design"}}" {{on "click" (fn this.onboarding.markStepCompleted "customize-design")}}>
                 <Dashboard::Onboarding::Step
                     @icon="brush"
-                    @title="Customize your publication"
-                    @description="Match the look and feel to your style and make it yours."
+                    @title="Customize your design"
+                    @description="Craft a look that reflects your own brand and style."
                     @complete={{is-onboarding-step-completed "customize-design"}}
                 />
             </LinkTo>

--- a/ghost/admin/app/styles/layouts/dashboard.css
+++ b/ghost/admin/app/styles/layouts/dashboard.css
@@ -2875,7 +2875,7 @@ Onboarding checklist */
 .gh-onboarding-item-title {
     font-weight: 700;
     font-size: 1.6rem;
-    line-height: 1;
+    line-height: 1.3;
     letter-spacing: 0;
     color: var(--darkgrey);
     padding: 0 32px 0 0;


### PR DESCRIPTION
fixes IPC-137

Descenders were being cut off in the titles due to the line-height not being set right.