### PR TITLE
Removed leftover alpha lab

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -52,10 +52,6 @@ const features = [{
     description: 'Adds a navigation link to the AdminX demo app',
     flag: 'adminXDemo'
 },{
-    title: 'New email addresses',
-    description: 'For self hosters, forces the usage of the mail.from config as from address for all outgoing emails',
-    flag: 'newEmailAddresses'
-},{
     title: 'Onboarding checklist',
     description: 'Onboarding checklist that helps new customers get started',
     flag: 'onboardingChecklist'


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1712150935653429

- the 'newEmailAddresses' feature has been released to GA, end of January (https://github.com/TryGhost/Ghost/commit/7d0be3f1a920c70cd48c76c765d8c67286698b6d)
- but, the flag was still shown as alpha in Settings
