### PR TITLE
Added queue depth to requests

### DIFF
--- a/ghost/core/core/server/web/parent/middleware/queue-request.js
+++ b/ghost/core/core/server/web/parent/middleware/queue-request.js
@@ -38,8 +38,6 @@ module.exports = function queueRequest(
      */
     queue.queue.on('queue', (job) => {
         debug(`Request queued: ${job.data.req.path}`);
-
-        job.data.req.queueDepth = job.queue.getLength();
     });
 
     queue.queue.on('complete', (job) => {
@@ -47,6 +45,8 @@ module.exports = function queueRequest(
     });
 
     return (req, res, next) => {
+        req.queueDepth = queue.queue.getLength();
+
         // Do not queue requests for static assets - We assume that any path
         // with a file extension is a static asset
         if (path.extname(req.path)) {


### PR DESCRIPTION
refs [CFR-14](https://linear.app/tryghost/issue/CFR-14/ensure-queue-depth-is-always-set-on-req)

Added queue depth to any request that passes through the request queue middleware instead of only adding it to the request if it is queued. This makes it easier to report on the queue depth within Elastic.