### PR TITLE
🐛 Fixed Gscan type error crashing settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
@@ -45,7 +45,7 @@ const ThemeInstalledModal: React.FC<{
     const handleError = useHandleError();
 
     let errorPrompt = null;
-    if (installedTheme.gscan_errors) {
+    if (installedTheme && installedTheme.gscan_errors) {
         errorPrompt = <div className="mt-6">
             <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
                 {installedTheme.gscan_errors?.map(error => <ThemeProblemView problem={error} />)}
@@ -54,7 +54,7 @@ const ThemeInstalledModal: React.FC<{
     }
 
     let warningPrompt = null;
-    if (installedTheme.warnings) {
+    if (installedTheme && installedTheme.warnings) {
         warningPrompt = <div className="mt-10">
             <List title="Warnings">
                 {installedTheme.warnings?.map(warning => <ThemeProblemView problem={warning} />)}


### PR DESCRIPTION
ref ENG-189

- A type error was flagged by Sentry where Settingscrashed where the API data wasn't formatted correctly and the error boundary didn't kick in.
- This adds additional safety to ensure the required data exists before attempting to render the elements.