### PR TITLE
Fixed browser tests broken by onboarding changes

### DIFF
--- a/ghost/admin/app/controllers/setup.js
+++ b/ghost/admin/app/controllers/setup.js
@@ -61,6 +61,11 @@ export default class SetupController extends Controller.extend(ValidationEngine)
 
             return true;
         } catch (error) {
+            // handle setup/done route redirecting to dashboard
+            if (error.message === 'TransitionAborted') {
+                return true;
+            }
+
             if (error && error.payload && error.payload.errors) {
                 if (isVersionMismatchError(error)) {
                     return this.notifications.showAPIError(error);
@@ -141,6 +146,11 @@ export default class SetupController extends Controller.extend(ValidationEngine)
             let [apiError] = error.payload.errors;
             this.set('flowErrors', [apiError.message, apiError.context].join(' '));
         } else {
+            // ignore setup/done route redirecting to dashboard
+            if (error.message === 'TransitionAborted') {
+                return true;
+            }
+
             // Connection errors don't return proper status message, only req.body
             this.notifications.showAlert('There was a problem on the server.', {type: 'error', key: 'setup.authenticate.failed'});
         }

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -60,7 +60,7 @@ const setupGhost = async (page) => {
         await page.getByPlaceholder('At least 10 characters').fill(ownerUser.password);
 
         await page.getByPlaceholder('At least 10 characters').press('Enter');
-        await page.locator('.gh-done-pink').click();
+
         await page.locator('.gh-nav').waitFor(options);
     }
 };


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/78311591d0947d3510b5c8584be39b1777a0bb60

- updated tests to not click a button on the setup/done screen that is no longer shown
- fixed setup flow showing an alert bar due to not handling the `TransitionAborted` error that is thrown by the setup/done->dashboard redirect