### PR TITLE
Removed admin-auth error logs for unknown message events

### DIFF
--- a/apps/comments-ui/src/utils/adminApi.ts
+++ b/apps/comments-ui/src/utils/adminApi.ts
@@ -14,9 +14,6 @@ export function setupAdminAPI({adminUrl}: {adminUrl: string}) {
         try {
             data = JSON.parse(event.data);
         } catch (err) {
-            /* eslint-disable no-console */
-            console.error('Error parsing event data', err);
-            /* eslint-enable no-console */
             return;
         }
 


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ENG-780

- the `admin-auth` frame was set up to log when any `message` event was handled but couldn't be parsed as JSON. For our own events that's fine but `message` events are also frequently triggered by browser extensions meaning the DevTools console log could become quite noisy for no reason
- removed the logging as it's noisy and not useful outside of development
