### PR TITLE
🎨 Changed TK reminders to be case-insensitive

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.3",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.1",
+    "@tryghost/koenig-lexical": "1.1.2",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,10 +7117,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.1.tgz#1ce93739a76a43016791e34b1b0c4e872c7fce5f"
-  integrity sha512-yUFEwaNLvqy+UtbyghwUsUPOgmhrlqw4LARp3ccO6dWp0LR6zL9r+nAjX6d0O/vZ6B6gWPYYlIWTS23vC0ti0Q==
+"@tryghost/koenig-lexical@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.2.tgz#309b9e98ba9a657750ba6719126ffa23685c8d6e"
+  integrity sha512-OPGJvOHr2JVT5X687JaXSHuArIw46uBAbfsL2QYdYc8HlHlvH1OibVdYEKPx2EVYIlKrqV8TB9T+LDRBq47D7Q==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-11

- updated Koenig packages to allow `tk`, `Tk`, and `tK` to be recognised as a TK reminder
