### PR TITLE
Improved long label handling

### DIFF
--- a/ghost/admin/app/components/gh-member-label-input.hbs
+++ b/ghost/admin/app/components/gh-member-label-input.hbs
@@ -19,7 +19,7 @@
     <div style="display: flex; width: 100%;">
         <span
             class="dropdown-label"
-            style="flex-grow: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+            style="display: -webkit-box; flex-grow: 1; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2;"
             title="{{label.name}}"
             data-test-label-filter={{label.name}}>
             {{label.name}}

--- a/ghost/admin/app/components/gh-token-input/label-token.js
+++ b/ghost/admin/app/components/gh-token-input/label-token.js
@@ -6,5 +6,5 @@ import {attributeBindings, classNames} from '@ember-decorators/component';
 @attributeBindings('title')
 @classNames('label-token')
 export default class LabelToken extends DraggableObject {
-    title = 'Label';
+    title = this.name ?? 'Label';
 }


### PR DESCRIPTION
ref DES-205

- label name is now used as the title on label pills instead of static text
- label names will now be truncated when it takes more than 2 lines instead of 1