### PR TITLE
Added initial support for /.well-known/webfinger 

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -388,6 +388,8 @@ async function initNestDependencies() {
     debug('Begin: initNestDependencies');
     const GhostNestApp = require('@tryghost/ghost');
     const providers = [];
+    const urlUtils = require('./shared/url-utils');
+    const activityPubBaseUrl = new URL('activitypub', urlUtils.urlFor('api', {type: 'admin'}, true));
     providers.push({
         provide: 'logger',
         useValue: require('@tryghost/logging')
@@ -400,6 +402,12 @@ async function initNestDependencies() {
     }, {
         provide: 'DomainEvents',
         useValue: require('@tryghost/domain-events')
+    }, {
+        provide: 'ActivityPubBaseURL',
+        useValue: activityPubBaseUrl
+    }, {
+        provide: 'SettingsCache',
+        useValue: require('./shared/settings-cache')
     });
     for (const provider of providers) {
         GhostNestApp.addProvider(provider);

--- a/ghost/ghost/src/common/entity.base.ts
+++ b/ghost/ghost/src/common/entity.base.ts
@@ -84,7 +84,7 @@ export class Entity<Data> {
     }
 
     get id() {
-        return this.attr.id;
+        return this.attr.id as ObjectID;
     }
 
     get createdAt() {

--- a/ghost/ghost/src/common/types/settings-cache.type.ts
+++ b/ghost/ghost/src/common/types/settings-cache.type.ts
@@ -1,0 +1,9 @@
+export type Settings = {
+    ghost_public_key: string;
+    ghost_private_key: string;
+    testing: boolean;
+};
+
+export interface SettingsCache {
+    get<KeyType extends keyof Settings>(key: KeyType): Settings[KeyType];
+}

--- a/ghost/ghost/src/core/activitypub/actor.entity.ts
+++ b/ghost/ghost/src/core/activitypub/actor.entity.ts
@@ -1,0 +1,79 @@
+import ObjectID from 'bson-objectid';
+import {Entity} from '../../common/entity.base';
+import {ActivityPub} from './types';
+
+type ActorData = {
+    username: string;
+    preferredUsername?: string;
+    publicKey: string;
+    privateKey: string;
+};
+
+type CreateActorData = ActorData & {
+    id? : ObjectID
+};
+
+function makeUrl(base: URL, props: Map<string, string>): URL {
+    const url = new URL(base.href);
+    for (const [key, value] of props.entries()) {
+        url.searchParams.set(key, value);
+    }
+    return url;
+}
+
+function toMap(obj: Record<string, string>): Map<string, string> {
+    return new Map(Object.entries(obj));
+}
+
+export class Actor extends Entity<ActorData> {
+    get username() {
+        return this.attr.username;
+    }
+
+    getJSONLD(url: URL): ActivityPub.Actor & ActivityPub.RootObject {
+        const actor = makeUrl(url, toMap({
+            type: 'actor',
+            id: this.id.toHexString()
+        }));
+
+        const publicKey = makeUrl(url, toMap({
+            type: 'key',
+            owner: this.id.toHexString()
+        }));
+
+        const inbox = makeUrl(url, toMap({
+            type: 'inbox',
+            owner: this.id.toHexString()
+        }));
+
+        const outbox = makeUrl(url, toMap({
+            type: 'outbox',
+            owner: this.id.toHexString()
+        }));
+
+        return {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'Person',
+            id: actor.href,
+            inbox: inbox.href,
+            outbox: outbox.href,
+            username: this.attr.username,
+            preferredUsername: this.attr.preferredUsername,
+            publicKey: {
+                id: publicKey.href,
+                owner: actor.href,
+                publicKeyPem: this.attr.publicKey
+            }
+        };
+    }
+
+    static create(data: CreateActorData) {
+        return new Actor({
+            id: data.id instanceof ObjectID ? data.id : undefined,
+            username: data.username,
+            preferredUsername: data.preferredUsername || data.username,
+            publicKey: data.publicKey,
+            privateKey: data.privateKey
+        });
+    }
+}

--- a/ghost/ghost/src/core/activitypub/actor.repository.ts
+++ b/ghost/ghost/src/core/activitypub/actor.repository.ts
@@ -1,0 +1,8 @@
+import ObjectID from 'bson-objectid';
+import {Actor} from './actor.entity';
+
+export interface ActorRepository {
+    getOne(username: string): Promise<Actor | null>
+    getOne(id: ObjectID): Promise<Actor | null>
+    save(actor: Actor): Promise<void>
+}

--- a/ghost/ghost/src/core/activitypub/types.ts
+++ b/ghost/ghost/src/core/activitypub/types.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ActivityPub {
+    export type AnonymousObject = {
+        '@context': string | string[];
+        id: null;
+        type: string | string[];
+    };
+
+    export type RootObject = {
+        '@context': string | string [];
+        id: string;
+        type: string | string[];
+    };
+
+    export type Object = RootObject | AnonymousObject;
+
+    export type Actor = ActivityPub.Object & {
+        inbox: string;
+        outbox: string;
+        username?: string;
+        preferredUsername?: string;
+        publicKey?: {
+            id: string,
+            owner: string,
+            publicKeyPem: string
+        }
+    };
+}

--- a/ghost/ghost/src/core/activitypub/webfinger.service.ts
+++ b/ghost/ghost/src/core/activitypub/webfinger.service.ts
@@ -1,0 +1,39 @@
+import {Inject} from '@nestjs/common';
+import {ActorRepository} from './actor.repository';
+
+const accountResource = /acct:(\w+)@(\w+)/;
+export class WebFingerService {
+    constructor(
+        @Inject('ActorRepository') private repository: ActorRepository,
+        @Inject('ActivityPubBaseURL') private url: URL
+    ) {}
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getResource(resource: string, rel?: string[]) {
+        const match = resource.match(accountResource);
+        if (!match) {
+            throw new Error('Invalid Resource');
+        }
+
+        const username = match[1];
+
+        const actor = await this.repository.getOne(username);
+
+        if (!actor) {
+            throw new Error('not found');
+        }
+
+        const result = {
+            subject: resource,
+            links: [
+                {
+                    rel: 'self',
+                    type: 'application/activity+json',
+                    href: actor.getJSONLD(this.url).id
+                }
+            ]
+        };
+
+        return result;
+    }
+}

--- a/ghost/ghost/src/db/in-memory/actor.repository.in-memory.ts
+++ b/ghost/ghost/src/db/in-memory/actor.repository.in-memory.ts
@@ -1,0 +1,41 @@
+import {Actor} from '../../core/activitypub/actor.entity';
+import {ActorRepository} from '../../core/activitypub/actor.repository';
+import ObjectID from 'bson-objectid';
+import {Inject} from '@nestjs/common';
+import {SettingsCache} from '../../common/types/settings-cache.type';
+
+export class ActorRepositoryInMemory implements ActorRepository {
+    actors: Actor[];
+
+    constructor(@Inject('SettingsCache') settingsCache: SettingsCache) {
+        this.actors = [
+            Actor.create({
+                id: ObjectID.createFromHexString('000000000000000000000000'),
+                username: 'index',
+                publicKey: settingsCache.get('ghost_public_key'),
+                privateKey: settingsCache.get('ghost_private_key')
+            })
+        ];
+    }
+
+    private getOneByUsername(username: string) {
+        return this.actors.find(actor => actor.username === username) || null;
+    }
+
+    private getOneById(id: ObjectID) {
+        return this.actors.find(actor => actor.id.equals(id)) || null;
+    }
+
+    async getOne(identifier: string | ObjectID) {
+        if (identifier instanceof ObjectID) {
+            return this.getOneById(identifier);
+        } else {
+            return this.getOneByUsername(identifier);
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async save(actor: Actor) {
+        throw new Error('Not Implemented');
+    }
+}

--- a/ghost/ghost/src/nestjs/modules/admin-api.module.ts
+++ b/ghost/ghost/src/nestjs/modules/admin-api.module.ts
@@ -2,18 +2,26 @@ import {DynamicModule} from '@nestjs/common';
 import {ExampleController} from '../../http/admin/controllers/example.controller';
 import {ExampleService} from '../../core/example/example.service';
 import {ExampleRepositoryInMemory} from '../../db/in-memory/example.repository.in-memory';
+import {ActorRepositoryInMemory} from '../../db/in-memory/actor.repository.in-memory';
+import {WebFingerService} from '../../core/activitypub/webfinger.service';
 
 class AdminAPIModuleClass {}
 
 export const AdminAPIModule: DynamicModule = {
     module: AdminAPIModuleClass,
     controllers: [ExampleController],
-    exports: [ExampleService],
+    exports: [ExampleService, 'WebFingerService'],
     providers: [
         ExampleService,
         {
             provide: 'ExampleRepository',
             useClass: ExampleRepositoryInMemory
+        }, {
+            provide: 'ActorRepository',
+            useClass: ActorRepositoryInMemory
+        }, {
+            provide: 'WebFingerService',
+            useClass: WebFingerService
         }
     ]
 };

--- a/ghost/ghost/src/nestjs/modules/admin-api.module.ts
+++ b/ghost/ghost/src/nestjs/modules/admin-api.module.ts
@@ -1,9 +1,12 @@
-import {Module} from '@nestjs/common';
+import {DynamicModule} from '@nestjs/common';
 import {ExampleController} from '../../http/admin/controllers/example.controller';
 import {ExampleService} from '../../core/example/example.service';
 import {ExampleRepositoryInMemory} from '../../db/in-memory/example.repository.in-memory';
 
-@Module({
+class AdminAPIModuleClass {}
+
+export const AdminAPIModule: DynamicModule = {
+    module: AdminAPIModuleClass,
     controllers: [ExampleController],
     exports: [ExampleService],
     providers: [
@@ -13,5 +16,4 @@ import {ExampleRepositoryInMemory} from '../../db/in-memory/example.repository.i
             useClass: ExampleRepositoryInMemory
         }
     ]
-})
-export class AdminAPIModule {}
+};


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-26
closes https://linear.app/tryghost/issue/MOM-27
ref https://webfinger.net/spec/

WebFinger is the protocol which allows different ActivityPub implementers to
find information about Actors, it's could be thought of as the entrypoint.
Given a username like @user@site.com, we can look up the URL for the Actor at

   https://website.com/.well-known/webfinger?resource=acct:user@site.com

This would then give us the info needed to discover the Actors Inbox & Outbox