### PR TITLE
Fixed length of `from` field in the `RedirectsImporter`

### DIFF
--- a/ghost/data-generator/lib/importers/RedirectsImporter.js
+++ b/ghost/data-generator/lib/importers/RedirectsImporter.js
@@ -37,7 +37,7 @@ class RedirectsImporter extends TableImporter {
         this.amount -= 1;
         return {
             id: this.fastFakeObjectId(),
-            from: `/r/${faker.datatype.hexadecimal({length: 32, prefix: '', case: 'lower'})}`,
+            from: `/r/${faker.datatype.hexadecimal({length: 8, prefix: '', case: 'lower'})}`,
             to: `${faker.internet.url()}/${faker.helpers.slugify(`${faker.word.adjective()} ${faker.word.noun()}`).toLowerCase()}`,
             post_id: this.model.id,
             created_at: this.model.published_at,


### PR DESCRIPTION
no issue

- The `RedirectsImporter` used by the data generator was creating redirects with the wrong length for the `from` field, which didn't match the actual behavior of Ghost.
- This commit corrects the length from 32 to 8, which is the actual length of the `from` field in production.
- This change has no impact on Ghost's behavior, but makes the data generator more representative of real world data for more accurate testing.