### PR TITLE
Moved ActivityPub API to frontend URL

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -389,7 +389,7 @@ async function initNestDependencies() {
     const GhostNestApp = require('@tryghost/ghost');
     const providers = [];
     const urlUtils = require('./shared/url-utils');
-    const activityPubBaseUrl = new URL('activitypub', urlUtils.urlFor('api', {type: 'admin'}, true));
+    const activityPubBaseUrl = new URL('activitypub', urlUtils.urlFor('home', true));
     providers.push({
         provide: 'logger',
         useValue: require('@tryghost/logging')

--- a/ghost/core/core/server/web/api/endpoints/admin/app.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/app.js
@@ -37,8 +37,17 @@ module.exports = function setupApiApp() {
 
     apiApp.use(async (req, res, next) => {
         if (labs.isSet('NestPlayground') || labs.isSet('ActivityPub')) {
+            const originalExpressApp = req.app;
             const app = await GhostNestApp.getApp();
-            app.getHttpAdapter().getInstance()(req, res, next);
+
+            const instance = app.getHttpAdapter().getInstance();
+            instance(Object.assign({}, req, {
+                url: req.originalUrl,
+                baseUrl: ''
+            }), res, function (err) {
+                req.app = originalExpressApp;
+                next(err);
+            });
             return;
         }
         return next();

--- a/ghost/ghost/src/http/admin/controllers/example.controller.ts
+++ b/ghost/ghost/src/http/admin/controllers/example.controller.ts
@@ -8,11 +8,18 @@
 import {
     Controller,
     Get,
-    Param
+    Param,
+    UseGuards,
+    UseInterceptors
 } from '@nestjs/common';
 import {Roles} from '../../../common/decorators/permissions.decorator';
 import {ExampleService} from '../../../core/example/example.service';
+import {LocationHeaderInterceptor} from '../../../nestjs/interceptors/location-header.interceptor';
+import {AdminAPIAuthentication} from '../../../nestjs/guards/admin-api-authentication.guard';
+import {PermissionsGuard} from '../../../nestjs/guards/permissions.guard';
 
+@UseInterceptors(LocationHeaderInterceptor)
+@UseGuards(AdminAPIAuthentication, PermissionsGuard)
 @Controller('greetings')
 export class ExampleController {
     constructor(private readonly service: ExampleService) {}

--- a/ghost/ghost/src/http/admin/controllers/webfinger.controller.ts
+++ b/ghost/ghost/src/http/admin/controllers/webfinger.controller.ts
@@ -1,0 +1,17 @@
+import {Controller, Get, Query} from '@nestjs/common';
+import {WebFingerService} from '../../../core/activitypub/webfinger.service';
+
+@Controller('.well-known/webfinger')
+export class WebFingerController {
+    constructor(
+        private readonly service: WebFingerService
+    ) {}
+
+    @Get('')
+    async getResource(@Query('resource') resource: unknown) {
+        if (typeof resource !== 'string') {
+            throw new Error('Bad Request');
+        }
+        return await this.service.getResource(resource);
+    }
+}

--- a/ghost/ghost/src/nestjs/modules/activitypub.module.ts
+++ b/ghost/ghost/src/nestjs/modules/activitypub.module.ts
@@ -1,0 +1,20 @@
+import {Module} from '@nestjs/common';
+import {ActorRepositoryInMemory} from '../../db/in-memory/actor.repository.in-memory';
+import {ActivityPubController} from '../../http/admin/controllers/activitypub.controller';
+import {WebFingerService} from '../../core/activitypub/webfinger.service';
+import {JSONLDService} from '../../core/activitypub/jsonld.service';
+import {WebFingerController} from '../../http/admin/controllers/webfinger.controller';
+
+@Module({
+    controllers: [ActivityPubController, WebFingerController],
+    exports: [],
+    providers: [
+        {
+            provide: 'ActorRepository',
+            useClass: ActorRepositoryInMemory
+        },
+        WebFingerService,
+        JSONLDService
+    ]
+})
+export class ActivityPubModule {}

--- a/ghost/ghost/src/nestjs/modules/admin-api.module.ts
+++ b/ghost/ghost/src/nestjs/modules/admin-api.module.ts
@@ -1,30 +1,17 @@
-import {DynamicModule} from '@nestjs/common';
+import {Module} from '@nestjs/common';
 import {ExampleController} from '../../http/admin/controllers/example.controller';
 import {ExampleService} from '../../core/example/example.service';
 import {ExampleRepositoryInMemory} from '../../db/in-memory/example.repository.in-memory';
-import {ActorRepositoryInMemory} from '../../db/in-memory/actor.repository.in-memory';
-import {ActivityPubController} from '../../http/admin/controllers/activitypub.controller';
-import {WebFingerService} from '../../core/activitypub/webfinger.service';
-import {JSONLDService} from '../../core/activitypub/jsonld.service';
 
-class AdminAPIModuleClass {}
-
-export const AdminAPIModule: DynamicModule = {
-    module: AdminAPIModuleClass,
-    controllers: [ExampleController, ActivityPubController],
-    exports: [ExampleService, 'WebFingerService'],
+@Module({
+    controllers: [ExampleController],
+    exports: [ExampleService],
     providers: [
         ExampleService,
         {
             provide: 'ExampleRepository',
             useClass: ExampleRepositoryInMemory
-        }, {
-            provide: 'ActorRepository',
-            useClass: ActorRepositoryInMemory
-        }, {
-            provide: 'WebFingerService',
-            useClass: WebFingerService
-        },
-        JSONLDService
+        }
     ]
-};
+})
+export class AdminAPIModule {}

--- a/ghost/ghost/src/nestjs/modules/app.module.ts
+++ b/ghost/ghost/src/nestjs/modules/app.module.ts
@@ -1,19 +1,29 @@
 import {DynamicModule} from '@nestjs/common';
-import {APP_FILTER, APP_GUARD, APP_INTERCEPTOR} from '@nestjs/core';
+import {APP_FILTER, RouterModule} from '@nestjs/core';
 import {AdminAPIModule} from './admin-api.module';
 import {NotFoundFallthroughExceptionFilter} from '../filters/not-found-fallthrough.filter';
 import {ExampleListener} from '../../listeners/example.listener';
-import {AdminAPIAuthentication} from '../guards/admin-api-authentication.guard';
-import {PermissionsGuard} from '../guards/permissions.guard';
-import {LocationHeaderInterceptor} from '../interceptors/location-header.interceptor';
 import {GlobalExceptionFilter} from '../filters/global-exception.filter';
+import {ActivityPubModule} from './activitypub.module';
 
 class AppModuleClass {}
 
 export const AppModule: DynamicModule = {
     global: true,
     module: AppModuleClass,
-    imports: [AdminAPIModule],
+    imports: [
+        RouterModule.register([
+            {
+                path: 'ghost/api/admin',
+                module: AdminAPIModule
+            }, {
+                path: '',
+                module: ActivityPubModule
+            }
+        ]),
+        AdminAPIModule,
+        ActivityPubModule
+    ],
     exports: [],
     controllers: [],
     providers: [
@@ -24,15 +34,6 @@ export const AppModule: DynamicModule = {
         }, {
             provide: APP_FILTER,
             useClass: NotFoundFallthroughExceptionFilter
-        }, {
-            provide: APP_GUARD,
-            useClass: AdminAPIAuthentication
-        }, {
-            provide: APP_GUARD,
-            useClass: PermissionsGuard
-        }, {
-            provide: APP_INTERCEPTOR,
-            useClass: LocationHeaderInterceptor
         }
     ]
 };


### PR DESCRIPTION
no-issue

There are a few changes here, we need to update the NestJS setup to handle the
entire URL, which means messing the with the req.url when feeding it requests
from the Admin API.

Then we split separate modules apart, so that long term we can add guards &
interceptors to the entire module, but that's not possible at the moment.

We also mount the NestJS application on the frontend, which means we can have
it handle the /.well-known/webfinger route!