### PR TITLE
Added missing JSON-LD context for publicKey definition

### DIFF
--- a/ghost/ghost/src/core/activitypub/actor.entity.ts
+++ b/ghost/ghost/src/core/activitypub/actor.entity.ts
@@ -29,7 +29,10 @@ export class Actor extends Entity<ActorData> {
         const outbox = new URL(`outbox/${id}`, url.href);
 
         return {
-            '@context': 'https://www.w3.org/ns/activitystreams',
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+                'https://w3id.org/security/v1'
+            ],
             type: 'Person',
             id: actor.href,
             inbox: inbox.href,


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-25

This _might_ be the reason that Mastodon doesn't recognise our Actor, but either way it's the correct thing to do so that JSON-LD parsers correctly understand that publicKey field