### PR TITLE
Wired up bookmark card internal linking proof of concept

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.3",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.2",
+    "@tryghost/koenig-lexical": "1.1.3",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,10 +7117,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.2.tgz#309b9e98ba9a657750ba6719126ffa23685c8d6e"
-  integrity sha512-OPGJvOHr2JVT5X687JaXSHuArIw46uBAbfsL2QYdYc8HlHlvH1OibVdYEKPx2EVYIlKrqV8TB9T+LDRBq47D7Q==
+"@tryghost/koenig-lexical@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.3.tgz#0136ae1d4f1086ebcd72dbb20439fa0668ebbcdf"
+  integrity sha512-2xKMlYqrfZyMLX57wZWYjLFKgZzC6EK8CubUBu5zeODKBfHsird4sofFP0R1yaRmc4qAdUgpQUW++/E65dM7Cw==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-1/

- added `feature.internalLinking` and `searchLinks` properties to the `cardConfig` object passed to the editor
- `searchLinks()` uses Admin's internal search to fetch and filter results
  - called with no search term to obtain default links to show as soon as the bookmark card is inserted, in our case we show the last 5 published posts. Result is cached for the duration of the editing session to avoid API queries/loading state after the first fetch
  - flattens search results for now because Koenig doesn't yet support grouped results
- bumps version of `@tryghost/koenig-lexical` to support the feature flag
