### PR TITLE
Updated `@doist/react-interpolate` to v1.0.0

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.23.3",
-    "@doist/react-interpolate": "0.4.1",
+    "@doist/react-interpolate": "1.0.0",
     "@sentry/react": "7.110.1",
     "@sentry/tracing": "7.110.1",
     "@testing-library/jest-dom": "5.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@doist/react-interpolate@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@doist/react-interpolate/-/react-interpolate-0.4.1.tgz#696d14e90ffc849e94a4e3e94578c5eade1590b8"
-  integrity sha512-JxBJMpDlXByMrA7T6Z+tRdCqXlbnM1ikfasLaqMrWvV4TvvrPuD7dngU/X01iP9tpAycfxasNvbNKFs/QehViQ==
+"@doist/react-interpolate@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@doist/react-interpolate/-/react-interpolate-1.0.0.tgz#902de7b590e53b81cf62f9f5d49aa625bad59653"
+  integrity sha512-Oxjv9eDN5tywsBnkF9sMBDt62i2Q9zU/92RaT+FO4/kH8h716eE8Oq09613mP2Y1ndRXDcxBTqk3RPvDM7RogQ==
 
 "@ebay/nice-modal-react@1.2.13":
   version "1.2.13"


### PR DESCRIPTION
refs https://github.com/Doist/react-interpolate/commit/ff466d4a8c3f87d91935a305eea5c3fefee45ffb refs https://ghost.slack.com/archives/CFH10N79S/p1713450302767339?thread_ts=1713439122.675249&cid=CFH10N79S refs https://linear.app/tryghost/issue/ENG-765/add-support-for-node-20

- this version has support for Node 20, which we need in order to add support for it