### PR TITLE
🐛 Fixed admin crash when deleting an unsaved or imported post

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -219,7 +219,7 @@
                 </form>
                 {{#unless this.post.isNew}}
                     <div class="settings-menu-delete-button">
-                        <button type="button" class="gh-btn gh-btn-outline gh-btn-icon gh-btn-fullwidth" {{action "deletePostInternal"}}>
+                        <button type="button" class="gh-btn gh-btn-outline gh-btn-icon gh-btn-fullwidth" {{action "deletePostInternal"}} data-test-button="delete-post">
                             <span>{{svg-jar "trash"}} Delete {{this.post.displayName}}</span>
                         </button>
                     </div>

--- a/ghost/admin/app/components/modals/delete-post.hbs
+++ b/ghost/admin/app/components/modals/delete-post.hbs
@@ -18,6 +18,7 @@
             @successText="Deleted"
             @task={{this.deletePostTask}}
             @class="gh-btn gh-btn-red gh-btn-icon"
+            data-test-button="delete-post-confirm"
         />
     </div>
 </div>

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1059,8 +1059,8 @@ export default class LexicalEditorController extends Controller {
         let deletedWithoutChanges = state.isDeleted
                 && (state.isSaving || !state.hasDirtyAttributes);
 
-        // If leaving the editor and the post has changed since we last saved a revision, always save a new revision
-        if (!this._saveOnLeavePerformed && hasChangedSinceLastRevision && hasDirtyAttributes) {
+        // If leaving the editor and the post has changed since we last saved a revision (and it's not deleted), always save a new revision
+        if (!this._saveOnLeavePerformed && hasChangedSinceLastRevision && hasDirtyAttributes && !state.isDeleted) {
             transition.abort();
             if (this._autosaveRunning) {
                 this.cancelAutosave();

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -646,3 +646,39 @@ test.describe('Updating post access', () => {
         ).toContainText(/\d+\s* subscriber/m);
     });
 });
+
+test.describe('Deleting a post', () => {
+    test('Delete a saved post', async ({page}) => {
+        await page.goto('/ghost');
+
+        await createPostDraft(page, {title: 'Delete a post test', body: 'This is the content'});
+
+        await expect(page.locator('[data-test-editor-post-status]')).toContainText('Draft - Saved');
+
+        await openPostSettingsMenu(page);
+
+        await page.locator('[data-test-button="delete-post"]').click();
+
+        await page.locator('[data-test-button="delete-post-confirm"]').click();
+        
+        await expect(
+            page.locator('[data-test-screen-title]')
+        ).toContainText('Posts');
+    });
+
+    test('Delete a post with unsaved changes', async ({page}) => {
+        await page.goto('/ghost');
+
+        await createPostDraft(page, {title: 'Delete a post test', body: 'This is the content'});
+
+        await openPostSettingsMenu(page);
+
+        await page.locator('[data-test-button="delete-post"]').click();
+
+        await page.locator('[data-test-button="delete-post-confirm"]').click();
+        
+        await expect(
+            page.locator('[data-test-screen-title]')
+        ).toContainText('Posts');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-845/error-attempted-to-set-lexical-on-the-deleted-record
ref https://linear.app/tryghost/issue/ENG-854/🐛-deleting-imported-posts-makes-ghost-unresponsive

- When deleting a post in the editor's Post Settings Menu, if the post has unsaved changes (indicated by the `hasDirtyAttributes` property in the editor), Admin will crash because it tries to save a post revision before leaving the editor, but the post has already been deleted so saving fails.
- This can occur when editing a post and quickly deleting it from the Post Settings Menu before saving is completed.
- It can also occur when attempting to delete an imported post, as the editor will parse the `lexical` from the server and may make some minor, invisible-to-the-user changes to the `lexical` string locally (e.g. JSON formatting, or updating the JSON to use extended version of base lexical nodes), which triggers the same error.
- This fix bypasses the attempt to save a post revision when leaving the editor if the post is already deleted, which allows the transition back to the Posts route to succeed.
