### PR TITLE
Fixed internal linking not correctly filtering to published-only

### DIFF
--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -18,14 +18,14 @@ export default class SearchService extends Service {
         {
             name: 'Posts',
             model: 'post',
-            fields: ['id', 'url', 'title'],
+            fields: ['id', 'url', 'title', 'status'],
             idField: 'id',
             titleField: 'title'
         },
         {
             name: 'Pages',
             model: 'page',
-            fields: ['id', 'url', 'title'],
+            fields: ['id', 'url', 'title', 'status'],
             idField: 'id',
             titleField: 'title'
         },
@@ -127,7 +127,8 @@ export default class SearchService extends Service {
                     id: `${searchable.model}.${item[searchable.idField]}`,
                     url: item.url,
                     title: item[searchable.titleField],
-                    groupName: searchable.name
+                    groupName: searchable.name,
+                    status: item.status
                 })
             );
 


### PR DESCRIPTION
no issue

- updated search to add `status` to the search results
- added filtering to the editor's `searchLinks()` method
- prevented TaskCancellation errors being thrown from the search task being cast to a Promise
