### PR TITLE
Updated mysql2 dependency

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -208,7 +208,7 @@
     "moment": "2.24.0",
     "moment-timezone": "0.5.23",
     "multer": "1.4.4",
-    "mysql2": "3.9.3",
+    "mysql2": "3.9.6",
     "nconf": "0.12.1",
     "node-jose": "2.2.0",
     "path-match": "1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22798,10 +22798,10 @@ mysql2@3.2.0:
     seq-queue "^0.0.5"
     sqlstring "^2.3.2"
 
-mysql2@3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-3.9.3.tgz#72a5e0c90d78ec2d8f9846e83727067c0cc8c25e"
-  integrity sha512-+ZaoF0llESUy7BffccHG+urErHcWPZ/WuzYAA9TEeLaDYyke3/3D+VQDzK9xzRnXpd0eMtRf0WNOeo4Q1Baung==
+mysql2@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.npmjs.org/mysql2/-/mysql2-3.9.6.tgz#93e21a2eebbe2c1dc8caca425e850aace2273b50"
+  integrity sha512-9NYUMLQv6yXnu+5hUh8PZ5CdKoG6VWDzXbojIdTyob8upNZXU3rBNQK9viaEqfgw+LMifhd+53VEZPxZk3bTWA==
   dependencies:
     denque "^2.1.0"
     generate-function "^2.3.1"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/20050

- Renovate seems to be unable to bump the package past the security release, but unfortunately this release contains a breaking bug
- this commit manually bumps the package so we can get things flowing again