### PR TITLE
Updated editor link search to group results

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -307,7 +307,10 @@ export default class KoenigLexicalEditor extends Component {
                     title: post.title,
                     url: post.url
                 }));
-                this.defaultLinks = results;
+                this.defaultLinks = [{
+                    label: 'Latest posts',
+                    items: results
+                }];
                 return this.defaultLinks;
             }
 
@@ -322,12 +325,15 @@ export default class KoenigLexicalEditor extends Component {
                 }
             }
 
-            // TODO: Add grouped results support to Koenig
-            const flattenedResults = [];
-            results.forEach(group => flattenedResults.push(...group.options));
-
             // only published posts/pages have URLs
-            const filteredResults = flattenedResults.filter(result => (result.groupName === 'Posts' || result.groupName === 'Pages') && result.status === 'published');
+            const filteredResults = results.map((group) => {
+                const items = (group.groupName === 'Posts' || group.groupName === 'Pages') ? group.options.filter(i => i.status === 'published') : group.options;
+
+                return {
+                    label: group.groupName,
+                    items
+                };
+            });
             return filteredResults;
         };
 

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "4.0.4",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.4",
+    "@tryghost/koenig-lexical": "1.1.5",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,10 +7117,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.4.tgz#9a6584eb57dbce46ab7f8e80f3d0d34a36e757e2"
-  integrity sha512-v7I21oLRl/7OIZZ75GL8Qh0hJ+x5+oGnQpvpXdhxrD060P6rSTSwM50mOTfrokczhH+BoOBOAQugramxser/Sw==
+"@tryghost/koenig-lexical@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.5.tgz#f31ab72ce792d6ed953e5ac72e429ee5965181ce"
+  integrity sha512-xaKVOXiENfi2FM9qdztrw7jPi9VEc+ovbu8C5hnvqLXBAA8SOpVaeSlJYWZulczi03IIyV9USs3s3KLaz1JGKg==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-49

- bumped koenig-lexical so the bookmark card has group support for testing
- updated `searchLinks` function passed to Koenig to match expected grouped results shape
