### PR TITLE
Updated Actor key id to use Actor URL with fragment 

### DIFF
--- a/ghost/ghost/src/core/activitypub/actor.entity.ts
+++ b/ghost/ghost/src/core/activitypub/actor.entity.ts
@@ -4,7 +4,6 @@ import {ActivityPub} from './types';
 
 type ActorData = {
     username: string;
-    preferredUsername?: string;
     publicKey: string;
     privateKey: string;
 };
@@ -24,7 +23,7 @@ export class Actor extends Entity<ActorData> {
         }
         const id = this.id.toHexString();
         const actor = new URL(`actor/${id}`, url.href);
-        const publicKey = new URL(`key/${id}`, url.href);
+        const publicKey = new URL(`actor/${id}#main-key`, url.href);
         const inbox = new URL(`inbox/${id}`, url.href);
         const outbox = new URL(`outbox/${id}`, url.href);
 
@@ -37,8 +36,7 @@ export class Actor extends Entity<ActorData> {
             id: actor.href,
             inbox: inbox.href,
             outbox: outbox.href,
-            username: this.attr.username,
-            preferredUsername: this.attr.preferredUsername,
+            preferredUsername: this.username,
             publicKey: {
                 id: publicKey.href,
                 owner: actor.href,
@@ -51,7 +49,6 @@ export class Actor extends Entity<ActorData> {
         return new Actor({
             id: data.id instanceof ObjectID ? data.id : undefined,
             username: data.username,
-            preferredUsername: data.preferredUsername || data.username,
             publicKey: data.publicKey,
             privateKey: data.privateKey
         });

--- a/ghost/ghost/src/core/activitypub/jsonld.service.ts
+++ b/ghost/ghost/src/core/activitypub/jsonld.service.ts
@@ -13,11 +13,6 @@ export class JSONLDService {
         return actor?.getJSONLD(this.url);
     }
 
-    async getPublicKey(owner: ObjectID) {
-        const actor = await this.repository.getOne(owner);
-        return actor?.getJSONLD(this.url).publicKey;
-    }
-
     async getOutbox(owner: ObjectID) {
         const actor = await this.repository.getOne(owner);
         if (!actor) {

--- a/ghost/ghost/src/http/admin/controllers/activitypub.controller.ts
+++ b/ghost/ghost/src/http/admin/controllers/activitypub.controller.ts
@@ -21,16 +21,6 @@ export class ActivityPubController {
 
     @Header('Cache-Control', 'no-store')
     @Roles(['Anon'])
-    @Get('key/:owner')
-    async getKey(@Param('owner') owner: unknown) {
-        if (typeof owner !== 'string') {
-            throw new Error('Bad Request');
-        }
-        return this.service.getPublicKey(ObjectID.createFromHexString(owner));
-    }
-
-    @Header('Cache-Control', 'no-store')
-    @Roles(['Anon'])
     @Get('outbox/:owner')
     async getOutbox(@Param('owner') owner: unknown) {
         if (typeof owner !== 'string') {

--- a/ghost/ghost/src/http/admin/controllers/activitypub.controller.ts
+++ b/ghost/ghost/src/http/admin/controllers/activitypub.controller.ts
@@ -10,6 +10,7 @@ export class ActivityPubController {
     ) {}
 
     @Header('Cache-Control', 'no-store')
+    @Header('Content-Type', 'application/ld+json')
     @Roles(['Anon'])
     @Get('actor/:id')
     async getActor(@Param('id') id: unknown) {
@@ -20,6 +21,7 @@ export class ActivityPubController {
     }
 
     @Header('Cache-Control', 'no-store')
+    @Header('Content-Type', 'application/ld+json')
     @Roles(['Anon'])
     @Get('outbox/:owner')
     async getOutbox(@Param('owner') owner: unknown) {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-25

This matches the way that mastodon handles the key url and may be the reason
these documents are incompatible. This also removes the `username` key as that
isn't used anywhere, instead we have a username property which is rendered as
the ActivityPub compat preferredUsername key.