### PR TITLE
Fixed email footer text styling inconsistencies

### DIFF
--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -1398,6 +1398,10 @@ a[data-flickr-embed] img {
         font-size: 12px !important;
     }
 
+    .footer p, .footer span, .footer a {
+        font-size: 12px !important;
+    }
+
     table.body .post-title a {
         font-size: 32px !important;
         line-height: 1.15em !important;

--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -1283,7 +1283,7 @@ a[data-flickr-embed] img {
     table.body ul,
     table.body ol,
     table.body td {
-        font-size: 16px !important;
+        font-size: 16px;
     }
 
     table.body pre {
@@ -1388,18 +1388,14 @@ a[data-flickr-embed] img {
     }
 
 
-    table.body .footer p {
-        font-size: 12px !important;
+    table.body .footer p, table.body .footer p span {
+        font-size: 13px !important;
     }
 
     table.body .view-online-link,
     table.body .footer,
-    table.body .footer a {
-        font-size: 12px !important;
-    }
-
-    .footer p, .footer span, .footer a {
-        font-size: 12px !important;
+    table.body .footer a, {
+        font-size: 13px !important;
     }
 
     table.body .post-title a {


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/DES-260/footer-link-text-smaller-than-regular-text

There was a bit of CSS in a media query aimed at other parts of the newsletter template that was causing the footer styling to break. I added some more specific styling for the footer as well, to make sure span's within the `<p>` element are covered as well.