### PR TITLE
Updated 'Users' to 'Staff' in search dropdown component

### DIFF
--- a/ghost/admin/app/components/gh-search-input.js
+++ b/ghost/admin/app/components/gh-search-input.js
@@ -25,7 +25,7 @@ export default class GhSearchInputComponent extends Component {
             this.router.transitionTo('lexical-editor.edit', 'page', id);
         }
 
-        if (selected.groupName === 'Users') {
+        if (selected.groupName === 'Staff') {
             let id = selected.id.replace('user.', '');
             this.router.transitionTo('settings-x.settings-x', `staff/${id}`);
         }

--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -30,7 +30,7 @@ export default class SearchService extends Service {
             titleField: 'title'
         },
         {
-            name: 'Users',
+            name: 'Staff',
             model: 'user',
             fields: ['id', 'slug', 'url', 'name'], // id not used but required for API to have correct url
             idField: 'slug',

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -65,7 +65,7 @@ describe('Acceptance: Search', function () {
         expect(find('[data-test-modal="search"]'), 'search modal').to.not.exist;
     });
 
-    it('finds posts, pages, users, and tags when typing', async function () {
+    it('finds posts, pages, staff, and tags when typing', async function () {
         await visit('/dashboard');
         await click('[data-test-button="search"]');
         await typeInSearch('first'); // search is not case sensitive
@@ -73,7 +73,7 @@ describe('Acceptance: Search', function () {
         // all groups are present
         const groupNames = findAll('.ember-power-select-group-name');
         expect(groupNames, 'group names').to.have.length(4);
-        expect(groupNames.map(el => el.textContent.trim())).to.deep.equal(['Posts', 'Pages', 'Users', 'Tags']);
+        expect(groupNames.map(el => el.textContent.trim())).to.deep.equal(['Posts', 'Pages', 'Staff', 'Tags']);
 
         // correct results are found
         const options = findAll('.ember-power-select-option');


### PR DESCRIPTION
No ref

- This copy change allows us to use consistent copy in both the general search as well as the internal linking search component in the editor.