### PR TITLE
Removed Sentry logging from XMLRPC service

### DIFF
--- a/ghost/core/core/server/services/xmlrpc.js
+++ b/ghost/core/core/server/services/xmlrpc.js
@@ -7,7 +7,6 @@ const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
 const settingsCache = require('../../shared/settings-cache');
-const sentry = require('../../shared/sentry');
 
 // Used to receive post.published model event
 const events = require('../lib/common/events');
@@ -110,7 +109,6 @@ function ping(post) {
                     });
                 }
                 logging.error(error);
-                sentry.captureException(error);
             });
     });
 }


### PR DESCRIPTION
refs https://ghost-foundation.sentry.io/issues/5135326925/

- the service tends to 503 all the time, and we don't really care enough for it to ping us in Sentry, as it's not something we control
- we can still keep logging the errors in case we need to go and look at what went wrong