### PR TITLE
Made subscription link in newsletter preview use brand color

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -92,6 +92,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
     } : {};
 
     return <NewsletterPreviewContent
+        accentColor={siteData.accent_color}
         authorPlaceholder={currentUser.name || currentUser.email}
         backgroundColor={colors.backgroundColor || '#ffffff'}
         bodyFontCategory={newsletter.body_font_category}

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -36,6 +36,7 @@ const NewsletterPreviewContent: React.FC<{
     backgroundColor?: string;
     borderColor?: string;
     secondaryBorderColor?: string;
+    accentColor?: string;
     textColor?: string;
     secondaryTextColor?: string;
     titleColor?: string;
@@ -66,6 +67,7 @@ const NewsletterPreviewContent: React.FC<{
     backgroundColor,
     borderColor,
     secondaryBorderColor,
+    accentColor,
     textColor,
     secondaryTextColor,
     titleColor
@@ -235,7 +237,7 @@ const NewsletterPreviewContent: React.FC<{
                                             <p style={{color: textColor}}>Email: jamie@example.com</p>
                                             <p style={{color: textColor}}>Member since: 17 July 2023</p>
                                         </div>
-                                        <span className={clsx('w-full self-end whitespace-nowrap text-right text-base font-semibold', backgroundColorIsDark ? 'text-white underline' : 'text-pink')}>
+                                        <span className={clsx('w-full self-end whitespace-nowrap text-right text-base font-semibold', backgroundColorIsDark && 'text-white underline')} style={{color: accentColor}}>
                                             Manage subscription →
                                         </span>
                                     </div>


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/DES-220/email-preview-manage-subscription-link-in-sub-details-is-hardcoded-to