### PR TITLE
Added Redis via Docker

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       interval: 1s
       retries: 120
   redis:
-    image: redis:7.2
+    image: redis:7.0
     container_name: ghost-redis
     ports:
       - "6379:6379"

--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -21,3 +21,9 @@ services:
       test: "mysql -uroot -proot ghost -e 'select 1'"
       interval: 1s
       retries: 120
+  redis:
+    image: redis:7.2
+    container_name: ghost-redis
+    ports:
+      - "6379:6379"
+    restart: always


### PR DESCRIPTION
no refs

Redis can be utilised for various caching purposes within Ghost. This PR adds a Redis service to the docker-compose file to allow for easier local development when Redis is required