### PR TITLE
Moved `internalLinking` and `stripeAutomaticTax` flags to beta

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -20,7 +20,7 @@ const features = [{
     description: <>Test out Websockets functionality at <code>/ghost/#/websockets</code>.</>,
     flag: 'websockets'
 },{
-    title: 'Stripe Automatic Tax',
+    title: 'Stripe Automatic Tax (private beta)',
     description: 'Use Stripe Automatic Tax at Stripe Checkout. Needs to be enabled in Stripe',
     flag: 'stripeAutomaticTax'
 },{
@@ -64,7 +64,7 @@ const features = [{
     description: 'Enables features to help combat spam member signups',
     flag: 'membersSpamPrevention'
 },{
-    title: 'Internal Linking',
+    title: 'Internal Linking (private beta)',
     description: 'Adds internal URL search to editor link inputs',
     flag: 'internalLinking'
 },{

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -34,6 +34,8 @@ const BETA_FEATURES = [
     'additionalPaymentMethods',
     'i18n',
     'activitypub',
+    'internalLinking',
+    'stripeAutomaticTax',
     'webmentions'
 ];
 
@@ -43,7 +45,6 @@ const ALPHA_FEATURES = [
     'urlCache',
     'lexicalMultiplayer',
     'websockets',
-    'stripeAutomaticTax',
     'emailCustomization',
     'mailEvents',
     'collectionsCard',
@@ -52,8 +53,7 @@ const ALPHA_FEATURES = [
     'lexicalIndicators',
     // 'adminXOffers',
     'adminXDemo',
-    'membersSpamPrevention',
-    'internalLinking'
+    'membersSpamPrevention'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1714051665654659?thread_ts=1713970812.191919&cid=C02G9E68C

- this enables us to enable the flags on sites without the need to enable developer experiments