### PR TITLE
Removed dupe ActivityPub labs key

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -53,7 +53,6 @@ const ALPHA_FEATURES = [
     // 'adminXOffers',
     'adminXDemo',
     'membersSpamPrevention',
-    'ActivityPub',
     'internalLinking'
 ];
 


### PR DESCRIPTION
no issue

- rebased from main without seeing there's an existing flag.
- this removes that flag