### PR TITLE
Fixed overly verbose DatabaseInfo require

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.0/2022-03-14-12-33-delete-duplicate-offer-redemptions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.0/2022-03-14-12-33-delete-duplicate-offer-redemptions.js
@@ -1,4 +1,4 @@
-const DatabaseInfo = require('@tryghost/database-info/lib/database-info');
+const DatabaseInfo = require('@tryghost/database-info');
 const logging = require('@tryghost/logging');
 
 const {createTransactionalMigration} = require('../../utils');


### PR DESCRIPTION
- we don't need to deep require into the library as it exports what we need on the surface
- this should unblock https://github.com/TryGhost/Ghost/pull/19002, as it's randomly failing with this require