### PR TITLE
Added `customer_update` param to StripeAPI

### DIFF
--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -475,9 +475,7 @@ module.exports = class StripeAPI {
             automatic_tax: {
                 enabled: this._config.enableAutomaticTax
             },
-            customer_update: {
-                address: 'auto'
-            },
+            customer_update: this._config.enableAutomaticTax ? {address: 'auto'} : {},
             metadata,
             discounts,
             /*
@@ -529,9 +527,7 @@ module.exports = class StripeAPI {
             automatic_tax: {
                 enabled: this._config.enableAutomaticTax
             },
-            customer_update: {
-                address: 'auto'
-            },
+            customer_update: this._config.enableAutomaticTax ? {address: 'auto'} : {},
             metadata,
             customer: customer ? customer.id : undefined,
             customer_email: !customer && customerEmail ? customerEmail : undefined,

--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -475,6 +475,9 @@ module.exports = class StripeAPI {
             automatic_tax: {
                 enabled: this._config.enableAutomaticTax
             },
+            customer_update: {
+                address: 'auto'
+            },
             metadata,
             discounts,
             /*
@@ -525,6 +528,9 @@ module.exports = class StripeAPI {
             cancel_url: cancelUrl || this._config.checkoutSessionCancelUrl,
             automatic_tax: {
                 enabled: this._config.enableAutomaticTax
+            },
+            customer_update: {
+                address: 'auto'
             },
             metadata,
             customer: customer ? customer.id : undefined,


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-881/stripe-tax-checkout-instantiation-fails-for-free-members-when-choosing

- For existing customers to be able to upgrade their account with automatic tax enabled, we need to pass in `customer_update[address]:auto` as per Stripe documentation.
- `Automatic tax calculation in Checkout requires a valid address on the Customer. Add a valid address to the Customer or set either 'customer_update[address]' to 'auto' or 'customer_update[shipping]' to 'auto' to save the address entered in Checkout to the Customer.`
- We update the existing customer details by passing in address `auto when they upgrade their accounts.
- Stripe captures the billing address information by default when new accounts are created and then that is used to calculate the tax rate.
