### PR TITLE
Removed Sentry error capturing for failed URL decoding

### DIFF
--- a/ghost/core/core/frontend/helpers/url.js
+++ b/ghost/core/core/frontend/helpers/url.js
@@ -7,7 +7,6 @@
 const {metaData} = require('../services/proxy');
 const {SafeString} = require('../services/handlebars');
 const logging = require('@tryghost/logging');
-const sentry = require('../../shared/sentry');
 const errors = require('@tryghost/errors');
 
 const {getMetaDataUrl} = metaData;
@@ -26,7 +25,6 @@ module.exports = function url(options) {
             message: `The url "${outputUrl}" couldn't be escaped correctly`,
             err: err
         });
-        sentry.captureException(error);
         logging.error(error);
 
         return new SafeString('');


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-79/incorrectusageerror-the-url-httpsblogkongregatecompercentc0-couldnt-be

- we added this Sentry captureException whilst fixing a bug where decodeUrl could fail, and throw a 500 exception
- we added handling for that case and returned an empty string, but we also added Sentry error capturing
- at this point, I don't think we need to be capturing errors in Sentry, because the issue is already handled, and it only usually happens with malicious/incorrect URLs
- this is our #2 cause of Sentry alerts, so it's good to clean it up