### PR TITLE
Updated canary build CI to use the main Moya build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -961,8 +961,8 @@ jobs:
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
           token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          workflow: .github/workflows/deploy-optimised.yml
-          ref: 'refs/heads/assets-build'
+          workflow: .github/workflows/deploy.yml
+          ref: 'refs/heads/main'
           repo: TryGhost/Ghost-Moya
           inputs: ${{ env.CANARY_BUILD_INPUTS }}
           wait-for-completion-timeout: 25m


### PR DESCRIPTION
ref ENG-807

The new moya build process has been merged into main so this needs to change to point back at the main build pipeline.
