### PR TITLE
Bumped koenig-lexical

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.0.4",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.6",
+    "@tryghost/koenig-lexical": "1.1.7",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,10 +7103,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.6.tgz#9e431b40ae0d5cc60ead8e679590c04c0a02bd36"
-  integrity sha512-BrUpMIjU4GrtsotruslhrcU2dRuWhpweEYVS19IhDqm/ShFYct6jBEpF7f/qOPgec1fZLuLOdvT6P5WNb08XOw==
+"@tryghost/koenig-lexical@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.7.tgz#1084b873e65c73816c378bf5e801600f43fc7add"
+  integrity sha512-TuxmAJAn+XpY81/gHDaiHI3AHqiYBXRERJUI6bRJkxOIQvaONknV4qwjnbdhePguh4HPYuWpcS0yaJO0F8IIuw==
 
 "@tryghost/limit-service@1.2.14", "@tryghost/limit-service@^1.2.10":
   version "1.2.14"


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PA-53/add-posthog-tracking-to-trackevent-in-admin-x-settings-and-lexical

- Added `posthog.capture` to koenig-lexical's existing `trackEvent` function to start sending events from the editor to PostHog