### PR TITLE
Added cache-control: private headers for all link redirects

### DIFF
--- a/ghost/link-redirects/lib/LinkRedirectsService.js
+++ b/ghost/link-redirects/lib/LinkRedirectsService.js
@@ -113,6 +113,8 @@ class LinkRedirectsService {
             DomainEvents.dispatch(event);
 
             res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+            // Don't cache redirects because we want to track the click events
+            res.setHeader('Cache-Control', 'private');
             return res.redirect(link.to.href);
         } catch (e) {
             return next(e);

--- a/ghost/link-redirects/test/LinkRedirectsService.test.js
+++ b/ghost/link-redirects/test/LinkRedirectsService.test.js
@@ -98,6 +98,7 @@ describe('LinkRedirectsService', function () {
             assert.equal(res.redirect.callCount, 1);
             assert.equal(res.redirect.getCall(0).args[0], 'https://localhost:2368/b');
             assert(res.setHeader.calledWith('X-Robots-Tag', 'noindex, nofollow'));
+            assert(res.setHeader.calledWith('Cache-Control', 'private'));
         });
 
         it('does not redirect if not found', async function () {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-883/add-cache-control-private-headers-to-the-link-redirects

- Link redirects shouldn't be cached because we record which member clicked the link on the redirect
- This PR adds `cache-control: private` headers to all link redirects to prevent them from being cached