### PR TITLE
Moved POST /members/api/member behind alpha flag

### DIFF
--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -38,7 +38,11 @@ module.exports = function setupMembersApp() {
     // We don't want to add global bodyParser middleware as that interferes with stripe webhook requests on - `/webhooks`.
 
     // Double opt-in subscription handling
-    membersApp.post('/api/member', membersService.api.middleware.createMemberFromToken);
+    membersApp.post(
+        '/api/member',
+        labs.enabledMiddleware('membersSpamPrevention'),
+        membersService.api.middleware.createMemberFromToken
+    );
 
     // Manage newsletter subscription via unsubscribe link
     membersApp.get('/api/member/newsletters', middleware.getMemberNewsletters);


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-78

- the `POST /members/api/member` endpoint is solely used by the alpha feature `membersSpamPrevention` and should not be available otherwise
