### PR TITLE
Protected against deleting non-existent image during upload

### DIFF
--- a/ghost/core/core/server/web/api/middleware/upload.js
+++ b/ghost/core/core/server/web/api/middleware/upload.js
@@ -45,7 +45,13 @@ const messages = {
 const enabledClear = config.get('uploadClear') || true;
 const upload = multer({dest: os.tmpdir()});
 
-const deleteSingleFile = file => fs.unlink(file.path).catch(err => logging.error(err));
+const deleteSingleFile = (file) => {
+    if (!file.path) {
+        return;
+    }
+
+    fs.unlink(file.path).catch(err => logging.error(err));
+};
 
 const single = name => function singleUploadFunction(req, res, next) {
     const singleUpload = upload.single(name);

--- a/ghost/core/test/e2e-api/admin/__snapshots__/images.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/images.test.js.snap
@@ -90,6 +90,24 @@ Object {
 }
 `;
 
+exports[`Images API Does not try to delete non-existing file upon invalid request 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Please select an image.",
+      "property": null,
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
 exports[`Images API Will error when filename is too long 1: [body] 1`] = `
 Object {
   "errors": Array [


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-93/undefined-path-error-with-bad-image-upload

- in the event we receive a request to upload an image, that doesn't contain an image, we still try and unlink the files
- this is a dangling promise, so it doesn't cause an explicit HTTP error, but it does show up as a console error
- fixed it by checking for the path, and early returning if it doesn't exist
- also added a test that would fail without this
