### PR TITLE
Added initial implementation of internal linking for standard links

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.0.4",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.7",
+    "@tryghost/koenig-lexical": "1.1.8",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,10 +7103,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.7.tgz#1084b873e65c73816c378bf5e801600f43fc7add"
-  integrity sha512-TuxmAJAn+XpY81/gHDaiHI3AHqiYBXRERJUI6bRJkxOIQvaONknV4qwjnbdhePguh4HPYuWpcS0yaJO0F8IIuw==
+"@tryghost/koenig-lexical@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.8.tgz#38155df321249d31195c25af5ec70a437036a5b0"
+  integrity sha512-XQkuBY/qBQNzidTawWLulT1dRSsrIuPUe46BSm2tmXJMAblw/IAu/ckS5nn0WfH7eqQQZuXeK7PTBWb1RQ6SlA==
 
 "@tryghost/limit-service@1.2.14", "@tryghost/limit-service@^1.2.10":
   version "1.2.14"


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-81

- bumps `@tryghost/koenig-lexical` to version with updated internal linking beta features
