### PR TITLE
Added an optional timeout parameter to `AdapterCacheRedis`

### DIFF
--- a/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
+++ b/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
@@ -59,6 +59,31 @@ describe('Adapter Cache Redis', function () {
 
             assert.equal(value, 'value from cache');
         });
+
+        it('returns null if getTimeoutMilliseconds is exceeded', async function () {
+            const redisCacheInstanceStub = {
+                get: sinon.stub().callsFake(async () => {
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve('value from cache');
+                        }, 200);
+                    });
+                }),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub,
+                getTimeoutMilliseconds: 100
+            });
+
+            const value = await cache.get('key');
+            assert.equal(value, null);
+        });
+
         it('can update the cache in the case of a cache miss', async function () {
             const KEY = 'update-cache-on-miss';
             let cachedValue = null;

--- a/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
+++ b/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
@@ -159,9 +159,9 @@ module.exports = class LinkRedirectRepository {
 
         if (this.#cache) {
             const cachedLink = await this.#cache.get(from);
+            debug(`getByUrl ${url}: Cache ${cachedLink ? 'HIT' : 'MISS'}`);
             // Cache hit, serve from cache
             if (cachedLink) {
-                debug('Cache hit for', from);
                 return this.#fromSerialized(cachedLink);
             }
         }
@@ -174,8 +174,6 @@ module.exports = class LinkRedirectRepository {
         if (linkRedirectModel) {
             const linkRedirect = this.fromModel(linkRedirectModel);
             if (this.#cache) {
-                debug('Cache miss for', from, '. Caching');
-                // Cache the link
                 this.#cache.set(from, this.#serialize(linkRedirect));
             }
             return linkRedirect;


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-902/add-an-optional-timeout-in-the-redis-cache-adapter-in-case-redis

- Added an optional timeout parameter to AdapterCacheRedis, so that the `get(key)` method will return `null` after the timeout if it hasn't received a response from Redis
- When load testing the `LinkRedirectRepository` with the Redis cache enabled on staging, we noticed that for some reason Redis stopped responding to commands for ~30 seconds.
- The `LinkRedirectRepository` was waiting for the Redis cache to respond and resulted in a drastic increase in response times for link redirects
- This change will allow us to set a timeout on the `get(key)` method, so that if Redis doesn't respond within the timeout, the method will return `null` as if it were a cache miss.
- Then the `LinkRedirectRepository` will fall back to the database and return the link redirect from the database instead of waiting indefinitely for Redis to respond