### PR TITLE
Fixed empty groups in internal link searches

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -326,14 +326,20 @@ export default class KoenigLexicalEditor extends Component {
             }
 
             // only published posts/pages have URLs
-            const filteredResults = results.map((group) => {
+            const filteredResults = [];
+            results.forEach((group) => {
                 const items = (group.groupName === 'Posts' || group.groupName === 'Pages') ? group.options.filter(i => i.status === 'published') : group.options;
 
-                return {
+                if (items.length === 0) {
+                    return;
+                }
+
+                filteredResults.push({
                     label: group.groupName,
                     items
-                };
+                });
             });
+
             return filteredResults;
         };
 


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-101

- we were mapping over the grouped search results which meant we still got a group even if it's options/items list was empty after filtering for published
