### PR TITLE
🐛 Fixed Admin search sometimes stalling on first query

### DIFF
--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import {isBlank, isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
-import {task, timeout, waitForProperty} from 'ember-concurrency';
+import {task, timeout} from 'ember-concurrency';
 
 export default class SearchService extends Service {
     @service ajax;
@@ -59,7 +59,7 @@ export default class SearchService extends Service {
 
         // wait for any on-going refresh to finish
         if (this.refreshContentTask.isRunning) {
-            yield waitForProperty(this, 'refreshContentTask.isIdle');
+            yield this.refreshContentTask.lastRunning;
         }
 
         const searchResult = this._searchContent(term);

--- a/ghost/admin/mirage/config/posts.js
+++ b/ghost/admin/mirage/config/posts.js
@@ -23,6 +23,28 @@ function extractTags(postAttrs, tags) {
     });
 }
 
+// TODO: handle authors filter
+export function getPosts({posts}, {queryParams}) {
+    let {filter, page, limit} = queryParams;
+
+    page = +page || 1;
+    limit = +limit || 15;
+
+    let statusFilter = extractFilterParam('status', filter);
+
+    let collection = posts.all().filter((post) => {
+        let matchesStatus = true;
+
+        if (!isEmpty(statusFilter)) {
+            matchesStatus = statusFilter.includes(post.status);
+        }
+
+        return matchesStatus;
+    });
+
+    return paginateModelCollection('posts', collection, page, limit);
+}
+
 export default function mockPosts(server) {
     server.post('/posts', function ({posts, users, tags}) {
         let attrs = this.normalizedRequestAttrs();
@@ -38,26 +60,7 @@ export default function mockPosts(server) {
     });
 
     // TODO: handle authors filter
-    server.get('/posts/', function ({posts}, {queryParams}) {
-        let {filter, page, limit} = queryParams;
-
-        page = +page || 1;
-        limit = +limit || 15;
-
-        let statusFilter = extractFilterParam('status', filter);
-
-        let collection = posts.all().filter((post) => {
-            let matchesStatus = true;
-
-            if (!isEmpty(statusFilter)) {
-                matchesStatus = statusFilter.includes(post.status);
-            }
-
-            return matchesStatus;
-        });
-
-        return paginateModelCollection('posts', collection, page, limit);
-    });
+    server.get('/posts/', getPosts);
 
     server.get('/posts/:id/', function ({posts}, {params}) {
         let {id} = params;


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-103

- the `yield waitForProperty(...)` call that was supposed to return once the content refresh occurred never reached a valid state so the first search query (or any later query) where a content refresh occurred would never resolve causing search to look like it had stalled
- switched to waiting for the last running task to resolve instead which does the same as the previous code intended
- exported the `getPosts` request handler function so in mirage config so we can re-use it with different timing on a per-case basis
