### PR TITLE
🐛 Fixed error rendering when using a duplicate offer code

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -37,6 +37,7 @@ interface MockRequestConfig {
     path: string | RegExp;
     response: unknown;
     responseStatus?: number;
+    responseHeaders?: {[key: string]: string};
 }
 
 interface RequestRecord {
@@ -189,7 +190,8 @@ export async function mockApi<Requests extends Record<string, MockRequestConfig>
 
         await route.fulfill({
             status: matchingMock.responseStatus || 200,
-            body: typeof matchingMock.response === 'string' ? matchingMock.response : JSON.stringify(matchingMock.response)
+            body: typeof matchingMock.response === 'string' ? matchingMock.response : JSON.stringify(matchingMock.response),
+            headers: matchingMock.responseHeaders || {}
         });
     });
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -1,8 +1,9 @@
 import NiceModal from '@ebay/nice-modal-react';
 import PortalFrame from '../../membership/portal/PortalFrame';
-// import useFeatureFlag from '../../../../hooks/useFeatureFlag';
+import toast from 'react-hot-toast';
 import {Button, ConfirmationModal, Form, PreviewModalContent, TextArea, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {Offer, useBrowseOffersById, useEditOffer} from '@tryghost/admin-x-framework/api/offers';
 import {createRedemptionFilterUrl} from './OffersIndex';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
@@ -280,10 +281,27 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
             }
         }}
         onOk={async () => {
-            if (!(await handleSave({fakeWhenUnchanged: true}))) {
+            try {
+                if (await handleSave({force: true})) {
+                    return;
+                } else {
+                    toast.remove();
+                    showToast({
+                        type: 'pageError',
+                        message: 'Can\'t save offer, please double check that you\'ve filled all mandatory fields correctly'
+                    });
+                }
+            } catch (e) {
+                let message;
+
+                if (e instanceof JSONError && e.data && e.data.errors[0]) {
+                    message = e.data.errors[0].context || e.data.errors[0].message;
+                }
+
+                toast.remove();
                 showToast({
                     type: 'pageError',
-                    message: 'Can\'t save offer, please double check that you\'ve filled all mandatory fields.'
+                    message: message || 'Something went wrong while saving the offer, please try again'
                 });
             }
         }} /> : null;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/ONC-15

- when adding or editing an offer, the backend throws an error if the offer code is already in use. This error was not being surfaced correctly in Admin
