### PR TITLE
Handled invalid timestamp format in filters

### DIFF
--- a/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -4909,3 +4909,21 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
   ],
 }
 `;
+
+exports[`Posts Content API Errors upon invalid filter value 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "ER_WRONG_VALUE",
+      "context": "Invalid value select count(distinct posts.id) as aggregate from \`posts\` where (\`posts\`.\`status\` = 'published' and (\`posts\`.\`published_at\` < '1715091791890' and \`posts\`.\`type\` = 'post')) - Incorrect DATETIME value: '1715091791890'",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot list posts.",
+      "property": null,
+      "type": "ValidationError",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -5,7 +5,7 @@ const testUtils = require('../../utils');
 const models = require('../../../core/server/models');
 
 const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
-const {anyArray, anyContentVersion, anyEtag, anyUuid, anyISODateTimeWithTZ} = matchers;
+const {anyArray, anyContentVersion, anyErrorId, anyEtag, anyUuid, anyISODateTimeWithTZ} = matchers;
 
 const postMatcher = {
     published_at: anyISODateTimeWithTZ,
@@ -90,6 +90,21 @@ describe('Posts Content API', function () {
             .expectStatus(200)
             .matchBodySnapshot({
                 posts: new Array(11).fill(postMatcher)
+            });
+    });
+
+    it('Errors upon invalid filter value', async function () {
+        if (process.env.NODE_ENV !== 'testing-mysql') {
+            this.skip();
+        }
+
+        await agent
+            .get(`posts/?filter=published_at%3A%3C%271715091791890%27`)
+            .expectStatus(422)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
             });
     });
 


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-85/fix-http-500-on-contentposts

- in the event we give the incorrect format in a filter, MySQL will throw an error and we'll throw a HTTP 500 error
- we can capture this error and return a more useful error to the user
- ideally we'd do this in a validation step before attempting the query, but parsing this out of NQL and detecting which columns are DATETIME could be quite tricky
