### PR TITLE
Added metadata column to jobs table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.84/2024-05-08-02-45-43-add-metadata-json-column-to-jobs.js
+++ b/ghost/core/core/server/data/migrations/versions/5.84/2024-05-08-02-45-43-add-metadata-json-column-to-jobs.js
@@ -1,0 +1,8 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('jobs', 'metadata', {
+    type: 'json',
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -976,7 +976,8 @@ module.exports = {
         started_at: {type: 'dateTime', nullable: true},
         finished_at: {type: 'dateTime', nullable: true},
         created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true}
+        updated_at: {type: 'dateTime', nullable: true},
+        metadata: {type: 'json', nullable: true}
     },
     redirects: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ccf3893bc3f8930f0d1188e646abda6d';
+    const currentSchemaHash = 'cffe8ec7f32d2998bcdf21b2ba874e2e';
     const currentFixturesHash = 'a489d615989eab1023d4b8af0ecee7fd';
     const currentSettingsHash = '5c957ceb48c4878767d7d3db484c592d';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -39,6 +39,10 @@ const VALID_KEYS = {
         'maxlength',
         'nullable',
         'validations'
+    ],
+    json: [
+        'nullable',
+        'index'
     ]
 };
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-11/avoid-expensive-latest-event-timestamp-queries-in-email-analytics

- added a new metadata column to the jobs table.
- as of mysql8, json data types are supported in which case we have to update the schema tests to be able to support this data type.