### PR TITLE
Added access and publish date display to internal link list on hover

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import fetch from 'fetch';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import moment from 'moment-timezone';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -39,6 +40,42 @@ export const fileTypes = {
         resourceName: 'files'
     }
 };
+
+function LockIcon({...props}) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+            <g transform="matrix(0.6666666666666666,0,0,0.6666666666666666,0,0)">
+                <path fill="currentColor" d="M19.5,9.5h-.75V6.75a6.75,6.75,0,0,0-13.5,0V9.5H4.5a2,2,0,0,0-2,2V22a2,2,0,0,0,2,2h15a2,2,0,0,0,2-2V11.5A2,2,0,0,0,19.5,9.5Zm-7.5,9a2,2,0,1,1,2-2A2,2,0,0,1,12,18.5ZM16.25,9a.5.5,0,0,1-.5.5H8.25a.5.5,0,0,1-.5-.5V6.75a4.25,4.25,0,0,1,8.5,0Z"></path>
+            </g>
+        </svg>
+    );
+}
+
+export function decoratePostSearchResult(item, settings) {
+    const date = moment.utc(item.publishedAt).tz(settings.timezone).format('D MMM YYYY');
+
+    if (settings.membersEnabled && item.visibility) {
+        let accessText;
+
+        if (item.visibility === 'public') {
+            accessText = 'Public';
+        } else if (item.visibility === 'members') {
+            accessText = 'Members';
+        } else if (item.visibility === 'paid') {
+            accessText = 'Paid members';
+        } else if (item.visibility === 'tiers'){
+            accessText = 'Specific tiers';
+        }
+
+        if (accessText && accessText !== 'Public') {
+            item.MetaIcon = LockIcon;
+        }
+
+        item.metaText = [accessText, date].filter(Boolean).join(' • ');
+    } else {
+        item.metaText = [date].join(' • ');
+    }
+}
 
 class ErrorHandler extends React.Component {
     state = {
@@ -300,13 +337,19 @@ export default class KoenigLexicalEditor extends Component {
                     return this.defaultLinks;
                 }
 
-                const posts = await this.store.query('post', {filter: 'status:published', fields: 'id,url,title', order: 'published_at desc', limit: 5});
+                const posts = await this.store.query('post', {filter: 'status:published', fields: 'id,url,title,visibility,published_at', order: 'published_at desc', limit: 5});
+                // NOTE: these posts are Ember Data models, not plain objects like the search results
                 const results = posts.toArray().map(post => ({
                     groupName: 'Latest posts',
                     id: post.id,
                     title: post.title,
-                    url: post.url
+                    url: post.url,
+                    visibility: post.visibility,
+                    publishedAt: post.publishedAtUTC.toISOString()
                 }));
+
+                results.forEach(item => decoratePostSearchResult(item, this.settings));
+
                 this.defaultLinks = [{
                     label: 'Latest posts',
                     items: results
@@ -332,6 +375,11 @@ export default class KoenigLexicalEditor extends Component {
 
                 if (items.length === 0) {
                     return;
+                }
+
+                // update the group items with metadata
+                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+                    items.forEach(item => decoratePostSearchResult(item, this.settings));
                 }
 
                 filteredResults.push({

--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -32,14 +32,14 @@ export default class SearchService extends Service {
         {
             name: 'Posts',
             model: 'post',
-            fields: ['id', 'url', 'title', 'status'],
+            fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
             idField: 'id',
             titleField: 'title'
         },
         {
             name: 'Pages',
             model: 'page',
-            fields: ['id', 'url', 'title', 'status'],
+            fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
             idField: 'id',
             titleField: 'title'
         }
@@ -132,7 +132,9 @@ export default class SearchService extends Service {
                     url: item.url,
                     title: item[searchable.titleField],
                     groupName: searchable.name,
-                    status: item.status
+                    status: item.status,
+                    visibility: item.visibility,
+                    publishedAt: item.published_at
                 })
             );
 

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.0.4",
     "@tryghost/kg-converters": "1.0.1",
-    "@tryghost/koenig-lexical": "1.1.9",
+    "@tryghost/koenig-lexical": "1.1.10",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.1",

--- a/ghost/admin/tests/integration/services/search-test.js
+++ b/ghost/admin/tests/integration/services/search-test.js
@@ -1,0 +1,30 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupMirage} from 'ember-cli-mirage/test-support';
+import {setupTest} from 'ember-mocha';
+
+describe('Integration: Service: search', function () {
+    const hooks = setupTest();
+    setupMirage(hooks);
+
+    let search;
+    // eslint-disable-next-line no-unused-vars
+    let firstUser, firstPost, secondPost, firstPage, firstTag;
+
+    beforeEach(function () {
+        search = this.owner.lookup('service:search');
+
+        // populate store with data we'll be searching
+        firstPost = this.server.create('post', {title: 'First post', slug: 'first-post', visibility: 'members', publishedAt: '2024-05-08T16:21:07.000Z'});
+        secondPost = this.server.create('post', {title: 'Second post', slug: 'second-post'});
+        firstPage = this.server.create('page', {title: 'First page', slug: 'first-page'});
+        firstTag = this.server.create('tag', {name: 'First tag', slug: 'first-tag'});
+    });
+
+    it('returns additional post-related fields', async function () {
+        const results = await search.searchTask.perform('post');
+
+        expect(results[0].options[0].visibility).to.equal('members');
+        expect(results[0].options[0].publishedAt).to.equal('2024-05-08T16:21:07.000Z');
+    });
+});

--- a/ghost/admin/tests/unit/components/koenig-lexical-editor-test.js
+++ b/ghost/admin/tests/unit/components/koenig-lexical-editor-test.js
@@ -1,0 +1,64 @@
+import {decoratePostSearchResult} from 'ghost-admin/components/koenig-lexical-editor';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('Unit: Component: koenig-lexical-editor', function () {
+    describe('decoratePostSearchResult()', function () {
+        let result;
+
+        beforeEach(function () {
+            result = {
+                title: 'Test Post',
+                url: '/test-post',
+                visibility: 'public',
+                publishedAt: '2024-05-08T16:21:07.000Z'
+            };
+        });
+
+        it('handles members disabled', function () {
+            decoratePostSearchResult(result, {membersEnabled: false, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('8 May 2024');
+            expect(result.MetaIcon).to.be.undefined;
+        });
+
+        it('handles public content', function () {
+            decoratePostSearchResult(result, {membersEnabled: true, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('Public • 8 May 2024');
+            expect(result.MetaIcon).to.be.undefined;
+        });
+
+        it('handles members content', function () {
+            result.visibility = 'members';
+            decoratePostSearchResult(result, {membersEnabled: true, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('Members • 8 May 2024');
+            expect(result.MetaIcon).to.exist;
+        });
+
+        it('handles paid members content', function () {
+            result.visibility = 'paid';
+            decoratePostSearchResult(result, {membersEnabled: true, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('Paid members • 8 May 2024');
+            expect(result.MetaIcon).to.exist;
+        });
+
+        it('handles specific tiers content', function () {
+            result.visibility = 'tiers';
+            decoratePostSearchResult(result, {membersEnabled: true, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('Specific tiers • 8 May 2024');
+            expect(result.MetaIcon).to.exist;
+        });
+
+        it('handles unknown visibility', function () {
+            result.visibility = 'unknown';
+            decoratePostSearchResult(result, {membersEnabled: true, timezone: 'Etc/UTC'});
+
+            expect(result.metaText).to.equal('8 May 2024');
+            expect(result.MetaIcon).to.be.undefined;
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,10 +7103,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.9.tgz#3d640bdd6ba187a7f74e5a8c68de11be42049da3"
-  integrity sha512-bhCAoWViEWpVIHNMTn8kzpE9Aa71m5a6HDDhg3PDx+nu7IsvasbneJcRwgksnZP2vdNY9YeriSPbqppsfFy6PQ==
+"@tryghost/koenig-lexical@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.1.10.tgz#eacb6a1caf01ce0b086fd90a720513ebc9282611"
+  integrity sha512-deL1M2qXoQHMZdsT/4v1cZN1mFW2P7Q56WdrZopSkKvsirv/KZxB51MtxtDK8rQ9itDNwKh58ckHFIXlu9EIQA==
 
 "@tryghost/limit-service@1.2.14", "@tryghost/limit-service@^1.2.10":
   version "1.2.14"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-80

- bumps @tryghost/koenig-lexical to add support for search result metadata in internal links as well as some improvements to the internal linking UI/UX
- updates search service to fetch and expose additional `visibility` and `published_at` fields for post/page resources
- updates `searchLinks` method passed to editor to decorate the search results with appropriate meta text and icon based on publish date, post visibility and member settings
