### PR TITLE
Added extra validation for reset_password endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/password_reset.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/password_reset.js
@@ -25,7 +25,7 @@ module.exports = {
     generateResetToken(apiConfig, frame) {
         debug('generateResetToken');
 
-        const email = frame.data.password_reset[0].email;
+        const email = frame.data.password_reset?.[0]?.email;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
             throw new errors.BadRequestError({

--- a/ghost/core/test/e2e-api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/authentication.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authentication API generateResetToken Cannot generate reset token without required info 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "The server did not receive a valid email",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/admin/authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/authentication.test.js
@@ -1,0 +1,25 @@
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {anyErrorId} = matchers;
+
+describe('Authentication API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    describe('generateResetToken', function () {
+        it('Cannot generate reset token without required info', async function () {
+            await agent
+                .post('authentication/password_reset')
+                .expectStatus(400)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                });
+        });
+    });
+});


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-104/cannot-read-properties-of-undefined-reading-0-an-unexpected-error

- if the request body didn't contain the correct keys, it'd just HTTP 500 out of there
- this adds some optional chaining so we end up with undefined if anything isn't as expected, and the following if-statement does the rest of the check for us
- this also adds a breaking test (the first E2E test for authentication, yay!)