### PR TITLE
Added jackspeak resolution to core to fix ESM + CJS compat issue

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -262,6 +262,7 @@
   "resolutions": {
     "@tryghost/errors": "1.3.2",
     "@tryghost/logging": "2.4.14",
+    "jackspeak": "2.1.1",
     "moment": "2.24.0",
     "moment-timezone": "0.5.23"
   },


### PR DESCRIPTION
Alternate to #20197

- [x] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)
