### PR TITLE
🐛 Fixed External Image URLs being incorrectly prefixed

### DIFF
--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -92,6 +92,10 @@ module.exports.getImageWithSize = function getImageWithSize(imagePath, sizeOptio
     const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
     const formatPrefix = requestedFormat && imageTransform.canTransformToFormat(requestedFormat) ? `/format/${requestedFormat}` : '';
 
+    if (!imageName) {
+        return imgBlogUrl;
+    }
+
     return [imgBlogUrl, urlUtils.STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}`, formatPrefix, imageName].join('');
 };
 

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -282,4 +282,49 @@ describe('getImageDimensions', function () {
             done();
         }).catch(done);
     });
+
+    it('does not append image size prefix to external images', function (done) {
+        const originalMetaData = {
+            coverImage: {
+                url: 'http://anothersite.com/some/storage/mypostcoverimage.jpg'
+            },
+            authorImage: {
+                url: 'http://anothersite.com/some/storage/me.jpg'
+            },
+            ogImage: {
+                url: 'http://anothersite.com/some/storage/super-facebook-image.jpg'
+            },
+            twitterImage: 'http://anothersite.com/some/storage/super-twitter-image.jpg',
+            site: {
+                logo: {
+                    url: 'http://anothersite.com/some/storage/logo.jpg'
+                }
+            }
+        };
+
+        const metaData = _.cloneDeep(originalMetaData);
+
+        sizeOfStub.callsFake(() => ({
+            width: 2000,
+            height: 1200,
+            type: 'jpg'
+        }));
+
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
+
+        getImageDimensions(metaData).then(function (result) {
+            should.exist(result);
+            result.coverImage.should.have.property('url');
+            result.coverImage.url.should.eql('http://anothersite.com/some/storage/mypostcoverimage.jpg');
+            result.authorImage.should.have.property('url');
+            result.authorImage.url.should.eql('http://anothersite.com/some/storage/me.jpg');
+            result.ogImage.should.have.property('url');
+            result.ogImage.url.should.eql('http://anothersite.com/some/storage/super-facebook-image.jpg');
+            result.site.logo.should.have.property('url');
+            result.site.logo.url.should.eql('http://anothersite.com/some/storage/logo.jpg');
+            done();
+        }).catch(done);
+    });
 });


### PR DESCRIPTION
ref ENG-824

- the bug is causing resize prefixes being added to images served from outside of Ghost.
- this now would only append the prefex to images served by Ghost and other images urls' would get served as is.
- we can determine that by checking whether imageName doesn't exist, meaning the source is a third party.
- this mostly affect edge case users, eg where a feature image url was passed in via the API and doesn't get served by Ghost.