### PR TITLE
Update post/page status change copy

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -15,6 +15,7 @@ import moment from 'moment-timezone';
 import {GENERIC_ERROR_MESSAGE} from '../services/notifications';
 import {action, computed} from '@ember/object';
 import {alias, mapBy} from '@ember/object/computed';
+import {capitalizeFirstLetter} from '../helpers/capitalize-first-letter';
 import {captureMessage} from '@sentry/ember';
 import {dropTask, enqueueTask, restartableTask, task, taskGroup, timeout} from 'ember-concurrency';
 import {htmlSafe} from '@ember/template';
@@ -1263,12 +1264,14 @@ export default class LexicalEditorController extends Controller {
         let notifications = this.notifications;
         let message = messageMap.success.post[prevStatus][status];
         let actions, type, path;
+        type = this.get('post.displayName');
 
         if (status === 'published' || status === 'scheduled') {
-            type = this.get('post.displayName');
             path = this.get('post.url');
-            actions = `<a href="${path}" target="_blank">View ${type}</a>`;
+            actions = `<a href="${path}" target="_blank">View on site</a>`;
         }
+
+        message = capitalizeFirstLetter(type) + ' ' + message.toLowerCase();
 
         notifications.showNotification(message, {type: 'success', actions: (actions && htmlSafe(actions)), delayed});
     }
@@ -1278,11 +1281,12 @@ export default class LexicalEditorController extends Controller {
             publishedAtUTC,
             previewUrl,
             emailOnly,
-            newsletter
+            newsletter,
+            displayName
         } = this.post;
         let publishedAtBlogTZ = moment.tz(publishedAtUTC, this.settings.timezone);
 
-        let title = 'Scheduled';
+        let title = capitalizeFirstLetter(displayName) + ' scheduled';
         let description = emailOnly ? ['Will be sent'] : ['Will be published'];
 
         if (newsletter) {
@@ -1300,7 +1304,7 @@ export default class LexicalEditorController extends Controller {
 
         description = htmlSafe(description.join(' '));
 
-        let actions = htmlSafe(`<a href="${previewUrl}" target="_blank">View Preview</a>`);
+        let actions = htmlSafe(`<a href="${previewUrl}" target="_blank">Show preview</a>`);
 
         return this.notifications.showNotification(title, {description, actions, type: 'success', delayed});
     }


### PR DESCRIPTION
DES-354

Minor copy improvements when a post or page changes status. E.g. instead of "Updated" show "Post updated"