### PR TITLE
Update twitter.com to x.com

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
@@ -76,7 +76,7 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <TextField
                 error={!!errors.twitter}
                 hint={errors.twitter}
-                placeholder="https://twitter.com/ghost"
+                placeholder="https://x.com/ghost"
                 title="URL of your X (formerly Twitter) profile"
                 value={twitterUrl}
                 onBlur={(e) => {

--- a/apps/admin-x-settings/src/utils/socialUrls.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls.ts
@@ -62,6 +62,6 @@ export const twitterHandleToUrl = (handle: string) => `https://x.com/${handle.re
 
 export const facebookUrlToHandle = (url: string) => url.match(/(?:https:\/\/)(?:www\.)(?:facebook\.com)\/(?:#!\/)?(\w+\/?\S+)/mi)?.[1] || null;
 export const twitterUrlToHandle = (url: string) => {
-    const handle = url.match(/(?:https:\/\/)(?:twitter\.com)\/(?:#!\/)?@?([^/]*)/)?.[1];
+    const handle = url.match(/(?:https:\/\/)(?:x\.com)\/(?:#!\/)?@?([^/]*)/)?.[1];
     return handle ? `@${handle}` : null;
 };

--- a/apps/admin-x-settings/src/utils/socialUrls.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls.ts
@@ -30,11 +30,11 @@ export function validateTwitterUrl(newUrl: string) {
     if (!newUrl) {
         return '';
     }
-    if (newUrl.match(/(?:twitter\.com\/)(\S+)/) || newUrl.match(/([a-z\d.]+)/i)) {
+    if (newUrl.match(/(?:x\.com\/)(\S+)/) || newUrl.match(/([a-z\d.]+)/i)) {
         let username = [];
 
-        if (newUrl.match(/(?:twitter\.com\/)(\S+)/)) {
-            [, username] = newUrl.match(/(?:twitter\.com\/)(\S+)/);
+        if (newUrl.match(/(?:x\.com\/)(\S+)/)) {
+            [, username] = newUrl.match(/(?:x\.com\/)(\S+)/);
         } else {
             [username] = newUrl.match(/([^/]+)\/?$/mi);
         }
@@ -47,18 +47,18 @@ export function validateTwitterUrl(newUrl: string) {
         if (username.match(/^(http|www)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
             const message = !username.match(/^[a-z\d._]{1,15}$/mi)
                 ? 'Your Username is not a valid Twitter Username'
-                : 'The URL must be in a format like https://twitter.com/yourUsername';
+                : 'The URL must be in a format like https://x.com/yourUsername';
             throw new Error(message);
         }
-        return `https://twitter.com/${username}`;
+        return `https://x.com/${username}`;
     } else {
-        const message = 'The URL must be in a format like https://twitter.com/yourUsername';
+        const message = 'The URL must be in a format like https://x.com/yourUsername';
         throw new Error(message);
     }
 }
 
 export const facebookHandleToUrl = (handle: string) => `https://www.facebook.com/${handle}`;
-export const twitterHandleToUrl = (handle: string) => `https://twitter.com/${handle.replace('@', '')}`;
+export const twitterHandleToUrl = (handle: string) => `https://x.com/${handle.replace('@', '')}`;
 
 export const facebookUrlToHandle = (url: string) => url.match(/(?:https:\/\/)(?:www\.)(?:facebook\.com)\/(?:#!\/)?(\w+\/?\S+)/mi)?.[1] || null;
 export const twitterUrlToHandle = (url: string) => {

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -17,19 +17,19 @@ test.describe('Social account settings', async () => {
         const section = page.getByTestId('social-accounts');
 
         await expect(section.getByText('https://www.facebook.com/ghost')).toHaveCount(1);
-        await expect(section.getByText('https://twitter.com/ghost')).toHaveCount(1);
+        await expect(section.getByText('https://x.com/ghost')).toHaveCount(1);
 
         await section.getByRole('button', {name: 'Edit'}).click();
 
         await section.getByLabel(`URL of your publication's Facebook Page`).fill('https://www.facebook.com/fb');
-        await section.getByLabel('URL of your X (formerly Twitter) profile').fill('https://twitter.com/tw');
+        await section.getByLabel('URL of your X (formerly Twitter) profile').fill('https://x.com/tw');
 
         await section.getByRole('button', {name: 'Save'}).click();
 
         await expect(section.getByLabel('URL of your X (formerly Twitter) profile')).toHaveCount(0);
 
         await expect(section.getByText('https://www.facebook.com/fb')).toHaveCount(1);
-        await expect(section.getByText('https://twitter.com/tw')).toHaveCount(1);
+        await expect(section.getByText('https://x.com/tw')).toHaveCount(1);
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [
@@ -112,26 +112,26 @@ test.describe('Social account settings', async () => {
         await testUrlValidation(
             twitterInput,
             'twitter.com/username',
-            'https://twitter.com/username'
+            'https://x.com/username'
         );
 
         await testUrlValidation(
             twitterInput,
             'testuser',
-            'https://twitter.com/testuser'
+            'https://x.com/testuser'
         );
 
         await testUrlValidation(
             twitterInput,
             'http://github.com/username',
-            'https://twitter.com/username'
+            'https://x.com/username'
         );
 
         await testUrlValidation(
             twitterInput,
             '*(&*(%%))',
             '*(&*(%%))',
-            'The URL must be in a format like https://twitter.com/yourUsername'
+            'The URL must be in a format like https://x.com/yourUsername'
         );
 
         await testUrlValidation(

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -116,27 +116,27 @@ test.describe('User profile', async () => {
 
         await testUrlValidation(
             twitterInput,
-            'twitter.com/username',
-            'https://twitter.com/username'
+            'x.com/username',
+            'https://x.com/username'
         );
 
         await testUrlValidation(
             twitterInput,
             'testuser',
-            'https://twitter.com/testuser'
+            'https://x.com/testuser'
         );
 
         await testUrlValidation(
             twitterInput,
             'http://github.com/username',
-            'https://twitter.com/username'
+            'https://x.com/username'
         );
 
         await testUrlValidation(
             twitterInput,
             '*(&*(%%))',
             '*(&*(%%))',
-            'The URL must be in a format like https://twitter.com/yourUsername'
+            'The URL must be in a format like https://x.com/yourUsername'
         );
 
         await testUrlValidation(


### PR DESCRIPTION
DES-351

There's a frontend validation in Settings that rewrites the Twitter (X) URL in social accounts to match the format: twitter.com. As of May 17, X officially changed their domain to x.com so this validation is outdated.