### PR TITLE
Fixed tooltip for scheduled posts in postlist

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -95,10 +95,14 @@
                                 <span class="schedule-details" {{css-transition "anim-fade-in-scale"}}>
                                     {{#if @post.emailOnly}}
                                         to be sent
+                                        {{this.scheduledText}} to {{humanize-recipient-filter @post.emailSegment}}
                                     {{else}}
                                         to be published {{if @post.newsletter "and sent "}}
+                                        {{this.scheduledText}}
+                                        {{#if @post.newsletter}}
+                                            to {{humanize-recipient-filter @post.emailSegment}}
+                                        {{/if}}
                                     {{/if}}
-                                    {{this.scheduledText}} to {{humanize-recipient-filter @post.emailSegment}}
                                 </span>
                             {{/if}}
                         </span>


### PR DESCRIPTION
DES-194

The tooltip of scheduled posts always showed subscribers even if it was not sent as a newsletter.