### PR TITLE
Prevent extraneous subscriptions

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2932,6 +2932,68 @@ Object {
 }
 `;
 
+exports[`Members API Can filter by conversion attribution 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member1@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Mr Egg",
+      "newsletters": Array [
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Daily newsletter",
+          "status": "active",
+        },
+      ],
+      "note": null,
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Members API Can filter by conversion attribution 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "830",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Can filter by paid status 1: [body] 1`] = `
 Object {
   "members": Array [

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -44,7 +44,7 @@ async function assertSubscription(subscriptionId, asserts) {
     models.Base.Model.prototype.serialize.call(subscription).should.match(asserts);
 }
 
-describe.only('Members API', function () {
+describe('Members API', function () {
     // @todo: Test what happens when a complimentary subscription ends (should create comped -> free event)
     // @todo: Test what happens when a complimentary subscription starts a paid subscription
 

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -44,7 +44,7 @@ async function assertSubscription(subscriptionId, asserts) {
     models.Base.Model.prototype.serialize.call(subscription).should.match(asserts);
 }
 
-describe('Members API', function () {
+describe.only('Members API', function () {
     // @todo: Test what happens when a complimentary subscription ends (should create comped -> free event)
     // @todo: Test what happens when a complimentary subscription starts a paid subscription
 
@@ -260,7 +260,15 @@ describe('Members API', function () {
                 email: 'cancel-paid-test@email.com',
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -481,7 +489,15 @@ describe('Members API', function () {
                 email: 'cancel-complimentary-test@email.com',
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -621,7 +637,15 @@ describe('Members API', function () {
                 email: 'checkout-webhook-test@email.com',
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -720,7 +744,15 @@ describe('Members API', function () {
                 email: 'checkout-newsletter-default-test@email.com',
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -767,7 +799,15 @@ describe('Members API', function () {
                 email: 'checkout-newsletter-test@email.com',
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -973,7 +1013,15 @@ describe('Members API', function () {
                 email: `${customer_id}@email.com`,
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -1372,7 +1420,15 @@ describe('Members API', function () {
                 email: `${customer_id}@email.com`,
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -1570,7 +1626,15 @@ describe('Members API', function () {
                 email: `${customer_id}@email.com`,
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 
@@ -1728,7 +1792,15 @@ describe('Members API', function () {
                 email: `${customer_id}@email.com`,
                 subscriptions: {
                     type: 'list',
-                    data: [subscription]
+                    data: [{
+                        plan: {
+                            product: {
+                                id: subscription.items.data[0].price.id,
+                                product: subscription.items.data[0].price.product
+                            }
+                        },
+                        ...subscription
+                    }]
                 }
             });
 

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -986,6 +986,7 @@ DataGenerator.Content.members_paid_subscription_events[2].member_id = DataGenera
 DataGenerator.Content.links[0].post_id = DataGenerator.Content.posts[0].id;
 DataGenerator.Content.links[1].post_id = DataGenerator.Content.posts[0].id;
 DataGenerator.Content.links[2].post_id = DataGenerator.Content.posts[0].id;
+DataGenerator.Content.stripe_products[0].product_id = DataGenerator.Content.products[0].id;
 
 DataGenerator.forKnex = (function () {
     function createBasic(overrides) {

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -250,17 +250,17 @@ module.exports = class WebhookController {
         }
 
         if (session.mode === 'subscription') {
+            const customer = await this.api.getCustomer(session.customer, {
+                expand: ['subscriptions.data.default_payment_method']
+            });
+
             const product = await this.deps.productRepository.get({
-                stripe_product_id: session.metadata.product
+                stripe_product_id: customer.subscriptions?.data?.[0].plan?.product
             });
             if (!product) {
                 sendSignupEmail = false;
                 return; // Ignore any Stripe subscriptions that do not exist in Ghost - we should not create members for these.
             }
-
-            const customer = await this.api.getCustomer(session.customer, {
-                expand: ['subscriptions.data.default_payment_method']
-            });
 
             let member = await this.deps.memberRepository.get({
                 email: customer.email

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -254,6 +254,7 @@ module.exports = class WebhookController {
                 expand: ['subscriptions.data.default_payment_method']
             });
 
+            // TODO - what if we don't have this data link?
             const product = await this.deps.productRepository.get({
                 stripe_product_id: customer.subscriptions?.data?.[0].plan?.product
             });

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -248,6 +248,13 @@ module.exports = class WebhookController {
         }
 
         if (session.mode === 'subscription') {
+            const product = await this.deps.productRepository.get({
+                stripe_product_id: session.metadata.product
+            });
+            if (!product) {
+                return; // Ignore any Stripe subscriptions that do not exist in Ghost - we should not create members for these.
+            }
+
             const customer = await this.api.getCustomer(session.customer, {
                 expand: ['subscriptions.data.default_payment_method']
             });

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -182,6 +182,8 @@ module.exports = class WebhookController {
      * @private
      */
     async checkoutSessionEvent(session) {
+        let sendSignupEmail = true;
+
         if (session.mode === 'setup') {
             const setupIntent = await this.api.getSetupIntent(session.setup_intent);
             const member = await this.deps.memberRepository.get({
@@ -252,6 +254,7 @@ module.exports = class WebhookController {
                 stripe_product_id: session.metadata.product
             });
             if (!product) {
+                sendSignupEmail = false;
                 return; // Ignore any Stripe subscriptions that do not exist in Ghost - we should not create members for these.
             }
 
@@ -340,7 +343,7 @@ module.exports = class WebhookController {
                 }
             }
 
-            if (checkoutType !== 'upgrade') {
+            if (checkoutType !== 'upgrade' && sendSignupEmail) {
                 this.sendSignupEmail(customer.email);
             }
         }

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const {DonationPaymentEvent} = require('@tryghost/donations');
-const { sendEmail } = require('../../core/test/utils/batch-email-utils');
 
 module.exports = class WebhookController {
     /**
@@ -183,8 +182,6 @@ module.exports = class WebhookController {
      * @private
      */
     async checkoutSessionEvent(session) {
-        let sendSignupEmail = true;
-
         if (session.mode === 'setup') {
             const setupIntent = await this.api.getSetupIntent(session.setup_intent);
             const member = await this.deps.memberRepository.get({


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-38/
- Stripe checkout webhooks should only create members for products that exist in Ghost
- Ghost makes assumptions about the default product that do not stand up to Stripe having extraneous subscription products

We found that members were being created when customers used Stripe for subscriptions that are for products unrelated to Ghost (shared Stripe account). This problem is two-fold: 1) these members have not been to/know of the Ghost site and 2) the subscription caused the member to be linked to the default subscription while using the price of the paid for subscription, causing errors in MRR reporting.