### PR TITLE
Reverted "Enabled `includeLocalVariables` option in Sentry"

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -115,7 +115,6 @@ if (sentryConfig && !sentryConfig.disabled) {
         release: 'ghost@' + version,
         environment: environment,
         maxValueLength: 1000,
-        includeLocalVariables: true,
         integrations: [
             Sentry.extraErrorDataIntegration()
         ],


### PR DESCRIPTION
refs https://app.incident.io/ghost/incidents/73
refs https://blog.sentry.io/local-variables-for-nodejs-in-sentry/

- this reverts commit cc76fda3e881f0a2937643323515eaf6c58dd01b
- it turns out that enabling this causes the entire program to pause whilst it collects local variables
- this was only added to aid with debugging, so it's not critical to have and can be disabled
