### PR TITLE
Cleaned up jsdom dependency usage

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react-refresh": "0.4.3",
     "eslint-plugin-tailwindcss": "3.13.0",
+    "jsdom": "24.1.0",
     "mocha": "10.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -73,6 +73,7 @@
     "c8": "8.0.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react-refresh": "0.4.3",
+    "jsdom": "24.1.0",
     "mocha": "10.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.2.1",
+    "jsdom": "24.1.0",
     "vite": "4.5.3",
     "vite-plugin-svgr": "3.3.0",
     "vitest": "0.34.3"

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -57,6 +57,7 @@
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-react-refresh": "0.4.3",
         "eslint-plugin-tailwindcss": "3.13.0",
+        "jsdom": "24.1.0",
         "postcss": "8.4.38",
         "postcss-import": "16.1.0",
         "prop-types": "15.8.1",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -85,6 +85,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@vitejs/plugin-react": "4.2.1",
+    "jsdom": "24.1.0",
     "nock": "13.3.3",
     "vite": "4.5.3",
     "vite-plugin-svgr": "3.3.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -194,7 +194,6 @@
     "intl": "1.2.5",
     "intl-messageformat": "5.4.3",
     "js-yaml": "4.1.0",
-    "jsdom": "24.1.0",
     "json-stable-stringify": "1.1.1",
     "jsonpath": "1.1.1",
     "jsonwebtoken": "8.5.1",


### PR DESCRIPTION
- we don't need this in `ghost/core` as it's not used in there
- we need to declare this dependency for the apps, as they use it for running tests
- this doesn't change the lockfile but it means we're declaring the dependency in the right places now