### PR TITLE
Added Sentry Session Replay in Ghost Admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -190,7 +190,12 @@ export default Route.extend(ShortcutsRoute, {
                     // ResizeObserver loop errors occur often from extensions and
                     // embedded content, generally harmless and not useful to report
                     /^ResizeObserver loop completed with undelivered notifications/
-                ]
+                ],
+
+                // Session Replay on errors
+                // Docs: https://docs.sentry.io/platforms/javascript/session-replay
+                replaysOnErrorSampleRate: 1.0
+
             };
             if (this.config.sentry_env === 'development') {
                 sentryConfig.integrations = [new Debug()];


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-128/enable-sentry-replay-in-admin-adminx-editor

- this option lets us replay a session in Sentry when an error happens
