### PR TITLE
Used a ~hex~ base64 encoded string for hmac secret

### DIFF
--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -47,7 +47,7 @@ const setAccessCookies = function setAccessCookies(member = undefined, res, free
     if (!hmacSecret) {
         return;
     }
-    const hmacSecretBuffer = Buffer.from(hmacSecret, 'hex');
+    const hmacSecretBuffer = Buffer.from(hmacSecret, 'base64');
     if (hmacSecretBuffer.length === 0) {
         return;
     }

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -47,12 +47,16 @@ const setAccessCookies = function setAccessCookies(member = undefined, res, free
     if (!hmacSecret) {
         return;
     }
+    const hmacSecretBuffer = Buffer.from(hmacSecret, 'hex');
+    if (hmacSecretBuffer.length === 0) {
+        return;
+    }
     const activeSubscription = member.subscriptions?.find(sub => sub.status === 'active');
 
     const cookieTimestamp = Math.floor(Date.now() / 1000); // to mitigate a cookie replay attack
     const memberTier = activeSubscription && activeSubscription.tier.id || freeTier.id;
     const memberTierAndTimestamp = `${memberTier}:${cookieTimestamp}`;
-    const memberTierHmac = crypto.createHmac('sha256', hmacSecret).update(memberTierAndTimestamp).digest('hex');
+    const memberTierHmac = crypto.createHmac('sha256', hmacSecretBuffer).update(memberTierAndTimestamp).digest('hex');
 
     const maxAge = 3600;
     const accessCookie = `ghost-access=${memberTierAndTimestamp}; Max-Age=${maxAge}; Path=/; HttpOnly; SameSite=Strict;`;

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -228,7 +228,7 @@ describe('Comments API', function () {
     describe('when caching members content is enabled', function () {
         it('sets ghost-access and ghost-access-hmac cookies', async function () {
             configUtils.set('cacheMembersContent:enabled', true);
-            configUtils.set('cacheMembersContent:hmacSecret', 'testsecret');
+            configUtils.set('cacheMembersContent:hmacSecret', 'deadbeef');
             membersAgent = await agentProvider.getMembersAPIAgent();
             await fixtureManager.init('newsletters', 'members:newsletters');
             await membersAgent.loginAs('member@example.com');

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyUuid, anyISODateTime, stringMatching} = matchers;
 const models = require('../../../core/server/models');
@@ -228,7 +229,7 @@ describe('Comments API', function () {
     describe('when caching members content is enabled', function () {
         it('sets ghost-access and ghost-access-hmac cookies', async function () {
             configUtils.set('cacheMembersContent:enabled', true);
-            configUtils.set('cacheMembersContent:hmacSecret', 'deadbeef');
+            configUtils.set('cacheMembersContent:hmacSecret', crypto.randomBytes(64).toString('base64'));
             membersAgent = await agentProvider.getMembersAPIAgent();
             await fixtureManager.init('newsletters', 'members:newsletters');
             await membersAgent.loginAs('member@example.com');


### PR DESCRIPTION
We want to use a randomly generated 64 byte secret for the hmac, and utf8 encoding isn't nice to work with for this, so we're going to use a hex string and decode it into a buffer for the secret.
