### PR TITLE
Fixed flaky Portal test

### DIFF
--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -261,13 +261,14 @@ export function getFreeProduct({
 }
 
 export function getBenefits({numOfBenefits}) {
+    const timestamp = Date.now();
     const random = Math.floor(Math.random() * 100);
 
     const beenfits = [
-        getBenefitData({name: `Limited early adopter pricing #${random}`}),
-        getBenefitData({name: `Latest gear reviews #${random}`}),
-        getBenefitData({name: `Weekly email newsletter #${random}`}),
-        getBenefitData({name: `Listen to my podcast #${random}`})
+        getBenefitData({name: `Limited early adopter pricing #${random}-${timestamp}`}),
+        getBenefitData({name: `Latest gear reviews #${random}-${timestamp}`}),
+        getBenefitData({name: `Weekly email newsletter #${random}-${timestamp}`}),
+        getBenefitData({name: `Listen to my podcast #$${random}-${timestamp}`})
     ];
     return beenfits.slice(0, numOfBenefits);
 }


### PR DESCRIPTION
no issue

- the signup flow tests check whether the benefits of the available tiers are rendering correctly. The test is based on a text match, which sometimes fails because of duplicate benefit descriptions
- this fix makes the benefit descriptions less likely to be the same, by using a timestamp in the randomisation function
