### PR TITLE
Removed staff with 404 URLs from internal link searches

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -374,10 +374,18 @@ export default class KoenigLexicalEditor extends Component {
                 }
             }
 
-            // only published posts/pages have URLs
+            // only published posts/pages and staff with posts have URLs
             const filteredResults = [];
             results.forEach((group) => {
-                const items = (group.groupName === 'Posts' || group.groupName === 'Pages') ? group.options.filter(i => i.status === 'published') : group.options;
+                let items = group.options;
+
+                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+                    items = items.filter(i => i.status === 'published');
+                }
+
+                if (group.groupName === 'Staff') {
+                    items = items.filter(i => !/\/404\//.test(i.url));
+                }
 
                 if (items.length === 0) {
                     return;


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-172

- staff users with no posts won't have a front-end URL so it can be confusing for them to appear in the internal link search results within the editor
- added filtering for `/404/` in staff URLs so we don't list unlinkable staff members
