### PR TITLE
✨ Added internal linking beta

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -60,10 +60,6 @@ const features = [{
     description: 'Wires up the Ghost NestJS App to the Admin API',
     flag: 'NestPlayground'
 },{
-    title: 'Internal Linking (private beta)',
-    description: 'Adds internal URL search to editor link inputs',
-    flag: 'internalLinking'
-},{
     title: 'Internal Linking @-links (internal alpha)',
     description: 'Adds internal URL search when typing @ in the editor',
     flag: 'internalLinkingAtLinks'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -16,6 +16,10 @@ const BetaFeatures: React.FC = () => {
     return (
         <List titleSeparator={false}>
             <LabItem
+                action={<FeatureToggle flag="internalLinking" />}
+                detail={<>Search and link to your own content directly inside the editor — so that your workflow is never interrupted</>}
+                title='Internal linking' />
+            <LabItem
                 action={<FeatureToggle flag="additionalPaymentMethods" />}
                 detail={<>Enable support for PayPal, iDEAL, WeChat Pay and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />


### PR DESCRIPTION
no issue

When enabled the URL inputs in the link toolbar and bookmark card will search for posts, pages, authors, and tags, allowing for faster link creation and less interruption to workflow.

- moved internal linking feature from private to public beta
