### PR TITLE
Aligned the subtitle font with the body font in the newsletter template

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -1079,7 +1079,7 @@ class EmailRenderer {
             classes: {
                 title: 'post-title' + (newsletter.get('title_font_category') === 'serif' ? ` post-title-serif` : ``) + (newsletter.get('title_alignment') === 'left' ? ` post-title-left` : ``),
                 titleLink: 'post-title-link' + (newsletter.get('title_alignment') === 'left' ? ` post-title-link-left` : ``),
-                subtitle: 'post-subtitle' + (newsletter.get('title_alignment') === 'left' ? ` post-subtitle-left` : ``),
+                subtitle: 'post-subtitle' + (newsletter.get('body_font_category') === 'serif' ? ` post-subtitle-serif` : ``) + (newsletter.get('title_alignment') === 'left' ? ` post-subtitle-left` : ``),
                 meta: 'post-meta' + (newsletter.get('title_alignment') === 'left' ? ` post-meta-left` : ` post-meta-center`),
                 body: newsletter.get('body_font_category') === 'sans_serif' ? `post-content-sans-serif` : `post-content`
             },

--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -391,6 +391,11 @@ figure blockquote p {
     text-align: center;
 }
 
+.post-subtitle-serif {
+    font-family: Georgia, serif;
+    letter-spacing: -0.01em;
+}
+
 .post-subtitle-left {
     text-align: left;
 }


### PR DESCRIPTION
REF MOM-146
- This ensures the body serif / sans-serif style is applied to the subtitle as well