### PR TITLE
Fixed "no results" state flashing in @-linking

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -372,6 +372,7 @@ export default class KoenigLexicalEditor extends Component {
                 if (!didCancel(error)) {
                     throw error;
                 }
+                return;
             }
 
             // only published posts/pages and staff with posts have URLs

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -47,7 +47,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.1.0",
     "@tryghost/kg-converters": "1.0.4",
-    "@tryghost/koenig-lexical": "1.2.2",
+    "@tryghost/koenig-lexical": "1.2.3",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7148,10 +7148,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.2.2.tgz#39cd50959de7b5ff8e0d2dbd8688ff83c81f57e1"
-  integrity sha512-1bFveIMMNg3Q6UPWGjTvg6m430N+4ZAMTWs2IfuR3iIVBPp687T41vgsiMQySfAepm/WKRAltpIh4kNYQOy1Ng==
+"@tryghost/koenig-lexical@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.2.3.tgz#392fe8189a54df2846d653ccc3e74ab92a385d3b"
+  integrity sha512-AQvgV6JrSgjk7EQZ16wrr6JBcM5V3EJg8z4cIeLCAyTY9Mc7Y6Pgh0evlabqCWwCqqXprMI1tjwptNmiwWd1vg==
 
 "@tryghost/limit-service@1.2.14":
   version "1.2.14"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-160

- return `undefined` early from `searchLinks` when the underlying task gets cancelled
- bump `@tryghost/koenig-lexical` so it properly handles cancelled search promises
