### PR TITLE
fix: Update srcDoc path in Frame component

### DIFF
--- a/apps/portal/src/components/Frame.js
+++ b/apps/portal/src/components/Frame.js
@@ -27,7 +27,7 @@ export default class Frame extends Component {
         const {children, head, title = '', style = {}, dataTestId = '', ...rest} = this.props;
         return (
             <iframe
-                srcDoc={`<!DOCTYPE html>`}
+                srcDoc={`https://account.ghost.org/signin`}
                 data-testid={dataTestId}
                 ref={node => (this.node = node)}
                 title={title}


### PR DESCRIPTION
- Changed srcDoc attribute in the Frame component to use a direct URL instead of a blank document.
- Modified the render method in Frame to set srcDoc with the specified path.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
