### PR TITLE
Fixed subtitle not fully collapsing for auto-expansion

### DIFF
--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -793,6 +793,7 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     width: 100%;
     max-width: unset;
     min-width: auto;
+    min-height: auto; /* Allows element to collapse for auto-expand calculation */
     margin: 0;
     padding: 0;
     border: none;


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-149

- our styles set all `textarea` elements to have a min-height of 100px which wasn't being overridden for our subtitle element meaning our auto-expand code was never able to fully collapse it to a single line
