### PR TITLE
Wired up subtitle in newsletter template

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -1035,6 +1035,7 @@ class EmailRenderer {
                 commentUrl: commentUrl.href,
                 authors,
                 publishedAt,
+                customExcerpt: post.get('custom_excerpt'),
                 feature_image: postFeatureImage,
                 feature_image_width: postFeatureImageWidth,
                 feature_image_height: postFeatureImageHeight,

--- a/ghost/email-service/lib/email-templates/template-old.hbs
+++ b/ghost/email-service/lib/email-templates/template-old.hbs
@@ -80,10 +80,10 @@
                                                 </td>
                                             </tr>
                                             {{#hasFeature 'newsletterSubtitle'}}
-                                                {{#if newsletter.showSubhead}}
+                                                {{#if (and newsletter.showSubhead post.customExcerpt)}}
                                                     <tr>
                                                         <td class="post-subtitle-wrapper" style="width: 100%">
-                                                            <p class="{{classes.subtitle}}">Jonathan Haidt wrote a best-selling book about teens and social media. Not everyone buys its thesis.</p>
+                                                            <p class="{{classes.subtitle}}">{{post.customExcerpt}}.</p>
                                                         </td>
                                                     </tr>
                                                 {{/if}}

--- a/ghost/email-service/test/email-helpers.test.js
+++ b/ghost/email-service/test/email-helpers.test.js
@@ -90,7 +90,7 @@ describe('registerHelpers', function () {
         assert.equal(result, true);
     });
 
-    it('usefeature helper returns true', function () {
+    it('hasFeature helper returns true', function () {
         const handlebars = {
             registerHelper: function (name, fn) {
                 this[name] = fn;
@@ -115,7 +115,7 @@ describe('registerHelpers', function () {
         assert.equal(result, true);
     });
 
-    it('usefeature helper returns false', function () {
+    it('hasFeature helper returns false', function () {
         const handlebars = {
             registerHelper: function (name, fn) {
                 this[name] = fn;


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-173

- updated email renderer to add `post.customExcerpt` data
- updated template to skip rendering subtitle when no custom excerpt is present
- updated template to use actual custom excerpt
