### PR TITLE
Replaced Array.at() for better browser compatibility

### DIFF
--- a/apps/admin-x-framework/src/api/actions.ts
+++ b/apps/admin-x-framework/src/api/actions.ts
@@ -78,7 +78,7 @@ export const useBrowseActions = createInfiniteQuery<ActionsList>({
             }
         });
 
-        const meta = pages.at(-1)!.meta;
+        const meta = pages[pages.length - 1].meta;
 
         return {
             actions: actions.reverse(),

--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -61,7 +61,7 @@ export const useBrowseNewsletters = createInfiniteQuery<NewslettersResponseType 
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<NewslettersResponseType>;
         const newsletters = pages.flatMap(page => page.newsletters);
-        const meta = pages.at(-1)!.meta;
+        const meta = pages[pages.length - 1].meta;
 
         return {
             newsletters: newsletters,

--- a/apps/admin-x-framework/src/api/tiers.ts
+++ b/apps/admin-x-framework/src/api/tiers.ts
@@ -41,7 +41,7 @@ export const useBrowseTiers = createInfiniteQuery<TiersResponseType & {isEnd: bo
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<TiersResponseType>;
         const tiers = pages.flatMap(page => page.tiers);
-        const meta = pages.at(-1)!.meta;
+        const meta = pages[pages.length - 1].meta;
 
         return {
             tiers,

--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -76,7 +76,7 @@ export const useBrowseUsers = createInfiniteQuery<UsersResponseType & {isEnd: bo
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<UsersResponseType>;
         const users = pages.flatMap(page => page.users);
-        const meta = pages.at(-1)!.meta;
+        const meta = pages[pages.length - 1].meta;
 
         return {
             users: users,

--- a/apps/admin-x-framework/src/utils/api/updateQueries.ts
+++ b/apps/admin-x-framework/src/utils/api/updateQueries.ts
@@ -10,7 +10,7 @@ export const insertToQueryCache = <ResponseData>(field: string, recordsToInsert?
 
         if (typeof currentData === 'object' && 'pages' in currentData) {
             const {pages} = currentData as InfiniteData<ResponseData>;
-            const lastPage = pages.at(-1)!;
+            const lastPage = pages[pages.length - 1];
             return {
                 ...currentData,
                 pages: pages.slice(0, -1).concat({


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-125

- Array.at() has been introduced in ECMAScript 2022 and is currently not supported by older browsers, e.g. Safari < 15.4
