### PR TITLE
Fixed ember concurrency cancellation errors

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -1,9 +1,9 @@
 import Component from '@glimmer/component';
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
+import {didCancel, task} from 'ember-concurrency';
 import {getNonDecimal, getSymbol} from 'ghost-admin/utils/currency';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 export default class extends Component {
@@ -137,8 +137,17 @@ export default class extends Component {
 
     @action
     setup() {
-        this.fetchTiers.perform();
-        this.fetchNewsletters.perform();
+        try {
+            this.fetchTiers.perform();
+            this.fetchNewsletters.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
+        }
     }
 
     @action

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -273,7 +273,17 @@ export default class KoenigLexicalEditor extends Component {
         };
 
         const fetchAutocompleteLinks = async () => {
-            const offers = await this.fetchOffersTask.perform();
+            let offers = [];
+            try {
+                offers = await this.fetchOffersTask.perform();
+            } catch (e) {
+                // Do not throw cancellation errors
+                if (didCancel(e)) {
+                    return;
+                }
+
+                throw e;
+            }
 
             const defaults = [
                 {label: 'Homepage', value: window.location.origin + '/'},
@@ -330,7 +340,17 @@ export default class KoenigLexicalEditor extends Component {
         };
 
         const fetchLabels = async () => {
-            const labels = await this.fetchLabelsTask.perform();
+            let labels = [];
+            try {
+                labels = await this.fetchLabelsTask.perform();
+            } catch (e) {
+                // Do not throw cancellation errors
+                if (didCancel(e)) {
+                    return;
+                }
+
+                throw e;
+            }
 
             return labels.map(label => label.name);
         };

--- a/ghost/admin/app/components/modal-member-tier.js
+++ b/ghost/admin/app/components/modal-member-tier.js
@@ -1,8 +1,8 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
+import {didCancel, task} from 'ember-concurrency';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 export default class ModalMemberTier extends ModalComponent {
@@ -77,7 +77,16 @@ export default class ModalMemberTier extends ModalComponent {
     @action
     setup() {
         this.loadingTiers = true;
-        this.fetchTiers.perform();
+        try {
+            this.fetchTiers.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
+        }
     }
 
     @action

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -201,18 +201,30 @@ export default class Analytics extends Component {
             }
             return this._fetchReferrersStats.perform();
         } catch (e) {
-            if (!didCancel(e)) {
-                // re-throw the non-cancelation error
-                throw e;
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
             }
+
+            throw e;
         }
     }
 
     async fetchLinks() {
-        if (this._fetchLinks.isRunning) {
-            return this._fetchLinks.last;
+        try {
+            if (this._fetchLinks.isRunning) {
+                return this._fetchLinks.last;
+            }
+
+            return this._fetchLinks.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
         }
-        return this._fetchLinks.perform();
     }
 
     @task

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -7,11 +7,11 @@ import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import moment from 'moment-timezone';
 import {A} from '@ember/array';
 import {action} from '@ember/object';
+import {didCancel, task, timeout} from 'ember-concurrency';
 import {ghPluralize} from 'ghost-admin/helpers/gh-pluralize';
 import {inject} from 'ghost-admin/decorators/inject';
 import {resetQueryParams} from 'ghost-admin/helpers/reset-query-params';
 import {inject as service} from '@ember/service';
-import {task, timeout} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 const PAID_PARAMS = [{
@@ -258,8 +258,18 @@ export default class MembersController extends Controller {
 
     @action
     refreshData() {
-        this.fetchMembersTask.perform();
-        this.fetchLabelsTask.perform();
+        try {
+            this.fetchMembersTask.perform();
+            this.fetchLabelsTask.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
+        }
+
         this.membersStats.invalidate();
         this.membersStats.fetchCounts();
         this.membersStats.fetchMemberCount();
@@ -415,7 +425,7 @@ export default class MembersController extends Controller {
         this.searchParam = query;
     }
 
-    @task
+    @task({restartable: true})
     *fetchLabelsTask() {
         yield this.store.query('label', {limit: 'all'});
     }

--- a/ghost/admin/app/controllers/offer.js
+++ b/ghost/admin/app/controllers/offer.js
@@ -4,11 +4,11 @@ import UnarchiveOfferModal from '../components/modals/offers/unarchive';
 import config from 'ghost-admin/config/environment';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import {action} from '@ember/object';
+import {didCancel, task} from 'ember-concurrency';
 import {getSymbol} from 'ghost-admin/utils/currency';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 import {slugify} from '@tryghost/string';
-import {task} from 'ember-concurrency';
 import {timeout} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
@@ -258,7 +258,16 @@ export default class OffersController extends Controller {
 
     @action
     setup() {
-        this.fetchTiers.perform();
+        try {
+            this.fetchTiers.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
+        }
     }
 
     @action

--- a/ghost/admin/app/routes/members.js
+++ b/ghost/admin/app/routes/members.js
@@ -1,4 +1,5 @@
 import AdminRoute from 'ghost-admin/routes/admin';
+import {didCancel} from 'ember-concurrency';
 import {inject as service} from '@ember/service';
 
 export default class MembersRoute extends AdminRoute {
@@ -27,7 +28,17 @@ export default class MembersRoute extends AdminRoute {
     // trigger a background load of members plus labels for filter dropdown
     setupController(controller) {
         super.setupController(...arguments);
-        controller.fetchLabelsTask.perform();
+
+        try {
+            controller.fetchLabelsTask.perform();
+        } catch (e) {
+            // Do not throw cancellation errors
+            if (didCancel(e)) {
+                return;
+            }
+
+            throw e;
+        }
     }
 
     resetController(controller, _isExiting, transition) {


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-121
fixes https://linear.app/tryghost/issue/SLO-138
fixes https://linear.app/tryghost/issue/SLO-139
fixes https://linear.app/tryghost/issue/SLO-140
fixes https://linear.app/tryghost/issue/SLO-141
fixes https://linear.app/tryghost/issue/SLO-142

- ember-concurrency prevents two executions of the same task from running at the same time
- when a task is cancelled, the library raises an error by default
- however, we don't need to surface that error as the cancellation of the second execution is intentional
