### PR TITLE
🐛 Fixed Slack integration using member content in excerpt

### DIFF
--- a/ghost/core/core/server/services/slack.js
+++ b/ghost/core/core/server/services/slack.js
@@ -63,7 +63,24 @@ function ping(post) {
         if (post.custom_excerpt) {
             description = post.custom_excerpt;
         } else if (post.html) {
-            description = `${post.html.replace(/<[^>]+>/g, '').split('.').slice(0, 3).join('.')}.`;
+            const membersContentIdx = post.html.indexOf('<!--members-only-->');
+            const substringEnd = membersContentIdx > -1 ? membersContentIdx : post.html.length;
+
+            description = `${
+                post.html
+                    // Remove members-only content
+                    .substring(0, substringEnd)
+                    // Strip out HTML
+                    .replace(/<[^>]+>/g, '')
+                    // Split into sentences
+                    .split('.')
+                    // Remove empty strings
+                    .filter(sentence => sentence.trim() !== '')
+                    // Get the first three sentences
+                    .slice(0, 3)
+                    // Join 'em back together
+                    .join('.')
+            }.`;
         } else {
             description = null;
         }
@@ -160,7 +177,10 @@ function slackListener(model, options) {
         return;
     }
 
-    ping(model.toJSON());
+    ping({
+        ...model.toJSON(),
+        authors: model.related('authors').toJSON()
+    });
 }
 
 function slackTestPing() {


### PR DESCRIPTION
- refs [ONC-63](https://linear.app/tryghost/issue/ONC-63/discordslack-webhook-integration)
- fixes [#20304](https://github.com/TryGhost/Ghost/issues/20304)

When a post is published and sent to Slack via webhook, the excerpt generated could contain member content. This change ensures that the excerpt does not contain member content. This change also ensures that the author for the post is correctly shown in Slack
