### PR TITLE
Update classnames to use `excerpt` in emails

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -1022,9 +1022,9 @@ class EmailRenderer {
         const titleFont = newsletter.get('title_font_category');
 
         if (titleFont === 'serif' && bodyFont === 'serif') {
-            subtitleFontClass = 'post-subtitle-serif-serif';
+            subtitleFontClass = 'post-excerpt-serif-serif';
         } else if (titleFont === 'serif' && bodyFont !== 'serif') {
-            subtitleFontClass = 'post-subtitle-serif-sans';
+            subtitleFontClass = 'post-excerpt-serif-sans';
         }
 
         const data = {
@@ -1090,7 +1090,7 @@ class EmailRenderer {
             classes: {
                 title: 'post-title' + (newsletter.get('title_font_category') === 'serif' ? ` post-title-serif` : ``) + (newsletter.get('title_alignment') === 'left' ? ` post-title-left` : ``),
                 titleLink: 'post-title-link' + (newsletter.get('title_alignment') === 'left' ? ` post-title-link-left` : ``),
-                subtitle: 'post-subtitle' + ` ` + subtitleFontClass + (newsletter.get('title_alignment') === 'left' ? ` post-subtitle-left` : ``),
+                subtitle: 'post-excerpt' + ` ` + subtitleFontClass + (newsletter.get('title_alignment') === 'left' ? ` post-excerpt-left` : ``),
                 meta: 'post-meta' + (newsletter.get('title_alignment') === 'left' ? ` post-meta-left` : ` post-meta-center`),
                 body: newsletter.get('body_font_category') === 'sans_serif' ? `post-content-sans-serif` : `post-content`
             },

--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -377,12 +377,12 @@ figure blockquote p {
     text-align: left;
 }
 
-.post-subtitle-wrapper {
+.post-excerpt-wrapper {
     width: 100%;
     max-width: 600px !important;
 }
 
-.post-subtitle {
+.post-excerpt {
     margin: 0;
     padding-bottom: 20px;
     color: #15212A;
@@ -391,17 +391,17 @@ figure blockquote p {
     text-align: center;
 }
 
-.post-subtitle-serif-serif {
+.post-excerpt-serif-serif {
     font-family: Georgia, serif;
     font-size: 18px;
 }
 
-.post-subtitle-serif-sans {
+.post-excerpt-serif-sans {
     font-size: 18px;
     font-family: Georgia, serif;
 }
 
-.post-subtitle-left {
+.post-excerpt-left {
     text-align: left;
 }
 
@@ -1313,7 +1313,7 @@ a[data-flickr-embed] img {
         font-size: 16px;
     }
 
-    table.body .post-subtitle {
+    table.body .post-excerpt {
         font-size: 16px !important;
     }
 

--- a/ghost/email-service/lib/email-templates/template-old.hbs
+++ b/ghost/email-service/lib/email-templates/template-old.hbs
@@ -82,7 +82,7 @@
                                             {{#hasFeature 'newsletterSubtitle'}}
                                                 {{#if (and newsletter.showSubtitle post.customExcerpt)}}
                                                     <tr>
-                                                        <td class="post-subtitle-wrapper" style="width: 100%">
+                                                        <td class="post-excerpt-wrapper" style="width: 100%">
                                                             <p class="{{classes.subtitle}}">{{post.customExcerpt}}</p>
                                                         </td>
                                                     </tr>

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1816,7 +1816,7 @@ describe('Email renderer', function () {
                 await validateHtml(response.html);
 
                 assert.equal(response.html.match(/This is a subtitle/g).length, 1, 'Subtitle should only appear once (preheader, subtitle section skipped)');
-                response.html.should.not.containEql('post-subtitle-wrapper');
+                response.html.should.not.containEql('post-excerpt-wrapper');
             });
 
             it('does not render when enabled and customExcerpt is not present', async function () {
@@ -1837,7 +1837,7 @@ describe('Email renderer', function () {
 
                 await validateHtml(response.html);
 
-                response.html.should.not.containEql('post-subtitle-wrapper');
+                response.html.should.not.containEql('post-excerpt-wrapper');
             });
         });
     });
@@ -2073,7 +2073,7 @@ describe('Email renderer', function () {
                 title: 'post-title post-title-serif post-title-left',
                 titleLink: 'post-title-link post-title-link-left',
                 meta: 'post-meta post-meta-left',
-                subtitle: 'post-subtitle post-subtitle-serif-sans post-subtitle-left',
+                subtitle: 'post-excerpt post-excerpt-serif-sans post-excerpt-left',
                 body: 'post-content-sans-serif'
             });
         });
@@ -2092,7 +2092,7 @@ describe('Email renderer', function () {
                 show_subtitle: true
             });
             const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
-            assert.equal(data.classes.subtitle, 'post-subtitle post-subtitle-serif-serif post-subtitle-left');
+            assert.equal(data.classes.subtitle, 'post-excerpt post-excerpt-serif-serif post-excerpt-left');
         });
 
         it('show comment CTA is enabled if labs disabled', async function () {


### PR DESCRIPTION
MOM-203

We'll be keeping `excerpt` as the technical name for subtitles. To avoid confusion in the future this PR changes all classnames in the email template to use `excerpt` instead of `subtitle`.