### PR TITLE
Fixed orphaned words in newsletter titles

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -1058,7 +1058,8 @@ class EmailRenderer {
                 showPostTitleSection: newsletter.get('show_post_title_section'),
                 showExcerpt: newsletter.get('show_excerpt'),
                 showCommentCta: newsletter.get('show_comment_cta') && this.#settingsCache.get('comments_enabled') !== 'off' && !hasEmailOnlyFlag,
-                showSubscriptionDetails: newsletter.get('show_subscription_details')
+                showSubscriptionDetails: newsletter.get('show_subscription_details'),
+                titleIsCentered: newsletter.get('title_alignment') !== 'left'
             },
             latestPosts,
             latestPostsHasImages,

--- a/ghost/email-service/lib/email-templates/template-old.hbs
+++ b/ghost/email-service/lib/email-templates/template-old.hbs
@@ -76,14 +76,14 @@
                                         {{#if newsletter.showPostTitleSection}}
                                             <tr>
                                                 <td class="{{classes.title}}">
-                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
+                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{avoidOrphanedWords post.title}}</a>
                                                 </td>
                                             </tr>
                                             {{#hasFeature 'newsletterExcerpt'}}
                                                 {{#if (and newsletter.showExcerpt post.customExcerpt)}}
                                                     <tr>
                                                         <td class="post-excerpt-wrapper" style="width: 100%">
-                                                            <p class="{{classes.excerpt}}">{{post.customExcerpt}}</p>
+                                                            <p class="{{classes.excerpt}}">{{avoidOrphanedWords post.customExcerpt}}</p>
                                                         </td>
                                                     </tr>
                                                 {{/if}}

--- a/ghost/email-service/lib/email-templates/template-old.hbs
+++ b/ghost/email-service/lib/email-templates/template-old.hbs
@@ -76,14 +76,14 @@
                                         {{#if newsletter.showPostTitleSection}}
                                             <tr>
                                                 <td class="{{classes.title}}">
-                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{avoidOrphanedWords post.title}}</a>
+                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{#if newsletter.titleIsCentered}}{{avoidOrphanedWords post.title}}{{else}}{{post.title}}{{/if}}</a>
                                                 </td>
                                             </tr>
                                             {{#hasFeature 'newsletterExcerpt'}}
                                                 {{#if (and newsletter.showExcerpt post.customExcerpt)}}
                                                     <tr>
                                                         <td class="post-excerpt-wrapper" style="width: 100%">
-                                                            <p class="{{classes.excerpt}}">{{avoidOrphanedWords post.customExcerpt}}</p>
+                                                            <p class="{{classes.excerpt}}">{{#if newsletter.titleIsCentered}}{{avoidOrphanedWords post.customExcerpt}}{{else}}{{post.customExcerpt}}{{/if}}</p>
                                                         </td>
                                                     </tr>
                                                 {{/if}}

--- a/ghost/email-service/lib/helpers/register-helpers.js
+++ b/ghost/email-service/lib/helpers/register-helpers.js
@@ -51,5 +51,24 @@ module.exports = {
                 return options.inverse(this);
             }
         });
+
+        handlebars.registerHelper('avoidOrphanedWords', function (text) {
+            let replacement = text?.trim?.();
+
+            if (!replacement) {
+                return '';
+            }
+
+            // replace last space with &nbsp; to avoid orphaned words when wrapping
+            const lastSpaceIndex = replacement.lastIndexOf(' ');
+            if (lastSpaceIndex !== -1) {
+                replacement =
+                    handlebars.escapeExpression(replacement.substring(0, lastSpaceIndex)) +
+                    '&nbsp;' +
+                    handlebars.escapeExpression(replacement.substring(lastSpaceIndex + 1));
+            }
+
+            return new handlebars.SafeString(replacement);
+        });
     }
 };

--- a/ghost/email-service/test/email-helpers.test.js
+++ b/ghost/email-service/test/email-helpers.test.js
@@ -1,6 +1,5 @@
 const assert = require('assert/strict');
 const {registerHelpers} = require('../lib/helpers/register-helpers');
-const {escape} = require('querystring');
 
 describe('registerHelpers', function () {
     it('registers helpers', function () {

--- a/ghost/email-service/test/email-helpers.test.js
+++ b/ghost/email-service/test/email-helpers.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert/strict');
 const {registerHelpers} = require('../lib/helpers/register-helpers');
+const {escape} = require('querystring');
 
 describe('registerHelpers', function () {
     it('registers helpers', function () {
@@ -138,5 +139,35 @@ describe('registerHelpers', function () {
         });
 
         assert.equal(result, false);
+    });
+
+    it('avoidOrphanedWords helper', function () {
+        const handlebars = {
+            registerHelper: function (name, fn) {
+                this[name] = fn;
+            },
+            escapeExpression(text) {
+                return text;
+            },
+            SafeString: class SafeString {
+                constructor(text) {
+                    this.text = text;
+                }
+            }
+        };
+
+        registerHelpers(handlebars, {});
+
+        const tests = [
+            {input: null, expected: ''},
+            {input: '', expected: ''},
+            {input: 'One-word', expected: new handlebars.SafeString('One-word')},
+            {input: 'Two words', expected: new handlebars.SafeString('Two&nbsp;words')}
+        ];
+
+        for (const test of tests) {
+            const result = handlebars.avoidOrphanedWords(test.input);
+            assert.deepEqual(result, test.expected);
+        }
     });
 });

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1794,7 +1794,8 @@ describe('Email renderer', function () {
 
                 await validateHtml(response.html);
 
-                assert.equal(response.html.match(/This is an excerpt/g).length, 2, 'Excerpt should appear twice (preheader and excerpt section)');
+                assert.equal(response.html.match(/This is an excerpt/g).length, 1, 'Preheader has no non-breaking space;');
+                assert.equal(response.html.match(/This is an&#xA0;excerpt/g).length, 1, 'Excerpt has last space replaced with non-breaking space;');
             });
 
             it('is not rendered when disabled and customExcerpt is present', async function () {

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1798,6 +1798,28 @@ describe('Email renderer', function () {
                 assert.equal(response.html.match(/This is an&#xA0;excerpt/g).length, 1, 'Excerpt has last space replaced with non-breaking space;');
             });
 
+            it('does not add nbsp when aligned left', async function () {
+                const post = createModel(Object.assign({}, basePost, {custom_excerpt: 'This is an excerpt'}));
+                const newsletter = createModel({
+                    show_post_title_section: true,
+                    show_excerpt: true,
+                    title_alignment: 'left'
+                });
+                const segment = null;
+                const options = {};
+
+                const response = await emailRenderer.renderBody(
+                    post,
+                    newsletter,
+                    segment,
+                    options
+                );
+
+                await validateHtml(response.html);
+
+                assert.equal(response.html.match(/This is an excerpt/g).length, 2, 'Excerpt appears twice (preheader + excerpt w/o nbsp)');
+            });
+
             it('is not rendered when disabled and customExcerpt is present', async function () {
                 const post = createModel(Object.assign({}, basePost, {custom_excerpt: 'This is an excerpt'}));
                 const newsletter = createModel({


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-191

- added `avoidOrphanedWords` helper that replaces the last space in the supplied text with `&nbsp;` so when the text wraps you're not left with a single word on the wrapped line
- updated email template to use the helper for the title and excerpt
