### PR TITLE
✨ Added newsletter design setting to display excerpt as subtitle

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,7 +25,8 @@ const GA_FEATURES = [
     'filterEmailDisabled',
     'newEmailAddresses',
     'portalImprovements',
-    'onboardingChecklist'
+    'onboardingChecklist',
+    'newsletterExcerpt'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -53,7 +54,6 @@ const ALPHA_FEATURES = [
     'lexicalIndicators',
     'adminXDemo',
     'editorExcerpt',
-    'newsletterExcerpt',
     'internalLinkingAtLinks'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1155,7 +1155,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4591",
+  "content-length": "4618",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
no issue

Full details coming soon to https://ghost.org/changelog/

- when enabled in newsletter design settings a post's custom excerpt will be displayed as a subtitle in the email
