### PR TITLE
Noop'ed the post_revisions.custom_excerpt population migration

### DIFF
--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -51,7 +51,10 @@ export default class ModalPostHistory extends Component {
                 latest: index === 0,
                 createdAt: revision.get('createdAt'),
                 title: revision.get('title'),
-                custom_excerpt: revision.get('customExcerpt'),
+                // custom_excerpt is a new field that was added to the post-revision model
+                // that may not have been populated for older revisions. To cover that case
+                // we revert to the current post's customExcerpt to avoid losing data when restoring.
+                custom_excerpt: revision.get('customExcerpt') ?? this.post.customExcerpt,
                 feature_image: revision.get('featureImage'),
                 feature_image_alt: revision.get('featureImageAlt'),
                 feature_image_caption: revision.get('featureImageCaption'),

--- a/ghost/core/core/server/data/migrations/versions/5.84/2024-06-05-08-42-34-populate-post-revisions-custom-excerpt.js
+++ b/ghost/core/core/server/data/migrations/versions/5.84/2024-06-05-08-42-34-populate-post-revisions-custom-excerpt.js
@@ -1,30 +1,9 @@
 const logging = require('@tryghost/logging');
 const {createTransactionalMigration} = require('../../utils');
-const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createTransactionalMigration(
-    async function up(knex) {
-        logging.info('Populating post_revisions.custom_excerpt with post.excerpt');
-
-        if (DatabaseInfo.isSQLite(knex)) {
-            // SQLite doesn't support JOINs in UPDATE queries
-            await knex.raw(`
-                UPDATE post_revisions
-                SET custom_excerpt = (
-                    SELECT posts.custom_excerpt
-                    FROM posts
-                    WHERE post_revisions.post_id = posts.id
-                )
-            `);
-        } else {
-            await knex.raw(`
-                UPDATE post_revisions
-                JOIN posts ON post_revisions.post_id = posts.id
-                SET post_revisions.custom_excerpt = posts.custom_excerpt
-            `);
-        }
-
-        logging.info('Finished populating post_revisions.custom_excerpt');
+    async function up() {
+        logging.warn('Skipping migration - noop');
     },
     async function down() {
         // Not required


### PR DESCRIPTION
no issue

- the query can take a very long time to run on large sites causing problems during the upgrade process
- impact from not populating the column:
  - only has an effect when the inline excerpt beta is enabled
  - when beta enabled, if a revision created before the upgrade is restored then the excerpt will be removed (will be visibly empty in preview before restoring, if any edit has occurred on the post after upgrading then it can still be recovered by restoring the later version or copy/pasting from the preview)
