### PR TITLE
🐛 Fixed cursor movement across fields in excerpt-in-editor beta

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -68,14 +68,14 @@
                         @value={{readonly this.excerpt}}
                         @input={{this.onExcerptInput}}
                         @keyDown={{this.onExcerptKeydown}}
-                        @didCreateTextarea={{this.registerSubtitleElement}}
+                        @didCreateTextarea={{this.registerExcerptElement}}
                         data-test-textarea="excerpt"
                     />
                     {{#if @excerptHasTk}}
                         <div
                             class="tk-indicator tk-indicator-excerpt"
                             data-testid="tk-indicator-excerpt"
-                            {{on "click" this.focusSubtitle}}
+                            {{on "click" this.focusExcerpt}}
                         >
                             TK
                         </div>
@@ -96,7 +96,7 @@
             @cardConfig={{@cardOptions}}
             @onChange={{@onBodyChange}}
             @registerAPI={{this.registerEditorAPI}}
-            @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusSubtitle this.focusTitle}}
+            @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
         />

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -4,7 +4,7 @@ import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
-export default class GhKoenigEditorReactComponent extends Component {
+export default class GhKoenigEditorLexical extends Component {
     @service settings;
     @service feature;
 
@@ -114,7 +114,7 @@ export default class GhKoenigEditorReactComponent extends Component {
 
     @action
     onTitleKeydown(event) {
-        if (this.feature.get('editorExcerpt')) {
+        if (this.feature.editorExcerpt) {
             // move cursor to the excerpt on
             // - Tab (handled by browser)
             // - Arrow Down/Right when input is empty or caret at end of input
@@ -167,12 +167,12 @@ export default class GhKoenigEditorReactComponent extends Component {
     // Subtitle ("excerpt") Actions -------------------------------------------
 
     @action
-    excerptSubtitleElement(element) {
+    registerExcerptElement(element) {
         this.excerptElement = element;
     }
 
     @action
-    focusSubtitle() {
+    focusExcerpt() {
         this.excerptElement?.focus();
 
         // timeout ensures this occurs after the keyboard events


### PR DESCRIPTION
no issue

- during the subtitle->excerpt rename some instances were missed resulting in the excerpt field element not being registered correctly
- fixed mismatched action name and renamed remaining uses of "subtitle"
