### PR TITLE
Removed Sentry error on multiple request attempts

### DIFF
--- a/apps/admin-x-framework/src/utils/api/fetchApi.ts
+++ b/apps/admin-x-framework/src/utils/api/fetchApi.ts
@@ -74,10 +74,6 @@ export const useFetchApi = () => {
                     ...options
                 });
 
-                if (attempts !== 0 && sentryDSN) {
-                    Sentry.captureMessage('Request took multiple attempts', {extra: getErrorData()});
-                }
-
                 return handleResponse(response) as ResponseData;
             } catch (error) {
                 retryingMs = Date.now() - startTime;


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/SLO-146
- this Sentry error is not a user-facing error
- the request is retried if it fails the first time

