### PR TITLE
✨ Added "@" shortcut to trigger internal linking search (beta)

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -60,10 +60,6 @@ const features = [{
     description: 'Wires up the Ghost NestJS App to the Admin API',
     flag: 'NestPlayground'
 },{
-    title: 'Internal Linking @-links (internal alpha)',
-    description: 'Adds internal URL search when typing @ in the editor',
-    flag: 'internalLinkingAtLinks'
-},{
     title: 'ActivityPub',
     description: '(Highly) Experimental support for ActivityPub.',
     flag: 'ActivityPub'

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -447,7 +447,7 @@ export default class KoenigLexicalEditor extends Component {
                 collectionsCard: this.feature.collectionsCard,
                 collections: this.feature.collections,
                 internalLinking: this.feature.internalLinking,
-                internalLinkingAtLinks: this.feature.internalLinkingAtLinks,
+                internalLinkingAtLinks: this.feature.internalLinking,
                 contentVisibility: this.feature.contentVisibility
             },
             deprecated: { // todo fix typo

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -83,7 +83,6 @@ export default class FeatureService extends Service {
     @feature('onboardingChecklist') onboardingChecklist;
     @feature('ActivityPub') ActivityPub;
     @feature('internalLinking') internalLinking;
-    @feature('internalLinkingAtLinks') internalLinkingAtLinks;
     @feature('editorExcerpt') editorExcerpt;
     @feature('newsletterExcerpt') newsletterExcerpt;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -54,7 +54,6 @@ const ALPHA_FEATURES = [
     'importMemberTier',
     'lexicalIndicators',
     'adminXDemo',
-    'internalLinkingAtLinks',
     'contentVisibility'
 ];
 


### PR DESCRIPTION
no issue

Typing "@" in the editor will immediately trigger an internal link search to make it faster to link to one of your articles. After typing "@" continue typing to search, results can be selected using Up/Down arrow keys or the mouse, then pressing Enter or clicking will insert the selected result's title pre-linked. Pressing Escape or moving the cursor out of the search box will cancel the search.

- removed labs flag
- updated Koenig feature flag for at-linking to use the same flag as our internal linking beta
