### PR TITLE
Fixed missing URLs in improved search results

### DIFF
--- a/ghost/admin/app/services/search-provider-beta.js
+++ b/ghost/admin/app/services/search-provider-beta.js
@@ -82,9 +82,10 @@ export default class SearchProviderService extends Service {
                     usedIds.add(id);
 
                     groupResults.push({
+                        groupName: searchable.name,
                         id: `${searchable.model}.${doc[searchable.pathField]}`,
                         title: doc[searchable.titleField],
-                        groupName: searchable.name,
+                        url: doc.url,
                         status: doc.status,
                         visibility: doc.visibility,
                         publishedAt: doc.published_at

--- a/ghost/admin/mirage/factories/page.js
+++ b/ghost/admin/mirage/factories/page.js
@@ -1,0 +1,54 @@
+import {Factory} from 'miragejs';
+import {isEmpty} from '@ember/utils';
+
+export default Factory.extend({
+    codeinjectionFoot: null,
+    codeinjectionHead: null,
+    createdAt: '2015-09-11T09:44:29.871Z',
+    createdBy: 1,
+    customExcerpt: null,
+    customTemplate: null,
+    description(i) { return `Title for page ${i}.`; },
+    featured: false,
+    featureImage(i) { return `/content/images/2015/10/page-${i}.jpg`; },
+    html(i) { return `<p>HTML for page ${i}.</p>`; },
+    visibility: 'public',
+    metaDescription(i) { return `Meta description for page ${i}.`; },
+    metaTitle(i) { return `Meta Title for page ${i}`; },
+    ogDescription: null,
+    ogImage: null,
+    ogTitle: null,
+    excerpt(i) { return `Excerpt for page ${i}.`; },
+    plaintext(i) { return `Plaintext for page ${i}.`; },
+    publishedAt: '2015-12-19T16:25:07.000Z',
+    publishedBy: 1,
+    status(i) {
+        let statuses = ['draft', 'published', 'scheduled'];
+        return statuses[i % statuses.length];
+    },
+    title(i) { return `Page ${i}`; },
+    twitterDescription: null,
+    twitterImage: null,
+    twitterTitle: null,
+    emailSubject: null,
+    updatedAt: '2015-10-19T16:25:07.756Z',
+    updatedBy: 1,
+    uuid(i) { return `page-${i}`; },
+
+    authors() { return []; },
+    tags() { return []; },
+
+    afterCreate(page, server) {
+        if (isEmpty(page.authors)) {
+            let user = server.schema.users.find(1);
+
+            if (!user) {
+                let role = server.schema.roles.find({name: 'Administrator'}) || server.create('role', {name: 'Administrator'});
+                user = server.create('user', {roles: [role]});
+            }
+
+            page.authors = [user];
+            page.save();
+        }
+    }
+});

--- a/ghost/admin/mirage/serializers/post.js
+++ b/ghost/admin/mirage/serializers/post.js
@@ -27,7 +27,7 @@ export default BaseSerializer.extend({
             if (post.status === 'published') {
                 post.update('url', `http://localhost:4200/${post.slug}/`);
             } else {
-                post.update('url', `http://localhost:4200/p/`);
+                post.update('url', `http://localhost:4200/p/${post.uuid}/`);
             }
         };
 

--- a/ghost/admin/tests/integration/services/search-test.js
+++ b/ghost/admin/tests/integration/services/search-test.js
@@ -1,30 +1,55 @@
 import {describe, it} from 'mocha';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {expect} from 'chai';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {setupTest} from 'ember-mocha';
 
-describe('Integration: Service: search', function () {
-    const hooks = setupTest();
-    setupMirage(hooks);
+const suites = [{
+    name: 'Integration: Service: Search',
+    beforeEach() {
+        // noop
+    }
+}, {
+    name: 'Integration: Service: Search (beta)',
+    beforeEach() {
+        enableLabsFlag(this.server, 'internalLinkingSearchImprovements');
+    }
+}];
 
-    let search;
-    // eslint-disable-next-line no-unused-vars
-    let firstUser, firstPost, secondPost, firstPage, firstTag;
+suites.forEach((suite) => {
+    describe(suite.name, function () {
+        const hooks = setupTest();
+        setupMirage(hooks);
 
-    beforeEach(function () {
-        search = this.owner.lookup('service:search');
+        let search;
+        // eslint-disable-next-line no-unused-vars
+        let firstUser, firstPost, secondPost, firstPage, firstTag;
 
-        // populate store with data we'll be searching
-        firstPost = this.server.create('post', {title: 'First post', slug: 'first-post', visibility: 'members', publishedAt: '2024-05-08T16:21:07.000Z'});
-        secondPost = this.server.create('post', {title: 'Second post', slug: 'second-post'});
-        firstPage = this.server.create('page', {title: 'First page', slug: 'first-page'});
-        firstTag = this.server.create('tag', {name: 'First tag', slug: 'first-tag'});
-    });
+        beforeEach(function () {
+            suite.beforeEach.bind(this)();
 
-    it('returns additional post-related fields', async function () {
-        const results = await search.searchTask.perform('post');
+            search = this.owner.lookup('service:search');
 
-        expect(results[0].options[0].visibility).to.equal('members');
-        expect(results[0].options[0].publishedAt).to.equal('2024-05-08T16:21:07.000Z');
+            // populate store with data we'll be searching
+            firstPost = this.server.create('post', {title: 'First post', slug: 'first-post', visibility: 'members', publishedAt: '2024-05-08T16:21:07.000Z'});
+            secondPost = this.server.create('post', {title: 'Second post', slug: 'second-post'});
+            firstPage = this.server.create('page', {title: 'First page', slug: 'first-page'});
+            firstTag = this.server.create('tag', {name: 'First tag', slug: 'first-tag'});
+        });
+
+        it('returns urls for search results', async function () {
+            const results = await search.searchTask.perform('first');
+
+            expect(results[0].options[0].url).to.equal('http://localhost:4200/tag/first-tag/');
+            expect(results[1].options[0].url).to.equal('http://localhost:4200/p/post-0/');
+            expect(results[2].options[0].url).to.equal('http://localhost:4200/p/page-0/');
+        });
+
+        it('returns additional post-related fields', async function () {
+            const results = await search.searchTask.perform('post');
+
+            expect(results[0].options[0].visibility).to.equal('members');
+            expect(results[0].options[0].publishedAt).to.equal('2024-05-08T16:21:07.000Z');
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-117

- `url` was missing in the results objects that we generate from the underlying search results
- updated service integration test with check for url presence
- updated service integration test to also run against the beta search
- added missing page factory to mirage setup
- updated mirage post serializer to include a uniquely identifiable URL for unpublished posts
