### PR TITLE
Fixed validation error handling before previewing a post

### DIFF
--- a/ghost/admin/app/components/editor/publish-management.js
+++ b/ghost/admin/app/components/editor/publish-management.js
@@ -56,7 +56,7 @@ export default class PublishManagement extends Component {
             }
         }
 
-        if (isValid && !this.publishFlowModal || this.publishFlowModal?.isClosing) {
+        if (isValid && (!this.publishFlowModal || this.publishFlowModal?.isClosing)) {
             this.publishOptions.resetPastScheduledAt();
 
             this.publishFlowModal = this.modals.open(PublishFlowModal, {
@@ -83,7 +83,7 @@ export default class PublishManagement extends Component {
 
         const isValid = await this._validatePost();
 
-        if (isValid && !this.updateFlowModal || this.updateFlowModal.isClosing) {
+        if (isValid && (!this.updateFlowModal || this.updateFlowModal.isClosing)) {
             this.updateFlowModal = this.modals.open(UpdateFlowModal, {
                 publishOptions: this.publishOptions,
                 saveTask: this.publishTask
@@ -99,10 +99,12 @@ export default class PublishManagement extends Component {
     }
 
     @action
-    openPreview(event, {skipAnimation} = {}) {
+    async openPreview(event, {skipAnimation} = {}) {
         event?.preventDefault();
 
-        if (!this.previewModal || this.previewModal.isClosing) {
+        const isValid = await this._validatePost();
+
+        if (isValid && (!this.previewModal || this.previewModal.isClosing)) {
             // open publish flow modal underneath to offer quick switching
             // without restarting the flow or causing flicker
 

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -642,8 +642,7 @@ export default class LexicalEditorController extends Controller {
             if (!options.silent) {
                 let errorOrMessages = error || this.get('post.errors.messages');
                 this._showErrorAlert(prevStatus, this.get('post.status'), errorOrMessages);
-                // simulate a validation error for upstream tasks
-                throw undefined;
+                return;
             }
 
             return this.post;


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-143

- in the editor, if there is a validation error on a post (e.g. the excerpt is longer than 300 chars), a validation error is rendered as a red banner error. However, when clicking on Preview, this error was bypassed
- additionally, we were throwing an undefined error when a validation error happened. This was unnecessary and causing hundreds of unhandled errors per week