### PR TITLE
Moved pagination button back to top in comments

### DIFF
--- a/apps/comments-ui/src/components/content/Content.tsx
+++ b/apps/comments-ui/src/components/content/Content.tsx
@@ -37,6 +37,7 @@ const Content = () => {
     return (
         <>
             <ContentTitle count={commentCount} showCount={showCount} title={title}/>
+            <Pagination />
             <div className={!pagination ? 'mt-4' : ''} data-test="comment-elements">
                 {commentsElements}
             </div>
@@ -46,7 +47,6 @@ const Content = () => {
                     : null
                 }
             </div>
-            <Pagination />
         </>
     );
 };

--- a/apps/comments-ui/test/e2e/pagination.test.ts
+++ b/apps/comments-ui/test/e2e/pagination.test.ts
@@ -2,7 +2,7 @@ import {MockedApi, addMultipleComments, initialize} from '../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Pagination', async () => {
-    test('Shows pagination button at bottom if more than 20 comments', async ({page}) => {
+    test('Shows pagination button at top if more than 20 comments', async ({page}) => {
         const mockedApi = new MockedApi({});
 
         addMultipleComments(mockedApi, 21);


### PR DESCRIPTION
no issue

- moving the pagination button back to the top since it's not needed now.
- Will move it to bottom in future along with additional enhancements.