### PR TITLE
Wired up contentVisibility flag to Koenig

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -447,9 +447,10 @@ export default class KoenigLexicalEditor extends Component {
                 collectionsCard: this.feature.collectionsCard,
                 collections: this.feature.collections,
                 internalLinking: this.feature.internalLinking,
-                internalLinkingAtLinks: this.feature.internalLinkingAtLinks
+                internalLinkingAtLinks: this.feature.internalLinkingAtLinks,
+                contentVisibility: this.feature.contentVisibility
             },
-            deprecated: {
+            deprecated: { // todo fix typo
                 headerV1: true // if false, shows header v1 in the menu
             },
             membersEnabled: this.settings.membersSignupAccess === 'all',


### PR DESCRIPTION
ref MOM-221

- wired up the contentVisibility flag to be passed to Koenig from Ghost / Admin.