### PR TITLE
Ignored posthog-js and ember-concurrency cancellation errors in Sentry

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -190,7 +190,12 @@ export default Route.extend(ShortcutsRoute, {
                     /^TransitionAborted$/,
                     // ResizeObserver loop errors occur often from extensions and
                     // embedded content, generally harmless and not useful to report
-                    /^ResizeObserver loop completed with undelivered notifications/
+                    /^ResizeObserver loop completed with undelivered notifications/,
+                    /^ResizeObserver loop limit exceeded/,
+                    // When tasks in ember-concurrency are canceled, they sometimes lead to unhandled Promise rejections
+                    // This doesn't affect the application and is not useful to report
+                    // - http://ember-concurrency.com/docs/cancelation
+                    'TaskCancelation'
                 ],
                 integrations: []
             };

--- a/ghost/admin/app/utils/sentry.js
+++ b/ghost/admin/app/utils/sentry.js
@@ -34,6 +34,13 @@ export function beforeSend(event, hint) {
             delete event.tags.ajax_url;
         }
 
+        // Do not report poshog-js errors to Sentry
+        if (hint && hint.originalException && hint.originalException.stack) {
+            if (hint.originalException.stack.includes('/posthog-js/')) {
+                return null;
+            }
+        }
+
         return event;
     } catch (error) {
         // If any errors occur in beforeSend, send the original event to Sentry


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-126
fixes https://linear.app/tryghost/issue/SLO-141
fixes https://linear.app/tryghost/issue/SLO-150

- during a session, posthog-js' rrweb extension can start throwing a lot of errors. These errors do not affect the application
- similarly, ember-concurrency's task cancellation errors do not affect the application. Task in ember-concurrency are expected to be canceled. However, if they're cast to a Promise, they show up as unhandled Promise rejections as Promises do not have a concept of cancellation
