### PR TITLE
Fixed data generator not setting `posts.plaintext` value

### DIFF
--- a/ghost/data-generator/lib/importers/PostsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsImporter.js
@@ -81,6 +81,7 @@ class PostsImporter extends TableImporter {
                 ])
             }),
             html: content.map(paragraph => `<p>${paragraph}</p>`).join(''),
+            plaintext: content.join('\n\n'),
             email_recipient_filter: 'all',
             newsletter_id: this.type === 'post' && status === 'published' && luck(90) ? (visibility === 'paid' ? this.newsletters[0].id : this.newsletters[1].id) : null
         };


### PR DESCRIPTION
no issue

- without `plaintext` set the API will not add generated excerpts to responses
