### PR TITLE
Added improved search into internal linking beta

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -64,10 +64,6 @@ const features = [{
     description: 'Adds internal URL search when typing @ in the editor',
     flag: 'internalLinkingAtLinks'
 },{
-    title: 'Internal Linking search improvements (internal alpha)',
-    description: 'Replaces Admin\'s search with flexsearch indexes',
-    flag: 'internalLinkingSearchImprovements'
-},{
     title: 'ActivityPub',
     description: '(Highly) Experimental support for ActivityPub.',
     flag: 'ActivityPub'

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -84,7 +84,6 @@ export default class FeatureService extends Service {
     @feature('ActivityPub') ActivityPub;
     @feature('internalLinking') internalLinking;
     @feature('internalLinkingAtLinks') internalLinkingAtLinks;
-    @feature('internalLinkingSearchImprovements') internalLinkingSearchImprovements;
     @feature('editorExcerpt') editorExcerpt;
     @feature('newsletterExcerpt') newsletterExcerpt;
 

--- a/ghost/admin/app/services/search.js
+++ b/ghost/admin/app/services/search.js
@@ -15,7 +15,7 @@ export default class SearchService extends Service {
     isContentStale = true;
 
     get provider() {
-        return this.feature.internalLinkingSearchImprovements
+        return this.feature.internalLinking
             ? this.searchProviderBeta
             : this.searchProvider;
     }

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -17,7 +17,7 @@ const suites = [{
 }, {
     name: 'Acceptance: Search (beta)',
     beforeEach() {
-        enableLabsFlag(this.server, 'internalLinkingSearchImprovements');
+        enableLabsFlag(this.server, 'internalLinking');
     }
 }];
 

--- a/ghost/admin/tests/integration/services/search-test.js
+++ b/ghost/admin/tests/integration/services/search-test.js
@@ -12,7 +12,7 @@ const suites = [{
 }, {
     name: 'Integration: Service: Search (beta)',
     beforeEach() {
-        enableLabsFlag(this.server, 'internalLinkingSearchImprovements');
+        enableLabsFlag(this.server, 'internalLinking');
     }
 }];
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -55,7 +55,6 @@ const ALPHA_FEATURES = [
     'lexicalIndicators',
     'adminXDemo',
     'internalLinkingAtLinks',
-    'internalLinkingSearchImprovements',
     'contentVisibility'
 ];
 


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-117
closes https://linear.app/tryghost/issue/MOM-70

- updated flag handling to move the improved search into the `internalLinking` beta flag
- removed now-unused `internalLinkingSearchImprovements` flag
