### PR TITLE
Updated data-generator to create lexical rather than mobiledoc posts

### DIFF
--- a/ghost/data-generator/lib/importers/PostsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsImporter.js
@@ -62,23 +62,34 @@ class PostsImporter extends TableImporter {
             slug: `${slugify(title)}-${faker.random.numeric(3)}`,
             status,
             visibility,
-            mobiledoc: JSON.stringify({
-                version: '0.3.1',
-                atoms: [],
-                cards: [],
-                markups: [['em']],
-                sections: content.map(paragraph => [
-                    1,
-                    'p',
-                    [
-                        [
-                            0,
-                            [],
-                            0,
-                            paragraph
-                        ]
-                    ]
-                ])
+            lexical: JSON.stringify({
+                root: {
+                    children: content.map(paragraph => (
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: paragraph,
+                                    type: 'extended-text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    )),
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
             }),
             html: content.map(paragraph => `<p>${paragraph}</p>`).join(''),
             plaintext: content.join('\n\n'),


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ONC-96

- better matches Ghost's current usage
- avoids mismatch in expected data when `post_revisions` is populated in future
