### PR TITLE
Fixed shutdown signal compatibility issue with Node 20

### DIFF
--- a/ghost/core/core/server/GhostServer.js
+++ b/ghost/core/core/server/GhostServer.js
@@ -127,8 +127,8 @@ class GhostServer {
 
             // ensure that Ghost exits correctly on Ctrl+C and SIGTERM
             process
-                .removeAllListeners('SIGINT').on('SIGINT', self.shutdown.bind(self))
-                .removeAllListeners('SIGTERM').on('SIGTERM', self.shutdown.bind(self));
+                .removeAllListeners('SIGINT').on('SIGINT', () => self.shutdown())
+                .removeAllListeners('SIGTERM').on('SIGTERM', () => self.shutdown());
         });
     }
 


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/ENG-1250/fix-node-20-shutdown-signal-compatibility-issue

- in Node 20, support for string-based arguments to `process.exit` are removed
- we can just switch this to an anonymous function and call `.shutdown` directly, as we don't need to pass any integer codes to it