### PR TITLE
Fixed "What's new" notification for contributors

### DIFF
--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -112,7 +112,15 @@
     border-right: none;
     background: unset;
     width: 100%;
-    pointer-events: none;
+    overflow: unset;
+}
+
+.gh-nav-contributor .gh-nav-body {
+    overflow: unset;
+}
+
+.gh-nav-contributor .gh-sidebar-banner {
+    max-width: 300px;
 }
 
 .gh-nav-menu {


### PR DESCRIPTION
DES-363

The "What's new" notification took up the whole width of the admin for contributors and it wasn't possible to interact with it.