### PR TITLE
🐛 Fixed button URL suggestions not loading for contributors, editors and authors

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -83,6 +83,28 @@ export function decoratePostSearchResult(item, settings) {
     }
 }
 
+/**
+ * Fetches the URLs of all active offers
+ * @returns {Promise<{label: string, value: string}[]>}
+ */
+export async function offerUrls() {
+    let offers = [];
+
+    try {
+        offers = await this.fetchOffersTask.perform();
+    } catch (e) {
+        // No-op: if offers are not available (e.g. missing permissions), return an empty array
+        return [];
+    }
+
+    return offers.map((offer) => {
+        return {
+            label: `Offer — ${offer.name}`,
+            value: this.config.getSiteUrl(offer.code)
+        };
+    });
+}
+
 class ErrorHandler extends React.Component {
     state = {
         hasError: false
@@ -273,18 +295,6 @@ export default class KoenigLexicalEditor extends Component {
         };
 
         const fetchAutocompleteLinks = async () => {
-            let offers = [];
-            try {
-                offers = await this.fetchOffersTask.perform();
-            } catch (e) {
-                // Do not throw cancellation errors
-                if (didCancel(e)) {
-                    return;
-                }
-
-                throw e;
-            }
-
             const defaults = [
                 {label: 'Homepage', value: window.location.origin + '/'},
                 {label: 'Free signup', value: '#/portal/signup/free'}
@@ -329,12 +339,7 @@ export default class KoenigLexicalEditor extends Component {
                 return [];
             };
 
-            const offersLinks = offers.toArray().map((offer) => {
-                return {
-                    label: `Offer - ${offer.name}`,
-                    value: this.config.getSiteUrl(offer.code)
-                };
-            });
+            const offersLinks = await offerUrls.call(this);
 
             return [...defaults, ...memberLinks(), ...donationLink(), ...recommendationLink(), ...offersLinks];
         };


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-127

- problem: when using a card with a button (Button, Email CTA, Header, Product), the Button URL suggestions fail to load for Contributors, Authors, and Editors
- cause: Contributors, Authors and Editors don’t have permission to fetch offers, and this causes the entire list of button url suggestions to break
- solution: if offers fail to fetch for any reason, the rest of the url suggestions for cards with a button is now still populated (i.e. offers URLs are ignored)

