### PR TITLE
🐛 Fixed dashboard appearing blank if members disabled before completing onboarding

### DIFF
--- a/ghost/admin/app/templates/dashboard.hbs
+++ b/ghost/admin/app/templates/dashboard.hbs
@@ -85,38 +85,34 @@
             {{#if this.isLoading }}
                 <GhLoadingSpinner />
             {{else}}
-                {{#if this.areMembersEnabled}}
-
-                    {{#if this.onboarding.isChecklistShown}}
-                        <Dashboard::OnboardingChecklist />
+                {{#if this.onboarding.isChecklistShown}}
+                    <Dashboard::OnboardingChecklist />
+                {{/if}}
+                {{#if (and this.areMembersEnabled (not this.onboarding.isChecklistShown))}}
+                    {{#if this.hasPaidTiers}}
+                        <Dashboard::Charts::Overview />
                     {{/if}}
-
-                    {{#unless this.onboarding.isChecklistShown}}
+                    <div class="gh-dashboard-group {{if this.isTotalMembersZero 'is-zero'}}" data-test-dashboard="attribution">
+                        <Dashboard::Charts::AnchorAttribution />
                         {{#if this.hasPaidTiers}}
-                            <Dashboard::Charts::Overview />
+                            <section class="gh-dashboard-section">
+                                <article class="gh-dashboard-box gh-dashboard-minicharts-attribution">
+                                    <Dashboard::Charts::PaidBreakdown />
+                                    <Dashboard::Charts::PaidMix />
+                                </article>
+                            </section>
                         {{/if}}
-                        <div class="gh-dashboard-group {{if this.isTotalMembersZero 'is-zero'}}" data-test-dashboard="attribution">
-                            <Dashboard::Charts::AnchorAttribution />
-                            {{#if this.hasPaidTiers}}
-                                <section class="gh-dashboard-section">
-                                    <article class="gh-dashboard-box gh-dashboard-minicharts-attribution">
-                                        <Dashboard::Charts::PaidBreakdown />
-                                        <Dashboard::Charts::PaidMix />
-                                    </article>
-                                </section>
-                            {{/if}}
-                            {{#unless this.membersUtils.isMembersInviteOnly}}
-                                <Dashboard::Charts::Attribution />
-                            {{/unless}}
-                            {{#if this.areNewslettersEnabled}}
-                                <Dashboard::Charts::Engagement />
-                            {{/if}}
+                        {{#unless this.membersUtils.isMembersInviteOnly}}
+                            <Dashboard::Charts::Attribution />
+                        {{/unless}}
+                        {{#if this.areNewslettersEnabled}}
+                            <Dashboard::Charts::Engagement />
+                        {{/if}}
 
-                            {{#if this.isTotalMembersZero}}
-                                <Dashboard::Parts::Zero />
-                            {{/if}}
-                        </div>
-                    {{/unless}}
+                        {{#if this.isTotalMembersZero}}
+                            <Dashboard::Parts::Zero />
+                        {{/if}}
+                    </div>
                 {{/if}}
 
                 {{#unless this.onboarding.isChecklistShown}}

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -50,6 +50,19 @@ describe('Acceptance: Onboarding', function () {
             expect(find('[data-test-dashboard="header"]'), 'header').to.not.exist;
             expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.not.exist;
         });
+
+        it('checklist is shown when members disabled', async function () {
+            this.server.db.settings.update({membersSignupAccess: 'none'});
+            await visit('/setup/done');
+            await visit('/dashboard');
+
+            // onboarding is't shown
+            expect(find('[data-test-dashboard="onboarding-checklist"]'), 'checklist').to.exist;
+
+            // other default dashboard elements are not visible
+            expect(find('[data-test-dashboard="header"]'), 'header').to.not.exist;
+            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.not.exist;
+        });
     });
 
     describe('checklist (non-owner)', function () {


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ONC-106

- moved onboarding display outside of the `isMembersEnabled` conditional block
