### PR TITLE
Added config to hide labels from the signup card for contributors

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -448,6 +448,7 @@ export default class KoenigLexicalEditor extends Component {
             fetchCollectionPosts,
             fetchEmbed,
             fetchLabels,
+            renderLabels: !this.session.user.isContributor,
             feature: {
                 collectionsCard: this.feature.collectionsCard,
                 collections: this.feature.collections,

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -48,7 +48,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.1.1",
     "@tryghost/kg-converters": "1.0.5",
-    "@tryghost/koenig-lexical": "1.2.7",
+    "@tryghost/koenig-lexical": "1.2.8",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7985,10 +7985,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.2.7.tgz#115f8f53d5e39a586cf7cb206ce0c962decab844"
-  integrity sha512-GzefNAJb/ta0/g38bGHtP8CzDfuRJO3AUtTsj0cfYQk4aEruAsSi54kjk+jc3d5DenXqzJF8iqAd0ZRCWAo3CA==
+"@tryghost/koenig-lexical@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/@tryghost/koenig-lexical/-/koenig-lexical-1.2.8.tgz#fa92c6dd065a4f4ed1388391898b3d75d6b2cd13"
+  integrity sha512-c4Igsw57s6u3b/EeO++Ov/GSGok9z7nCt8Jo1o2mHhOwFEgBwv4rQg+4xbxqwcTX4Fdnapr4IdhRcuoQle8HlA==
 
 "@tryghost/limit-service@1.2.14":
   version "1.2.14"


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-127

- problem: contributors see an empty list of labels in the Signup card, even if some exist
- cause: contributors do not have permission to browse labels
- solution: hide the label input entirely for contributors in the Signup card, based on the new `renderLabels` config parameter
