### PR TITLE
Lazyloaded OpenTelemetry packages to avoid boot time regression

### DIFF
--- a/ghost/core/core/shared/instrumentation.js
+++ b/ghost/core/core/shared/instrumentation.js
@@ -1,7 +1,3 @@
-const {NodeSDK} = require('@opentelemetry/sdk-node');
-const {OTLPTraceExporter} = require('@opentelemetry/exporter-trace-otlp-http');
-const {getNodeAutoInstrumentations} = require('@opentelemetry/auto-instrumentations-node');
-
 async function initOpenTelemetry({config}) {
     // Always enable in development environment
     // In production, only enable if explicitly enabled via config `opentelemetry:enabled`
@@ -16,6 +12,12 @@ async function initOpenTelemetry({config}) {
         headers: {},
         concurrencyLimit: 10
     };
+
+    // Lazyloaded to avoid boot time overhead when not enabled
+    const {NodeSDK} = require('@opentelemetry/sdk-node');
+    const {OTLPTraceExporter} = require('@opentelemetry/exporter-trace-otlp-http');
+    const {getNodeAutoInstrumentations} = require('@opentelemetry/auto-instrumentations-node');
+
     const sdk = new NodeSDK({
         serviceName: 'ghost',
         traceExporter: new OTLPTraceExporter(collectorOptions),


### PR DESCRIPTION
- if the instrumentation is disabled, we don't want to load the packages because they increase the boot time (2x locally!), even when they're not used
