### PR TITLE
🐛 Fixed 500 errors when viewing posts in development mode

### DIFF
--- a/ghost/core/core/shared/instrumentation.js
+++ b/ghost/core/core/shared/instrumentation.js
@@ -1,9 +1,10 @@
 async function initOpenTelemetry({config}) {
     // Always enable in development environment
     // In production, only enable if explicitly enabled via config `opentelemetry:enabled`
-    const isDevelopment = process.env.NODE_ENV === 'development';
+    // TODO: Instrumentation currently breaks viewing posts - disabled until we can fix
+    // const isDevelopment = process.env.NODE_ENV === 'development';
     const isConfigured = config.get('opentelemetry:enabled');
-    const enabled = isDevelopment || isConfigured;
+    const enabled = isConfigured; // || isDevelopment;
     if (!enabled) {
         return;
     }


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ONC-115

- OpenTelemetry was throwing errors when viewing posts
- disabled the instrumentation in development mode so it requires explicit config to enable
