### PR TITLE
🐛 Fixed YouTube bookmark creation

### DIFF
--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -7,7 +7,7 @@ const charset = require('charset');
 const iconv = require('iconv-lite');
 
 // Some sites block non-standard user agents so we need to mimic a typical browser
-const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9';
+const USER_AGENT = 'Mozilla/5.0 (compatible; Ghost/5.0; +https://ghost.org/)';
 
 const messages = {
     noUrlProvided: 'No url provided.',


### PR DESCRIPTION
https://github.com/TryGhost/Ghost/issues/20445

- after switching to a browser-like user-agent, YouTube started responding with a "supported browsers" message rather than the actual video meaning bookmark creation failed
- when trying other user-agents it was discovered that nytimes.com (why the user-agent was originally changed) had a problem with the github.com address in the user-agent. By switching to using https://ghost.org instead the request was allowed through fixing both YouTube and NYTimes embeds
