### PR TITLE
Prevented pages content api queries from returning mobiledoc or lexical fields

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -69,7 +69,6 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             frame.options.formats.should.containEql('plaintext');
         });
 
-
         describe('Content API', function () {
             it('selects all columns from the posts schema but mobiledoc and lexical when no columns are specified', function () {
                 const apiConfig = {};

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
 
 const mobiledocLib = require('@tryghost/html-to-mobiledoc');
 
@@ -66,6 +67,66 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             frame.options.formats.should.not.containEql('lexical');
             frame.options.formats.should.containEql('html');
             frame.options.formats.should.containEql('plaintext');
+        });
+
+
+        describe('Content API', function () {
+            it('selects all columns from the posts schema but mobiledoc and lexical when no columns are specified', function () {
+                const apiConfig = {};
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {}
+                    }
+                };
+
+                serializers.input.pages.browse(apiConfig, frame);
+                const columns = Object.keys(postsSchema);
+                const parsedSelectRaw = frame.options.selectRaw.split(',').map(column => column.trim());
+                parsedSelectRaw.should.eql(columns.filter(column => !['mobiledoc', 'lexical','@@UNIQUE_CONSTRAINTS@@','@@INDEXES@@'].includes(column)));
+            });
+
+            it('strips mobiledoc and lexical columns from a specified columns option', function () {
+                const apiConfig = {};
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {},
+                        columns: ['id', 'mobiledoc', 'lexical', 'visibility']
+                    }
+                };
+
+                serializers.input.pages.browse(apiConfig, frame);
+                frame.options.columns.should.eql(['id', 'visibility']);
+            });
+
+            it('forces visibility column if columns are specified', function () {
+                const apiConfig = {};
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {},
+                        columns: ['id']
+                    }
+                };
+                
+                serializers.input.pages.browse(apiConfig, frame);
+                frame.options.columns.should.eql(['id', 'visibility']);
+            });
+                
+            it('strips mobiledoc and lexical columns from a specified selectRaw option', function () {
+                const apiConfig = {};
+                const frame = {
+                    apiType: 'content',
+                    options: {
+                        context: {},
+                        selectRaw: 'id, mobiledoc, lexical'
+                    }
+                };
+
+                serializers.input.posts.browse(apiConfig, frame);
+                frame.options.selectRaw.should.eql('id');
+            });
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/CFR-43/
ref 9d9a421

We recently stopped `select *` from posts when making Content API requests. This is now being applied to the pages endpoint to help improve performance. These fields were already being stripped out in the output serializer, and they will now no longer be returned from the db at all, reducing the amount of data transferred.