### PR TITLE
Added analytic events to internal linking feature

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -462,7 +462,8 @@ export default class KoenigLexicalEditor extends Component {
             membersEnabled: this.settings.membersSignupAccess === 'all',
             searchLinks,
             siteTitle: this.settings.title,
-            siteDescription: this.settings.description
+            siteDescription: this.settings.description,
+            siteUrl: this.config.getSiteUrl('/')
         };
         const cardConfig = Object.assign({}, defaultCardConfig, props.cardConfig, {pinturaConfig: this.pinturaConfig});
 

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -48,7 +48,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.1.1",
     "@tryghost/kg-converters": "1.0.5",
-    "@tryghost/koenig-lexical": "1.2.8",
+    "@tryghost/koenig-lexical": "1.2.9",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7939,10 +7939,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.npmjs.org/@tryghost/koenig-lexical/-/koenig-lexical-1.2.8.tgz#fa92c6dd065a4f4ed1388391898b3d75d6b2cd13"
-  integrity sha512-c4Igsw57s6u3b/EeO++Ov/GSGok9z7nCt8Jo1o2mHhOwFEgBwv4rQg+4xbxqwcTX4Fdnapr4IdhRcuoQle8HlA==
+"@tryghost/koenig-lexical@1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.2.9.tgz#ab922c51b2ddaa8bb361fd7e4c5760bb6e902055"
+  integrity sha512-1PrM2qCJFyMpUSxrzL8IuzY2OAYbeUKuVSEX/GKOxk/zZRib0Q5dsfjrhVv3iurvBg2Gmg5yyzXC60FDqXLR9w==
 
 "@tryghost/limit-service@1.2.14":
   version "1.2.14"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-77
closes https://linear.app/tryghost/issue/MOM-78

- bumps Koenig to support events
- adds `siteUrl` pass-through to Koenig to allow differentiation between internal and external URLs
