### PR TITLE
Reduced Sentry replays sample rate to 50%

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -203,7 +203,7 @@ export default Route.extend(ShortcutsRoute, {
             try {
                 // Session Replay on errors
                 // Docs: https://docs.sentry.io/platforms/javascript/session-replay
-                sentryConfig.replaysOnErrorSampleRate = 1.0;
+                sentryConfig.replaysOnErrorSampleRate = 0.5;
                 sentryConfig.integrations.push(
                     // Replace with `Sentry.replayIntegration()` once we've migrated to @sentry/ember 8.x
                     // Docs: https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#removal-of-sentryreplay-package


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-156
- we have reached our 10k replays per month quota in 20 days, by using a 100% error sampling rate
- we would need a sampling rate < 0.64% to stay under the quota
- from now on, we will be using a 50% error sampling rate to have a bit of margin, and have a rounder number that is easier to reason about (1 out of 2 error sessions are recorded in Sentry)

