### PR TITLE
Fixed TypeError when editor is focussed when not loaded

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -236,7 +236,7 @@ export default class GhKoenigEditorLexical extends Component {
     // otherwise the browser will defocus the editor and the cursor will disappear
     @action
     focusEditor(event) {
-        if (!this.skipFocusEditor && event.target.classList.contains('gh-koenig-editor-pane')) {
+        if (!this.skipFocusEditor && event.target.classList.contains('gh-koenig-editor-pane') && this.editorAPI) {
             let editorCanvas = this.editorAPI.editorInstance.getRootElement();
             let {bottom} = editorCanvas.getBoundingClientRect();
 

--- a/ghost/admin/app/utils/sentry.js
+++ b/ghost/admin/app/utils/sentry.js
@@ -14,6 +14,11 @@ export function beforeSend(event, hint) {
             return null;
         }
 
+        // Ignore errors that are due to browser power saving settings
+        if (exception?.message?.includes('The play() request was interrupted because video-only background media was paused to save power.')) {
+            return null;
+        }
+
         // if the error value includes a model id then overwrite it to improve grouping
         if (event.exception && event.exception.values && event.exception.values.length > 0) {
             const pattern = /<(post|page):[a-f0-9]+>/;


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-162/typeerror-thiseditorapi-is-null

- if the editor does not load for some reason (network issue), and the editor area is clicked, we throw an error because we don't protect against a null `editorAPI`
- this adds that check