### PR TITLE
Added more errors to Sentry exclusion list

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -185,6 +185,11 @@ export default Route.extend(ShortcutsRoute, {
                 release: `ghost@${this.config.version}`,
                 beforeSend,
                 ignoreErrors: [
+                    // Network errors that we don't control
+                    /Server was unreachable/,
+                    /NetworkError when attempting to fetch resource./,
+                    /Failed to fetch/,
+                    /Load failed/,
                     // TransitionAborted errors surface from normal application behaviour
                     // - https://github.com/emberjs/ember.js/issues/12505
                     /^TransitionAborted$/,

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -185,6 +185,9 @@ export default Route.extend(ShortcutsRoute, {
                 release: `ghost@${this.config.version}`,
                 beforeSend,
                 ignoreErrors: [
+                    // Browser autoplay policies
+                    /The play() request was interrupted because video-only background media was paused to save power./,
+
                     // Network errors that we don't control
                     /Server was unreachable/,
                     /NetworkError when attempting to fetch resource./,

--- a/ghost/admin/app/utils/sentry.js
+++ b/ghost/admin/app/utils/sentry.js
@@ -14,11 +14,6 @@ export function beforeSend(event, hint) {
             return null;
         }
 
-        // Ignore errors that are due to browser power saving settings
-        if (exception?.message?.includes('The play() request was interrupted because video-only background media was paused to save power.')) {
-            return null;
-        }
-
         // if the error value includes a model id then overwrite it to improve grouping
         if (event.exception && event.exception.values && event.exception.values.length > 0) {
             const pattern = /<(post|page):[a-f0-9]+>/;


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-165/add-more-errors-to-allowlist

- we don't want to capture Sentry errors for these because they are out
  of our control (like the user's internet connection dropping out)