### PR TITLE
Adjusted Sentry ignore list to cover more browser play errors

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -185,8 +185,8 @@ export default Route.extend(ShortcutsRoute, {
                 release: `ghost@${this.config.version}`,
                 beforeSend,
                 ignoreErrors: [
-                    // Browser autoplay policies
-                    /The play() request was interrupted because video-only background media was paused to save power./,
+                    // Browser autoplay policies (this regex covers a few)
+                    /The play() request was interrupted/,
 
                     // Network errors that we don't control
                     /Server was unreachable/,


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-172/error-aborterror-the-play-request-was-interrupted-because-the-media

- there are a few error messages we can ignore here, as browsers output slightly different messages for various types of these errors, which don't affect the user
