### PR TITLE
Removed unused type field

### DIFF
--- a/apps/admin-x-design-system/src/global/form/TextArea.tsx
+++ b/apps/admin-x-design-system/src/global/form/TextArea.tsx
@@ -18,7 +18,6 @@ export interface TextAreaProps extends HTMLProps<HTMLTextAreaElement> {
     error?: boolean;
     placeholder?: string;
     hint?: React.ReactNode;
-    clearBg?: boolean;
     fontStyle?: FontStyles;
     className?: string;
     onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/apps/admin-x-settings/src/components/settings/growth/embedSignup/EmbedSignupSidebar.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embedSignup/EmbedSignupSidebar.tsx
@@ -129,7 +129,6 @@ const EmbedSignupSidebar: React.FC<SidebarProps> = ({selectedLayout,
                     />
                     <TextArea
                         className='text-grey-800'
-                        clearBg={false}
                         fontStyle='mono'
                         hint={`Paste this code onto any website where you'd like your signup to appear.`}
                         title='Embed code'

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/RecommendationDescriptionForm.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/RecommendationDescriptionForm.tsx
@@ -109,7 +109,6 @@ const RecommendationDescriptionForm: React.FC<Props<EditOrAddRecommendation | Re
             }}
         />
         <TextArea
-            clearBg={true}
             error={Boolean(errors.description)}
             // Note: we don't show the error text here, because errors are related to the character count
             hint={<>Max: <strong>200</strong> characters. You&#8217;ve used <strong className={descriptionLengthColor}>{descriptionLength}</strong></>}

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
@@ -136,7 +136,7 @@ const Connect: React.FC = () => {
             </div>
             <StripeButton href={stripeConnectUrl} tag='a' target='_blank' />
             <Heading className='mb-2 mt-8' level={6} grey>Step 2 — <span className='text-black dark:text-white'>Paste secure key</span></Heading>
-            <TextArea clearBg={false} error={Boolean(error)} hint={error || undefined} placeholder='Paste your secure key here' onChange={onTokenChange}></TextArea>
+            <TextArea error={Boolean(error)} hint={error || undefined} placeholder='Paste your secure key here' onChange={onTokenChange}></TextArea>
             {submitEnabled && <Button className='mt-5' color='green' label='Save Stripe settings' onClick={onSubmit} />}
         </div>
     );


### PR DESCRIPTION
- this is no longer used and causes a React warning because we end up passing it to a textarea