### PR TITLE
Added AbortError to list of excluded errors

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -193,6 +193,8 @@ export default Route.extend(ShortcutsRoute, {
                     /NetworkError when attempting to fetch resource./,
                     /Failed to fetch/,
                     /Load failed/,
+                    /The operation was aborted./,
+
                     // TransitionAborted errors surface from normal application behaviour
                     // - https://github.com/emberjs/ember.js/issues/12505
                     /^TransitionAborted$/,


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-175/error-aborterror-the-operation-was-aborted

- this error can occur when a user's browser navigates away mid-request, which causes the request to be aborted. However, we don't control this, nor do we particularly care, so we can just ignore it
