### PR TITLE
Added browser autoplay error to Sentry ignore list

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -187,6 +187,7 @@ export default Route.extend(ShortcutsRoute, {
                 ignoreErrors: [
                     // Browser autoplay policies (this regex covers a few)
                     /The play() request was interrupted/,
+                    /The request is not allowed by the user agent or the platform in the current context/,
 
                     // Network errors that we don't control
                     /Server was unreachable/,


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-179/notallowederror-the-request-is-not-allowed-by-the-user-agent-or-the

- this adds another browser error to the Sentry ignore list, as we don't have control over it, and it doesn't affect the user
