### PR TITLE
🐛 Fixed staff user modal not showing example slug

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/ProfileBasics.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/ProfileBasics.tsx
@@ -33,7 +33,7 @@ const BasicInputs: React.FC<UserDetailProps> = ({errors, clearError, user, setUs
                 onKeyDown={() => clearError('email')}
             />
             <TextField
-                hint="https://example.com/author"
+                hint={`https://example.com/author/${user.slug}`}
                 maxLength={191}
                 title="Slug"
                 value={user.slug}

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -151,6 +151,7 @@ test.describe('User profile', async () => {
         await modal.getByLabel('Full name').fill('New Admin');
         await modal.getByLabel('Email').fill('newadmin@test.com');
         await modal.getByLabel('Slug').fill('newadmin');
+        await expect(modal.getByText('https://example.com/author/newadmin')).toBeVisible();
         await modal.getByLabel('Location').fill('some location');
         await modal.getByLabel('Website').fill('https://example.com');
         await modal.getByLabel('Facebook profile').fill('fb');


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/ENG-928/regression-author-url-slug-preview-broken

- simple change to append the slug to the end of the example hint
- also added test
