### PR TITLE
Changed "commented" link in member feed to post

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -330,7 +330,7 @@ export default class ParseMemberEventHelper extends Helper {
      * Get internal route props for a clickable object
      */
     getRoute(event) {
-        if (['comment_event', 'click_event', 'feedback_event'].includes(event.type)) {
+        if (['click_event', 'feedback_event'].includes(event.type)) {
             if (event.data.post) {
                 return {
                     name: 'posts.analytics',


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/ENG-1217/activity-log-link-for-comments-goes-to-wrong-place

- the post analytics page does not contain any comments, so it's not the most intuitive location to point the user. Instead, we can send them to the frontend of the post, where they can view comments
