### PR TITLE
Updated copy for default recipients hint

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/DefaultRecipients.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/DefaultRecipients.tsx
@@ -125,7 +125,7 @@ const DefaultRecipients: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const form = (
         <SettingGroupContent columns={1}>
             <Select
-                hint='Who should be able to subscribe to your site?'
+                hint='Who should receive your posts by default?'
                 options={RECIPIENT_FILTER_OPTIONS}
                 selectedOption={RECIPIENT_FILTER_OPTIONS.find(option => option.value === selectedOption)}
                 testId='default-recipients-select'


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-179/inappropriate-copy-in-default-recipient-settings

The hint for _default recipients_ referenced the wrong setting. It now reflects the right one.