### PR TITLE
🐛 Fixed unexpected leave confirmation after Cmd+S on member profile

### DIFF
--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -29,6 +29,7 @@ export default class MemberController extends Controller {
     @tracked showImpersonateMemberModal = false;
     @tracked modalLabel = null;
     @tracked showLabelModal = false;
+    @tracked scratchMember = null;
 
     _previousLabels = null;
     _previousNewsletters = null;
@@ -56,6 +57,12 @@ export default class MemberController extends Controller {
 
     set member(member) {
         this.model = member;
+
+        if (member !== this.scratchMember?.member) {
+            const scratchMember = EmberObject.create({member});
+            SCRATCH_PROPS.forEach(prop => defineProperty(scratchMember, prop, boundOneWay(`member.${prop}`)));
+            this.scratchMember = scratchMember;
+        }
     }
 
     get dirtyAttributes() {
@@ -90,12 +97,6 @@ export default class MemberController extends Controller {
         options.unshiftObject({name: 'All labels', slug: null});
 
         return options;
-    }
-
-    get scratchMember() {
-        let scratchMember = EmberObject.create({member: this.member});
-        SCRATCH_PROPS.forEach(prop => defineProperty(scratchMember, prop, boundOneWay(`member.${prop}`)));
-        return scratchMember;
     }
 
     get subscribedAt() {

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -34,6 +34,7 @@ export default class MembersRoute extends AdminRoute {
 
     setupController(controller, member, transition) {
         super.setupController(...arguments);
+        controller.member = member;
 
         controller.setInitialRelationshipValues();
 


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/ENG-779/%F0%9F%90%9B-cmds-does-not-save-member-profile-changes

- previously, pressing Cmd+S on a member profile would save the profile, but the dirty attributes weren't being cleaned, so the application would trigger the leave confirmation when exiting
- now, we've fixed the code to keep a dynamic scratch member,
- long term, we should get rid of the scratch model, but this still allows us to fix the bug for now