### PR TITLE
Added innodb_force_recovery config to local mysql

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       # Turns out you can drop .sql or .sql.gz files in here, cool!
       - ./mysql-preload:/docker-entrypoint-initdb.d
+      - ./mysql-config:/etc/mysql/conf.d
     healthcheck:
       test: "mysql -uroot -proot ghost -e 'select 1'"
       interval: 1s

--- a/.github/scripts/mysql-config/innodb-recovery.cnf
+++ b/.github/scripts/mysql-config/innodb-recovery.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+innodb_force_recovery = 6


### PR DESCRIPTION
ref https://dev.mysql.com/doc/refman/8.4/en/forcing-innodb-recovery.html

Docker on MacOS can sometimes force quit the container and we end up with a broken MySQL container which can't boot. This config forced MySQL to attempt to recover the DB. The value of 6 is suggested by the logs when MySQL breaks - but this will open InnoDB in a readonly mode, which isn't suitable for us.

I think we wanna have a way to run this just once, and then exit, maybe with like `yarn recover-db`