### PR TITLE
Optimized aggregating member attribution statistics

### DIFF
--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -242,11 +242,14 @@ export default class DashboardStatsService extends Service {
         if (!this.memberAttributionStats) {
             return [];
         }
+
+        const firstChartDay = moment().add(-this.chartDays, 'days').format('YYYY-MM-DD');
+
         return this.memberAttributionStats.filter((stat) => {
             if (this.chartDays === 'all') {
                 return true;
             }
-            return stat.date >= moment().add(-this.chartDays, 'days').format('YYYY-MM-DD');
+            return stat.date >= firstChartDay;
         }).reduce((acc, stat) => {
             const statSource = stat.source ?? '';
             const existingSource = acc.find(s => s.source.toLowerCase() === statSource.toLowerCase());


### PR DESCRIPTION
- the existing code creates a new moment instance, takes away some days and then formats the result
- this is run for every entry of the member attribution stats, which means dashboards for big sites with a lot of attribution data become slow
- this value doesn't change across each iteration of the filter, so we can just extract it out and calculate it once
- this commit removes this code block from the flamegraph completely