### PR TITLE
Added custom redirects ReDoS validation

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/validation.js
+++ b/ghost/core/core/server/services/custom-redirects/validation.js
@@ -33,7 +33,6 @@ const validate = (redirects) => {
         if (!redirect.from || !redirect.to) {
             throw new errors.ValidationError({
                 message: tpl(messages.redirectsWrongFormat),
-                context: redirect,
                 help: tpl(messages.redirectsHelp)
             });
         }
@@ -44,7 +43,6 @@ const validate = (redirects) => {
         } catch (error) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidRedirectsFromRegex),
-                context: redirect,
                 help: tpl(messages.redirectsHelp)
             });
         }

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -219,7 +219,7 @@
     "node-jose": "2.2.0",
     "path-match": "1.2.4",
     "probe-image-size": "7.2.3",
-    "redos-detector": "^5.1.0",
+    "redos-detector": "5.1.0",
     "rss": "1.2.2",
     "sanitize-html": "2.13.0",
     "semver": "7.6.2",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -219,6 +219,7 @@
     "node-jose": "2.2.0",
     "path-match": "1.2.4",
     "probe-image-size": "7.2.3",
+    "redos-detector": "^5.1.0",
     "rss": "1.2.2",
     "sanitize-html": "2.13.0",
     "semver": "7.6.2",

--- a/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
@@ -39,6 +39,26 @@ describe('UNIT: custom redirects validation', function () {
             should.fail('should have thrown');
         } catch (err) {
             err.message.should.equal('Incorrect RegEx in redirects file.');
+            err.errorDetails.redirect.should.equal(config[0]);
+            err.errorDetails.invalid.should.be.true();
+        }
+    });
+
+    it('throws for an invalid redirects config having unsafe RegExp in from field', function () {
+        const config = [{
+            permanent: true,
+            from: '^\/episodes\/([a-z0-9-]+)+\/$', // Unsafe due to the surplus + at the end causing infinite backtracking
+            to: '/'
+        }];
+
+        try {
+            validate(config);
+            should.fail('should have thrown');
+        } catch (err) {
+            err.message.should.equal('Incorrect RegEx in redirects file.');
+            err.errorDetails.redirect.should.equal(config[0]);
+            err.errorDetails.unsafe.should.be.true();
+            err.errorDetails.reason.should.equal('hitMaxBacktracks');
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27331,7 +27331,7 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-redos-detector@^5.1.0:
+redos-detector@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/redos-detector/-/redos-detector-5.1.0.tgz#67660c896a48490e80b35557f876a529680f0f8d"
   integrity sha512-08en/ij0//HwKZdKlelRZGQKmQhmKMQPVJPD+1THfYm64mZhLPOG0NBa47+DrOF53DyaRsCFyD7JHJaYITnt9g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -27331,6 +27331,13 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
+redos-detector@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/redos-detector/-/redos-detector-5.1.0.tgz#67660c896a48490e80b35557f876a529680f0f8d"
+  integrity sha512-08en/ij0//HwKZdKlelRZGQKmQhmKMQPVJPD+1THfYm64mZhLPOG0NBa47+DrOF53DyaRsCFyD7JHJaYITnt9g==
+  dependencies:
+    regjsparser "0.10.0"
+
 reflect-metadata@0.1.14:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.14.tgz#24cf721fe60677146bb77eeb0e1f9dece3d65859"
@@ -27451,6 +27458,13 @@ regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
   integrity sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g==
+
+regjsparser@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.10.0.tgz#b1ed26051736b436f22fdec1c8f72635f9f44892"
+  integrity sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==
+  dependencies:
+    jsesc "~0.5.0"
 
 regjsparser@^0.1.4:
   version "0.1.5"


### PR DESCRIPTION
refs [ENG-709](https://linear.app/tryghost/issue/ENG-709/%F0%9F%90%9B-bad-redirects-causing-container-tear-down)

Added validation to prevent RegEx's susceptible to ReDoS from being used with custom redirects. Also moved error details out of `context` and into `errorDetails` to be consistent with error logging elsewhere as well as fix issue in admin-x where blank screen would be shown when an error occurred during redirects upload (due to logic not accounting for `context` being an object)