### PR TITLE
Added test assertion to verify limit modal redirects to `/pro` route

### DIFF
--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -168,7 +168,7 @@ test.describe('Theme settings', async () => {
         expect(lastApiRequests.uploadTheme).toBeTruthy();
     });
 
-    test('Limits uploading new themes', async ({page}) => {
+    test('Limits uploading new themes and redirect to /pro', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             ...limitRequests,
@@ -206,6 +206,18 @@ test.describe('Theme settings', async () => {
         await modal.getByRole('button', {name: 'Upload theme'}).click();
 
         await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to enable custom themes/);
+
+        const limitModal = page.getByTestId('limit-modal');
+
+        await limitModal.getByRole('button', {name: 'Upgrade'}).click();
+
+        // The route should be updated
+        const newPageUrl = page.url();
+        const newPageUrlObject = new URL(newPageUrl);
+        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
+
+        // expect the route to be updated to /pro
+        await expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
     });
 
     test('Prevents overwriting the default theme', async ({page}) => {


### PR DESCRIPTION
ref ENG-1035

We didn't have a test assertion for when a user is prompted with a limit upgrade modal, which verifies that a click on the `Upgrade` button will redirect correctly to the Billing App (`\pro` route).