### PR TITLE
Fixed Follow for ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/FollowSite.tsx
+++ b/apps/admin-x-activitypub/src/components/FollowSite.tsx
@@ -39,8 +39,11 @@ const FollowSite = NiceModal.create(() => {
 
     const handleFollow = async () => {
         try {
+            const url = new URL(`.ghost/activitypub/actions/follow/${profileName}`, siteUrl);
+            await fetch(url, {
+                method: 'POST'
+            });
             // Perform the mutation
-            await mutation.mutateAsync({username: profileName});
             // If successful, set the success state to true
             // setSuccess(true);
             showToast({

--- a/apps/admin-x-activitypub/src/components/FollowSite.tsx
+++ b/apps/admin-x-activitypub/src/components/FollowSite.tsx
@@ -19,12 +19,7 @@ const FollowSite = NiceModal.create(() => {
     const client = useQueryClient();
     const site = useBrowseSite();
     const siteData = site.data?.site;
-    const siteUrl = siteData?.url;
-    console.log(JSON.stringify("This is my site Data: " + JSON.stringify(siteData)));
-    if(siteUrl) {
-        console.log(JSON.stringify("This is my site URL: " + siteUrl));
-    }
-
+    const siteUrl = siteData?.url ?? window.location;
 
     // mutation.isPending
     // mutation.isError

--- a/apps/admin-x-activitypub/src/components/FollowSite.tsx
+++ b/apps/admin-x-activitypub/src/components/FollowSite.tsx
@@ -19,7 +19,7 @@ const FollowSite = NiceModal.create(() => {
     const client = useQueryClient();
     const site = useBrowseSite();
     const siteData = site.data?.site;
-    const siteUrl = siteData?.url ?? window.location.href;
+    const siteUrl = siteData?.url ?? window.location.origin;
 
     // mutation.isPending
     // mutation.isError

--- a/apps/admin-x-activitypub/src/components/FollowSite.tsx
+++ b/apps/admin-x-activitypub/src/components/FollowSite.tsx
@@ -19,7 +19,7 @@ const FollowSite = NiceModal.create(() => {
     const client = useQueryClient();
     const site = useBrowseSite();
     const siteData = site.data?.site;
-    const siteUrl = siteData?.url ?? window.location;
+    const siteUrl = siteData?.url ?? window.location.href;
 
     // mutation.isPending
     // mutation.isError

--- a/apps/admin-x-activitypub/src/components/FollowSite.tsx
+++ b/apps/admin-x-activitypub/src/components/FollowSite.tsx
@@ -1,5 +1,6 @@
 import NiceModal from '@ebay/nice-modal-react';
 import {Modal, TextField, showToast} from '@tryghost/admin-x-design-system';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useFollow} from '@tryghost/admin-x-framework/api/activitypub';
 import {useQueryClient} from '@tryghost/admin-x-framework';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -16,6 +17,14 @@ const FollowSite = NiceModal.create(() => {
     const modal = NiceModal.useModal();
     const mutation = useFollow();
     const client = useQueryClient();
+    const site = useBrowseSite();
+    const siteData = site.data?.site;
+    const siteUrl = siteData?.url;
+    console.log(JSON.stringify("This is my site Data: " + JSON.stringify(siteData)));
+    if(siteUrl) {
+        console.log(JSON.stringify("This is my site URL: " + siteUrl));
+    }
+
 
     // mutation.isPending
     // mutation.isError


### PR DESCRIPTION

We need to make requests to the frontend URL, not the Admin API - but the Admin X Framework doesn't currently support that, so instead we'll use a simple `fetch` for now.