### PR TITLE
Removed `urlCache` flag and code

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -4,10 +4,6 @@ import React from 'react';
 import {List} from '@tryghost/admin-x-design-system';
 
 const features = [{
-    title: 'URL cache',
-    description: 'Enable URL Caching',
-    flag: 'urlCache'
-},{
     title: 'Lexical multiplayer',
     description: 'Enables multiplayer editing in the lexical editor.',
     flag: 'lexicalMultiplayer'

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -59,7 +59,6 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
-    @feature('urlCache') urlCache;
     @feature('lexicalMultiplayer') lexicalMultiplayer;
     @feature('audienceFeedback') audienceFeedback;
     @feature('webmentions') webmentions;

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -79,9 +79,8 @@ async function initDatabase({config}) {
  * @param {object} options.ghostServer
  * @param {object} options.config
  * @param {object} options.bootLogger
- * @param {boolean} options.frontend
  */
-async function initCore({ghostServer, config, bootLogger, frontend}) {
+async function initCore({ghostServer, config, bootLogger}) {
     debug('Begin: initCore');
 
     // URL Utils is a bit slow, put it here so the timing is visible separate from models
@@ -118,8 +117,7 @@ async function initCore({ghostServer, config, bootLogger, frontend}) {
         onFinished: () => {
             bootLogger.metric('url-service', urlServiceStart);
             bootLogger.log('URL Service Ready');
-        },
-        urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
+        }
     });
     debug('End: Url Service');
 
@@ -544,7 +542,7 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
 
         // Step 4 - Load Ghost with all its services
         debug('Begin: Load Ghost Services & Apps');
-        await initCore({ghostServer, config, bootLogger, frontend});
+        await initCore({ghostServer, config, bootLogger});
         const {dataService} = await initServicesForFrontend({bootLogger});
 
         if (frontend) {

--- a/ghost/core/core/server/services/url/UrlService.js
+++ b/ghost/core/core/server/services/url/UrlService.js
@@ -2,7 +2,6 @@ const _debug = require('@tryghost/debug')._base;
 const debug = _debug('ghost:services:url:service');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
-const labs = require('../../../shared/labs');
 const UrlGenerator = require('./UrlGenerator');
 const Queue = require('./Queue');
 const Urls = require('./Urls');
@@ -16,16 +15,8 @@ const resourcesConfig = require('./config');
  * It will tell you if the url generation is in progress or not.
  */
 class UrlService {
-    /**
-     *
-     * @param {Object} [options]
-     * @param {Object} [options.cache] - cache handler instance
-     * @param {Function} [options.cache.read] - read cache by type
-     * @param {Function} [options.cache.write] - write into cache by type
-     */
-    constructor({cache} = {}) {
+    constructor() {
         this.utils = urlUtils;
-        this.cache = cache;
         this.onFinished = null;
         this.finished = false;
         this.urlGenerators = [];
@@ -305,44 +296,22 @@ class UrlService {
      * @description Initializes components needed for the URL Service to function
      * @param {Object} options
      * @param {Function} [options.onFinished] - callback when url generation is finished
-     * @param {Boolean} [options.urlCache] - whether to init using url cache or not
      */
-    async init({onFinished, urlCache} = {}) {
+    async init({onFinished} = {}) {
         this.onFinished = onFinished;
 
-        let persistedUrls;
-        let persistedResources;
-
-        if (this.cache && (labs.isSet('urlCache') || urlCache)) {
-            persistedUrls = await this.cache.read('urls');
-            persistedResources = await this.cache.read('resources');
-        }
-
-        if (persistedUrls && persistedResources) {
-            this.urls.urls = persistedUrls;
-            this.resources.data = persistedResources;
-            this.resources.initEventListeners();
-
-            this._onQueueEnded('init');
-        } else {
-            this.resources.initEventListeners();
-            await this.resources.fetchResources();
-            // CASE: all resources are fetched, start the queue
-            this.queue.start({
-                event: 'init',
-                tolerance: 100,
-                requiredSubscriberCount: 1
-            });
-        }
+        this.resources.initEventListeners();
+        await this.resources.fetchResources();
+        // CASE: all resources are fetched, start the queue
+        this.queue.start({
+            event: 'init',
+            tolerance: 100,
+            requiredSubscriberCount: 1
+        });
     }
 
     async shutdown() {
-        if (!labs.isSet('urlCache')) {
-            return null;
-        }
-
-        await this.cache.write('urls', this.urls.urls);
-        await this.cache.write('resources', this.resources.getAll());
+        // Nothing to do here :(
     }
 
     /**

--- a/ghost/core/core/server/services/url/index.js
+++ b/ghost/core/core/server/services/url/index.js
@@ -1,26 +1,6 @@
-const config = require('../../../shared/config');
-const LocalFileCache = require('./LocalFileCache');
 const UrlService = require('./UrlService');
 
-// NOTE: instead of a path we could give UrlService a "data-resolver" of some sort
-//       so it doesn't have to contain the logic to read data at all. This would be
-//       a possible improvement in the future
-let writeDisabled = false;
-let storagePath = config.getContentPath('data');
-
-// TODO: remove this hack in favor of loading from the content path when it's possible to do so
-//       by mocking content folders in pre-boot phase
-if (process.env.NODE_ENV.startsWith('test')){
-    storagePath = config.get('paths').urlCache;
-
-    // NOTE: prevents test suites from overwriting cache fixtures.
-    //       A better solution would be injecting a different implementation of the
-    //       cache based on the environment, this approach should do the trick for now
-    writeDisabled = true;
-}
-
-const cache = new LocalFileCache({storagePath, writeDisabled});
-const urlService = new UrlService({cache});
+const urlService = new UrlService();
 
 // Singleton
 module.exports = urlService;

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -64,8 +64,7 @@
     "useMinFiles": false,
     "paths": {
         "fixtures": "test/utils/fixtures/fixtures",
-        "defaultSettings": "test/utils/fixtures/default-settings-browser.json",
-        "urlCache": "test/utils/fixtures/urls"
+        "defaultSettings": "test/utils/fixtures/default-settings-browser.json"
     },
     "enableDeveloperExperiments": true
 }

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -65,7 +65,6 @@
     "useMinFiles": false,
     "paths": {
         "fixtures": "test/utils/fixtures/fixtures",
-        "defaultSettings": "test/utils/fixtures/default-settings.json",
-        "urlCache": "test/utils/fixtures/urls"
+        "defaultSettings": "test/utils/fixtures/default-settings.json"
     }
 }

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -64,7 +64,6 @@
     "useMinFiles": false,
     "paths": {
         "fixtures": "test/utils/fixtures/fixtures",
-        "defaultSettings": "test/utils/fixtures/default-settings.json",
-        "urlCache": "test/utils/fixtures/urls"
+        "defaultSettings": "test/utils/fixtures/default-settings.json"
     }
 }

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -42,7 +42,6 @@ const BETA_FEATURES = [
 const ALPHA_FEATURES = [
     'ActivityPub',
     'NestPlayground',
-    'urlCache',
     'lexicalMultiplayer',
     'websockets',
     'emailCustomization',

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -98,7 +98,6 @@ describe('Config Loader', function () {
                 'fixtures',
                 'defaultSettings',
                 'assetSrc',
-                'urlCache',
                 'appRoot',
                 'corePath',
                 'adminAssets',

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -33,18 +33,18 @@ describe('Labs Service', function () {
         sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
-            urlCache: true
+            testFeature: true
         });
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
         //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
         assert.deepEqual(labs.getAll(), expectedLabsObject({
-            urlCache: true,
+            testFeature: true,
             members: true
         }));
 
         assert.equal(labs.isSet('members'), true);
-        assert.equal(labs.isSet('urlCache'), true);
+        assert.equal(labs.isSet('testFeature'), true);
     });
 
     it('returns a falsy alpha flag when dev experiments in NOT toggled', function () {
@@ -52,7 +52,7 @@ describe('Labs Service', function () {
         sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
-            urlCache: true
+            testFeature: true
         });
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
@@ -62,7 +62,7 @@ describe('Labs Service', function () {
         }));
 
         assert.equal(labs.isSet('members'), true);
-        assert.equal(labs.isSet('urlCache'), false);
+        assert.equal(labs.isSet('testFeature'), false);
     });
 
     it('respects the value in config over settings', function () {

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -133,7 +133,7 @@ const restartModeGhostStart = async ({frontend, copyThemes, copySettings}) => {
     // Reload the URL service & wait for it to be ready again
     // @TODO: why/how is this different to urlService.resetGenerators?
     urlServiceUtils.reset();
-    urlServiceUtils.init({urlCache: !frontend});
+    urlServiceUtils.init();
 
     if (frontend) {
         await urlServiceUtils.isFinished();

--- a/ghost/core/test/utils/url-service-utils.js
+++ b/ghost/core/test/utils/url-service-utils.js
@@ -17,8 +17,8 @@ module.exports.isFinished = async () => {
 };
 
 // @TODO: unify all the reset/softTeset helpers so they either work how the main code works or the reasons why they are different are clear
-module.exports.init = ({urlCache} = {}) => {
-    urlService.init({urlCache});
+module.exports.init = () => {
+    urlService.init();
 };
 
 module.exports.reset = () => {


### PR DESCRIPTION
- this was an experimental feature to persist the URL cache to disk so it can be read upon boot, which would save recalculating it and hopefully speed up boot times
- it was never fleshed out and the code here is a bit of a hack, so it's not really worth keeping it around
- worst case, we can revert this if we ever decide to move forwards with it
