### PR TITLE
🐛 Fixed bad redirects yaml overriding backed up working yaml file

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/CustomRedirectsAPI.js
+++ b/ghost/core/core/server/services/custom-redirects/CustomRedirectsAPI.js
@@ -211,6 +211,9 @@ class CustomRedirectsAPI {
      */
     async setFromFilePath(filePath, ext = '.json') {
         const redirectsFilePath = await this.getRedirectsFilePath();
+        const content = await readRedirectsFile(filePath);
+        const parsed = parseRedirectsFile(content, ext);
+        this.validate(parsed);
 
         if (redirectsFilePath) {
             const backupRedirectsPath = this.getBackupFilePath(redirectsFilePath);
@@ -222,10 +225,6 @@ class CustomRedirectsAPI {
 
             await fs.move(redirectsFilePath, backupRedirectsPath);
         }
-
-        const content = await readRedirectsFile(filePath);
-        const parsed = parseRedirectsFile(content, ext);
-        this.validate(parsed);
 
         if (ext === '.json') {
             await fs.writeFile(this.createRedirectsFilePath('.json'), JSON.stringify(parsed), 'utf-8');

--- a/ghost/core/test/unit/server/services/custom-redirects/api.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/api.test.js
@@ -295,10 +295,8 @@ describe('UNIT: redirects CustomRedirectsAPI class', function () {
                 await customRedirectsAPI.setFromFilePath(incomingFilePath, '.yaml');
                 should.fail('setFromFilePath did not throw');
             } catch (err) {
-                // console.log(err);
                 should.exist(err);
                 err.errorType.should.eql('BadRequestError');
-                // err.message.should.match(/BadRequestError: Could not parse YAML: duplicated mapping key \(\d+:\d+\)/);
             }
 
             fs.unlink.called.should.not.be.true();

--- a/ghost/core/test/unit/server/services/custom-redirects/api.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/api.test.js
@@ -259,5 +259,50 @@ describe('UNIT: redirects CustomRedirectsAPI class', function () {
             // two redirects in total
             redirectManager.addRedirect.calledTwice.should.be.true();
         });
+
+        it('does not create a backup file from a bad redirect yaml file', async function () {
+            const incomingFilePath = path.join(__dirname, '/invalid/path/redirects_incoming.yaml');
+            const backupFilePath = path.join(basePath, 'backup.yaml');
+
+            const invalidYaml = `
+                301:
+                    /my-old-blog-post/: /revamped-url/
+                    /my-old-blog-post/: /revamped-url/
+
+                302:
+                    /another-old-blog-post/: /hello-there/
+            `;
+
+            // redirects.json file already exits
+            fs.pathExists.withArgs(`${basePath}redirects.json`).resolves(false);
+            fs.pathExists.withArgs(`${basePath}redirects.yaml`).resolves(true);
+            // incoming redirects file
+            fs.readFile.withArgs(incomingFilePath, 'utf-8').resolves(invalidYaml);
+            // backup file DOES not exists yet
+            fs.pathExists.withArgs(backupFilePath).resolves(false);
+            // should not be called
+            fs.unlink.withArgs(backupFilePath).resolves(false);
+            fs.move.withArgs(`${basePath}redirects.yaml`, backupFilePath).resolves(true);
+
+            customRedirectsAPI = new CustomRedirectsAPI({
+                basePath,
+                redirectManager,
+                getBackupFilePath: () => backupFilePath,
+                validate: () => {}
+            });
+
+            try {
+                await customRedirectsAPI.setFromFilePath(incomingFilePath, '.yaml');
+                should.fail('setFromFilePath did not throw');
+            } catch (err) {
+                // console.log(err);
+                should.exist(err);
+                err.errorType.should.eql('BadRequestError');
+                // err.message.should.match(/BadRequestError: Could not parse YAML: duplicated mapping key \(\d+:\d+\)/);
+            }
+
+            fs.unlink.called.should.not.be.true();
+            fs.move.called.should.not.be.true();
+        });
     });
 });


### PR DESCRIPTION
ref ENG-945

- Fixed an issue where upload a broken redirects yaml will override the last working yaml.
- Instead it will now do the validation before saving and overriding the yaml.
