### PR TITLE
Fixes complimentary subscription display issues

### DIFF
--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
@@ -32,6 +32,14 @@ const AccountWelcome = () => {
             return null;
         }
 
+        if (isComplimentary) {
+            return (
+                <div className='gh-portal-section'>
+                    <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`You currently have a complimentary subscription`)}</p>
+                </div>
+            );
+        }
+
         if (subscriptionHasFreeTrial({sub: subscription})) {
             const trialEnd = getDateString(subscription.trial_end_at);
             return (

--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
@@ -33,11 +33,7 @@ const AccountWelcome = () => {
         }
 
         if (isComplimentary) {
-            return (
-                <div className='gh-portal-section'>
-                    <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`You currently have a complimentary subscription`)}</p>
-                </div>
-            );
+            return null;
         }
 
         if (subscriptionHasFreeTrial({sub: subscription})) {

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -143,10 +143,11 @@
                                         {{else}}
                                             {{#if (or (eq sub.price.nickname "Monthly") (eq sub.price.nickname "Yearly"))}}
                                             {{else}}
-                                                <span class="gh-cp-membertier-pricelabel">{{sub.price.nickname}}</span><span class="gh-cp-membertier-renewal"> &ndash; </span>
+                                                <span class="gh-cp-membertier-pricelabel">{{sub.price.nickname}}</span>
                                             {{/if}}
                                         {{/if}}
 
+                                         <span class="gh-cp-membertier-renewal"> &ndash; </span>
                                          <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
                                     </div>
                                     <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -147,8 +147,11 @@
                                             {{/if}}
                                         {{/if}}
 
-                                         <span class="gh-cp-membertier-renewal"> &ndash; </span>
-                                         <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
+                                        {{#unless sub.isComplimentary}}
+                                            <span class="gh-cp-membertier-renewal"> &ndash; </span>
+                                            <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
+                                        {{/unless}}
+
                                     </div>
                                     <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />
                                 </div>

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -147,10 +147,12 @@
                                             {{/if}}
                                         {{/if}}
 
-                                        {{#unless sub.isComplimentary}}
+                                        {{#if sub.validityDetails}}
                                             <span class="gh-cp-membertier-renewal"> &ndash; </span>
                                             <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
-                                        {{/unless}}
+                                        {{/if}}
+
+                                   
 
                                     </div>
                                     <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -147,13 +147,17 @@
                                             {{/if}}
                                         {{/if}}
 
-                                        {{#if sub.validityDetails}}
+                                        {{#if sub.trialUntil}}
                                             <span class="gh-cp-membertier-renewal"> &ndash; </span>
                                             <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
                                         {{/if}}
 
-                                   
+                                        {{#if sub.compExpiry}}
+                                            <span class="gh-cp-membertier-renewal"> &ndash; </span>
+                                            <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
+                                        {{/if}}
 
+                                         
                                     </div>
                                     <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />
                                 </div>


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-324/complimentary-plan-issues

We were showing renewal copy for subscriptions that are forever complimentary. We also had a trailing en-dash in the Member detail screen when their subscription was complimentary and had no end date. 

Those things are solved now. We don't show dates or renewal copy when we don't need to.