### PR TITLE
🐛 Fixed pasting product URLs into the editor

### DIFF
--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -260,7 +260,7 @@ describe('Oembed API', function () {
 
             const pageMock = nock('http://oembed.test.com')
                 .get('/')
-                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://oembed.test.com/my-embed"></head></html>');
+                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://oembed.test.com/my-embed"><title>Title</title></head></html>');
 
             const oembedMock = nock('http://oembed.test.com')
                 .get('/my-embed')

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -284,7 +284,7 @@ describe('Oembed API', function () {
         it('fetches url and follows <link rel="alternate">', async function () {
             const pageMock = nock('http://test.com')
                 .get('/')
-                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"></head></html>');
+                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"><title>Title</title></head></html>');
 
             const oembedMock = nock('http://test.com')
                 .get('/oembed')
@@ -307,7 +307,7 @@ describe('Oembed API', function () {
         it('follows redirects when fetching <link rel="alternate">', async function () {
             const pageMock = nock('http://test.com')
                 .get('/')
-                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"></head></html>');
+                .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://test.com/oembed"><title>Title</title></head></html>');
 
             const alternateRedirectMock = nock('http://test.com')
                 .get('/oembed')

--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -340,6 +340,11 @@ class OEmbedService {
                 ];
                 const oembed = _.pick(body, knownFields);
 
+                // Fallback to bookmark if it's a link type
+                if (oembed.type === 'link') {
+                    return;
+                }
+
                 // ensure we have required data for certain types
                 if (oembed.type === 'photo' && !oembed.url) {
                     return;

--- a/ghost/oembed-service/test/oembed-service.test.js
+++ b/ghost/oembed-service/test/oembed-service.test.js
@@ -146,5 +146,31 @@ describe('oembed-service', function () {
             assert.equal(response.url, 'https://www.example.com');
             assert.equal(response.metadata.title, 'Example');
         });
+
+        it('should return a bookmark response when the oembed endpoint returns a link type', async function () {
+            nock('https://www.example.com')
+                .get('/')
+                .query(true)
+                .reply(200, `<html><head><link type="application/json+oembed" href="https://www.example.com/oembed"><title>Example</title></head></html>`);
+
+            nock('https://www.example.com')
+                .get('/oembed')
+                .query(true)
+                .reply(200, {
+                    type: 'link',
+                    version: '1.0',
+                    title: 'Test Title',
+                    author_name: 'Test Author',
+                    author_url: 'https://example.com/user/testauthor',
+                    url: 'https://www.example.com'
+                });
+
+            const response = await oembedService.fetchOembedDataFromUrl('https://www.example.com');
+
+            assert.equal(response.version, '1.0');
+            assert.equal(response.type, 'bookmark');
+            assert.equal(response.url, 'https://www.example.com');
+            assert.equal(response.metadata.title, 'Example');
+        });
     });
 });


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-1215

- when pasting URLs that return `type: link` from the oembed service, we now fallback to using a Bookmark card
- previously, this would render a plain link in the editor
- example product URL with `type: link`: https://indiebeer.co.uk/products/terra-tempo-vinicius-red-wine-ba-wild-ale-with-mango-pineapple-honeydew-melon-and-banana-750ml-7