### PR TITLE
🐛 Fixed bug with persisting offer redemptions for existing free members

### DIFF
--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -11,5 +11,6 @@ module.exports = {
     SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
     SubscriptionActivatedEvent: require('./lib/SubscriptionActivatedEvent'),
     SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent'),
+    OfferRedemptionEvent: require('./lib/OfferRedemptionEvent'),
     MemberLinkClickEvent: require('./lib/MemberLinkClickEvent')
 };

--- a/ghost/member-events/lib/OfferRedemptionEvent.js
+++ b/ghost/member-events/lib/OfferRedemptionEvent.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} OfferRedemptionEventData
+ * @prop {string} memberId
+ * @prop {string} offerId
+ * @prop {string} subscriptionId
+ */
+
+/**
+ * Server-side event firing on page views (page, post, tags...)
+ */
+module.exports = class OfferRedemptionEvent {
+    /**
+     * @param {OfferRedemptionEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {OfferRedemptionEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new OfferRedemptionEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -3,7 +3,6 @@ const sinon = require('sinon');
 const DomainEvents = require('@tryghost/domain-events');
 const MemberRepository = require('../../../../lib/repositories/MemberRepository');
 const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('@tryghost/member-events');
-const {off} = require('process');
 
 const mockOfferRedemption = {
     add: sinon.stub(),

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -2,10 +2,12 @@ const assert = require('assert/strict');
 const sinon = require('sinon');
 const DomainEvents = require('@tryghost/domain-events');
 const MemberRepository = require('../../../../lib/repositories/MemberRepository');
-const {SubscriptionCreatedEvent} = require('@tryghost/member-events');
+const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('@tryghost/member-events');
+const {off} = require('process');
 
 const mockOfferRedemption = {
-    add: sinon.stub()
+    add: sinon.stub(),
+    findOne: sinon.stub()
 };
 
 describe('MemberRepository', function () {
@@ -238,14 +240,16 @@ describe('MemberRepository', function () {
         let offerRepository;
         let labsService;
         let subscriptionData;
-        let notifySpy;
+        let subscriptionCreatedNotifySpy;
+        let offerRedemptionNotifySpy;
 
         afterEach(function () {
             sinon.restore();
         });
 
         beforeEach(async function () {
-            notifySpy = sinon.spy();
+            subscriptionCreatedNotifySpy = sinon.spy();
+            offerRedemptionNotifySpy = sinon.spy();
 
             subscriptionData = {
                 id: 'sub_123',
@@ -283,7 +287,8 @@ describe('MemberRepository', function () {
                             }),
                             toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
                             fetch: sinon.stub().resolves({
-                                toJSON: sinon.stub().returns(relation === 'products' ? [] : {})
+                                toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
+                                models: []
                             })
                         };
                     },
@@ -299,6 +304,9 @@ describe('MemberRepository', function () {
             };
             StripeCustomerSubscription = {
                 add: sinon.stub().resolves({
+                    get: sinon.stub().returns()
+                }),
+                edit: sinon.stub().resolves({
                     get: sinon.stub().returns()
                 })
             };
@@ -344,7 +352,8 @@ describe('MemberRepository', function () {
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
 
-            DomainEvents.subscribe(SubscriptionCreatedEvent, notifySpy);
+            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
+            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
 
             await repo.linkSubscription({
                 subscription: subscriptionData
@@ -355,10 +364,12 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            notifySpy.calledOnce.should.be.true();
+            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
+            offerRedemptionNotifySpy.called.should.be.false();
         });
 
-        it('attaches offer information to subscription event', async function (){
+        it('dispatches the offer redemption event for a new member starting a subscription', async function (){
+            // When a new member starts a paid subscription, the subscription is created with the offer ID
             const repo = new MemberRepository({
                 stripeAPIService,
                 StripeCustomerSubscription,
@@ -371,9 +382,11 @@ describe('MemberRepository', function () {
                 OfferRedemption: mockOfferRedemption
             });
 
+            // No existing subscription
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
 
-            DomainEvents.subscribe(SubscriptionCreatedEvent, notifySpy);
+            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
+            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
 
             await repo.linkSubscription({
                 id: 'member_id_123',
@@ -386,8 +399,60 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            notifySpy.calledOnce.should.be.true();
-            notifySpy.calledWith(sinon.match((event) => {
+            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
+            subscriptionCreatedNotifySpy.calledWith(sinon.match((event) => {
+                if (event.data.offerId === 'offer_123') {
+                    return true;
+                }
+                return false;
+            })).should.be.true();
+
+            offerRedemptionNotifySpy.called.should.be.true();
+            offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+                if (event.data.offerId === 'offer_123') {
+                    return true;
+                }
+                return false;
+            })).should.be.true();
+        });
+
+        it('dispatches the offer redemption event for an existing member upgrading to a paid subscription', async function (){
+            // When an existing free member upgrades to a paid subscription, the subscription is first created _without_ the offer id
+            // Then it is updated with the offer id after the checkout.completed webhook is received
+            const repo = new MemberRepository({
+                stripeAPIService,
+                StripeCustomerSubscription,
+                MemberPaidSubscriptionEvent,
+                MemberProductEvent,
+                productRepository,
+                offerRepository,
+                labsService,
+                Member,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                get: sinon.stub().withArgs('offer_id').returns(null)
+            });
+
+            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
+            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
+
+            await repo.linkSubscription({
+                id: 'member_id_123',
+                subscription: subscriptionData,
+                offerId: 'offer_123'
+            }, {
+                transacting: {
+                    executionPromise: Promise.resolve()
+                },
+                context: {}
+            });
+
+            subscriptionCreatedNotifySpy.calledOnce.should.be.false();
+
+            offerRedemptionNotifySpy.called.should.be.true();
+            offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1251/support-escalation-re-offers-not-tracking

- Offer Redemptions were not being persisted in the database for existing free members who upgrade to a paid plan with an offer, which resulted in inaccurate offer redemption counts. This made it difficult to assess the performance of an offer.
- Previously, Ghost recorded an offer redemption in the DB in response to the `SubscriptionCreatedEvent`, under the assumption that the offer details would be included in this event. This assumption was valid for brand new members starting a subscription with an offer, but not for existing free members upgrading to a paid plan with an offer.
- For existing free members, the subscription is first stored in Ghost in response to the `customer.subscription.created` Stripe webhook. At this point, the offer/discount is not attached to the subscription, so the `SubscriptionCreatedEvent` triggers without the offer information, and the offer redemption is not recorded. After the `checkout.session.completed` webhook is received (which _does_ include the offer details), the subscription is updated in Ghost, but the Offer Redemption is not stored.
- For brand new members, the `customer.subscription.created` webhook no-ops, because the member and Stripe Customer don't exist yet. Therefore, the subscription is first created in Ghost in response to the `checkout.session.completed` webhook, which _does_ include the offer information, so the offer information is included in the `SubscriptionCreatedEvent` and the offer redemption is recorded as expected.
- This change adds an explicit `OfferRedemptionEvent`, which triggers either: (1) when a new subscription is created with an offer (as in the case of a brand new member), or (2) when an existing subscription is first updated to include an offer (as in the case of an existing free member upgrading with an offer). The Offer Redemption is then persisted in the DB in response to the `OfferRedemptionEvent` rather than the `SubscriptionCreatedEvent`.