### PR TITLE
Set explicit text color to the bookmark card content

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/bookmark.css
+++ b/ghost/core/core/frontend/src/cards/css/bookmark.css
@@ -17,7 +17,7 @@
     border-radius: 6px;
     border: 1px solid rgb(124 139 154 / 25%);
     overflow: hidden;
-    color: inherit;
+    color: #222;
 }
 
 .kg-bookmark-content {


### PR DESCRIPTION
ref DES-263

- we've recently started forcing white background color to the bookmark card by default
- the reason was making it look good regardless of the site background color
- it caused an issue to some sites, mostly in dark mode, because the text color was inherited from the theme
- this sets explicit color to the bookmark content which is consistent with the nft card

