### PR TITLE
Changed button labels in Navigation modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/NavigationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/NavigationModal.tsx
@@ -43,8 +43,9 @@ const NavigationModal = NiceModal.create(() => {
                 updateRoute('navigation');
             }}
             buttonsDisabled={saveState === 'saving'}
+            cancelLabel='Close'
             dirty={localSettings.some(setting => setting.dirty)}
-            okLabel={saveState === 'saving' ? 'Saving...' : 'OK'}
+            okLabel={saveState === 'saving' ? 'Saving...' : 'Save'}
             scrolling={true}
             size='lg'
             stickyFooter={true}

--- a/apps/admin-x-settings/test/acceptance/site/navigation.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/navigation.test.ts
@@ -39,7 +39,7 @@ test.describe('Navigation settings', async () => {
         await secondaryNavigationTab.getByTestId('new-navigation-item').getByLabel('URL').fill('https://google.com');
         await secondaryNavigationTab.getByTestId('new-navigation-item').getByLabel('URL').blur();
 
-        await modal.getByRole('button', {name: 'OK'}).click();
+        await modal.getByRole('button', {name: 'Save'}).click();
 
         await expect(modal).not.toBeVisible();
 
@@ -68,7 +68,7 @@ test.describe('Navigation settings', async () => {
         await primaryItem.getByLabel('URL').press('Backspace');
         await primaryItem.getByLabel('URL').fill('google.com');
 
-        await modal.getByRole('button', {name: 'OK'}).click();
+        await modal.getByRole('button', {name: 'Save'}).click();
 
         await expect(primaryItem.getByText('You must specify a label')).toHaveCount(1);
         await expect(primaryItem.getByText('You must specify a valid URL or relative path')).toHaveCount(1);
@@ -149,7 +149,7 @@ test.describe('Navigation settings', async () => {
 
         await newItem.getByTestId('add-button').click();
 
-        await modal.getByRole('button', {name: 'Cancel'}).click();
+        await modal.getByRole('button', {name: 'Close'}).click();
 
         await expect(page.getByTestId('confirmation-modal')).toHaveText(/leave/i);
 


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-474/update-navigation-modal-to-use-close-and-save-buttons

We've changed buttons throughout the product to Close/Save, rather than Cancel/OK. This applies the same pattern to the Navigation modal in the Admin.