### PR TITLE
Fixes Resource articles overflowing on Post Analytics

### DIFF
--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -842,13 +842,11 @@
     background: var(--white);
     border-radius: var(--border-radius);
     box-shadow: 0 1px 4px -1px rgba(0,0,0,.1);
-}
-
-.gh-post-analytics-resource {
     flex: 1;
     display: grid;
     grid-template-columns: 2fr 3fr;
     grid-gap: 24px;
+    min-width: 0;
 }
 
 .gh-post-analytics-resource .thumbnail {
@@ -1534,7 +1532,7 @@
     color: var(--green-d1);
 }
 
-@media screen and (max-width: 1080px) {
+@media screen and (max-width: 1280px) {
     .gh-post-analytics-box.resources {
         flex-direction: column;
     }

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -843,6 +843,7 @@
     border-radius: var(--border-radius);
     box-shadow: 0 1px 4px -1px rgba(0,0,0,.1);
     flex: 1;
+    align-items: flex-start;
     display: grid;
     grid-template-columns: 2fr 3fr;
     grid-gap: 24px;
@@ -1532,7 +1533,7 @@
     color: var(--green-d1);
 }
 
-@media screen and (max-width: 1280px) {
+@media screen and (max-width: 1200px) {
     .gh-post-analytics-box.resources {
         flex-direction: column;
     }


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-546/resource-articles-on-post-analytics-overflowing-window

The articles in the Resources box on the Post Analytics page were previously overflowing their container. These changes fix that, and allow them to scale up/down more gracefully for different screen sizes.