### PR TITLE
🐛 Fixed image dimension retrieval causing Ghost requests to hang

### DIFF
--- a/ghost/core/core/server/lib/image/ImageSize.js
+++ b/ghost/core/core/server/lib/image/ImageSize.js
@@ -1,6 +1,6 @@
 const debug = require('@tryghost/debug')('utils:image-size');
 const sizeOf = require('image-size');
-const probeSizeOf = require('probe-image-size');
+
 const url = require('url');
 const path = require('path');
 const _ = require('lodash');
@@ -17,13 +17,14 @@ const FETCH_ONLY_FORMATS = [
 ];
 
 class ImageSize {
-    constructor({config, storage, storageUtils, validator, urlUtils, request}) {
+    constructor({config, storage, storageUtils, validator, urlUtils, request, probe}) {
         this.config = config;
         this.storage = storage;
         this.storageUtils = storageUtils;
         this.validator = validator;
         this.urlUtils = urlUtils;
         this.request = request;
+        this.probe = probe;
 
         this.REQUEST_OPTIONS = {
             // we need the user-agent, otherwise some https request may fail (e.g. cloudfare)
@@ -82,7 +83,18 @@ class ImageSize {
             }));
         }
 
-        return probeSizeOf(imageUrl, this.NEEDLE_OPTIONS);
+        // wrap probe-image-size in a promise in case it is unresponsive/the timeout itself doesn't work
+        return (Promise.race([
+            this.probe(imageUrl, this.NEEDLE_OPTIONS),
+            new Promise((res, rej) => {
+                setTimeout(() => {
+                    rej(new errors.InternalServerError({
+                        message: 'Probe unresponsive.',
+                        code: 'IMAGE_SIZE_URL'
+                    }));
+                }, this.NEEDLE_OPTIONS.response_timeout);
+            })
+        ]));
     }
 
     // download full image then use image-size to get it's dimensions
@@ -118,17 +130,7 @@ class ImageSize {
             if (FETCH_ONLY_FORMATS.includes(extension)) {
                 resolve(this._fetchImageSizeFromUrl(imageUrl));
             } else {
-                resolve(Promise.race([
-                    this._probeImageSizeFromUrl(imageUrl),
-                    new Promise((res, rej) => {
-                        setTimeout(() => {
-                            rej(new errors.InternalServerError({
-                                message: 'Request timed out.',
-                                code: 'IMAGE_SIZE_URL'
-                            }));
-                        }, this.NEEDLE_OPTIONS.response_timeout);
-                    })
-                ]));
+                resolve(this._probeImageSizeFromUrl(imageUrl));
             }
         });
     }

--- a/ghost/core/core/server/lib/image/ImageSize.js
+++ b/ghost/core/core/server/lib/image/ImageSize.js
@@ -120,9 +120,12 @@ class ImageSize {
             } else {
                 resolve(Promise.race([
                     this._probeImageSizeFromUrl(imageUrl),
-                    new Promise((resolve, reject) => {
+                    new Promise(() => {
                         setTimeout(() => {
-                            reject(new Error('Image size retrieval timed out'));
+                            return Promise.reject(new errors.InternalServerError({
+                                message: 'Request timed out.',
+                                code: 'IMAGE_SIZE_URL'
+                            }));
                         }, this.NEEDLE_OPTIONS.response_timeout);
                     })
                 ]));

--- a/ghost/core/core/server/lib/image/ImageSize.js
+++ b/ghost/core/core/server/lib/image/ImageSize.js
@@ -120,9 +120,9 @@ class ImageSize {
             } else {
                 resolve(Promise.race([
                     this._probeImageSizeFromUrl(imageUrl),
-                    new Promise(() => {
+                    new Promise((res, rej) => {
                         setTimeout(() => {
-                            return Promise.reject(new errors.InternalServerError({
+                            rej(new errors.InternalServerError({
                                 message: 'Request timed out.',
                                 code: 'IMAGE_SIZE_URL'
                             }));

--- a/ghost/core/core/server/lib/image/ImageSize.js
+++ b/ghost/core/core/server/lib/image/ImageSize.js
@@ -118,7 +118,14 @@ class ImageSize {
             if (FETCH_ONLY_FORMATS.includes(extension)) {
                 resolve(this._fetchImageSizeFromUrl(imageUrl));
             } else {
-                resolve(this._probeImageSizeFromUrl(imageUrl));
+                resolve(Promise.race([
+                    this._probeImageSizeFromUrl(imageUrl),
+                    new Promise((resolve, reject) => {
+                        setTimeout(() => {
+                            reject(new Error('Image size retrieval timed out'));
+                        }, this.NEEDLE_OPTIONS.response_timeout);
+                    })
+                ]));
             }
         });
     }

--- a/ghost/core/core/server/lib/image/ImageUtils.js
+++ b/ghost/core/core/server/lib/image/ImageUtils.js
@@ -2,11 +2,12 @@ const BlogIcon = require('./BlogIcon');
 const CachedImageSizeFromUrl = require('./CachedImageSizeFromUrl');
 const Gravatar = require('./Gravatar');
 const ImageSize = require('./ImageSize');
+const probe = require('probe-image-size');
 
 class ImageUtils {
     constructor({config, urlUtils, settingsCache, storageUtils, storage, validator, request, cacheStore}) {
         this.blogIcon = new BlogIcon({config, urlUtils, settingsCache, storageUtils});
-        this.imageSize = new ImageSize({config, storage, storageUtils, validator, urlUtils, request});
+        this.imageSize = new ImageSize({config, storage, storageUtils, validator, urlUtils, request, probe});
         this.cachedImageSizeFromUrl = new CachedImageSizeFromUrl({
             getImageSizeFromUrl: this.imageSize.getImageSizeFromUrl.bind(this.imageSize),
             cache: cacheStore


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1408/
- added additional safeguards to the image size dimensions probing

For some reason that requires further investigation, the probe-image-size package was silently failing (neither resolving nor rejecting) for a particular URL. This was causing Ghost to hang on to serving the request, and after a few of these came in, ultimately caused Ghost to stop being responsive.

Rather than trying to patch a dependency, we'll wrap the call to this package and use the same timeout we pass into the package (which is ignored in this particular case) as an additional safeguard.