### PR TITLE
Updated Archive Newsletter modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -129,8 +129,8 @@ const Sidebar: React.FC<{
             NiceModal.show(ConfirmationModal, {
                 title: 'Archive newsletter',
                 prompt: <>
-                    <p>Your newsletter <strong>{newsletter.name}</strong> will no longer be visible to members or available as an option when publishing new posts.</p>
-                    <p>Existing posts previously sent as this newsletter will remain unchanged.</p>
+                    <div className="mb-6">Your newsletter <strong>{newsletter.name}</strong> will no longer be visible to members or available as an option when publishing new posts.</div>
+                    <div>Existing posts previously sent as this newsletter will remain unchanged.</div>
                 </>,
                 okLabel: 'Archive',
                 okColor: 'red',


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-470/spacing-on-newsletter-archive-warning-modal-is-missing-between

The modal now follows the same markup as the _Archive Tier_ modal, and therefore shows whitespace between both paragraphs.


