### PR TITLE
🐛 Removed method="post" on sign in/up forms in Admin

### DIFF
--- a/ghost/admin/app/templates/signin.hbs
+++ b/ghost/admin/app/templates/signin.hbs
@@ -12,7 +12,7 @@
                     </header>
                 </div>
             {{else}}
-                <form id="login" method="post" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.validateAndAuthenticateTask)}}>
+                <form id="login" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.validateAndAuthenticateTask)}}>
                     <header>
                         <div class="gh-site-icon" style={{site-icon-style}}></div>
                         <h1>{{this.config.blogTitle}}</h1>

--- a/ghost/admin/app/templates/signup.hbs
+++ b/ghost/admin/app/templates/signup.hbs
@@ -7,7 +7,7 @@
                 <h1>Create your account.</h1>
             </header>
 
-            <form id="signup" class="gh-signup" method="post" novalidate="novalidate" {{on "submit" this.submit}}>
+            <form id="signup" class="gh-signup" novalidate="novalidate" {{on "submit" this.submit}}>
                 <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="name">
                     <label for="name">Full name</label>
                     <span class="gh-input-icon gh-icon-user">


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-160
- POST is incorrect as the form itself doesn't post to any path; all we want are the authentication flows to kick off on submit

We've had reports of users experiencing a 404 error on attempting to sign in to Ghost Admin (at /ghost/), where the login form seems to submit a POST request to the /ghost/ path (we don't have a route for that method, hence the 404; only GET). While I haven't been able to reproduce the issue, there's very few places in Ghost that actually issue a POST request.

Removing this method here has no impact to Ghost auth and may prevent some unexpected default behavior from the browser.