### PR TITLE
🎨 Improved error message when uploading invalid `redirects.yaml`

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/validation.js
+++ b/ghost/core/core/server/services/custom-redirects/validation.js
@@ -5,7 +5,8 @@ const {isSafePattern} = require('redos-detector');
 
 const messages = {
     redirectsWrongFormat: 'Incorrect redirects file format.',
-    invalidRedirectsFromRegex: 'Incorrect RegEx in redirects file.',
+    invalidRegex: 'Invalid RegEx in redirects file: {regex}',
+    unsafeRegex: 'Potentially unsafe RegEx in redirects file: {regex}',
     redirectsHelp: 'https://ghost.org/docs/themes/routing/#redirects'
 };
 
@@ -43,7 +44,7 @@ const validate = (redirects) => {
             new RegExp(redirect.from);
         } catch (error) {
             throw new errors.ValidationError({
-                message: tpl(messages.invalidRedirectsFromRegex),
+                message: tpl(messages.invalidRegex, {regex: redirect.from}),
                 errorDetails: {
                     redirect,
                     invalid: true
@@ -57,7 +58,7 @@ const validate = (redirects) => {
 
         if (analysis.safe === false) {
             throw new errors.ValidationError({
-                message: tpl(messages.invalidRedirectsFromRegex),
+                message: tpl(messages.unsafeRegex, {regex: redirect.from}),
                 errorDetails: {
                     redirect,
                     unsafe: true,

--- a/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
@@ -28,9 +28,10 @@ describe('UNIT: custom redirects validation', function () {
     });
 
     it('throws for an invalid redirects config having invalid RegExp in from field', function () {
+        const invalidRegex = '/\/invalid_regex\/(\/size\/[a-zA-Z0-9_-.]*\/[a-zA-Z0-9_-.]*\/[0-9]*\/[0-9]*\/)([a-zA-Z0-9_-.]*)/';
         const config = [{
             permanent: true,
-            from: '/invalid_regex/(/size/[a-zA-Z0-9_-.]*/[a-zA-Z0-9_-.]*/[0-9]*/[0-9]*/)([a-zA-Z0-9_-.]*)',
+            from: invalidRegex,
             to: '/'
         }];
 
@@ -38,16 +39,17 @@ describe('UNIT: custom redirects validation', function () {
             validate(config);
             should.fail('should have thrown');
         } catch (err) {
-            err.message.should.equal('Incorrect RegEx in redirects file.');
+            err.message.should.equal(`Invalid RegEx in redirects file: ${invalidRegex}`);
             err.errorDetails.redirect.should.equal(config[0]);
             err.errorDetails.invalid.should.be.true();
         }
     });
 
     it('throws for an invalid redirects config having unsafe RegExp in from field', function () {
+        const unsafeRegex = '^\/episodes\/([a-z0-9-]+)+\/$'; // Unsafe due to the surplus + at the end causing infinite backtracking
         const config = [{
             permanent: true,
-            from: '^\/episodes\/([a-z0-9-]+)+\/$', // Unsafe due to the surplus + at the end causing infinite backtracking
+            from: unsafeRegex,
             to: '/'
         }];
 
@@ -55,7 +57,7 @@ describe('UNIT: custom redirects validation', function () {
             validate(config);
             should.fail('should have thrown');
         } catch (err) {
-            err.message.should.equal('Incorrect RegEx in redirects file.');
+            err.message.should.equal(`Potentially unsafe RegEx in redirects file: ${unsafeRegex}`);
             err.errorDetails.redirect.should.equal(config[0]);
             err.errorDetails.unsafe.should.be.true();
             err.errorDetails.reason.should.equal('hitMaxBacktracks');


### PR DESCRIPTION
refs [ONC-176](https://linear.app/tryghost/issue/ONC-176/improve-validation-error-message-when-redos-validation-fails-on)

Improved the error message displayed when a validation error occurs due to uploading an invalid `redirects.yaml` file. The error message now includes the invalid regex pattern that caused the validation to fail