### PR TITLE
Extended timeouts on image size test

### DIFF
--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -410,7 +410,7 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: (key) => {
                     if (key === 'times:getImageSizeTimeoutInMS') {
-                        return 10;
+                        return 50;
                     }
                 }
             }, tpl: {}, storage: {}, storageUtils: {
@@ -535,7 +535,7 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {},
             probe(reqUrl, options) {
                 // simulate probe being unresponsive by making the timeout longer than the request
-                return probe(reqUrl, {...options, response_timeout: 10});
+                return probe(reqUrl, {...options, response_timeout: 50});
             }});
 
             imageSize.getImageSizeFromUrl(url)


### PR DESCRIPTION
ref e626dd9

There has been some flakiness in Github CI with the new tests for the probe library. We'll start with extending timeouts in case CI is running particularly slowly.