### PR TITLE
🐛 Fixed member subscription details in Admin

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -111,122 +111,104 @@
                     <div class="gh-main-section-content grey gh-member-tier-container" data-test-tier={{tier.id}}>
                         <div class="gh-main-content-card gh-cp-membertier gh-cp-membertier-attribution gh-membertier-subscription {{if (gt tier.subscriptions.length 1) "multiple-subs" ""}}">
                             {{#each tier.subscriptions as |sub index|}}
-                            <div class="gh-tier-card-header flex items-center">
-                                <div class="gh-tier-card-price">
-                                    <div class="flex items-start">
-                                        <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                        <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                <div class="gh-tier-card-header flex items-center">
+                                    <div class="gh-tier-card-price">
+                                        <div class="flex items-start">
+                                            <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
+                                            <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                        </div>
+                                        <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>
                                     </div>
-                                    <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>
-                                </div>
-                                <div style="margin-left: 16px; flex-grow: 1;">
-                                    <h3 class="gh-membertier-name" data-test-text="tier-name" style="align-items:center !important; justify-content:flex-start !important;">
-                                        {{tier.name}}
-                                        {{#if (eq sub.status "canceled")}}
-                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
-                                        {{else if sub.cancel_at_period_end}}
-                                            <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
-                                        {{else if sub.compExpiry}}
-                                            <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
-                                        {{else if sub.trialUntil}}
-                                            <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
-                                        {{else}}
-                                            <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
-                                        {{/if}}
-                                        {{#if (gt tier.subscriptions.length 1)}}
-                                            <span class="gh-membertier-subcount">{{tier.subscriptions.length}} subscriptions</span>
-                                        {{/if}}
-                                    </h3>
-                                    <div>
-                                        {{#if sub.trialUntil}}
-                                            <span class="gh-cp-membertier-pricelabel">Free trial </span>
-                                        {{else}}
-                                            {{#if (or (eq sub.price.nickname "Monthly") (eq sub.price.nickname "Yearly"))}}
+                                    <div style="margin-left: 16px; flex-grow: 1;">
+                                        <h3 class="gh-membertier-name" data-test-text="tier-name" style="align-items:center !important; justify-content:flex-start !important;">
+                                            {{tier.name}}
+                                            {{#if (eq sub.status "canceled")}}
+                                                <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
+                                            {{else if sub.cancel_at_period_end}}
+                                                <span class="gh-badge archived" data-test-text="member-subscription-status">Canceled</span>
+                                            {{else if sub.compExpiry}}
+                                                <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
+                                            {{else if sub.trialUntil}}
+                                                <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                             {{else}}
-                                                <span class="gh-cp-membertier-pricelabel">{{sub.price.nickname}}</span>
+                                                <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                             {{/if}}
-                                        {{/if}}
-
-                                        {{#if sub.trialUntil}}
-                                            <span class="gh-cp-membertier-renewal"> &ndash; </span>
+                                            {{#if (gt tier.subscriptions.length 1)}}
+                                                <span class="gh-membertier-subcount">{{tier.subscriptions.length}} subscriptions</span>
+                                            {{/if}}
+                                        </h3>
+                                        <div>
+                                            <span class="gh-cp-membertier-pricelabel">{{sub.priceLabel}}</span>
                                             <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
-                                        {{/if}}
-
-                                        {{#if sub.compExpiry}}
-                                            <span class="gh-cp-membertier-renewal"> &ndash; </span>
-                                            <span class="gh-cp-membertier-renewal">{{sub.validityDetails}}</span>
-                                        {{/if}}
-
-                                         
+                                        </div>
+                                        <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />
                                     </div>
-                                    <Member::SubscriptionDetailBox @sub={{sub}} @index={{index}} />
-                                </div>
-                                {{#if sub.isComplimentary}}
-                                    <span class="action-menu">
-                                        <GhDropdownButton
-                                            @dropdownName="subscription-menu-complimentary"
-                                            @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only"
-                                            @title="Actions"
-                                            data-test-button="subscription-actions"
-                                        >
-                                            <span>
-                                                {{svg-jar "dotdotdot"}}
-                                                <span class="hidden">Subscription menu</span>
-                                            </span>
-                                        </GhDropdownButton>
-                                        <GhDropdown
-                                            @name="subscription-menu-complimentary"
-                                            @tagName="ul"
-                                            @classNames="tier-actions-menu dropdown-menu dropdown-align-right"
-                                        >
-                                            <li>
-                                                <button
-                                                    type="button"
-                                                    {{on "click" (fn this.removeComplimentary (or tier.id tier.tier_id))}}
-                                                    data-test-button="remove-complimentary"
-                                                >
-                                                    <span class="red">Remove complimentary subscription</span>
-                                                </button>
-                                            </li>
-                                        </GhDropdown>
-                                    </span>
-                                {{else}}
-                                    <span class="action-menu">
-                                        <GhDropdownButton @dropdownName="subscription-menu-{{sub.id}}" @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only" @title="Actions">
-                                            <span>
-                                                {{svg-jar "dotdotdot"}}
-                                                <span class="hidden">Subscription menu</span>
-                                            </span>
-                                        </GhDropdownButton>
-                                        <GhDropdown @name="subscription-menu-{{sub.id}}" @tagName="ul" @classNames="tier-actions-menu dropdown-menu dropdown-align-right">
-                                            <li>
-                                                <a href="https://dashboard.stripe.com/customers/{{sub.customer.id}}" target="_blank" rel="noopener noreferrer">
-                                                    View Stripe customer
-                                                </a>
-                                            </li>
-                                            <li class="divider"></li>
-                                            <li>
-                                                <a href="https://dashboard.stripe.com/subscriptions/{{sub.id}}" target="_blank" rel="noopener noreferrer">
-                                                    View Stripe subscription
-                                                </a>
-                                            </li>
-                                            <li>
-                                            {{#if (not-eq sub.status "canceled")}}
-                                                {{#if sub.cancel_at_period_end}}
-                                                    <button type="button" {{on "click" (fn this.continueSubscription sub.id)}}>
-                                                        <span>Continue subscription</span>
+                                    {{#if sub.isComplimentary}}
+                                        <span class="action-menu">
+                                            <GhDropdownButton
+                                                @dropdownName="subscription-menu-complimentary"
+                                                @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only"
+                                                @title="Actions"
+                                                data-test-button="subscription-actions"
+                                            >
+                                                <span>
+                                                    {{svg-jar "dotdotdot"}}
+                                                    <span class="hidden">Subscription menu</span>
+                                                </span>
+                                            </GhDropdownButton>
+                                            <GhDropdown
+                                                @name="subscription-menu-complimentary"
+                                                @tagName="ul"
+                                                @classNames="tier-actions-menu dropdown-menu dropdown-align-right"
+                                            >
+                                                <li>
+                                                    <button
+                                                        type="button"
+                                                        {{on "click" (fn this.removeComplimentary (or tier.id tier.tier_id))}}
+                                                        data-test-button="remove-complimentary"
+                                                    >
+                                                        <span class="red">Remove complimentary subscription</span>
                                                     </button>
-                                                {{else}}
-                                                    <button type="button" {{on "click" (fn this.cancelSubscription sub.id)}}>
-                                                        <span class="red">Cancel subscription</span>
-                                                    </button>
+                                                </li>
+                                            </GhDropdown>
+                                        </span>
+                                    {{else}}
+                                        <span class="action-menu">
+                                            <GhDropdownButton @dropdownName="subscription-menu-{{sub.id}}" @classNames="gh-btn gh-btn-outline gh-btn-icon fill gh-btn-subscription-action icon-only" @title="Actions">
+                                                <span>
+                                                    {{svg-jar "dotdotdot"}}
+                                                    <span class="hidden">Subscription menu</span>
+                                                </span>
+                                            </GhDropdownButton>
+                                            <GhDropdown @name="subscription-menu-{{sub.id}}" @tagName="ul" @classNames="tier-actions-menu dropdown-menu dropdown-align-right">
+                                                <li>
+                                                    <a href="https://dashboard.stripe.com/customers/{{sub.customer.id}}" target="_blank" rel="noopener noreferrer">
+                                                        View Stripe customer
+                                                    </a>
+                                                </li>
+                                                <li class="divider"></li>
+                                                <li>
+                                                    <a href="https://dashboard.stripe.com/subscriptions/{{sub.id}}" target="_blank" rel="noopener noreferrer">
+                                                        View Stripe subscription
+                                                    </a>
+                                                </li>
+                                                <li>
+                                                {{#if (not-eq sub.status "canceled")}}
+                                                    {{#if sub.cancel_at_period_end}}
+                                                        <button type="button" {{on "click" (fn this.continueSubscription sub.id)}}>
+                                                            <span>Continue subscription</span>
+                                                        </button>
+                                                    {{else}}
+                                                        <button type="button" {{on "click" (fn this.cancelSubscription sub.id)}}>
+                                                            <span class="red">Cancel subscription</span>
+                                                        </button>
+                                                    {{/if}}
                                                 {{/if}}
-                                            {{/if}}
-                                            </li>
-                                        </GhDropdown>
-                                    </span>
-                                {{/if}}
-                            </div>
+                                                </li>
+                                            </GhDropdown>
+                                        </span>
+                                    {{/if}}
+                                </div>
                             {{/each}}
 
                             {{#if (eq tier.subscriptions.length 0)}}

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -24,7 +24,8 @@ export function getSubscriptionData(sub) {
         trialUntil: trialUntil(sub)
     };
 
-    data.validityDetails = validityDetails(data);
+    data.priceLabel = priceLabel(data);
+    data.validityDetails = validityDetails(data, !!data.priceLabel);
 
     return data;
 }
@@ -77,22 +78,39 @@ export function trialUntil(sub) {
     return undefined;
 }
 
-export function validityDetails(data) {
-    if (data.isComplimentary && data.compExpiry) {
-        return `Expires ${data.compExpiry}`;
+export function validityDetails(data, separatorNeeded = false) {
+    const separator = separatorNeeded ? ' – ' : '';
+    const space = data.validUntil ? ' ' : '';
+
+    if (data.isComplimentary) {
+        if (data.compExpiry) {
+            return `${separator}Expires ${data.compExpiry}`;
+        } else {
+            return '';
+        }
     }
 
     if (data.hasEnded) {
-        return `Ended ${data.validUntil}`;
+        return `${separator}Ended${space}${data.validUntil}`;
     }
 
     if (data.willEndSoon) {
-        return `Has access until ${data.validUntil}`;
+        return `${separator}Has access until${space}${data.validUntil}`;
     }
 
     if (data.trialUntil) {
-        return `Ends ${data.trialUntil}`;
+        return `${separator}Ends ${data.trialUntil}`;
     }
 
-    return `Renews ${data.validUntil}`;
+    return `${separator}Renews${space}${data.validUntil}`;
+}
+
+export function priceLabel(data) {
+    if (data.trialUntil) {
+        return 'Free trial';
+    }
+
+    if (data.price.nickname && data.price.nickname.length > 0 && data.price.nickname !== 'Monthly' && data.price.nickname !== 'Yearly') {
+        return data.price.nickname;
+    }
 }


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ONC-189

- commit 4084a3d introduced a regression that caused member subscription details to not be rendered for active/canceled subscriptions
- with this fix, the rendering logic in Admin for member subscription details has been fully moved to a helper and is now covered by additional unit tests