### PR TITLE
🐛 Fixed admin crashing when deleting a tier benefit that was last moved

### DIFF
--- a/apps/admin-x-design-system/src/global/SortableList.tsx
+++ b/apps/admin-x-design-system/src/global/SortableList.tsx
@@ -139,7 +139,10 @@ const SortableList = <Item extends {id: string}>({
             <div className={`${title && titleSeparator ? '-mt-2' : ''}`}>
                 <DndContext
                     collisionDetection={closestCenter}
-                    onDragEnd={event => onMove(event.active.id as string, event.over?.id as string)}
+                    onDragEnd={(event) => {
+                        onMove(event.active.id as string, event.over?.id as string);
+                        setDraggingId(null);
+                    }}
                     onDragStart={event => setDraggingId(event.active.id as string)}
                 >
                     <Wrapper>


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1433/
- in the tiers details modal, if a tier was deleted after being moved it would crash admin

The SortableList component calls renderItem for the drag overlay on the dragged item. However, if that item was deleted, the draggingId never got reset causing the drag overlay to try to call renderItem on a nonexistent item.

As a note, we don't actually use this overlay... it could be best to strip it out to prevent causing issues.