### PR TITLE
Published new versions of apps to support BS locale 

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "0.17.1",
+  "version": "0.17.3",
   "license": "MIT",
   "repository": "git@github.com:TryGhost/comments-ui.git",
   "author": "Ghost Foundation",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.37.8",
+  "version": "2.37.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tryghost/signup-form",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -3,6 +3,7 @@ const i18next = require('i18next');
 const SUPPORTED_LOCALES = [
     'af', // Afrikaans
     'bg', // Bulgarian
+    'bs', // Bosnian
     'ca', // Catalan
     'cs', // Czech
     'da', // Danish


### PR DESCRIPTION
refs [ONC-150](https://linear.app/tryghost/issue/ONC-150/support-escalation-re-trouble-with-new-languages)

Published new versions of apps to support BS locale
- comments-ui@0.17.3
- signup-form@0.1.5
- portal@2.37.10