### PR TITLE
Fixed regex to ignore AbortError in Sentry

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -186,7 +186,7 @@ export default Route.extend(ShortcutsRoute, {
                 beforeSend,
                 ignoreErrors: [
                     // Browser autoplay policies (this regex covers a few)
-                    /The play() request was interrupted/,
+                    /^The play\(\) request was interrupted.*/,
                     /The request is not allowed by the user agent or the platform in the current context/,
 
                     // Network errors that we don't control

--- a/ghost/admin/app/utils/sentry.js
+++ b/ghost/admin/app/utils/sentry.js
@@ -34,7 +34,7 @@ export function beforeSend(event, hint) {
             delete event.tags.ajax_url;
         }
 
-        // Do not report poshog-js errors to Sentry
+        // Do not report posthog-js errors to Sentry
         if (hint && hint.originalException && hint.originalException.stack) {
             if (hint.originalException.stack.includes('/posthog-js/')) {
                 return null;


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-175
