### PR TITLE
Fixed members list when scrolled down too quickly

### DIFF
--- a/ghost/admin/app/templates/members.hbs
+++ b/ghost/admin/app/templates/members.hbs
@@ -143,7 +143,7 @@
                                 {{/each}}
                             </tr>
                         </thead>
-                        <VerticalCollection @tagName="tbody" @items={{this.members}} @key="id" @containerSelector=".gh-list-scrolling" @estimateHeight={{69}} @staticHeight={{true}} @bufferSize={{20}} as |member|>
+                        <VerticalCollection @tagName="tbody" @items={{this.members}} @key="id" @containerSelector=".gh-list-scrolling" @estimateHeight={{75}} @staticHeight={{true}} @bufferSize={{5}} @renderAll={{false}} as |member|>
                             {{#if member.is_loading}}
                                 <Members::ListItemLoading
                                     @newsletterEnabled={{and (not-eq this.settings.editorDefaultEmailRecipients "disabled") this.settings.emailTrackOpens}}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-160

- in the Members list, we were using VerticalCollection with `@bufferSize` set to 20, which means that 20 additional items before and after the visible items in the viewport were pre-loaded
- however, scrolling down too quickly (e.g. dragging the scrollbar thumb to the bottom) breaks the list
- with this fix, we adjust `@estimateHeight` parameter to the correct item size, and reduce the `@bufferSize`
