### PR TITLE
Removed cache buster from client extensions script

### DIFF
--- a/ghost/admin/app/controllers/application.js
+++ b/ghost/admin/app/controllers/application.js
@@ -27,10 +27,6 @@ export default class ApplicationController extends Controller {
         return this.config.clientExtensions?.script;
     }
 
-    get cacheBuster() {
-        return Date.now();
-    }
-
     get showNavMenu() {
         let {router, session, ui} = this;
 

--- a/ghost/admin/app/templates/application.hbs
+++ b/ghost/admin/app/templates/application.hbs
@@ -40,7 +40,7 @@
     {{#if this.showScriptExtension}}
         {{{this.showScriptExtension.container}}}
         {{!-- template-lint-disable no-forbidden-elements --}}
-        <script src="{{this.showScriptExtension.src}}?v={{this.cacheBuster}}"></script>
+        <script src="{{this.showScriptExtension.src}}"></script>
     {{/if}}
 
     {{#if this.settings.accentColor}}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PA-71/remove-cache-bust-from-projs-in-admin
ref https://github.com/TryGhost/Ghost/commit/15ed2eb245d880a292375a18c61444eff7da66f0

- This cache bust was added previously to mitigate an error in pro.js, to effectively force browsers to redownload the file.
- It's not needed anymore, as the error has been fixed for a few months now, so we can remove it.