### PR TITLE
🐛 Fixed Content-Type for RSS feed

### DIFF
--- a/ghost/core/core/frontend/services/rss/renderer.js
+++ b/ghost/core/core/frontend/services/rss/renderer.js
@@ -9,7 +9,7 @@ module.exports.render = function render(res, baseUrl, data) {
     return rssCache
         .getXML(baseUrl, rssData)
         .then(function then(feedXml) {
-            res.set('Content-Type', 'text/xml; charset=UTF-8');
+            res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
             res.send(feedXml);
         });
 };

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -271,7 +271,7 @@ describe('Default Frontend routing', function () {
             await request.get('/rss/')
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
@@ -283,7 +283,7 @@ describe('Default Frontend routing', function () {
             await request.get('/author/ghost/rss/')
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
@@ -295,7 +295,7 @@ describe('Default Frontend routing', function () {
             await request.get('/tag/getting-started/rss/')
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
@@ -461,7 +461,7 @@ describe('Default Frontend routing', function () {
             await request.get(`/${settingsCache.get('public_hash')}/rss/`)
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
@@ -472,7 +472,7 @@ describe('Default Frontend routing', function () {
             await request.get(`/tag/getting-started/${settingsCache.get('public_hash')}/rss/`)
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);

--- a/ghost/core/test/regression/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/regression/mock-express-style/api-vs-frontend.test.js
@@ -1560,7 +1560,7 @@ describe('Frontend behavior tests', function () {
                 .then(function (response) {
                     response.statusCode.should.eql(200);
                     response.template.should.eql('podcast/rss');
-                    response.headers['content-type'].should.eql('application/rss+xml; charset=utf-8');
+                    response.headers['content-type'].should.eql('application/rss+xml');
                     response.body.match(/<link>/g).length.should.eql(2);
                 });
         });

--- a/ghost/core/test/regression/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/regression/mock-express-style/api-vs-frontend.test.js
@@ -1294,7 +1294,7 @@ describe('Frontend behavior tests', function () {
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
                         response.statusCode.should.eql(200);
-                        response.headers['content-type'].should.eql('text/xml; charset=UTF-8');
+                        response.headers['content-type'].should.eql('application/rss+xml; charset=UTF-8');
                     });
             });
 
@@ -1448,7 +1448,7 @@ describe('Frontend behavior tests', function () {
                 routes: {
                     '/podcast/rss/': {
                         templates: ['podcast/rss'],
-                        content_type: 'text/xml'
+                        content_type: 'application/rss+xml'
                     },
                     '/cooking/': {
                         controller: 'channel',
@@ -1560,7 +1560,7 @@ describe('Frontend behavior tests', function () {
                 .then(function (response) {
                     response.statusCode.should.eql(200);
                     response.template.should.eql('podcast/rss');
-                    response.headers['content-type'].should.eql('text/xml; charset=utf-8');
+                    response.headers['content-type'].should.eql('application/rss+xml; charset=utf-8');
                     response.body.match(/<link>/g).length.should.eql(2);
                 });
         });

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -32,7 +32,7 @@ describe('RSS: Renderer', function () {
             rssCacheStub.firstCall.args.should.eql(['/rss/', {}]);
 
             res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'text/xml; charset=UTF-8').should.be.true();
+            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
 
             res.send.calledOnce.should.be.true();
             res.send.calledWith('dummyxml').should.be.true();
@@ -51,7 +51,7 @@ describe('RSS: Renderer', function () {
             rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'bar'}]);
 
             res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'text/xml; charset=UTF-8').should.be.true();
+            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
 
             res.send.calledOnce.should.be.true();
             res.send.calledWith('dummyxml').should.be.true();
@@ -71,7 +71,7 @@ describe('RSS: Renderer', function () {
             rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
             res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'text/xml; charset=UTF-8').should.be.true();
+            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
 
             res.send.calledOnce.should.be.true();
             res.send.calledWith('dummyxml').should.be.true();


### PR DESCRIPTION
This sets the correct Content-Type (`application/rss+xml; charset=utf-8`) for the RSS Endpoint as mentioned in the issue #20634 

I hope I did everything correct here - when running `yarn dev`, it definitely sends the correct Content-Type now.

Closes #20634 