### PR TITLE
Protected against quick escapes when loading post

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -871,11 +871,11 @@ export default class LexicalEditorController extends Controller {
         this.ui.updateDocumentTitle();
     }
 
-    /* 
+    /*
         // sync the post slug with the post title, except when:
         // - the user has already typed a custom slug, which should not be overwritten
         // - the post has been published, so that published URLs are not broken
-    */ 
+    */
     @enqueueTask
     *generateSlugTask() {
         const currentTitle = this.get('post.title');
@@ -916,7 +916,7 @@ export default class LexicalEditorController extends Controller {
     *backgroundLoaderTask() {
         yield this.store.query('snippet', {limit: 'all'});
 
-        if (this.post.displayName === 'page' && this.feature.get('collections') && this.feature.get('collectionsCard')) {
+        if (this.post?.displayName === 'page' && this.feature.get('collections') && this.feature.get('collectionsCard')) {
             yield this.store.query('collection', {limit: 'all'});
         }
 


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-180/typeerror-cannot-read-properties-of-null-reading-displayname

- in the event you click on a post and then press Back really quickly, `this.post` will be null because the post is not loaded
- the code here fails because it tries to read a property from `null`
- we can protect against that by using optional chaining on the property
