### PR TITLE
🐛 Disabled bulk deletion when multiple member filters are applied (#20681)

### DIFF
--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -209,6 +209,10 @@ export default class MembersController extends Controller {
         return uniqueColumns.splice(0, 2); // Maximum 2 columns
     }
 
+    get isMultiFiltered() {
+        return this.isFiltered && this.filters.length >= 2;
+    }
+
     includeTierQuery() {
         const availableFilters = this.filters.length ? this.filters : this.softFilters;
         return availableFilters.some((f) => {

--- a/ghost/admin/app/templates/members.hbs
+++ b/ghost/admin/app/templates/members.hbs
@@ -104,12 +104,14 @@
                                         </button>
                                     </li>
                                 {{/if}}
-                                <li class="divider"></li>
-                                <li>
-                                    <button class="mr2" data-test-button="delete-selected" type="button" {{on "click" this.bulkDelete}}>
-                                        <span class="red">Delete selected members ({{this.members.length}})</span>
-                                    </button>
-                                </li>
+                                {{#unless this.isMultiFiltered}}
+                                    <li class="divider"></li>
+                                    <li>
+                                        <button class="mr2" data-test-button="delete-selected" type="button" {{on "click" this.bulkDelete}}>
+                                            <span class="red">Delete selected members ({{this.members.length}})</span>
+                                        </button>
+                                    </li>
+                                {{/unless}}
                             {{/if}}
                         </GhDropdown>
                     </span>

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -1328,7 +1328,12 @@ describe('Acceptance: Members filtering', function () {
             expect(find('[data-test-button="add-label-selected"]'), 'add label to selected button').to.exist;
             expect(find('[data-test-button="remove-label-selected"]'), 'remove label from selected button').to.exist;
             expect(find('[data-test-button="unsubscribe-selected"]'), 'unsubscribe selected button').to.exist;
-            expect(find('[data-test-button="delete-selected"]'), 'delete selected button').to.exist;
+
+            /* NOTE: Bulk deletion is disabled temporarily when multiple filters are applied, due to a NQL limitation.
+            * Re-enable following line once we have fixed the root NQL limitation.
+            * See https://linear.app/tryghost/issue/ONC-203
+            */
+            // expect(find('[data-test-button="delete-selected"]'), 'delete selected button').to.exist;
 
             // filter is active and has # of filters
             expect(find('[data-test-button="members-filter-actions"] span'), 'filter button').to.have.class('gh-btn-label-green');


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ONC-206
ref https://app.incident.io/ghost/incidents/90

- when multiple member filters are used in combination, NQL sometimes hit a limitation that results in the wrong members being returned
- while we work on the NQL limitation, we are temporarily disabling bulk member deletion when more than one member filter has been applied
