### PR TITLE
🐛 Fixed no redirect on Portal signin when trying to access newsletters

### DIFF
--- a/apps/portal/src/components/pages/AccountEmailPage.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.js
@@ -9,7 +9,10 @@ export default function AccountEmailPage() {
     useEffect(() => {
         if (!member) {
             onAction('switchPage', {
-                page: 'signin'
+                page: 'signin',
+                pageData: {
+                    redirect: window.location.href // This includes the search/fragment of the URL (#/portal/account) which is missing from the default referer header
+                }
             });
         }
     }, [member, onAction]);

--- a/apps/portal/src/components/pages/AccountEmailPage.test.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.test.js
@@ -112,6 +112,6 @@ describe('Account Email Page', () => {
             newsletters: newsletterData
         });
         const {mockOnActionFn} = setup({site: siteData, member: null});
-        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
+        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin', pageData: {redirect: window.location.href}});
     });
 });

--- a/apps/portal/src/tests/EmailSubscriptionsFlow.test.js
+++ b/apps/portal/src/tests/EmailSubscriptionsFlow.test.js
@@ -254,33 +254,4 @@ describe('Newsletter Subscriptions', () => {
             expect(newsletter2Toggle).toHaveClass('gh-portal-toggle-checked');
         });
     });
-
-    // describe('navigating straight to /portal/account/newsletters', () => {
-    //     it('shows the newsletter management page when signed in', async () => {
-    //         const {popupFrame, triggerButton, queryAllByText, popupIframeDocument} = await setup({
-    //             site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
-    //             member: FixtureMember.subbedToNewsletter,
-    //             newsletters: Newsletters
-    //         });
-
-    //         const manageSubscriptionsButton = within(popupIframeDocument).queryByRole('button', {name: 'Manage'});
-    //         await userEvent.click(manageSubscriptionsButton);
-
-    //         const newsletter1 = within(popupIframeDocument).queryAllByText('Newsletter 1');
-    //         expect(newsletter1).toBeInTheDocument();
-    //     });
-
-    //     it('redirects to the sign in page when not signed in', async () => {
-    //         const {popupFrame, queryByTitle, popupIframeDocument} = await setup({
-    //             site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
-    //             member: FixtureMember.subbedToNewsletter,
-    //             newsletters: Newsletters
-    //         }, true);
-
-    //         // console.log(`popupFrame`, popupFrame);
-    //         // console.log(`queryByTitle`, queryByTitle);
-    //         // console.log(`popupIframeDocument`, popupIframeDocument);
-
-    //     });
-    // });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1464
- added redirect to sign in page when trying to access newsletter management

If a user tries to access newsletter management when not logged in, Portal requires sign in via magic link. This magic link didn't previous redirect the user back to newsletter management, requiring some extra clicks.