### PR TITLE
🐛 Fixed unsaved changes confirmation on Lexical schema change

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -101,7 +101,6 @@
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
             @initLexical={{@initLexical}}
-            @initLexicalState={{@initLexicalState}}
         />
     </div>
 </div>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -100,6 +100,7 @@
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
             @initLexical={{@initLexical}}
+            @initLexicalState={{@initLexicalState}}
         />
     </div>
 </div>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -95,12 +95,12 @@
             @placeholder={{@bodyPlaceholder}}
             @cardConfig={{@cardOptions}}
             @onChange={{@onBodyChange}}
+            @updateSecondaryInstanceModel={{@updateSecondaryInstanceModel}}
             @registerAPI={{this.registerEditorAPI}}
             @registerSecondaryAPI={{this.registerSecondaryEditorAPI}}
             @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
-            @initLexical={{@initLexical}}
         />
     </div>
 </div>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -99,6 +99,7 @@
             @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
+            @initLexicalScratch={{@initLexicalScratch}}
         />
     </div>
 </div>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -96,6 +96,7 @@
             @cardConfig={{@cardOptions}}
             @onChange={{@onBodyChange}}
             @registerAPI={{this.registerEditorAPI}}
+            @registerSecondaryAPI={{this.registerSecondaryEditorAPI}}
             @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -99,7 +99,7 @@
             @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}
-            @initLexicalScratch={{@initLexicalScratch}}
+            @initLexical={{@initLexical}}
         />
     </div>
 </div>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -15,6 +15,7 @@ export default class GhKoenigEditorLexical extends Component {
     uploadUrl = `${ghostPaths().apiRoot}/images/upload/`;
 
     editorAPI = null;
+    secondaryEditorAPI = null;
     skipFocusEditor = false;
 
     @tracked titleIsHovered = false;
@@ -230,6 +231,12 @@ export default class GhKoenigEditorLexical extends Component {
     registerEditorAPI(API) {
         this.editorAPI = API;
         this.args.registerAPI(API);
+    }
+
+    @action
+    registerSecondaryEditorAPI(API) {
+        this.secondaryEditorAPI = API;
+        this.args.registerSecondaryAPI(API);
     }
 
     // focus the editor when the editor canvas is clicked below the editor content,

--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -853,6 +853,7 @@
                     post=this.post
                     editorAPI=this.editorAPI
                     toggleSettingsMenu=this.toggleSettingsMenu
+                    secondaryEditorAPI=this.secondaryEditorAPI
                 }}
                 @close={{this.closePostHistory}}
                 @modifier="total-overlay post-history" />

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -682,7 +682,7 @@ export default class KoenigLexicalEditor extends Component {
                         cardConfig={cardConfig}
                         enableMultiplayer={enableMultiplayer}
                         fileUploader={{useFileUpload, fileTypes}}
-                        initialEditorState={this.args.lexical}
+                        initialEditorState={isInitInstance ? this.args.initLexicalState || this.args.lexical : this.args.lexical}
                         multiplayerUsername={multiplayerUsername}
                         multiplayerDocId={multiplayerDocId}
                         multiplayerEndpoint={multiplayerEndpoint}

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -670,12 +670,6 @@ export default class KoenigLexicalEditor extends Component {
         const multiplayerUsername = this.session.user.name;
 
         const KGEditorComponent = ({isInitInstance}) => {
-            const handleInitInstance = (data) => {
-                if (this.args.initLexical && isInitInstance) {
-                    this.args.initLexical(data);
-                }
-            };
-
             return (
                 <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
                     <KoenigComposer
@@ -696,7 +690,7 @@ export default class KoenigLexicalEditor extends Component {
                             cursorDidExitAtTop={isInitInstance ? null : this.args.cursorDidExitAtTop}
                             placeholderText={isInitInstance ? null : this.args.placeholderText}
                             darkMode={isInitInstance ? null : this.feature.nightShift}
-                            onChange={isInitInstance ? e => handleInitInstance(e) : this.args.onChange}
+                            onChange={isInitInstance ? this.args.updateSecondaryInstanceModel : this.args.onChange}
                             registerAPI={isInitInstance ? this.args.registerSecondaryAPI : this.args.registerAPI}
                         />
                         <WordCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updateWordCount} />

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -669,17 +669,14 @@ export default class KoenigLexicalEditor extends Component {
         const multiplayerDocId = cardConfig.post.id;
         const multiplayerUsername = this.session.user.name;
 
-        const [hasInitialised, setHasInitialised] = React.useState(false);
-
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
-                if (this.args.initLexical && isInitInstance && !hasInitialised) {
+                if (this.args.initLexical && isInitInstance) {
                     this.args.initLexical(data);
-                    setHasInitialised(true);
                 }
             };
             return (
-                <div style={isInitInstance && !hasInitialised ? {visibility: 'hidden', position: 'absolute'} : {}}>
+                <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
                     <KoenigComposer
                         editorResource={this.editorResource}
                         cardConfig={cardConfig}
@@ -695,14 +692,14 @@ export default class KoenigLexicalEditor extends Component {
                     >
                         <KoenigEditor
                             editorResource={this.editorResource}
-                            cursorDidExitAtTop={this.args.cursorDidExitAtTop}
-                            placeholderText={this.args.placeholder}
-                            darkMode={this.feature.nightShift}
+                            cursorDidExitAtTop={isInitInstance ? null : this.args.cursorDidExitAtTop}
+                            placeholderText={isInitInstance ? null : this.args.placeholderText}
+                            darkMode={isInitInstance ? null : this.feature.nightShift}
                             onChange={isInitInstance ? e => handleInitInstance(e) : this.args.onChange}
-                            registerAPI={this.args.registerAPI}
+                            registerAPI={isInitInstance ? null : this.args.registerAPI}
                         />
-                        <WordCountPlugin editorResource={this.editorResource} onChange={this.args.updateWordCount} />
-                        <TKCountPlugin editorResource={this.editorResource} onChange={this.args.updatePostTkCount} />
+                        <WordCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updateWordCount} />
+                        <TKCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updatePostTkCount} />
                     </KoenigComposer>
                 </div>
             );
@@ -713,9 +710,7 @@ export default class KoenigLexicalEditor extends Component {
                 <ErrorHandler config={this.config}>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
                         <KGEditorComponent />
-                        {
-                            !hasInitialised && <KGEditorComponent isInitInstance={true} /> 
-                        }
+                        <KGEditorComponent isInitInstance={true} /> 
                     </Suspense>
                 </ErrorHandler>
             </div>

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -671,7 +671,12 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
-                this.args.initLexicalScratch(data);
+                try {
+                    console.log('data-- ', data);
+                    this.args.initLexical(data);
+                } catch (error) {
+                    this.onError(error); // eslint-disable-line
+                }
             };
             return (
                 <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -669,17 +669,17 @@ export default class KoenigLexicalEditor extends Component {
         const multiplayerDocId = cardConfig.post.id;
         const multiplayerUsername = this.session.user.name;
 
+        const [hasInitialised, setHasInitialised] = React.useState(false);
+
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
-                try {
+                if (this.args.initLexical && isInitInstance && !hasInitialised) {
                     this.args.initLexical(data);
-                } catch (error) {
-                    console.log('unable to initialise, skipping'); // eslint-disable-line
-                    // This is a catch-all, however it's current implementation is to catch it when loading revisions
+                    setHasInitialised(true);
                 }
             };
             return (
-                <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
+                <div style={isInitInstance && !hasInitialised ? {visibility: 'hidden', position: 'absolute'} : {}}>
                     <KoenigComposer
                         editorResource={this.editorResource}
                         cardConfig={cardConfig}
@@ -713,7 +713,9 @@ export default class KoenigLexicalEditor extends Component {
                 <ErrorHandler config={this.config}>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
                         <KGEditorComponent />
-                        <KGEditorComponent isInitInstance={true} />
+                        {
+                            !hasInitialised && <KGEditorComponent isInitInstance={true} /> 
+                        }
                     </Suspense>
                 </ErrorHandler>
             </div>

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -672,10 +672,10 @@ export default class KoenigLexicalEditor extends Component {
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
                 try {
-                    console.log('data-- ', data);
                     this.args.initLexical(data);
                 } catch (error) {
-                    this.onError(error); // eslint-disable-line
+                    console.log('unable to initialise, skipping'); // eslint-disable-line
+                    // This is a catch-all, however it's current implementation is to catch it when loading revisions
                 }
             };
             return (

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -675,6 +675,7 @@ export default class KoenigLexicalEditor extends Component {
                     this.args.initLexical(data);
                 }
             };
+
             return (
                 <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
                     <KoenigComposer

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -669,34 +669,46 @@ export default class KoenigLexicalEditor extends Component {
         const multiplayerDocId = cardConfig.post.id;
         const multiplayerUsername = this.session.user.name;
 
+        const KGEditorComponent = ({isInitInstance}) => {
+            const handleInitInstance = (data) => {
+                
+            };
+            return (
+                <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
+                    <KoenigComposer
+                        editorResource={this.editorResource}
+                        cardConfig={cardConfig}
+                        enableMultiplayer={enableMultiplayer}
+                        fileUploader={{useFileUpload, fileTypes}}
+                        initialEditorState={this.args.lexical}
+                        multiplayerUsername={multiplayerUsername}
+                        multiplayerDocId={multiplayerDocId}
+                        multiplayerEndpoint={multiplayerEndpoint}
+                        onError={this.onError}
+                        darkMode={this.feature.nightShift}
+                        isTKEnabled={true}
+                    >
+                        <KoenigEditor
+                            editorResource={this.editorResource}
+                            cursorDidExitAtTop={this.args.cursorDidExitAtTop}
+                            placeholderText={this.args.placeholder}
+                            darkMode={this.feature.nightShift}
+                            onChange={isInitInstance ? handleInitInstance : this.args.onChange}
+                            registerAPI={this.args.registerAPI}
+                        />
+                        <WordCountPlugin editorResource={this.editorResource} onChange={this.args.updateWordCount} />
+                        <TKCountPlugin editorResource={this.editorResource} onChange={this.args.updatePostTkCount} />
+                    </KoenigComposer>
+                </div>
+            );
+        };
+
         return (
             <div className={['koenig-react-editor', 'koenig-lexical', this.args.className].filter(Boolean).join(' ')}>
                 <ErrorHandler config={this.config}>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
-                        <KoenigComposer
-                            editorResource={this.editorResource}
-                            cardConfig={cardConfig}
-                            enableMultiplayer={enableMultiplayer}
-                            fileUploader={{useFileUpload, fileTypes}}
-                            initialEditorState={this.args.lexical}
-                            multiplayerUsername={multiplayerUsername}
-                            multiplayerDocId={multiplayerDocId}
-                            multiplayerEndpoint={multiplayerEndpoint}
-                            onError={this.onError}
-                            darkMode={this.feature.nightShift}
-                            isTKEnabled={true}
-                        >
-                            <KoenigEditor
-                                editorResource={this.editorResource}
-                                cursorDidExitAtTop={this.args.cursorDidExitAtTop}
-                                placeholderText={this.args.placeholder}
-                                darkMode={this.feature.nightShift}
-                                onChange={this.args.onChange}
-                                registerAPI={this.args.registerAPI}
-                            />
-                            <WordCountPlugin editorResource={this.editorResource} onChange={this.args.updateWordCount} />
-                            <TKCountPlugin editorResource={this.editorResource} onChange={this.args.updatePostTkCount} />
-                        </KoenigComposer>
+                        <KGEditorComponent />
+                        <KGEditorComponent isInitInstance={true} />
                     </Suspense>
                 </ErrorHandler>
             </div>

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -683,7 +683,7 @@ export default class KoenigLexicalEditor extends Component {
                         cardConfig={cardConfig}
                         enableMultiplayer={enableMultiplayer}
                         fileUploader={{useFileUpload, fileTypes}}
-                        initialEditorState={isInitInstance ? this.args.initLexicalState || this.args.lexical : this.args.lexical}
+                        initialEditorState={this.args.lexical}
                         multiplayerUsername={multiplayerUsername}
                         multiplayerDocId={multiplayerDocId}
                         multiplayerEndpoint={multiplayerEndpoint}
@@ -697,7 +697,7 @@ export default class KoenigLexicalEditor extends Component {
                             placeholderText={isInitInstance ? null : this.args.placeholderText}
                             darkMode={isInitInstance ? null : this.feature.nightShift}
                             onChange={isInitInstance ? e => handleInitInstance(e) : this.args.onChange}
-                            registerAPI={isInitInstance ? null : this.args.registerAPI}
+                            registerAPI={isInitInstance ? this.args.registerSecondaryAPI : this.args.registerAPI}
                         />
                         <WordCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updateWordCount} />
                         <TKCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updatePostTkCount} />

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -671,7 +671,8 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
-                
+                // const newjson = JSON.stringify(data);
+                this.args.initLexicalScratch(data);
             };
             return (
                 <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
@@ -693,7 +694,7 @@ export default class KoenigLexicalEditor extends Component {
                             cursorDidExitAtTop={this.args.cursorDidExitAtTop}
                             placeholderText={this.args.placeholder}
                             darkMode={this.feature.nightShift}
-                            onChange={isInitInstance ? handleInitInstance : this.args.onChange}
+                            onChange={isInitInstance ? e => handleInitInstance(e) : this.args.onChange}
                             registerAPI={this.args.registerAPI}
                         />
                         <WordCountPlugin editorResource={this.editorResource} onChange={this.args.updateWordCount} />

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -671,7 +671,6 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             const handleInitInstance = (data) => {
-                // const newjson = JSON.stringify(data);
                 this.args.initLexicalScratch(data);
             };
             return (

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -33,6 +33,7 @@
                     @lexical={{this.selectedRevision.lexical}}
                     @cardConfig={{this.cardConfig}}
                     @registerAPI={{this.registerSelectedEditorApi}}
+                    @registerSecondaryAPI={{this.registerSecondarySelectedEditorApi}}
                 />
             </div>
         </div>

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -31,6 +31,7 @@ export default class ModalPostHistory extends Component {
         super(...arguments);
         this.post = this.args.model.post;
         this.editorAPI = this.args.model.editorAPI;
+        this.secondaryEditorAPI = this.args.model.secondaryEditorAPI;
         this.toggleSettingsMenu = this.args.model.toggleSettingsMenu;
     }
 
@@ -102,6 +103,11 @@ export default class ModalPostHistory extends Component {
     }
 
     @action
+    registerSecondarySelectedEditorApi(api) {
+        this.secondarySelectedEditor = api;
+    }
+
+    @action
     registerComparisonEditorApi(api) {
         this.comparisonEditor = api;
     }
@@ -130,7 +136,7 @@ export default class ModalPostHistory extends Component {
             updateEditor: () => {
                 const state = this.editorAPI.editorInstance.parseEditorState(revision.lexical);
                 this.editorAPI.editorInstance.setEditorState(state);
-                set(this.post, 'initLexicalState', revision.lexical);
+                this.secondaryEditorAPI.editorInstance.setEditorState(state);
             },
             closePostHistoryModal: () => {
                 this.closeModal();

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -130,6 +130,7 @@ export default class ModalPostHistory extends Component {
             updateEditor: () => {
                 const state = this.editorAPI.editorInstance.parseEditorState(revision.lexical);
                 this.editorAPI.editorInstance.setEditorState(state);
+                set(this.post, 'initLexicalState', revision.lexical);
             },
             closePostHistoryModal: () => {
                 this.closeModal();

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -184,8 +184,6 @@ export default class LexicalEditorController extends Controller {
     _saveOnLeavePerformed = false;
     _previousTagNames = null; // set by setPost and _postSaved, used in hasDirtyAttributes
 
-    _initLexical = null;
-
     /* computed properties ---------------------------------------------------*/
 
     @alias('model')
@@ -414,8 +412,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     initLexical(data) {
-        this.post.set('initLexicalState', JSON.stringify(data));
-        this._initLexical = JSON.stringify(data);
+        this.post.set('initLexicalState', JSON.stringify(data)); // sets the initial lexical state from the secondary editor
     }
 
     @action

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -407,9 +407,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     initLexicalScratch(data) {
-        console.log(data);
         this.set('post.initLexicalScratch', JSON.stringify(data));
-        // this.set('post.lexicalScratch', JSON.stringify(data));
     }
 
     @action

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1244,7 +1244,8 @@ export default class LexicalEditorController extends Controller {
             return true;
         }
 
-        // Post tags comparison
+        // post.tags is an array so hasDirtyAttributes doesn't pick up
+        // changes unless the array ref is changed
         let currentTags = (this._tagNames || []).join(', ');
         let previousTags = (this._previousTagNames || []).join(', ');
         if (currentTags !== previousTags) {

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -43,7 +43,6 @@ const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
 // this array will hold properties we need to watch for this.hasDirtyAttributes
 let watchedProps = [
     'post.lexicalScratch',
-    // 'post.lexical', // the lexical object might be refreshed by the initial instance with new schema so it needs to be watched
     'post.titleScratch',
     'post.hasDirtyAttributes',
     'post.tags.[]',

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1267,7 +1267,10 @@ export default class LexicalEditorController extends Controller {
         // Lexical and scratch comparison
         let lexical = post.get('lexical');
         let scratch = post.get('lexicalScratch');
-        let initLexical = this.initLexicalState;
+        // let initLexical = this.initLexicalState;
+        let initLexical = this.secondaryEditorAPI?.editorInstance?.getEditorState().toJSON();
+        // convert initLexical to string
+        initLexical = JSON.stringify(initLexical);
 
         let lexicalChildNodes = lexical ? JSON.parse(lexical).root?.children : [];
         let scratchChildNodes = scratch ? JSON.parse(scratch).root?.children : [];

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1297,7 +1297,6 @@ export default class LexicalEditorController extends Controller {
         // we've covered all the non-tracked cases we care about so fall
         // back on Ember Data's default dirty attribute checks
         let {hasDirtyAttributes} = post;
-
         if (hasDirtyAttributes) {
             this._leaveModalReason = {reason: 'post.hasDirtyAttributes === true', context: post.changedAttributes()};
         }

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -438,6 +438,11 @@ export default class LexicalEditorController extends Controller {
     }
 
     @action
+    registerSecondaryEditorAPI(API) {
+        this.secondaryEditorAPI = API;
+    }
+
+    @action
     clearFeatureImage() {
         this.post.set('featureImage', null);
         this.post.set('featureImageAlt', null);
@@ -1265,7 +1270,7 @@ export default class LexicalEditorController extends Controller {
         // Lexical and scratch comparison
         let lexical = post.get('lexical');
         let scratch = post.get('lexicalScratch');
-        let initLexical = post.get('initLexicalState') || this._initLexical;
+        let initLexical = this.initLexicalState;
 
         let lexicalChildNodes = lexical ? JSON.parse(lexical).root?.children : [];
         let scratchChildNodes = scratch ? JSON.parse(scratch).root?.children : [];
@@ -1300,7 +1305,7 @@ export default class LexicalEditorController extends Controller {
             return true;
         }
 
-        // If either comparison is not dirty, return false
+        // If either comparison is not dirty, return false, because we scratch is always up to date.
         if (!isInitLexicalDirty || !isLexicalDirty) {
             return false;
         }

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -43,6 +43,7 @@ const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
 // this array will hold properties we need to watch for this.hasDirtyAttributes
 let watchedProps = [
     'post.lexicalScratch',
+    'post.initLexicalScratch',
     'post.titleScratch',
     'post.hasDirtyAttributes',
     'post.tags.[]',
@@ -402,6 +403,13 @@ export default class LexicalEditorController extends Controller {
     @action
     updatePostTkCount(count) {
         this.set('postTkCount', count);
+    }
+
+    @action
+    initLexicalScratch(data) {
+        console.log(data);
+        this.set('post.initLexicalScratch', JSON.stringify(data));
+        // this.set('post.lexicalScratch', JSON.stringify(data));
     }
 
     @action
@@ -1026,6 +1034,7 @@ export default class LexicalEditorController extends Controller {
         // TODO: can these be `boundOneWay` on the model as per the other attrs?
         post.set('titleScratch', post.get('title'));
         post.set('lexicalScratch', post.get('lexical'));
+        // post.set('initLexicalScratch', post.get('lexical'));
 
         this._previousTagNames = this._tagNames;
 
@@ -1252,8 +1261,10 @@ export default class LexicalEditorController extends Controller {
         }
 
         // scratch isn't an attr so needs a manual dirty check
-        let lexical = post.get('lexical');
+        let lexical = post.get('initLexicalScratch');
         let scratch = post.get('lexicalScratch');
+
+        console.log('lexical', lexical);
         // additional guard in case we are trying to compare null with undefined
         if (scratch || lexical) {
             if (scratch !== lexical) {

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1264,7 +1264,6 @@ export default class LexicalEditorController extends Controller {
         let lexical = post.get('initLexicalScratch');
         let scratch = post.get('lexicalScratch');
 
-        console.log('lexical', lexical);
         // additional guard in case we are trying to compare null with undefined
         if (scratch || lexical) {
             if (scratch !== lexical) {

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -43,7 +43,7 @@ const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
 // this array will hold properties we need to watch for this.hasDirtyAttributes
 let watchedProps = [
     'post.lexicalScratch',
-    'post.initLexicalScratch',
+    // 'post.lexical', // the lexical object might be refreshed by the initial instance with new schema so it needs to be watched
     'post.titleScratch',
     'post.hasDirtyAttributes',
     'post.tags.[]',
@@ -406,8 +406,9 @@ export default class LexicalEditorController extends Controller {
     }
 
     @action
-    initLexicalScratch(data) {
-        this.set('post.initLexicalScratch', JSON.stringify(data));
+    initLexical(data) {
+        this.post.set('lexical', JSON.stringify(data));
+        this.post.set('hasDirtyAttributes', false); // we need to reset this so that the initilised state is not considered dirty
     }
 
     @action
@@ -1032,7 +1033,6 @@ export default class LexicalEditorController extends Controller {
         // TODO: can these be `boundOneWay` on the model as per the other attrs?
         post.set('titleScratch', post.get('title'));
         post.set('lexicalScratch', post.get('lexical'));
-        // post.set('initLexicalScratch', post.get('lexical'));
 
         this._previousTagNames = this._tagNames;
 
@@ -1259,7 +1259,7 @@ export default class LexicalEditorController extends Controller {
         }
 
         // scratch isn't an attr so needs a manual dirty check
-        let lexical = post.get('initLexicalScratch');
+        let lexical = post.get('lexical');
         let scratch = post.get('lexicalScratch');
 
         // additional guard in case we are trying to compare null with undefined

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1262,8 +1262,6 @@ export default class LexicalEditorController extends Controller {
         let lexical = post.get('lexical');
         let scratch = post.get('lexicalScratch');
         let secondaryLexical = post.get('secondaryLexicalState');
-        // let initLexical = this.secondaryEditorAPI?.editorInstance?.getEditorState().toJSON();
-        // initLexical = JSON.stringify(initLexical);
 
         let lexicalChildNodes = lexical ? JSON.parse(lexical).root?.children : [];
         let scratchChildNodes = scratch ? JSON.parse(scratch).root?.children : [];
@@ -1298,7 +1296,7 @@ export default class LexicalEditorController extends Controller {
             return true;
         }
 
-        // If either comparison is not dirty, return false, because we scratch is always up to date.
+        // If either comparison is not dirty, return false, because scratch is always up to date.
         if (!isSecondaryDirty || !isLexicalDirty) {
             return false;
         }

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -138,7 +138,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     titleScratch: null,
     //This is used to store the initial lexical state from the
     // secondary editor to get the schema up to date in case its outdated
-    initLexicalState: null,
+    secondaryLexicalState: null,
 
     // For use by date/time pickers - will be validated then converted to UTC
     // on save. Updated by an observer whenever publishedAtUTC changes.

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -136,6 +136,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     scratch: null,
     lexicalScratch: null,
     titleScratch: null,
+    initLexicalScratch: null,
 
     // For use by date/time pickers - will be validated then converted to UTC
     // on save. Updated by an observer whenever publishedAtUTC changes.

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -136,7 +136,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     scratch: null,
     lexicalScratch: null,
     titleScratch: null,
-    initLexicalScratch: null,
 
     // For use by date/time pickers - will be validated then converted to UTC
     // on save. Updated by an observer whenever publishedAtUTC changes.

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -136,6 +136,9 @@ export default Model.extend(Comparable, ValidationEngine, {
     scratch: null,
     lexicalScratch: null,
     titleScratch: null,
+    //This is used to store the initial lexical state from the
+    // secondary editor to get the schema up to date in case its outdated
+    initLexicalState: null,
 
     // For use by date/time pickers - will be validated then converted to UTC
     // on save. Updated by an observer whenever publishedAtUTC changes.

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -80,7 +80,6 @@
                 @updateWordCount={{this.updateWordCount}}
                 @updatePostTkCount={{this.updatePostTkCount}}
                 @initLexical={{this.initLexical}}
-                @initLexicalState={{this.initLexicalState}}
                 @updateFeatureImageTkCount={{this.updateFeatureImageTkCount}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -79,6 +79,7 @@
                 @onEditorCreated={{this.setKoenigEditor}}
                 @updateWordCount={{this.updateWordCount}}
                 @updatePostTkCount={{this.updatePostTkCount}}
+                @initLexicalScratch={{this.initLexicalScratch}}
                 @updateFeatureImageTkCount={{this.updateFeatureImageTkCount}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -99,6 +99,7 @@
                 }}
                 @postType={{this.post.displayName}}
                 @registerAPI={{this.registerEditorAPI}}
+                @registerSecondaryAPI={{this.registerSecondaryEditorAPI}}
                 @savePostTask={{this.savePostTask}}
             />
 
@@ -138,6 +139,7 @@
                 @updateSlugTask={{this.updateSlugTask}}
                 @savePostTask={{this.savePostTask}}
                 @editorAPI={{this.editorAPI}}
+                @secondaryEditorAPI={{this.secondaryEditorAPI}}
                 @toggleSettingsMenu={{this.toggleSettingsMenu}}
             />
         {{/if}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -79,7 +79,7 @@
                 @onEditorCreated={{this.setKoenigEditor}}
                 @updateWordCount={{this.updateWordCount}}
                 @updatePostTkCount={{this.updatePostTkCount}}
-                @initLexicalScratch={{this.initLexicalScratch}}
+                @initLexical={{this.initLexical}}
                 @updateFeatureImageTkCount={{this.updateFeatureImageTkCount}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -80,6 +80,7 @@
                 @updateWordCount={{this.updateWordCount}}
                 @updatePostTkCount={{this.updatePostTkCount}}
                 @initLexical={{this.initLexical}}
+                @initLexicalState={{this.initLexicalState}}
                 @updateFeatureImageTkCount={{this.updateFeatureImageTkCount}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -73,13 +73,13 @@
                 @body={{readonly this.post.lexicalScratch}}
                 @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}
                 @onBodyChange={{this.updateScratch}}
+                @updateSecondaryInstanceModel={{this.updateSecondaryInstanceModel}}
                 @headerOffset={{editor.headerHeight}}
                 @scrollContainerSelector=".gh-koenig-editor"
                 @scrollOffsetBottomSelector=".gh-mobile-nav-bar"
                 @onEditorCreated={{this.setKoenigEditor}}
                 @updateWordCount={{this.updateWordCount}}
                 @updatePostTkCount={{this.updatePostTkCount}}
-                @initLexical={{this.initLexical}}
                 @updateFeatureImageTkCount={{this.updateFeatureImageTkCount}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -209,7 +209,7 @@ describe('Unit: Controller: lexical-editor', function () {
                 status: 'published',
                 lexical: initialLexicalString,
                 lexicalScratch: initialLexicalString,
-                initLexicalState: initialLexicalString
+                secondaryLexicalState: initialLexicalString
             }));
 
             // synthetically update the lexicalScratch as if the editor itself made the modifications on loading the initial editorState
@@ -239,7 +239,7 @@ describe('Unit: Controller: lexical-editor', function () {
                 status: 'published',
                 lexical: initialLexicalString,
                 lexicalScratch: lexicalScratch,
-                initLexicalState: secondLexicalInstance
+                secondaryLexicalState: secondLexicalInstance
             }));
 
             let isDirty = controller.get('hasDirtyAttributes');
@@ -259,7 +259,7 @@ describe('Unit: Controller: lexical-editor', function () {
                 status: 'published',
                 lexical: initialLexicalString,
                 lexicalScratch: lexicalScratch,
-                initLexicalState: secondLexicalInstance
+                secondaryLexicalState: secondLexicalInstance
             }));
 
             controller.send('updateScratch',JSON.parse(lexicalScratch));

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -226,5 +226,25 @@ describe('Unit: Controller: lexical-editor', function () {
             isDirty = controller.get('hasDirtyAttributes');
             expect(isDirty).to.be.true;
         });
+
+        it.only('dirty is false if initlexical and scratch matches, but lexical is outdated', async function () {
+            const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const lexicalStringNoNullDirection = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const lexicalStringUpdatedContent = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+
+            let controller = this.owner.lookup('controller:lexical-editor');
+            controller.set('post', EmberObject.create({
+                title: 'this is a title',
+                titleScratch: 'this is a title',
+                status: 'published',
+                lexical: initialLexicalString,
+                lexicalScratch: lexicalStringNoNullDirection,
+                initLexicalState: lexicalStringUpdatedContent
+            }));
+
+            let isDirty = controller.get('hasDirtyAttributes');
+
+            expect(isDirty).to.be.false;
+        });
     });
 });

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -229,8 +229,8 @@ describe('Unit: Controller: lexical-editor', function () {
 
         it('dirty is false if initlexical and scratch matches, but lexical is outdated', async function () {
             const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const lexicalStringNoNullDirection = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const lexicalStringUpdatedContent = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
 
             let controller = this.owner.lookup('controller:lexical-editor');
             controller.set('post', EmberObject.create({
@@ -238,13 +238,35 @@ describe('Unit: Controller: lexical-editor', function () {
                 titleScratch: 'this is a title',
                 status: 'published',
                 lexical: initialLexicalString,
-                lexicalScratch: lexicalStringNoNullDirection,
-                initLexicalState: lexicalStringUpdatedContent
+                lexicalScratch: lexicalScratch,
+                initLexicalState: secondLexicalInstance
             }));
 
             let isDirty = controller.get('hasDirtyAttributes');
 
             expect(isDirty).to.be.false;
+        });
+
+        it('dirty is true if initLexical and lexical does not match scratch', async function () {
+            const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content1234","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+            const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
+
+            let controller = this.owner.lookup('controller:lexical-editor');
+            controller.set('post', EmberObject.create({
+                title: 'this is a title',
+                titleScratch: 'this is a title',
+                status: 'published',
+                lexical: initialLexicalString,
+                lexicalScratch: lexicalScratch,
+                initLexicalState: secondLexicalInstance
+            }));
+
+            controller.send('updateScratch',JSON.parse(lexicalScratch));
+
+            let isDirty = controller.get('hasDirtyAttributes');
+
+            expect(isDirty).to.be.true;
         });
     });
 });

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -227,7 +227,7 @@ describe('Unit: Controller: lexical-editor', function () {
             expect(isDirty).to.be.true;
         });
 
-        it('dirty is false if initlexical and scratch matches, but lexical is outdated', async function () {
+        it('dirty is false if secondaryLexical and scratch matches, but lexical is outdated', async function () {
             const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
@@ -247,7 +247,7 @@ describe('Unit: Controller: lexical-editor', function () {
             expect(isDirty).to.be.false;
         });
 
-        it('dirty is true if initLexical and lexical does not match scratch', async function () {
+        it('dirty is true if secondaryLexical and lexical does not match scratch', async function () {
             const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content1234","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -227,7 +227,7 @@ describe('Unit: Controller: lexical-editor', function () {
             expect(isDirty).to.be.true;
         });
 
-        it.only('dirty is false if initlexical and scratch matches, but lexical is outdated', async function () {
+        it('dirty is false if initlexical and scratch matches, but lexical is outdated', async function () {
             const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const lexicalStringNoNullDirection = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
             const lexicalStringUpdatedContent = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -208,7 +208,8 @@ describe('Unit: Controller: lexical-editor', function () {
                 titleScratch: 'this is a title',
                 status: 'published',
                 lexical: initialLexicalString,
-                lexicalScratch: initialLexicalString
+                lexicalScratch: initialLexicalString,
+                initLexicalState: initialLexicalString
             }));
 
             // synthetically update the lexicalScratch as if the editor itself made the modifications on loading the initial editorState


### PR DESCRIPTION
refs ENG-661

Fixes a long-standing issue where an outdated Lexical schema in the database triggered the unsaved changes confirmation dialog incorrectly. 
Implemented a secondary hidden Lexical instance that loads the state from the database, renders it, and uses this updated state to compare with the live editor's scratch. 
This ensures the unsaved changes prompt appears only when there are real changes from the user.