### PR TITLE
Fixed followers / following not displaying correctly in the activitypub app

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -225,7 +225,7 @@ describe('ActivityPubAPI', function () {
                 'https://activitypub.api/.ghost/activitypub/following/index': {
                     response: JSONResponse({
                         type: 'Collection',
-                        items: []
+                        orderedItems: []
                     })
                 }
             });
@@ -255,46 +255,9 @@ describe('ActivityPubAPI', function () {
                     response:
                      JSONResponse({
                          type: 'Collection',
-                         items: [{
+                         orderedItems: [{
                              type: 'Person'
                          }]
-                     })
-                }
-            });
-
-            const api = new ActivityPubAPI(
-                new URL('https://activitypub.api'),
-                new URL('https://auth.api'),
-                'index',
-                fakeFetch
-            );
-
-            const actual = await api.getFollowing();
-            const expected: Activity[] = [
-                {
-                    type: 'Person'
-                }
-            ];
-
-            expect(actual).toEqual(expected);
-        });
-
-        test('Returns an array when the items key is a single object', async function () {
-            const fakeFetch = Fetch({
-                'https://auth.api/': {
-                    response: JSONResponse({
-                        identities: [{
-                            token: 'fake-token'
-                        }]
-                    })
-                },
-                'https://activitypub.api/.ghost/activitypub/following/index': {
-                    response:
-                     JSONResponse({
-                         type: 'Collection',
-                         items: {
-                             type: 'Person'
-                         }
                      })
                 }
             });
@@ -360,7 +323,7 @@ describe('ActivityPubAPI', function () {
                 'https://activitypub.api/.ghost/activitypub/followers/index': {
                     response: JSONResponse({
                         type: 'Collection',
-                        items: []
+                        orderedItems: []
                     })
                 }
             });
@@ -390,46 +353,9 @@ describe('ActivityPubAPI', function () {
                     response:
                      JSONResponse({
                          type: 'Collection',
-                         items: [{
+                         orderedItems: [{
                              type: 'Person'
                          }]
-                     })
-                }
-            });
-
-            const api = new ActivityPubAPI(
-                new URL('https://activitypub.api'),
-                new URL('https://auth.api'),
-                'index',
-                fakeFetch
-            );
-
-            const actual = await api.getFollowers();
-            const expected: Activity[] = [
-                {
-                    type: 'Person'
-                }
-            ];
-
-            expect(actual).toEqual(expected);
-        });
-
-        test('Returns an array when the items key is a single object', async function () {
-            const fakeFetch = Fetch({
-                'https://auth.api/': {
-                    response: JSONResponse({
-                        identities: [{
-                            token: 'fake-token'
-                        }]
-                    })
-                },
-                'https://activitypub.api/.ghost/activitypub/followers/index': {
-                    response:
-                     JSONResponse({
-                         type: 'Collection',
-                         items: {
-                             type: 'Person'
-                         }
                      })
                 }
             });

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -59,8 +59,8 @@ export class ActivityPubAPI {
         if (json === null) {
             return [];
         }
-        if ('items' in json) {
-            return Array.isArray(json.items) ? json.items : [json.items];
+        if ('orderedItems' in json) {
+            return Array.isArray(json.orderedItems) ? json.orderedItems : [];
         }
         return [];
     }
@@ -85,8 +85,8 @@ export class ActivityPubAPI {
         if (json === null) {
             return [];
         }
-        if ('items' in json) {
-            return Array.isArray(json.items) ? json.items : [json.items];
+        if ('orderedItems' in json) {
+            return Array.isArray(json.orderedItems) ? json.orderedItems : [];
         }
         return [];
     }


### PR DESCRIPTION
no refs

In a recent upgrade to fedify, the name of the key that represents the items in a collection was renamed from `items` to `orderedItems`. This change updates the API queries to use the updated key name

Related: https://github.com/TryGhost/Ghost/pull/20688
