### PR TITLE
Optimising count query : Added option param to skip distinct from count query for members events API

### DIFF
--- a/ghost/members-api/lib/repositories/EventRepository.js
+++ b/ghost/members-api/lib/repositories/EventRepository.js
@@ -507,6 +507,7 @@ module.exports = class EventRepository {
             ...options,
             withRelated: ['member'],
             filter: 'custom:true',
+            useBasicCount: true,
             mongoTransformer: chainTransformers(
                 // First set the filter manually
                 replaceCustomFilterTransformer(filter),


### PR DESCRIPTION
Ref: https://linear.app/tryghost/issue/ENG-1470/improve-the-performance-of-the-membersevents-aggregated-click-event

`DISTINCT` is not required as members_click_events.id is a primary key. This change would reduce about 7-9 sec from the query. 

Inition Query 

```
EXPLAIN ANALYZE 
SELECT count(DISTINCT members_click_events.id) AS aggregate 
FROM `members_click_events` 
WHERE (`members_click_events`.`created_at` < '2024-07-30 19:21:28' 
AND `members_click_events`.`id` 
IN 
(SELECT `members_click_events`.`id` FROM `members_click_events` 
INNER JOIN `redirects` AS `link` ON `link`.`id` = `members_click_events`.`redirect_id` 
WHERE `link`.`post_id` = '66a6e891e3f68c00017c202f')) 
AND (SELECT count(DISTINCT A.redirect_id) 
FROM members_click_events A 
LEFT JOIN redirects A_r ON A_r.id = A.redirect_id 
LEFT JOIN redirects B_r ON B_r.id = members_click_events.redirect_id 
WHERE A.member_id = members_click_events.member_id AND A_r.post_id = B_r.post_id 
AND (A.created_at < members_click_events.created_at OR (A.created_at = members_click_events.created_at 
AND A.id < members_click_events.id))) = 0;
```

Result

```
| -> Aggregate: count(distinct members_click_events.id)  (cost=9129 rows=1) (actual time=39717..39717 rows=1 loops=1)
    -> Nested loop inner join  (cost=8894 rows=2352) (actual time=2.07..39692 rows=3799 loops=1)
        -> Nested loop inner join  (cost=1136 rows=7056) (actual time=1.18..36.8 rows=12324 loops=1)
            -> Covering index lookup on link using redirects_post_id_foreign (post_id='66a6e891e3f68c00017c202f')  (cost=30.8 rows=241) (actual time=0.28..1.13 rows=241 loops=1)
            -> Covering index lookup on members_click_events using members_click_events_redirect_id_foreign (redirect_id=link.id)  (cost=1.67 rows=29.3) (actual time=0.0428..0.141 rows=51.1 loops=241)
        -> Filter: ((members_click_events.created_at < TIMESTAMP'2024-07-30 19:21:28') and ((select #3) = 0))  (cost=1 rows=0.333) (actual time=3.22..3.22 rows=0.308 loops=12324)
            -> Single-row index lookup on members_click_events using PRIMARY (id=members_click_events.id)  (cost=1 rows=1) (actual time=0.00609..0.00613 rows=1 loops=12324)
            -> Select #3 (subquery in condition; dependent)
                -> Aggregate: count(distinct A.redirect_id)  (cost=25.4 rows=1) (actual time=5.46..5.46 rows=1 loops=7230)
                    -> Nested loop inner join  (cost=25.3 rows=0.357) (actual time=5.38..5.45 rows=6.12 loops=7230)
                        -> Nested loop inner join  (cost=22.5 rows=7.15) (actual time=0.351..3.21 rows=589 loops=7230)
                            -> Single-row index lookup on B_r using PRIMARY (id=members_click_events.redirect_id)  (cost=0.394 rows=1) (actual time=0.00626..0.00632 rows=1 loops=7230)
                            -> Filter: ((A.created_at < members_click_events.created_at) or ((A.created_at = members_click_events.created_at) and (A.id < members_click_events.id)))  (cost=20.8 rows=7.15) (actual time=0.344..3.17 rows=589 loops=7230)
                                -> Index lookup on A using members_click_events_member_id_foreign (member_id=members_click_events.member_id)  (cost=20.8 rows=20.1) (actual time=0.342..3.06 rows=603 loops=7230)
                        -> Filter: (A_r.post_id = B_r.post_id)  (cost=0.295 rows=0.05) (actual time=0.00369..0.00369 rows=0.0104 loops=4.26e+6)
                            -> Single-row index lookup on A_r using PRIMARY (id=A.redirect_id)  (cost=0.295 rows=1) (actual time=0.00338..0.00341 rows=1 loops=4.26e+6)
 |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set, 5 warnings (39.79 sec)
```


After Change
Query:-
```
EXPLAIN ANALYZE 
SELECT count(*) AS aggregate 
FROM `members_click_events` 
WHERE (`members_click_events`.`created_at` < '2024-07-30 19:21:28' 
AND `members_click_events`.`id` 
IN 
(SELECT `members_click_events`.`id` FROM `members_click_events` 
INNER JOIN `redirects` AS `link` ON `link`.`id` = `members_click_events`.`redirect_id` 
WHERE `link`.`post_id` = '66a6e891e3f68c00017c202f')) 
AND (SELECT count(DISTINCT A.redirect_id) 
FROM members_click_events A 
LEFT JOIN redirects A_r ON A_r.id = A.redirect_id 
LEFT JOIN redirects B_r ON B_r.id = members_click_events.redirect_id 
WHERE A.member_id = members_click_events.member_id AND A_r.post_id = B_r.post_id 
AND (A.created_at < members_click_events.created_at OR (A.created_at = members_click_events.created_at 
AND A.id < members_click_events.id))) = 0;
```

Result

```
| -> Aggregate: count(0)  (cost=3839 rows=1) (actual time=30824..30824 rows=1 loops=1)
    -> Nested loop inner join  (cost=3604 rows=2352) (actual time=0.402..30821 rows=3799 loops=1)
        -> Nested loop inner join  (cost=1135 rows=7056) (actual time=0.284..23.9 rows=12324 loops=1)
            -> Covering index lookup on link using redirects_post_id_foreign (post_id='66a6e891e3f68c00017c202f')  (cost=30.7 rows=241) (actual time=0.245..1.07 rows=241 loops=1)
            -> Covering index lookup on members_click_events using members_click_events_redirect_id_foreign (redirect_id=link.id)  (cost=1.67 rows=29.3) (actual time=0.0231..0.089 rows=51.1 loops=241)
        -> Filter: ((members_click_events.created_at < TIMESTAMP'2024-07-30 19:21:28') and ((select #3) = 0))  (cost=0.25 rows=0.333) (actual time=2.5..2.5 rows=0.308 loops=12324)
            -> Single-row index lookup on members_click_events using PRIMARY (id=members_click_events.id)  (cost=0.25 rows=1) (actual time=0.00404..0.00407 rows=1 loops=12324)
            -> Select #3 (subquery in condition; dependent)
                -> Aggregate: count(distinct A.redirect_id)  (cost=9.93 rows=1) (actual time=4.25..4.25 rows=1 loops=7230)
                    -> Nested loop inner join  (cost=9.89 rows=0.357) (actual time=4.16..4.23 rows=6.12 loops=7230)
                        -> Nested loop inner join  (cost=7.39 rows=7.15) (actual time=0.0756..2.15 rows=589 loops=7230)
                            -> Single-row index lookup on B_r using PRIMARY (id=members_click_events.redirect_id)  (cost=0.35 rows=1) (actual time=0.00478..0.00482 rows=1 loops=7230)
                            -> Filter: ((A.created_at < members_click_events.created_at) or ((A.created_at = members_click_events.created_at) and (A.id < members_click_events.id)))  (cost=5.74 rows=7.15) (actual time=0.0705..2.1 rows=589 loops=7230)
                                -> Index lookup on A using members_click_events_member_id_foreign (member_id=members_click_events.member_id)  (cost=5.74 rows=20.1) (actual time=0.0696..2 rows=603 loops=7230)
                        -> Filter: (A_r.post_id = B_r.post_id)  (cost=0.251 rows=0.05) (actual time=0.00343..0.00343 rows=0.0104 loops=4.26e+6)
                            -> Single-row index lookup on A_r using PRIMARY (id=A.redirect_id)  (cost=0.251 rows=1) (actual time=0.00314..0.00317 rows=1 loops=4.26e+6)
 |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set, 5 warnings (30.83 sec)
```
