### PR TITLE
Fixed YT live embeds for non-www URLs

### DIFF
--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -378,7 +378,7 @@ class OEmbedService {
             // We convert live URLs to watch URLs so we can go straight to the
             // oembed request via a known provider rather than going through the page fetch routine.
             const ytLiveRegex = /^\/live\/([a-zA-Z0-9_-]+)$/;
-            if (urlObject.hostname === 'www.youtube.com' && ytLiveRegex.test(urlObject.pathname)) {
+            if (urlObject.hostname.match(/(?:www\.)?youtube\.com/) && ytLiveRegex.test(urlObject.pathname)) {
                 const videoId = ytLiveRegex.exec(urlObject.pathname)[1];
                 urlObject.pathname = '/watch';
                 urlObject.searchParams.set('v', videoId);

--- a/ghost/oembed-service/test/oembed-service.test.js
+++ b/ghost/oembed-service/test/oembed-service.test.js
@@ -198,5 +198,31 @@ describe('oembed-service', function () {
 
             await oembedService.fetchOembedDataFromUrl('https://www.youtube.com/live/1234?param=existing');
         });
+
+        it('converts YT live URLs to watch URLs (non-www)', async function () {
+            nock('https://www.youtube.com')
+                .get('/oembed')
+                .query((query) => {
+                    // Ensure the URL is converted to a watch URL and retains existing query params.
+                    const actual = query.url;
+                    const expected = 'https://youtube.com/watch?param=existing&v=1234';
+
+                    assert.equal(actual, expected, 'URL passed to oembed endpoint is incorrect');
+
+                    return actual === expected;
+                })
+                .reply(200, {
+                    type: 'rich',
+                    version: '1.0',
+                    title: 'Test Title',
+                    author_name: 'Test Author',
+                    author_url: 'https://example.com/user/testauthor',
+                    html: '<iframe src="https://www.example.com/embed"></iframe>',
+                    width: 640,
+                    height: null
+                });
+
+            await oembedService.fetchOembedDataFromUrl('https://youtube.com/live/1234?param=existing');
+        });
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/20706
ref https://linear.app/tryghost/issue/ONC-197

- previous check for YT live match was a little too specific and required the www which should have been optional
