### PR TITLE
Added SQLite and MySQL check to migration review checklist

### DIFF
--- a/.github/workflows/migration-review.yml
+++ b/.github/workflows/migration-review.yml
@@ -38,6 +38,7 @@ jobs:
             - [ ]  Uses the correct utils
             - [ ]  Contains a minimal changeset
             - [ ]  Does not mix DDL/DML operations
+            - [ ]  Tested in MySQL and SQLite
 
             ### Schema changes
 


### PR DESCRIPTION
no issue

- knex can behave differently with SQLite and MySQL, which can cause migrations to behave differently in each database. This PR adds a check to the migration review checklist to remind us to test the migration in both databases before merging.