### PR TITLE
Added configurable target delivery window for batch sending

### DIFF
--- a/ghost/email-service/lib/BatchSendingService.js
+++ b/ghost/email-service/lib/BatchSendingService.js
@@ -221,7 +221,9 @@ class BatchSendingService {
     async getBatches(email) {
         logging.info(`Getting batches for email ${email.id}`);
 
-        return await this.#models.EmailBatch.findAll({filter: 'email_id:\'' + email.id + '\''});
+        // findAll returns a bookshelf collection, we want to return a plain array to align with the createBatches method
+        const batches = await this.#models.EmailBatch.findAll({filter: 'email_id:\'' + email.id + '\''});
+        return batches.models;
     }
 
     /**
@@ -354,9 +356,16 @@ class BatchSendingService {
 
     async sendBatches({email, batches, post, newsletter}) {
         logging.info(`Sending ${batches.length} batches for email ${email.id}`);
-
+        const deadline = this.getDeliveryDeadline(email);
+        
+        if (deadline) {
+            logging.info(`Delivery deadline for email ${email.id} is ${deadline}`);
+        }
         // Reuse same HTML body if we send an email to the same segment
         const emailBodyCache = new EmailBodyCache();
+
+        // Calculate deliverytimes for the batches
+        const deliveryTimes = this.calculateDeliveryTimes(email, batches.length);
 
         // Loop batches and send them via the EmailProvider
         let succeededCount = 0;
@@ -367,7 +376,15 @@ class BatchSendingService {
         runNext = async () => {
             const batch = queue.shift();
             if (batch) {
-                if (await this.sendBatch({email, batch, post, newsletter, emailBodyCache})) {
+                const batchData = {email, batch, post, newsletter, emailBodyCache, deliveryTime: undefined};
+                // Only set a delivery time if we have a deadline and it hasn't past yet
+                if (deadline && deadline.getTime() > Date.now()) {
+                    const deliveryTime = deliveryTimes.shift();
+                    if (deliveryTime && deliveryTime >= Date.now()) {
+                        batchData.deliveryTime = deliveryTime;
+                    }
+                }
+                if (await this.sendBatch(batchData)) {
                     succeededCount += 1;
                 }
                 await runNext();
@@ -391,10 +408,10 @@ class BatchSendingService {
 
     /**
      *
-     * @param {{email: Email, batch: EmailBatch, post: Post, newsletter: Newsletter}} data
+     * @param {{email: Email, batch: EmailBatch, post: Post, newsletter: Newsletter, emailBodyCache: EmailBodyCache, deliveryTime:(Date|undefined) }} data
      * @returns {Promise<boolean>} True when succeeded, false when failed with an error
      */
-    async sendBatch({email, batch: originalBatch, post, newsletter, emailBodyCache}) {
+    async sendBatch({email, batch: originalBatch, post, newsletter, emailBodyCache, deliveryTime}) {
         logging.info(`Sending batch ${originalBatch.id} for email ${email.id}`);
 
         // Check the status of the email batch in a 'for update' transaction
@@ -440,9 +457,10 @@ class BatchSendingService {
                 }, {
                     openTrackingEnabled: !!email.get('track_opens'),
                     clickTrackingEnabled: !!email.get('track_clicks'),
+                    deliveryTime,
                     emailBodyCache
                 });
-            }, {...this.#MAILGUN_API_RETRY_CONFIG, description: `Sending email batch ${originalBatch.id}`});
+            }, {...this.#MAILGUN_API_RETRY_CONFIG, description: `Sending email batch ${originalBatch.id} ${deliveryTime ? `with delivery time ${deliveryTime}` : ''}`});
             succeeded = true;
 
             await this.retryDb(
@@ -633,6 +651,51 @@ class BatchSendingService {
                 });
             }
             return await this.retryDb(func, {...options, retryCount: retryCount + 1, sleep: sleep * 2});
+        }
+    }
+
+    /**
+     * Returns the sending deadline for an email
+     * Based on the email.created_at timestamp and the configured target delivery window
+     * @param {*} email 
+     * @returns Date | undefined
+     */
+    getDeliveryDeadline(email) {
+        // Return undefined if targetDeliveryWindow is 0 (or less)
+        const targetDeliveryWindow = this.#sendingService.getTargetDeliveryWindow();
+        if (targetDeliveryWindow === undefined || targetDeliveryWindow <= 0) {
+            return undefined;
+        }
+        try {
+            const startTime = email.get('created_at');
+            const deadline = new Date(startTime.getTime() + targetDeliveryWindow);
+            return deadline;
+        } catch (err) {
+            return undefined;
+        }
+    }
+
+    /**
+     * Adds deliverytimes to the passed in batches, based on the delivery deadline
+     * @param {Email} email - the email model to be sent
+     * @param {number} numBatches - the number of batches to be sent
+     */
+    calculateDeliveryTimes(email, numBatches) {
+        const deadline = this.getDeliveryDeadline(email);
+        const now = new Date();
+        // If there is no deadline (target delivery window is not set) or the deadline is in the past, delivery immediately
+        if (!deadline || now >= deadline) {
+            return new Array(numBatches).fill(undefined);
+        } else {
+            const timeToDeadline = deadline.getTime() - now.getTime();
+            const batchDelay = timeToDeadline / numBatches;
+            const deliveryTimes = [];
+            for (let i = 0; i < numBatches; i++) {
+                const delay = batchDelay * i;
+                const deliveryTime = new Date(now.getTime() + delay);
+                deliveryTimes.push(deliveryTime);
+            }
+            return deliveryTimes;
         }
     }
 }

--- a/ghost/email-service/lib/MailgunEmailProvider.js
+++ b/ghost/email-service/lib/MailgunEmailProvider.js
@@ -19,6 +19,7 @@ const debug = require('@tryghost/debug')('email-service:mailgun-provider-service
  * @typedef {object} EmailSendingOptions
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
+ * @prop {Date} deliveryTime
  */
 
 /**
@@ -111,6 +112,10 @@ class MailgunEmailProvider {
                 track_clicks: !!options.clickTrackingEnabled
             };
 
+            if (options.deliveryTime && options.deliveryTime instanceof Date) {
+                messageData.deliveryTime = options.deliveryTime;
+            }
+
             // create recipient data for Mailgun using replacement definitions
             const recipientData = recipients.reduce((acc, recipient) => {
                 acc[recipient.email] = this.#createRecipientData(recipient.replacements);
@@ -171,6 +176,15 @@ class MailgunEmailProvider {
 
     getMaximumRecipients() {
         return this.#mailgunClient.getBatchSize();
+    }
+
+    /**
+     * Returns the configured delay between batches in milliseconds
+     * 
+     * @returns {number}
+     */
+    getTargetDeliveryWindow() {
+        return this.#mailgunClient.getTargetDeliveryWindow();
     }
 }
 

--- a/ghost/email-service/lib/SendingService.js
+++ b/ghost/email-service/lib/SendingService.js
@@ -15,6 +15,7 @@ const logging = require('@tryghost/logging');
  * @typedef {object} IEmailProviderService
  * @prop {(emailData: EmailData, options: EmailSendingOptions) => Promise<EmailProviderSuccessResponse>} send
  * @prop {() => number} getMaximumRecipients
+ * @prop {() => number} getTargetDeliveryWindow
  *
  * @typedef {object} Post
  * @typedef {object} Newsletter
@@ -29,6 +30,7 @@ const logging = require('@tryghost/logging');
  * @typedef {object} EmailSendingOptions
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
+ * @prop {Date} deliveryTime
  * @prop {{get(id: string): EmailBody | null, set(id: string, body: EmailBody): void}} [emailBodyCache]
  */
 
@@ -73,6 +75,15 @@ class SendingService {
 
     getMaximumRecipients() {
         return this.#emailProvider.getMaximumRecipients();
+    }
+
+    /**
+     * Returns the configured target delivery window in seconds
+     * 
+     * @returns {number}
+     */
+    getTargetDeliveryWindow() {
+        return this.#emailProvider.getTargetDeliveryWindow();
     }
 
     /**
@@ -125,7 +136,8 @@ class SendingService {
             replacementDefinitions: emailBody.replacements
         }, {
             clickTrackingEnabled: !!options.clickTrackingEnabled,
-            openTrackingEnabled: !!options.openTrackingEnabled
+            openTrackingEnabled: !!options.openTrackingEnabled,
+            ...(options.deliveryTime && {deliveryTime: options.deliveryTime})
         });
     }
 

--- a/ghost/email-service/test/mailgun-email-provider.test.js
+++ b/ghost/email-service/test/mailgun-email-provider.test.js
@@ -27,6 +27,8 @@ describe('Mailgun Email Provider', function () {
                 mailgunClient,
                 errorHandler: () => {}
             });
+            
+            const deliveryTime = new Date();
 
             const response = await mailgunEmailProvider.send({
                 subject: 'Hi',
@@ -56,7 +58,8 @@ describe('Mailgun Email Provider', function () {
                 ]
             }, {
                 clickTrackingEnabled: true,
-                openTrackingEnabled: true
+                openTrackingEnabled: true,
+                deliveryTime
             });
             should(response.id).eql('provider-123');
             should(sendStub.calledOnce).be.true();
@@ -68,6 +71,7 @@ describe('Mailgun Email Provider', function () {
                     from: 'ghost@example.com',
                     replyTo: 'ghost@example.com',
                     id: '123',
+                    deliveryTime,
                     track_opens: true,
                     track_clicks: true
                 },
@@ -240,6 +244,25 @@ describe('Mailgun Email Provider', function () {
                 errorHandler: () => {}
             });
             assert.equal(provider.getMaximumRecipients(), 1000);
+        });
+    });
+
+    describe('getTargetDeliveryWindow', function () {
+        let mailgunClient;
+        let getTargetDeliveryWindowStub;
+
+        it('returns the configured target delivery window', function () {
+            getTargetDeliveryWindowStub = sinon.stub().returns(0);
+
+            mailgunClient = {
+                getTargetDeliveryWindow: getTargetDeliveryWindowStub
+            };
+            
+            const provider = new MailgunEmailProvider({
+                mailgunClient,
+                errorHandler: () => {}
+            });
+            assert.equal(provider.getTargetDeliveryWindow(), 0);
         });
     });
 });

--- a/ghost/mailgun-client/lib/MailgunClient.js
+++ b/ghost/mailgun-client/lib/MailgunClient.js
@@ -97,6 +97,11 @@ module.exports = class MailgunClient {
                 messageData['o:tracking-opens'] = true;
             }
 
+            // set the delivery time if specified
+            if (message.deliveryTime && message.deliveryTime instanceof Date) {
+                messageData['o:deliverytime'] = message.deliveryTime.toUTCString();
+            }
+
             const mailgunConfig = this.#getConfig();
             startTime = Date.now();
             const response = await mailgunInstance.messages.create(mailgunConfig.domain, messageData);
@@ -338,5 +343,22 @@ module.exports = class MailgunClient {
      */
     getBatchSize() {
         return this.#config.get('bulkEmail')?.batchSize ?? this.DEFAULT_BATCH_SIZE;
+    }
+
+    /**
+     * Returns the configured target delivery window in seconds
+     * Ghost will attempt to deliver emails evenly distributed over this window
+     * 
+     * Defaults to 0 (no delay) if not set
+     * 
+     * @returns {number}
+     */
+    getTargetDeliveryWindow() {
+        const targetDeliveryWindow = this.#config.get('bulkEmail')?.targetDeliveryWindow;
+        // If targetDeliveryWindow is not set or is not a positive integer, return 0
+        if (targetDeliveryWindow === undefined || !Number.isInteger(parseInt(targetDeliveryWindow)) || parseInt(targetDeliveryWindow) < 0) {
+            return 0;
+        }
+        return parseInt(targetDeliveryWindow);
     }
 };

--- a/ghost/mailgun-client/test/fixtures/send-success.json
+++ b/ghost/mailgun-client/test/fixtures/send-success.json
@@ -1,0 +1,4 @@
+{
+    "id": "message-id",
+    "message": "Queued. Thank you."
+}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-217/implement-the-deliverytime-option-in-mailgun-api-calls

Ghost experiences its highest peak load immediately after sending out a newsletter, as it recieves an influx of traffic from users clicking on the links in the email, a burst of email analytics events to process from mailgun, and an increase in organic traffic to the site's frontend as well as the admin analytics pages. The `BatchSendingService` currently sends all the batches to Mailgun as quickly as possible, which may contribute to higher peak loads.

This commit adds a `deliverytime` parameter to our API calls to Mailgun, which allows us to specify a time in the future when we want the email to be delivered. This will allow us to moderate the rate at which emails are delivered, and in turn that should moderate the peak traffic volume that Ghost receives in the first 2-3 minutes after sending an email. 

The `deliverytime` is calculated based on a configurable parameter: `bulkEmail.targetDeliveryWindow`, which specifies the maximum allowable time (in milliseconds) after the email is first sent for Ghost to instruct Mailgun to deliver the emails. Ghost will attempt to space out all the batches as evenly as possible throughout the specified window. For example, if the targetDeliveryWindow is set to `300000` (5 minutes) and there are 100 batches, Ghost will set the `deliveryTime` for each batch ~3 seconds apart.