### PR TITLE
Fixed matching ignored errors

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -186,7 +186,7 @@ export default Route.extend(ShortcutsRoute, {
                 beforeSend,
                 ignoreErrors: [
                     // Browser autoplay policies (this regex covers a few)
-                    /^The play\(\) request was interrupted.*/,
+                    /The play\(\) request was interrupted.*/,
                     /The request is not allowed by the user agent or the platform in the current context/,
 
                     // Network errors that we don't control


### PR DESCRIPTION
refs https://ghost-foundation.sentry.io/issues/4907452370/

- we want to ignore these errors but the caret is stopping us from doing so because the errors usually start with AbortError
- we can remove the caret to do so and clean up Sentry
