### PR TITLE
Hide overflow on member list container

### DIFF
--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -68,6 +68,7 @@
 @media (max-width: 1450px) {
     .members-list-container-stretch {
         min-height: calc(100vh - 176px);
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-561/horizontal-scroll-on-members-index-shows-on-both-sides-of-table

On resolutions where the members list needed horizontal scrollbars, the table was overflowing on the left side of the list. This hides that overflow and fixes the issue.