### PR TITLE
Excerpt form error fix

### DIFF
--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -368,6 +368,10 @@ li.nav-list-item .for-switch.x-small label {
     letter-spacing: 0;
 }
 
+.post-setting-custom-excerpt textarea.error {
+    border-color: var(--red);
+}
+
 .settings-menu-content .gh-seo-preview-title {
     white-space: inherit;
 }

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -368,10 +368,6 @@ li.nav-list-item .for-switch.x-small label {
     letter-spacing: 0;
 }
 
-.post-setting-custom-excerpt textarea.error {
-    border-color: var(--red);
-}
-
 .settings-menu-content .gh-seo-preview-title {
     white-space: inherit;
 }

--- a/ghost/admin/app/styles/patterns/forms.css
+++ b/ghost/admin/app/styles/patterns/forms.css
@@ -225,7 +225,7 @@ select {
 .gh-select.error,
 .error .gh-input-append,
 select.error {
-    border-color: var(--red);
+    border-color: var(--red)!important;
 }
 
 .gh-input:focus,

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -61,13 +61,21 @@ export default BaseValidator.create({
     },
 
     customExcerpt(model) {
+        // if (!validator.isLength(model.customExcerpt || '', 0, 300)) {
+        //     if (model.feature.editorExcerpt) {
+        //         model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
+        //     } else {
+        //         model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
+        //     }
+        //     this.invalidate();
+        // }
+
         if (!validator.isLength(model.customExcerpt || '', 0, 300)) {
-            if (model.feature.editorExcerpt) {
-                model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
-            } else {
-                model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
-            }
+            const errorMessage = 'Excerpt cannot be longer than 300 characters.';
+            model.errors.add('customExcerpt', errorMessage);
             this.invalidate();
+        } else {
+            model.errors.remove('customExcerpt');
         }
     },
 

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -61,15 +61,6 @@ export default BaseValidator.create({
     },
 
     customExcerpt(model) {
-        // if (!validator.isLength(model.customExcerpt || '', 0, 300)) {
-        //     if (model.feature.editorExcerpt) {
-        //         model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
-        //     } else {
-        //         model.errors.add('customExcerpt', 'Excerpt cannot be longer than 300 characters.');
-        //     }
-        //     this.invalidate();
-        // }
-
         if (!validator.isLength(model.customExcerpt || '', 0, 300)) {
             const errorMessage = 'Excerpt cannot be longer than 300 characters.';
             model.errors.add('customExcerpt', errorMessage);


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DES-435/excerpt-in-post-settings-has-an-inconsistent-error-state

The excerpt form field seemed to not be properly handling errors. However, it was a case of the error styling being overruled by the regular styling, causing the red border to only show upon `:focus` when there is an error in the excerpt. 

I've rewritten the logic to be slightly less obfuscated and added some CSS to circumvent the issue, but it's not perfect.