### PR TITLE
🐛 Fixed additional white space appearing at bottom of editor

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -680,7 +680,7 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             return (
-                <div style={isInitInstance ? {visibility: 'hidden', position: 'absolute'} : {}}>
+                <div style={isInitInstance ? {width: 0, height: 0, overflow: 'hidden'} : {}}>
                     <KoenigComposer
                         editorResource={this.editorResource}
                         cardConfig={cardConfig}

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -680,7 +680,7 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             return (
-                <div style={isInitInstance ? {width: 0, height: 0, overflow: 'hidden'} : {}}>
+                <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {width: 0, height: 0, overflow: 'hidden'} : {}}>
                     <KoenigComposer
                         editorResource={this.editorResource}
                         cardConfig={cardConfig}

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -284,6 +284,28 @@ test.describe('Publishing', () => {
         });
     });
 
+    test.describe('Lexical Rendering', () => {
+        test.describe.configure({retries: 1});
+
+        test('Renders Lexical editor', async ({sharedPage: adminPage}) => {
+            await adminPage.goto('/ghost');
+
+            await createPostDraft(adminPage, {title: 'Lexical editor test', body: 'This is my post body.'});
+
+            // Check if the lexical editor is present
+            expect(await adminPage.locator('[data-kg="editor"]').first()).toBeVisible();
+        });
+
+        test('Renders secondary hidden lexical editor', async ({sharedPage: adminPage}) => {
+            await adminPage.goto('/ghost');
+
+            await createPostDraft(adminPage, {title: 'Secondary lexical editor test', body: 'This is my post body.'});
+
+            // Check if the secondary lexical editor exists but is hidden.
+            expect(await adminPage.locator('[data-secondary-instance="true"]')).toBeHidden();
+        });
+    });
+
     test.describe('Update post', () => {
         test.describe.configure({retries: 1});
 


### PR DESCRIPTION
ref ENG-1490

- Regression from the secondary lexical instance.
- Replaced the visibility and positioning styles with width, height, and overflow to prevent layout space issues.
- Ensured the element takes up no space and is not visible, while allowing proper initialisation.

