### PR TITLE
🐛 Fixed a bug causing new drafts to only save if the title is populated

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -95,9 +95,7 @@
             @placeholder={{@bodyPlaceholder}}
             @cardConfig={{@cardOptions}}
             @onChange={{@onBodyChange}}
-            @updateSecondaryInstanceModel={{@updateSecondaryInstanceModel}}
             @registerAPI={{this.registerEditorAPI}}
-            @registerSecondaryAPI={{this.registerSecondaryEditorAPI}}
             @cursorDidExitAtTop={{if this.feature.editorExcerpt this.focusExcerpt this.focusTitle}}
             @updateWordCount={{@updateWordCount}}
             @updatePostTkCount={{@updatePostTkCount}}

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -15,7 +15,6 @@ export default class GhKoenigEditorLexical extends Component {
     uploadUrl = `${ghostPaths().apiRoot}/images/upload/`;
 
     editorAPI = null;
-    secondaryEditorAPI = null;
     skipFocusEditor = false;
 
     @tracked titleIsHovered = false;
@@ -231,12 +230,6 @@ export default class GhKoenigEditorLexical extends Component {
     registerEditorAPI(API) {
         this.editorAPI = API;
         this.args.registerAPI(API);
-    }
-
-    @action
-    registerSecondaryEditorAPI(API) {
-        this.secondaryEditorAPI = API;
-        this.args.registerSecondaryAPI(API);
     }
 
     // focus the editor when the editor canvas is clicked below the editor content,

--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -853,7 +853,6 @@
                     post=this.post
                     editorAPI=this.editorAPI
                     toggleSettingsMenu=this.toggleSettingsMenu
-                    secondaryEditorAPI=this.secondaryEditorAPI
                 }}
                 @close={{this.closePostHistory}}
                 @modifier="total-overlay post-history" />

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -678,43 +678,34 @@ export default class KoenigLexicalEditor extends Component {
         const multiplayerDocId = cardConfig.post.id;
         const multiplayerUsername = this.session.user.name;
 
-        const KGEditorComponent = ({isInitInstance}) => {
-            return (
-                <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {width: 0, height: 0, overflow: 'hidden'} : {}}>
-                    <KoenigComposer
-                        editorResource={this.editorResource}
-                        cardConfig={cardConfig}
-                        enableMultiplayer={enableMultiplayer}
-                        fileUploader={{useFileUpload, fileTypes}}
-                        initialEditorState={this.args.lexical}
-                        multiplayerUsername={multiplayerUsername}
-                        multiplayerDocId={multiplayerDocId}
-                        multiplayerEndpoint={multiplayerEndpoint}
-                        onError={this.onError}
-                        darkMode={this.feature.nightShift}
-                        isTKEnabled={true}
-                    >
-                        <KoenigEditor
-                            editorResource={this.editorResource}
-                            cursorDidExitAtTop={isInitInstance ? null : this.args.cursorDidExitAtTop}
-                            placeholderText={isInitInstance ? null : this.args.placeholderText}
-                            darkMode={isInitInstance ? null : this.feature.nightShift}
-                            onChange={isInitInstance ? this.args.updateSecondaryInstanceModel : this.args.onChange}
-                            registerAPI={isInitInstance ? this.args.registerSecondaryAPI : this.args.registerAPI}
-                        />
-                        <WordCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updateWordCount} />
-                        <TKCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updatePostTkCount} />
-                    </KoenigComposer>
-                </div>
-            );
-        };
-
         return (
             <div className={['koenig-react-editor', 'koenig-lexical', this.args.className].filter(Boolean).join(' ')}>
                 <ErrorHandler config={this.config}>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
-                        <KGEditorComponent />
-                        <KGEditorComponent isInitInstance={true} />
+                        <KoenigComposer
+                            editorResource={this.editorResource}
+                            cardConfig={cardConfig}
+                            enableMultiplayer={enableMultiplayer}
+                            fileUploader={{useFileUpload, fileTypes}}
+                            initialEditorState={this.args.lexical}
+                            multiplayerUsername={multiplayerUsername}
+                            multiplayerDocId={multiplayerDocId}
+                            multiplayerEndpoint={multiplayerEndpoint}
+                            onError={this.onError}
+                            darkMode={this.feature.nightShift}
+                            isTKEnabled={true}
+                        >
+                            <KoenigEditor
+                                editorResource={this.editorResource}
+                                cursorDidExitAtTop={this.args.cursorDidExitAtTop}
+                                placeholderText={this.args.placeholder}
+                                darkMode={this.feature.nightShift}
+                                onChange={this.args.onChange}
+                                registerAPI={this.args.registerAPI}
+                            />
+                            <WordCountPlugin editorResource={this.editorResource} onChange={this.args.updateWordCount} />
+                            <TKCountPlugin editorResource={this.editorResource} onChange={this.args.updatePostTkCount} />
+                        </KoenigComposer>
                     </Suspense>
                 </ErrorHandler>
             </div>

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -33,7 +33,6 @@
                     @lexical={{this.selectedRevision.lexical}}
                     @cardConfig={{this.cardConfig}}
                     @registerAPI={{this.registerSelectedEditorApi}}
-                    @registerSecondaryAPI={{this.registerSecondarySelectedEditorApi}}
                 />
             </div>
         </div>

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -31,7 +31,6 @@ export default class ModalPostHistory extends Component {
         super(...arguments);
         this.post = this.args.model.post;
         this.editorAPI = this.args.model.editorAPI;
-        this.secondaryEditorAPI = this.args.model.secondaryEditorAPI;
         this.toggleSettingsMenu = this.args.model.toggleSettingsMenu;
     }
 
@@ -103,11 +102,6 @@ export default class ModalPostHistory extends Component {
     }
 
     @action
-    registerSecondarySelectedEditorApi(api) {
-        this.secondarySelectedEditor = api;
-    }
-
-    @action
     registerComparisonEditorApi(api) {
         this.comparisonEditor = api;
     }
@@ -136,7 +130,6 @@ export default class ModalPostHistory extends Component {
             updateEditor: () => {
                 const state = this.editorAPI.editorInstance.parseEditorState(revision.lexical);
                 this.editorAPI.editorInstance.setEditorState(state);
-                this.secondaryEditorAPI.editorInstance.setEditorState(state);
             },
             closePostHistoryModal: () => {
                 this.closeModal();

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -136,9 +136,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     scratch: null,
     lexicalScratch: null,
     titleScratch: null,
-    //This is used to store the initial lexical state from the
-    // secondary editor to get the schema up to date in case its outdated
-    secondaryLexicalState: null,
 
     // For use by date/time pickers - will be validated then converted to UTC
     // on save. Updated by an observer whenever publishedAtUTC changes.

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -73,7 +73,6 @@
                 @body={{readonly this.post.lexicalScratch}}
                 @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}
                 @onBodyChange={{this.updateScratch}}
-                @updateSecondaryInstanceModel={{this.updateSecondaryInstanceModel}}
                 @headerOffset={{editor.headerHeight}}
                 @scrollContainerSelector=".gh-koenig-editor"
                 @scrollOffsetBottomSelector=".gh-mobile-nav-bar"
@@ -98,7 +97,6 @@
                 }}
                 @postType={{this.post.displayName}}
                 @registerAPI={{this.registerEditorAPI}}
-                @registerSecondaryAPI={{this.registerSecondaryEditorAPI}}
                 @savePostTask={{this.savePostTask}}
             />
 
@@ -138,7 +136,6 @@
                 @updateSlugTask={{this.updateSlugTask}}
                 @savePostTask={{this.savePostTask}}
                 @editorAPI={{this.editorAPI}}
-                @secondaryEditorAPI={{this.secondaryEditorAPI}}
                 @toggleSettingsMenu={{this.toggleSettingsMenu}}
             />
         {{/if}}

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -208,8 +208,7 @@ describe('Unit: Controller: lexical-editor', function () {
                 titleScratch: 'this is a title',
                 status: 'published',
                 lexical: initialLexicalString,
-                lexicalScratch: initialLexicalString,
-                secondaryLexicalState: initialLexicalString
+                lexicalScratch: initialLexicalString
             }));
 
             // synthetically update the lexicalScratch as if the editor itself made the modifications on loading the initial editorState
@@ -224,48 +223,6 @@ describe('Unit: Controller: lexical-editor', function () {
 
             // this should NOT result in the post being dirty - while lexical !== lexicalScratch, we ignore the direction field
             isDirty = controller.get('hasDirtyAttributes');
-            expect(isDirty).to.be.true;
-        });
-
-        it('dirty is false if secondaryLexical and scratch matches, but lexical is outdated', async function () {
-            const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-
-            let controller = this.owner.lookup('controller:lexical-editor');
-            controller.set('post', EmberObject.create({
-                title: 'this is a title',
-                titleScratch: 'this is a title',
-                status: 'published',
-                lexical: initialLexicalString,
-                lexicalScratch: lexicalScratch,
-                secondaryLexicalState: secondLexicalInstance
-            }));
-
-            let isDirty = controller.get('hasDirtyAttributes');
-
-            expect(isDirty).to.be.false;
-        });
-
-        it('dirty is true if secondaryLexical and lexical does not match scratch', async function () {
-            const initialLexicalString = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content","type": "extended-text","version": 1}],"direction": null,"format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const lexicalScratch = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Sample content1234","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-            const secondLexicalInstance = `{"root":{"children":[{"children": [{"detail": 0,"format": 0,"mode": "normal","style": "","text": "Here's some new text","type": "extended-text","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "paragraph","version": 1}],"direction": "ltr","format": "","indent": 0,"type": "root","version": 1}}`;
-
-            let controller = this.owner.lookup('controller:lexical-editor');
-            controller.set('post', EmberObject.create({
-                title: 'this is a title',
-                titleScratch: 'this is a title',
-                status: 'published',
-                lexical: initialLexicalString,
-                lexicalScratch: lexicalScratch,
-                secondaryLexicalState: secondLexicalInstance
-            }));
-
-            controller.send('updateScratch',JSON.parse(lexicalScratch));
-
-            let isDirty = controller.get('hasDirtyAttributes');
-
             expect(isDirty).to.be.true;
         });
     });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-253/drafts-only-save-if-the-title-is-populated

- A [commit](https://github.com/TryGhost/Ghost/commit/c8ba9e8027bd8269f8fb0ff3303da6d1e34b9696) in `v5.89.1` introduced a bug that caused new drafts to only save if the post title was populated, causing potential data loss if a user is working on a new draft without setting the title.
- This commit reverts the one that introduced this bug to prevent data loss.

This reverts commit c8ba9e8027bd8269f8fb0ff3303da6d1e34b9696.