### PR TITLE
Fix browser tests for Radix migration

### DIFF
--- a/ghost/core/test/e2e-browser/admin/tiers.spec.js
+++ b/ghost/core/test/e2e-browser/admin/tiers.spec.js
@@ -147,7 +147,7 @@ test.describe('Admin', () => {
 
                 const portalSettings = sharedPage.getByTestId('portal-modal');
 
-                await portalSettings.locator('input[type=checkbox]').first().waitFor();
+                await portalSettings.locator('button[role="checkbox"]').first().waitFor();
 
                 await expect(portalSettings.getByLabel(tierName).first()).toBeHidden();
 
@@ -172,7 +172,7 @@ test.describe('Admin', () => {
 
                 const portalSettings = sharedPage.getByTestId('portal-modal');
 
-                await portalSettings.locator('input[type=checkbox]').first().waitFor();
+                await portalSettings.locator('button[role="checkbox"]').first().waitFor();
 
                 await expect(portalSettings.getByLabel(tierName).first()).toBeVisible();
 


### PR DESCRIPTION
DES-696

We upgraded the AdminX Design System to use Radix UI components. However browser tests fail for checkboxes at the moment which must be fixed for release.