### PR TITLE
🐛 Fixed autosave not triggering when in-editor excerpt is changed

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -69,6 +69,7 @@
                         @input={{this.onExcerptInput}}
                         @keyDown={{this.onExcerptKeydown}}
                         @didCreateTextarea={{this.registerExcerptElement}}
+                        {{on "blur" @onExcerptBlur}}
                         data-test-textarea="excerpt"
                     />
                     {{#if @excerptHasTk}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -69,6 +69,7 @@
                 @excerpt={{readonly this.post.customExcerpt}}
                 @excerptHasTk={{this.excerptHasTk}}
                 @setExcerpt={{this.updateExcerpt}}
+                @onExcerptBlur={{perform this.autosaveTask}}
                 @excerptErrorMessage={{this.excerptErrorMessage}}
                 @body={{readonly this.post.lexicalScratch}}
                 @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}

--- a/ghost/admin/tests/acceptance/editor/lexical-test.js
+++ b/ghost/admin/tests/acceptance/editor/lexical-test.js
@@ -1,6 +1,8 @@
 import loginAsRole from '../../helpers/login-as-role';
-import {currentURL} from '@ember/test-helpers';
+import {blur, currentURL, fillIn, find, waitUntil} from '@ember/test-helpers';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {expect} from 'chai';
+import {invalidateSession} from 'ember-simple-auth/test-support';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';
@@ -11,16 +13,55 @@ describe('Acceptance: Lexical editor', function () {
 
     beforeEach(async function () {
         this.server.loadFixtures();
+        await loginAsRole('Administrator', this.server);
     });
 
     it('redirects to signin when not authenticated', async function () {
+        await invalidateSession();
         await visit('/editor/post/');
         expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('loads editor', async function () {
-        await loginAsRole('Administrator', this.server);
-        await visit('/editor/post/');
-        expect(currentURL(), 'currentURL').to.equal('/editor/post/');
+    describe('new post', function () {
+        // TODO: test it actually loads the editor
+        it('loads editor', async function () {
+            await visit('/editor/post/');
+            expect(currentURL(), 'currentURL').to.equal('/editor/post/');
+        });
+
+        it('saves on title change', async function () {
+            await visit('/editor/post/');
+            await fillIn('[data-test-editor-title-input]', 'Test Post');
+            await blur('[data-test-editor-title-input]');
+
+            // NOTE: during testing we switch status so quickly this doesn't catch the intermediate state
+            // await waitUntil(function () {
+            //     return find('[data-test-editor-post-status]').textContent.includes('Saving...');
+            // });
+
+            await waitUntil(function () {
+                return find('[data-test-editor-post-status]').textContent.includes('Saved');
+            }, {timeoutMessage: 'Timed out waiting for "Saved" status'});
+
+            expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
+        });
+
+        it('saves on excerpt change', async function () {
+            // excerpt is not shown by default
+            enableLabsFlag(this.server, 'editorExcerpt');
+
+            await visit('/editor/post/');
+            await fillIn('[data-test-textarea="excerpt"]', 'Test Post');
+            await blur('[data-test-textarea="excerpt"]');
+
+            await waitUntil(function () {
+                return find('[data-test-editor-post-status]').textContent.includes('Saved');
+            }, {timeoutMessage: 'Timed out waiting for "Saved" status'});
+
+            expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
+        });
+
+        // TODO: requires editor to be loading
+        it('saves on content change');
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLG-174

- added `blur` handler to excerpt field so it acts the same as the title field and triggers a save when it loses focus
