### PR TITLE
Fixed excerpt blur saving non-draft posts

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -323,6 +323,13 @@ export default class LexicalEditorController extends Controller {
         }
     }
 
+    @task
+    *saveExcerptTask() {
+        if (this.post.status === 'draft') {
+            yield this.autosaveTask.perform();
+        }
+    }
+
     // updates local willPublish/Schedule values, does not get applied to
     // the post's `status` value until a save is triggered
     @action

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -69,7 +69,7 @@
                 @excerpt={{readonly this.post.customExcerpt}}
                 @excerptHasTk={{this.excerptHasTk}}
                 @setExcerpt={{this.updateExcerpt}}
-                @onExcerptBlur={{perform this.autosaveTask}}
+                @onExcerptBlur={{perform this.saveExcerptTask}}
                 @excerptErrorMessage={{this.excerptErrorMessage}}
                 @body={{readonly this.post.lexicalScratch}}
                 @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}

--- a/ghost/admin/tests/acceptance/editor/lexical-test.js
+++ b/ghost/admin/tests/acceptance/editor/lexical-test.js
@@ -71,4 +71,47 @@ describe('Acceptance: Lexical editor', function () {
         // TODO: requires editor to be loading
         it('saves on content change');
     });
+
+    describe('existing post', function () {
+        it('does not save post on title blur', async function () {
+            const post = this.server.create('post', {status: 'published'});
+            const originalTitle = post.title;
+
+            await visit('/editor/post/1');
+            await fillIn('[data-test-editor-title-input]', 'Change test');
+            await blur('[data-test-editor-title-input]');
+
+            expect(find('[data-test-editor-post-status]')).not.to.contain.text('Saved');
+            expect(post.status, 'post status').to.equal('published');
+            expect(post.title, 'saved title').to.equal(originalTitle);
+
+            await click('[data-test-link="posts"]');
+
+            expect(find('[data-test-modal="unsaved-post-changes"]'), 'unsaved changes modal').to.exist;
+
+            expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
+        });
+
+        it('does not save post on excerpt blur', async function () {
+            // excerpt is not shown by default
+            enableLabsFlag(this.server, 'editorExcerpt');
+
+            const post = this.server.create('post', {status: 'published'});
+            const originalExcerpt = post.excerpt;
+
+            await visit('/editor/post/1');
+            await fillIn('[data-test-textarea="excerpt"]', 'Change test');
+            await blur('[data-test-textarea="excerpt"]');
+
+            expect(find('[data-test-editor-post-status]')).not.to.contain.text('Saved');
+            expect(post.status, 'post status').to.equal('published');
+            expect(post.excerpt, 'saved excerpt').to.equal(originalExcerpt);
+
+            await click('[data-test-link="posts"]');
+
+            expect(find('[data-test-modal="unsaved-post-changes"]'), 'unsaved changes modal').to.exist;
+
+            expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLG-174

- forcing autosave on excerpt blur caused posts to revert to `draft` and save immediately even when they were published/scheduled
- updated the save-on-excerpt-blur to only autosave drafts
- added acceptance tests for title and excerpt change+blur on published posts
