### PR TITLE
Changed color of adminX prefix for `yarn dev`

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -72,13 +72,13 @@ const COMMANDS_ADMINX = [{
     name: 'adminXDeps',
     command: 'while [ 1 ]; do nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework -- nx run \\$NX_PROJECT_NAME:build; done',
     cwd: path.resolve(__dirname, '../..'),
-    prefixColor: '#C35831',
+    prefixColor: '#C72AF7',
     env: {}
 }, {
     name: 'adminX',
     command: `nx run-many --projects=${adminXApps} --parallel=${adminXApps.length} --targets=dev`,
     cwd: path.resolve(__dirname, '../../apps/admin-x-settings', '../../apps/admin-x-activitypub'),
-    prefixColor: '#C35831',
+    prefixColor: '#C72AF7',
     env: {}
 }];
 


### PR DESCRIPTION
- red makes it look like an error, which is very misleading
- I've changed this to a random purple I found
- credits to @vershwal and @dvdwinden
