### PR TITLE
Updated tips & donations default suggested value

### DIFF
--- a/apps/admin-x-design-system/src/settings/SettingValue.tsx
+++ b/apps/admin-x-design-system/src/settings/SettingValue.tsx
@@ -8,6 +8,7 @@ export interface SettingValueProps {
     value: ReactNode;
     hint?: ReactNode;
     hideEmptyValue?: boolean;
+    'data-testid'?: string;
 }
 
 const SettingValue: React.FC<SettingValueProps> = ({heading, value, hint, hideEmptyValue, ...props}) => {

--- a/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
@@ -30,7 +30,7 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
     });
 
-    const [donationsCurrency = 'USD', donationsSuggestedAmount = '0'] = getSettingValues<string>(
+    const [donationsCurrency = 'USD', donationsSuggestedAmount = '500'] = getSettingValues<string>(
         localSettings,
         ['donations_currency', 'donations_suggested_amount']
     );
@@ -62,7 +62,8 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 {
                     heading: 'Suggested amount',
                     key: 'suggested-amount',
-                    value: `${getSymbol(donationsCurrency)}${suggestedAmountInDollars}`
+                    value: `${getSymbol(donationsCurrency)}${suggestedAmountInDollars}`,
+                    'data-testid': 'suggested-amount'
                 },
                 {
                     heading: '',
@@ -73,10 +74,10 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
                                 <Heading level={6}>Shareable link</Heading>
                             </div>
                             <div className='w-100 group relative mt-0 flex items-center justify-between overflow-hidden border-b border-transparent pb-2 pt-1 hover:border-grey-300 dark:hover:border-grey-600'>
-                                {donateUrl}
+                                <span data-testid="donate-url">{donateUrl}</span>
                                 <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
-                                    <Button color='clear' label={'Preview'} size='sm' onClick={openPreview} />
-                                    <Button color='light-grey' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
+                                    <Button color='clear' data-testid="preview-shareable-link" label={'Preview'} size='sm' onClick={openPreview} />
+                                    <Button color='light-grey' data-testid="copy-shareable-link" label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
                                 </div>
                             </div>
                         </div>

--- a/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests} from '../../utils/acceptance';
+import {mockApi, toggleLabsFlag} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('Tips and donations', () => {
+    test.beforeEach(async () => {
+        toggleLabsFlag('tipsAndDonations', true);
+    });
+
+    test('Shows suggested amount and shareable link', async ({page}) => {
+        await mockApi({page, requests: {...globalDataRequests}});
+        await page.goto('/');
+
+        const section = page.getByTestId('tips-and-donations');
+
+        await expect(section.getByTestId('suggested-amount')).toHaveText(/\$5/);
+        await expect(section.getByTestId('donate-url')).toHaveText('http://test.com/#/portal/support');
+        await expect(section.getByTestId('preview-shareable-link')).not.toBeVisible();
+        await expect(section.getByTestId('copy-shareable-link')).not.toBeVisible();
+
+        await section.getByTestId('donate-url').hover();
+
+        await expect(section.getByTestId('preview-shareable-link')).toBeVisible();
+        await expect(section.getByTestId('copy-shareable-link')).toBeVisible();
+    });
+});

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -129,6 +129,6 @@ export default [
     setting('editor', 'editor_default_email_recipients_filter', 'all'),
 
     // DONATIONS
-    setting('donations_suggested_amount', 'donations', 0),
+    setting('donations_suggested_amount', 'donations', 500),
     setting('donations_currency', 'donations', 'USD')
 ];

--- a/ghost/core/core/server/data/migrations/versions/5.90/2024-08-20-09-40-24-update-default-donations-suggested-amount.js
+++ b/ghost/core/core/server/data/migrations/versions/5.90/2024-08-20-09-40-24-update-default-donations-suggested-amount.js
@@ -1,0 +1,42 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const logging = require('@tryghost/logging');
+
+// For DDL - schema changes
+// const {createNonTransactionalMigration} = require('../../utils');
+
+// For DML - data changes
+const {createTransactionalMigration} = require('../../utils');
+
+// Or use a specific helper
+// const {addTable, createAddColumnMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        try {
+            // find the existing donations_suggested_amount setting
+            const existingSuggestedAmount = await knex('settings')
+                .where({key: 'donations_suggested_amount'})
+                .first();
+
+            // previous default is '0', if it's been set to something else we don't want to change it
+            if (existingSuggestedAmount.value !== '0') {
+                logging.info('donations_suggested_amount setting does not have previous default of 0, skipping migration');
+                return;
+            }
+
+            // new default is '500', update the setting
+            logging.info('Updating donations_suggested_amount default setting to 500');
+            await knex('settings')
+                .where({key: 'donations_suggested_amount'})
+                .update({value: '500'});
+        } catch (error) {
+            logging.error(`Error updating donations_suggested_amount setting: ${error.message}`);
+        }
+    },
+    async function down() {
+        // no-op
+        // we can't guarantee that a suggested amount of 500 now isn't
+        // something that was set explicitly
+    }
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -567,7 +567,7 @@
             "type": "string"
         },
         "donations_suggested_amount": {
-            "defaultValue": 0,
+            "defaultValue": 500,
             "validations": {
                 "isEmpty": false
             },

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -314,7 +314,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -740,7 +740,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -1109,7 +1109,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -1155,7 +1155,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4429",
+  "content-length": "4431",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1479,7 +1479,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -1848,7 +1848,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -2680,7 +2680,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -3050,7 +3050,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -3420,7 +3420,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -3794,7 +3794,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -4163,7 +4163,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -4537,7 +4537,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -5275,7 +5275,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -5645,7 +5645,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",
@@ -6079,7 +6079,7 @@ Object {
     },
     Object {
       "key": "donations_suggested_amount",
-      "value": "0",
+      "value": "500",
     },
     Object {
       "key": "recommendations_enabled",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'ce97eff9bf1b3c215fed1271f9275f83';
     const currentFixturesHash = 'a489d615989eab1023d4b8af0ecee7fd';
-    const currentSettingsHash = '5c957ceb48c4878767d7d3db484c592d';
+    const currentSettingsHash = '051ef2a50e2edb8723e89461448313cb';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings-browser.json
+++ b/ghost/core/test/utils/fixtures/default-settings-browser.json
@@ -542,7 +542,7 @@
             "type": "string"
         },
         "donations_suggested_amount": {
-            "defaultValue": 0,
+            "defaultValue": 500,
             "validations": {
                 "isEmpty": false
             },

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -575,7 +575,7 @@
             "type": "string"
         },
         "donations_suggested_amount": {
-            "defaultValue": 0,
+            "defaultValue": 500,
             "validations": {
                 "isEmpty": false
             },


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/PLG-156

- updated all default fixtures to use `500` ($5) as the default suggested donation value
- added migration to update existing settings using the old default of `0` to `500`
  - this is fine to apply because the feature hasn't been released so there's no explicit `0` values in the wild
- added an acceptance test for the adminx-settings tips & donations section
