### PR TITLE
Updated donations browser tests for new default suggested value

### DIFF
--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -8,6 +8,9 @@ test.describe('Portal', () => {
             // go to website and open portal
             await sharedPage.goto('/#/portal/support');
 
+            const totalAmount = sharedPage.getByTestId('product-summary-total-amount');
+            await expect(totalAmount).toHaveText('$5.00');
+            await sharedPage.getByText('Change amount').click();
             await sharedPage.locator('#customUnitAmount').fill('12.50');
             await sharedPage.locator('#email').fill('member-donation-test-1@ghost.org');
             await completeStripeSubscription(sharedPage);
@@ -34,6 +37,7 @@ test.describe('Portal', () => {
             await sharedPage.goto('#/portal/support');
 
             // Don't need to fill email as it's already filled
+            await sharedPage.getByText('Change amount').click();
             await sharedPage.locator('#customUnitAmount').fill('12.50');
             await completeStripeSubscription(sharedPage);
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/20793

- now that there's a non-zero suggested value amount Stripe's UI shows a button to change the amount rather than showing the amount input field immediately
- added extra click to the tests and an expectation that the default value is set correctly
