### PR TITLE
🐛 Fixed editor performance issues in Safari for posts with HTML or Markdown cards

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -680,7 +680,7 @@ export default class KoenigLexicalEditor extends Component {
 
         const KGEditorComponent = ({isInitInstance}) => {
             return (
-                <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {width: 0, height: 0, overflow: 'hidden'} : {}}>
+                <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {display: 'none'} : {}}>
                     <KoenigComposer
                         editorResource={this.editorResource}
                         cardConfig={cardConfig}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-261

- Previous method of hiding the second Lexical instance using `width: 0`, `height: 0`, and `overflow: hidden` caused CPU usage to spike, likely due to CodeMirror continuously processing the element.

