### PR TITLE
🔒 Fixed admin forms defaulting to GET method

### DIFF
--- a/ghost/admin/app/templates/setup.hbs
+++ b/ghost/admin/app/templates/setup.hbs
@@ -6,7 +6,7 @@
             <p>All over the world, people have started 3,000,000+ incredible sites with Ghost. Today, we’re starting yours.</p>
         </header>
 
-        <form id="setup" class="gh-flow-form">
+        <form id="setup" method="post" action="javascript:void(0)" class="gh-flow-form">
             <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="blogTitle">
                 <label for="blog-title">Site title</label>
                 <span class="gh-input-icon gh-icon-content">

--- a/ghost/admin/app/templates/signin.hbs
+++ b/ghost/admin/app/templates/signin.hbs
@@ -12,7 +12,7 @@
                     </header>
                 </div>
             {{else}}
-                <form id="login" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.validateAndAuthenticateTask)}}>
+                <form id="login" method="post" action="javascript:void(0)" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.validateAndAuthenticateTask)}}>
                     <header>
                         <div class="gh-site-icon" style={{site-icon-style}}></div>
                         <h1>{{this.config.blogTitle}}</h1>

--- a/ghost/admin/app/templates/signup.hbs
+++ b/ghost/admin/app/templates/signup.hbs
@@ -7,7 +7,7 @@
                 <h1>Create your account.</h1>
             </header>
 
-            <form id="signup" class="gh-signup" novalidate="novalidate" {{on "submit" this.submit}}>
+            <form id="signup" method="post" action="javascript:void(0)" class="gh-signup" novalidate="novalidate" {{on "submit" this.submit}}>
                 <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="name">
                     <label for="name">Full name</label>
                     <span class="gh-input-icon gh-icon-user">


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1497/admin-signin-signup-and-setup-forms-default-to-get

- If method is not specified, the form will default to GET, which is incorrect
- This commit sets the method to POST and action to javascript:void(0) to prevent the form from submitting via GET if JavaScript is disabled or not fully loaded yet