### PR TITLE
Added integrity tokens for magic link email requests

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -79,7 +79,8 @@ async function signout({api, state}) {
 
 async function signin({data, api, state}) {
     try {
-        await api.member.sendMagicLink({...data, emailType: 'signin'});
+        const integrityToken = await api.member.getIntegrityToken();
+        await api.member.sendMagicLink({...data, emailType: 'signin', integrityToken});
         return {
             page: 'magiclink',
             lastPage: 'signin'
@@ -100,7 +101,8 @@ async function signup({data, state, api}) {
         let {plan, tierId, cadence, email, name, newsletters, offerId} = data;
 
         if (plan.toLowerCase() === 'free') {
-            await api.member.sendMagicLink({emailType: 'signup', ...data});
+            const integrityToken = await api.member.getIntegrityToken();
+            await api.member.sendMagicLink({emailType: 'signup', integrityToken, ...data});
         } else {
             if (tierId && cadence) {
                 await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -56,12 +56,21 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
         }
     }
 
-    fetch(`${siteUrl}/members/api/send-magic-link/`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(reqBody)
+    return fetch(`${siteUrl}/members/api/integrity-token/`, {
+        method: 'GET'
+    }).then((res) => {
+        return res.text();
+    }).then((integrityToken) => {
+        return fetch(`${siteUrl}/members/api/send-magic-link/`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                ...reqBody,
+                integrityToken
+            })
+        });
     }).then(function (res) {
         form.addEventListener('submit', submitHandler);
         form.classList.remove('loading');

--- a/apps/portal/src/tests/SigninFlow.test.js
+++ b/apps/portal/src/tests/SigninFlow.test.js
@@ -16,6 +16,10 @@ const setup = async ({site, member = null}) => {
         return Promise.resolve('success');
     });
 
+    ghostApi.member.getIntegrityToken = jest.fn(() => {
+        return Promise.resolve('testtoken');
+    });
+
     ghostApi.member.checkoutPlan = jest.fn(() => {
         return Promise.resolve();
     });
@@ -65,6 +69,10 @@ const multiTierSetup = async ({site, member = null}) => {
 
     ghostApi.member.sendMagicLink = jest.fn(() => {
         return Promise.resolve('success');
+    });
+
+    ghostApi.member.getIntegrityToken = jest.fn(() => {
+        return Promise.resolve(`testtoken`);
     });
 
     ghostApi.member.checkoutPlan = jest.fn(() => {
@@ -139,13 +147,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
 
         test('without name field', async () => {
@@ -165,13 +175,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
 
         test('with only free plan', async () => {
@@ -191,13 +203,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
     });
 });
@@ -231,13 +245,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
 
         test('without name field', async () => {
@@ -257,13 +273,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
 
         test('with only free plan available', async () => {
@@ -283,13 +301,15 @@ describe('Signin', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
 
             fireEvent.click(submitButton);
-            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com',
-                emailType: 'signin'
-            });
 
             const magicLink = await within(popupIframeDocument).findByText(/Now check your email/i);
             expect(magicLink).toBeInTheDocument();
+
+            expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
+                email: 'jamie@example.com',
+                emailType: 'signin',
+                integrityToken: 'testtoken'
+            });
         });
     });
 });

--- a/apps/portal/src/tests/SignupFlow.test.js
+++ b/apps/portal/src/tests/SignupFlow.test.js
@@ -16,6 +16,10 @@ const offerSetup = async ({site, member = null, offer}) => {
         return Promise.resolve('success');
     });
 
+    ghostApi.member.getIntegrityToken = jest.fn(() => {
+        return Promise.resolve(`testtoken`);
+    });
+
     ghostApi.site.offer = jest.fn(() => {
         return Promise.resolve({
             offers: [offer]
@@ -80,6 +84,10 @@ const setup = async ({site, member = null}) => {
         return Promise.resolve('success');
     });
 
+    ghostApi.member.getIntegrityToken = jest.fn(() => {
+        return Promise.resolve(`testtoken`);
+    });
+
     ghostApi.member.checkoutPlan = jest.fn(() => {
         return Promise.resolve();
     });
@@ -131,6 +139,10 @@ const multiTierSetup = async ({site, member = null}) => {
 
     ghostApi.member.sendMagicLink = jest.fn(() => {
         return Promise.resolve('success');
+    });
+
+    ghostApi.member.getIntegrityToken = jest.fn(() => {
+        return Promise.resolve(`testtoken`);
     });
 
     ghostApi.member.checkoutPlan = jest.fn(() => {
@@ -205,14 +217,17 @@ describe('Signup', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(chooseBtns[0]);
+
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: 'Jamie Larsen',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
 
         test('without name field', async () => {
@@ -240,16 +255,17 @@ describe('Signup', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
             fireEvent.click(chooseBtns[0]);
 
+            // Check if magic link page is shown
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: '',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-
-            // Check if magic link page is shown
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
 
         test('with only free plan', async () => {
@@ -288,16 +304,17 @@ describe('Signup', () => {
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(submitButton);
 
+            // Check if magic link page is shown
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: 'Jamie Larsen',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-
-            // Check if magic link page is shown
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
     });
 
@@ -570,14 +587,17 @@ describe('Signup', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(chooseBtns[0]);
+
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: 'Jamie Larsen',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
 
         test('without name field', async () => {
@@ -601,16 +621,17 @@ describe('Signup', () => {
             expect(emailInput).toHaveValue('jamie@example.com');
             fireEvent.click(chooseBtns[0]);
 
+            // Check if magic link page is shown
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: '',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-
-            // Check if magic link page is shown
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
 
         test('with only free plan available', async () => {
@@ -646,16 +667,17 @@ describe('Signup', () => {
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(submitButton);
 
+            // Check if magic link page is shown
+            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
+            expect(magicLink).toBeInTheDocument();
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 name: 'Jamie Larsen',
-                plan: 'free'
+                plan: 'free',
+                integrityToken: 'testtoken'
             });
-
-            // Check if magic link page is shown
-            const magicLink = await within(popupIframeDocument).findByText(/now check your email/i);
-            expect(magicLink).toBeInTheDocument();
         });
 
         test('should not show free plan if it is hidden', async () => {
@@ -799,4 +821,3 @@ describe('Signup', () => {
         });
     });
 });
-

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -86,6 +86,13 @@ describe('Member Data attributes:', () => {
                 });
             }
 
+            if (url.includes('api/integrity-token')) {
+                return Promise.resolve({
+                    ok: true,
+                    text: async () => 'testtoken'
+                });
+            }
+
             if (url.includes('api/session')) {
                 return Promise.resolve({
                     ok: true,
@@ -139,12 +146,12 @@ describe('Member Data attributes:', () => {
         jest.restoreAllMocks();
     });
     describe('data-members-form', () => {
-        test('allows free signup', () => {
+        test('allows free signup', async () => {
             const {event, form, errorEl, siteUrl, submitHandler} = getMockData();
 
-            formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
 
-            expect(window.fetch).toHaveBeenCalledTimes(1);
+            expect(window.fetch).toHaveBeenCalledTimes(2);
             const expectedBody = JSON.stringify({
                 email: 'jamie@example.com',
                 emailType: 'signup',
@@ -157,9 +164,10 @@ describe('Member Data attributes:', () => {
                     refSource: 'ghost-explore',
                     refUrl: 'https://example.com/blog/',
                     time: 1611234567890
-                }]
+                }],
+                integrityToken: 'testtoken'
             });
-            expect(window.fetch).toHaveBeenCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
+            expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });
     });
 
@@ -241,16 +249,16 @@ describe('Member Data attributes:', () => {
     });
 
     describe('data-members-newsletter', () => {
-        test('includes specified newsletters in request', () => {
+        test('includes specified newsletters in request', async () => {
             const {event, form, errorEl, siteUrl, submitHandler} = getMockData({
                 newsletterQuerySelectorResult: [{
                     value: 'Some Newsletter'
                 }]
             });
 
-            formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
 
-            expect(window.fetch).toHaveBeenCalledTimes(1);
+            expect(window.fetch).toHaveBeenCalledTimes(2);
             const expectedBody = JSON.stringify({
                 email: 'jamie@example.com',
                 emailType: 'signup',
@@ -264,19 +272,20 @@ describe('Member Data attributes:', () => {
                     refUrl: 'https://example.com/blog/',
                     time: 1611234567890
                 }],
-                newsletters: [{name: 'Some Newsletter'}]
+                newsletters: [{name: 'Some Newsletter'}],
+                integrityToken: 'testtoken'
             });
-            expect(window.fetch).toHaveBeenCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
+            expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });
 
-        test('does not include newsletters in request if there are no newsletter inputs', () => {
+        test('does not include newsletters in request if there are no newsletter inputs', async () => {
             const {event, form, errorEl, siteUrl, submitHandler} = getMockData({
                 newsletterQuerySelectorResult: []
             });
 
-            formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler});
 
-            expect(window.fetch).toHaveBeenCalledTimes(1);
+            expect(window.fetch).toHaveBeenCalledTimes(2);
             const expectedBody = JSON.stringify({
                 email: 'jamie@example.com',
                 emailType: 'signup',
@@ -289,9 +298,10 @@ describe('Member Data attributes:', () => {
                     refSource: 'ghost-explore',
                     refUrl: 'https://example.com/blog/',
                     time: 1611234567890
-                }]
+                }],
+                integrityToken: 'testtoken'
             });
-            expect(window.fetch).toHaveBeenCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
+            expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });
     });
 });

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -244,7 +244,21 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
-        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, customUrlHistory, autoRedirect = true}) {
+        async getIntegrityToken() {
+            const url = endpointFor({type: 'members', resource: 'integrity-token'});
+            const res = await makeRequest({
+                url,
+                method: 'GET'
+            });
+
+            if (res.ok) {
+                return res.text();
+            } else {
+                throw new Error('Failed to start a members session');
+            }
+        },
+
+        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, integrityToken, customUrlHistory, autoRedirect = true}) {
             const url = endpointFor({type: 'members', resource: 'send-magic-link'});
             const body = {
                 name,
@@ -255,6 +269,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 labels,
                 requestSrc: 'portal',
                 redirect,
+                integrityToken,
                 autoRedirect
             };
             const urlHistory = customUrlHistory ?? getUrlHistory();

--- a/apps/signup-form/src/Preview.stories.tsx
+++ b/apps/signup-form/src/Preview.stories.tsx
@@ -45,6 +45,13 @@ const Preview: React.FC<SignupFormOptions & {
                 }
 
                 return;
+            },
+            getIntegrityToken: async () => {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 500);
+                });
+
+                return 'testtoken';
             }
         },
         t: i18n.t,

--- a/apps/signup-form/src/components/pages/FormPage.tsx
+++ b/apps/signup-form/src/components/pages/FormPage.tsx
@@ -21,7 +21,8 @@ export const FormPage: React.FC = () => {
         setLoading(true);
 
         try {
-            await api.sendMagicLink({email, labels: options.labels});
+            const integrityToken = await api.getIntegrityToken();
+            await api.sendMagicLink({email, labels: options.labels, integrityToken});
 
             if (minimal) {
                 // Don't go to the success page, but show the success state in the form

--- a/apps/signup-form/src/utils/api.tsx
+++ b/apps/signup-form/src/utils/api.tsx
@@ -12,14 +12,31 @@ export const setupGhostApi = ({siteUrl}: {siteUrl: string}) => {
     }
 
     return {
-        sendMagicLink: async ({email, labels}: {email: string, labels: string[]}) => {
+        getIntegrityToken: async (): Promise<string> => {
+            const url = endpointFor({type: 'members', resource: 'integrity-token'});
+
+            const response = await fetch(url, {
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.90'
+                }
+            });
+
+            if (response.status < 200 || response.status >= 300) {
+                throw new Error(response.statusText);
+            }
+
+            return response.text();
+        },
+        sendMagicLink: async ({email, integrityToken, labels}: {email: string, labels: string[], integrityToken: string}) => {
             const url = endpointFor({type: 'members', resource: 'send-magic-link'});
 
             const payload = JSON.stringify({
                 email,
                 emailType: 'signup',
                 labels,
-                urlHistory: getUrlHistory({siteUrl})
+                urlHistory: getUrlHistory({siteUrl}),
+                integrityToken
             });
 
             const response = await fetch(url, {

--- a/apps/signup-form/test/utils/e2e.ts
+++ b/apps/signup-form/test/utils/e2e.ts
@@ -65,5 +65,9 @@ export async function mockApi({page, status = 200}: {page: any, status?: number}
         await route.abort('addressunreachable');
     });
 
+    await page.route(`${MOCKED_SITE_URL}/members/api/integrity-token/`, async (route) => {
+        await route.fulfill('testtoken');
+    });
+
     return lastApiRequest;
 }

--- a/ghost/core/core/server/services/members/RequestIntegrityTokenProvider.js
+++ b/ghost/core/core/server/services/members/RequestIntegrityTokenProvider.js
@@ -1,0 +1,62 @@
+const crypto = require('crypto');
+
+class RequestIntegrityTokenProvider {
+    #themeSecret;
+    #tokenDuration;
+
+    /**
+     * @param {object} options
+     * @param {string} options.themeSecret
+     * @param {number} options.tokenDuration
+     */
+    constructor(options) {
+        this.#themeSecret = options.themeSecret;
+        this.#tokenDuration = options.tokenDuration;
+    }
+
+    /**
+     * @returns {string}
+     */
+    create() {
+        const currentTime = Date.now();
+        const expiryTime = currentTime + this.#tokenDuration;
+        const nonce = crypto.randomBytes(16).toString('hex');
+        const hmac = crypto.createHmac('sha256', this.#themeSecret);
+        hmac.update(`${expiryTime.toString()}:${nonce}`);
+        return `${expiryTime.toString()}:${nonce}:${hmac.digest('hex')}`;
+    }
+
+    /**
+     * @param {string} token
+     * @returns {boolean}
+     */
+    validate(token) {
+        const parts = token.split(':');
+        if (parts.length !== 3) {
+            // Invalid token string
+            return false;
+        }
+
+        const nonce = parts[0];
+        const timestamp = parseInt(parts[1], 10);
+        const hmacDigest = parts[2];
+
+        const hmac = crypto.createHmac('sha256', this.#themeSecret);
+        hmac.update(`${nonce}:${timestamp.toString()}`);
+        const expectedHmac = hmac.digest('hex');
+
+        if (expectedHmac !== hmacDigest) {
+            // HMAC mismatch
+            return false;
+        }
+
+        if (Date.now() > timestamp) {
+            // Token expired
+            return false;
+        }
+
+        return true;
+    }
+}
+
+module.exports = RequestIntegrityTokenProvider;

--- a/ghost/core/core/server/services/members/RequestIntegrityTokenProvider.js
+++ b/ghost/core/core/server/services/members/RequestIntegrityTokenProvider.js
@@ -7,7 +7,7 @@ class RequestIntegrityTokenProvider {
     /**
      * @param {object} options
      * @param {string} options.themeSecret
-     * @param {number} options.tokenDuration
+     * @param {number} options.tokenDuration - in milliseconds
      */
     constructor(options) {
         this.#themeSecret = options.themeSecret;
@@ -37,12 +37,12 @@ class RequestIntegrityTokenProvider {
             return false;
         }
 
-        const nonce = parts[0];
-        const timestamp = parseInt(parts[1], 10);
+        const timestamp = parseInt(parts[0], 10);
+        const nonce = parts[1];
         const hmacDigest = parts[2];
 
         const hmac = crypto.createHmac('sha256', this.#themeSecret);
-        hmac.update(`${nonce}:${timestamp.toString()}`);
+        hmac.update(`${timestamp.toString()}:${nonce}`);
         const expectedHmac = hmac.digest('hex');
 
         if (expectedHmac !== hmacDigest) {

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -169,19 +169,26 @@ const createIntegrityToken = async function createIntegrityToken(req, res) {
 };
 
 const verifyIntegrityToken = async function verifyIntegrityToken(req, res, next) {
+    const shouldThrowForInvalidToken = config.get('verifyRequestIntegrity');
     try {
         const token = req.body.integrityToken;
         if (!token) {
             logging.warn('Request with missing integrity token.');
-            // In future this will throw an error
-            return next();
+            if (shouldThrowForInvalidToken) {
+                throw new errors.BadRequestError();
+            } else {
+                return next();
+            }
         }
         if (membersService.requestIntegrityTokenProvider.validate(token)) {
             return next();
         } else {
             logging.warn('Request with invalid integrity token.');
-            // In future this will throw an error
-            return next();
+            if (shouldThrowForInvalidToken) {
+                throw new errors.BadRequestError();
+            } else {
+                return next();
+            }
         }
     } catch (err) {
         next(err);

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -170,7 +170,7 @@ const createIntegrityToken = async function createIntegrityToken(req, res) {
 
 const verifyIntegrityToken = async function verifyIntegrityToken(req, res, next) {
     try {
-        const token = req.query.requestIntegrityToken;
+        const token = req.body.integrityToken;
         if (!token) {
             logging.warn('Request with missing integrity token.');
             // In future this will throw an error

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -35,7 +35,7 @@ const getFreeTier = async function getFreeTier() {
  * @param {import('express').Request} req - The member object
  * @param {import('express').Response} res - The express response object to set the cookies on
  * @param {Object} freeTier - The free tier object
- * @returns 
+ * @returns
  */
 const setAccessCookies = function setAccessCookies(member, req, res, freeTier) {
     if (!member) {
@@ -154,6 +154,37 @@ const getIdentityToken = async function getIdentityToken(req, res) {
     } catch (err) {
         res.writeHead(204);
         res.end();
+    }
+};
+
+const createIntegrityToken = async function createIntegrityToken(req, res) {
+    try {
+        const token = membersService.requestIntegrityTokenProvider.create();
+        res.writeHead(200);
+        res.end(token);
+    } catch (err) {
+        res.writeHead(204);
+        res.end();
+    }
+};
+
+const verifyIntegrityToken = async function verifyIntegrityToken(req, res, next) {
+    try {
+        const token = req.query.requestIntegrityToken;
+        if (!token) {
+            logging.warn('Request with missing integrity token.');
+            // In future this will throw an error
+            return next();
+        }
+        if (membersService.requestIntegrityTokenProvider.validate(token)) {
+            return next();
+        } else {
+            logging.warn('Request with invalid integrity token.');
+            // In future this will throw an error
+            return next();
+        }
+    } catch (err) {
+        next(err);
     }
 };
 
@@ -397,5 +428,7 @@ module.exports = {
     updateMemberNewsletters,
     deleteSession,
     accessInfoSession,
-    deleteSuppression
+    deleteSuppression,
+    createIntegrityToken,
+    verifyIntegrityToken
 };

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -19,6 +19,7 @@ const tiersService = require('../tiers');
 const VerificationTrigger = require('@tryghost/verification-trigger');
 const DatabaseInfo = require('@tryghost/database-info');
 const settingsHelpers = require('../settings-helpers');
+const RequestIntegrityTokenProvider = require('./RequestIntegrityTokenProvider');
 
 const messages = {
     noLiveKeysInDevelopment: 'Cannot use live stripe keys in development. Please restart in production mode.',
@@ -192,6 +193,11 @@ module.exports = {
 
     ssr: null,
     verificationTrigger: null,
+
+    requestIntegrityTokenProvider: new RequestIntegrityTokenProvider({
+        themeSecret: settingsCache.get('theme_session_secret'),
+        tokenDuration: 1000 * 60 * 5
+    }),
 
     stripeConnect: require('./stripe-connect'),
 

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -70,10 +70,13 @@ module.exports = function setupMembersApp() {
     membersApp.get('/api/session', middleware.getIdentityToken);
     membersApp.delete('/api/session', bodyParser.json({limit: '5mb'}), middleware.deleteSession);
 
+    membersApp.get('/api/integrity-token', middleware.createIntegrityToken);
+
     // NOTE: this is wrapped in a function to ensure we always go via the getter
     membersApp.post(
         '/api/send-magic-link',
         bodyParser.json(),
+        middleware.verifyIntegrityToken,
         // Prevent brute forcing email addresses (user enumeration)
         shared.middleware.brute.membersAuthEnumeration,
         // Prevent brute forcing passwords for the same email address

--- a/ghost/core/test/unit/server/services/members/RequestIntegrityTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/RequestIntegrityTokenProvider.test.js
@@ -1,0 +1,70 @@
+const sinon = require('sinon');
+const should = require('should');
+
+const RequestIntegrityTokenProvider = require('../../../../../core/server/services/members/RequestIntegrityTokenProvider');
+
+const tokenProvider = new RequestIntegrityTokenProvider({
+    themeSecret: 'test',
+    tokenDuration: 100
+});
+
+describe('RequestIntegrityTokenProvider', function () {
+    beforeEach(function () {
+        sinon.useFakeTimers(new Date('2021-01-01'));
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('create', function () {
+        it('should create a HMAC digest from the secret', function () {
+            const token = tokenProvider.create();
+
+            token.should.be.a.String();
+            token.split(':').should.be.an.Array().with.lengthOf(3);
+            const [timestamp, nonce, digest] = token.split(':');
+
+            timestamp.should.equal((new Date('2021-01-01').valueOf() + 100).toString());
+
+            nonce.should.match(/[0-9a-f]{16}/);
+
+            digest.should.be.a.String().with.lengthOf(64);
+        });
+    });
+
+    describe('validate', function () {
+        it('should verify a HMAC digest from the secret', function () {
+            const token = tokenProvider.create();
+            const result = tokenProvider.validate(token);
+
+            result.should.be.true();
+        });
+
+        it('should fail to verify an expired token', function () {
+            const token = tokenProvider.create();
+            sinon.clock.tick(101);
+            const result = tokenProvider.validate(token);
+
+            result.should.be.false();
+        });
+
+        it('should fail to verify a malformed token', function () {
+            const token = 'invalid_token';
+            const result = tokenProvider.validate(token);
+
+            result.should.be.false();
+        });
+
+        it('should fail to verify a token with an invalid signature', function () {
+            const token = tokenProvider.create();
+            const [timestamp, nonce] = token.split(':');
+            const invalidDigest = 'a'.repeat(64); // Create an invalid digest
+            const invalidToken = `${timestamp}:${nonce}:${invalidDigest}`;
+
+            const result = tokenProvider.validate(invalidToken);
+
+            result.should.be.false();
+        });
+    });
+});


### PR DESCRIPTION
This should prevent untargeted attacks, since the back-end requires a token that is generated by the server before processing the request.

This is enabled as a warning in the logs only, until we're happy with the breaking change to the `send-magic-link` API.