### PR TITLE
🐛 Fixed fetching labels and offers in the editor

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -248,7 +248,7 @@ export default class KoenigLexicalEditor extends Component {
         // don't rethrow, Lexical will attempt to gracefully recover
     }
 
-    @task({restartable: true})
+    @task({restartable: false})
     *fetchOffersTask() {
         if (this.offers) {
             return this.offers;
@@ -257,7 +257,7 @@ export default class KoenigLexicalEditor extends Component {
         return this.offers;
     }
 
-    @task({restartable: true})
+    @task({restartable: false})
     *fetchLabelsTask() {
         if (this.labels) {
             return this.labels;


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-263/
- labels dropdown in sign up card was not successfully fetching labels
- offers dropdown suffered the same fate

When introducing the second editor instance, it appears we ran into some race conditions with the Ember tasks used to fetch the resources. The init instance was beating the other to the punch, and so the state was never successfully updated, as it is only fetched once on mounting the card.