### PR TITLE
🐛 Added integrity token to one click subscribe

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -484,11 +484,13 @@ async function oneClickSubscribe({data: {siteUrl}, state}) {
     const referrerUrl = window.location.href;
     const referrerSource = getRefDomain();
 
+    const integrityToken = await externalSiteApi.member.getIntegrityToken();
     await externalSiteApi.member.sendMagicLink({
         emailType: 'signup',
         name: member.name,
         email: member.email,
         autoRedirect: false,
+        integrityToken,
         customUrlHistory: state.site.outbound_link_tagging ? [
             {
                 time: Date.now(),


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-269

When we added the integrity token to all `send-magic-link` callers in Portal, we missed one.