### PR TITLE
Fixed failing type check in storybook story for admin-x-design-system

### DIFF
--- a/apps/admin-x-design-system/src/global/SortMenu.stories.tsx
+++ b/apps/admin-x-design-system/src/global/SortMenu.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
         items: items,
         onSortChange: () => {},
         onDirectionChange: () => {},
-        position: 'left'
+        position: 'start'
     },
     decorators: [
         ThisStory => (


### PR DESCRIPTION
no issue

- The type checks for `admin-x-design-system` were failing for me locally for a Storybook story. It looks like we changed the `PopoverPosition` type to use 'start'/'end' rather than 'left'/'right', but this story was still using 'left'. This was causing `yarn test` to fail in the `admin-x-design-system` app.
- This commit updates the story to use 'start' instead of 'left', which allows the type checks to pass.
