### PR TITLE
Fixed error closing donation success modal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.42.0",
+  "version": "2.42.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/portal/src/components/pages/SupportPage.js
+++ b/apps/portal/src/components/pages/SupportPage.js
@@ -14,7 +14,7 @@ const SupportPage = () => {
         async function checkoutDonation() {
             const siteUrl = window.location.origin;
             const currentUrl = siteUrl + window.location.pathname;
-            const successUrl = member ? `${currentUrl}?action=support&success=true` : `${currentUrl}/#/portal/support/success`;
+            const successUrl = member ? `${currentUrl}?action=support&success=true` : `${currentUrl}#/portal/support/success`;
             const cancelUrl = currentUrl;
             const api = setupGhostApi({siteUrl});
 

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -18,6 +18,7 @@ test.describe('Portal', () => {
             await sharedPage.pause();
             // Check success modal
             await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
+            expect(sharedPage.url()).toMatch(/[^\/]\/#\/portal\/support\/success/); // Ensure correct URL and no double-slash
             const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
             await expect(portalFrame.getByText('Thank you for your support')).toBeVisible();
             // Modal has working subscribe action


### PR DESCRIPTION
no issue

- when redirecting from Stripe back to Ghost after making a donation the URL contained a double slash (`//#/portal/...`) which triggered browser security errors when Portal modified the browser history stack when navigating
- the above could prevent the donation success modal from closing
