### PR TITLE
Removed unnused items from config API

### DIFF
--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -19,9 +19,7 @@ module.exports = function getConfigProperties() {
         emailAnalytics: config.get('emailAnalytics'),
         hostSettings: config.get('hostSettings'),
         tenor: config.get('tenor'),
-        editor: config.get('editor'),
         pintura: config.get('pintura'),
-        adminX: config.get('adminX'),
         signupForm: config.get('signupForm')
     };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/639be25f1dfcd0a1014bd534742d198d6447d600 refs https://github.com/TryGhost/Ghost/commit/f705dda314a554c60ecc57e0f4b9bf542320b277

- These items are never returned from the API as they've been removed from the serializer
- The tests also check that they are not present
- They were removed by the referenced commits, which changed how these things were built

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
