### PR TITLE
Removed unused billing url from config API

### DIFF
--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -23,10 +23,5 @@ module.exports = function getConfigProperties() {
         signupForm: config.get('signupForm')
     };
 
-    const billingUrl = config.get('hostSettings:billing:enabled') ? config.get('hostSettings:billing:url') : '';
-    if (billingUrl) {
-        configProperties.billingUrl = billingUrl;
-    }
-
     return configProperties;
 };


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/40cedb84ff20b971c0c3dc76dcf6ad19817c2857#diff-dba52cb217f89ed45931ded5618ce83294fc32cf4a8dec73aa605c65441331b3R43 
ref https://github.com/TryGhost/Ghost/blob/639be25f1dfcd0a1014bd534742d198d6447d600/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js

- This was moved under hostSettings very early on in development and should have been cleaned up
- As this property wasn't listed in the output serializer, we know it's not being used anywhere
- We can see from the limit code that it looks for hostSettings.billing.url

