### PR TITLE
 Updated Config API testing to use snapshot + unit tests

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Config API Can retrieve config and all expected properties 1: [body] 1`] = `
+Object {
+  "config": Object {
+    "clientExtensions": Object {},
+    "database": StringMatching /sqlite3\\|mysql\\|mysql2/,
+    "emailAnalytics": true,
+    "enableDeveloperExperiments": false,
+    "environment": StringMatching /\\^testing/,
+    "labs": Object {
+      "ActivityPub": true,
+      "NestPlayground": true,
+      "activitypub": true,
+      "additionalPaymentMethods": true,
+      "adminXDemo": true,
+      "announcementBar": true,
+      "audienceFeedback": true,
+      "collections": true,
+      "collectionsCard": true,
+      "contentVisibility": true,
+      "editorExcerpt": true,
+      "emailCustomization": true,
+      "i18n": true,
+      "importMemberTier": true,
+      "lexicalIndicators": true,
+      "lexicalMultiplayer": true,
+      "mailEvents": true,
+      "members": true,
+      "newEmailAddresses": true,
+      "outboundLinkTagging": true,
+      "postAnalyticsRefresh": true,
+      "publishFlowEndScreen": true,
+      "stripeAutomaticTax": true,
+      "themeErrorsNotification": true,
+      "tipsAndDonations": true,
+      "urlCache": true,
+      "webmentions": true,
+    },
+    "mail": "",
+    "mailgunIsConfigured": false,
+    "signupForm": Object {
+      "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
+      "version": "0.1",
+    },
+    "stripeDirect": false,
+    "tenor": Object {
+      "contentFilter": "off",
+      "googleApiKey": null,
+    },
+    "useGravatar": false,
+    "version": StringMatching /\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+/,
+  },
+}
+`;
+
+exports[`Config API Can retrieve config and all expected properties 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert/strict');
+const configUtils = require('../../../../utils/configUtils');
+const getConfigProperties = require('../../../../../core/server/services/public-config/config');
+
+// List of allowed keys to be returned by the public-config service
+// This is kind of a duplicate of the keys in the config.js output serializer in the api-framework
+// However the list of keys returned by the public-config service can differ based on flags and config set, so we want to keep this explicit
+
+const allowedKeys = [
+    'version',
+    'environment',
+    'database',
+    'mail',
+    'useGravatar',
+    'labs',
+    'clientExtensions',
+    'enableDeveloperExperiments',
+    'stripeDirect',
+    'mailgunIsConfigured',
+    'emailAnalytics',
+    'hostSettings',
+    'tenor',
+    'pintura',
+    'signupForm'
+];
+
+describe('Public-config Service', function () {
+    describe('Config Properties', function () {
+        afterEach(async function () {
+            await configUtils.restore();
+        });
+
+        it('should return the correct default config properties', function () {
+            const configProperties = getConfigProperties();
+
+            assert.deepEqual(Object.keys(configProperties), allowedKeys);
+        });
+
+        it('should return null for tenor apikey when unset', function () {
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.tenor.googleApiKey, null);
+        });
+
+        it('should return tenor apikey when set', function () {
+            configUtils.set('tenor:googleApiKey', 'TENOR_KEY');
+
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.tenor.googleApiKey, 'TENOR_KEY');
+        });
+
+        it('should return true for mailgunIsConfigured when mailgun is configured', function () {
+            configUtils.set('bulkEmail', {
+                mailgun: 'exists'
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.mailgunIsConfigured, true);
+        });
+
+        it('should return false for mailgunIsConfigured when mailgun is not configured', function () {
+            configUtils.set('bulkEmail', {});
+
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.mailgunIsConfigured, false);
+        });
+    });
+});


### PR DESCRIPTION
- Swap the e2e test to use the newer framework, and match against a snapshot for the default case
- Move the individual test cases to unit tests - there are more to add here, but this is parity with what we had before
- We use unit tests for checking through various cases for how config changes modify the output as this is faster and more explicit