### PR TITLE
Removed Refresh button if a post is not emailed

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -37,6 +37,7 @@
                 {{#if (feature "publishFlowEndScreen")}}
                     <div style="display: flex; gap: 8px;">
                         {{#if (feature "postAnalyticsRefresh")}}
+                            {{#if (or this.post.emailOnly this.post.hasBeenEmailed)}}
                             <GhTaskButton
                                 @buttonText="Refresh"
                                 @task={{this.fetchPostTask}}
@@ -45,6 +46,7 @@
                                 @successText="Refreshed"
                                 @class="gh-btn gh-btn-icon refresh"
                                 @successClass="gh-btn gh-btn-icon refresh" />
+                            {{/if}}
                         {{/if}}
                         {{#unless this.post.emailOnly}}
                             <button type="button" class="gh-post-list-cta share" {{on "click" this.togglePublishFlowModal}}>


### PR DESCRIPTION
The `Refresh` button on Post Analytics was showing for posts that are only published, which made it break upon interaction. I've removed it for those cases, and it now only shows if a post has been emailed or published + emailed.