### PR TITLE
Added type checks to admin-x-design-system unit tests

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.declaration.json && vite build",
     "prepare": "yarn build",
-    "test": "yarn test:unit && yarn test:types",
-    "test:unit": "yarn nx build && vitest run",
+    "test": "yarn test:unit",
+    "test:unit": "yarn test:types && yarn nx build && vitest run",
     "test:types": "tsc --noEmit",
     "lint:code": "eslint --ext .js,.ts,.cjs,.tsx src/ --cache",
     "lint": "yarn lint:code && yarn lint:test",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -103,14 +103,14 @@
     "targets": {
       "dev": {
         "dependsOn": [
-          "^build",
-          "@tryghost/admin-x-design-system:build"
+          "^build"
         ]
       },
       "test:unit": {
         "dependsOn": [
           "test:unit",
-          "^build"
+          "^build",
+          "@tryghost/admin-x-design-system:test:unit"
         ]
       }
     }

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -103,7 +103,8 @@
     "targets": {
       "dev": {
         "dependsOn": [
-          "^build"
+          "^build",
+          "@tryghost/admin-x-design-system:build"
         ]
       },
       "test:unit": {


### PR DESCRIPTION
no issue

- Previously we weren't running the type checks in the `admin-x-design-system` in CI, because we only run `yarn test:unit` in CI. This adds the typechecks to the `yarn test:unit` command so CI will fail if the type checks fail.
