### PR TITLE
feat: Added Elestio as one-click deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ ghost install
 
 Check out our [official documentation](https://ghost.org/docs/) for more information about our [recommended hosting stack](https://ghost.org/docs/hosting/) & properly [upgrading Ghost](https://ghost.org/docs/update/), plus everything you need to develop your own Ghost [themes](https://ghost.org/docs/themes/) or work with [our API](https://ghost.org/docs/content-api/).
 
+### One-click Deployment
+
+You can deploy Ghost on Elestio using one-click-deployment.
+
+[![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/ghost)
+
 ### Contributors & advanced developers
 
 For anyone wishing to contribute to Ghost or to hack/customize core files we recommend following our full development setup guides: [Contributor guide](https://ghost.org/docs/contributing/) • [Developer setup](https://ghost.org/docs/install/source/)


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing Ghost application as shown [here](https://elest.io/open-source/ghost). I think it would be a great idea if we can add it to official readme/documentation here.
🔔 In addition to this, if you are interested we provide partnership opportunities with tools we support by **revenue share** upon addition of this method in docs. I see we already have conversation regarding the same. If you would like me to bump it up just shoot me an email at [kaiwalya@elest.io](mailto:kaiwalya@elest.io) :)

- [ ] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
