### PR TITLE
Added core and comments-ui test-results directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ typings/
 *.db
 *.db-journal
 
+/ghost/core/test-results/
 /ghost/core/core/server/data/export/exported*
 /ghost/core/content/tmp/*
 /ghost/core/content/data/*
@@ -133,7 +134,7 @@ Caddyfile
 /apps/comments-ui/umd
 /apps/comments-ui/playwright-report
 /ghost/comments-ui/playwright/.cache/
-/ghost/comments-ui/test-results/
+/apps/comments-ui/test-results/
 
 # Portal
 !/apps/portal/.env


### PR DESCRIPTION
no issue

- These directories are made when running browser tests locally — added to `.gitignore` so we don't accidentally commit our local test results to version control