### PR TITLE
Gated NestJS framework behind environment variable

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -49,7 +49,7 @@ const features = [{
     flag: 'adminXDemo'
 },{
     title: 'NestJS Playground',
-    description: 'Wires up the Ghost NestJS App to the Admin API',
+    description: 'Wires up the Ghost NestJS App to the Admin API (also needs GHOST_ENABLE_NEST_FRAMEWORK=1 env var)',
     flag: 'NestPlayground'
 },{
     title: 'ActivityPub',

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -568,7 +568,13 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
         }
 
         await initServices({config});
-        await initNestDependencies();
+
+        // Gate the NestJS framework behind an env var to prevent it from being loaded (and slowing down boot)
+        // If we ever ship the new framework, we can remove this
+        // Using an env var because you can't use labs flags here
+        if (process.env.GHOST_ENABLE_NEST_FRAMEWORK) {
+            await initNestDependencies();
+        }
         debug('End: Load Ghost Services & Apps');
 
         // Step 5 - Mount the full Ghost app onto the minimal root app & disable maintenance mode

--- a/ghost/core/core/server/web/api/endpoints/admin/app.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/app.js
@@ -39,7 +39,7 @@ module.exports = function setupApiApp() {
     apiApp.use(routes());
 
     apiApp.use(async function nestApp(req, res, next) {
-        if (labs.isSet('NestPlayground')) {
+        if (process.env.GHOST_ENABLE_NEST_FRAMEWORK && labs.isSet('NestPlayground')) {
             const originalExpressApp = req.app;
             const app = await GhostNestApp.getApp();
 


### PR DESCRIPTION
- we added NestJS to Ghost as a way forwards for a new framework within Ghost but we haven't added much to it
- requiring all the NestJS code adds about 6-9% to our boot time, so if we're not using it, it's just time we're burning for no benefit
- for now, I've gated this behind an env var to prevent it from loading
- we can't use labs flags in the boot process, so I've gone for an env var