### PR TITLE
Added initial stats config to API

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -20,7 +20,8 @@ module.exports = {
             'hostSettings',
             'tenor',
             'pintura',
-            'signupForm'
+            'signupForm',
+            'stats'
         ];
 
         frame.response = {

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -23,5 +23,10 @@ module.exports = function getConfigProperties() {
         signupForm: config.get('signupForm')
     };
 
+    // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now
+    if (config.get('tinybird') && config.get('tinybird:stats')) {
+        configProperties.stats = config.get('tinybird:stats');
+    }
+
     return configProperties;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Config API Can retrieve config and all expected properties 1: [body] 1`] = `
+exports[`Config API As Owner Can retrieve config and all expected properties 1: [body] 1`] = `
 Object {
   "config": Object {
     "clientExtensions": Object {},
@@ -54,7 +54,7 @@ Object {
 }
 `;
 
-exports[`Config API Can retrieve config and all expected properties 2: [headers] 1`] = `
+exports[`Config API As Owner Can retrieve config and all expected properties 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/e2e-api/admin/config.test.js
+++ b/ghost/core/test/e2e-api/admin/config.test.js
@@ -11,25 +11,37 @@ describe('Config API', function () {
 
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
-        await fixtureManager.init();
-        await agent.loginAsOwner();
+        await fixtureManager.init('users');
     });
 
-    it('Can retrieve config and all expected properties', async function () {
-        await agent
-            .get('/config/')
-            .expectStatus(200)
-            .matchBodySnapshot({
-                config: {
-                    database: stringMatching(/sqlite3|mysql|mysql2/),
-                    environment: stringMatching(/^testing/),
-                    version: stringMatching(/\d+\.\d+\.\d+/)
-                }
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                'content-length': anyContentLength, // Length can differ slightly based on the database, environment and version values
-                etag: anyEtag
-            });
+    describe('As Unauthorized User', function () {
+        it('Cannot fetch the config endpoint', async function () {
+            await agent.get('/config/')
+                .expectStatus(403);
+        });
+    });
+
+    describe('As Owner', function () {
+        before(async function () {
+            await agent.loginAsOwner();
+        });
+
+        it('Can retrieve config and all expected properties', async function () {
+            await agent
+                .get('/config/')
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    config: {
+                        database: stringMatching(/sqlite3|mysql|mysql2/),
+                        environment: stringMatching(/^testing/),
+                        version: stringMatching(/\d+\.\d+\.\d+/)
+                    }
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    'content-length': anyContentLength, // Length can differ slightly based on the database, environment and version values
+                    etag: anyEtag
+                });
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -67,5 +67,33 @@ describe('Public-config Service', function () {
 
             assert.equal(configProperties.mailgunIsConfigured, false);
         });
+
+        it('should NOT return stats by default', function () {
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.stats, undefined);
+        });
+
+        it('should return stats when tinybird config is set with the stats key', function () {
+            configUtils.set('tinybird', {
+                stats: {
+                    endpoint: 'xxx'
+                }
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.deepEqual(configProperties.stats, {endpoint: 'xxx'});
+        });
+
+        it('should NOT return stats when tinybird config is set without the stats key', function () {
+            configUtils.set('tinybird', {
+                url: 'xxx'
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.stats, undefined);
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ANAL-8/flag-and-config

- This checks if tinybird:stats is set, and if so passes through the config that is set via the config API
- This is used by Ghost admin to configure where to pull charts from

