### PR TITLE
✨ Improved publishing flow

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -59,14 +59,6 @@ const features = [{
     title: 'Content Visibility',
     description: 'Enables content visibility in Emails',
     flag: 'contentVisibility'
-},{
-    title: 'Publish Flow — End Screen',
-    description: 'Enables improved publish flow',
-    flag: 'publishFlowEndScreen'
-},{
-    title: 'Post Analytics — Refresh',
-    description: 'Adds a refresh button to the post analytics screen',
-    flag: 'postAnalyticsRefresh'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/components/editor/modals/publish-flow.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow.hbs
@@ -45,14 +45,6 @@
                 @close={{@close}}
             />
         {{else if this.isComplete}}
-            {{#unless (feature "publishFlowEndScreen")}}
-                <Editor::Modals::PublishFlow::Complete
-                    @publishOptions={{@data.publishOptions}}
-                    @recipientType={{this.recipientType}}
-                    @postCount={{this.postCount}}
-                    @close={{@close}}
-                />
-            {{/unless}}
         {{else}}
             <Editor::Modals::PublishFlow::Options
                 @publishOptions={{@data.publishOptions}}

--- a/ghost/admin/app/components/editor/modals/publish-flow.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow.hbs
@@ -1,6 +1,6 @@
 <div class="flex flex-column h-100 items-center overflow-auto" data-test-modal="publish-flow">
     <header class="gh-publish-header">
-        <button class="gh-btn-editor gh-publish-back-button" title="Close" type="button" {{on "click" @close}} data-test-button="close-publish-flow">
+        <button class="gh-btn-editor gh-publish-back-button" title="Close" type="button" {{on "click" @close}}>
             <span>{{svg-jar "arrow-left"}} Editor</span>
         </button>
 

--- a/ghost/admin/app/components/editor/modals/publish-flow/confirm.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow/confirm.js
@@ -93,31 +93,30 @@ export default class PublishFlowOptions extends Component {
 
         try {
             yield this.args.saveTask.perform();
-            if (this.feature.publishFlowEndScreen) {
-                if (this.args.publishOptions.isScheduled) {
-                    localStorage.setItem('ghost-last-scheduled-post', JSON.stringify({
-                        id: this.args.publishOptions.post.id,
-                        type: this.args.publishOptions.post.displayName
-                    }));
-                    if (this.args.publishOptions.post.displayName !== 'page') {
-                        this.router.transitionTo('posts');
+
+            if (this.args.publishOptions.isScheduled) {
+                localStorage.setItem('ghost-last-scheduled-post', JSON.stringify({
+                    id: this.args.publishOptions.post.id,
+                    type: this.args.publishOptions.post.displayName
+                }));
+                if (this.args.publishOptions.post.displayName !== 'page') {
+                    this.router.transitionTo('posts');
+                } else {
+                    this.router.transitionTo('pages');
+                }
+            } else {
+                localStorage.setItem('ghost-last-published-post', JSON.stringify({
+                    id: this.args.publishOptions.post.id,
+                    type: this.args.publishOptions.post.displayName
+                }));
+                if (this.args.publishOptions.post.displayName !== 'page') {
+                    if (this.args.publishOptions.post.hasEmail) {
+                        this.router.transitionTo('posts.analytics', this.args.publishOptions.post.id);
                     } else {
-                        this.router.transitionTo('pages');
+                        this.router.transitionTo('posts');
                     }
                 } else {
-                    localStorage.setItem('ghost-last-published-post', JSON.stringify({
-                        id: this.args.publishOptions.post.id,
-                        type: this.args.publishOptions.post.displayName
-                    }));
-                    if (this.args.publishOptions.post.displayName !== 'page') {
-                        if (this.args.publishOptions.post.hasEmail) {
-                            this.router.transitionTo('posts.analytics', this.args.publishOptions.post.id);
-                        } else {
-                            this.router.transitionTo('posts');
-                        }
-                    } else {
-                        this.router.transitionTo('pages');
-                    }
+                    this.router.transitionTo('pages');
                 }
             }
         } catch (e) {

--- a/ghost/admin/app/components/modal-post-success.hbs
+++ b/ghost/admin/app/components/modal-post-success.hbs
@@ -70,7 +70,7 @@
                     <img src="{{or this.post.featureImage this.post.twitterImage this.post.ogImage}}" alt="{{this.post.title}}">
                 </figure>
             {{/if}}
-            
+
             <div class="modal-body">
                 <h2>{{this.post.title}}</h2>
                 {{#if this.post.excerpt}}

--- a/ghost/admin/app/components/modal-post-success.hbs
+++ b/ghost/admin/app/components/modal-post-success.hbs
@@ -103,10 +103,10 @@
         </footer>
     {{/if}}
 
-    <button type="button" class="close" title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
+    <button type="button" class="close" title="Close" {{on "click" @close}} data-test-button="close-publish-flow">{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
     {{#unless this.post.emailOnly}}
-    <a href="{{this.post.url}}" target="_blank" rel="noopener noreferrer" title="View post: {{this.post.title}}">
+    <a href="{{this.post.url}}" target="_blank" rel="noopener noreferrer" title="View post: {{this.post.title}}" data-test-complete-bookmark>
         <div class="gh-post-card">
             {{#if this.post.featureImage}}
                 <figure class="modal-image">

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -32,7 +32,7 @@
                         </span>
                     {{/if}}
                 </p>
-                <p class="gh-content-entry-status">
+                <p class="gh-content-entry-status" data-test-editor-post-status>
                     <span class="published">
                         Published
                         {{#if @post.hasEmail}}
@@ -87,7 +87,7 @@
                         <span class="gh-content-entry-date">– Lexical</span>
                     {{/if}} --}}
                 </p>
-                <p class="gh-content-entry-status">
+                <p class="gh-content-entry-status" data-test-editor-post-status>
                     {{#if @post.isScheduled}}
                         <span class="scheduled">
                             Scheduled

--- a/ghost/admin/app/components/posts-list/list.js
+++ b/ghost/admin/app/components/posts-list/list.js
@@ -16,9 +16,7 @@ export default class PostsList extends Component {
 
     constructor() {
         super(...arguments);
-        if (this.feature.publishFlowEndScreen) {
-            this.checkPublishFlowModal();
-        }
+        this.checkPublishFlowModal();
     }
 
     async checkPublishFlowModal() {

--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -34,66 +34,58 @@
                         {{moment-format publishedAt "HH:mm"}}
                     {{/let}}
                 </div>
-                {{#if (feature "publishFlowEndScreen")}}
-                    <div style="display: flex; gap: 8px;">
-                        {{#if (feature "postAnalyticsRefresh")}}
-                            <GhTaskButton
-                                @buttonText="Refresh"
-                                @task={{this.fetchPostTask}}
-                                @showIcon={{true}}
-                                @idleIcon="reload"
-                                @successText="Refreshed"
-                                @class="gh-btn gh-btn-icon refresh"
-                                @successClass="gh-btn gh-btn-icon refresh" />
-                        {{/if}}
-                        {{#unless this.post.emailOnly}}
-                            <button type="button" class="gh-post-list-cta share" {{on "click" this.togglePublishFlowModal}}>
-                                {{svg-jar "share" title="Share post"}}<span>Share</span>
-                            </button>
-                        {{/unless}}
+                <div style="display: flex; gap: 8px;">
+                    <GhTaskButton
+                        @buttonText="Refresh"
+                        @task={{this.fetchPostTask}}
+                        @showIcon={{true}}
+                        @idleIcon="reload"
+                        @successText="Refreshed"
+                        @class="gh-btn gh-btn-icon refresh"
+                        @successClass="gh-btn gh-btn-icon refresh" />
+                    {{#unless this.post.emailOnly}}
+                        <button type="button" class="gh-post-list-cta share" {{on "click" this.togglePublishFlowModal}}>
+                            {{svg-jar "share" title="Share post"}}<span>Share</span>
+                        </button>
+                    {{/unless}}
 
-                        <span class="dropdown">
-                            <GhDropdownButton
-                                @dropdownName="analytics-actions-menu"
-                                @classNames="gh-post-list-cta gh-btn-icon icon-only gh-btn-action-icon"
-                                @title="Analytics Actions"
-                                data-test-button="analytics-actions"
-                            >
-                                <span>
-                                    {{svg-jar "dotdotdot"}}
-                                    <span class="hidden">Actions</span>
-                                </span>
-                            </GhDropdownButton>
-                            <GhDropdown
-                                @name="analytics-actions-menu"
-                                @tagName="ul"
-                                @classNames="gh-analytics-actions-menu dropdown-menu dropdown-triangle-top-right"
-                                @closeOnClick={{true}}
-                            >
-                                <li>
-                                    <LinkTo class="edit-post" @route="lexical-editor.edit" @models={{array this.post.displayName this.post.id}}>Edit post</LinkTo>
-                                </li>
-                                <li>
-                                    <a class="view-browser" href="{{this.post.url}}" target="_blank" rel="noopener noreferrer">View in browser</a>
-                                </li>
-                                <li>
-                                    <button
-                                        type="button"
-                                        class="delete-post mr2"
-                                        {{on "click" this.confirmDeleteMember}}
-                                        data-test-button="delete-post"
-                                    >
-                                        <span class="red">Delete post</span>
-                                    </button>
-                                </li>
-                            </GhDropdown>
-                        </span>
-                    </div>
-                {{else}}
-                    <LinkTo @route="lexical-editor.edit" @models={{array this.post.displayName this.post.id}} class="gh-post-list-cta edit" title="">
-                        {{svg-jar "pen" title=""}}<span>Edit post</span>
-                    </LinkTo>
-                {{/if}}
+                    <span class="dropdown">
+                        <GhDropdownButton
+                            @dropdownName="analytics-actions-menu"
+                            @classNames="gh-post-list-cta gh-btn-icon icon-only gh-btn-action-icon"
+                            @title="Analytics Actions"
+                            data-test-button="analytics-actions"
+                        >
+                            <span>
+                                {{svg-jar "dotdotdot"}}
+                                <span class="hidden">Actions</span>
+                            </span>
+                        </GhDropdownButton>
+                        <GhDropdown
+                            @name="analytics-actions-menu"
+                            @tagName="ul"
+                            @classNames="gh-analytics-actions-menu dropdown-menu dropdown-triangle-top-right"
+                            @closeOnClick={{true}}
+                        >
+                            <li>
+                                <LinkTo class="edit-post" @route="lexical-editor.edit" @models={{array this.post.displayName this.post.id}}>Edit post</LinkTo>
+                            </li>
+                            <li>
+                                <a class="view-browser" href="{{this.post.url}}" target="_blank" rel="noopener noreferrer">View in browser</a>
+                            </li>
+                            <li>
+                                <button
+                                    type="button"
+                                    class="delete-post mr2"
+                                    {{on "click" this.confirmDeleteMember}}
+                                    data-test-button="delete-post"
+                                >
+                                    <span class="red">Delete post</span>
+                                </button>
+                            </li>
+                        </GhDropdown>
+                    </span>
+                </div>
             </div>
         </div>
     </GhCanvasHeader>

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -50,9 +50,7 @@ export default class Analytics extends Component {
 
     constructor() {
         super(...arguments);
-        if (this.feature.publishFlowEndScreen) {
-            this.checkPublishFlowModal();
-        }
+        this.checkPublishFlowModal();
     }
 
     openPublishFlowModal() {
@@ -73,11 +71,7 @@ export default class Analytics extends Component {
     }
 
     get post() {
-        if (this.feature.publishFlowEndScreen) {
-            return this._post ?? this.args.post;
-        }
-
-        return this.args.post;
+        return this._post ?? this.args.post;
     }
 
     set post(value) {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -78,8 +78,6 @@ export default class FeatureService extends Service {
     @feature('ActivityPub') ActivityPub;
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
-    @feature('publishFlowEndScreen') publishFlowEndScreen;
-    @feature('postAnalyticsRefresh') postAnalyticsRefresh;
 
     _user = null;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -45,9 +45,7 @@ const ALPHA_FEATURES = [
     'importMemberTier',
     'lexicalIndicators',
     'adminXDemo',
-    'contentVisibility',
-    'publishFlowEndScreen',
-    'postAnalyticsRefresh'
+    'contentVisibility'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -29,8 +29,6 @@ Object {
       "members": true,
       "newEmailAddresses": true,
       "outboundLinkTagging": true,
-      "postAnalyticsRefresh": true,
-      "publishFlowEndScreen": true,
       "stripeAutomaticTax": true,
       "themeErrorsNotification": true,
       "tipsAndDonations": true,


### PR DESCRIPTION
ref DES-706

* When a user publishes a post or sends it via email, they are directed to the post's analytics page and shown a confirmation modal. If the post is published on their site, they can immediately share it from the modal
* For scheduled posts or emails, users are taken to the post list with a confirmation prompt
* Added a "Share" button and some functions (view, edit, delete post) to published posts in post analytics
* Added a manual "Refresh" button to post analytics so that people wouldn't need to reload the whole app to update the data