### PR TITLE
Added config flag to disable recommendations service

### DIFF
--- a/ghost/core/core/server/services/recommendations/RecommendationServiceWrapper.js
+++ b/ghost/core/core/server/services/recommendations/RecommendationServiceWrapper.js
@@ -39,11 +39,16 @@ class RecommendationServiceWrapper {
     incomingRecommendationService;
 
     init() {
+        const config = require('../../../shared/config');
+        if (config.get('services:recommendations:enabled') === false) {
+            logging.info('[Recommendations] Service is disabled via config');
+            return;
+        }
+
         if (this.repository) {
             return;
         }
 
-        const config = require('../../../shared/config');
         const urlUtils = require('../../../shared/url-utils');
         const models = require('../../models');
         const sentry = require('../../../shared/sentry');


### PR DESCRIPTION
no ref

This service can get rather noisy when doing local development with our data generator, as we do not use real urls, and therefore generate a lot of not found errors in the console.