### PR TITLE
Renamed `ghost:build` to `ghost:build:assets`

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "archive": "npm pack",
     "dev": "node --watch index.js",
-    "build": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",
+    "build:assets": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",
     "test": "yarn test:unit",
     "test:base": "mocha --reporter dot --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js",
     "test:single": "yarn test:base --timeout=60000",
@@ -272,7 +272,7 @@
     "targets": {
       "archive": {
         "dependsOn": [
-          "build",
+          "build:assets",
           "^build:ts",
           {
             "projects": [


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DEV-20/faster-builds

- this was previously causing duplicate builds of the TS projects because Nx was building all projects with `build` targets, and we were also calling `build:ts`
- this cuts 12 compilation jobs from the archive process, which should help with container build times