### PR TITLE
Updated URL encoding

### DIFF
--- a/ghost/admin/app/components/modal-post-success.hbs
+++ b/ghost/admin/app/components/modal-post-success.hbs
@@ -147,7 +147,7 @@
     <footer class="modal-footer">
         {{#if (and this.post.isPublished (not this.post.emailOnly))}}
             <div class="share-buttons">
-                <a href="https://twitter.com/intent/tweet?text={{this.encodedTitle}}&url={{this.encodedUrl}}" class="gh-btn twitter" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
+                <a href="https://twitter.com/intent/tweet?text={{this.encodedTitle}}%0A{{this.encodedUrl}}" class="gh-btn twitter" target="_blank" rel="noopener noreferrer" title="Share on Twitter">
                     <span>{{svg-jar "social-x"}}</span>
                 </a>
                 <a href="https://threads.net/intent/post?text={{this.encodedTitleAndUrl}}" class="gh-btn threads" target="_blank" rel="noopener noreferrer" title="Share on Threads">


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-760/make-a-line-break-between-the-post-title-and-url-when-sharing-to

When a post is shared to Twitter from the 'Share' modal (or in the publishing flow), the URL now sits on the second line. 

<img width="653" alt="Screenshot 2024-09-02 at 11 20 53" src="https://github.com/user-attachments/assets/178066cc-01da-41b6-bf1d-d00943881209">
