### PR TITLE
Removed sqlite skip in recommendation email test

### DIFF
--- a/ghost/core/test/e2e-server/services/recommendation-emails.test.js
+++ b/ghost/core/test/e2e-server/services/recommendation-emails.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, mockManager, dbUtils} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
 const assert = require('assert/strict');
 const mentionsService = require('../../../core/server/services/mentions');
 const recommendationsService = require('../../../core/server/services/recommendations');
@@ -66,10 +66,6 @@ describe('Incoming Recommendation Emails', function () {
     });
 
     it('Sends a different email if we receive a recommendation back', async function () {
-        if (dbUtils.isSQLite()) {
-            this.skip();
-        }
-
         // Create a recommendation to otherghostsite.com
         const recommendation = Recommendation.create({
             title: `Recommendation`,


### PR DESCRIPTION
no issue

- test runs OK locally in SQLite
- enabling it to run eliminates a potential tripping point when generating updated snapshots locally
