### PR TITLE
Removed concurrently from building apps

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",
-    "build": "concurrently \"tsc\" \"vite build\"",
+    "build": "tsc && vite build",
     "lint": "yarn run lint:code && yarn run lint:test",
     "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
     "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx --cache test",

--- a/apps/admin-x-demo/package.json
+++ b/apps/admin-x-demo/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",
-    "build": "concurrently \"tsc\" \"vite build\"",
+    "build": "tsc && vite build",
     "lint": "yarn run lint:code && yarn run lint:test",
     "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
     "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx --cache test",

--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -9,7 +9,7 @@
   "types": "types/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "concurrently \"vite build\" \"tsc -p tsconfig.declaration.json\"",
+    "build": "tsc -p tsconfig.declaration.json && vite build",
     "prepare": "yarn build",
     "test": "yarn test:unit && yarn test:types",
     "test:unit": "yarn nx build && vitest run",

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -54,7 +54,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "concurrently \"vite build\" \"tsc -p tsconfig.declaration.json\"",
+    "build": "tsc -p tsconfig.declaration.json && vite build",
     "prepare": "yarn build",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",
-    "build": "concurrently \"tsc\" \"vite build\"",
+    "build": "tsc && vite build",
     "lint": "yarn run lint:js",
     "lint:js": "eslint --ext .js,.ts,.cjs,.tsx --cache src test",
     "test:unit": "yarn nx build && vitest run",


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DEV-20/faster-builds

- we added concurrently because, in theory, it should make builds faster by utilizing more cores
- however, when combined with Nx, it seems that we are trying to exceed the number of cores, which actually makes individual builds slower
- I've removed concurrently from the apps, which should improve the build time significantly
