### PR TITLE
Switched `build` and `build:ts` scripts

### DIFF
--- a/ghost/bookshelf-repository/package.json
+++ b/ghost/bookshelf-repository/package.json
@@ -7,8 +7,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/collections/package.json
+++ b/ghost/collections/package.json
@@ -7,8 +7,8 @@
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "scripts": {
-        "build": "tsc",
-        "build:ts": "yarn build",
+        "build": "yarn build:ts",
+        "build:ts": "tsc",
         "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
         "test": "yarn test:types && yarn test:unit",
         "test:types": "tsc --noEmit",

--- a/ghost/donations/package.json
+++ b/ghost/donations/package.json
@@ -8,8 +8,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "prepare": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",

--- a/ghost/email-addresses/package.json
+++ b/ghost/email-addresses/package.json
@@ -8,8 +8,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "prepare": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",

--- a/ghost/ghost/package.json
+++ b/ghost/ghost/package.json
@@ -8,8 +8,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --reporter text --reporter cobertura mocha -r ts-node/register/transpile-only './**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/in-memory-repository/package.json
+++ b/ghost/in-memory-repository/package.json
@@ -7,8 +7,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/mail-events/package.json
+++ b/ghost/mail-events/package.json
@@ -7,8 +7,8 @@
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "scripts": {
-        "build": "tsc",
-        "build:ts": "yarn build",
+        "build": "yarn build:ts",
+        "build:ts": "tsc",
         "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
         "test": "yarn test:types && yarn test:unit",
         "test:types": "tsc --noEmit",

--- a/ghost/model-to-domain-event-interceptor/package.json
+++ b/ghost/model-to-domain-event-interceptor/package.json
@@ -7,8 +7,8 @@
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "scripts": {
-        "build": "tsc",
-        "build:ts": "yarn build",
+        "build": "yarn build:ts",
+        "build:ts": "tsc",
         "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
         "test": "yarn test:types && yarn test:unit",
         "test:types": "tsc --noEmit",

--- a/ghost/nql-filter-expansions/package.json
+++ b/ghost/nql-filter-expansions/package.json
@@ -7,8 +7,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/post-events/package.json
+++ b/ghost/post-events/package.json
@@ -8,8 +8,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/post-revisions/package.json
+++ b/ghost/post-revisions/package.json
@@ -7,8 +7,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "test:types": "tsc --noEmit",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100  --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:unit && yarn test:types",

--- a/ghost/recommendations/package.json
+++ b/ghost/recommendations/package.json
@@ -8,8 +8,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "tsc",
-    "build:ts": "yarn build",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
     "prepare": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura -- mocha --reporter dot -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DEV-20/faster-builds

- `build` should be the overall script to build the package
- `build:ts` should only build TypeScript
- by having them switched around, `build:ts` would call `yarn build`, and `yarn` adds several hundreds of milliseconds of time to each build
