### PR TITLE
Updated date notation

### DIFF
--- a/ghost/admin/app/components/modal-post-success.hbs
+++ b/ghost/admin/app/components/modal-post-success.hbs
@@ -54,7 +54,7 @@
                 {{/let}}
             {{/if}}
 
-            {{#let (moment-site-tz @post.publishedAtUTC) as |scheduledAt|}}
+            {{#let (moment-site-tz this.post.publishedAtUTC) as |scheduledAt|}}
                 {{#if (is-moment-today scheduledAt)}}
                     <strong class="nowrap">today</strong>
                 {{else}}


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/DES-771/publish-flow-modal-shows-the-wrong-published-time-for-scheduled-posts

Scheduled post's date and time was shown as the date of creation, not the date it was going to be scheduled. This fixes that.