### PR TITLE
🐛 Fixed "Unsaved changes" modal showing for some published posts with images

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -50,7 +50,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.1.4",
     "@tryghost/kg-converters": "1.0.7",
-    "@tryghost/koenig-lexical": "1.3.24",
+    "@tryghost/koenig-lexical": "1.3.25",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.4",

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -681,7 +681,7 @@ test.describe('Deleting a post', () => {
         await page.locator('[data-test-button="delete-post"]').click();
 
         await page.locator('[data-test-button="delete-post-confirm"]').click();
-        
+
         await expect(
             page.locator('[data-test-screen-title]')
         ).toContainText('Posts');
@@ -697,7 +697,7 @@ test.describe('Deleting a post', () => {
         await page.locator('[data-test-button="delete-post"]').click();
 
         await page.locator('[data-test-button="delete-post-confirm"]').click();
-        
+
         await expect(
             page.locator('[data-test-screen-title]')
         ).toContainText('Posts');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7825,10 +7825,10 @@
   dependencies:
     semver "^7.6.2"
 
-"@tryghost/koenig-lexical@1.3.24":
-  version "1.3.24"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.3.24.tgz#4e4fd5c9c46741268505276bfda4707fae71414e"
-  integrity sha512-34hThZymmbo3swirMR8n7hpPZRdDJ654lsd9nMxjVJvyu33VWN+72JFN9cxPMR8fgylNqetk8r7Rk3ofrLsu8Q==
+"@tryghost/koenig-lexical@1.3.25":
+  version "1.3.25"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.3.25.tgz#3e624f548033abcadd4bfdb827eea985418eca0a"
+  integrity sha512-VX7y63xaBsXoMpljnvya9OvngtEDzgwEziOE2/ktSvDllY4QmG/wescARBMCpoIZQrWAsrA2yl6GLgFO1Sp7dA==
 
 "@tryghost/limit-service@1.2.14":
   version "1.2.14"


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ENG-1532

- bumps Koenig to version that doesn't re-populate image node dimensions when they already exist
