### PR TITLE
Fixed missing initials on staff invites' avatars

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -183,7 +183,7 @@ const InvitesUserList: React.FC<InviteListProps> = ({users}) => {
                     <ListItem
                         key={user.id}
                         action={<UserInviteActions invite={user} />}
-                        avatar={(<Avatar bgColor={generateAvatarColor((user.email))} image={''} label={''} labelColor='white' />)}
+                        avatar={(<Avatar bgColor={generateAvatarColor((user.email))} image={''} label={user.email.charAt(0).toUpperCase()} labelColor='white' />)}
                         className='min-h-[64px]'
                         detail={user.role}
                         hideActions={true}


### PR DESCRIPTION
DES-775

- Initials were missing on avatars in the invite list of Settings/Staff