### PR TITLE
Removed `yarn` from `main:submodules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:unit": "nx run-many -t test:unit",
     "main": "yarn main:monorepo && yarn main:submodules",
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
-    "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn\"",
+    "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
     "tb": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/tinybird -it tinybirdco/tinybird-cli-docker"
   },


### PR DESCRIPTION
- we don't really need to run `yarn` here, as it pulls down all the dependencies for the 2 themes
- we rarely need these locally, and it's also slowing down CI, so we can just remove it from here for now