### PR TITLE
Fixed TS types being cached by Nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,6 +34,7 @@
             "outputs": [
                 "{projectRoot}/dist",
                 "{projectRoot}/es",
+                "{projectRoot}/types",
                 "{projectRoot}/umd"
             ]
         },


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DEV-20/faster-builds

- we need these to be cache so we can restore them in subsequent builds