### PR TITLE
Added MySQL data volume to docker compose

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       # Turns out you can drop .sql or .sql.gz files in here, cool!
       - ./mysql-preload:/docker-entrypoint-initdb.d
+      - mysql-data:/var/lib/mysql
     healthcheck:
       test: "mysql -uroot -proot ghost -e 'select 1'"
       interval: 1s
@@ -37,3 +38,5 @@ services:
       restart: always
       environment:
         COLLECTOR_ZIPKIN_HOST_PORT: :9411
+volumes:
+  mysql-data:


### PR DESCRIPTION
no issue

- This allows us to run `docker-compose down` or to restart docker desktop without losing all our local databases
- Added a data volume to the MySQL service in the `docker-compose.yml` file to persist the data between container restarts
- The `yarn docker:reset` command will still reset all the data in the database since it uses `down -v` to remove the volumes as well