### PR TITLE
Removed jaeger container from docker compose

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -28,15 +28,5 @@ services:
     ports:
       - "6379:6379"
     restart: always
-  jaeger:
-      image: jaegertracing/all-in-one:1.58
-      container_name: ghost-jaeger
-      ports:
-        - "4318:4318"
-        - "16686:16686"
-        - "9411:9411"
-      restart: always
-      environment:
-        COLLECTOR_ZIPKIN_HOST_PORT: :9411
 volumes:
   mysql-data:


### PR DESCRIPTION
no issue

- OpenTelemetry has been problematic in a number of ways (boot time, breaking the frontend). May revisit it at some point in the future, but for now it is only exporting metrics via prometheus and not traces, so there's currently nothing sending data to this jaeger container
- Cleaning it up for now as it's just sitting there idly consuming resources