### PR TITLE
Used attributedTo over actor when available

### DIFF
--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -70,7 +70,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
                                     data-test-view-article
                                     onClick={() => handleViewContent(
                                         activity.object,
-                                        activity.actor,
+                                        typeof activity.object.attributedTo !== 'string' && !Array.isArray(activity.object.attributedTo) ? activity.object.attributedTo : activity.actor,
                                         getCommentsForObject(activity.object.id)
                                     )}
                                 >

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -53,6 +53,30 @@ const Inbox: React.FC<InboxProps> = ({}) => {
         NiceModal.show(ArticleModal, {object, actor, comments, allComments: commentsMap});
     };
 
+    function getContentAuthor(activity: Activity) {
+        const actor = activity.actor;
+        const attributedTo = activity.object.attributedTo;
+
+        if (!attributedTo) {
+            return actor;
+        }
+
+        if (typeof attributedTo === 'string') {
+            return actor;
+        }
+
+        if (Array.isArray(attributedTo)) {
+            const found = attributedTo.find(item => typeof item !== 'string');
+            if (found) {
+                return found;
+            } else {
+                return actor;
+            }
+        }
+
+        return attributedTo;
+    }
+
     const handleLayoutChange = (newLayout: string) => {
         setLayout(newLayout);
     };
@@ -70,7 +94,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
                                     data-test-view-article
                                     onClick={() => handleViewContent(
                                         activity.object,
-                                        typeof activity.object.attributedTo !== 'string' && !Array.isArray(activity.object.attributedTo) ? activity.object.attributedTo : activity.actor,
+                                        getContentAuthor(activity),
                                         getCommentsForObject(activity.object.id)
                                     )}
                                 >


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/AP-388

The attributedTo property of objects refers to the author of the object, wheras the actor of an activity refers to the author of the activity - in the case of a `Create` activity - these are generally the same, but in the case of an `Announce` they are different, the author refers to the "announcer" and the attributedTo the author of the content! This is a quick patch to use the true author when it's available, and in a format we can handle.
