### PR TITLE
Fixed hostname check for reply notificiations

### DIFF
--- a/apps/admin-x-activitypub/src/components/Activities.tsx
+++ b/apps/admin-x-activitypub/src/components/Activities.tsx
@@ -7,6 +7,7 @@ import {Button, NoValueLabel} from '@tryghost/admin-x-design-system';
 
 import getUsername from '../utils/get-username';
 import {useBrowseInboxForUser, useBrowseOutboxForUser, useFollowersForUser} from '../MainContent';
+import {useSiteUrl} from '../hooks/useActivityPubQueries';
 
 interface ActivitiesProps {}
 
@@ -112,6 +113,7 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
     // that a reply was made to)
     const {data: inboxActivities = []} = useBrowseInboxForUser(user);
     const {data: outboxActivities = []} = useBrowseOutboxForUser(user);
+    const siteUrl = useSiteUrl();
 
     // Create a map of activity objects from activities in the inbox and outbox.
     // This allows us to quickly look up an object associated with an activity
@@ -147,7 +149,7 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
             // checking that the hostname associated with the reply object
             // is the same as the hostname of the site. This is not a bullet
             // proof check, but it's a good enough for now
-            const hostname = new URL(window.location.href).hostname;
+            const hostname = new URL(siteUrl).hostname;
             const replyToObjectHostname = new URL(replyToObject.url).hostname;
 
             return hostname === replyToObjectHostname;

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -2,7 +2,7 @@ import {ActivityPubAPI} from '../api/activitypub';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
-const useSiteUrl = () => {
+export function useSiteUrl() {
     const site = useBrowseSite();
     return site.data?.site?.url ?? window.location.origin;
 };


### PR DESCRIPTION
In order to show replies in our notifications, we loop through all the replies in our inbox, and filter them by the ones replying to an account on our domain, however the check we were doing was on the admin domain - which is sometimes the same as the frontend domain, but not always. This fixes the check so that we check the frontend domain, which is the one used by activitypub.
