### PR TITLE
Improved displayed error message when editor reaches bad saving state

### DIFF
--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -706,7 +706,8 @@ describe('Acceptance: Editor', function () {
             await pasteInEditor('Testing');
 
             // we should see an error - previously this was failing silently
-            expect(find('.gh-alert-content')).to.have.trimmed.text('Resource could not be found.');
+            // error message comes from editor's own handling rather than our generic API error fallback
+            expect(find('.gh-alert-content')).to.have.trimmed.text('Saving failed: Editor has crashed. Please copy your content and start a new post.');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-323

- added explicit 404 handling to the editor's save task so we can display a more direct/useful error message
