### PR TITLE
Updated version handling in Admin-X Settings

### DIFF
--- a/apps/admin-x-settings/src/utils/linkToGithubReleases.ts
+++ b/apps/admin-x-settings/src/utils/linkToGithubReleases.ts
@@ -1,20 +1,35 @@
 import semverParse from 'semver/functions/parse';
 
-export function linkToGitHubReleases(version: string):string {
-    if (version.includes('-pre.')) {
-        try {
-            const semverVersion = semverParse(version, {includePrerelease: true} as any);
+// This function needs to support:
+// - 5.94.1+moya
+// - 5.94.1-0-g1f3e72eac8+moya
+// - 5.95.0-pre-g028c1a6+moya
+export function linkToGitHubReleases(version: string): string {
+    if (!version) {
+        return '';
+    }
 
-            if (semverVersion && semverVersion.build?.[0]) {
-                return `https://github.com/TryGhost/Ghost/commit/${semverVersion.build[0]}`;
+    const cleanedVersion = version.replace('+moya', '');
+
+    try {
+        const semverVersion = semverParse(cleanedVersion, {includePrerelease: true} as any);
+        const prerelease = semverVersion?.prerelease;
+
+        if (prerelease && prerelease?.length > 0) {
+            const splitPrerelease = String(prerelease[0]).split('-');
+            const commitHash = splitPrerelease[1];
+
+            if (!commitHash || !commitHash.startsWith('g')) {
+                return '';
             }
 
-            return '';
-        } catch (e) {
-            return '';
-        }
-    }
-    let cleanedVersion = version.replace('+moya', '');
+            const commitHashWithoutG = commitHash.slice(1);
 
-    return `https://github.com/TryGhost/Ghost/releases/tag/v${cleanedVersion}`;
+            return `https://github.com/TryGhost/Ghost/commit/${commitHashWithoutG}`;
+        }
+
+        return `https://github.com/TryGhost/Ghost/releases/tag/v${cleanedVersion}`;
+    } catch (e) {
+        return '';
+    }
 }

--- a/apps/admin-x-settings/test/unit/utils/linkToGithubReleases.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkToGithubReleases.test.ts
@@ -2,15 +2,33 @@ import * as assert from 'assert/strict';
 import {linkToGitHubReleases} from '../../../src/utils/linkToGithubReleases';
 
 describe('linkToGithubRelease', function () {
-    it('generates a link to a release', function () {
-        let version = '5.69.0';
-        let link = linkToGitHubReleases(version);
+    it('handles empty version', function () {
+        const link = linkToGitHubReleases('');
+        assert.equal(link, '');
+    });
+
+    it('handles plain version release', function () {
+        const link = linkToGitHubReleases('5.69.0');
         assert.equal(link, 'https://github.com/TryGhost/Ghost/releases/tag/v5.69.0');
     });
 
-    it('strips moya from the version', function () {
-        let version = '5.69.0+moya';
-        let link = linkToGitHubReleases(version);
+    it('handles plain version with +moya suffix', function () {
+        const link = linkToGitHubReleases('5.69.0+moya');
         assert.equal(link, 'https://github.com/TryGhost/Ghost/releases/tag/v5.69.0');
+    });
+
+    it('handles git describe output', function () {
+        const link = linkToGitHubReleases('5.69.0-0-gabcdef');
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abcdef');
+    });
+
+    it('handles git describe output with +moya suffix', function () {
+        const link = linkToGitHubReleases('5.69.0-0-gabcdef+moya');
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abcdef');
+    });
+
+    it('handles prerelease version', function () {
+        const link = linkToGitHubReleases('5.70.0-pre-gabcdef+moya');
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abcdef');
     });
 });


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/DEV-22/add-support-to-admin-for-parsing-ghost-git-version

- we need to be handle the output given by `git describe`, to account for upcoming changes to our versioning
- this commit allows Admin-X Settings to parse these strings, and adds tests to check for this