### PR TITLE
Updated activitypub app to utilise new activities endpoint

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -443,4 +443,45 @@ describe('ActivityPubAPI', function () {
             await api.follow('@user@domain.com');
         });
     });
+
+    describe('getAllActivities', function () {
+        test('It fetches all activities navigating pagination', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50': {
+                    response: JSONResponse({
+                        items: [{type: 'Create', object: {type: 'Note'}}],
+                        nextCursor: 'next-cursor'
+                    })
+                },
+                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50&cursor=next-cursor': {
+                    response: JSONResponse({
+                        items: [{type: 'Announce', object: {type: 'Article'}}],
+                        nextCursor: null
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.getAllActivities();
+            const expected: Activity[] = [
+                {type: 'Create', object: {type: 'Note'}},
+                {type: 'Announce', object: {type: 'Article'}}
+            ];
+
+            expect(actual).toEqual(expected);
+        });
+    });
 });

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -24,10 +24,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
         const isAnnounce = activity.type === 'Announce' && activity.object.type === 'Note';
 
         return isCreate || isAnnounce;
-    })
-        // API endpoint currently returns items oldest-newest, so reverse them
-        // to show the most recent activities first
-        .reverse();
+    });
 
     // Create a map of activity comments, grouping them by the parent activity
     // This allows us to quickly look up all comments for a given activity

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -7,7 +7,7 @@ import React, {useState} from 'react';
 import {type Activity} from './activities/ActivityItem';
 import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, Heading} from '@tryghost/admin-x-design-system';
-import {useBrowseInboxForUser} from '../MainContent';
+import {useAllActivitiesForUser} from '../hooks/useActivityPubQueries';
 
 interface InboxProps {}
 
@@ -16,10 +16,10 @@ const Inbox: React.FC<InboxProps> = ({}) => {
     const [, setArticleActor] = useState<ActorProperties | null>(null);
     const [layout, setLayout] = useState('inbox');
 
-    // Retrieve activities from the inbox
-    const {data: inboxActivities = []} = useBrowseInboxForUser('index');
+    // Retrieve all activities for the user
+    let {data: activities = []} = useAllActivitiesForUser('index');
 
-    const activities = inboxActivities.filter((activity: Activity) => {
+    activities = activities.filter((activity: Activity) => {
         const isCreate = activity.type === 'Create' && ['Article', 'Note'].includes(activity.object.type);
         const isAnnounce = activity.type === 'Announce' && activity.object.type === 'Note';
 

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -165,3 +165,14 @@ export function useFollowersForUser(handle: string) {
         }
     });
 }
+
+export function useAllActivitiesForUser(handle: string) {
+    const siteUrl = useSiteUrl();
+    const api = createActivityPubAPI(handle, siteUrl);
+    return useQuery({
+        queryKey: [`activities:${handle}`],
+        async queryFn() {
+            return api.getAllActivities();
+        }
+    });
+}


### PR DESCRIPTION
refs [AP-377](https://linear.app/tryghost/issue/AP-377/inbox-returning-33mb-of-data), [TryGhost/ActivityPub#40](https://github.com/TryGhost/ActivityPub/pull/40)

Updated activitypub app to utilise new activities endpoint which returns a paginated list of activities