### PR TITLE
Updated kpi-overview top bar fetch to use params

### DIFF
--- a/ghost/admin/app/components/stats/kpis-overview.hbs
+++ b/ghost/admin/app/components/stats/kpis-overview.hbs
@@ -1,4 +1,5 @@
-<div class="gh-stats-tabs-header ">
+
+<div class="gh-stats-tabs-header">
     <div class="gh-stats-tabs">
         <button type="button" class="gh-stats-tab min-width {{if this.uniqueVisitorsTabSelected 'is-selected'}}" {{on "click" this.changeTabToUniqueVisitors}}>
             <Stats::Parts::Metric


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ANAL-67/audience-filtering-doesnt-update-the-top-metrics-just-the-charts

- At the moment we are manually fetching the top bar data for KPIs via Ember.
- This was done quickly, and didn't make use of the params for audience or chartRange
- We need these params to fetch filtered data results