### PR TITLE
Updated activities tab to use the activities endpoint in the activitypub app

### DIFF
--- a/apps/admin-x-activitypub/src/MainContent.tsx
+++ b/apps/admin-x-activitypub/src/MainContent.tsx
@@ -24,23 +24,6 @@ export function useBrowseInboxForUser(handle: string) {
     });
 }
 
-export function useBrowseOutboxForUser(handle: string) {
-    const site = useBrowseSite();
-    const siteData = site.data?.site;
-    const siteUrl = siteData?.url ?? window.location.origin;
-    const api = new ActivityPubAPI(
-        new URL(siteUrl),
-        new URL('/ghost/api/admin/identities/', window.location.origin),
-        handle
-    );
-    return useQuery({
-        queryKey: [`outbox:${handle}`],
-        async queryFn() {
-            return api.getOutbox();
-        }
-    });
-}
-
 export function useFollowersForUser(handle: string) {
     const site = useBrowseSite();
     const siteData = site.data?.site;

--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -454,13 +454,13 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50': {
+                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50&includeOwn=false': {
                     response: JSONResponse({
                         items: [{type: 'Create', object: {type: 'Note'}}],
                         nextCursor: 'next-cursor'
                     })
                 },
-                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50&cursor=next-cursor': {
+                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50&includeOwn=false&cursor=next-cursor': {
                     response: JSONResponse({
                         items: [{type: 'Announce', object: {type: 'Article'}}],
                         nextCursor: null
@@ -479,6 +479,38 @@ describe('ActivityPubAPI', function () {
             const expected: Activity[] = [
                 {type: 'Create', object: {type: 'Note'}},
                 {type: 'Announce', object: {type: 'Article'}}
+            ];
+
+            expect(actual).toEqual(expected);
+        });
+
+        test('It fetches a user\'s own activities', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                'https://activitypub.api/.ghost/activitypub/activities/index?limit=50&includeOwn=true': {
+                    response: JSONResponse({
+                        items: [{type: 'Create', object: {type: 'Note'}}],
+                        nextCursor: null
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.getAllActivities(true);
+            const expected: Activity[] = [
+                {type: 'Create', object: {type: 'Note'}}
             ];
 
             expect(actual).toEqual(expected);

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -53,24 +53,6 @@ export class ActivityPubAPI {
         return [];
     }
 
-    get outboxApiUrl() {
-        return new URL(`.ghost/activitypub/outbox/${this.handle}`, this.apiUrl);
-    }
-
-    async getOutbox(): Promise<Activity[]> {
-        const json = await this.fetchJSON(this.outboxApiUrl);
-        if (json === null) {
-            return [];
-        }
-        if ('orderedItems' in json) {
-            return Array.isArray(json.orderedItems) ? json.orderedItems : [json.orderedItems];
-        }
-        if ('items' in json) {
-            return Array.isArray(json.items) ? json.items : [json.items];
-        }
-        return [];
-    }
-
     get followingApiUrl() {
         return new URL(`.ghost/activitypub/following/${this.handle}`, this.apiUrl);
     }
@@ -165,7 +147,7 @@ export class ActivityPubAPI {
         return new URL(`.ghost/activitypub/activities/${this.handle}`, this.apiUrl);
     }
 
-    async getAllActivities(): Promise<Activity[]> {
+    async getAllActivities(includeOwn: boolean = false): Promise<Activity[]> {
         const LIMIT = 50;
 
         const fetchActivities = async (url: URL): Promise<Activity[]> => {
@@ -192,6 +174,7 @@ export class ActivityPubAPI {
 
                 nextUrl.searchParams.set('cursor', json.nextCursor);
                 nextUrl.searchParams.set('limit', LIMIT.toString());
+                nextUrl.searchParams.set('includeOwn', includeOwn.toString());
 
                 const nextItems = await fetchActivities(nextUrl);
 
@@ -204,6 +187,7 @@ export class ActivityPubAPI {
         // Make a copy of the activities API URL and set the limit
         const url = new URL(this.activitiesApiUrl);
         url.searchParams.set('limit', LIMIT.toString());
+        url.searchParams.set('includeOwn', includeOwn.toString());
 
         // Fetch the activities
         return fetchActivities(url);

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -17,7 +17,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
     const [layout, setLayout] = useState('inbox');
 
     // Retrieve all activities for the user
-    let {data: activities = []} = useAllActivitiesForUser('index');
+    let {data: activities = []} = useAllActivitiesForUser({handle: 'index'});
 
     activities = activities.filter((activity: Activity) => {
         const isCreate = activity.type === 'Create' && ['Article', 'Note'].includes(activity.object.type);

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -157,7 +157,6 @@ export function useFollowingForUser(handle: string) {
 export function useFollowersForUser(handle: string) {
     const siteUrl = useSiteUrl();
     const api = createActivityPubAPI(handle, siteUrl);
-
     return useQuery({
         queryKey: [`followers:${handle}`],
         async queryFn() {
@@ -166,13 +165,13 @@ export function useFollowersForUser(handle: string) {
     });
 }
 
-export function useAllActivitiesForUser(handle: string) {
+export function useAllActivitiesForUser({handle, includeOwn = false}: {handle: string, includeOwn?: boolean}) {
     const siteUrl = useSiteUrl();
     const api = createActivityPubAPI(handle, siteUrl);
     return useQuery({
-        queryKey: [`activities:${handle}`],
+        queryKey: [`activities:${handle}:includeOwn=${includeOwn.toString()}`],
         async queryFn() {
-            return api.getAllActivities();
+            return api.getAllActivities(includeOwn);
         }
     });
 }


### PR DESCRIPTION
refs [AP-377](https://linear.app/tryghost/issue/AP-377/inbox-returning-33mb-of-data), [TryGhost/ActivityPub#43](https://github.com/TryGhost/ActivityPub/pull/43)

Updated activities tab to use the activities endpoint in the activitypub app