### PR TITLE
Fixed date storage for analytics job using sqlite

### DIFF
--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -117,8 +117,8 @@ module.exports = {
                 await db.knex('jobs').insert({
                     id: new ObjectID().toHexString(),
                     name: jobName,
-                    [updateField]: date,
-                    updated_at: date,
+                    [updateField]: date.toISOString(), // force to iso string for sqlite
+                    updated_at: date.toISOString(), // force to iso string for sqlite
                     status: status
                 });
             }


### PR DESCRIPTION
no ref

With sqlite the dates were being stored as unix timestamps, which led to occasional ingestion issues as we assume the date is a date.