### PR TITLE
Fixed missing `extra` context for Sentry report for editor 404

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -662,9 +662,9 @@ export default class LexicalEditorController extends Controller {
             // it as saved and performing PUT requests with no id. We want to
             // be noisy about this early to avoid data loss
             if (isNotFoundError(error)) {
-                const context = this._getNotFoundErrorContext();
-                console.error('saveTask failed with 404', context); // eslint-disable-line no-console
-                Sentry.captureException(error, {tags: {savePostTask: true}, context});
+                const notFoundContext = this._getNotFoundErrorContext();
+                console.error('saveTask failed with 404', notFoundContext); // eslint-disable-line no-console
+                Sentry.captureException(error, {tags: {savePostTask: true}, extra: notFoundContext});
                 this._showErrorAlert(prevStatus, this.post.status, 'Editor has crashed. Please copy your content and start a new post.');
                 return;
             }


### PR DESCRIPTION
no issue

- Sentry requires additional data to be passed in under the `extra` property
