### PR TITLE
Filtered Sentry network breadcrumbs to reduce noise

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -213,7 +213,14 @@ export default Route.extend(ShortcutsRoute, {
                     // - http://ember-concurrency.com/docs/cancelation
                     'TaskCancelation'
                 ],
-                integrations: []
+                integrations: [],
+                beforeBreadcrumb(breadcrumb) {
+                    // ignore breadcrumbs for event tracking to reduce noise in error reports
+                    if (breadcrumb.category === 'http' && breadcrumb.data?.url?.match(/\/e\.ghost\.org|plausible\.io/)) {
+                        return null;
+                    }
+                    return breadcrumb;
+                }
             };
 
             try {


### PR DESCRIPTION
no issue

- Sentry error reports were full of network breadcrumbs that weren't useful, added filtering to remove ones that aren't helpful in error logs
