### PR TITLE
🐛 Fixed wrong breadcrumb and missing post status when starting new post from analytics

### DIFF
--- a/ghost/admin/app/routes/lexical-editor.js
+++ b/ghost/admin/app/routes/lexical-editor.js
@@ -17,7 +17,7 @@ export default AuthenticatedRoute.extend({
     },
 
     setupController(controller, model, transition) {
-        if (transition.from?.name === 'posts.analytics') {
+        if (transition.from?.name === 'posts.analytics' && transition.to?.name !== 'lexical-editor.new') {
             controller.fromAnalytics = true;
         }
     },

--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -606,6 +606,23 @@ describe('Acceptance: Editor', function () {
             ).to.equal(`/ghost/posts/analytics/${post.id}`);
         });
 
+        it('does not render analytics breadcrumb for a new post', async function () {
+            const post = this.server.create('post', {
+                authors: [author],
+                status: 'published',
+                title: 'Published Post'
+            });
+
+            // visit the analytics page for the post
+            await visit(`/posts/analytics/${post.id}`);
+            // start a new post
+            await visit('/editor/post');
+
+            // Breadcrumbs should not contain Analytics link
+            expect(find('[data-test-breadcrumb]'), 'breadcrumb text').to.contain.text('Posts');
+            expect(find('[data-test-editor-post-status]')).to.contain.text('New');
+        });
+
         it('handles TKs in title', async function () {
             let post = this.server.create('post', {authors: [author]});
 


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/ENG-1533

- the code to switch to "from analytics" state for the editor was applying when clicking the create post button in the nav menu whilst on the analytics screen which was confusing because you not only lost the `< Posts` link in the editor but you couldn't see the post's saving status
