### PR TITLE
Added logging of post state changes

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -25,6 +25,7 @@ import {isArray as isEmberArray} from '@ember/array';
 import {isHostLimitError, isServerUnreachableError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {isInvalidError, isNotFoundError} from 'ember-ajax/errors';
 import {mobiledocToLexical} from '@tryghost/kg-converters';
+import {observes} from '@ember-decorators/object';
 import {inject as service} from '@ember/service';
 import {slugify} from '@tryghost/string';
 import {tracked} from '@glimmer/tracking';
@@ -187,6 +188,17 @@ export default class LexicalEditorController extends Controller {
     /* debug properties ------------------------------------------------------*/
 
     _setPostState = null;
+    _postStates = [];
+
+    // eslint-disable-next-line ghost/ember/no-observers
+    @observes('post.currentState.stateName')
+    _pushPostState() {
+        const stateName = this.post?.currentState.stateName;
+        if (stateName) {
+            console.log('post state changed:', stateName); // eslint-disable-line no-console
+            this._postStates.push(stateName);
+        }
+    }
 
     /* computed properties ---------------------------------------------------*/
 
@@ -689,7 +701,8 @@ export default class LexicalEditorController extends Controller {
     _getNotFoundErrorContext() {
         return {
             setPostState: this._setPostState,
-            currentPostState: this.post.currentState.stateName
+            currentPostState: this.post.currentState.stateName,
+            allPostStates: this._postStates
         };
     }
 
@@ -1226,6 +1239,7 @@ export default class LexicalEditorController extends Controller {
         this._saveOnLeavePerformed = false;
 
         this._setPostState = null;
+        this._postStates = [];
 
         this.set('post', null);
         this.set('hasDirtyAttributes', false);

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -473,5 +473,15 @@ describe('Unit: Controller: lexical-editor', function () {
             controller.post = {currentState: {stateName: 'this.is.a.test'}};
             expect(controller._getNotFoundErrorContext().currentPostState).to.equal('this.is.a.test');
         });
+
+        it('_getNotFoundErrorContext() includes all post states', async function () {
+            const newPost = store.createRecord('post');
+            controller.setPost(newPost);
+            controller.post = {currentState: {stateName: 'state.one'}};
+            controller.post = {currentState: {stateName: 'state.two'}};
+            expect(controller._getNotFoundErrorContext().allPostStates).to.deep.equal(
+                ['root.loaded.created.uncommitted', 'state.one', 'state.two']
+            );
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-323

- added debug logs to print to console each time the post state changes and include a full list of post state changes within the editor session in the error reports when we hit the 404 error caused by a bad editor state
