### PR TITLE
🐛 Fixed migrations for SQLite database users (#19839)

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.55/2023-07-10-05-16-55-add-built-in-collection-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.55/2023-07-10-05-16-55-add-built-in-collection-posts.js
@@ -14,7 +14,7 @@ const insertPostCollections = async (knex, collectionId, postIds) => {
         };
     });
 
-    await knex.batchInsert('collections_posts', collectionPosts, 1000);
+    await knex.batchInsert('collections_posts', collectionPosts, 100);
 };
 
 module.exports = createTransactionalMigration(

--- a/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-55-repopulate-built-in-featured-collection-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-55-repopulate-built-in-featured-collection-posts.js
@@ -14,7 +14,7 @@ const insertPostCollections = async (knex, collectionId, postIds) => {
         };
     });
 
-    await knex.batchInsert('collections_posts', collectionPosts, 1000);
+    await knex.batchInsert('collections_posts', collectionPosts, 100);
 };
 
 module.exports = createTransactionalMigration(

--- a/ghost/core/core/server/data/migrations/versions/5.89/2024-07-30-19-51-06-backfill-offer-redemptions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.89/2024-07-30-19-51-06-backfill-offer-redemptions.js
@@ -50,7 +50,7 @@ module.exports = createTransactionalMigration(
                     };
                 });
                 // Batch insert rows into the offer_redemptions table
-                await knex.batchInsert('offer_redemptions', offerRedemptions, 1000);
+                await knex.batchInsert('offer_redemptions', offerRedemptions, 100);
             } else {
                 logging.info('No offer redemptions to backfill');
             }


### PR DESCRIPTION
SQLite has limit of 500 items in a compound select statement.

This limit could be hit when a complex select statement was being generated
as part of a batch insert statement.

Lowering the batch size will have minimal impact on migration performance
while improving SQLite compatibility.

One of these bulk inserts is confirmed to be affected through the linked issue.
I did confirm if the other two cases would trigger it, but the change won't hurt there
either.

Ref: https://www.sqlite.org/limits.html
Issue: #19839

