### PR TITLE
Added more specificity to newsletter title line-height

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
@@ -118,10 +118,11 @@ Object {
         <title>Post with email-only card</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -561,7 +562,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -778,7 +779,7 @@ exports[`Email Preview API Read can read post email preview with email card and 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24733",
+  "content-length": "24776",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -810,10 +811,11 @@ Object {
         <title>HTML Ipsum</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1253,7 +1255,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-with-excerpt\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 8px;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">HTML Ipsum</a>
+                                                    <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">HTML Ipsum</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -1492,7 +1494,7 @@ exports[`Email Preview API Read can read post email preview with fields 4: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "29513",
+  "content-length": "29556",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1555,10 +1557,11 @@ Object {
         <title>Post with email-only card</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1998,7 +2001,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -2222,7 +2225,7 @@ exports[`Email Preview API Read has custom content transformations for email com
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24487",
+  "content-length": "24530",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2614,10 +2617,11 @@ Object {
         <title>Post with email-only card</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -3064,7 +3068,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -3295,7 +3299,7 @@ exports[`Email Preview API Read uses the newsletter provided through ?newsletter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "25270",
+  "content-length": "25313",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3713,10 +3717,11 @@ Object {
         <title>Post with email-only card</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -4163,7 +4168,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">Post with email-only card</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -4394,7 +4399,7 @@ exports[`Email Preview API Read uses the posts newsletter by default 4: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "25270",
+  "content-length": "25313",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
@@ -11,10 +11,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -461,7 +462,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -692,10 +693,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1142,7 +1144,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/email/post-uuid/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/email/post-uuid/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -1349,10 +1351,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1799,7 +1802,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-6/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-6/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -2006,10 +2009,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -2456,7 +2460,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-7/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-7/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -2663,10 +2667,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -3268,10 +3273,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -3718,7 +3724,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -3925,10 +3931,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -4375,7 +4382,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -4676,10 +4683,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -5126,7 +5134,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-3/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-3/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -6747,10 +6755,11 @@ Object {
         <title>This is the main post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -7197,7 +7206,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is the main post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is the main post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -7549,10 +7558,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -7999,7 +8009,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-12/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-12/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -8261,10 +8271,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -8711,7 +8722,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-9/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-9/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -8973,10 +8984,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -9423,7 +9435,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-8/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-8/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -9685,10 +9697,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -10135,7 +10148,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-11/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-11/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -10397,10 +10410,11 @@ Object {
         <title>This is a test post title</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -10847,7 +10861,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-10/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
+                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-10/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">This is a test post title</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -11109,10 +11123,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -11559,7 +11574,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -11768,10 +11783,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -12218,7 +12234,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -11,10 +11,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -461,7 +462,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -668,10 +669,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1118,7 +1120,7 @@ table.body h2 span {
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -1325,10 +1327,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -1803,7 +1806,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -2517,10 +2520,11 @@ Object {
         <title>A random test post</title>
         <style>
 .post-title-link {
-  color: #15212A;
   display: block;
-  text-align: center;
   margin-top: 32px;
+  color: #15212A;
+  text-align: center;
+  line-height: 1.1em;
 }
 .post-title-link-left {
   text-align: left;
@@ -2995,7 +2999,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
 
                                             <tr>
                                                 <td class=\\"post-title post-title-no-excerpt post-title-serif\\" style=\\"vertical-align: top; color: #15212A; font-size: 36px; line-height: 1.1em; font-weight: 700; text-align: center; padding-bottom: 16px; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
-                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; color: #15212A; display: block; text-align: center; margin-top: 32px; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; color: #15212A; text-align: center; line-height: 1.1em; overflow-wrap: anywhere;\\" target=\\"_blank\\">A random test post</a>
                                                 </td>
                                             </tr>
                                             <tr>

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -381,11 +381,13 @@ figure blockquote p {
 }
 
 .post-title-link {
-    color: #15212A;
     display: block;
-    text-align: center;
     margin-top: 32px;
+    color: #15212A;
+    text-align: center;
+    line-height: 1.1em;
 }
+
 .post-title-link-left {
     text-align: left;
 }


### PR DESCRIPTION
REF DES-770
- In certain email clients such as Protonmail, the newsletter title line-height was inherited from the `body` rather than the parent `td`. This commit adds line-height to the title link explicitly.