### PR TITLE
Fixed browser tests executing incorrect Stripe CLI

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -196,7 +196,7 @@ if (DASH_DASH_ARGS.includes('comments') || DASH_DASH_ARGS.includes('all')) {
 
 async function handleStripe() {
     if (DASH_DASH_ARGS.includes('stripe') || DASH_DASH_ARGS.includes('all')) {
-        if (DASH_DASH_ARGS.includes('offline')) {
+        if (DASH_DASH_ARGS.includes('offline') || DASH_DASH_ARGS.includes('browser-tests')) {
             return;
         }
 


### PR DESCRIPTION
- we shouldn't try and load the Stripe CLI via the dev script because it's done in the browser tests and involves more setup than the dev script contains
- this cuts 2mins from the browser tests because they're no longer waiting for the Stripe CLI to be auth'd
