### PR TITLE
ActivityPub design improvements

### DIFF
--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -145,7 +145,10 @@ const Profile: React.FC<ProfileProps> = ({}) => {
                         <Heading className='mt-4' level={3}>Building ActivityPub</Heading>
                         <span className='mt-1 text-[1.5rem] text-grey-800'>@index@activitypub.ghost.org</span>
                         <p className='mt-3 text-[1.5rem]'>Ghost is federating over ActivityPub to become part of the world&apos;s largest publishing network</p>
-                        <a className='mt-3 block text-[1.5rem] underline' href='https://activitypub.ghost.org'>activitypub.ghost.org</a>
+                        <span className='mt-3 line-clamp-1 flex'>
+                            <span className={`mr-1 after:content-[":"]`}>Website</span>
+                            <a className='truncate text-[1.5rem] underline' href='https://activitypub.ghost.org'>activitypub.ghost.org</a>
+                        </span>
                         <TabView<'posts' | 'likes' | 'following' | 'followers'> containerClassName='mt-6' selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />
                     </div>
                 </div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -137,6 +137,14 @@ function renderInboxAttachment(object: ObjectProperties) {
     }
 }
 
+function renderTimestamp(object: ObjectProperties) {
+    const timestamp =
+        new Date(object?.published ?? new Date()).toLocaleDateString('default', {year: 'numeric', month: 'short', day: '2-digit'}) + ', ' + new Date(object?.published ?? new Date()).toLocaleTimeString('default', {hour: '2-digit', minute: '2-digit'});
+
+    const date = new Date(object?.published ?? new Date());
+    return (<a className='whitespace-nowrap text-grey-700 hover:underline' href={object.url} title={`${timestamp}`}>{getRelativeTimestamp(date)}</a>);
+}
+
 const FeedItemStats: React.FC<{
     object: ObjectProperties;
     likeCount: number;
@@ -217,6 +225,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
         new Date(object?.published ?? new Date()).toLocaleDateString('default', {year: 'numeric', month: 'short', day: '2-digit'}) + ', ' + new Date(object?.published ?? new Date()).toLocaleTimeString('default', {hour: '2-digit', minute: '2-digit'});
 
     const date = new Date(object?.published ?? new Date());
+
     const [isCopied, setIsCopied] = useState(false);
 
     const onLikeClick = () => {
@@ -291,7 +300,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                             <span className='truncate whitespace-nowrap font-bold' data-test-activity-heading>{author.name}</span>
                                             <span className='ml-1 truncate text-grey-700'>{getUsername(author)}</span>
                                         </div>
-                                        <span className='whitespace-nowrap text-grey-700' title={`${timestamp}`}>{getRelativeTimestamp(date)}</span>
+                                        {renderTimestamp(object)}
                                     </div>
                                 </div>
                             </div>
@@ -338,8 +347,8 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                 {/* <div className='border-1 z-10 -mt-1 flex w-full flex-col items-start justify-between border-b border-b-grey-200 pb-4' data-test-activity> */}
                                 <div className='relative z-10 flex w-full flex-col overflow-visible text-[1.5rem]'>
                                     <div className='flex'>
-                                        <span className='truncate whitespace-nowrap font-bold' data-test-activity-heading>{author.name}</span>
-                                        <span className='whitespace-nowrap text-grey-700 before:mx-1 before:content-["·"]' title={`${timestamp}`}>{getRelativeTimestamp(date)}</span>
+                                        <span className='truncate whitespace-nowrap font-bold after:mx-1 after:font-normal after:text-grey-700 after:content-["·"]' data-test-activity-heading>{author.name}</span>
+                                        {renderTimestamp(object)}
                                     </div>
                                     <div className='flex'>
                                         <span className='truncate text-grey-700'>{getUsername(author)}</span>
@@ -385,11 +394,10 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                             <div className='relative z-10 pt-[3px]'>
                                 <APAvatar author={author}/>
                             </div>
-                            {/* <div className='border-1 z-10 -mt-1 flex w-full flex-col items-start justify-between border-b border-b-grey-200 pb-4' data-test-activity> */}
                             <div className='relative z-10 flex w-full flex-col overflow-visible text-[1.5rem]'>
                                 <div className='flex'>
-                                    <span className='truncate whitespace-nowrap font-bold' data-test-activity-heading>{author.name}</span>
-                                    <span className='whitespace-nowrap text-grey-700 before:mx-1 before:content-["·"]' title={`${timestamp}`}>{getRelativeTimestamp(date)}</span>
+                                    <span className='truncate whitespace-nowrap font-bold after:mx-1 after:font-normal after:text-grey-700 after:content-["·"]' data-test-activity-heading>{author.name}</span>
+                                    {renderTimestamp(object)}
                                 </div>
                                 <div className='flex'>
                                     <span className='truncate text-grey-700'>{getUsername(author)}</span>
@@ -412,7 +420,6 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                     </div>
                                 </div>
                             </div>
-                            {/* </div> */}
                         </div>
                         <div className={`absolute -inset-x-3 -inset-y-0 z-0 rounded transition-colors`}></div>
                         {!last && <div className="absolute bottom-0 left-[18px] top-[6.5rem] z-0 mb-[-13px] w-[2px] rounded-sm bg-grey-200"></div>}

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -185,7 +185,7 @@ const FeedItemStats: React.FC<{
                     handleLikeClick();
                 }}
             />
-            {isLiked && <span className={`text-grey-900`}>{likeCount}</span>}
+            {isLiked && <span className={`text-grey-900`}>{new Intl.NumberFormat().format(likeCount)}</span>}
         </div>
         <div className='flex gap-1'>
             <Button
@@ -201,7 +201,7 @@ const FeedItemStats: React.FC<{
                 }}
             />
             {commentCount > 0 && (
-                <span className={`text-grey-900`}>{commentCount}</span>
+                <span className={`text-grey-900`}>{new Intl.NumberFormat().format(commentCount)}</span>
             )}
         </div>
     </div>);

--- a/apps/admin-x-activitypub/src/styles/index.css
+++ b/apps/admin-x-activitypub/src/styles/index.css
@@ -26,6 +26,7 @@ animation: bump 0.3s ease-in-out;
 
 .ap-note-content a {
   color: rgb(236 72 153) !important;
+  word-break: break-all;
 }
 
 .ap-note-content a:hover {

--- a/apps/admin-x-design-system/src/global/TabView.tsx
+++ b/apps/admin-x-design-system/src/global/TabView.tsx
@@ -50,7 +50,11 @@ export const TabButton: React.FC<TabButtonProps> = ({
         >
             {icon && <Icon className='mb-0.5 mr-1.5 inline' name={icon} size='sm' />}
             {title}
-            {(typeof counter === 'number') && <span className='ml-1.5 rounded-full bg-grey-200 px-1.5 py-[2px] text-xs font-medium text-grey-800 dark:bg-grey-900 dark:text-grey-300'>{counter}</span>}
+            {(typeof counter === 'number') && 
+                <span className='ml-1.5 rounded-full bg-grey-200 px-1.5 py-[2px] text-xs font-medium text-grey-800 dark:bg-grey-900 dark:text-grey-300'>
+                    {new Intl.NumberFormat().format(counter)}
+                </span>
+            }
         </TabsPrimitive.Trigger>
     );
 };


### PR DESCRIPTION
- Linked timestamps to original post URLs for easier navigation
- Added more flexible layout for profile attachments
- Added formatting for numbers in Tab counters and FeedItem stat counters
- Added break-all to links inside Notes to avoid overflows