### PR TITLE
Added sentry logging to local revisions service for localStorage errors

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow/confirm.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow/confirm.js
@@ -95,20 +95,28 @@ export default class PublishFlowOptions extends Component {
             yield this.args.saveTask.perform();
 
             if (this.args.publishOptions.isScheduled) {
-                localStorage.setItem('ghost-last-scheduled-post', JSON.stringify({
-                    id: this.args.publishOptions.post.id,
-                    type: this.args.publishOptions.post.displayName
-                }));
+                try {
+                    localStorage.setItem('ghost-last-scheduled-post', JSON.stringify({
+                        id: this.args.publishOptions.post.id,
+                        type: this.args.publishOptions.post.displayName
+                    }));
+                } catch (e) {
+                    // ignore localStorage errors
+                }
                 if (this.args.publishOptions.post.displayName !== 'page') {
                     this.router.transitionTo('posts');
                 } else {
                     this.router.transitionTo('pages');
                 }
             } else {
-                localStorage.setItem('ghost-last-published-post', JSON.stringify({
-                    id: this.args.publishOptions.post.id,
-                    type: this.args.publishOptions.post.displayName
-                }));
+                try {
+                    localStorage.setItem('ghost-last-published-post', JSON.stringify({
+                        id: this.args.publishOptions.post.id,
+                        type: this.args.publishOptions.post.displayName
+                    }));
+                } catch (e) {
+                    // ignore localStorage errors
+                }
                 if (this.args.publishOptions.post.displayName !== 'page') {
                     if (this.args.publishOptions.post.hasEmail) {
                         this.router.transitionTo('posts.analytics', this.args.publishOptions.post.id);

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -316,15 +316,7 @@ export default class LexicalEditorController extends Controller {
     updateScratch(lexical) {
         const lexicalString = JSON.stringify(lexical);
         this.set('post.lexicalScratch', lexicalString);
-
-        try {
-            // schedule a local revision save
-            if (this.post.status === 'draft') {
-                this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), lexical: lexicalString});
-            }
-        } catch (err) {
-            // ignore errors
-        }
+        this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), lexical: lexicalString});
 
         // save 3 seconds after last edit
         this._autosaveTask.perform();
@@ -340,14 +332,7 @@ export default class LexicalEditorController extends Controller {
     @action
     updateTitleScratch(title) {
         this.set('post.titleScratch', title);
-        try {
-            // schedule a local revision save
-            if (this.post.status === 'draft') {
-                this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), title: title});
-            }
-        } catch (err) {
-            // ignore errors
-        }
+        this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), title: title});
     }
 
     @action

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -316,7 +316,11 @@ export default class LexicalEditorController extends Controller {
     updateScratch(lexical) {
         const lexicalString = JSON.stringify(lexical);
         this.set('post.lexicalScratch', lexicalString);
-        this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), lexical: lexicalString});
+        try {
+            this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), lexical: lexicalString});
+        } catch (e) {
+            // ignore revision save errors
+        }
 
         // save 3 seconds after last edit
         this._autosaveTask.perform();
@@ -332,7 +336,11 @@ export default class LexicalEditorController extends Controller {
     @action
     updateTitleScratch(title) {
         this.set('post.titleScratch', title);
-        this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), title: title});
+        try {
+            this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), title: title});
+        } catch (e) {
+            // ignore revision save errors
+        }
     }
 
     @action

--- a/ghost/admin/app/services/local-revisions.js
+++ b/ghost/admin/app/services/local-revisions.js
@@ -14,6 +14,7 @@ export default class LocalRevisionsService extends Service {
         }
         this.MIN_REVISION_TIME = this.isTesting ? 50 : 60000; // 1 minute in ms
         this.performSave = this.performSave.bind(this);
+        this.storage = window.localStorage;
     }
 
     @service store;
@@ -75,8 +76,8 @@ export default class LocalRevisionsService extends Service {
         try {
             const allKeys = this.keys();
             allKeys.push(key);
-            localStorage.setItem(this._indexKey, JSON.stringify(allKeys));
-            localStorage.setItem(key, JSON.stringify(data));
+            this.storage.setItem(this._indexKey, JSON.stringify(allKeys));
+            this.storage.setItem(key, JSON.stringify(data));
             
             // Apply the filter after saving
             this.filterRevisions(data.id);
@@ -121,7 +122,7 @@ export default class LocalRevisionsService extends Service {
      * @returns {string | null}
      */
     find(key) {
-        return JSON.parse(localStorage.getItem(key));
+        return JSON.parse(this.storage.getItem(key));
     }
 
     /**
@@ -132,7 +133,7 @@ export default class LocalRevisionsService extends Service {
     findAll(prefix = this._prefix) {
         const keys = this.keys(prefix);
         const revisions = keys.map((key) => {
-            const revision = JSON.parse(localStorage.getItem(key));
+            const revision = JSON.parse(this.storage.getItem(key));
             return {
                 key,
                 ...revision
@@ -150,13 +151,13 @@ export default class LocalRevisionsService extends Service {
      * @param {string} key 
      */
     remove(key) {
-        localStorage.removeItem(key);
+        this.storage.removeItem(key);
         const keys = this.keys();
         let index = keys.indexOf(key);
         if (index !== -1) {
             keys.splice(index, 1);
         }
-        localStorage.setItem(this._indexKey, JSON.stringify(keys));
+        this.storage.setItem(this._indexKey, JSON.stringify(keys));
     }
 
     /**
@@ -185,7 +186,7 @@ export default class LocalRevisionsService extends Service {
      * @returns {string[]}
      */
     keys(prefix = undefined) {
-        let keys = JSON.parse(localStorage.getItem(this._indexKey) || '[]');
+        let keys = JSON.parse(this.storage.getItem(this._indexKey) || '[]');
         if (prefix) {
             keys = keys.filter(key => key.startsWith(prefix));
         }

--- a/ghost/admin/app/services/local-revisions.js
+++ b/ghost/admin/app/services/local-revisions.js
@@ -110,7 +110,7 @@ export default class LocalRevisionsService extends Service {
      * @param {object} data - serialized post data
      */
     scheduleSave(type, data) {
-        if (data.status && data.status === 'draft') {
+        if (data && data.status && data.status === 'draft') {
             this.saveTask.perform(type, data);
         }
     }


### PR DESCRIPTION
no issue

- Added Sentry logs to capture how often we are running into `QuotaExceededErrors` when saving local revisions to localStorage, to help in deciding if localStorage is sufficient, or if we need to expand to e.g. IndexedDB.
- Also adds some handling to ignore errors when calling `localStorage.setItem()` elsewhere in the admin app to avoid crashing if localStorage isn't supported or the quota is exceeded.