### PR TITLE
Added version bumping script to repo

### DIFF
--- a/.github/scripts/bump-version.js
+++ b/.github/scripts/bump-version.js
@@ -1,0 +1,43 @@
+const fs = require('fs/promises');
+const exec = require('util').promisify(require('child_process').exec);
+const path = require('path');
+
+const core = require('@actions/core');
+const semver = require('semver');
+
+(async () => {
+    const corePackageJsonPath = path.join(__dirname, '../../ghost/core/package.json');
+    const corePackageJson = require(corePackageJsonPath);
+
+    const current_version = corePackageJson.version;
+    console.log(`Current version: ${current_version}`);
+
+    const firstArg = process.argv[2];
+    console.log('firstArg', firstArg);
+
+    let newVersion;
+
+    if (firstArg === 'canary') {
+        const bumpedVersion = semver.inc(current_version, 'minor');
+        const buildString = await exec('git rev-parse --short HEAD').then(({stdout}) => stdout.trim());
+        newVersion = `${bumpedVersion}-pre-g${buildString}`;
+    } else {
+        const gitVersion = await exec('git describe --long HEAD').then(({stdout}) => stdout.trim().replace(/^v/, ''));
+        newVersion = gitVersion;
+    }
+
+    newVersion += '+moya';
+    console.log('newVersion', newVersion);
+
+    corePackageJson.version = newVersion;
+    await fs.writeFile(corePackageJsonPath, JSON.stringify(corePackageJson, null, 2));
+
+    const adminPackageJsonPath = path.join(__dirname, '../../ghost/admin/package.json');
+    const adminPackageJson = require(adminPackageJsonPath);
+    adminPackageJson.version = newVersion;
+    await fs.writeFile(adminPackageJsonPath, JSON.stringify(adminPackageJson, null, 2));
+
+    console.log('Version bumped to', newVersion);
+
+    core.setOutput('BUILD_VERSION', newVersion);
+})();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,8 +814,7 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run
-        working-directory: ghost/core
+      - run: node .github/scripts/bump-version.js canary
 
       - run: npm pack
         working-directory: ghost/core

--- a/package.json
+++ b/package.json
@@ -111,17 +111,18 @@
     "*.js": "eslint"
   },
   "devDependencies": {
+    "@actions/core": "1.10.1",
     "chalk": "4.1.2",
     "concurrently": "8.2.2",
     "eslint": "8.44.0",
     "eslint-plugin-ghost": "3.4.0",
     "eslint-plugin-react": "7.33.0",
     "husky": "8.0.3",
+    "inquirer": "8.2.6",
     "lint-staged": "15.2.10",
     "nx": "16.8.1",
     "rimraf": "5.0.10",
     "ts-node": "10.9.2",
-    "typescript": "5.4.5",
-    "inquirer": "8.2.6"
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DEV-25/move-version-bumping-logic-into-ghost-repo

- we're slowly migrating our build code into the OSS repo, which means we need to move scripts over
- we have this as a bash script, but I've rewritten it to JS so it's a little more maintainable
- this script will just bump the version in the package.json files and set the GHA output
