### PR TITLE
🐛 Fixed infinite loops in `setFeatureImageCaption` for deleted posts

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -505,7 +505,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     setFeatureImageCaption(html) {
-        if (!this.post.isDestroyed && !this.post.isDestroying || this.post) {
+        if (!this.post.isDestroyed || !this.post.isDestroying) {
             this.post.set('featureImageCaption', html);
         }
     }

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -505,7 +505,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     setFeatureImageCaption(html) {
-        if (!this.post.isDestroyed || !this.post.isDestroying) {
+        if (!this.post.isDestroyed && !this.post.isDestroying || this.post) {
             this.post.set('featureImageCaption', html);
         }
     }

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1170,6 +1170,11 @@ export default class LexicalEditorController extends Controller {
         let hasDirtyAttributes = this.hasDirtyAttributes;
         let state = post.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
 
+        if (state.isDeleted) {
+            // if the post is deleted, we don't need to save it
+            hasDirtyAttributes = false;
+        }
+
         // Check if anything has changed since the last revision
         let postRevisions = post.get('postRevisions').toArray();
         let latestRevision = postRevisions[postRevisions.length - 1];

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -505,7 +505,9 @@ export default class LexicalEditorController extends Controller {
 
     @action
     setFeatureImageCaption(html) {
-        this.post.set('featureImageCaption', html);
+        if (!this.post.isDestroyed || !this.post.isDestroying) {
+            this.post.set('featureImageCaption', html);
+        }
     }
 
     @action

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -17,29 +17,19 @@ describe('Acceptance: Feature Image', function () {
     it('can display feature image with caption', async function () {
         const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});
         await visit(`/editor/post/${post.id}`);
-        expect(find('.gh-editor-feature-image img').src).to.equal('https://static.ghost.org/v4.0.0/images/feature-image.jpg');
-        expect(find('.gh-editor-feature-image-caption').textContent).to.contain('Hello dogggos');
+        expect(await find('.gh-editor-feature-image img').src).to.equal('https://static.ghost.org/v4.0.0/images/feature-image.jpg');
+        expect(await find('.gh-editor-feature-image-caption').textContent).to.contain('Hello dogggos');
     });
 
-    it('can delete a post', async function () {
-        const post = this.server.create('post', {status: 'published'});
-        await visit(`/editor/post/${post.id}`);
-
-        await click('[data-test-psm-trigger]');
-        await click('[data-test-button="delete-post"]');
-
-        await click('[data-test-button="delete-post-confirm"]');
-
-        expect(currentURL()).to.equal('/posts');
-    });
-
-    it('does not attempt to save if already deleted', async function () {
+    it('does not attempt to save if already deleted and goes back to posts', async function () {
+        // avoids an infinite loop when the post is deleted and the save button is clicked, potential race condition
         const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});
         await visit(`/editor/post/${post.id}`);
+        const createdPost = this.server.schema.posts.find(post.id);
 
-        // destroy post
+        // delete created post
 
-        await post.destroy();
+        await createdPost.destroy();
 
         await click('[data-test-psm-trigger]');
         await click('[data-test-button="delete-post"]');

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -25,15 +25,11 @@ describe('Acceptance: Feature Image', function () {
         // avoids an infinite loop when the post is deleted and the save button is clicked, potential race condition
         const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});
         await visit(`/editor/post/${post.id}`);
-        const createdPost = this.server.schema.posts.find(post.id);
 
-        // delete created post
-
-        await createdPost.destroy();
+        this.server.db.posts.update(post.id, {isDeleted: true});
 
         await click('[data-test-psm-trigger]');
         await click('[data-test-button="delete-post"]');
-
         await click('[data-test-button="delete-post-confirm"]');
 
         expect(currentURL()).to.equal('/posts');

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -46,8 +46,6 @@ describe('Acceptance: Feature Image', function () {
 
         await click('[data-test-button="delete-post-confirm"]');
 
-        await this.pauseTest();
-
         expect(currentURL()).to.equal('/posts');
     });
 });

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -1,9 +1,6 @@
 import loginAsRole from '../../helpers/login-as-role';
-import {blur, click, currentURL, fillIn, find, waitFor, waitUntil} from '@ember/test-helpers';
-// import {enableLabsFlag} from '../../helpers/labs-flag';
+import {click, currentURL, find} from '@ember/test-helpers';
 import {expect} from 'chai';
-// import {feature} from '../../../app/services/feature';
-// import {invalidateSession} from 'ember-simple-auth/test-support';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';

--- a/ghost/admin/tests/acceptance/editor/feature-image-test.js
+++ b/ghost/admin/tests/acceptance/editor/feature-image-test.js
@@ -1,0 +1,56 @@
+import loginAsRole from '../../helpers/login-as-role';
+import {blur, click, currentURL, fillIn, find, waitFor, waitUntil} from '@ember/test-helpers';
+// import {enableLabsFlag} from '../../helpers/labs-flag';
+import {expect} from 'chai';
+// import {feature} from '../../../app/services/feature';
+// import {invalidateSession} from 'ember-simple-auth/test-support';
+import {setupApplicationTest} from 'ember-mocha';
+import {setupMirage} from 'ember-cli-mirage/test-support';
+import {visit} from '../../helpers/visit';
+
+describe('Acceptance: Feature Image', function () {
+    let hooks = setupApplicationTest();
+    setupMirage(hooks);
+
+    beforeEach(async function () {
+        this.server.loadFixtures();
+        await loginAsRole('Administrator', this.server);
+    });
+
+    it('can display feature image with caption', async function () {
+        const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});
+        await visit(`/editor/post/${post.id}`);
+        expect(find('.gh-editor-feature-image img').src).to.equal('https://static.ghost.org/v4.0.0/images/feature-image.jpg');
+        expect(find('.gh-editor-feature-image-caption').textContent).to.contain('Hello dogggos');
+    });
+
+    it('can delete a post', async function () {
+        const post = this.server.create('post', {status: 'published'});
+        await visit(`/editor/post/${post.id}`);
+
+        await click('[data-test-psm-trigger]');
+        await click('[data-test-button="delete-post"]');
+
+        await click('[data-test-button="delete-post-confirm"]');
+
+        expect(currentURL()).to.equal('/posts');
+    });
+
+    it('does not attempt to save if already deleted', async function () {
+        const post = this.server.create('post', {status: 'published', featureImage: 'https://static.ghost.org/v4.0.0/images/feature-image.jpg', featureImageCaption: '<span style="white-space: pre-wrap;">Hello dogggos</span>'});
+        await visit(`/editor/post/${post.id}`);
+
+        // destroy post
+
+        await post.destroy();
+
+        await click('[data-test-psm-trigger]');
+        await click('[data-test-button="delete-post"]');
+
+        await click('[data-test-button="delete-post-confirm"]');
+
+        await this.pauseTest();
+
+        expect(currentURL()).to.equal('/posts');
+    });
+});


### PR DESCRIPTION
ref ONC-364

- Adds a condition to check whether the record is deleted or if deleting is in progress before firing the `setFeatureImageCaption`.
- Adds tests. Managed to reproduce the issue using tests.