### PR TITLE
Fixed branch name in canary workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,6 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      - name: Get branch name
-        id: branch_name
-        run: echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
-
       - name: Get metadata (push)
         if: github.event_name == 'push'
         run: |
@@ -183,7 +179,7 @@ jobs:
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
-      branch_name: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+      branch_name: ${{ github.ref_name }}
       is_canary_branch: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/arch') }}
       is_main: ${{ env.IS_MAIN }}
       has_browser_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browser-tests') }}


### PR DESCRIPTION
- `github.ref_name` is a more reliable way to find the branch name than we were previously doing
