### PR TITLE
Added script for unsafe redeploys to tinybird

### DIFF
--- a/ghost/tinybird/scripts/unsafe_redeploy.sh
+++ b/ghost/tinybird/scripts/unsafe_redeploy.sh
@@ -1,0 +1,20 @@
+# Remove our materialized views and their pipes
+tb datasource rm analytics_pages_mv  --yes
+tb datasource rm analytics_sessions_mv  --yes
+tb datasource rm analytics_sources_mv  --yes
+tb pipe rm analytics_pages  --yes
+tb pipe rm analytics_sessions  --yes
+tb pipe rm analytics_sources  --yes
+tb pipe rm analytics_hits  --yes
+
+# Remove all the endpoints
+tb pipe rm pipes/kpis.pipe  --yes
+tb pipe rm pipes/top_browsers.pipe  --yes
+tb pipe rm pipes/top_devices.pipe  --yes
+tb pipe rm pipes/top_locations.pipe  --yes
+tb pipe rm pipes/top_pages.pipe  --yes
+tb pipe rm pipes/top_sources.pipe  --yes
+tb pipe rm pipes/trend.pipe  --yes
+
+# Push all the changes
+tb push --only-changes --force --populate


### PR DESCRIPTION
- Whilst we are in development, we can safely make changes to all aspects of our pipeline without worrying
- This is because currently, it's safe to delete all data and start over
- This script removes everything excepts the analytics_events datasource, and then recreates everything fresh, repopulating from the datasource where possible
- This shouldn't be used after tinybird is in production, we need a better change process


