### PR TITLE
Renamed referrer without www to source in tinybird

### DIFF
--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -53,7 +53,7 @@ export default class TopSources extends Component {
                 meta={meta}
                 error={error}
                 loading={loading}
-                index="referrer"
+                index="source"
                 indexConfig={{
                     label: <span className="gh-stats-detail-header">Source</span>,
                     renderBarContent: ({label}) => (

--- a/ghost/admin/app/components/stats/modal-stats-all.js
+++ b/ghost/admin/app/components/stats/modal-stats-all.js
@@ -50,7 +50,7 @@ export default class AllStatsModal extends Component {
         case 'top-sources':
             endpoint = `${this.config.stats.endpoint}/v0/pipes/top_sources.json`;
             labelText = 'Source';
-            indexBy = 'referrer';
+            indexBy = 'source';
             unknownOption = 'Direct';
             break;
         case 'top-locations':

--- a/ghost/tinybird/datasources/analytics_sources_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_sources_mv.datasource
@@ -4,11 +4,11 @@ SCHEMA >
     `device` String,
     `browser` String,
     `location` String,
-    `referrer` String,
+    `source` String,
     `member_status` SimpleAggregateFunction(any, String),
     `visits` AggregateFunction(uniq, String),
     `hits` AggregateFunction(count)
 
 ENGINE AggregatingMergeTree
 ENGINE_PARTITION_KEY toYYYYMM(date)
-ENGINE_SORTING_KEY date, device, browser, location, referrer, site_uuid
+ENGINE_SORTING_KEY date, device, browser, location, source, site_uuid

--- a/ghost/tinybird/pipes/analytics_hits.pipe
+++ b/ghost/tinybird/pipes/analytics_hits.pipe
@@ -39,7 +39,7 @@ SQL >
         member_status,
         post_uuid,
         location,
-        referrer,
+        domainWithoutWWW(referrer) as source,
         pathname,
         href,
         case

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -10,7 +10,7 @@ SQL >
         device,
         browser,
         location,
-        referrer,
+        source,
         maxIf(
             member_status,
             member_status IN ('paid', 'free', 'undefined')
@@ -18,8 +18,8 @@ SQL >
         uniqState(session_id) AS visits,
         countState() AS hits
     FROM analytics_hits
-    WHERE domainWithoutWWW(referrer) != current_domain
-    GROUP BY date, device, browser, location, referrer, site_uuid
+    WHERE source != current_domain
+    GROUP BY date, device, browser, location, source, site_uuid
 
 TYPE MATERIALIZED
 DATASOURCE analytics_sources_mv

--- a/ghost/tinybird/pipes/top_sources.pipe
+++ b/ghost/tinybird/pipes/top_sources.pipe
@@ -9,11 +9,11 @@ TOKEN "stats page" READ
 
 NODE endpoint
 DESCRIPTION >
-    Group by referral and calculate hits and visits
+    Group by source and calculate hits and visits
 
 SQL >
     %
-    select domainWithoutWWW(referrer) as referrer, uniqMerge(visits) as visits, countMerge(hits) as hits
+    select source, uniqMerge(visits) as visits, countMerge(hits) as hits
     from analytics_sources_mv
     where
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
@@ -33,6 +33,6 @@ SQL >
             {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
         {% else %} and date <= today()
         {% end %}
-    group by referrer
+    group by source
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ANAL-60/click-through-filtering-for-sources

- In our stats page we use the referrer without a protocol or www, that is the pure domain as our source that we output
- Meanwhile all the data pipelines had the full url as the referrer passed through
- When we come to add clickthroughs/filtering, we'll need to use this value to filter the data. If we have a different value locally in the UI to what is in the DB, we won't be able to make the filters match
- Also, we pay for everything we store, and this removes all the https:// and www. data

