### PR TITLE
Fixed versioning and npm visibility for internal apps

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,10 +14,7 @@
   ],
   "main": "./dist/admin-x-activitypub.umd.cjs",
   "module": "./dist/admin-x-activitypub.js",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
+  "private": true,
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",

--- a/apps/admin-x-demo/package.json
+++ b/apps/admin-x-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-demo",
-  "version": "0.0.20",
+  "version": "0.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,10 +14,7 @@
   ],
   "main": "./dist/admin-x-demo.umd.cjs",
   "module": "./dist/admin-x-demo.js",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
+  "private": true,
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-settings",
-  "version": "0.0.20",
+  "version": "0.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -20,10 +20,7 @@
       "require": "./dist/admin-x-settings.umd.cjs"
     }
   },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
+  "private": true,
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",


### PR DESCRIPTION
- these apps don't need to be published because they're internal and get compiled into Admin
- therefore, we can reset their versions back to 0.0.0 and remove the publishConfig block so we don't accidentally publish them
