### PR TITLE
Increased parallelisation of Nx processes

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,7 @@
     "namedInputs": {
         "default": ["{projectRoot}/**/*", "{workspaceRoot}/ghost/tsconfig.json"]
     },
+    "parallel": 4,
     "targetDefaults": {
         "build": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
refs https://nx.dev/recipes/running-tasks/run-tasks-in-parallel

- CI has 4 cores and our local machines are also very powerful, so we can just set the default parallelisation to higher than is currently set to make things run quicker