### PR TITLE
Fixed flaky member expertise test

### DIFF
--- a/apps/comments-ui/test/e2e/actions.test.ts
+++ b/apps/comments-ui/test/e2e/actions.test.ts
@@ -143,6 +143,11 @@ test.describe('Actions', async () => {
 
         await expect(profileModal).not.toBeVisible();
 
+        // playwright can lose focus on the editor which hides the member details,
+        // re-clicking here brings the member details back into view
+        await editor.click({force: true});
+        await waitEditorFocused(editor);
+
         await expect(frame.getByTestId('member-name')).toHaveText('Testy McTest');
         await expect(frame.getByTestId('expertise-button')).toHaveText('·Software development');
     });


### PR DESCRIPTION
no issue

- a change in browser version/dependency versions/playwright/something else has made this test flaky because the reply editor form loses focus when the expertise field gains focus (this doesn't happen in the browser) meaning when we get to our assertions the elements we care about are missing
- forcing focus back puts us into a known state for our assertions
