### PR TITLE
Moved importer require into describe block in importer integration tests

### DIFF
--- a/ghost/core/test/integration/importer/legacy.test.js
+++ b/ghost/core/test/integration/importer/legacy.test.js
@@ -1,8 +1,4 @@
 const testUtils = require('../../utils');
-const importer = require('../../../core/server/data/importer');
-const dataImporter = importer.importers.find((instance) => {
-    return instance.type === 'data';
-});
 
 const {exportedBodyLegacy} = require('../../utils/fixtures/export/body-generator');
 
@@ -11,6 +7,13 @@ const importOptions = {
 };
 
 describe('Importer Legacy', function () {
+    let dataImporter;
+    before(function () {
+        const importer = require('../../../core/server/data/importer');
+        dataImporter = importer.importers.find((instance) => {
+            return instance.type === 'data';
+        });
+    });
     beforeEach(testUtils.teardownDb);
     beforeEach(testUtils.setup('roles', 'owner'));
 

--- a/ghost/core/test/integration/importer/v1.test.js
+++ b/ghost/core/test/integration/importer/v1.test.js
@@ -2,16 +2,19 @@ const testUtils = require('../../utils');
 const {exportedBodyV1} = require('../../utils/fixtures/export/body-generator');
 
 const models = require('../../../core/server/models');
-const importer = require('../../../core/server/data/importer');
-const dataImporter = importer.importers.find((instance) => {
-    return instance.type === 'data';
-});
 
 const importOptions = {
     returnImportedData: true
 };
 
 describe('Importer 1.0', function () {
+    let dataImporter;
+    before(function () {
+        const importer = require('../../../core/server/data/importer');
+        dataImporter = importer.importers.find((instance) => {
+            return instance.type === 'data';
+        });
+    });
     beforeEach(testUtils.teardownDb);
     beforeEach(testUtils.setup('roles', 'owner'));
 

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -11,10 +11,6 @@ const validator = require('@tryghost/validator');
 const db = require('../../../core/server/data/db');
 
 const models = require('../../../core/server/models');
-const importer = require('../../../core/server/data/importer');
-const dataImporter = importer.importers.find((instance) => {
-    return instance.type === 'data';
-});
 
 const importOptions = {
     returnImportedData: true
@@ -26,6 +22,13 @@ const {exportedBodyV2} = require('../../utils/fixtures/export/body-generator');
 
 // Tests in here do an import for each test
 describe('Importer', function () {
+    let dataImporter, importer;
+    before(function () {
+        importer = require('../../../core/server/data/importer');
+        dataImporter = importer.importers.find((instance) => {
+            return instance.type === 'data';
+        });
+    });
     before(testUtils.teardownDb);
 
     beforeEach(function () {


### PR DESCRIPTION
The jobService was being instantiated prior to the models being initiated, through a chain of `require()`s in the importer integration tests. When we required the jobService in our `job-queue` tests, we were getting this version of the jobService, with the JobModel being undefined.

These `require()` are running before the `job-queue` tests, because Mocha seems to load all the test files before running any of them — since the `require()` are a the top level, they were running and instantiating the corrupted jobService before we had a chance to initialize the models. This change moves the `require()`s in the importer integration tests into the `describe` block, so they will only run within the scope of the tests that need them.