### PR TITLE
Added createJobManager factory function to use in tests

### DIFF
--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -43,7 +43,13 @@ const initTestMode = () => {
     }, 5000);
 };
 
-const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config});
+function createJobManager() {
+    return new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config});
+}
+
+const jobManager = createJobManager();
 
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;
+module.exports.createJobManager = createJobManager; // export for testing
+

--- a/ghost/core/test/integration/jobs/job-queue.test.js
+++ b/ghost/core/test/integration/jobs/job-queue.test.js
@@ -3,6 +3,7 @@ const path = require('path');
 const configUtils = require('../../utils/configUtils');
 const models = require('../../../core/server/models');
 const testUtils = require('../../utils/');
+const {createJobManager} = require('../../../core/server/services/jobs/job-service');
 
 // Helper function to wait for job completion
 async function waitForJobCompletion(jobName, maxWaitTimeMs = 5000, checkIntervalMs = 50) {
@@ -33,7 +34,7 @@ describe('Job Queue', function () {
     describe('enabled by config', function () {
         beforeEach(async function () {
             configUtils.set('services:jobs:queue:enabled', true);
-            jobService = require('../../../core/server/services/jobs/job-service');
+            jobService = createJobManager();
         });
 
         it('should add and execute a job in the queue', async function () {


### PR DESCRIPTION
Since the `jobService` singleton is required in other integration tests, we aren't getting a `clean` version of it in our Job Queue integration tests. This commit adds a `createJobManager` factory function which returns the `jobService` with all the same arguments that are currently used, and exports it for use in tests. This was we can always get a clean instance of the `jobService` in our integration tests, without it being potentially polluted by other test files.