### PR TITLE
Admin X activitypub app independent release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,3 +965,63 @@ jobs:
           inputs: '{"version":"canary","environment":"staging","version_extra":"${{ needs.job_setup.outputs.branch_name }}"}'
           wait-for-completion-timeout: 25m
           wait-for-completion-interval: 30s
+
+  publish_admin_x_activitypub:
+    needs: [
+      job_setup,
+      job_lint,
+      job_unit-tests
+    ]
+    name: Publish @tryghost/admin-x-activitypub
+    runs-on: ubuntu-latest
+    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.12.1'
+
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
+
+      - name: Build the package
+        run: yarn run nx build @tryghost/admin-x-activitypub
+
+      - name: Check if version changed
+        id: version_check
+        working-directory: apps/admin-x-activitypub
+        run: |
+          CURRENT_VERSION=$(cat package.json | jq -r .version)
+          PUBLISHED_VERSION=$(npm show @tryghost/admin-x-activitypub version || echo "0.0.0")
+          echo "Current version: $CURRENT_VERSION"
+          echo "Published version: $PUBLISHED_VERSION"
+          if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Version is unchanged."
+            echo "version_changed=false" >> $GITHUB_ENV
+          else
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_ENV
+          fi
+
+      - name: Configure .npmrc
+        run: |
+          echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+
+      - name: Publish to npm
+        if: env.version_changed == 'true'
+        working-directory: apps/admin-x-activitypub
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Purge jsdelivr cache
+        uses: gacts/purge-jsdelivr-cache@v1
+        with:
+          url: |
+            https://cdn.jsdelivr.net/npm/@tryghost/admin-x-activitypub@0/dist/admin-x-activitypub.js

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "./dist/admin-x-activitypub.umd.cjs",
   "module": "./dist/admin-x-activitypub.js",
-  "private": true,
+  "private": false,
   "scripts": {
     "dev": "vite build --watch",
     "dev:start": "vite",

--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -58,7 +58,12 @@ export const importComponent = async (packageName) => {
     }
 
     const baseUrl = (config.cdnUrl ? `${config.cdnUrl}assets/` : ghostPaths().assetRootWithHost);
-    const url = new URL(`${baseUrl}${relativePath}/${config[`${configKey}Filename`]}?v=${config[`${configKey}Hash`]}`);
+    let url = new URL(`${baseUrl}${relativePath}/${config[`${configKey}Filename`]}?v=${config[`${configKey}Hash`]}`);
+
+    const customUrl = config[`${configKey}CustomUrl`];
+    if (customUrl) {
+        url = new URL(customUrl);
+    }
 
     if (url.protocol === 'http:') {
         window[packageName] = await import(`http://${url.host}${url.pathname}${url.search}`);

--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -43,6 +43,8 @@ module.exports = {
                 for (const [key, value] of Object.entries(this.packageConfig)) {
                     console.log(`Asset-Delivery: ${key} = ${value}`);
                 }
+
+                this.packageConfig[`adminXActivitypubCustomUrl`] = 'https://cdn.jsdelivr.net/npm/@tryghost/admin-x-activitypub@0/dist/admin-x-activitypub.js'
             }
 
             return this.packageConfig;


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/AP-438

We want to have continuous deployment (or thereabouts) for the activitypub frontend, and to do that we're going to load it from the jsdelivr cdn, and deploy via npm package updates.