### PR TITLE
Updated stats page to show visits instead of hits

### DIFF
--- a/ghost/admin/app/components/stats/charts/technical.js
+++ b/ghost/admin/app/components/stats/charts/technical.js
@@ -60,7 +60,7 @@ export default class TechnicalComponent extends Component {
 
         const transformedData = (data ?? []).map((item, index) => ({
             name: item[indexBy].charAt(0).toUpperCase() + item[indexBy].slice(1),
-            value: item.hits,
+            value: item.visits,
             color: colorPalette[index]
         }));
 
@@ -101,7 +101,7 @@ export default class TechnicalComponent extends Component {
                         loading={loading}
                         error={error}
                         index={indexBy}
-                        categories={['hits']}
+                        categories={['visits']}
                         colorPalette={colorPalette}
                         backgroundColor="transparent"
                         fontSize="13px"

--- a/ghost/admin/app/components/stats/charts/top-locations.js
+++ b/ghost/admin/app/components/stats/charts/top-locations.js
@@ -73,9 +73,9 @@ export default class TopLocations extends Component {
                         </span>
                     )
                 }}
-                categories={['hits']}
+                categories={['visits']}
                 categoryConfig={{
-                    hits: {
+                    visits: {
                         label: <span className="gh-stats-data-header">Visits</span>,
                         renderValue: ({value}) => <span className="gh-stats-data-value">{formatNumber(value)}</span>
                     }

--- a/ghost/admin/app/components/stats/charts/top-pages.js
+++ b/ghost/admin/app/components/stats/charts/top-pages.js
@@ -82,9 +82,9 @@ export default class TopPages extends Component {
                         </span>
                     )
                 }}
-                categories={['hits']}
+                categories={['visits']}
                 categoryConfig={{
-                    hits: {
+                    visits: {
                         label: <span className="gh-stats-data-header">Visits</span>,
                         renderValue: ({value}) => <span className="gh-stats-data-value">{formatNumber(value)}</span>
                     }

--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -81,9 +81,9 @@ export default class TopSources extends Component {
                         </span>
                     )
                 }}
-                categories={['hits']}
+                categories={['visits']}
                 categoryConfig={{
-                    hits: {
+                    visits: {
                         label: <span className="gh-stats-data-header">Visits</span>,
                         renderValue: ({value}) => <span className="gh-stats-data-value">{formatNumber(value)}</span>
                     }

--- a/ghost/admin/app/components/stats/modal-stats-all.js
+++ b/ghost/admin/app/components/stats/modal-stats-all.js
@@ -126,9 +126,9 @@ export default class AllStatsModal extends Component {
                         </span>
                     )
                 }}
-                categories={['hits']}
+                categories={['visits']}
                 categoryConfig={{
-                    hits: {
+                    visits: {
                         label: <span className="gh-stats-data-header">Visits</span>,
                         renderValue: ({value}) => <span className="gh-stats-data-value">{formatNumber(value)}</span>
                     }


### PR DESCRIPTION
closes: https://linear.app/tryghost/issue/ANAL-102/visits-on-tables-is-actually-displaying-pageviews

- The expectation is that the UI shows unique visits, not pageviews for the breakdown charts

