### PR TITLE
Fixed tests failing with native stack traces due to blob.slice() calls

### DIFF
--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -342,7 +342,7 @@ describe('Images API', function () {
         const brokenPayload = '--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"example.png\"\r\nContent-Type: image/png\r\n\r\n';
 
         // eslint-disable-next-line no-undef
-        const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, blob.size / 2)], {
+        const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, Math.floor(blob.size / 2))], {
             type: 'multipart/form-data; boundary=boundary'
         })).text();
 
@@ -367,7 +367,7 @@ describe('Images API', function () {
         const brokenPayload = '--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"example.png\"\r\nContent-Type: image/png\r\n';
 
         // eslint-disable-next-line no-undef
-        const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, blob.size / 2)], {
+        const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, Math.floor(blob.size / 2))], {
             type: 'multipart/form-data; boundary=boundary'
         })).text();
 

--- a/ghost/core/test/e2e-api/admin/media.test.js
+++ b/ghost/core/test/e2e-api/admin/media.test.js
@@ -140,7 +140,7 @@ describe('Media API', function () {
             const brokenPayload = '--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"example.png\"\r\nContent-Type: image/png\r\n\r\n';
 
             // eslint-disable-next-line no-undef
-            const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, blob.size / 2)], {
+            const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, Math.floor(blob.size / 2))], {
                 type: 'multipart/form-data; boundary=boundary'
             })).text();
 
@@ -164,7 +164,7 @@ describe('Media API', function () {
             const brokenPayload = '--boundary\r\nContent-Disposition: form-data; name=\"image\"; filename=\"example.png\"\r\nContent-Type: image/png\r\n';
 
             // eslint-disable-next-line no-undef
-            const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, blob.size / 2)], {
+            const brokenDataBlob = await (new Blob([brokenPayload, blob.slice(0, Math.floor(blob.size / 2))], {
                 type: 'multipart/form-data; boundary=boundary'
             })).text();
 


### PR DESCRIPTION
no issue

Either a node or macOS update resulted in our broken image upload tests causing native stack traces:

```
  #  /Users/kevin/.nvm/versions/node/v20.16.0/bin/node[8841]: static void node::Blob::ToSlice(const FunctionCallbackInfo<v8::Value> &) at ../src/node_blob.cc:248
  #  Assertion failed: args[1]->IsUint32()
```

- updated our `blob.slice()` calls to ensure the second argument is always an integer rather than possibly a float
