### PR TITLE
Added missing if-statement to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1055,6 +1055,7 @@ jobs:
         run: npm publish --access public
 
       - name: Purge jsdelivr cache
+        if: env.version_changed == 'true'
         uses: gacts/purge-jsdelivr-cache@v1
         with:
           url: |


### PR DESCRIPTION
- without this, we're constantly purging the cache, which exceeds the rate limit afforded to us from jsdelivr