### PR TITLE
Fixed looking up users with special username characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "Looking up: ${{ github.event.pull_request.user.login }}"
+          ENCODED_USERNAME=$(printf '%s' '${{ github.event.pull_request.user.login }}' | jq -sRr @uri)
 
-          LOOKUP_USER=$(curl --write-out "%{http_code}" --silent --output /dev/null --location 'https://api.github.com/orgs/tryghost/members/${{ github.event.pull_request.user.login }}' --header 'Authorization: Bearer ${{ secrets.CANARY_DOCKER_BUILD }}')
+          LOOKUP_USER=$(curl --write-out "%{http_code}" --silent --output /dev/null --location "https://api.github.com/orgs/tryghost/members/$ENCODED_USERNAME" --header "Authorization: Bearer ${{ secrets.CANARY_DOCKER_BUILD }}")
 
           if [ "$LOOKUP_USER" == "204" ]; then
             echo "User is in the org"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,7 @@ on:
   push:
     branches:
       - main
-      - arch
       - 'v5.*'
-      - 3.x
-      - 2.x
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
- users like `renovate[bot]` have brackets in the username
- this breaks the command and it exits with `exit code 3.`
- to fix this, we can encode the username before passing it in