### PR TITLE
Bumped CI `fetch-depth` to 1000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 100
+          fetch-depth: 1000
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0
@@ -432,7 +432,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 100
+          fetch-depth: 1000
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1727704490753759

- if you open a PR and it becomes outdated enough such that the base commit was 100 commits ago, the workflow starts to fail
- to help prevent this, we can increase it by 1000, which should more than cover enough use-cases but still keep checkout quick