### PR TITLE
Added beforeunload debug log to editor

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1112,13 +1112,12 @@ export default class LexicalEditorController extends Controller {
 
         // triggered any time the admin tab is closed, we need to use a native
         // dialog here instead of our custom modal
-        window.onbeforeunload = () => {
+        window.onbeforeunload = (event) => {
             if (this.hasDirtyAttributes) {
-                return '==============================\n\n'
-                     + 'Hey there! It looks like you\'re in the middle of writing'
-                     + ' something and you haven\'t saved all of your content.'
-                     + '\n\nSave before you go!\n\n'
-                     + '==============================';
+                console.log('Preventing unload due to hasDirtyAttributes'); // eslint-disable-line
+                event.preventDefault();
+                // Included for legacy support, e.g. Chrome/Edge < 119
+                event.returnValue = true;
             }
         };
     }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-323

- we're sometimes seeing our force-refresh failing when Ember Data gets into a bad state but we're not sure why so this log should tell us if it's the browser's native "leave site" modal that is preventing the refresh
- updated the `onbeforeunload` event handler to match modern JS approach
  - modern browsers use `event.preventDefault()` to show their dialog
  - older browsers use `event.returnValue = true` (this is what our old string return was triggering)
  - no browser supports a custom message in the native dialog
