### PR TITLE
Extracted `createStripeCustomerSubscription` method from `linkSubscription`

### DIFF
--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -896,7 +896,6 @@ module.exports = class MemberRepository {
      * @returns
      */
     async linkSubscription(data, options = {}) {
-        let dispatchedEvents = {};
         if (!this._stripeAPIService.configured) {
             throw new errors.BadRequestError({message: tpl(messages.noStripeConnection, {action: 'link Stripe Subscription'})});
         }
@@ -1161,9 +1160,7 @@ module.exports = class MemberRepository {
                 }
             }
         } else {
-            const {subscriptionModel, subscriptionCreatedPayload, source} = await this.createStripeSubscriptionThenFireSubscriptionCreated(eventData, subscription, subscriptionData, options, member, subscriptionPriceData, ghostProduct, offerId, data);
-
-            dispatchedEvents.SubscriptionCreated = subscriptionCreatedPayload;
+            const {subscriptionModel, source} = await this.createStripeSubscriptionThenFireSubscriptionCreated(eventData, subscription, subscriptionData, options, member, subscriptionPriceData, ghostProduct, offerId, data);
 
             if (offerId) {
                 const offerRedemptionEvent = OfferRedemptionEvent.create({
@@ -1328,7 +1325,6 @@ module.exports = class MemberRepository {
                 ...eventData
             }, options);
         }
-        return dispatchedEvents;
     }
 
     async createStripeSubscriptionThenFireSubscriptionCreated(eventData, subscription, subscriptionData, options, member, subscriptionPriceData, ghostProduct, offerId, data) {
@@ -1361,7 +1357,7 @@ module.exports = class MemberRepository {
         const subscriptionCreatedEvent = SubscriptionCreatedEvent.create(subscriptionCreatedPayload);
 
         this.dispatchEvent(subscriptionCreatedEvent, options);
-        return {subscriptionModel,subscriptionCreatedPayload, source};
+        return {subscriptionModel, source};
     }
 
     getCancellationReason(subscription) {

--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -1343,10 +1343,10 @@ module.exports = class MemberRepository {
         }, options);
 
         const context = options?.context || {};
-        const source = this._resolveContextSource(context);
+        const subscriptionCreatedEventSource = this._resolveContextSource(context);
 
         const subscriptionCreatedPayload = {
-            source,
+            source: subscriptionCreatedEventSource,
             tierId: ghostProduct?.get('id'),
             memberId: member.id,
             subscriptionId: subscriptionModel.get('id'),
@@ -1357,7 +1357,7 @@ module.exports = class MemberRepository {
         const subscriptionCreatedEvent = SubscriptionCreatedEvent.create(subscriptionCreatedPayload);
 
         this.dispatchEvent(subscriptionCreatedEvent, options);
-        return {subscriptionModel, source};
+        return {subscriptionModel, source: subscriptionCreatedEventSource};
     }
 
     getCancellationReason(subscription) {

--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -1162,7 +1162,7 @@ module.exports = class MemberRepository {
         } else {
             const context = options?.context || {};
             const source = this._resolveContextSource(context);
-            const subscriptionModel = await this.createStripeSubscriptionThenFireSubscriptionCreated(eventData, subscription, subscriptionData, source, options, member, subscriptionPriceData, ghostProduct, offerId, data);
+            const subscriptionModel = await this.createStripeCustomerSubscription(eventData, subscription, subscriptionData, source, options, member, subscriptionPriceData, ghostProduct, offerId, data);
 
             if (offerId) {
                 const offerRedemptionEvent = OfferRedemptionEvent.create({
@@ -1329,7 +1329,7 @@ module.exports = class MemberRepository {
         }
     }
 
-    async createStripeSubscriptionThenFireSubscriptionCreated(eventData, subscription, subscriptionData, subscriptionCreatedEventSource, options, member, subscriptionPriceData, ghostProduct, offerId, data) {
+    async createStripeCustomerSubscription(eventData, subscription, subscriptionData, subscriptionCreatedEventSource, options, member, subscriptionPriceData, ghostProduct, offerId, data) {
         eventData.created_at = new Date(subscription.start_date * 1000);
         const subscriptionModel = await this._StripeCustomerSubscription.add(subscriptionData, options);
         await this._MemberPaidSubscriptionEvent.add({

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -350,7 +350,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
-            const subscriptionCreatedSpy = sinon.spy(repo, 'createStripeSubscriptionThenFireSubscriptionCreated');
+            const subscriptionCreatedSpy = sinon.spy(repo, 'createStripeCustomerSubscription');
 
             await repo.linkSubscription({
                 subscription: subscriptionData

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -354,7 +354,7 @@ describe('MemberRepository', function () {
             DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
             DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
 
-            const result = await repo.linkSubscription({
+            await repo.linkSubscription({
                 subscription: subscriptionData
             }, {
                 transacting: {
@@ -365,7 +365,6 @@ describe('MemberRepository', function () {
 
             subscriptionCreatedNotifySpy.calledOnce.should.be.true();
             offerRedemptionNotifySpy.called.should.be.false();
-            Object.keys(result).should.deepEqual(['SubscriptionCreated']);
         });
 
         it('dispatches the offer redemption event for a new member starting a subscription', async function (){

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -337,7 +337,7 @@ describe('MemberRepository', function () {
             };
         });
 
-        it('dispatches paid subscription event', async function (){
+        it('adds new Stripe subscription for member', async function (){
             const repo = new MemberRepository({
                 stripeAPIService,
                 StripeCustomerSubscription,
@@ -352,9 +352,6 @@ describe('MemberRepository', function () {
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
             const subscriptionCreatedSpy = sinon.spy(repo, 'createStripeSubscriptionThenFireSubscriptionCreated');
 
-            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
-            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
-
             await repo.linkSubscription({
                 subscription: subscriptionData
             }, {
@@ -363,9 +360,6 @@ describe('MemberRepository', function () {
                 },
                 context: {}
             });
-
-            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
-            offerRedemptionNotifySpy.called.should.be.false();
 
             subscriptionCreatedSpy.calledOnce.should.be.true();
         });

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -350,6 +350,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+            const subscriptionCreatedSpy = sinon.spy(repo, 'createStripeSubscriptionThenFireSubscriptionCreated');
 
             DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
             DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
@@ -365,6 +366,8 @@ describe('MemberRepository', function () {
 
             subscriptionCreatedNotifySpy.calledOnce.should.be.true();
             offerRedemptionNotifySpy.called.should.be.false();
+
+            subscriptionCreatedSpy.calledOnce.should.be.true();
         });
 
         it('dispatches the offer redemption event for a new member starting a subscription', async function (){

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -351,6 +351,9 @@ describe('MemberRepository', function () {
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
 
+            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
+            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
+
             const result = await repo.linkSubscription({
                 subscription: subscriptionData
             }, {
@@ -360,6 +363,8 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
+            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
+            offerRedemptionNotifySpy.called.should.be.false();
             Object.keys(result).should.deepEqual(['SubscriptionCreated']);
         });
 

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -351,10 +351,7 @@ describe('MemberRepository', function () {
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
 
-            DomainEvents.subscribe(SubscriptionCreatedEvent, subscriptionCreatedNotifySpy);
-            DomainEvents.subscribe(OfferRedemptionEvent, offerRedemptionNotifySpy);
-
-            await repo.linkSubscription({
+            const result = await repo.linkSubscription({
                 subscription: subscriptionData
             }, {
                 transacting: {
@@ -363,8 +360,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
-            offerRedemptionNotifySpy.called.should.be.false();
+            Object.keys(result).should.deepEqual(['SubscriptionCreated']);
         });
 
         it('dispatches the offer redemption event for a new member starting a subscription', async function (){


### PR DESCRIPTION
no issue

The `MemberRepository` in the members-api has a really long and complex `linkSubscription` method, which updates a member's internal subscription state in response to Stripe webhooks, member imports, etc. This change is a first step toward making this method more testable, by breaking it up into smaller methods and beginning to separate the concerns of 'calculating what should change' and 'actually changing it'.