### PR TITLE
Fix German translation for "Sign up" in comments

### DIFF
--- a/ghost/i18n/locales/de/comments.json
+++ b/ghost/i18n/locales/de/comments.json
@@ -61,7 +61,7 @@
     "Show 1 previous comment": "1 vorherigen Kommentar anzeigen",
     "Show comment": "Kommentar anzeigen",
     "Sign in": "Anmelden",
-    "Sign up now": "Jetzt anmelden",
+    "Sign up now": "Jetzt registrieren",
     "Start the conversation": "Beginne das Gespräch",
     "This comment has been hidden.": "Dieser Kommentar wurde ausgeblendet.",
     "This comment has been removed.": "Dieser Kommentar wurde entfernt.",

--- a/ghost/i18n/locales/de/comments.json
+++ b/ghost/i18n/locales/de/comments.json
@@ -60,7 +60,7 @@
     "Show 1 more reply": "1 weitere Antwort anzeigen",
     "Show 1 previous comment": "1 vorherigen Kommentar anzeigen",
     "Show comment": "Kommentar anzeigen",
-    "Sign in": "Anmelden",
+    "Sign in": "Einloggen",
     "Sign up now": "Jetzt registrieren",
     "Start the conversation": "Beginne das Gespräch",
     "This comment has been hidden.": "Dieser Kommentar wurde ausgeblendet.",


### PR DESCRIPTION
- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

This PR corrects a single translation. The German translations for "sign up" and "sign in" _can_ both be "anmelden", but are confusing when used together. So here we're switch to "register now" and "sign in" to make the distinction clearer. IMHO even in English "register now" and "sign in" might be a better (more distinguishable) combination, but it's much harsher in German. 

Fixes #21104.
