### PR TITLE
🐛 Fixed errors creating new posts after a post access change via context menu

### DIFF
--- a/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
+++ b/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
@@ -1,15 +1,23 @@
 import Component from '@glimmer/component';
+import EmberObject from '@ember/object';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
+const PostValidatorProxy = EmberObject.extend(ValidationEngine, {
+    validationType: 'post',
+    isNew: false // required for our visibility and tiers validations to work
+});
+
 export default class EditPostsAccessModal extends Component {
     @service store;
     @service settings;
 
-    // We createa new post model to use the same validations as the post model
-    @tracked post = this.store.createRecord('post', {});
+    // We use a simulated post model to use the same validations as the post model without
+    // putting any dummy records in the store and needing to force an "isNew: false" state
+    @tracked post = PostValidatorProxy.create();
 
     get selectionList() {
         return this.args.data.selectionList;
@@ -18,29 +26,27 @@ export default class EditPostsAccessModal extends Component {
     @action
     setup() {
         if (this.selectionList.first && this.selectionList.isSingle) {
-            this.post.set('visibility', this.selectionList.first.visibility);
-            this.post.set('tiers', this.selectionList.first.tiers);
+            this.post.visibility = this.selectionList.first.visibility;
+            this.post.tiers = this.selectionList.first.tiers;
         } else {
             // Use default
-            this.post.set('visibility', this.settings.defaultContentVisibility);
-            this.post.set('tiers', this.settings.defaultContentVisibilityTiers.map((tier) => {
+            this.post.visibility = this.settings.defaultContentVisibility;
+            this.post.tiers = this.settings.defaultContentVisibilityTiers.map((tier) => {
                 return {
                     id: tier
                 };
-            }));
+            });
         }
     }
 
     async validate() {
-        // Mark as not new
-        this.post.set('currentState.parentState.isNew', false);
         await this.post.validate({property: 'visibility'});
         await this.post.validate({property: 'tiers'});
     }
 
     @action
     async setVisibility(segment) {
-        this.post.set('tiers', segment);
+        this.post.tiers = segment;
         try {
             await this.validate();
         } catch (e) {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-323

After changing a post's access via the posts list context menu, creating new posts or members would not work correctly.

- the issue stemmed from `this.post.set('currentState.parentState.isNew', false);` that was called when changing a post's access level, after that all Ember Data models created from the store would have `isNew: false` causing Ember Data to attempt a PUT request to update the not-yet-created model rather than a POST request to create it
- we were only using a real post model instance in order to run validations against the post access level settings but we can do that just as easily by creating a new object and injecting our validation mixin
