### PR TITLE
Updated following/followers in activitypub profile preview to be dynamic

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -15,6 +15,22 @@ export interface SearchResults {
     profiles: ProfileSearchResult[];
 }
 
+export interface GetFollowersForProfileResponse {
+    followers: {
+        actor: Actor;
+        isFollowing: boolean;
+    }[];
+    next: string | null;
+}
+
+export interface GetFollowingForProfileResponse {
+    following: {
+        actor: Actor;
+        isFollowing: boolean;
+    }[];
+    next: string | null;
+}
+
 export class ActivityPubAPI {
     constructor(
         private readonly apiUrl: URL,
@@ -123,6 +139,68 @@ export class ActivityPubAPI {
             return json.totalItems;
         }
         return 0;
+    }
+
+    async getFollowersForProfile(handle: string, next?: string): Promise<GetFollowersForProfileResponse> {
+        const url = new URL(`.ghost/activitypub/profile/${handle}/followers`, this.apiUrl);
+        if (next) {
+            url.searchParams.set('next', next);
+        }
+
+        const json = await this.fetchJSON(url);
+
+        if (json === null) {
+            return {
+                followers: [],
+                next: null
+            };
+        }
+
+        if (!('followers' in json)) {
+            return {
+                followers: [],
+                next: null
+            };
+        }
+
+        const followers = Array.isArray(json.followers) ? json.followers : [];
+        const nextPage = 'next' in json && typeof json.next === 'string' ? json.next : null;
+
+        return {
+            followers,
+            next: nextPage
+        };
+    }
+
+    async getFollowingForProfile(handle: string, next?: string): Promise<GetFollowingForProfileResponse> {
+        const url = new URL(`.ghost/activitypub/profile/${handle}/following`, this.apiUrl);
+        if (next) {
+            url.searchParams.set('next', next);
+        }
+
+        const json = await this.fetchJSON(url);
+
+        if (json === null) {
+            return {
+                following: [],
+                next: null
+            };
+        }
+
+        if (!('following' in json)) {
+            return {
+                following: [],
+                next: null
+            };
+        }
+
+        const following = Array.isArray(json.following) ? json.following : [];
+        const nextPage = 'next' in json && typeof json.next === 'string' ? json.next : null;
+
+        return {
+            following,
+            next: nextPage
+        };
     }
 
     async follow(username: string): Promise<void> {

--- a/apps/admin-x-activitypub/src/components/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/Search.tsx
@@ -18,6 +18,7 @@ interface SearchResultItem {
     actor: ActorProperties;
     handle: string;
     followerCount: number;
+    followingCount: number;
     isFollowing: boolean;
     posts: Activity[];
 }
@@ -84,10 +85,10 @@ const Search: React.FC<SearchProps> = ({}) => {
                 icon: {
                     url: 'https://anujahooja.com/assets/images/image12.jpg?v=601ebe30'
                 }
-                
             } as ActorProperties,
             handle: '@quillmatiq@mastodon.social',
             followerCount: 436,
+            followingCount: 634,
             isFollowing: false,
             posts: []
         },
@@ -105,6 +106,7 @@ const Search: React.FC<SearchProps> = ({}) => {
             } as ActorProperties,
             handle: '@miaq@flipboard.social',
             followerCount: 533,
+            followingCount: 335,
             isFollowing: false,
             posts: []
         },
@@ -122,6 +124,7 @@ const Search: React.FC<SearchProps> = ({}) => {
             } as ActorProperties,
             handle: '@mallory@techpolicy.social',
             followerCount: 1100,
+            followingCount: 11,
             isFollowing: false,
             posts: []
         }

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -279,3 +279,30 @@ export function useFollow(handle: string, onSuccess: () => void, onError: () => 
     });
 }
 
+export function useFollowersForProfile(handle: string) {
+    const siteUrl = useSiteUrl();
+    const api = createActivityPubAPI(handle, siteUrl);
+    return useInfiniteQuery({
+        queryKey: [`followers:${handle}`],
+        async queryFn({pageParam}: {pageParam?: string}) {
+            return api.getFollowersForProfile(handle, pageParam);
+        },
+        getNextPageParam(prevPage) {
+            return prevPage.next;
+        }
+    });
+}
+
+export function useFollowingForProfile(handle: string) {
+    const siteUrl = useSiteUrl();
+    const api = createActivityPubAPI(handle, siteUrl);
+    return useInfiniteQuery({
+        queryKey: [`following:${handle}`],
+        async queryFn({pageParam}: {pageParam?: string}) {
+            return api.getFollowingForProfile(handle, pageParam);
+        },
+        getNextPageParam(prevPage) {
+            return prevPage.next;
+        }
+    });
+}


### PR DESCRIPTION
refs [AP-442](https://linear.app/tryghost/issue/AP-442/add-dynamic-following-followers-to-search-result-profile), [TryGhost/ActivityPub#53](https://github.com/TryGhost/ActivityPub/pull/53)

Updated following/followers in activitypub profile preview to be dynamic