### PR TITLE
Fixed test that left an instance of ghost running

### DIFF
--- a/ghost/core/test/e2e-server/click-tracking.test.js
+++ b/ghost/core/test/e2e-server/click-tracking.test.js
@@ -8,11 +8,11 @@ const membersEventsService = require('../../core/server/services/members-events'
 
 describe('Click Tracking', function () {
     let agent;
+    let ghostServer;
     let webhookMockReceiver;
 
     before(async function () {
-        const {adminAgent} = await agentProvider.getAgentsWithFrontend();
-        agent = adminAgent;
+        ({adminAgent: agent, ghostServer} = await agentProvider.getAgentsWithFrontend());
         await fixtureManager.init('newsletters', 'members:newsletters', 'integrations');
         await agent.loginAsOwner();
     });
@@ -26,6 +26,10 @@ describe('Click Tracking', function () {
 
     afterEach(function () {
         mockManager.restore();
+    });
+
+    after(async function () {
+        await ghostServer.stop();
     });
 
     it('Full test', async function () {


### PR DESCRIPTION
no issue

- This test file starts a Ghost server, but doesn't close it, which can cause other tests to fail when they try to start an instance of Ghost, with an `EADDRINUSE` error.
- This change closes the server in the `after` hook