### PR TITLE
Increased feature image alt text length to 191 chars

### DIFF
--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -113,7 +113,7 @@ module.exports = {
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
         email_subject: {type: 'string', maxlength: 300, nullable: true},
         frontmatter: {type: 'text', maxlength: 65535, nullable: true},
-        feature_image_alt: {type: 'string', maxlength: 191, nullable: true, validations: {isLength: {max: 125}}},
+        feature_image_alt: {type: 'string', maxlength: 191, nullable: true},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
         email_only: {type: 'boolean', nullable: false, defaultTo: false}
     },
@@ -418,7 +418,7 @@ module.exports = {
         post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled', 'sent']]}},
         reason: {type: 'string', maxlength: 50, nullable: true},
         feature_image: {type: 'string', maxlength: 2000, nullable: true},
-        feature_image_alt: {type: 'string', maxlength: 191, nullable: true, validations: {isLength: {max: 125}}},
+        feature_image_alt: {type: 'string', maxlength: 191, nullable: true},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
         custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}}
     },

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -1457,6 +1457,24 @@ Object {
 }
 `;
 
+exports[`Posts API Create Errors if feature_image_alt is too long 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": StringMatching /\\.\\*post_revisions\\\\\\.feature_image_alt\\] exceeds maximum length of 191 characters\\.\\*/,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot save post.",
+      "property": null,
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
 exports[`Posts API Create Errors with an invalid lexical state object 1: [body] 1`] = `
 Object {
   "errors": Array [


### PR DESCRIPTION
no issue

- removed the 125 char soft limit so the full 191 char db field length can be used
