### PR TITLE
Fix origin attribution in Tinybird analytics hits

### DIFF
--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -3,24 +3,29 @@ DESCRIPTION >
     Aggregate by referral and calculate session and views
 
 SQL >
-    WITH (SELECT domainWithoutWWW(href) FROM analytics_hits LIMIT 1) AS current_domain
+    WITH (SELECT domainWithoutWWW(href) FROM analytics_hits LIMIT 1) AS current_domain,
+    sessions AS (
+        SELECT
+            session_id, argMin(source, timestamp) AS source, 
+            maxIf(member_status, member_status IN ('paid', 'free', 'undefined')) AS member_status
+        FROM analytics_hits
+        GROUP BY session_id
+    )
     SELECT
-        site_uuid,
-        toDate(timestamp) AS date,
-        device,
-        browser,
-        location,
-        source,
-        pathname,
-        maxIf(
-            member_status,
-            member_status IN ('paid', 'free', 'undefined')
-        ) AS member_status,
-        uniqState(session_id) AS visits,
+        a.site_uuid,
+        toDate(a.timestamp) AS date,
+        a.device,
+        a.browser,
+        a.location,
+        b.source AS source,
+        a.pathname,
+        b.member_status AS member_status,
+        uniqState(a.session_id) AS visits,
         countState() AS pageviews
-    FROM analytics_hits
-    WHERE source != current_domain
-    GROUP BY date, device, browser, location, source, pathname, site_uuid
+    FROM analytics_hits as a
+    INNER JOIN sessions AS b ON a.session_id = b.session_id
+    GROUP BY a.site_uuid, toDate(a.timestamp), a.device, a.browser, a.location, b.member_status, b.source, a.pathname
+    HAVING b.source != current_domain
 
 TYPE MATERIALIZED
 DATASOURCE analytics_sources_mv

--- a/ghost/tinybird/tests/all_top_sources.test.result
+++ b/ghost/tinybird/tests/all_top_sources.test.result
@@ -1,9 +1,9 @@
 "source","visits","pageviews"
-"",6,6
-"bing.com",2,2
-"search.yahoo.com",2,2
-"google.com",1,1
-"baidu.com",1,1
+"",6,12
+"bing.com",2,5
+"search.yahoo.com",2,3
+"google.com",1,3
+"baidu.com",1,3
 "wilted-tick.com",1,1
-"duckduckgo.com",1,1
+"duckduckgo.com",1,2
 "petty-queen.com",1,1

--- a/ghost/tinybird/tests/filter_browser_chrome_top_sources.test.result
+++ b/ghost/tinybird/tests/filter_browser_chrome_top_sources.test.result
@@ -1,5 +1,5 @@
 "source","visits","pageviews"
-"",4,4
-"bing.com",1,1
+"",4,9
+"bing.com",1,3
 "search.yahoo.com",1,1
-"baidu.com",1,1
+"baidu.com",1,3

--- a/ghost/tinybird/tests/filter_source_bing_top_sources.test.result
+++ b/ghost/tinybird/tests/filter_source_bing_top_sources.test.result
@@ -1,2 +1,2 @@
 "source","visits","pageviews"
-"bing.com",2,2
+"bing.com",2,5


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ANAL-96/data-discrepancy-between-charts-when-filtering

- This fixes the test data so that the session first hit and subsequent hits are in chronological order
- It also makes sure there isn't more than 30 minutes between hits, as our tracking script is only designed to keep sessions alive for 30 minutes so the data wasn't realistic
- NOTE: This data was generated by a script https://gist.github.com/ErisDS/25bb36f38d4c5a3f01d86f34ea5be707 - which didn't take these things into account

Co-authored-by: alejandromav <hi@alejandromav.com>

This is a rebased / reordered version of https://github.com/TryGhost/Ghost/pull/21166
