### PR TITLE
Fixed Date.now() use in email analytics unit tests

### DIFF
--- a/ghost/email-analytics-service/test/email-analytics-service.test.js
+++ b/ghost/email-analytics-service/test/email-analytics-service.test.js
@@ -10,6 +10,16 @@ const {
 const EventProcessingResult = require('../lib/EventProcessingResult');
 
 describe('EmailAnalyticsService', function () {
+    let clock;
+    
+    beforeEach(function () {
+        clock = sinon.useFakeTimers(new Date(2024, 0, 1));
+    });
+
+    afterEach(function () {
+        clock.restore();
+    });
+
     describe('getStatus', function () {
         it('returns status object', function () {
             // these are null because we're not running them before calling this


### PR DESCRIPTION
no ref

We had an instance where this was a ms off and I should've used mock timers when I first wrote this. This should prevent any rare clock mishaps.