### PR TITLE
Refactored members-comments e2e test

### DIFF
--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -147,7 +147,7 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;
@@ -1678,7 +1678,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -1695,7 +1695,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -1717,14 +1717,14 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>This is a message</p><p></p><p>New line</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
         "expertise": null,
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
+        "name": "Egon Spengler",
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "replies": Array [],
@@ -1766,7 +1766,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -1783,7 +1783,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -1805,14 +1805,14 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>This is a message</p><p></p><p>New line</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
         "expertise": null,
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
+        "name": "Egon Spengler",
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "replies": Array [],
@@ -1854,14 +1854,14 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>This is a message</p><p></p><p>New line</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
         "expertise": null,
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
+        "name": "Egon Spengler",
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "replies": Array [],
@@ -1874,7 +1874,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -1891,7 +1891,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -1979,7 +1979,7 @@ Object {
     Object {
       "count": Object {
         "likes": Any<Number>,
-        "replies": Any<Number>,
+        "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -1993,26 +1993,7 @@ Object {
         "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": Any<Number>,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "This is a reply",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "liked": Any<Boolean>,
-          "member": Object {
-            "avatar_image": null,
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": null,
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "status": "published",
-        },
-      ],
+      "replies": Array [],
       "status": "published",
     },
   ],
@@ -2023,7 +2004,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can edi
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "678",
+  "content-length": "370",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2034,9 +2015,9 @@ Object {
 
 exports[`Comments API when commenting enabled for all when authenticated Can fetch counts 1: [body] 1`] = `
 Object {
-  "618ba1ffbe2896088840a6df": 15,
-  "618ba1ffbe2896088840a6e1": 0,
-  "618ba1ffbe2896088840a6e3": 0,
+  "618ba1ffbe2896088840a6df": 1,
+  "618ba1ffbe2896088840a6e1": 2,
+  "618ba1ffbe2896088840a6e3": 3,
 }
 `;
 
@@ -2044,7 +2025,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can fet
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "public, max-age=0",
-  "content-length": "89",
+  "content-length": "88",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2064,6 +2045,7 @@ Object {
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2081,6 +2063,7 @@ Object {
           "edited_at": null,
           "html": "This is a reply",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -2098,11 +2081,48 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated Can like a comment 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can like a comment 2: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Egon Spengler",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated Can like a comment 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "687",
+  "content-length": "731",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2114,8 +2134,10 @@ exports[`Comments API when commenting enabled for all when authenticated Can lik
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "367",
+  "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/",
+  "vary": "Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;
@@ -2132,6 +2154,7 @@ Object {
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2149,6 +2172,7 @@ Object {
           "edited_at": null,
           "html": "This is a reply",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -2170,7 +2194,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can lik
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "686",
+  "content-length": "730",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2183,7 +2207,7 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;
@@ -2194,11 +2218,11 @@ Object {
     Object {
       "count": Object {
         "likes": Any<Number>,
-        "replies": Any<Number>,
+        "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply 0",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2219,7 +2243,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can lik
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "349",
+  "content-length": "356",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2233,7 +2257,7 @@ Object {
     Object {
       "count": Object {
         "likes": Any<Number>,
-        "replies": Any<Number>,
+        "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -2247,26 +2271,7 @@ Object {
         "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": Any<Number>,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "This is a reply",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "liked": Any<Boolean>,
-          "member": Object {
-            "avatar_image": null,
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": null,
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "status": "published",
-        },
-      ],
+      "replies": Array [],
       "status": "published",
     },
   ],
@@ -2277,7 +2282,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can not
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "685",
+  "content-length": "377",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2361,11 +2366,11 @@ Object {
     Object {
       "count": Object {
         "likes": Any<Number>,
-        "replies": Any<Number>,
+        "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>This is a message</p><p></p><p>New line</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2375,26 +2380,7 @@ Object {
         "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": Any<Number>,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "This is a reply",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "liked": Any<Boolean>,
-          "member": Object {
-            "avatar_image": null,
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": null,
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "status": "published",
-        },
-      ],
+      "replies": Array [],
       "status": "published",
     },
   ],
@@ -2405,7 +2391,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rem
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "687",
+  "content-length": "357",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2449,7 +2435,7 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;
@@ -2490,7 +2476,7 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;
@@ -2531,7 +2517,7 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;
@@ -2595,7 +2581,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2625,7 +2611,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can req
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "407",
+  "content-length": "414",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2707,7 +2693,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>Really original</p>",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2725,7 +2711,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2743,7 +2729,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply 0",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2761,7 +2747,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply 1",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2779,7 +2765,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply 2",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2797,7 +2783,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2815,7 +2801,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "This is a reply",
+      "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2845,7 +2831,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can ret
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2277",
+  "content-length": "2313",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2932,7 +2918,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -2949,7 +2935,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -2967,7 +2953,25 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "This is a reply",
+          "html": "<p>This is a reply</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "status": "published",
+        },
+        Object {
+          "count": Object {
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "edited_at": null,
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -2990,7 +2994,7 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "974",
+  "content-length": "1308",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3010,6 +3014,7 @@ Object {
       "edited_at": null,
       "html": "This is a reply 0",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -3029,7 +3034,7 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "350",
+  "content-length": "372",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -3051,6 +3056,7 @@ Object {
       "edited_at": null,
       "html": "This is a reply 1",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -3070,7 +3076,7 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "350",
+  "content-length": "372",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -3092,6 +3098,7 @@ Object {
       "edited_at": null,
       "html": "This is a reply 2",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -3111,7 +3118,7 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "350",
+  "content-length": "372",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -3133,6 +3140,7 @@ Object {
       "edited_at": null,
       "html": "<p>First.</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -3150,6 +3158,7 @@ Object {
           "edited_at": null,
           "html": "<p>Really original</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -3168,6 +3177,7 @@ Object {
           "edited_at": null,
           "html": "This is a reply",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -3186,6 +3196,7 @@ Object {
           "edited_at": null,
           "html": "This is a reply 0",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -3207,7 +3218,7 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1285",
+  "content-length": "1373",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3225,7 +3236,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -3242,7 +3253,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -3275,7 +3286,7 @@ exports[`Comments API when commenting enabled for all when not authenticated Can
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "753",
+  "content-length": "764",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3293,7 +3304,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>First.</p>",
+      "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "liked": Any<Boolean>,
       "member": Object {
@@ -3310,7 +3321,7 @@ Object {
           },
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "edited_at": null,
-          "html": "<p>Really original</p>",
+          "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "liked": Any<Boolean>,
           "member": Object {
@@ -3343,7 +3354,7 @@ exports[`Comments API when commenting enabled for all when not authenticated Can
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "753",
+  "content-length": "764",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3834,7 +3845,7 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
   "vary": "Accept-Encoding",
-  "x-cache-invalidate": "/api/members/comments/post/618ba1ffbe2896088840a6df/, /api/members/comments/6195c6a1e792de832cd08144/replies/",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert/strict');
-const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, matchers, configUtils, dbUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyErrorId, anyUuid, anyNumber, anyBoolean} = matchers;
 const should = require('should');
 const models = require('../../../core/server/models');
@@ -8,11 +8,88 @@ const settingsCache = require('../../../core/shared/settings-cache');
 const sinon = require('sinon');
 const DomainEvents = require('@tryghost/domain-events');
 
-let membersAgent, membersAgent2, postId, postTitle, commentId;
+let membersAgent, membersAgent2, postId, postAuthorEmail, postTitle;
 
 async function getPaidProduct() {
     return await models.Product.findOne({type: 'paid'});
 }
+
+const dbFns = {
+    /**
+     * @typedef {Object} AddCommentData
+     * @property {string} [post_id=postId]
+     * @property {string} member_id
+     * @property {string} [parent_id]
+     * @property {string} [html='This is a comment']
+     */
+    /**
+     * @typedef {Object} AddCommentReplyData
+     * @property {string} member_id
+     * @property {string} [html='This is a reply']
+     */
+    /**
+     * @typedef {AddCommentData & {replies: AddCommentReplyData[]}} AddCommentWithRepliesData
+     */
+
+    /**
+     * @param {AddCommentData} data
+     * @returns {Promise<any>}
+     */
+    addComment: async (data) => {
+        return await models.Comment.add({
+            post_id: data.post_id || postId,
+            member_id: data.member_id,
+            parent_id: data.parent_id,
+            html: data.html || '<p>This is a comment</p>'
+        });
+    },
+    /**
+     * @param {AddCommentWithRepliesData}  data
+     * @returns {Promise<any>}
+     */
+    addCommentWithReplies: async (data) => {
+        const {replies, ...commentData} = data;
+
+        const parent = await dbFns.addComment(commentData);
+        const createdReplies = [];
+
+        for (const reply of replies) {
+            const createdReply = await dbFns.addComment({
+                post_id: parent.get('post_id'),
+                member_id: reply.member_id,
+                parent_id: parent.get('id'),
+                html: reply.html || '<p>This is a reply</p>'
+            });
+            createdReplies.push(createdReply);
+        }
+
+        return {parent, replies: createdReplies};
+    },
+    /**
+     * @param {Object} data
+     * @param {string} data.comment_id
+     * @param {string} data.member_id
+     * @returns {Promise<any>}
+     */
+    addLike: async (data) => {
+        return await models.CommentLike.add({
+            comment_id: data.comment_id,
+            member_id: data.member_id
+        });
+    },
+    /**
+     * @param {Object} data
+     * @param {string} data.comment_id
+     * @param {string} data.member_id
+     * @returns {Promise<any>}
+     */
+    addReport: async (data) => {
+        return await models.CommentReport.add({
+            comment_id: data.comment_id,
+            member_id: data.member_id
+        });
+    }
+};
 
 const commentMatcher = {
     id: anyObjectId,
@@ -53,31 +130,68 @@ function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function testGetComments(url, commentsMatcher) {
+    return membersAgent
+        .get(url)
+        .expectStatus(200)
+        .matchHeaderSnapshot({
+            etag: anyEtag
+        })
+        .matchBodySnapshot({
+            comments: commentsMatcher
+        });
+}
+
+/**
+ * @param {Object} data
+ * @param {string} data.post_id
+ * @param {string} data.html
+ * @param {string} [data.parent_id]
+ * @param {Object} [options]
+ * @param {number} [options.status = 201]
+ * @param {Object} [options.matchHeaderSnapshot]
+ * @param {Object} [options.matchBodySnapshot]
+ * @returns {any} ExpectRequest
+ */
+function testPostComment({post_id, html, parent_id}, {status = 201, matchHeaderSnapshot = {}, matchBodySnapshot} = {}) {
+    return membersAgent
+        .post(`/api/comments/`)
+        .body({comments: [{
+            post_id,
+            parent_id,
+            html
+        }]})
+        .expectStatus(status)
+        .matchHeaderSnapshot({
+            etag: anyEtag,
+            location: anyLocationFor('comments'),
+            ...matchHeaderSnapshot
+        })
+        .matchBodySnapshot({
+            comments: [commentMatcher],
+            ...matchBodySnapshot
+        });
+}
+
+function assertAuthorEmailSent(email, title, extraAssertions = {}) {
+    mockManager.assert.sentEmail({
+        subject: '💬 New comment on your post: ' + title,
+        to: email,
+        ...extraAssertions
+    });
+}
+
 async function testCanCommentOnPost(member) {
     await models.Member.edit({last_seen_at: null, last_commented_at: null}, {id: member.get('id')});
 
-    const {body} = await membersAgent
-        .post(`/api/comments/`)
-        .body({comments: [{
-            post_id: postId,
-            html: '<div></div><p></p><p>This is a <strong>message</strong></p><p></p><p></p><p>New line</p><p></p>'
-        }]})
-        .expectStatus(201)
-        .matchHeaderSnapshot({
-            etag: anyEtag,
-            location: anyLocationFor('comments')
-        })
-        .matchBodySnapshot({
-            comments: [commentMatcher]
-        });
-    // Save for other tests
-    commentId = body.comments[0].id;
+    await testPostComment({
+        post_id: postId,
+        html: '<div></div><p></p><p>This is a <strong>message</strong></p><p></p><p></p><p>New line</p><p></p>'
+    });
 
     // Check if author got an email
     mockManager.assert.sentEmailCount(1);
-    mockManager.assert.sentEmail({
-        subject: '💬 New comment on your post: ' + postTitle,
-        to: fixtureManager.get('users', 0).email,
+    assertAuthorEmailSent(postAuthorEmail, postTitle, {
         // Note that the <strong> tag is removed by the sanitizer
         html: new RegExp(escapeRegExp('<p>This is a message</p><p></p><p>New line</p>'))
     });
@@ -94,35 +208,32 @@ async function testCanCommentOnPost(member) {
 }
 
 async function testCanReply(member, emailMatchers = {}) {
+    const parentComment = await dbFns.addComment({
+        member_id: fixtureManager.get('members', 2).id
+    });
+
     const date = new Date(0);
     await models.Member.edit({last_seen_at: date, last_commented_at: date}, {id: member.get('id')});
 
-    await membersAgent
-        .post(`/api/comments/`)
-        .body({comments: [{
-            post_id: postId,
-            parent_id: fixtureManager.get('comments', 0).id,
-            html: 'This is a reply'
-        }]})
-        .expectStatus(201)
-        .matchHeaderSnapshot({
-            etag: anyEtag,
-            location: anyLocationFor('comments')
-        })
-        .matchBodySnapshot({
-            comments: [commentMatcher]
-        });
+    await testPostComment({
+        post_id: postId,
+        parent_id: parentComment.get('id'),
+        html: 'This is a reply'
+    }, {
+        matchHeaderSnapshot: {
+            'x-cache-invalidate': matchers.stringMatching(
+                new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/replies/')
+            )
+        }
+    });
 
     mockManager.assert.sentEmailCount(2);
-    mockManager.assert.sentEmail({
-        subject: '💬 New comment on your post: ' + postTitle,
-        to: fixtureManager.get('users', 0).email
-    });
+    assertAuthorEmailSent(postAuthorEmail, postTitle);
 
     mockManager.assert.sentEmail({
         ...emailMatchers,
         subject: '↪️ New reply to your comment on Ghost',
-        to: fixtureManager.get('members', 0).email
+        to: fixtureManager.get('members', 2).email
     });
 
     // Wait for the dispatched events (because this happens async)
@@ -154,12 +265,12 @@ async function testCannotCommentOnPost(status = 403) {
         });
 }
 
-async function testCannotReply(status = 403) {
+async function testCannotReply(parentId, status = 403) {
     await membersAgent
         .post(`/api/comments/`)
         .body({comments: [{
             post_id: postId,
-            parent_id: fixtureManager.get('comments', 0).id,
+            parent_id: parentId,
             html: 'This is a reply'
         }]})
         .expectStatus(status)
@@ -174,20 +285,26 @@ async function testCannotReply(status = 403) {
 }
 
 describe('Comments API', function () {
-    let member;
+    let loggedInMember;
 
     before(async function () {
         membersAgent = await agentProvider.getMembersAPIAgent();
         membersAgent2 = membersAgent.duplicate();
 
-        await fixtureManager.init('posts', 'members', 'comments');
+        await fixtureManager.init('posts', 'members');
 
         postId = fixtureManager.get('posts', 0).id;
         postTitle = fixtureManager.get('posts', 0).title;
+        postAuthorEmail = fixtureManager.get('users', 0).email;
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
         mockManager.mockMail();
+
+        // ensure we don't have data dependencies across tests
+        await dbUtils.truncate('comments');
+        await dbUtils.truncate('comment_likes');
+        await dbUtils.truncate('comment_reports');
     });
 
     afterEach(async function () {
@@ -211,28 +328,27 @@ describe('Comments API', function () {
                 sinon.restore();
             });
 
+            async function setupBrowseCommentsData() {
+                await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id
+                    }]
+                });
+            }
+
             it('Can browse all comments of a post (legacy)', async function () {
-                await membersAgent
-                    .get(`/api/comments/?filter=post_id:'${postId}'`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [commentMatcherWithReplies({replies: 1})]
-                    });
+                await setupBrowseCommentsData();
+                await testGetComments(`/api/comments/?filter=post_id:'${postId}'`, [
+                    commentMatcherWithReplies({replies: 1})
+                ]);
             });
 
             it('Can browse all comments of a post', async function () {
-                await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [commentMatcherWithReplies({replies: 1})]
-                    });
+                await setupBrowseCommentsData();
+                await testGetComments(`/api/comments/post/${postId}/`, [
+                    commentMatcherWithReplies({replies: 1})
+                ]);
             });
 
             it('cannot comment on a post', async function () {
@@ -240,15 +356,19 @@ describe('Comments API', function () {
             });
 
             it('cannot reply on a post', async function () {
-                await testCannotReply(401);
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id
+                });
+                await testCannotReply(comment.get('id'), 401);
             });
 
             it('cannot report a comment', async function () {
-                commentId = fixtureManager.get('comments', 0).id;
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
 
-                // Create a temporary comment
                 await membersAgent
-                    .post(`/api/comments/${commentId}/report/`)
+                    .post(`/api/comments/${comment.get('id')}/report/`)
                     .expectStatus(401)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -261,9 +381,12 @@ describe('Comments API', function () {
             });
 
             it('cannot like a comment', async function () {
-                // Create a temporary comment
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+
                 await membersAgent
-                    .post(`/api/comments/${commentId}/like/`)
+                    .post(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(401)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -276,9 +399,17 @@ describe('Comments API', function () {
             });
 
             it('cannot unlike a comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+                await dbFns.addLike({
+                    comment_id: comment.get('id'),
+                    member_id: fixtureManager.get('members', 0).id
+                });
+
                 // Create a temporary comment
                 await membersAgent
-                    .delete(`/api/comments/${commentId}/like/`)
+                    .delete(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(401)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -296,7 +427,7 @@ describe('Comments API', function () {
 
             before(async function () {
                 await membersAgent.loginAs('member@example.com');
-                member = await models.Member.findOne({email: 'member@example.com'}, {require: true});
+                loggedInMember = await models.Member.findOne({email: 'member@example.com'}, {require: true});
                 await membersAgent2.loginAs('member2@example.com');
             });
 
@@ -315,153 +446,98 @@ describe('Comments API', function () {
             });
 
             it('Can comment on a post', async function () {
-                await testCanCommentOnPost(member);
+                await testCanCommentOnPost(loggedInMember);
             });
 
+            async function setupBrowseCommentsData() {
+                await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id
+                    }]
+                });
+                await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+            }
+
             it('Can browse all comments of a post (legacy)', async function () {
+                await setupBrowseCommentsData();
                 // uses explicit order to match db ordering
-                await membersAgent
-                    .get(`/api/comments/?filter=post_id:'${postId}'&order=id%20ASC`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [
-                            commentMatcherWithReplies({replies: 1}),
-                            commentMatcher
-                        ]
-                    });
+                await testGetComments(`/api/comments/?filter=post_id:'${postId}'&order=id%20ASC`, [
+                    commentMatcherWithReplies({replies: 1}),
+                    commentMatcher
+                ]);
             });
 
             it('Can browse all comments of a post', async function () {
+                await setupBrowseCommentsData();
                 // uses explicit order to match db ordering
-                await membersAgent
-                    .get(`/api/comments/post/${postId}/?order=id%20ASC`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [
-                            commentMatcherWithReplies({replies: 1}),
-                            commentMatcher
-                        ]
-                    });
+                await testGetComments(`/api/comments/post/${postId}/?order=id%20ASC`, [
+                    commentMatcherWithReplies({replies: 1}),
+                    commentMatcher
+                ]);
             });
 
             it('Can browse all comments of a post with default order', async function () {
-                await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [
-                            commentMatcher,
-                            commentMatcherWithReplies({replies: 1})
-                        ]
-                    });
+                await setupBrowseCommentsData();
+                await testGetComments(`/api/comments/post/${postId}/`, [
+                    commentMatcher,
+                    commentMatcherWithReplies({replies: 1})
+                ]);
             });
 
             it('Can reply to your own comment', async function () {
                 // Should not update last_seen_at or last_commented_at when both are already set to a value on the same day
                 const timezone = settingsCache.get('timezone');
                 const date = moment.utc(new Date()).tz(timezone).startOf('day').toDate();
-                await models.Member.edit({last_seen_at: date, last_commented_at: date}, {id: member.get('id')});
+                await models.Member.edit({last_seen_at: date, last_commented_at: date}, {id: loggedInMember.get('id')});
 
-                await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        parent_id: commentId,
-                        html: 'This is a reply'
-                    }]})
-                    .expectStatus(201)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag,
-                        location: anyLocationFor('comments'),
+                const parentComment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+
+                await testPostComment({
+                    post_id: postId,
+                    parent_id: parentComment.id,
+                    html: 'This is a reply'
+                }, {
+                    matchHeaderSnapshot: {
                         'x-cache-invalidate': matchers.stringMatching(
                             new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/replies/')
                         )
-                    })
-                    .matchBodySnapshot({
-                        comments: [commentMatcher]
-                    });
+                    }
+                });
 
                 // Check only the author got an email (because we are the author of this parent comment)
                 mockManager.assert.sentEmailCount(1);
-                mockManager.assert.sentEmail({
-                    subject: '💬 New comment on your post: ' + postTitle,
-                    to: fixtureManager.get('users', 0).email
-                });
+                assertAuthorEmailSent(postAuthorEmail, postTitle);
 
                 // Wait for the dispatched events (because this happens async)
                 await DomainEvents.allSettled();
 
                 // Check last updated_at is not changed?
-                member = await models.Member.findOne({id: member.id});
-                should.equal(member.get('last_seen_at').getTime(), date.getTime(), 'The member should not update `last_seen_at` if last seen at is same day');
+                loggedInMember = await models.Member.findOne({id: loggedInMember.id});
+                should.equal(loggedInMember.get('last_seen_at').getTime(), date.getTime(), 'The member should not update `last_seen_at` if last seen at is same day');
 
                 // Check last_commented_at changed?
-                should.equal(member.get('last_commented_at').getTime(), date.getTime(), 'The member should not update `last_commented_at` f last seen at is same day');
+                should.equal(loggedInMember.get('last_commented_at').getTime(), date.getTime(), 'The member should not update `last_commented_at` f last seen at is same day');
             });
 
             it('Can reply to a comment', async function () {
-                await testCanReply(member);
+                await testCanReply(loggedInMember);
             });
 
-            let testReplyId;
             it('Limits returned replies to 3', async function () {
-                const parentId = fixtureManager.get('comments', 0).id;
-
-                // Check initial status: two replies before test
-                await membersAgent
-                    .get(`/api/comments/${parentId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: new Array(5).fill({
+                        member_id: fixtureManager.get('members', 1).id
                     })
-                    .matchBodySnapshot({
-                        comments: [commentMatcherWithReplies({replies: 2})]
-                    })
-                    .expect(({body}) => {
-                        body.comments[0].count.replies.should.eql(2);
-                    });
-
-                // Add some replies
-                for (let index = 0; index < 3; index++) {
-                    const {body: reply} = await membersAgent
-                        .post(`/api/comments/`)
-                        .body({comments: [{
-                            post_id: postId,
-                            parent_id: parentId,
-                            html: 'This is a reply ' + index
-                        }]})
-                        .expectStatus(201)
-                        .matchHeaderSnapshot({
-                            etag: anyEtag,
-                            location: anyLocationFor('comments')
-                        })
-                        .matchBodySnapshot({
-                            comments: [commentMatcher]
-                        });
-                    if (index === 0) {
-                        testReplyId = reply.comments[0].id;
-                    }
-                }
+                });
 
                 // Check if we have count.replies = 4, and replies.length == 3
-                await membersAgent
-                    .get(`/api/comments/${parentId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [commentMatcherWithReplies({replies: 3})]
-                    })
+                await testGetComments(`/api/comments/${parent.get('id')}/`, [commentMatcherWithReplies({replies: 3})])
                     .expect(({body}) => {
                         body.comments[0].count.replies.should.eql(5);
                     });
@@ -470,7 +546,7 @@ describe('Comments API', function () {
             it('Can reply to a comment with www domain', async function () {
                 // Test that the www. is stripped from the default
                 configUtils.set('url', 'http://www.domain.example/');
-                await testCanReply(member, {from: '"Ghost" <noreply@domain.example>'});
+                await testCanReply(loggedInMember, {from: '"Ghost" <noreply@domain.example>'});
             });
 
             it('Can reply to a comment with custom support email', async function () {
@@ -484,28 +560,17 @@ describe('Comments API', function () {
                     }
                     return getStub.wrappedMethod.call(settingsCache, key, options);
                 });
-                await testCanReply(member, {from: '"Ghost" <support@example.com>'});
+                await testCanReply(loggedInMember, {from: '"Ghost" <support@example.com>'});
             });
 
             it('Can like a comment', async function () {
-                // Check not liked
-                await membersAgent
-                    .get(`/api/comments/${commentId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(1).fill(commentMatcherWithReplies({replies: 1}))
-                    })
-                    .expect(({body}) => {
-                        body.comments[0].liked.should.eql(false);
-                        body.comments[0].count.likes.should.eql(0);
-                    });
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
 
-                // Create a temporary comment
+                // Like the comment
                 await membersAgent
-                    .post(`/api/comments/${commentId}/like/`)
+                    .post(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -513,15 +578,7 @@ describe('Comments API', function () {
                     .expectEmptyBody();
 
                 // Check liked
-                await membersAgent
-                    .get(`/api/comments/${commentId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(1).fill(commentMatcherWithReplies({replies: 1}))
-                    })
+                await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
                     .expect(({body}) => {
                         body.comments[0].liked.should.eql(true);
                         body.comments[0].count.likes.should.eql(1);
@@ -529,9 +586,17 @@ describe('Comments API', function () {
             });
 
             it('Cannot like a comment multiple times', async function () {
-                // Create a temporary comment
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+                await dbFns.addLike({
+                    comment_id: comment.get('id'),
+                    member_id: loggedInMember.id
+                });
+
+                // Comment was already liked above
                 await membersAgent
-                    .post(`/api/comments/${commentId}/like/`)
+                    .post(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(400)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -544,25 +609,28 @@ describe('Comments API', function () {
             });
 
             it('Can like a reply', async function () {
-                // Check initial status: two replies before test
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+                const reply = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 1).id,
+                    parent_id: comment.get('id')
+                });
+
+                // Like the reply
                 await membersAgent
-                    .post(`/api/comments/${testReplyId}/like/`)
+                    .post(`/api/comments/${reply.get('id')}/like/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
-                        etag: anyEtag
+                        etag: anyEtag,
+                        'x-cache-invalidate': matchers.stringMatching(
+                            new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/replies/')
+                        )
                     })
                     .expectEmptyBody();
 
                 // Check liked
-                await membersAgent
-                    .get(`/api/comments/${testReplyId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(1).fill(commentMatcherWithReplies({replies: 0}))
-                    })
+                await testGetComments(`/api/comments/${reply.id}/`, [commentMatcher])
                     .expect(({body}) => {
                         body.comments[0].liked.should.eql(true);
                         body.comments[0].count.likes.should.eql(1);
@@ -570,43 +638,39 @@ describe('Comments API', function () {
             });
 
             it('Can return replies', async function () {
-                const parentId = fixtureManager.get('comments', 0).id;
+                const {parent, replies} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: new Array(7).fill({
+                        member_id: fixtureManager.get('members', 1).id
+                    })
+                });
+                await dbFns.addLike({
+                    comment_id: replies[2].get('id'),
+                    member_id: loggedInMember.id
+                });
 
-                // Check initial status: two replies before test
-                await membersAgent
-                    .get(`/api/comments/${parentId}/replies/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(7).fill(commentMatcher)
-                    })
+                await testGetComments(`/api/comments/${parent.get('id')}/replies/`, new Array(7).fill(commentMatcher))
                     .expect(({body}) => {
                         should(body.comments[0].count.replies).be.undefined();
                         should(body.meta.pagination.total).eql(7);
                         should(body.meta.pagination.next).eql(null);
 
                         // Check liked + likes working for replies too
-                        should(body.comments[2].id).eql(testReplyId);
+                        should(body.comments[2].id).eql(replies[2].get('id'));
                         should(body.comments[2].count.likes).eql(1);
                         should(body.comments[2].liked).eql(true);
                     });
             });
 
             it('Can request last page of replies', async function () {
-                const parentId = fixtureManager.get('comments', 0).id;
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: new Array(7).fill({
+                        member_id: fixtureManager.get('members', 1).id
+                    })
+                });
 
-                // Check initial status: two replies before test
-                await membersAgent
-                    .get(`/api/comments/${parentId}/replies/?page=3&limit=3`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(1).fill(commentMatcher)
-                    })
+                await testGetComments(`/api/comments/${parent.get('id')}/replies/?page=3&limit=3`, [commentMatcher])
                     .expect(({body}) => {
                         should(body.comments[0].count.replies).be.undefined();
                         should(body.meta.pagination.total).eql(7);
@@ -615,9 +679,17 @@ describe('Comments API', function () {
             });
 
             it('Can remove a like (unlike)', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+                await dbFns.addLike({
+                    comment_id: comment.get('id'),
+                    member_id: loggedInMember.id
+                });
+
                 // Unlike
                 await membersAgent
-                    .delete(`/api/comments/${commentId}/like/`)
+                    .delete(`/api/comments/${comment.get('id')}/like/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -625,15 +697,7 @@ describe('Comments API', function () {
                     .expectEmptyBody();
 
                 // Check not liked
-                await membersAgent
-                    .get(`/api/comments/${commentId}/`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: new Array(1).fill(commentMatcherWithReplies({replies: 1}))
-                    })
+                await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
                     .expect(({body}) => {
                         body.comments[0].liked.should.eql(false);
                         body.comments[0].count.likes.should.eql(0);
@@ -641,9 +705,13 @@ describe('Comments API', function () {
             });
 
             it('Cannot unlike a comment if it has not been liked', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+
                 // Remove like
                 await membersAgent
-                    .delete(`/api/comments/${commentId}/like/`)
+                    .delete(`/api/comments/${comment.get('id')}/like/`)
                     //.expectStatus(404)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -656,9 +724,13 @@ describe('Comments API', function () {
             });
 
             it('Can report a comment', async function () {
-                // Create a temporary comment
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id,
+                    html: '<p>This is a message</p><p></p><p>New line</p>'
+                });
+
                 await membersAgent
-                    .post(`/api/comments/${commentId}/report/`)
+                    .post(`/api/comments/${comment.get('id')}/report/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -666,24 +738,31 @@ describe('Comments API', function () {
                     .expectEmptyBody();
 
                 // Check report
-                const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + commentId + '\''});
+                const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + comment.get('id') + '\''});
                 reports.models.length.should.eql(1);
 
                 const report = reports.models[0];
-                report.get('member_id').should.eql(member.id);
+                report.get('member_id').should.eql(loggedInMember.id);
 
                 mockManager.assert.sentEmail({
                     subject: '🚩 A comment has been reported on your post',
-                    to: fixtureManager.get('users', 0).email,
+                    to: postAuthorEmail,
                     html: new RegExp(escapeRegExp('<p>This is a message</p><p></p><p>New line</p>')),
                     text: new RegExp(escapeRegExp('This is a message\n\nNew line'))
                 });
             });
 
             it('Cannot report a comment twice', async function () {
-                // Create a temporary comment
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+                await dbFns.addReport({
+                    comment_id: comment.get('id'),
+                    member_id: loggedInMember.id
+                });
+
                 await membersAgent
-                    .post(`/api/comments/${commentId}/report/`)
+                    .post(`/api/comments/${comment.get('id')}/report/`)
                     .expectStatus(204)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -691,18 +770,22 @@ describe('Comments API', function () {
                     .expectEmptyBody();
 
                 // Check report should be the same (no extra created)
-                const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + commentId + '\''});
+                const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + comment.get('id') + '\''});
                 reports.models.length.should.eql(1);
 
                 const report = reports.models[0];
-                report.get('member_id').should.eql(member.id);
+                report.get('member_id').should.eql(loggedInMember.id);
 
                 mockManager.assert.sentEmailCount(0);
             });
 
             it('Can edit a comment on a post', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+
                 const {body} = await membersAgent
-                    .put(`/api/comments/${commentId}`)
+                    .put(`/api/comments/${comment.get('id')}`)
                     .body({comments: [{
                         html: 'Updated comment'
                     }]})
@@ -712,7 +795,7 @@ describe('Comments API', function () {
                     })
                     .matchBodySnapshot({
                         comments: [{
-                            ...commentMatcherWithReplies({replies: 1}),
+                            ...commentMatcher,
                             edited_at: anyISODateTime
                         }]
                     });
@@ -721,9 +804,14 @@ describe('Comments API', function () {
             });
 
             it('Can not edit a comment post_id', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
+
                 const anotherPostId = fixtureManager.get('posts', 1).id;
+
                 await membersAgent
-                    .put(`/api/comments/${commentId}`)
+                    .put(`/api/comments/${comment.get('id')}`)
                     .body({comments: [{
                         post_id: anotherPostId
                     }]});
@@ -731,12 +819,16 @@ describe('Comments API', function () {
                 const {body} = await membersAgent
                     .get(`/api/comments/?filter=post_id:'${anotherPostId}'`);
 
-                assert(!body.comments.find(comment => comment.id === commentId), 'The comment should not have moved post');
+                assert(!body.comments.find(c => c.id === comment.get('id')), 'The comment should not have moved post');
             });
 
             it('Can not edit a comment which does not belong to you', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+
                 await membersAgent2
-                    .put(`/api/comments/${commentId}`)
+                    .put(`/api/comments/${comment.get('id')}`)
                     .body({comments: [{
                         html: 'Illegal comment update'
                     }]})
@@ -753,9 +845,12 @@ describe('Comments API', function () {
             });
 
             it('Can not edit a comment as a member who is not you', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: loggedInMember.id
+                });
                 const memberId = fixtureManager.get('members', 1).id;
                 await membersAgent
-                    .put(`/api/comments/${commentId}`)
+                    .put(`/api/comments/${comment.get('id')}`)
                     .body({comments: [{
                         html: 'Illegal comment update',
                         member_id: memberId
@@ -764,57 +859,32 @@ describe('Comments API', function () {
                 const {
                     body: {
                         comments: [
-                            comment
+                            fetchedComment
                         ]
                     }
-                } = await membersAgent.get(`/api/comments/${commentId}`)
-                    .expectStatus(200)
-                    .matchHeaderSnapshot({
-                        etag: anyEtag
-                    })
-                    .matchBodySnapshot({
-                        comments: [{
-                            ...commentMatcherWithReplies({replies: 1}),
-                            edited_at: anyISODateTime
-                        }]
-                    });
+                } = await testGetComments(`/api/comments/${comment.get('id')}`, [{
+                    ...commentMatcher,
+                    edited_at: anyISODateTime
+                }]);
 
-                assert(comment.member.id !== memberId);
+                assert(fetchedComment.member.id !== memberId);
             });
 
             it('Can not reply to a reply', async function () {
-                const {
-                    body: {
-                        comments: [{
-                            id: parentId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        html: 'Parent'
-                    }]});
-
-                const {
-                    body: {
-                        comments: [{
-                            id: replyId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        parent_id: parentId,
+                const {replies} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 1).id,
+                    html: 'Parent',
+                    replies: [{
+                        member_id: fixtureManager.get('members', 3).id,
                         html: 'Reply'
-                    }]});
+                    }]
+                });
 
                 await membersAgent
                     .post(`/api/comments/`)
                     .body({comments: [{
                         post_id: postId,
-                        parent_id: replyId,
+                        parent_id: replies[0].get('id'),
                         html: 'Reply to a reply!'
                     }]})
                     .expectStatus(400)
@@ -830,45 +900,21 @@ describe('Comments API', function () {
             });
 
             it('Can not edit a replies parent', async function () {
-                const {
-                    body: {
-                        comments: [{
-                            id: parentId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        html: 'Parent'
-                    }]});
+                const parentId = (await dbFns.addComment({
+                    member_id: loggedInMember.id,
+                    html: 'Parent'
+                })).get('id');
 
-                const {
-                    body: {
-                        comments: [{
-                            id: newParentId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        html: 'New Parent'
-                    }]});
+                const newParentId = (await dbFns.addComment({
+                    member_id: loggedInMember.id,
+                    html: 'New Parent'
+                })).get('id');
 
-                const {
-                    body: {
-                        comments: [{
-                            id: replyId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        parent_id: parentId,
-                        html: 'Reply'
-                    }]});
+                const replyId = (await dbFns.addComment({
+                    member_id: loggedInMember.id,
+                    parent_id: parentId,
+                    html: 'Reply'
+                })).get('id');
 
                 // Attempt to edit the parent
                 await membersAgent
@@ -889,6 +935,17 @@ describe('Comments API', function () {
                     fixtureManager.get('posts', 1).id,
                     fixtureManager.get('posts', 2).id
                 ];
+
+                for (const i of ids.keys()) {
+                    // add i+1 comments so we have a different count for each post
+                    for (let j = 0; j < i + 1; j++) {
+                        await dbFns.addComment({
+                            post_id: ids[i],
+                            member_id: loggedInMember.id
+                        });
+                    }
+                }
+
                 await membersAgent
                     .get(`api/comments/counts/?ids=${ids.join(',')}`)
                     .expectStatus(200)
@@ -899,18 +956,10 @@ describe('Comments API', function () {
             });
 
             it('Can delete a comment, and it is redacted from', async function () {
-                const {
-                    body: {
-                        comments: [{
-                            id: commentToDeleteId
-                        }]
-                    }
-                } = await membersAgent
-                    .post(`/api/comments/`)
-                    .body({comments: [{
-                        post_id: postId,
-                        html: 'Comment to delete'
-                    }]});
+                const commentToDeleteId = (await dbFns.addComment({
+                    member_id: loggedInMember.id,
+                    html: 'Comment to delete'
+                })).get('id');
 
                 const {
                     body: {
@@ -972,7 +1021,7 @@ describe('Comments API', function () {
         describe('Members with access', function () {
             before(async function () {
                 await membersAgent.loginAs('paid@example.com');
-                member = await models.Member.findOne({email: 'paid@example.com'}, {require: true});
+                loggedInMember = await models.Member.findOne({email: 'paid@example.com'}, {require: true});
 
                 const product = await getPaidProduct();
 
@@ -984,15 +1033,15 @@ describe('Comments API', function () {
                             id: product.id
                         }
                     ]
-                }, {id: member.id});
+                }, {id: loggedInMember.id});
             });
 
             it('Can comment on a post', async function () {
-                await testCanCommentOnPost(member);
+                await testCanCommentOnPost(loggedInMember);
             });
 
             it('Can reply to a comment', async function () {
-                await testCanReply(member);
+                await testCanReply(loggedInMember);
             });
         });
 
@@ -1049,7 +1098,7 @@ describe('Comments API', function () {
         describe('Members with access', function () {
             before(async function () {
                 await membersAgent.loginAs('member-premium@example.com');
-                member = await models.Member.findOne({email: 'member-premium@example.com'}, {require: true});
+                loggedInMember = await models.Member.findOne({email: 'member-premium@example.com'}, {require: true});
 
                 // Attach comped subscription to this member
                 await models.Member.edit({
@@ -1059,15 +1108,15 @@ describe('Comments API', function () {
                             id: product.id
                         }
                     ]
-                }, {id: member.id});
+                }, {id: loggedInMember.id});
             });
 
             it('Can comment on a post', async function () {
-                await testCanCommentOnPost(member);
+                await testCanCommentOnPost(loggedInMember);
             });
 
             it('Can reply to a comment', async function () {
-                await testCanReply(member);
+                await testCanReply(loggedInMember);
             });
         });
 


### PR DESCRIPTION
no issue

Initial pass at refactoring the tests and making each independent so they aren't relying on data from previous tests.

- DRYed up some repeated API requests by extracting `testPostComment()`, `testGetComments()`, and `assertAuthorEmailSent()`
- removed data inter-dependency across tests
  - truncated the tables under test before each test is run
  - added suite of db fns to populate the database without having to do so via API requests
  - updated all tests to include their own data setup calls rather than relying on fixtures and modifications from earlier tests
