### PR TITLE
Run i18n tests for sodo-search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
     if: |
         needs.job_setup.outputs.changed_comments_ui == 'true'
         || needs.job_setup.outputs.changed_signup_form == 'true'
+        || needs.job_setup.outputs.changed_sodo_search == 'true'
         || needs.job_setup.outputs.changed_portal == 'true'
         || needs.job_setup.outputs.changed_core == 'true'
     steps:


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/21055

- Now that sodo-search has i18n, we should run i18n tests when this package changes as well

