### PR TITLE
Skipped admin-x-demo tests

### DIFF
--- a/apps/admin-x-demo/test/acceptance/example.test.ts
+++ b/apps/admin-x-demo/test/acceptance/example.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@playwright/test';
 import {mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
 
-test.describe('Demo', async () => {
+test.describe.skip('Demo', async () => {
     test('Renders the list page', async ({page}) => {
         await mockApi({page, requests: {
             browseSettings: {

--- a/apps/admin-x-demo/test/unit/example.test.tsx
+++ b/apps/admin-x-demo/test/unit/example.test.tsx
@@ -1,7 +1,7 @@
 import ListPage from '../../src/ListPage';
 import {render, screen} from '@testing-library/react';
 
-describe('Demo', function () {
+describe.skip('Demo', function () {
     it('renders a component', async function () {
         render(<ListPage />);
 


### PR DESCRIPTION
no ref

These are flaky on CI this week and we're not currently making use of this demo.