### PR TITLE
Improved pre-commit hook to automatically remove submodules

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -34,7 +34,7 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
         echo -e "\t${grey}removed:\t$SUB${no_color}"
     done
     echo
-    echo -e "Submodules removed from commit, continuing..."
+    echo -e "${grey}Submodules removed from commit, continuing...${no_color}"
 
     # If there are no changes to commit after removing submodules, abort to avoid an empty commit
     if output=$(git status --porcelain) && [ -z "$output" ]; then

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -27,7 +27,7 @@ echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
 
 # If no modified submodules, exit with status code 0, else remove them and continue
 if [[ -n "$MOD_SUBMODULES" ]]; then
-    echo "${grey}Removing submodules from commit...${no_color}"
+    echo -e "${grey}Removing submodules from commit...${no_color}"
     for SUB in $MOD_SUBMODULES
     do
         git reset --quiet HEAD "$SUB"

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -25,13 +25,12 @@ MOD_SUBMODULES=$(git diff --cached --name-only --ignore-submodules=none | grep -
 
 echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
 
-# If no modified submodules, exit with status code 0, else prompt the
-# user and exit accordingly
+# If no modified submodules, exit with status code 0, else remove them and continue
 if [[ -n "$MOD_SUBMODULES" ]]; then
     echo "${grey}Removing submodules from commit...${no_color}"
     for SUB in $MOD_SUBMODULES
     do
-        git reset HEAD "$SUB"
+        git reset --quiet HEAD "$SUB"
         echo -e "\t${grey}removed:\t$SUB${no_color}"
     done
     echo

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -37,9 +37,9 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
     echo
     echo -e "Submodules removed from commit, continuing..."
 
+    # If there are no changes to commit after removing submodules, abort to avoid an empty commit
     if output=$(git status --porcelain) && [ -z "$output" ]; then
-        # Working directory clean
-        echo -e "${grey}No changes to commit, aborting...${no_color}"
+        echo -e "${red}No changes to commit, aborting...${no_color}"
         exit 1
     fi
     exit 0

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -38,7 +38,7 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
 
     # If there are no changes to commit after removing submodules, abort to avoid an empty commit
     if output=$(git status --porcelain) && [ -z "$output" ]; then
-        echo -e "${red}No changes to commit, aborting...${no_color}"
+        echo -e "nothing to commit, working tree clean"
         exit 1
     fi
     exit 0

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -28,17 +28,15 @@ echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
 # If no modified submodules, exit with status code 0, else prompt the
 # user and exit accordingly
 if [[ -n "$MOD_SUBMODULES" ]]; then
-    echo "Submodules to be committed:"
-    echo "  (use \"git reset HEAD <file>...\" to unstage)"
-    echo
-
+    echo "${grey}Removing submodules from commit...${no_color}"
     for SUB in $MOD_SUBMODULES
     do
-        echo -e "\t${green}modified:\t$SUB${no_color}"
+        git reset HEAD "$SUB"
+        echo -e "\t${grey}removed:\t$SUB${no_color}"
     done
     echo
-    echo -e "${red}Aborting commit due to submodule update. Please unstage the submodule(s) and commit again.${no_color}"
-    exit 1
+    echo -e "Submodules removed from commit, continuing..."
+    exit 0
 else
     echo "No submodules in commit, continuing..."
     exit 0

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -36,6 +36,12 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
     done
     echo
     echo -e "Submodules removed from commit, continuing..."
+
+    if output=$(git status --porcelain) && [ -z "$output" ]; then
+        # Working directory clean
+        echo -e "${grey}No changes to commit, aborting...${no_color}"
+        exit 1
+    fi
     exit 0
 else
     echo "No submodules in commit, continuing..."


### PR DESCRIPTION
no issue

# Before
The pre-commit hook would abort the commit if any submodules were staged for commit, and prompt the user to manually un-stage them and retry the commit.

# Now
The pre-commit hook automatically un-stages any staged submodules, then allows the commit to proceed.

# Why?
This was a daily annoyance that caused many common git commands to abort, and required manual un-staging of the submodules before retrying the commit:
- `git commit -a`
- `git add . && git commit`
- `git add -A && git commit`

If we ever _do_ need to commit submodules, we can always add them back and run `git commit --no-verify` to accomplish that (which we would have needed to do before regardless). This should accomplish the same goal of not allowing submodules to be committed, but reduce the day to day friction of making commits in Ghost.