### PR TITLE
Removed duplicate calls to `moment()`

### DIFF
--- a/ghost/core/core/frontend/services/sitemap/BaseSiteMapGenerator.js
+++ b/ghost/core/core/frontend/services/sitemap/BaseSiteMapGenerator.js
@@ -95,6 +95,9 @@ class BaseSiteMapGenerator {
         this.lastModified = Date.now();
     }
 
+    /**
+     * @returns {moment.Moment}
+     */
     getLastModifiedForDatum(datum) {
         if (datum.updated_at || datum.published_at || datum.created_at) {
             const modifiedDate = datum.updated_at || datum.published_at || datum.created_at;
@@ -126,7 +129,7 @@ class BaseSiteMapGenerator {
         node = {
             url: [
                 {loc: url},
-                {lastmod: moment(this.getLastModifiedForDatum(datum)).toISOString()}
+                {lastmod: this.getLastModifiedForDatum(datum).toISOString()}
             ]
         };
 


### PR DESCRIPTION
- the return type of `getLastModifiedForDatum` is a moment object, and we're just wrapping it again in another moment call
- moment is very heavy so we shouldn't do it unnecessarily
- this makes boot time 1% quicker of heavy sites
