### PR TITLE
🐛 fixed the slug generator to not allow single character slugs

### DIFF
--- a/ghost/core/core/server/models/base/plugins/generate-slug.js
+++ b/ghost/core/core/server/models/base/plugins/generate-slug.js
@@ -20,6 +20,7 @@ module.exports = function (Bookshelf) {
             let slug;
             let slugTryCount = 1;
             const baseName = Model.prototype.tableName.replace(/s$/, '');
+
             let longSlug;
 
             // Look for a matching slug, append an incrementing number if so
@@ -81,7 +82,6 @@ module.exports = function (Bookshelf) {
                 // find the index of the first hyphen after the second character.
                 const hyphenIndex = slug.indexOf('-', 3);
 
-                //slug = (slug.indexOf('-') > -1) ? slug.slice(0, slug.indexOf('-')) : slug;
                 slug = hyphenIndex > -1 ? slug.slice(0, hyphenIndex) : slug;
             }
 
@@ -92,10 +92,12 @@ module.exports = function (Bookshelf) {
                     slug = 'hash-' + slug;
                 }
             }
+
             // single character slugs break things. Don't let that happen.
             if (slug.length === 1) {
                 slug = baseName + '-' + slug;
             }
+            
             // Some keywords cannot be changed
             slug = _.includes(urlUtils.getProtectedSlugs(), slug) ? slug + '-' + baseName : slug;
 

--- a/ghost/core/core/server/models/base/plugins/generate-slug.js
+++ b/ghost/core/core/server/models/base/plugins/generate-slug.js
@@ -17,10 +17,12 @@ module.exports = function (Bookshelf) {
          * @return {Promise<String>} Resolves to a unique slug string
          */
         generateSlug: function generateSlug(Model, base, options) {
+            console.log('generate-slug called with base', base);
+            console.log('generate-slug called with options', options);
             let slug;
             let slugTryCount = 1;
             const baseName = Model.prototype.tableName.replace(/s$/, '');
-
+            console.log('baseName is', baseName);
             let longSlug;
 
             // Look for a matching slug, append an incrementing number if so
@@ -79,7 +81,11 @@ module.exports = function (Bookshelf) {
             // If it's a user, let's try to cut it down (unless this is a human request)
             if (baseName === 'user' && options && options.shortSlug && slugTryCount === 1 && slug !== 'ghost-owner') {
                 longSlug = slug;
-                slug = (slug.indexOf('-') > -1) ? slug.slice(0, slug.indexOf('-')) : slug;
+                // find the index of the first hyphen after the second character.
+                const hyphenIndex = slug.indexOf('-', 3);
+
+                //slug = (slug.indexOf('-') > -1) ? slug.slice(0, slug.indexOf('-')) : slug;
+                slug = hyphenIndex > -1 ? slug.slice(0, hyphenIndex) : slug;
             }
 
             if (!_.has(options, 'importing') || !options.importing) {
@@ -89,7 +95,10 @@ module.exports = function (Bookshelf) {
                     slug = 'hash-' + slug;
                 }
             }
-
+            // single character slugs break things. Don't let that happen.
+            if (slug.length === 1) {
+                slug = baseName + '-' + slug;
+            }
             // Some keywords cannot be changed
             slug = _.includes(urlUtils.getProtectedSlugs(), slug) ? slug + '-' + baseName : slug;
 
@@ -103,6 +112,7 @@ module.exports = function (Bookshelf) {
             }
 
             // Test for duplicate slugs.
+            console.log('try this slug', slug);
             return checkIfSlugExists(slug);
         }
     });

--- a/ghost/core/core/server/models/base/plugins/generate-slug.js
+++ b/ghost/core/core/server/models/base/plugins/generate-slug.js
@@ -17,12 +17,9 @@ module.exports = function (Bookshelf) {
          * @return {Promise<String>} Resolves to a unique slug string
          */
         generateSlug: function generateSlug(Model, base, options) {
-            console.log('generate-slug called with base', base);
-            console.log('generate-slug called with options', options);
             let slug;
             let slugTryCount = 1;
             const baseName = Model.prototype.tableName.replace(/s$/, '');
-            console.log('baseName is', baseName);
             let longSlug;
 
             // Look for a matching slug, append an incrementing number if so
@@ -112,7 +109,6 @@ module.exports = function (Bookshelf) {
             }
 
             // Test for duplicate slugs.
-            console.log('try this slug', slug);
             return checkIfSlugExists(slug);
         }
     });

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -1897,9 +1897,9 @@ describe('Post Model', function () {
 
                 updatedPost.tags.should.have.lengthOf(3);
 
-                updatedPost.tags[0].should.have.properties({name: 'C', slug: 'c'});
-                updatedPost.tags[1].should.have.properties({name: 'C++', slug: 'c-2'});
-                updatedPost.tags[2].should.have.properties({name: 'C#', slug: 'c-3'});
+                updatedPost.tags[0].should.have.properties({name: 'C', slug: 'tag-c'});
+                updatedPost.tags[1].should.have.properties({name: 'C++', slug: 'tag-c-2'});
+                updatedPost.tags[2].should.have.properties({name: 'C#', slug: 'tag-c-3'});
             });
         });
 


### PR DESCRIPTION
closes #20133 and masks the effects of https://github.com/TryGhost/NQL/issues/20

It is currently possible to create a user, tag, post, etc with a single character slug.
(It is far too easy to do this with users, if your users have names like C. Ann Smythe.)

Single character slugs break things. They break displaying the posts of a user with a single character slug, and displaying posts with a single-character tag slug, and so on.  

Since fixing the underlying NQL parser glitch isn't an easy option, this patch tweaks the logic for generating slugs by 
(1) not truncating user names during user creating before the second character (so C. Ann Smythe becomes c-ann instead of c)
(2) checking late in the process for single character slugs, and changing them to baseName-slug, such that a post with title 'q' becomes 'post-q', and a user requesting a change to their slug to the slug 't' will be 'user-t' instead, or if they're new and we are generating the slug from their name, they'll be user-t if their whole name is 'T', or t-lastname if there's more to work with.

The one spot where I feel like this could be improved is user-requested slugs from the profile, where slug generation happens on clicking save (I think), rather than the field updating live like the it does with post slugs.  