### PR TITLE
Released Portal v2.44.1

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.44.0",
+  "version": "2.44.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no issue
- this release contains a fix for Tips & Donations for Ghost sites hosted on subdirectories (commit: 55e415c0c75fa6491ef1776d6f9f74c0c88047cd)

