### PR TITLE
Removed init of mobiledoc html renderer on boot

### DIFF
--- a/ghost/core/core/server/data/importer/importers/data/PostsImporter.js
+++ b/ghost/core/core/server/data/importer/importers/data/PostsImporter.js
@@ -271,10 +271,10 @@ class PostsImporter extends BaseImporter {
                 });
 
                 model.mobiledoc = JSON.stringify(mobiledoc);
-                model.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(model.mobiledoc));
+                model.html = mobiledocLib.render(JSON.parse(model.mobiledoc));
             } else if (model.html && !model.lexical) {
                 model.mobiledoc = JSON.stringify(mobiledocLib.htmlToMobiledocConverter(model.html));
-                model.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(model.mobiledoc));
+                model.html = mobiledocLib.render(JSON.parse(model.mobiledoc));
             }
 
             this.sanitizePostsMeta(model);

--- a/ghost/core/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
+++ b/ghost/core/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
@@ -39,7 +39,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
                 continue;
             }
 
-            const html = mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc);
+            const html = mobiledocLib.render(mobiledoc);
 
             const updatedAttrs = {
                 html: html

--- a/ghost/core/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
+++ b/ghost/core/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
@@ -59,7 +59,7 @@ module.exports = createTransactionalMigration(
                 }
 
                 try {
-                    html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(mobiledoc));
+                    html = mobiledocLib.render(JSON.parse(mobiledoc));
                 } catch (err) {
                     logging.warn(`Invalid mobiledoc content structure for ${id}, unable to render. Skipping`);
                     continue;

--- a/ghost/core/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
+++ b/ghost/core/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
@@ -43,7 +43,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
                 continue;
             }
 
-            const html = mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc);
+            const html = mobiledocLib.render(mobiledoc);
 
             const updatedAttrs = {
                 html

--- a/ghost/core/core/server/lib/mobiledoc.js
+++ b/ghost/core/core/server/lib/mobiledoc.js
@@ -73,6 +73,10 @@ module.exports = {
         return mobiledocHtmlRenderer;
     },
 
+    render(mobiledoc, options) {
+        return this.mobiledocHtmlRenderer.render(mobiledoc, options);
+    },
+
     get htmlToMobiledocConverter() {
         try {
             if (process.env.CI) {

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -742,7 +742,7 @@ Post = ghostBookshelf.Model.extend({
             )
         ) {
             try {
-                this.set('html', mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(this.get('mobiledoc'))));
+                this.set('html', mobiledocLib.render(JSON.parse(this.get('mobiledoc'))));
             } catch (err) {
                 throw new errors.ValidationError({
                     message: tpl(messages.invalidMobiledocStructure),

--- a/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
+++ b/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
@@ -59,7 +59,7 @@ class EmailServiceWrapper {
             settingsCache,
             settingsHelpers,
             renderers: {
-                mobiledoc: mobiledocLib.mobiledocHtmlRenderer,
+                mobiledoc: mobiledocLib,
                 lexical: lexicalLib
             },
             imageSize,


### PR DESCRIPTION
no issue

- the lazy-loading `mobiledocHtmlRenderer` getter was being accessed by the email renderer that gets initialized during boot
- switched the pattern to match our lexical lib where we have a `render()` method that doesn't load the renderer until it's actually needed
