### PR TITLE
Made newsletter preference toggles more compact on Member details screen

### DIFF
--- a/ghost/admin/app/components/member/newsletter-preference.hbs
+++ b/ghost/admin/app/components/member/newsletter-preference.hbs
@@ -7,7 +7,7 @@
                     <div>
                         <h4 class="gh-member-newsletter-title">{{newsletter.name}}</h4>
                     </div>
-                    <div class="for-switch {{if this.suppressionData.suppressed 'disabled'}}">
+                    <div class="for-switch xs {{if this.suppressionData.suppressed 'disabled'}}">
                         <label class="switch" for={{newsletter.forId}}>
                             <Input
                                 @checked={{newsletter.subscribed}}

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -1101,6 +1101,10 @@ textarea.gh-member-details-textarea {
     padding: 16px 0;
 }
 
+.gh-member-newsletter-row .for-switch {
+    display: flex;
+}
+
 .gh-member-newsletter-row:first-child {
     padding-top: 0;
 }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/DES-818/toggles-are-huge-lets-make-them-more-elegant

- They were too big and stood out too much on this screen, the `xs` variant fits better