### PR TITLE
Removed Sentry span creation from get helper

### DIFF
--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -7,7 +7,6 @@ const {hbs, SafeString} = require('../services/handlebars');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
-const Sentry = require('@sentry/node');
 
 const _ = require('lodash');
 const jsonpath = require('jsonpath');
@@ -292,53 +291,37 @@ module.exports = async function get(resource, options) {
 
     // Parse the options we're going to pass to the API
     apiOptions = parseOptions(ghostGlobals, this, apiOptions);
-    let apiOptionsString = Object.entries(apiOptions)
-        .map(([key, value]) => ` ${key}="${value}"`)
-        .join('');
     apiOptions.context = {member: data.member};
     try {
-        const spanName = `{{#get "${resource}"${apiOptionsString}}} ${data.member ? 'member' : 'public'}`;
-        const result = await Sentry.startSpan({
-            op: 'frontend.helpers.get',
-            name: spanName,
-            tags: {
-                resource,
-                ...apiOptions,
-                context: data.member ? 'member' : 'public'
-            }
-        }, async (span) => {
-            const response = await makeAPICall(resource, controllerName, action, apiOptions);
+        const response = await makeAPICall(resource, controllerName, action, apiOptions);
 
-            // prepare data properties for use with handlebars
-            if (response[resource] && response[resource].length) {
-                response[resource].forEach(prepareContextResource);
-            }
+        // prepare data properties for use with handlebars
+        if (response[resource] && response[resource].length) {
+            response[resource].forEach(prepareContextResource);
+        }
 
-            // used for logging details of slow requests
-            returnedRowsCount = response[resource] && response[resource].length;
-            span?.setTag('returnedRows', returnedRowsCount);
+        // used for logging details of slow requests
+        returnedRowsCount = response[resource] && response[resource].length;
 
-            // block params allows the theme developer to name the data using something like
-            // `{{#get "posts" as |result pageInfo|}}`
-            const blockParams = [response[resource]];
-            if (response.meta && response.meta.pagination) {
-                response.pagination = response.meta.pagination;
-                blockParams.push(response.meta.pagination);
-            }
+        // block params allows the theme developer to name the data using something like
+        // `{{#get "posts" as |result pageInfo|}}`
+        const blockParams = [response[resource]];
+        if (response.meta && response.meta.pagination) {
+            response.pagination = response.meta.pagination;
+            blockParams.push(response.meta.pagination);
+        }
 
-            // Call the main template function
-            const rendered = options.fn(response, {
-                data: data,
-                blockParams: blockParams
-            });
-
-            if (response['@@ABORTED_GET_HELPER@@']) {
-                return new SafeString(`<span data-aborted-get-helper>Could not load content</span>` + rendered);
-            } else {
-                return rendered;
-            }
+        // Call the main template function
+        const rendered = options.fn(response, {
+            data: data,
+            blockParams: blockParams
         });
-        return result;
+
+        if (response['@@ABORTED_GET_HELPER@@']) {
+            return new SafeString(`<span data-aborted-get-helper>Could not load content</span>` + rendered);
+        } else {
+            return rendered;
+        }
     } catch (error) {
         logging.error(error);
         data.error = error.message;

--- a/ghost/core/core/frontend/meta/generate-excerpt.js
+++ b/ghost/core/core/frontend/meta/generate-excerpt.js
@@ -1,5 +1,3 @@
-const downsize = require('downsize');
-
 function generateExcerpt(excerpt, truncateOptions) {
     truncateOptions = truncateOptions || {};
 
@@ -8,6 +6,7 @@ function generateExcerpt(excerpt, truncateOptions) {
     }
 
     // Just uses downsize to truncate, not format
+    const downsize = require('downsize');
     return downsize(excerpt, truncateOptions);
 }
 

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -2,7 +2,6 @@ const ghostBookshelf = require('./base');
 const crypto = require('crypto');
 const _ = require('lodash');
 const config = require('../../shared/config');
-const {gravatar} = require('../lib/image');
 
 const Member = ghostBookshelf.Model.extend({
     tableName: 'members',
@@ -397,6 +396,7 @@ const Member = ghostBookshelf.Model.extend({
         // Will not use gravatar if privacy.useGravatar is false in config
         attrs.avatar_image = null;
         if (attrs.email && !config.isPrivacyDisabled('useGravatar')) {
+            const {gravatar} = require('../lib/image');
             attrs.avatar_image = gravatar.url(attrs.email, {size: 250, default: 'blank'});
         }
 

--- a/ghost/core/core/shared/config/utils.js
+++ b/ghost/core/core/shared/config/utils.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 const _ = require('lodash');
 
 /**
@@ -25,7 +25,7 @@ const makePathsAbsolute = function makePathsAbsolute(nconf, obj, parent) {
 };
 
 const doesContentPathExist = function doesContentPathExist(contentPath) {
-    if (!fs.pathExistsSync(contentPath)) {
+    if (!fs.existsSync(contentPath)) {
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition
         // eslint-disable-next-line ghost/ghost-custom/no-native-error

--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -3,8 +3,6 @@ const {VersionMismatchError} = require('@tryghost/errors');
 // @ts-ignore
 const debug = require('@tryghost/debug')('stripe');
 const Stripe = require('stripe').Stripe;
-// @ts-ignore
-const LeakyBucket = require('leaky-bucket');
 
 /* Stripe has the following rate limits:
 *  - For most APIs, 100 read requests per second in live mode, 25 read requests per second in test mode
@@ -78,6 +76,10 @@ module.exports = class StripeAPI {
             this._configured = false;
             return;
         }
+
+        // Lazyloaded to protect sites without Stripe configured
+        const LeakyBucket = require('leaky-bucket');
+
         this._stripe = new Stripe(config.secretKey, {
             apiVersion: STRIPE_API_VERSION
         });


### PR DESCRIPTION
- this didn't really end up being useful and it just forces us to
  require the `@sentry/node` dependency, so we can remove it
