### PR TITLE
Removed lodash usage from config helpers

### DIFF
--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -1,6 +1,9 @@
 const path = require('path');
-const escapeRegExp = require('lodash/escapeRegExp');
 const {URL} = require('url');
+
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 const DEFAULT_HOST_ARG = /.*/;
 


### PR DESCRIPTION
no issue

- config helpers are required early during boot and it requiring lodash added some unnecessary require+compile time
- switched to using an inlined escapeRegExp function in place of requiring lodash
