### PR TITLE
Changed VSCode settings.json to ignore git submodules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
   },
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-  ]
+  ],
+  "git": {
+    "detectSubmodules": false
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,5 @@
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
   ],
-  "git": {
-    "detectSubmodules": false
-  }
+  "git.detectSubmodules": false
 }


### PR DESCRIPTION
no issue

- This removes the `casper` and `source` submodules from the VSCode source control sidebar to simplify the view.
- It also points all of VSCode's `git` commands in the command palette to the root of the repository, so you don't have to specify which repo you want to commit to every time.
- With this, you can simply run the "Git commit all" command in VSCode (and optionally map a keybinding to it), which adds all changed files to the commit and prompts for a commit message.