### PR TITLE
Fixed setting minification ready state upon failure

### DIFF
--- a/ghost/core/core/frontend/services/assets-minification/AssetsMinificationBase.js
+++ b/ghost/core/core/frontend/services/assets-minification/AssetsMinificationBase.js
@@ -48,16 +48,16 @@ module.exports = class AssetsMinificationBase {
 
     async minify(globs, options) {
         try {
-            return await this.minifier.minify(globs, options);
+            const result = await this.minifier.minify(globs, options);
+            this.ready = true;
+            return result;
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write asset files due to permissions.');
                 return;
             }
 
-            throw error;
-        } finally {
-            this.ready = true;
+            throw error;           
         }
     }
 


### PR DESCRIPTION
- this will prevent the `ready` variable from being set to true if there is an error with minification, as we have not correctly generated the assets yet
