### PR TITLE
Optimized loading dynamic redirects

### DIFF
--- a/ghost/express-dynamic-redirects/lib/DynamicRedirectManager.js
+++ b/ghost/express-dynamic-redirects/lib/DynamicRedirectManager.js
@@ -16,8 +16,6 @@ class DynamicRedirectManager {
 
         /** @private */
         this.router = express.Router();
-        /** @private @type {string[]} */
-        this.redirectIds = [];
         /** @private @type {Object.<string, {fromRegex: RegExp, to: string, options: {permanent: boolean}}>} */
         this.redirects = {};
 
@@ -103,10 +101,6 @@ class DynamicRedirectManager {
 
             const fromRegex = this.buildRegex(from);
             const redirectId = from;
-
-            if (!this.redirectIds.includes(redirectId)) {
-                this.redirectIds.push(redirectId);
-            }
             
             this.redirects[redirectId] = {
                 fromRegex,
@@ -131,11 +125,10 @@ class DynamicRedirectManager {
      * @returns {void}
      */
     removeRedirect(redirectId) {
-        this.redirectIds.splice(this.redirectIds.indexOf(redirectId), 1);
         delete this.redirects[redirectId];
 
         this.router = express.Router();
-        this.redirectIds.forEach(id => this.setupRedirect(id));
+        Object.keys(this.redirects).forEach(id => this.setupRedirect(id));
 
         return;
     }
@@ -144,7 +137,6 @@ class DynamicRedirectManager {
      * @returns {void}
      */
     removeAllRedirects() {
-        this.redirectIds = [];
         this.redirects = {};
         this.router = express.Router();
     }

--- a/ghost/express-dynamic-redirects/test/DynamicRedirectManager.test.js
+++ b/ghost/express-dynamic-redirects/test/DynamicRedirectManager.test.js
@@ -137,7 +137,6 @@ describe('DynamicRedirectManager', function () {
             req.url = '/redirect-me';
 
             manager.removeAllRedirects();
-            manager.redirectIds.should.be.empty();
             manager.redirects.should.be.empty();
 
             manager.handleRequest(req, res, function next() {


### PR DESCRIPTION
- the code kept an array of IDs, and would check new entries against the values of this array
- this algorithm is O(n^2) and became quite slow when the site had a lot of redirects
- we can do away with this entirely, and just compute the keys of the redirects to get the IDs
- this speeds up loading redirects by 3x or so

Before:
![CleanShot 2024-10-14 at 17 05 09@2x](https://github.com/user-attachments/assets/75e8d15c-fbf5-45ec-83a9-fb54d6bc13b8)

After:
![CleanShot 2024-10-14 at 17 05 22@2x](https://github.com/user-attachments/assets/8919915e-4161-4a6e-b506-83a9eecef8ba)
