### PR TITLE
Updated media query

### DIFF
--- a/ghost/admin/app/styles/components/lists.css
+++ b/ghost/admin/app/styles/components/lists.css
@@ -507,6 +507,11 @@ ul.nostyle li {
         padding-left: 0;
         padding-right: 4vw;
     }
+    
+    .gh-list-scrolling thead {
+        position: relative;
+        z-index: 780;
+    }
 }
 
 @media (max-width: 450px) {


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-317/adminx-members-list-header-column-overlaps-sidebar-in-mobile-viewport

Added a positioning and z-index change to the `thead` within the media query to make sure it moved back behind the overlay.

