### PR TITLE
🐛 Fixed missing incoming recommendations

### DIFF
--- a/ghost/core/core/server/models/mention.js
+++ b/ghost/core/core/server/models/mention.js
@@ -6,7 +6,7 @@ const Mention = ghostBookshelf.Model.extend({
         deleted: false,
         verified: false
     },
-    enforcedFilters() {
+    defaultFilters() {
         return 'deleted:false';
     }
 }, {

--- a/ghost/recommendations/src/IncomingRecommendationService.ts
+++ b/ghost/recommendations/src/IncomingRecommendationService.ts
@@ -95,8 +95,10 @@ export class IncomingRecommendationService {
     }
 
     async #updateIncomingRecommendations() {
-        // Note: we also recheck recommendations that were not verified (verification could have failed)
-        const filter = this.#getMentionFilter();
+        // We refresh all incoming recommendations, including:
+        // - recommendations that were not verified, as the verification could have failed
+        // - recommendations that were deleted previously. Implementation note: given that we have `deleted:false` as default filter in the Mention model, we need to override it here
+        const filter = this.#getMentionFilter() + '+deleted:[true,false]';
         await this.#mentionsApi.refreshMentions({filter, limit: 100});
     }
 

--- a/ghost/recommendations/test/IncomingRecommendationService.test.ts
+++ b/ghost/recommendations/test/IncomingRecommendationService.test.ts
@@ -52,6 +52,10 @@ describe('IncomingRecommendationService', function () {
                 await service.init();
                 clock.tick(1000 * 60 * 60 * 24);
                 assert(refreshMentions.calledOnce);
+                assert(refreshMentions.calledWith({
+                    filter: `source:~$'/.well-known/recommendations.json'+deleted:[true,false]`,
+                    limit: 100
+                }));
             } finally {
                 process.env.NODE_ENV = saved;
             }

--- a/ghost/webmentions/lib/Mention.js
+++ b/ghost/webmentions/lib/Mention.js
@@ -33,7 +33,6 @@ module.exports = class Mention {
         // When an earlier mention is deleted, but then it gets verified again, we need to undelete it
         if (this.#deleted) {
             this.#deleted = false;
-            this.events.push(MentionCreatedEvent.create({mention: this}));
         }
     }
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-433

- due to a regression introduced in commit 871d21a, incoming recommendations were not rendering in Admin Settings anymore, as they were marked as deleted
- this commit updates the refresh logic of incoming recommendations on boot: previously deleted incoming recommendations are refetched, and if now available, restored
- when a recommendation is restored, we don't send a staff email notification