### PR TITLE
Added `created_at` field to member fixtures for consistent sort

### DIFF
--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -305,7 +305,8 @@ DataGenerator.Content = {
             name: 'Mr Egg',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b340',
             status: 'free',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(8, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -313,7 +314,8 @@ DataGenerator.Content = {
             email_open_rate: 50,
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b341',
             status: 'free',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(7, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -322,7 +324,8 @@ DataGenerator.Content = {
             email_open_rate: 80,
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b342',
             status: 'paid',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(6, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -330,7 +333,8 @@ DataGenerator.Content = {
             name: 'Ray Stantz',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b343',
             status: 'paid',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(5, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -338,7 +342,8 @@ DataGenerator.Content = {
             name: 'Vinz Clortho',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b344',
             status: 'paid',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(4, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -346,7 +351,8 @@ DataGenerator.Content = {
             name: 'Winston Zeddemore',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b345',
             status: 'free',
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(3, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -355,7 +361,8 @@ DataGenerator.Content = {
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b346',
             status: 'paid',
             subscribed: false,
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(2, 'day').toDate()
         },
         {
             id: ObjectId().toHexString(),
@@ -364,7 +371,8 @@ DataGenerator.Content = {
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b347',
             status: 'paid',
             subscribed: false,
-            email_disabled: false
+            email_disabled: false,
+            created_at: moment().subtract(1, 'day').toDate()
         }
     ],
 


### PR DESCRIPTION
no ref

When running tests, occasionally we'll see some varying sort in the members api response because members are generally all created with the same timestamp. While `ObjectId` should be progressive, and our defalut sort is `ORDER BY created_at desc, id desc`, we still would sometimes see issues. This ought to remove any flakiness.