### PR TITLE
Added build:ts dependency to yarn test:unit

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -35,6 +35,7 @@
             "cache": true
         },
         "test:unit": {
+            "dependsOn": ["^build:ts"],
             "cache": true
         }
     },


### PR DESCRIPTION
no issue

- Running `yarn test:unit` fails unless you've previously run `yarn build:ts`. This change tells `nx` about this dependency, so it will run `yarn build:ts` before `yarn test:unit`. It should take advantage of the nx cache though, so it will only run the `build:ts` task if necessary