### PR TITLE
Added @tryghost/metrics-server to package.json

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -126,6 +126,7 @@
     "@tryghost/members-stripe-service": "0.0.0",
     "@tryghost/mentions-email-report": "0.0.0",
     "@tryghost/metrics": "1.0.34",
+    "@tryghost/metrics-server": "0.0.0",
     "@tryghost/milestones": "0.0.0",
     "@tryghost/minifier": "0.0.0",
     "@tryghost/model-to-domain-event-interceptor": "0.0.0",


### PR DESCRIPTION
no issue

- I apparently never added @tryghost/metrics-server as a dependency to ghost/core/package.json. It worked in most cases as a 'phantom dependency' — yarn installs all node_modules in a flat structure, so even though it wasn't a dependency in package.json, it still resolved to the correct package, as long as the typescript packages were all built first.
- This passed CI because we explicitly run ts:build on all packages before running tests, and it worked in production because we build the TS packages as part of the docker build. However, when trying to run tests locally, it would sometimes fail unless you explicitly ran nx run-many -t build:ts at the top level before running the tests.
- Adding it as a dependency in package.json fixes this problem.