### PR TITLE
Added target dependencies to test scripts in ghost/core

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -285,6 +285,71 @@
         "dependsOn": [
           "^build:ts"
         ]
+      },
+      "test": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:single": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:all": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:unit": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:integration": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:regression": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:browser": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:browser:admin": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:browser:portal": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:e2e": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:ci:e2e": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:ci:regression": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "test:ci:integration": {
+        "dependsOn": [
+          "^build:ts"
+        ]
       }
     }
   }


### PR DESCRIPTION
no issue

- The `test:*` commands in `ghost/core` are all implicitly dependent on the TS packages in the whole monorepo being built, but we hadn't explicitly declared this dependency to NX.
- Now if you run `yarn nx run ghost:test:e2e` (or any other `test:*` commands in ghost), NX will know that it needs to rebuild the TS packages, unless they are cached and haven't changed.
- With this, you should be able to directly clone the repo and run `yarn nx run ghost:test:e2e` to run e2e tests, without running `yarn dev` or `yarn nx run-many -t build:ts` first.
- This is especially useful for getting tests to run properly in docker