### PR TITLE
Amp.hbs file should have a lang attribute on HTML entity

### DIFF
--- a/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="{{@site.locale}}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">


### PR DESCRIPTION
After analysing my blog with SEMRush, I had an issue on the amp analysis. The lang was missing from the AMP pages ...
I propose to add the lang attribute regarding the AMP specifications : 

https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-html-components.md

`<html ⚡ lang="en">`

We reuse the site.local from the setttings to set the good information.

