### PR TITLE
Added migration for new settings keys

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -72,7 +72,9 @@ const EDITABLE_SETTINGS = [
     'pintura_css_url',
     'donations_currency',
     'donations_suggested_amount',
-    'recommendations_enabled'
+    'recommendations_enabled',
+    'body_font',
+    'heading_font'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/migrations/versions/5.97/2024-10-08-14-25-27-added-body-font-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.97/2024-10-08-14-25-27-added-body-font-settings.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'body_font',
+    value: '',
+    type: 'string',
+    group: 'site'
+});

--- a/ghost/core/core/server/data/migrations/versions/5.97/2024-10-08-14-36-58-added-heading-font-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.97/2024-10-08-14-36-58-added-heading-font-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'heading_font',
+    value: '',
+    type: 'string',
+    group: 'site'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -82,6 +82,14 @@
             "flags": "PUBLIC",
             "type": "string"
         },
+        "heading_font": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "body_font": {
+            "defaultValue": "",
+            "type": "string"
+        },
         "logo": {
             "defaultValue": "",
             "type": "string"

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 86;
+            const allowedKeysLength = 88;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'a4f016480ff73c6f52ee4c86482b45a7';
     const currentFixturesHash = '475f488105c390bb0018db90dce845f1';
-    const currentSettingsHash = '051ef2a50e2edb8723e89461448313cb';
+    const currentSettingsHash = '47a75e8898fab270174a0c905cb3e914';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
This adds a new migration needed for custom fonts with `body_font` and `heading_font` as new possible site settings in our default settings.
