### PR TITLE
Improved validation behaviour on 2fa code verification screen

### DIFF
--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -27,7 +27,6 @@
                             value={{this.token}}
                             data-test-input="token"
                             {{on "input" this.handleTokenInput}}
-                            {{on "blur" this.validateToken}}
                         />
 
                         <GhTaskButton
@@ -37,6 +36,7 @@
                             @successClass=""
                             @failureClass=""
                             @disabled={{this.resendTokenCountdownStarted}}
+                            data-test-button="resend-token"
                             as |task|
                         >
                             {{#if this.resendTokenCountdownStarted}}
@@ -58,7 +58,9 @@
                     data-test-button="verify" />
             </form>
 
-            <p class="{{if this.flowErrors "main-error" "main-notification"}}" data-test-flow-notification>{{if this.flowErrors this.flowErrors this.flowNotification}}&nbsp;</p>
+            {{#let (or this.flowErrors this.verifyData.validationMessage) as |error|}}
+                <p class="{{if error "main-error" "main-notification"}}" data-test-flow-notification>{{error}}&nbsp;</p>
+            {{/let}}
         </section>
     </div>
 </div>

--- a/ghost/admin/mirage/config/authentication.js
+++ b/ghost/admin/mirage/config/authentication.js
@@ -4,9 +4,19 @@ import {dasherize} from '@ember/string';
 import {isBlank} from '@ember/utils';
 
 export default function mockAuthentication(server) {
+    // Password sign-in
     server.post('/session', function () {
-        // Password sign-in
         return new Response(201);
+    });
+
+    // 2fa code verification
+    server.put('/session/verify', function () {
+        return new Response(201);
+    });
+
+    // 2fa code re-send
+    server.post('/session/verify', function () {
+        return new Response(200);
     });
 
     server.post('/authentication/password_reset', function (schema, request) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-1672

- removed input on-blur validation because it can be triggered when clicking reset button giving a misleading error state
- added client-side validation for 6-digit code
- added validation when submitting the form
- added error reset when typing in the code field, including removal of button failure state, so it's clearer you're in a new submit state
