### PR TITLE
MRR/Members chart axis fix

### DIFF
--- a/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
+++ b/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
@@ -816,20 +816,14 @@ export default class Anchor extends Component {
     }
 
     getYAxisMin() {
-        if (this.selectedChartDisplay !== 'mrr') {
-            return 0;
-        }
         const data = this.chartData.datasets[0].data;
         const min = Math.min(...data);
         return Math.floor(min * 0.95); // Start y-axis at 95% of the minimum value
     }
 
     getYAxisMax() {
-        if (this.selectedChartDisplay !== 'mrr') {
-            return null; // Let Chart.js decide the max for other chart types
-        }
         const data = this.chartData.datasets[0].data;
         const max = Math.max(...data);
-        return Math.ceil(max * 1.05); // End y-axis at 105% of the maximum value
+        return Math.ceil(max * 1.05); // End y-axis at 105% of the maximum value for all chart types
     }
 }

--- a/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
+++ b/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
@@ -815,15 +815,27 @@ export default class Anchor extends Component {
         return Math.round((to - from) / from * 100);
     }
 
-    getYAxisMin() {
-        const data = this.chartData.datasets[0].data;
-        const min = Math.min(...data);
-        return Math.floor(min * 0.95); // Start y-axis at 95% of the minimum value
-    }
-
     getYAxisMax() {
+        if (!this.chartData || !this.chartData.datasets || !this.chartData.datasets[0]) {
+            return null; // Let Chart.js handle it if data is not available
+        }
         const data = this.chartData.datasets[0].data;
+        if (!data || data.length === 0) {
+            return null; 
+        }
         const max = Math.max(...data);
         return Math.ceil(max * 1.05); // End y-axis at 105% of the maximum value for all chart types
+    }
+
+    getYAxisMin() {
+        if (!this.chartData || !this.chartData.datasets || !this.chartData.datasets[0]) {
+            return null; 
+        }
+        const data = this.chartData.datasets[0].data;
+        if (!data || data.length === 0) {
+            return null; 
+        }
+        const min = Math.min(...data);
+        return Math.floor(min * 0.95); // Start y-axis at 95% of the minimum value for all chart types
     }
 }

--- a/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
+++ b/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
@@ -224,17 +224,7 @@ export default class Anchor extends Component {
         } else if (this.selectedChartDisplay === 'mrr') {
             stats = this.dashboardStats.filledMrrStats;
             labels = stats.map(stat => stat.date);
-            
-            // Use mrrChartRange to calculate the chart range
-            const mrrRange = this.dashboardStats.mrrChartRange;
-            const minValue = mrrRange.min;
-            const maxValue = mrrRange.max;
-            
-            // Adjust the data points based on the calculated range
-            data = stats.map(stat => {
-                const normalizedValue = (stat.mrr - minValue) / (maxValue - minValue);
-                return minValue + (normalizedValue * (maxValue - minValue));
-            });
+            data = stats.map(stat => stat.mrr);
         } else {
             // total
             stats = this.dashboardStats.filledMemberCountStats;

--- a/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
+++ b/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
@@ -374,7 +374,10 @@ export default class Anchor extends Component {
                         zeroLineWidth: 1
                     },
                     ticks: {
-                        display: false
+                        display: false,
+                        beginAtZero: false,
+                        suggestedMin: this.getYAxisMin(),
+                        suggestedMax: this.getYAxisMax()
                     }
                 }],
                 xAxes: [{
@@ -810,5 +813,23 @@ export default class Anchor extends Component {
         }
 
         return Math.round((to - from) / from * 100);
+    }
+
+    getYAxisMin() {
+        if (this.selectedChartDisplay !== 'mrr') {
+            return 0;
+        }
+        const data = this.chartData.datasets[0].data;
+        const min = Math.min(...data);
+        return Math.floor(min * 0.95); // Start y-axis at 95% of the minimum value
+    }
+
+    getYAxisMax() {
+        if (this.selectedChartDisplay !== 'mrr') {
+            return null; // Let Chart.js decide the max for other chart types
+        }
+        const data = this.chartData.datasets[0].data;
+        const max = Math.max(...data);
+        return Math.ceil(max * 1.05); // End y-axis at 105% of the maximum value
     }
 }

--- a/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
+++ b/ghost/admin/app/components/dashboard/charts/anchor-attribution.js
@@ -224,7 +224,17 @@ export default class Anchor extends Component {
         } else if (this.selectedChartDisplay === 'mrr') {
             stats = this.dashboardStats.filledMrrStats;
             labels = stats.map(stat => stat.date);
-            data = stats.map(stat => stat.mrr);
+            
+            // Use mrrChartRange to calculate the chart range
+            const mrrRange = this.dashboardStats.mrrChartRange;
+            const minValue = mrrRange.min;
+            const maxValue = mrrRange.max;
+            
+            // Adjust the data points based on the calculated range
+            data = stats.map(stat => {
+                const normalizedValue = (stat.mrr - minValue) / (maxValue - minValue);
+                return minValue + (normalizedValue * (maxValue - minValue));
+            });
         } else {
             // total
             stats = this.dashboardStats.filledMemberCountStats;

--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -845,4 +845,36 @@ export default class DashboardStatsService extends Service {
         }
         return output;
     }
+
+    /**
+     * Calculate the Y-axis range for the MRR chart
+     * @returns {Object} An object with min and max values for the Y-axis
+     */
+    get mrrChartRange() {
+        if (!this.mrrStats || this.mrrStats.length === 0) {
+            return { min: 0, max: 100 };
+        }
+
+        const values = this.mrrStats.map(stat => stat.mrr);
+        const minValue = Math.min(...values);
+        const maxValue = Math.max(...values);
+
+        // Ensure a minimum range of 10% of the maximum value
+        const minRange = maxValue * 0.1;
+
+        let min = Math.floor(minValue * 0.9);
+        let max = Math.ceil(maxValue * 1.1);
+
+        // If the range is too small, adjust it
+        if (max - min < minRange) {
+            const middle = (max + min) / 2;
+            min = Math.floor(middle - minRange / 2);
+            max = Math.ceil(middle + minRange / 2);
+        }
+
+        // Ensure min is never negative for MRR
+        min = Math.max(0, min);
+
+        return { min, max };
+    }
 }

--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -845,36 +845,4 @@ export default class DashboardStatsService extends Service {
         }
         return output;
     }
-
-    /**
-     * Calculate the Y-axis range for the MRR chart
-     * @returns {Object} An object with min and max values for the Y-axis
-     */
-    get mrrChartRange() {
-        if (!this.mrrStats || this.mrrStats.length === 0) {
-            return { min: 0, max: 100 };
-        }
-
-        const values = this.mrrStats.map(stat => stat.mrr);
-        const minValue = Math.min(...values);
-        const maxValue = Math.max(...values);
-
-        // Ensure a minimum range of 10% of the maximum value
-        const minRange = maxValue * 0.1;
-
-        let min = Math.floor(minValue * 0.9);
-        let max = Math.ceil(maxValue * 1.1);
-
-        // If the range is too small, adjust it
-        if (max - min < minRange) {
-            const middle = (max + min) / 2;
-            min = Math.floor(middle - minRange / 2);
-            max = Math.ceil(middle + minRange / 2);
-        }
-
-        // Ensure min is never negative for MRR
-        min = Math.max(0, min);
-
-        return { min, max };
-    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-869/dashboard-mrr-member-chart-axis-is-making-flat-growth-look-like

A slight decline/increase on the MRR/members chart was shown as a very dramatic shift. These changes will make the chart appear more gradual when the changes are small. The chart will effectively "zoom in" on the range where the values fluctuate, making small changes more visible without appearing overly dramatic.

I've tested it with hardcoded values, as well as values inserted via the API, and the charts look a lot better.

**Before**
<img width="1257" alt="1 - chart before" src="https://github.com/user-attachments/assets/8d59fc38-0a57-4a7a-a83f-06e045057f45">
<img width="1255" alt="2 - chart before" src="https://github.com/user-attachments/assets/46476d88-3991-4253-a5bc-76591ea67e39">

**After (same two values)**
<img width="1260" alt="3 - chart after" src="https://github.com/user-attachments/assets/d5bcfdb2-40dd-4655-afd4-ba19a62d76b9">
<img width="1263" alt="4 - chart after" src="https://github.com/user-attachments/assets/6c8cf189-6497-482e-9414-a7d77c00c533">

**Gradual decline**
<img width="1259" alt="5 - chart gradual" src="https://github.com/user-attachments/assets/5ec2b470-f1d2-45cd-aba5-5f11e6e718fd">
<img width="1250" alt="6 - chart gradual" src="https://github.com/user-attachments/assets/b6dd67ab-0b5e-47db-a9ef-d4ae10b78f73">

**More pronounced decline**
<img width="1270" alt="7 - chart dramatic" src="https://github.com/user-attachments/assets/c43215c3-a687-47be-ab05-70fee855a345">
<img width="1256" alt="8 - chart dramatic" src="https://github.com/user-attachments/assets/55ae833b-e47d-441a-98e0-fcfa2e9734a0">
<img width="1258" alt="9 - chart dramatic" src="https://github.com/user-attachments/assets/b9fdef8f-61fa-4315-a662-b37eea2259d3">
