### PR TITLE
Used `attributedTo` for the `Like` activities on the profile page

### DIFF
--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -58,7 +58,7 @@ const Profile: React.FC<ProfileProps> = ({}) => {
                                     data-test-view-article
                                 >
                                     <FeedItem
-                                        actor={activity.actor}
+                                        actor={activity.object?.attributedTo || activity.actor}
                                         layout={layout}
                                         object={Object.assign({}, activity.object, {liked: true})}
                                         type={activity.type}


### PR DESCRIPTION
refs [AP-487](https://linear.app/ghost/issue/AP-487/likes-on-profile-info-displaying-incorrect-actor-info)

Used `attributedTo` for the `Like` activities on the profile page of the `admin-x-activitypub` app