### PR TITLE
🎨Changed hover color of ExitButton

### DIFF
--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -9,7 +9,7 @@ const ExitSettingsButton: React.FC = () => {
     };
 
     return (
-        <Button className='text-grey-700 hover:!text-black' data-testid="exit-settings" icon='close' id="done-button" label='' link={true} title='Close (ESC)' onClick={() => confirmIfDirty(isDirty, navigateAway)} />
+        <Button className='text-grey-700 hover:!text-grey-900' data-testid="exit-settings" icon='close' id="done-button" label='' link={true} title='Close (ESC)' onClick={() => confirmIfDirty(isDirty, navigateAway)} />
     );
 };
 


### PR DESCRIPTION
no issue

- changed the hover color of the settings exit button from black to grey-900
- keeps the X visible when hovering over it (before it was the same color as the background)
