### PR TITLE
Fixed browser tests yielding a false passing result in CI

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -239,7 +239,8 @@ async function handleStripe() {
 
     const {result} = concurrently(commands, {
         prefix: 'name',
-        killOthers: ['failure', 'success']
+        killOthers: ['failure', 'success'],
+        successCondition: 'first'
     });
 
     try {

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -250,5 +250,6 @@ async function handleStripe() {
         console.error(chalk.red(`If you've recently done a \`yarn main\`, dependencies might be out of sync. Try running \`${chalk.green('yarn fix')}\` to fix this.`));
         console.error(chalk.red(`If not, something else went wrong. Please report this to the Ghost team.`));
         console.error();
+        process.exit(1);
     }
 })();

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -60,6 +60,10 @@ const features = [{
     description: 'Enables new comment features',
     flag: 'commentImprovements'
 }, {
+    title: 'Staff 2FA',
+    description: 'Enables email verification for staff logins',
+    flag: 'staff2fa'
+}, {
     title: 'Custom Fonts',
     description: 'Enables new custom font settings',
     flag: 'customFonts'

--- a/ghost/admin/app/controllers/signin-verify.js
+++ b/ghost/admin/app/controllers/signin-verify.js
@@ -121,7 +121,15 @@ export default class SigninVerifyController extends Controller {
         const resendTokenPath = `${this.ghostPaths.apiRoot}/session/verify`;
 
         try {
-            yield this.ajax.post(resendTokenPath);
+            try {
+                yield this.ajax.post(resendTokenPath);
+            } catch (error) {
+                // HACK: For some reason, the server returns 200: OK and sends the email but the client still throws an error
+                // So we need to catch the error and throw it if it's not 'OK'
+                if (error !== 'OK') {
+                    throw error;
+                }
+            }
             this.startResendTokenCountdown();
             return TASK_SUCCESS;
         } catch (error) {

--- a/ghost/core/test/e2e-browser/admin/2fa.spec.js
+++ b/ghost/core/test/e2e-browser/admin/2fa.spec.js
@@ -49,7 +49,7 @@ test.describe('2FA', () => {
         await expect(page.locator('.gh-nav-menu-details-sitetitle')).toHaveText(/The Local Test/);
     });
 
-    test('Using the re-send button sends a second email', async ({page, verificationToken}) => {
+    test.fixme('Using the re-send button sends a second email', async ({page, verificationToken}) => {
         // Logout
         const context = await page.context();
         await context.clearCookies();

--- a/ghost/core/test/e2e-browser/admin/2fa.spec.js
+++ b/ghost/core/test/e2e-browser/admin/2fa.spec.js
@@ -49,7 +49,7 @@ test.describe('2FA', () => {
         await expect(page.locator('.gh-nav-menu-details-sitetitle')).toHaveText(/The Local Test/);
     });
 
-    test.fixme('Using the re-send button sends a second email', async ({page, verificationToken}) => {
+    test('Using the re-send button sends a second email', async ({page, verificationToken}) => {
         // Logout
         const context = await page.context();
         await context.clearCookies();


### PR DESCRIPTION
no issue

- Browser tests in CI were yielding a passing result even if one or more tests failed (including retries).
- The `yarn dev` command that triggers the browser tests in CI was catching any errors and exiting with code 0, resulting in a ✅ in CI.
- This commit changes `yarn dev` to exit with code 1 if the browser tests fail, so that CI will correctly fail if any of the browser tests fail.