### PR TITLE
Fixed browser tests giving false passing results in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
       run: yarn nx run ghost-admin:build:dev
 
     - name: Run Playwright tests locally
+      working-directory: ghost/core
       run: yarn test:browser
       env:
         CI: true

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -60,6 +60,10 @@ const features = [{
     description: 'Enables new comment features',
     flag: 'commentImprovements'
 }, {
+    title: 'Staff 2FA',
+    description: 'Enables email verification for staff logins',
+    flag: 'staff2fa'
+}, {
     title: 'Custom Fonts',
     description: 'Enables new custom font settings',
     flag: 'customFonts'

--- a/ghost/admin/app/controllers/signin-verify.js
+++ b/ghost/admin/app/controllers/signin-verify.js
@@ -121,7 +121,15 @@ export default class SigninVerifyController extends Controller {
         const resendTokenPath = `${this.ghostPaths.apiRoot}/session/verify`;
 
         try {
-            yield this.ajax.post(resendTokenPath);
+            try {
+                yield this.ajax.post(resendTokenPath);
+            } catch (error) {
+                // HACK: For some reason, the server returns 200: OK and sends the email but the client still throws an error
+                // So we need to catch the error and throw it if it's not 'OK'
+                if (error !== 'OK') {
+                    throw error;
+                }
+            }
             this.startResendTokenCountdown();
             return TASK_SUCCESS;
         } catch (error) {


### PR DESCRIPTION
no issue

- Browser tests were failing in CI but giving a passing result nonetheless
- This commit switches back to using the old method of running browser tests, using the version of the apps in the CDN rather than the local versions, because the command using the local versions wasn't exiting with the right code to trigger a failure in CI.
- This commit also fixes a few browser tests that were consistently failing, since we weren't catching them in CI.