### PR TITLE
Fixed "specific tiers" flaky publishing test

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -568,8 +568,8 @@ test.describe('Updating post access', () => {
 
         // publish
         await publishPost(sharedPage);
-        await closePublishFlow(sharedPage);
         const frontendPage = await openPublishedPostBookmark(sharedPage);
+        await closePublishFlow(sharedPage);
 
         // non-member doesn't have access
         await expect(frontendPage.locator('.gh-post-upgrade-cta-content h2')).toContainText('on the Gold tier only');


### PR DESCRIPTION
no issue

- Fixed a flaky [publishing test](https://github.com/TryGhost/Ghost/actions/runs/11509561903/job/32039943951) that was suffering from a race condition. It was trying to copy the bookmark link shown on the publishing complete modal, but it was sometimes already closed by that point. 
- It seemed to pass consistently locally, but in CI it would frequently fail. This commit should wait to copy the link before closing the modal.