### PR TITLE
Removed resend countdown from 2fa flow

### DIFF
--- a/ghost/admin/app/components/gh-task-button.hbs
+++ b/ghost/admin/app/components/gh-task-button.hbs
@@ -9,28 +9,28 @@
     {{#if this.isRunning}}
         <span data-test-task-button-state="running">
             {{#if this.showIcon}}
-                {{svg-jar "spinner" class="gh-icon-spinner"}} 
+                {{svg-jar "spinner" class="gh-icon-spinner"}}
             {{/if}}
             {{this.runningText}}
         </span>
     {{/if}}
 
     {{#if (and this.isIdle (not (or this.isRunning this.isSuccess this.isFailure)))}}
-    <span data-test-task-button-state="idle">
-        {{#if this.showIcon}}
-            {{#if this.idleIcon}}
-                {{svg-jar this.idleIcon}}
+        <span data-test-task-button-state="idle">
+            {{#if this.showIcon}}
+                {{#if this.idleIcon}}
+                    {{svg-jar this.idleIcon}}
+                {{/if}}
             {{/if}}
-        {{/if}}
-        {{this.buttonText}}
-    </span>
-{{/if}}
+            {{this.buttonText}}
+        </span>
+    {{/if}}
 
 
     {{#if this.isSuccess}}
         <span {{did-insert this.handleReset}} data-test-task-button-state="success">
             {{#if this.showIcon}}
-                {{svg-jar "check-circle"}} 
+                {{svg-jar "check-circle"}}
             {{/if}}
             {{this.successText}}
         </span>
@@ -38,7 +38,7 @@
     {{#if this.isFailure}}
         <span data-test-task-button-state="failure">
             {{#if this.showIcon}}
-                {{svg-jar "retry"}} 
+                {{svg-jar "retry"}}
             {{/if}}
             {{this.failureText}}
         </span>

--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -35,12 +35,12 @@
                             @type="button"
                             @successClass=""
                             @failureClass=""
-                            @disabled={{this.resendTokenCountdownStarted}}
+                            @disabled={{or this.resendTokenTask.isRunning this.delayResendAvailabilityTask.isRunning}}
                             data-test-button="resend-token"
                             as |task|
                         >
-                            {{#if this.resendTokenCountdownStarted}}
-                                <span>Resend again in {{this.resendTokenCountdown}}s</span>
+                            {{#if this.delayResendAvailabilityTask.isRunning}}
+                                <span>Sent</span>
                             {{else}}
                                 <span>{{#if task.isRunning}}{{svg-jar "spinner" class="gh-spinner"}}&nbsp;Sending{{else}}Resend{{/if}}</span>
                             {{/if}}

--- a/ghost/admin/mirage/config/authentication.js
+++ b/ghost/admin/mirage/config/authentication.js
@@ -16,7 +16,7 @@ export default function mockAuthentication(server) {
 
     // 2fa code re-send
     server.post('/session/verify', function () {
-        return new Response(200);
+        return new Response(200, {}, 'OK');
     });
 
     server.post('/authentication/password_reset', function (schema, request) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-1658

- switched to using a task to match patterns elsewhere and have better cancellation behaviour if code is re-used in a short-lived component
- added `drop: true` task modifier to our main tasks so they can't be triggered again whilst we're waiting on an API request
- removed confusing countdown in button text
- restored forced "text" data type for resend API request to match API behavior
- added acceptance tests for resend behaviour
