### PR TITLE
Fixed some elements overlapping mobile nav

### DIFF
--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -887,6 +887,7 @@
 
     .mobile-menu-expanded .gh-nav {
         transform: translate3d(0,0,0);
+        z-index: 1000;
     }
 
     .mobile-menu-expanded .content-cover {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/21418

- adjusted z-index for the mobile nav expanded state so elements like members filters no longer overlap
