### PR TITLE
Updated Signup Page

### DIFF
--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -354,6 +354,8 @@ class SignupPage extends React.Component {
             showNewsletterSelection: false,
             termsCheckboxChecked: false
         };
+    
+        this.termsRef = React.createRef();
     }
 
     componentDidMount() {
@@ -407,6 +409,16 @@ class SignupPage extends React.Component {
             const {site, onAction} = this.context;
             const {name, email, plan, phonenumber, errors} = this.state;
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
+            
+            // Only scroll checkbox into view if it's the only error
+            const otherErrors = {...errors};
+            delete otherErrors.checkbox;
+            const hasOnlyCheckboxError = errors?.checkbox && Object.values(otherErrors).every(error => !error);
+            
+            if (hasOnlyCheckboxError && this.termsRef.current) {
+                this.termsRef.current.scrollIntoView({behavior: 'smooth', block: 'center'});
+            }
+
             if (!hasFormErrors) {
                 if (hasMultipleNewsletters({site})) {
                     this.setState({
@@ -566,7 +578,7 @@ class SignupPage extends React.Component {
         const className = `gh-portal-signup-terms ${errorClassName}`;
 
         return (
-            <div className={className} onClick={interceptAnchorClicks}>
+            <div className={className} onClick={interceptAnchorClicks} ref={this.termsRef}>
                 {signupTerms}
             </div>
         );
@@ -622,7 +634,7 @@ class SignupPage extends React.Component {
 
         // If we have at least one error, set an error message for the current selected plan
         if (Object.keys(errors).length > 0 && this.state.plan) {
-            priceErrors[this.state.plan] = t('Please fill in required fields');
+            priceErrors[this.state.plan] = t('Please fill in the required fields');
         }
 
         return (
@@ -755,7 +767,7 @@ class SignupPage extends React.Component {
                             </>)}
 
                         {(hasOnlyFree ?
-                            <div className={'gh-portal-btn-container' + (sticky ? ' sticky m24' : '')}>
+                            <div className='gh-portal-btn-container'>
                                 <div className='gh-portal-logged-out-form-container'>
                                     {this.renderSubmitButton()}
                                     {this.renderLoginMessage()}

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -733,7 +733,6 @@ class SignupPage extends React.Component {
         const freeDescription = getFreeTierDescription({site});
         const showOnlyFree = pageQuery === 'free';
         const hasOnlyFree = hasOnlyFreeProduct({site}) || showOnlyFree;
-        const sticky = !showOnlyFree && (freeBenefits.length || freeDescription);
 
         const signupTerms = this.renderSignupTerms();
 

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -7,7 +7,7 @@ import NewsletterSelectionPage from './NewsletterSelectionPage';
 import ProductsSection from '../common/ProductsSection';
 import InputForm from '../common/InputForm';
 import {ValidateInputForm} from '../../utils/form';
-import {getSiteProducts, getSitePrices, hasOnlyFreePlan, isInviteOnlySite, freeHasBenefitsOrDescription, hasOnlyFreeProduct, getFreeProductBenefits, getFreeTierDescription, hasMultipleNewsletters, hasFreeTrialTier, isSignupAllowed} from '../../utils/helpers';
+import {getSiteProducts, getSitePrices, hasOnlyFreePlan, isInviteOnlySite, freeHasBenefitsOrDescription, hasOnlyFreeProduct, hasMultipleNewsletters, hasFreeTrialTier, isSignupAllowed} from '../../utils/helpers';
 import {ReactComponent as InvitationIcon} from '../../images/icons/invitation.svg';
 import {interceptAnchorClicks} from '../../utils/links';
 
@@ -729,8 +729,6 @@ class SignupPage extends React.Component {
             );
         }
 
-        const freeBenefits = getFreeProductBenefits({site});
-        const freeDescription = getFreeTierDescription({site});
         const showOnlyFree = pageQuery === 'free';
         const hasOnlyFree = hasOnlyFreeProduct({site}) || showOnlyFree;
 

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -634,7 +634,7 @@ class SignupPage extends React.Component {
 
         // If we have at least one error, set an error message for the current selected plan
         if (Object.keys(errors).length > 0 && this.state.plan) {
-            priceErrors[this.state.plan] = t('Please fill in the required fields');
+            priceErrors[this.state.plan] = t('Please fill in required fields');
         }
 
         return (


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-881/sign-up-flow-on-mobile-with-checkbox-on-requires-ux-improvement

On mobile, the Sign Up button is no longer sticky. This ensures customers scroll down and see the checkbox before they hit the button.

If they do still miss the checkbox, we now have a check in place that — if the checkbox is the last missing thing — scrolls the checkbox into view upon submission.

https://github.com/user-attachments/assets/5d7867b6-d60c-4844-9482-af04a0eb1eaf

@minimaluminium — I'm asking for your review because I suspect the sticky button may have something to do with the changes made for [DES-785](https://linear.app/ghost/issue/DES-785/make-unsubscribe-from-all-sticky-on-email-prefs-modal-when-many), but I'm not 100% sure.