### PR TITLE
ActivityPub refactor for viewing content

### DIFF
--- a/apps/admin-x-activitypub/src/hooks/useArticleModal.ts
+++ b/apps/admin-x-activitypub/src/hooks/useArticleModal.ts
@@ -1,0 +1,27 @@
+import ArticleModal from '../components/feed/ArticleModal';
+import NiceModal from '@ebay/nice-modal-react';
+import {type Activity} from '../components/activities/ActivityItem';
+import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
+import {useState} from 'react';
+
+export function useArticleModal() {
+    const [articleContent, setArticleContent] = useState<ObjectProperties | null>(null);
+    const [articleActor, setArticleActor] = useState<ActorProperties | null>(null);
+
+    const handleViewContent = (
+        object: ObjectProperties, 
+        contentActor: ActorProperties, 
+        comments: Activity[], 
+        focusReply = false
+    ) => {
+        setArticleContent(object);
+        setArticleActor(contentActor);
+        NiceModal.show(ArticleModal, {object, actor: contentActor, comments, focusReply});
+    };
+
+    return {
+        articleContent,
+        articleActor,
+        handleViewContent
+    };
+}

--- a/apps/admin-x-activitypub/src/utils/content-helpers.ts
+++ b/apps/admin-x-activitypub/src/utils/content-helpers.ts
@@ -1,0 +1,25 @@
+import {type Activity} from '../components/activities/ActivityItem';
+
+export function getContentAuthor(activity: Activity) {
+    const actor = activity.actor;
+    const attributedTo = activity.object.attributedTo;
+
+    if (!attributedTo) {
+        return actor;
+    }
+
+    if (typeof attributedTo === 'string') {
+        return actor;
+    }
+
+    if (Array.isArray(attributedTo)) {
+        const found = attributedTo.find(item => typeof item !== 'string');
+        if (found) {
+            return found;
+        } else {
+            return actor;
+        }
+    }
+
+    return attributedTo;
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-540/clicking-comment-icon-on-posts-and-likes-tabs-of-your-profile-doesnt

We should probably pull out `handleViewContent` and `getContentAuthor` out of `Inbox.tsx` because it would be nice to use them from both `Inbox.tsx` and `Profile.tsx` (“Posts” and “Likes” tabs). Cursor suggested we pull out `handleViewContent` as a hook and `getContentAuthor` as a utility function.

I did so, and it works fine in `Inbox.tsx` and “Posts” tab on `Profile.tsx`, but I can’t figure out how to make it work on the “Likes” tab.
