### PR TITLE
Adds a margin between buttons

### DIFF
--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -923,6 +923,7 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     line-height: 34px;
     background: var(--white);
     border-radius: var(--border-radius);
+    margin-left: 8px;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-919/missing-space-between-back-button-and-status-indicator-in-editor

The `editor-post-status` needed a margin on its left side.


