### PR TITLE
Added from address to autocreated mail configuration

### DIFF
--- a/.devcontainer/createLocalConfig.js
+++ b/.devcontainer/createLocalConfig.js
@@ -51,9 +51,10 @@ newConfig.adapters = {
 
 
 // Only update the mail settings if they aren't already set
-if (!originalConfig.mail && process.env.MAILGUN_SMTP_PASS && process.env.MAILGUN_SMTP_USER) {
+if (!originalConfig.mail && process.env.MAILGUN_SMTP_PASS && process.env.MAILGUN_SMTP_USER && process.env.MAILGUN_FROM_ADDRESS) {
     newConfig.mail = {
         transport: 'SMTP',
+        from: process.env.MAILGUN_FROM_ADDRESS,
         options: {
             service: 'Mailgun',
             host: 'smtp.mailgun.org',

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
         "STRIPE_ACCOUNT_ID": "${localEnv:STRIPE_ACCOUNT_ID}",
         "MAILGUN_SMTP_USER": "${localEnv:MAILGUN_SMTP_USER}",
         "MAILGUN_SMTP_PASS": "${localEnv:MAILGUN_SMTP_PASS}",
+        "MAILGUN_FROM_ADDRESS": "${localEnv:MAILGUN_FROM_ADDRESS}",
         "MAILGUN_API_KEY": "${localEnv:MAILGUN_API_KEY}",
         "MAILGUN_DOMAIN": "${localEnv:MAILGUN_DOMAIN}"
     },
@@ -127,13 +128,17 @@
             "description": "Your Mailgun account's SMTP password",
             "documentationUrl": "https://app.mailgun.com/mg/sending/domains"
         },
+        "MAILGUN_FROM_ADDRESS": {
+            "description": "The email address that will be used as the `from` address when sending emails via Mailgun",
+            "documentationUrl": "https://app.mailgun.com/mg/sending/domains"
+        },
         "MAILGUN_API_KEY": {
             "description": "Your Mailgun account's API key",
-            "documentationUrl": ""
+            "documentationUrl": "https://app.mailgun.com/mg/sending/domains"
         },
         "MAILGUN_DOMAIN": {
             "description": "Your Mailgun account's domain, e.g. sandbox1234567890.mailgun.org",
-            "documentationUrl": ""
+            "documentationUrl": "https://app.mailgun.com/mg/sending/domains"
         }
     }
 }


### PR DESCRIPTION
refs https://linear.app/ghost/issue/ENG-1686/mail-auto-configuration-doesnt-work

- Previously the `mail` configuration that is auto-generated didn't work because the `from` address wasn't being set, and requests were consequently failing due to some Mailgun internal validation. 
- This change requires the `MAILGUN_FROM_ADDRESS` environment variable to be set for it to automatically configure the `mail` block, and if it is, it adds it as `mail.from`. Now with all three of `MAILGUN_SMTP_AUTH`, `MAILGUN_SMTP_PASS` and `MAILGUN_FROM_ADDRESS` setup, transactional emails work out of the box in the Dev Container.