### PR TITLE
Prevent replies from being shown on profile page in admin-x-activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -28,7 +28,9 @@ const Profile: React.FC<ProfileProps> = ({}) => {
     const {data: following = []} = useFollowingForUser('index');
     const {data: followers = []} = useFollowersForUser('index');
     const {data: liked = []} = useLikedForUser('index');
-    const {data: posts = []} = useOutboxForUser('index');
+    const {data: outboxPosts = []} = useOutboxForUser('index');
+
+    const posts = outboxPosts.filter(post => post.type === 'Create' && !post.object.inReplyTo);
 
     // Replace 'index' with the actual handle of the user
     const {data: userProfile} = useUserDataForUser('index') as {data: ActorProperties | null};


### PR DESCRIPTION
refs [AP-543](https://linear.app/ghost/issue/AP-543/posts-on-profile-should-not-include-replies)

Filtered the posts on the profile page to only show `Create` activities that are not replies.