### PR TITLE
🐛 Fixed "Access Denied" error when accepting staff invite

### DIFF
--- a/ghost/admin/app/controllers/signup.js
+++ b/ghost/admin/app/controllers/signup.js
@@ -104,6 +104,6 @@ export default class SignupController extends Controller {
         const {email, password} = this.signupDetails;
 
         return this.session
-            .authenticate('authenticator:cookie', email, password);
+            .authenticate('authenticator:cookie', {identification: email, password});
     }
 }

--- a/ghost/admin/mirage/config/authentication.js
+++ b/ghost/admin/mirage/config/authentication.js
@@ -5,7 +5,12 @@ import {isBlank} from '@ember/utils';
 
 export default function mockAuthentication(server) {
     // Password sign-in
-    server.post('/session', function () {
+    server.post('/session', function (schema, request) {
+        const data = JSON.parse(request.requestBody);
+        if (!data.username || !data.password) {
+            return new Response(401);
+        }
+
         return new Response(201);
     });
 


### PR DESCRIPTION
ref https://app.incident.io/ghost/incidents/117

- the authenticate call made as part of signup was missed as part of the update when we adjusted the params for `cookie` authenticator's `authenticate` method in Admin so it could switch behaviour for 2fa
- fixed the authenticate call params and updated our mocked `/session` endpoint to check for expected POST data which would have let tests catch this error
