### PR TITLE
Added configuration of git remotes to dev container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,11 @@
         "MAILGUN_SMTP_PASS": "${localEnv:MAILGUN_SMTP_PASS}",
         "MAILGUN_FROM_ADDRESS": "${localEnv:MAILGUN_FROM_ADDRESS}",
         "MAILGUN_API_KEY": "${localEnv:MAILGUN_API_KEY}",
-        "MAILGUN_DOMAIN": "${localEnv:MAILGUN_DOMAIN}"
+        "MAILGUN_DOMAIN": "${localEnv:MAILGUN_DOMAIN}",
+        "GHOST_UPSTREAM": "${localEnv:GHOST_UPSTREAM}",
+        "GHOST_FORK_REMOTE_URL": "${localEnv:GHOST_FORK_REMOTE_URL}",
+        "GHOST_FORK_REMOTE_NAME": "${localEnv:GHOST_FORK_REMOTE_NAME}",
+        "GHOST_FORCE_SSH": "${localEnv:GHOST_FORCE_SSH}"
     },
     "forwardPorts": [2368,4200],
     "portsAttributes": {

--- a/.devcontainer/onCreateCommand.js
+++ b/.devcontainer/onCreateCommand.js
@@ -48,7 +48,7 @@ function setupGitRemotes() {
 
         if (GHOST_UPSTREAM) {
             // Check if the upstream remote already exists
-            if (!remotes.includes(GHOST_UPSTREAM)) {
+            if (!remotes.includes(GHOST_UPSTREAM) && remotes.includes('origin')) {
                 log(`Renaming the default remote from origin to ${GHOST_UPSTREAM}...`, colors.blue);
                 execSync(`git remote rename origin ${GHOST_UPSTREAM}`);
             }

--- a/.devcontainer/onCreateCommand.js
+++ b/.devcontainer/onCreateCommand.js
@@ -217,7 +217,7 @@ function runSubmoduleUpdate() {
         // Otherwise `yarn main:submodules` will fail
         const GHOST_UPSTREAM = process.env.GHOST_UPSTREAM;
         if (GHOST_UPSTREAM) {
-            execSync(`git submodule foreach "git remote get-url ${GHOST_UPSTREAM} 2>/dev/null || git remote rename origin ${GHOST_UPSTREAM}"`);
+            execSync(`git submodule foreach "git remote | grep -q '^${GHOST_UPSTREAM}$' || (git remote | grep -q '^origin$' && git remote rename origin ${GHOST_UPSTREAM})"`);
         }
 
         log('Successfully ran git submodule update', colors.dim);

--- a/.devcontainer/onCreateCommand.js
+++ b/.devcontainer/onCreateCommand.js
@@ -49,9 +49,10 @@ function setupGitRemotes() {
 
         }
 
-        if (GHOST_FORK_REMOTE_URL && GHOST_FORK_REMOTE_NAME) {
-            log(`Adding fork remote ${GHOST_FORK_REMOTE_URL} as ${GHOST_FORK_REMOTE_NAME}...`, colors.blue);
-            execSync(`git remote add ${GHOST_FORK_REMOTE_NAME} ${GHOST_FORK_REMOTE_URL}`);
+        if (GHOST_FORK_REMOTE_URL) {
+            const remoteName = GHOST_FORK_REMOTE_NAME || 'origin';
+            log(`Adding fork remote ${GHOST_FORK_REMOTE_URL} as ${remoteName}...`, colors.blue);
+            execSync(`git remote add ${remoteName} ${GHOST_FORK_REMOTE_URL}`);
         }
 
         if (GHOST_FORCE_SSH) {
@@ -205,6 +206,7 @@ function runSubmoduleUpdate() {
         log('Updating git submodules...', colors.blue);
         execSync('git submodule update --init --recursive', { stdio: 'inherit' });
         // Rename the default remote to $GHOST_UPSTREAM if it's set
+        // Otherwise `yarn main:submodules` will fail
         const GHOST_UPSTREAM = process.env.GHOST_UPSTREAM;
         if (GHOST_UPSTREAM) {
             // Get a list of all submodules


### PR DESCRIPTION
no issue

- Added function to Dev Container onCreateCommand to setup git remotes when creating the Dev Container
- If `$GHOST_UPSTREAM` is set, it will rename the default `origin` remote to its value
- It will also update the remotes for the submodules, otherwise `yarn main` will fail
- If `$GHOST_FORK_REMOTE_URL` is set, it will add it as `origin`, or the value of `$GHOST_FORK_REMOTE_NAME` if set.
- If `$GHOST_FORCE_SSH` is set to `true`, it will change all remotes URL's to use ssh instead of https
