### PR TITLE
Fixed git remote configuration in dev container

### DIFF
--- a/.devcontainer/onCreateCommand.js
+++ b/.devcontainer/onCreateCommand.js
@@ -54,6 +54,7 @@ function setupGitRemotes() {
             }
         }
 
+        remotes = execSync('git remote').toString().trim().split('\n');
         if (GHOST_FORK_REMOTE_URL) {
             const remoteName = GHOST_FORK_REMOTE_NAME || 'origin';
             // Check if the fork remote already exists


### PR DESCRIPTION
no issue

- When creating a dev container, the onCreateCommand script will try to setup the git remotes according to the environment variables defined for e.g. `$GHOST_UPSTREAM`. There was a bug that caused the `origin` remote to successfully be renamed to `$GHOST_UPSTREAM`, but the `origin` remote was not being created successfully on the first try. This commit fixes that bug.
