### PR TITLE
Added github-cli and some zsh plugins to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,11 @@
 {
     "name": "Ghost Local DevContainer",
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {
+            "plugins": "git yarn gh"
+        }
+    },
     "dockerComposeFile": ["./.docker/base.compose.yml", "./.docker/base-devcontainer.compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",


### PR DESCRIPTION
no issue

- The Dev Container didn't have the Github CLI installed, so this adds that using Dev Container "[features](https://containers.dev/implementors/features/)"
- It also adds oh-my-zsh and a few plugins that are nice to have when developing.
