### PR TITLE
Removed the typescript command from browser tests

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -95,7 +95,7 @@ if (DASH_DASH_ARGS.includes('ghost')) {
 } else if (DASH_DASH_ARGS.includes('admin')) {
     commands = [COMMAND_ADMIN, ...COMMANDS_ADMINX];
 } else if (DASH_DASH_ARGS.includes('browser-tests')) {
-    commands = [COMMAND_BROWSERTESTS, COMMAND_TYPESCRIPT];
+    commands = [COMMAND_BROWSERTESTS];
 } else {
     commands = [COMMAND_GHOST, COMMAND_TYPESCRIPT, COMMAND_ADMIN, ...COMMANDS_ADMINX];
 }


### PR DESCRIPTION
no issue

- Running browser tests from the root of the repo had a lot of extra output in CI because the NX daemon is disabled in CI, and it was using nx to watch & rebuild the typescript packages.
- Since the nx command for running browser tests already has the `build:ts` command as a dependency, we don't have to run it explicitly in `dev.js`, so I removed the command to watch & rebuild typescript.
- This should clean up the CI output a lot to make it easier to quickly see which browser test failed