### PR TITLE
Cleaned up browser test output in CI

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -95,7 +95,7 @@ if (DASH_DASH_ARGS.includes('ghost')) {
 } else if (DASH_DASH_ARGS.includes('admin')) {
     commands = [COMMAND_ADMIN, ...COMMANDS_ADMINX];
 } else if (DASH_DASH_ARGS.includes('browser-tests')) {
-    commands = [COMMAND_BROWSERTESTS, COMMAND_TYPESCRIPT];
+    commands = [COMMAND_BROWSERTESTS];
 } else {
     commands = [COMMAND_GHOST, COMMAND_TYPESCRIPT, COMMAND_ADMIN, ...COMMANDS_ADMINX];
 }

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -198,7 +198,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'publish+send'});
             await closePublishFlow(sharedPage);
-            await checkPostPublished(sharedPage, {title: 'incorrect title', body: 'incorrect body'});
+            await checkPostPublished(sharedPage, postData);
         });
 
         // Post should only be available on web

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -187,7 +187,7 @@ test.describe('Publishing', () => {
         // Post should be available on web and sent as a newsletter
         test('Publish and Email', async ({sharedPage}) => {
             const postData = {
-                title: 'Publish and email post',
+                title: 'Publish and email post test failure',
                 body: 'This is my post body.'
             };
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -187,7 +187,7 @@ test.describe('Publishing', () => {
         // Post should be available on web and sent as a newsletter
         test('Publish and Email', async ({sharedPage}) => {
             const postData = {
-                title: 'Publish and email post test failure',
+                title: 'Publish and email post',
                 body: 'This is my post body.'
             };
 
@@ -198,7 +198,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'publish+send'});
             await closePublishFlow(sharedPage);
-            await checkPostPublished(sharedPage, postData);
+            await checkPostPublished(sharedPage, {title: 'incorrect title', body: 'incorrect body'});
         });
 
         // Post should only be available on web


### PR DESCRIPTION
no issue

- The browser test output in CI is really noisy, because the `NX_DAEMON` doens't run in CI, but we're trying to use NX to watch and rebuild the typescript modules. This is outputting a ton of "NX Daemon is not running" type of errors, which make it difficult to sift through the actual test results.
- We don't actually need to watch the typescript files, we just need to build them once before starting. This is defined as an NX dependency for the browser tests target, so we don't need to explicitly build the TS packages at all. Removing the typescript watch & build command removes the noisy errors, without impacting how the tests actually run.