### PR TITLE
Added `ps` dependency to Dockerfile

### DIFF
--- a/.devcontainer/.docker/Dockerfile
+++ b/.devcontainer/.docker/Dockerfile
@@ -21,6 +21,7 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
         git \
         stripe \
         zsh \
+        procps \
         default-mysql-client && \
     npx -y playwright@1.46.1 install --with-deps
 


### PR DESCRIPTION
no issue

- When stopping `yarn dev` with ctrl+c in the dev container, you'd get an error because the container doens't have `ps` installed, which is used by node under the hood. Adding this dependency fixed the error so `yarn dev` (and other commands) exit cleanly