### PR TITLE
Updated `admin-x-activitypub` to use consistent URL encoding

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -721,6 +721,8 @@ describe('ActivityPubAPI', function () {
 
     describe('search', function () {
         test('It returns the results of the search', async function () {
+            const handle = '@foo@bar.baz';
+
             const fakeFetch = Fetch({
                 'https://auth.api/': {
                     response: JSONResponse({
@@ -729,11 +731,11 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                'https://activitypub.api/.ghost/activitypub/actions/search?query=%40foo%40bar.baz': {
+                [`https://activitypub.api/.ghost/activitypub/actions/search?query=${encodeURIComponent(handle)}`]: {
                     response: JSONResponse({
                         profiles: [
                             {
-                                handle: '@foo@bar.baz',
+                                handle,
                                 name: 'Foo Bar'
                             }
                         ]
@@ -748,14 +750,45 @@ describe('ActivityPubAPI', function () {
                 fakeFetch
             );
 
-            const actual = await api.search('@foo@bar.baz');
+            const actual = await api.search(handle);
             const expected = {
                 profiles: [
                     {
-                        handle: '@foo@bar.baz',
+                        handle,
                         name: 'Foo Bar'
                     }
                 ]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        test('It returns an empty array when there are no profiles in the response', async function () {
+            const handle = '@foo@bar.baz';
+
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/actions/search?query=${encodeURIComponent(handle)}`]: {
+                    response: JSONResponse({})
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.search(handle);
+            const expected = {
+                profiles: []
             };
 
             expect(actual).toEqual(expected);
@@ -997,7 +1030,7 @@ describe('ActivityPubAPI', function () {
     });
 
     describe('getFollowingForProfile', function () {
-        test('It returns a following arrayfor a profile', async function () {
+        test('It returns an array of following actors for a profile', async function () {
             const handle = '@foo@bar.baz';
 
             const fakeFetch = Fetch({
@@ -1260,6 +1293,43 @@ describe('ActivityPubAPI', function () {
             const actual = await api.getProfile(handle);
             const expected = {
                 handle,
+                name: 'Foo Bar'
+            };
+
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('getThread', function () {
+        test('It returns a thread', async function () {
+            const activityId = 'https://example.com/thread/abc123';
+
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/thread/${encodeURIComponent(activityId)}`]: {
+                    response: JSONResponse({
+                        id: activityId,
+                        name: 'Foo Bar'
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.getThread(activityId);
+            const expected = {
+                id: activityId,
                 name: 'Foo Bar'
             };
 

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -272,7 +272,7 @@ export class ActivityPubAPI {
         excludeNonFollowers: boolean = false,
         filter: {type?: string[]} | null = null,
         cursor?: string
-    ): Promise<{data: Activity[], nextCursor: string | null}> {
+    ): Promise<{data: Activity[], next: string | null}> {
         const LIMIT = 50;
 
         const url = new URL(this.activitiesApiUrl);
@@ -298,23 +298,23 @@ export class ActivityPubAPI {
         if (json === null) {
             return {
                 data: [],
-                nextCursor: null
+                next: null
             };
         }
 
         if (!('items' in json)) {
             return {
                 data: [],
-                nextCursor: null
+                next: null
             };
         }
 
         const data = Array.isArray(json.items) ? json.items : [];
-        const nextCursor = 'nextCursor' in json && typeof json.nextCursor === 'string' ? json.nextCursor : null;
+        const next = 'next' in json && typeof json.next === 'string' ? json.next : null;
 
         return {
             data,
-            nextCursor
+            next
         };
     }
 
@@ -360,7 +360,7 @@ export class ActivityPubAPI {
     }
 
     async getThread(id: string): Promise<ActivityThread> {
-        const url = new URL(`.ghost/activitypub/thread/${btoa(id)}`, this.apiUrl);
+        const url = new URL(`.ghost/activitypub/thread/${encodeURIComponent(id)}`, this.apiUrl);
         const json = await this.fetchJSON(url);
         return json as ActivityThread;
     }

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -217,7 +217,7 @@ export function useActivitiesForUser({
             return api.getActivities(includeOwn, includeReplies, excludeNonFollowers, filter, pageParam);
         },
         getNextPageParam(prevPage) {
-            return prevPage.nextCursor;
+            return prevPage.next;
         }
     });
 


### PR DESCRIPTION
refs [TryGhost/ActivityPub](https://github.com/TryGhost/ActivityPub/pull/103)

Updated the API requests made by the `admin-x-activitypub` app to use consistent URL encoding when making requests to the ActivityPub API