### PR TITLE
Fixed sorting by best Comment with pagination

### DIFF
--- a/ghost/core/core/server/services/comments/CommentsController.js
+++ b/ghost/core/core/server/services/comments/CommentsController.js
@@ -52,6 +52,7 @@ module.exports = class CommentsController {
             }
         }
         return this.service.getComments(frame.options);
+
     }
 
     /**

--- a/ghost/core/core/server/services/comments/CommentsController.js
+++ b/ghost/core/core/server/services/comments/CommentsController.js
@@ -52,7 +52,6 @@ module.exports = class CommentsController {
             }
         }
         return this.service.getComments(frame.options);
-
     }
 
     /**

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -521,7 +521,7 @@ describe('Comments API', function () {
                 });
 
                 const data2 = await membersAgent
-                    .get(`/api/comments/post/${postId}/?order=best`)
+                    .get(`/api/comments/post/${postId}/?page=1&order=count__likes%20desc%2C%20created_at%20desc`)
                     .expectStatus(200);
 
                 should(data2.body.comments[0].id).eql(data.body.comments[1].id);
@@ -536,6 +536,25 @@ describe('Comments API', function () {
                     comment_id: data.body.comments[1].id,
                     member_id: loggedInMember.id
                 });
+
+                await dbFns.addLike({
+                    comment_id: comment.id,
+                    member_id: fixtureManager.get('members', 1).id
+                });
+
+                const data = await membersAgent
+                    .get(`/api/comments/post/${postId}/?limit=5&page=1&order=count__likes%20desc%2C%20created_at%20desc`)
+                    .expectStatus(200);
+
+                // TODO for the first page only we don't fully respect the limit, since we need to get the best comments first
+                // We need to find a better way to handle this, preferable without changing the order of the comments
+                should(data.body.comments.length).eql(5);
+                should(data.body.meta.pagination.total).eql(13);
+                should(data.body.meta.pagination.pages).eql(3);
+                should(data.body.meta.pagination.next).eql(2);
+                should(data.body.meta.pagination.prev).eql(null);
+                should(data.body.meta.pagination.limit).eql(5);
+                should(data.body.comments[0].id).eql(comment.id);
 
                 const data2 = await membersAgent
                     .get(`/api/comments/post/${postId}/`)

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -510,57 +510,66 @@ describe('Comments API', function () {
                 should.not.exist(response.body.comments[0].unsubscribe_url);
             });
 
-            it('can show most liked comment first when order param = best', async function () {
-                await setupBrowseCommentsData();
-                const data = await membersAgent
-                    .get(`/api/comments/post/${postId}`);
+            it('can show most liked comment first when order param = best followed by most recent', async function () {
+                // await setupBrowseCommentsData();
+                // add another comment
+                await dbFns.addComment({
+                    html: 'This is the newest comment',
+                    member_id: fixtureManager.get('members', 2).id,
+                    created_at: new Date('2024-08-18')
+                });
+
+                const secondBest = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'This will be the second best comment',
+                    created_at: new Date('2022-01-01')
+                });
+
+                await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 1).id,
+                    created_at: new Date('2023-01-01')
+                });
+
+                const bestComment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id,
+                    html: 'This will be the best comment',
+                    created_at: new Date('2021-01-01')
+                });
+
+                const oldestComment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 1).id,
+                    html: 'ancient comment',
+                    created_at: new Date('2019-01-01')
+                });
 
                 await dbFns.addLike({
-                    comment_id: data.body.comments[1].id,
+                    comment_id: secondBest.id,
                     member_id: loggedInMember.id
+                });
+
+                await dbFns.addLike({
+                    comment_id: bestComment.id,
+                    member_id: loggedInMember.id
+                });
+
+                await dbFns.addLike({
+                    comment_id: bestComment.id,
+                    member_id: fixtureManager.get('members', 0).id
+                });
+
+                await dbFns.addLike({
+                    comment_id: bestComment.id,
+                    member_id: fixtureManager.get('members', 1).id
                 });
 
                 const data2 = await membersAgent
                     .get(`/api/comments/post/${postId}/?page=1&order=count__likes%20desc%2C%20created_at%20desc`)
                     .expectStatus(200);
 
-                should(data2.body.comments[0].id).eql(data.body.comments[1].id);
-            });
+                // get the LAST comment from data2
+                let lastComment = data2.body.comments[data2.body.comments.length - 1];
 
-            it('does not most liked comment first when order param and keeps normal order', async function () {
-                await setupBrowseCommentsData();
-                const data = await membersAgent
-                    .get(`/api/comments/post/${postId}`);
-
-                await dbFns.addLike({
-                    comment_id: data.body.comments[1].id,
-                    member_id: loggedInMember.id
-                });
-
-                await dbFns.addLike({
-                    comment_id: comment.id,
-                    member_id: fixtureManager.get('members', 1).id
-                });
-
-                const data = await membersAgent
-                    .get(`/api/comments/post/${postId}/?limit=5&page=1&order=count__likes%20desc%2C%20created_at%20desc`)
-                    .expectStatus(200);
-
-                // TODO for the first page only we don't fully respect the limit, since we need to get the best comments first
-                // We need to find a better way to handle this, preferable without changing the order of the comments
-                should(data.body.comments.length).eql(5);
-                should(data.body.meta.pagination.total).eql(13);
-                should(data.body.meta.pagination.pages).eql(3);
-                should(data.body.meta.pagination.next).eql(2);
-                should(data.body.meta.pagination.prev).eql(null);
-                should(data.body.meta.pagination.limit).eql(5);
-                should(data.body.comments[0].id).eql(comment.id);
-
-                const data2 = await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200);
-
-                should(data2.body.comments[0].id).not.eql(data.body.comments[1].id);
+                should(lastComment.id).eql(oldestComment.id);
             });
 
             it('Can reply to your own comment', async function () {


### PR DESCRIPTION
ref PLG-220

- Added an `orderAttributes` override method to be able to pass `count__likes` to the `findPage` DB helper.
- Unknowingly, without that override method in the model, it would strip all 'non-default' queries.
- Adding that means we could remove our custom database queries and use the regular `findPage` helper that also handles pagination.