### PR TITLE
Makes newsletter comments toggle conditional

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -10,7 +10,7 @@ import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {renderReplyToEmail, renderSenderEmail} from '../../../../utils/newsletterEmails';
 import {textColorForBackgroundColor} from '@tryghost/color-utils';
@@ -107,6 +107,7 @@ const Sidebar: React.FC<{
     const [siteTitle] = getSettingValues(localSettings, ['title']) as string[];
     const handleError = useHandleError();
     const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
+    const commentsEnabled = getSettingValue(settings, 'comments_enabled') === 'all';
 
     let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
@@ -456,12 +457,12 @@ const Sidebar: React.FC<{
                             label='Ask your readers for feedback'
                             onChange={e => updateNewsletter({feedback_enabled: e.target.checked})}
                         />
-                        <Toggle
+                        {commentsEnabled && <Toggle
                             checked={newsletter.show_comment_cta}
                             direction="rtl"
                             label='Add a link to your comments'
                             onChange={e => updateNewsletter({show_comment_cta: e.target.checked})}
-                        />
+                        />}
                         <Toggle
                             checked={newsletter.show_latest_posts}
                             direction="rtl"

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -107,7 +107,7 @@ const Sidebar: React.FC<{
     const [siteTitle] = getSettingValues(localSettings, ['title']) as string[];
     const handleError = useHandleError();
     const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
-    const commentsEnabled = getSettingValue(settings, 'comments_enabled') === 'all';
+    const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled'));
 
     let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -107,7 +107,7 @@ const Sidebar: React.FC<{
     const [siteTitle] = getSettingValues(localSettings, ['title']) as string[];
     const handleError = useHandleError();
     const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
-    const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled'));
+    const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled') || '');
 
     let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-796/shouldnt-show-email-template-option-when-commenting-is-disabled

Previously, if you had comments turned off on your site, you would still see the toggle in newsletter settings. Clicking it would do nothing. 

Now, if comments are enabled (for all members, or paid members), it will show; if they're not, it won't.


https://github.com/user-attachments/assets/80b8e2dc-a0ed-40bc-ada5-40141676e38b



