### PR TITLE
Removed duplicate serialization for offers

### DIFF
--- a/ghost/core/core/server/services/offers/OfferBookshelfRepository.js
+++ b/ghost/core/core/server/services/offers/OfferBookshelfRepository.js
@@ -107,6 +107,8 @@ class OfferBookshelfRepository {
         });
 
         try {
+            const lastRedeemedObject = lastRedeemed.toJSON();
+
             return await Offer.create({
                 id: json.id,
                 name: json.name,
@@ -126,7 +128,7 @@ class OfferBookshelfRepository {
                     name: json.product.name
                 },
                 created_at: json.created_at,
-                last_redeemed: lastRedeemed.toJSON().length > 0 ? lastRedeemed.toJSON()[0].created_at : null
+                last_redeemed: lastRedeemedObject.length > 0 ? lastRedeemedObject[0].created_at : null
             }, null);
         } catch (err) {
             logger.error(err);

--- a/ghost/email-analytics-service/lib/EventProcessingResult.js
+++ b/ghost/email-analytics-service/lib/EventProcessingResult.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 class EventProcessingResult {
     /**
      * @param {object} result
@@ -59,8 +57,9 @@ class EventProcessingResult {
 
         this.processingFailures += other.processingFailures || 0;
 
-        this.emailIds = _.compact(_.union(this.emailIds, other.emailIds || []));
-        this.memberIds = _.compact(_.union(this.memberIds, other.memberIds || []));
+        // TODO: come up with a cleaner way to merge these without churning through Array and Set
+        this.emailIds = Array.from(new Set([...this.emailIds, ...(other.emailIds || [])])).filter(Boolean);
+        this.memberIds = Array.from(new Set([...this.memberIds, ...(other.memberIds || [])])).filter(Boolean);
     }
 }
 


### PR DESCRIPTION
- we can skip an extra `toJSON` call here by storing the value and
  re-using it, which means we can cut down on the number of calls, which
  can be particularly heavy when this codepath is hit hardGot some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
