### PR TITLE
Fixed comments placeholder

### DIFF
--- a/apps/comments-ui/src/components/content/Content.tsx
+++ b/apps/comments-ui/src/components/content/Content.tsx
@@ -49,7 +49,7 @@ const Content = () => {
                 <ContentTitle count={commentCount} showCount={showCount} title={title}/>
                 <div>
                     {(member && (isPaidMember || !isPaidOnly)) ? (
-                        <MainForm commentsCount={commentCount} />
+                        <MainForm commentsCount={comments.length} />
                     ) : (
                         <section className="flex flex-col items-center py-6 sm:px-8 sm:py-10" data-testid="cta-box">
                             <CTABox isFirst={isFirst} isPaid={isPaidOnly} />

--- a/apps/comments-ui/src/components/content/forms/MainForm.tsx
+++ b/apps/comments-ui/src/components/content/forms/MainForm.tsx
@@ -18,7 +18,7 @@ const MainForm: React.FC<Props> = ({commentsCount}) => {
 
     const editor = useEditor({
         ...getEditorConfig(config)
-    });
+    }, [commentsCount]);
 
     const submit = useCallback(async ({html}) => {
         // Send comment to server

--- a/apps/comments-ui/test/e2e/editor.test.ts
+++ b/apps/comments-ui/test/e2e/editor.test.ts
@@ -2,6 +2,21 @@ import {MockedApi, getModifierKey, initialize, selectText, setClipboard, waitEdi
 import {expect, test} from '@playwright/test';
 
 test.describe('Editor', async () => {
+    test('Editor placeholder shows Start the conversation when no existing comments ', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.setMember({});
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const editor = frame.getByTestId('editor');
+
+        const placeholderElement = editor.locator('[data-placeholder="Start the conversation"]');
+        await expect(placeholderElement).toBeVisible();
+    });
     test('Can comment on a post', async ({page}) => {
         const mockedApi = new MockedApi({});
         mockedApi.setMember({});
@@ -59,7 +74,7 @@ test.describe('Editor', async () => {
         await page.waitForTimeout(200);
     });
 
-    test('Can use CMD+ENTER to submmit', async ({page}) => {
+    test('Can use CMD+ENTER to submit', async ({page}) => {
         const mockedApi = new MockedApi({});
         mockedApi.setMember({});
 
@@ -102,6 +117,45 @@ test.describe('Editor', async () => {
 
         await expect(frame.getByText('This is comment 1')).toBeVisible();
         await expect(frame.getByText('Newly added comment')).toBeVisible();
+    });
+
+    test('Start the conversation changes to Join the Discussion if more 0 comments. ', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.setMember({});
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly'
+        });
+
+        const editor = frame.getByTestId('form-editor');
+
+        const placeholderElement = editor.locator('[data-placeholder="Start the conversation"]');
+        await expect(placeholderElement).toBeVisible();
+
+        await editor.click({force: true});
+
+        // Wait for focused
+        await waitEditorFocused(editor);
+
+        // Wait for animation to finish
+        await page.waitForTimeout(200);
+
+        // Type in the editor
+        await editor.type('Newly added comment');
+
+        // Post the comment
+        const button = await frame.getByTestId('submit-form-button');
+        await button.click();
+
+        await expect(editor).toHaveText('');
+
+        await expect(frame.getByText('Newly added comment')).toBeVisible();
+
+        const newPlaceholderElement = editor.locator('[data-placeholder="Join the discussion"]');
+
+        await expect(newPlaceholderElement).toBeVisible();
     });
 
     test.describe('Markdown', () => {


### PR DESCRIPTION
ref PLG-251

- Fixed comments placeholder to change from "Start the conversation" to "Join the discussion" when there's more than 1 comment.
- Previously, it only worked after a refresh. This fix ensures it's reactive and would update the placeholder without the need for a refresh.
