### PR TITLE
Attempt to import all fonts into `ghost_head` and only handle CSS for selected ones

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -4,7 +4,7 @@
 // Outputs scripts and other assets at the top of a Ghost theme
 const {labs, metaData, settingsCache, config, blogIcon, urlUtils, getFrontendKey} = require('../services/proxy');
 const {escapeExpression, SafeString} = require('../services/handlebars');
-const {generateCustomFontCss, isValidCustomFont, isValidCustomHeadingFont} = require('@tryghost/custom-fonts');
+const {generateCustomFontCss, isValidCustomFont, isValidCustomHeadingFont, getAllCustomFontsImports} = require('@tryghost/custom-fonts');
 // BAD REQUIRE
 // @TODO fix this require
 const {cardAssets} = require('../services/assets-minification');
@@ -354,6 +354,8 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
             }
 
             if (labs.isSet('customFonts')) {
+                // Add all custom fonts imports to the head
+                head.push(new SafeString(getAllCustomFontsImports()));
                 // Check if if the request is for a site preview, in which case we **always** use the custom font values
                 // from the passed in data, even when they're empty strings or settings cache has values.
                 const isSitePreview = options.data.site._preview;
@@ -373,7 +375,9 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
                     if (bodyFont) {
                         fontSelection.body = bodyFont;
                     }
+                    // Generate the custom CSS for the selected fonts
                     const customCSS = generateCustomFontCss(fontSelection);
+                    // Add the custom CSS to the head
                     head.push(new SafeString(customCSS));
                 }
             }

--- a/ghost/custom-fonts/src/index.ts
+++ b/ghost/custom-fonts/src/index.ts
@@ -108,93 +108,95 @@ const classFontNames = {
     'Libre Baskerville': 'libre-baskerville'
 };
 
+const importStrings = {
+    Cardo: {
+        family: 'cardo:400,700'
+    },
+    Manrope: {
+        family: 'manrope:300,500,700'
+    },
+    Merriweather: {
+        family: 'merriweather:300,700'
+    },
+    Nunito: {
+        family: 'nunito:400,600,700'
+    },
+    'Old Standard TT': {
+        family: 'old-standard-tt:400,700'
+    },
+    Roboto: {
+        family: 'roboto:400,500,700'
+    },
+    Rufina: {
+        family: 'rufina:400,500,700'
+    },
+    'Tenor Sans': {
+        family: 'tenor-sans:400'
+    },
+    'Space Grotesk': {
+        family: 'space-grotesk:700'
+    },
+    'Chakra Petch': {
+        family: 'chakra-petch:400'
+    },
+    'Noto Sans': {
+        family: 'noto-sans:400,700'
+    },
+    Poppins: {
+        family: 'poppins:400,500,600'
+    },
+    'Fira Sans': {
+        family: 'fira-sans:400,500,600'
+    },
+    Inter: {
+        family: 'inter:400,500,600'
+    },
+    'Noto Serif': {
+        family: 'noto-serif:400,700'
+    },
+    Lora: {
+        family: 'lora:400,700'
+    },
+    'IBM Plex Serif': {
+        family: 'ibm-plex-serif:400,500,600'
+    },
+    'Space Mono': {
+        family: 'space-mono:400,700'
+    },
+    'Fira Mono': {
+        family: 'fira-mono:400,700'
+    },
+    'JetBrains Mono': {
+        family: 'jetbrains-mono:400,700'
+    },
+    'Libre Baskerville': {
+        family: 'libre-baskerville:700'
+    }
+};
+
 export function generateCustomFontCss(fonts: FontSelection) {
-    let fontImports: string = '';
+    // let fontImports: string = '';
     let fontCSS: string = '';
 
-    const importStrings = {
-        Cardo: {
-            family: 'cardo:400,700'
-        },
-        Manrope: {
-            family: 'manrope:300,500,700'
-        },
-        Merriweather: {
-            family: 'merriweather:300,700'
-        },
-        Nunito: {
-            family: 'nunito:400,600,700'
-        },
-        'Old Standard TT': {
-            family: 'old-standard-tt:400,700'
-        },
-        Roboto: {
-            family: 'roboto:400,500,700'
-        },
-        Rufina: {
-            family: 'rufina:400,500,700'
-        },
-        'Tenor Sans': {
-            family: 'tenor-sans:400'
-        },
-        'Space Grotesk': {
-            family: 'space-grotesk:700'
-        },
-        'Chakra Petch': {
-            family: 'chakra-petch:400'
-        },
-        'Noto Sans': {
-            family: 'noto-sans:400,700'
-        },
-        Poppins: {
-            family: 'poppins:400,500,600'
-        },
-        'Fira Sans': {
-            family: 'fira-sans:400,500,600'
-        },
-        Inter: {
-            family: 'inter:400,500,600'
-        },
-        'Noto Serif': {
-            family: 'noto-serif:400,700'
-        },
-        Lora: {
-            family: 'lora:400,700'
-        },
-        'IBM Plex Serif': {
-            family: 'ibm-plex-serif:400,500,600'
-        },
-        'Space Mono': {
-            family: 'space-mono:400,700'
-        },
-        'Fira Mono': {
-            family: 'fira-mono:400,700'
-        },
-        'JetBrains Mono': {
-            family: 'jetbrains-mono:400,700'
-        },
-        'Libre Baskerville': {
-            family: 'libre-baskerville:700'
-        }
-    };
+    // Moved the import logic to the getAllCustomFontsImports function,
+    // so this function only returns the CSS.
+    // if (fonts?.heading && fonts?.body && fonts?.heading === fonts?.body) {
+    //     fontImports = `<link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}&display=swap">`;
+    // } else {
+    //     fontImports = '';
 
-    if (fonts?.heading && fonts?.body && fonts?.heading === fonts?.body) {
-        fontImports = `<link rel="stylesheet" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}">`;
-    } else {
-        fontImports = '';
+    //     if (fonts?.heading && fonts?.body) {
+    //         fontImports += `<link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}|${importStrings[fonts?.body]?.family}&display=swap">`;
+    //     } else {
+    //         if (fonts?.heading) {
+    //             fontImports += `<link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}&display=swap">`;
+    //         }
 
-        if (fonts?.heading && fonts?.body) {
-            fontImports += `<link rel="stylesheet" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}|${importStrings[fonts?.body]?.family}">`;
-        } else {
-            if (fonts?.heading) {
-                fontImports += `<link rel="stylesheet" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.heading]?.family}">`;
-            }
-
-            if (fonts?.body) {
-                fontImports += `<link rel="stylesheet" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.body]?.family}">`;
-            }
-        }
-    }
+    //         if (fonts?.body) {
+    //             fontImports += `<link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=${importStrings[fonts?.body]?.family}&display=swap">`;
+    //         }
+    //     }
+    // }
 
     if (fonts?.body || fonts?.heading) {
         fontCSS = ':root {';
@@ -210,7 +212,7 @@ export function generateCustomFontCss(fonts: FontSelection) {
         fontCSS += '}';
     }
 
-    return `<link rel="preconnect" href="https://fonts.bunny.net">${fontImports}<style>${fontCSS}</style>`;
+    return `<style>${fontCSS}</style>`;
 }
 
 export function generateCustomFontBodyClass(fonts: FontSelection) {
@@ -228,6 +230,14 @@ export function generateCustomFontBodyClass(fonts: FontSelection) {
     }
 
     return bodyClass;
+}
+
+export function getAllCustomFontsImports() {
+    let importString = '<link rel="preconnect" href="https://fonts.bunny.net"><link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=';
+    const allFonts = Object.values(importStrings).map(font => font.family);
+    importString += allFonts.join('|');
+    importString += '&display=swap">';
+    return importString;
 }
 
 export function getCSSFriendlyFontClassName(font: string) {

--- a/ghost/custom-fonts/test/index.test.ts
+++ b/ghost/custom-fonts/test/index.test.ts
@@ -121,4 +121,11 @@ describe('Custom Fonts', function () {
             assert.equal(result, '', 'Returns an empty string with no fonts');
         });
     });
+
+    describe('getAllCustomFontsImports', function () {
+        it('returns the correct imports for all custom fonts', function () {
+            const result = customFonts.getAllCustomFontsImports();
+            assert.equal(result, '<link rel="stylesheet" media="all" href="https://fonts.bunny.net/css?family=cardo:400,700|manrope:300,500,700|merriweather:300,700|nunito:400,600,700|old-standard-tt:400,700|roboto:400,500,700|rufina:400,500,700|tenor-sans:400|space-grotesk:700|chakra-petch:400|noto-sans:400,700|poppins:400,500,600|fira-sans:400,500,600|inter:400,500,600|noto-serif:400,700|lora:400,700|ibm-plex-serif:400,500,600|space-mono:400,700|fira-mono:400,700|jetbrains-mono:400,700&display=swap">');
+        });
+    });
 });


### PR DESCRIPTION
ref DES-934

- This is an attempt to improve the performance by importing all fonts at all times into the `ghost_head`
- The CSS still gets generated for the selected fonts
- This breaks the tests, as it's only a PoC that we'll have to test out