### PR TITLE
Initialised ActivityPub integration on boot

### DIFF
--- a/ghost/activitypub/.eslintrc.js
+++ b/ghost/activitypub/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/ts'
+    ]
+};

--- a/ghost/activitypub/README.md
+++ b/ghost/activitypub/README.md
@@ -1,0 +1,23 @@
+# Activitypub
+
+Service for managing the integration of ActivityPub and Ghost
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/activitypub/package.json
+++ b/ghost/activitypub/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@tryghost/activitypub",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/activitypub",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "dev": "tsc --watch --preserveWatchOutput --sourceMap",
+    "build": "tsc",
+    "build:ts": "tsc",
+    "prepare": "tsc",
+    "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
+    "test": "yarn test:types && yarn test:unit",
+    "test:types": "tsc --noEmit",
+    "lint:code": "eslint src/ --ext .ts --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .ts --cache"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "@tryghost/identity-token-service": "0.0.0",
+    "@tryghost/logging": "2.4.19",
+    "c8": "10.1.2",
+    "knex": "3.1.0",
+    "mocha": "10.8.2",
+    "nock": "13.5.5",
+    "sinon": "19.0.2",
+    "sqlite3": "5.1.7",
+    "ts-node": "10.9.2",
+    "typescript": "5.6.3"
+  },
+  "dependencies": {
+    "bson-objectid": "2.0.4"
+  }
+}

--- a/ghost/activitypub/src/ActivityPubService.ts
+++ b/ghost/activitypub/src/ActivityPubService.ts
@@ -1,0 +1,139 @@
+import ObjectID from 'bson-objectid';
+import {Knex} from 'knex';
+import {IdentityTokenService} from '@tryghost/identity-token-service';
+import fetch from 'node-fetch';
+
+type ExpectedWebhook = {
+    event: string;
+    target_url: URL;
+    api_version: string;
+    secret: string;
+};
+
+interface Logger {
+    info(message: string): void
+    warn(message: string): void
+    error(message: string): void
+}
+
+export class ActivityPubService {
+    constructor(
+        private knex: Knex,
+        private siteUrl: URL,
+        private logging: Logger,
+        private identityTokenService: IdentityTokenService
+    ) {}
+
+    getExpectedWebhooks(secret: string): ExpectedWebhook[] {
+        return [{
+            event: 'post.published',
+            target_url: new URL('.ghost/activitypub/webhooks/post/published', this.siteUrl),
+            api_version: 'v5.100.0',
+            secret
+        }, {
+            event: 'site.changed',
+            target_url: new URL('.ghost/activitypub/webhooks/site/changed', this.siteUrl),
+            api_version: 'v5.100.0',
+            secret
+        }];
+    }
+
+    async checkWebhookState(expectedWebhooks: ExpectedWebhook[], integration: {id: string}) {
+        this.logging.info(`Checking ActivityPub Webhook state`);
+
+        const webhooks = await this.knex
+            .select('*')
+            .from('webhooks')
+            .where('integration_id', '=', integration.id);
+
+        if (webhooks.length !== expectedWebhooks.length) {
+            this.logging.warn(`Expected ${expectedWebhooks.length} webhooks for ActivityPub`);
+            return false;
+        }
+
+        for (const expectedWebhook of expectedWebhooks) {
+            const foundWebhook = webhooks.find((webhook) => {
+                return webhook.event === expectedWebhook.event && webhook.target_url === expectedWebhook.target_url.href && webhook.secret === expectedWebhook.secret;
+            });
+            if (!foundWebhook) {
+                this.logging.error(`Could not find webhook for ${expectedWebhook.event} ${expectedWebhook.target_url}`);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    async getWebhookSecret(): Promise<string | null> {
+        try {
+            const ownerUser = await this.knex.select('*').from('users').where('id', '=', '1').first();
+            const token = await this.identityTokenService.getTokenForUser(ownerUser.email, 'Owner');
+
+            const res = await fetch(new URL('.ghost/activitypub/site', this.siteUrl), {
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            });
+
+            const body = await res.json();
+
+            return body.webhook_secret;
+        } catch (err: unknown) {
+            this.logging.error(`Could not get webhook secret for ActivityPub ${err}`);
+            return null;
+        }
+    }
+
+    async initialiseWebhooks() {
+        const integration = await this.knex
+            .select('*')
+            .from('integrations')
+            .where('slug', '=', 'ghost-activitypub')
+            .andWhere('type', '=', 'internal')
+            .first();
+
+        if (!integration) {
+            this.logging.error('No ActivityPub integration found - cannot initialise');
+            return;
+        }
+
+        const secret = await this.getWebhookSecret();
+
+        if (!secret) {
+            this.logging.error('No webhook secret found - cannot initialise');
+            return;
+        }
+
+        const expectedWebhooks = this.getExpectedWebhooks(secret);
+        const isInCorrectState = await this.checkWebhookState(expectedWebhooks, integration);
+
+        if (isInCorrectState) {
+            this.logging.info(`ActivityPub webhooks in correct state`);
+            return;
+        }
+
+        this.logging.info(`ActivityPub webhooks in incorrect state, deleting all of them and starting fresh`);
+        await this.knex
+            .del()
+            .from('webhooks')
+            .where('integration_id', '=', integration.id);
+
+        const webhooksToInsert = expectedWebhooks.map((expectedWebhook) => {
+            return {
+                id: (new ObjectID).toHexString(),
+                event: expectedWebhook.event,
+                target_url: expectedWebhook.target_url.href,
+                api_version: expectedWebhook.api_version,
+                name: `ActivityPub ${expectedWebhook.event} Webhook`,
+                secret: secret,
+                integration_id: integration.id,
+                created_at: this.knex.raw('current_timestamp'),
+                created_by: '1'
+            };
+        });
+
+        await this.knex
+            .insert(webhooksToInsert)
+            .into('webhooks');
+    }
+}

--- a/ghost/activitypub/src/index.ts
+++ b/ghost/activitypub/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityPubService';

--- a/ghost/activitypub/test/.eslintrc.js
+++ b/ghost/activitypub/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/activitypub/test/ActivityPubService.test.ts
+++ b/ghost/activitypub/test/ActivityPubService.test.ts
@@ -1,0 +1,289 @@
+import assert from 'assert/strict';
+import {ActivityPubService} from '../src';
+import knex, {Knex} from 'knex';
+import {IdentityTokenService} from '@tryghost/identity-token-service';
+import nock from 'nock';
+
+async function getKnexInstance() {
+    const knexInstance = knex({
+        client: 'sqlite',
+        connection: {
+            filename: ':memory:'
+        },
+        useNullAsDefault: true
+    });
+
+    await knexInstance.schema.createTable('users', (table) => {
+        table.string('id').primary();
+        table.string('email');
+    });
+
+    await knexInstance.schema.createTable('integrations', (table) => {
+        table.string('id').primary();
+        table.string('slug');
+        table.string('type');
+    });
+
+    await knexInstance.schema.createTable('webhooks', (table) => {
+        table.string('id').primary();
+        table.string('event');
+        table.string('target_url');
+        table.string('api_version');
+        table.string('name');
+        table.string('secret');
+        table.string('integration_id');
+        table.datetime('created_at');
+        table.string('created_by');
+    });
+
+    return knexInstance;
+}
+
+async function addOwnerUser(knexInstance: Knex) {
+    await knexInstance.insert({
+        id: '1',
+        email: 'owner@user.com'
+    }).into('users');
+}
+async function addActivityPubIntegration(knexInstance: Knex) {
+    await knexInstance.insert({
+        id: 'integration_id',
+        slug: 'ghost-activitypub',
+        type: 'internal'
+    }).into('integrations');
+}
+
+describe('ActivityPubService', function () {
+    it('Can initialise the webhooks', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+        const scope = nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        const logging = console;
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await service.initialiseWebhooks();
+
+        assert(scope.isDone(), 'Expected the ActivityPub site endpoint to be called');
+
+        const webhooks = await knexInstance.select('*').from('webhooks');
+
+        const expectedWebhookCount = 2;
+        const expectedWebhookSecret = 'webhook_secret_baby!!';
+        const expectedWebhookIntegrationId = 'integration_id';
+
+        assert.equal(webhooks.length, expectedWebhookCount);
+
+        for (const webhook of webhooks) {
+            assert.equal(webhook.secret, expectedWebhookSecret);
+            assert.equal(webhook.integration_id, expectedWebhookIntegrationId);
+        }
+
+        await knexInstance.destroy();
+    });
+
+    it('Will not reinitialise webhooks if they are already good', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+        const scope = nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        const logging = console;
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await service.initialiseWebhooks();
+
+        assert(scope.isDone(), 'Expected the ActivityPub site endpoint to be called');
+
+        const webhooks = await knexInstance.select('*').from('webhooks');
+
+        const expectedWebhookCount = 2;
+        const expectedWebhookSecret = 'webhook_secret_baby!!';
+        const expectedWebhookIntegrationId = 'integration_id';
+
+        assert.equal(webhooks.length, expectedWebhookCount);
+
+        for (const webhook of webhooks) {
+            assert.equal(webhook.secret, expectedWebhookSecret);
+            assert.equal(webhook.integration_id, expectedWebhookIntegrationId);
+        }
+
+        nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        await service.initialiseWebhooks();
+
+        const webhooksAfterSecondInitialisation = await knexInstance.select('*').from('webhooks');
+
+        assert.deepEqual(webhooksAfterSecondInitialisation, webhooks, 'Expected webhooks to be unchanged');
+
+        await knexInstance.destroy();
+    });
+
+    it('Can handle a misconfigured webhook', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+        const scope = nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        const logging = console;
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await service.initialiseWebhooks();
+
+        assert(scope.isDone(), 'Expected the ActivityPub site endpoint to be called');
+
+        const webhooks = await knexInstance.select('*').from('webhooks');
+
+        const expectedWebhookCount = 2;
+        const expectedWebhookSecret = 'webhook_secret_baby!!';
+        const expectedWebhookIntegrationId = 'integration_id';
+
+        assert.equal(webhooks.length, expectedWebhookCount);
+
+        for (const webhook of webhooks) {
+            assert.equal(webhook.secret, expectedWebhookSecret);
+            assert.equal(webhook.integration_id, expectedWebhookIntegrationId);
+        }
+
+        await knexInstance('webhooks').update({event: 'wrong.event'}).limit(1);
+
+        nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        await service.initialiseWebhooks();
+
+        const webhooksAfterSecondInitialisation = await knexInstance.select('*').from('webhooks');
+
+        assert.equal(webhooksAfterSecondInitialisation.length, expectedWebhookCount);
+
+        for (const webhook of webhooksAfterSecondInitialisation) {
+            assert.equal(webhook.secret, expectedWebhookSecret);
+            assert.equal(webhook.integration_id, expectedWebhookIntegrationId);
+        }
+
+        assert.notDeepEqual(webhooksAfterSecondInitialisation, webhooks, 'Expected webhooks to be changed');
+
+        await knexInstance.destroy();
+    });
+
+    it('Can handle missing integration without erroring', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+        const scope = nock(siteUrl)
+            .get('/.ghost/activitypub/site')
+            .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
+            .reply(200, {
+                webhook_secret: 'webhook_secret_baby!!'
+            });
+
+        const logging = console;
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await service.initialiseWebhooks();
+
+        assert(!scope.isDone(), 'Expected the ActivityPub site endpoint not to be called');
+
+        await knexInstance.destroy();
+    });
+
+    it('Can handle errors getting the webhook secret without erroring', async function () {
+        const knexInstance = await getKnexInstance();
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+
+        const logging = console;
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await service.initialiseWebhooks();
+
+        const webhooks = await knexInstance.select('*').from('webhooks');
+
+        assert.equal(webhooks.length, 0, 'There should be no webhooks');
+
+        await knexInstance.destroy();
+    });
+});

--- a/ghost/activitypub/tsconfig.json
+++ b/ghost/activitypub/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": ["es2019"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*"]
+}

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -474,6 +474,8 @@ async function initBackgroundServices({config}) {
         return;
     }
 
+    const activitypub = require('./server/services/activitypub');
+    await activitypub.init();
     // Load email analytics recurring jobs
     if (config.get('backgroundJobs:emailAnalytics')) {
         const emailAnalyticsJobs = require('./server/services/email-analytics/jobs');

--- a/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
+++ b/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
@@ -1,0 +1,42 @@
+const {ActivityPubService} = require('@tryghost/activitypub');
+
+module.exports = class ActivityPubServiceWrapper {
+    /** @type ActivityPubService */
+    static instance;
+
+    static async init() {
+        if (ActivityPubServiceWrapper.instance) {
+            return;
+        }
+        const labs = require('../../../shared/labs');
+
+        if (!labs.isSet('ActivityPub')) {
+            return;
+        }
+
+        const urlUtils = require('../../../shared/url-utils');
+        const siteUrl = new URL(urlUtils.getSiteUrl());
+
+        const db = require('../../data/db');
+        const knex = db.knex;
+
+        const logging = require('@tryghost/logging');
+
+        const IdentityTokenServiceWrapper = require('../identity-tokens');
+
+        if (!IdentityTokenServiceWrapper.instance) {
+            logging.error(`IdentityTokenService needs to be initialised before ActivityPubService`);
+        }
+
+        ActivityPubServiceWrapper.instance = new ActivityPubService(
+            knex,
+            siteUrl,
+            logging,
+            IdentityTokenServiceWrapper.instance
+        );
+
+        if (labs.isSet('ActivityPub') && IdentityTokenServiceWrapper.instance) {
+            await ActivityPubServiceWrapper.instance.initialiseWebhooks();
+        }
+    }
+};

--- a/ghost/core/core/server/services/activitypub/index.js
+++ b/ghost/core/core/server/services/activitypub/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./ActivityPubServiceWrapper');

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -60,6 +60,7 @@
     "@extractus/oembed-extractor": "3.2.1",
     "@sentry/node": "7.119.2",
     "@slack/webhook": "7.0.3",
+    "@tryghost/activitypub": "0.0.0",
     "@tryghost/adapter-base-cache": "0.1.12",
     "@tryghost/adapter-cache-redis": "0.0.0",
     "@tryghost/adapter-manager": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12958,6 +12958,11 @@ commander@5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 commander@^2.19.0, commander@^2.20.0, commander@^2.6.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -21608,6 +21613,26 @@ knex@2.4.2:
     tarn "^3.0.2"
     tildify "2.0.0"
 
+knex@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-3.1.0.tgz#b6ddd5b5ad26a6315234a5b09ec38dc4a370bd8c"
+  integrity sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==
+  dependencies:
+    colorette "2.0.19"
+    commander "^10.0.0"
+    debug "4.3.4"
+    escalade "^3.1.1"
+    esm "^3.2.25"
+    get-package-type "^0.1.0"
+    getopts "2.3.0"
+    interpret "^2.2.0"
+    lodash "^4.17.21"
+    pg-connection-string "2.6.2"
+    rechoir "^0.8.0"
+    resolve-from "^5.0.0"
+    tarn "^3.0.2"
+    tildify "2.0.0"
+
 knex@^0.20:
   version "0.20.15"
   resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.15.tgz#b7e9e1efd9cf35d214440d9439ed21153574679d"
@@ -23953,6 +23978,15 @@ nock@13.3.3:
     lodash "^4.17.21"
     propagate "^2.0.0"
 
+nock@13.5.5:
+  version "13.5.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.5.tgz#cd1caaca281d42be17d51946367a3d53a6af3e78"
+  integrity sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
+
 nock@^14.0.0-beta.6:
   version "14.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.0-beta.6.tgz#beefba44893b89596bc9a526db50f8f0567403a9"
@@ -25225,6 +25259,11 @@ pg-connection-string@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-connection-string@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.2.tgz#713d82053de4e2bd166fab70cd4f26ad36aab475"
+  integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
 
 picocolors@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
refs https://linear.app/ghost/issue/AP-500

We've got a new @tryghost/activitypub package, which is gonna handle all of the wiring between Ghost and ActivityPub. Currently that is just the configuration of webhooks for the internal ActivityPub integration.

All this logic is run on the boot of Ghost, though notably in a non-blocking manner, it's initialised as part of the background services so it should not have an effect on the time to serving requests. having said that - it needs to be defensive against errors, which is why the entire network request is in a try/catch, as well as lookups for the integration able to handle missing data.

Unit tests use an in-memory sqlite instance, which means we're testing a full flow, ideally there would be a way to get the schema from Ghost for this, but for now this is acceptable IMO.
