### PR TITLE
Revert "Admin navigation settings fix (#21323)"

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/navigation/NavigationEditForm.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/navigation/NavigationEditForm.tsx
@@ -7,10 +7,6 @@ const NavigationEditForm: React.FC<{
     baseUrl: string;
     navigation: NavigationEditor;
 }> = ({baseUrl, navigation}) => {
-    const onAddItem = () => {
-        navigation.addItem();
-    };
-
     return <div className="w-full pt-2">
         <SortableList
             items={navigation.items}
@@ -29,7 +25,7 @@ const NavigationEditForm: React.FC<{
         <div className='flex items-center gap-3'>
             <Icon colorClass='text-grey-300 dark:text-grey-900 mt-1' name='add' size='sm' />
             <NavigationItemEditor
-                action={<Button className='mx-2 mt-2.5 self-start rounded bg-green p-1' data-testid="add-button" icon="add" iconColorClass='text-white' size='sm' unstyled onClick={onAddItem} />}
+                action={<Button className='mx-2 mt-1 self-center rounded bg-green p-1' data-testid="add-button" icon="add" iconColorClass='text-white' size='sm' unstyled onClick={navigation.addItem} />}
                 baseUrl={baseUrl}
                 className="mt-1"
                 clearError={key => navigation.clearError(navigation.newItem.id, key)}
@@ -37,7 +33,6 @@ const NavigationEditForm: React.FC<{
                 item={navigation.newItem}
                 labelPlaceholder="New item label"
                 updateItem={navigation.setNewItem}
-                onAddItem={onAddItem}
             />
         </div>
     </div>;

--- a/apps/admin-x-settings/src/components/settings/site/navigation/NavigationItemEditor.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/navigation/NavigationItemEditor.tsx
@@ -12,17 +12,9 @@ export type NavigationItemEditorProps = React.HTMLAttributes<HTMLDivElement> & {
     unstyled?: boolean
     textFieldClasses?: string
     action?: ReactNode
-    onAddItem?: () => void; // New prop
 }
 
-const NavigationItemEditor: React.FC<NavigationItemEditorProps> = ({baseUrl, item, updateItem, clearError, labelPlaceholder, unstyled, textFieldClasses, action, className, onAddItem,...props}) => {
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            onAddItem?.();
-        }
-    };
-
+const NavigationItemEditor: React.FC<NavigationItemEditorProps> = ({baseUrl, item, updateItem, clearError, labelPlaceholder, unstyled, textFieldClasses, action, className, ...props}) => {
     return (
         <div className={clsx('flex w-full items-start gap-3', className)} data-testid='navigation-item-editor' {...props}>
             <div className="flex flex-1 pt-1">
@@ -37,10 +29,7 @@ const NavigationItemEditor: React.FC<NavigationItemEditorProps> = ({baseUrl, ite
                     value={item.label}
                     hideTitle
                     onChange={e => updateItem?.({label: e.target.value})}
-                    onKeyDown={(e) => {
-                        clearError?.('label');
-                        handleKeyDown(e);
-                    }}
+                    onKeyDown={() => clearError?.('label')}
                 />
             </div>
             <div className="flex flex-1 pt-1">
@@ -55,10 +44,7 @@ const NavigationItemEditor: React.FC<NavigationItemEditorProps> = ({baseUrl, ite
                     value={item.url}
                     hideTitle
                     onChange={value => updateItem?.({url: value || ''})}
-                    onKeyDown={(e) => {
-                        clearError?.('url');
-                        handleKeyDown(e);
-                    }}
+                    onKeyDown={() => clearError?.('url')}
                 />
             </div>
             {action}


### PR DESCRIPTION
This reverts commit eaed33972fa3b504a8416ad40572beaac0cf8b62.

The fix we shipped for using the `RETURN` key to create navigation items in Admin broke something with regards to saving the URL, so we're reverting that change.
