### PR TITLE
Custom Integrations and Webhooks layout fixes

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -173,7 +173,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                 {integrations.map(integration => (
                     <IntegrationItem
                         action={() => updateRoute({route: `integrations/${integration.id}`})}
-                        detail={<div className="line-clamp-2">{integration.description || 'No description'}</div>}
+                        detail={<div className="line-clamp-2 break-all">{integration.description || 'No description'}</div>}
                         icon={
                             integration.icon_image ?
                                 <img className='h-8 w-8 shrink-0 object-cover' role='presentation' src={integration.icon_image} /> :

--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -173,7 +173,9 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                 {integrations.map(integration => (
                     <IntegrationItem
                         action={() => updateRoute({route: `integrations/${integration.id}`})}
-                        detail={<div className="line-clamp-2 break-words">{integration.description || 'No description'}</div>}
+                        detail={<div className="line-clamp-2 break-words">
+                            <span title={`${integration.name}: ${integration.description || 'No description'}`}>{integration.description || 'No description'}</span>
+                        </div>}
                         icon={
                             integration.icon_image ?
                                 <img className='h-8 w-8 shrink-0 object-cover' role='presentation' src={integration.icon_image} /> :

--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -18,7 +18,7 @@ import {useRouting} from '@tryghost/admin-x-framework/routing';
 interface IntegrationItemProps {
     icon?: React.ReactNode,
     title: string,
-    detail: string,
+    detail: string | React.ReactNode,
     action: () => void;
     onDelete?: () => void;
     active?: boolean;
@@ -173,7 +173,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                 {integrations.map(integration => (
                     <IntegrationItem
                         action={() => updateRoute({route: `integrations/${integration.id}`})}
-                        detail={integration.description || 'No description'}
+                        detail={<div className="line-clamp-2">{integration.description || 'No description'}</div>}
                         icon={
                             integration.icon_image ?
                                 <img className='h-8 w-8 object-cover' role='presentation' src={integration.icon_image} /> :

--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -173,7 +173,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                 {integrations.map(integration => (
                     <IntegrationItem
                         action={() => updateRoute({route: `integrations/${integration.id}`})}
-                        detail={<div className="line-clamp-2 break-all">{integration.description || 'No description'}</div>}
+                        detail={<div className="line-clamp-2 break-words">{integration.description || 'No description'}</div>}
                         icon={
                             integration.icon_image ?
                                 <img className='h-8 w-8 shrink-0 object-cover' role='presentation' src={integration.icon_image} /> :

--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -176,8 +176,8 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                         detail={<div className="line-clamp-2">{integration.description || 'No description'}</div>}
                         icon={
                             integration.icon_image ?
-                                <img className='h-8 w-8 object-cover' role='presentation' src={integration.icon_image} /> :
-                                <Icon className='w-8' name='integration' />
+                                <img className='h-8 w-8 shrink-0 object-cover' role='presentation' src={integration.icon_image} /> :
+                                <Icon className='w-8 shrink-0' name='integration' />
                         }
                         title={integration.name}
                         custom

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
@@ -60,7 +60,7 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                             <span className='text-grey-600'>Event:</span>
                             <span>{getWebhookEventLabel(webhook.event)}</span>
                             <span className='text-grey-600'>URL:</span>
-                            <span className='line-clamp-2 break-words' title={webhook.target_url}>
+                            <span className='line-clamp-3 break-all' title={webhook.target_url}>
                                 {webhook.target_url}
                             </span>
                         </div>

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
@@ -38,32 +38,34 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                 <TableHead>Last triggered</TableHead>
             </TableRow>
             {integration.webhooks?.map(webhook => (
-                <TableRow
-                    action={
-                        <Button color='red' label='Delete' link onClick={(e) => {
-                            e?.stopPropagation();
-                            handleDelete(webhook.id);
-                        }} />
-                    }
-                    hideActions
-                    onClick={() => {
-                        NiceModal.show(WebhookModal, {
-                            webhook,
-                            integrationId:
+                <TableRow action={
+                    <Button color='red' label='Delete' link onClick={(e) => {
+                        e?.stopPropagation();
+                        handleDelete(webhook.id);
+                    }} />
+                }
+                bgOnHover={false}
+                hideActions
+                onClick={() => {
+                    NiceModal.show(WebhookModal, {
+                        webhook,
+                        integrationId:
                         integration.id
-                        });
-                    }}
+                    });
+                }}
                 >
-                    <TableCell className='w-1/2'>
+                    <TableCell className='w-3/4'>
                         <div className='text-sm font-semibold'>{webhook.name}</div>
                         <div className='grid grid-cols-[max-content_1fr] gap-x-1 text-xs leading-snug'>
                             <span className='text-grey-600'>Event:</span>
                             <span>{getWebhookEventLabel(webhook.event)}</span>
                             <span className='text-grey-600'>URL:</span>
-                            <span>{webhook.target_url}</span>
+                            <span className='line-clamp-2 break-words' title={webhook.target_url}>
+                                {webhook.target_url}
+                            </span>
                         </div>
                     </TableCell>
-                    <TableCell className='w-1/2 text-sm'>
+                    <TableCell className='w-1/4 text-sm'>
                         {webhook.last_triggered_at && new Date(webhook.last_triggered_at).toLocaleString('default', {
                             weekday: 'short',
                             month: 'short',

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/WebhooksTable.tsx
@@ -36,7 +36,6 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
             <TableRow bgOnHover={false}>
                 <TableHead>{integration.webhooks?.length || 0} {integration.webhooks?.length === 1 ? 'webhook' : 'webhooks'}</TableHead>
                 <TableHead>Last triggered</TableHead>
-                <TableHead />
             </TableRow>
             {integration.webhooks?.map(webhook => (
                 <TableRow


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-790/some-urls-not-wrapping-in-integration-detail-modal

- Webhook URLs were breaking out of the modal container. They now wrap across a few lines.
- Long descriptions of Custom Integrations caused the integration's icon to scale down. That no longer happens.
- Descriptions of Custom Integrations wrap properly.