### PR TITLE
Fixed CPU Usage chart in grafana dashboard

### DIFF
--- a/.github/scripts/grafana/dashboards/main-dashboard.json
+++ b/.github/scripts/grafana/dashboards/main-dashboard.json
@@ -312,19 +312,19 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(ghost_process_cpu_user_seconds_total{job=~\"$job\"}[1m]) * 100",
+            "expr": "rate(ghost_process_cpu_user_seconds_total{job=~\"$job\"}[1m]) * 100",
             "interval": "",
             "legendFormat": "User CPU - {{job}}",
             "refId": "A"
           },
           {
-            "expr": "irate(ghost_process_cpu_system_seconds_total{job=~\"$job\"}[1m]) * 100",
+            "expr": "rate(ghost_process_cpu_system_seconds_total{job=~\"$job\"}[1m]) * 100",
             "interval": "",
             "legendFormat": "System CPU - {{job}}",
             "refId": "B"
           },
           {
-            "expr": "irate(ghost_process_cpu_seconds_total{job=~\"$job\"}[1m]) * 100",
+            "expr": "rate(ghost_process_cpu_seconds_total{job=~\"$job\"}[1m]) * 100",
             "interval": "",
             "legendFormat": "Total CPU - {{job}}",
             "refId": "C"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1505/start-monitoring-ghosts-constraints-and-our-3-goals-using-prometheus

- Using `irate` for aggregating CPU usage was resulting in some strange behavior — the CPU Usage chart would zero out after a few mins of running. Switching to regular `rate` seems to have fixed the issue completely.