### PR TITLE
Moved newsletter date localisation behind labs flag

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -229,6 +229,10 @@ class EmailRenderer {
     #getValidLocale() {
         let locale = this.#settingsCache.get('locale') || DEFAULT_LOCALE;
 
+        if (!this.#labs.isSet('i18n')) {
+            locale = DEFAULT_LOCALE;
+        }
+
         // Remove any trailing whitespace
         locale = locale.trim();
 

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -358,15 +358,14 @@ describe('Email renderer', function () {
         let emailRenderer;
         let newsletter;
         let member;
-        let labsEnabled = true;
+
         beforeEach(function () {
-            labsEnabled = false;
             emailRenderer = new EmailRenderer({
                 urlUtils: {
                     urlFor: () => 'http://example.com/subdirectory/'
                 },
                 labs: {
-                    isSet: () => labsEnabled
+                    isSet: () => true
                 },
                 settingsCache: {
                     get: (key) => {
@@ -400,13 +399,13 @@ describe('Email renderer', function () {
             assert.equal(replacements[0].getValue(member), '13 March 2023');
         });
 
-        it('handles dates when the locale is fr', function () {
+        it('handles dates when the locale is fr and labs enabled', function () {
             emailRenderer = new EmailRenderer({
                 urlUtils: {
                     urlFor: () => 'http://example.com/subdirectory/'
                 },
                 labs: {
-                    isSet: () => labsEnabled
+                    isSet: () => true
                 },
                 settingsCache: {
                     get: (key) => {
@@ -429,13 +428,42 @@ describe('Email renderer', function () {
             assert.equal(replacements[0].getValue(member), '13 mars 2023');
         });
 
+        it('handles dates when the locale is fr and labs is disabled', function () {
+            emailRenderer = new EmailRenderer({
+                urlUtils: {
+                    urlFor: () => 'http://example.com/subdirectory/'
+                },
+                labs: {
+                    isSet: () => false
+                },
+                settingsCache: {
+                    get: (key) => {
+                        if (key === 'timezone') {
+                            return 'UTC';
+                        }
+                        if (key === 'locale') {
+                            return 'fr';
+                        }
+                    }
+                },
+                settingsHelpers: {getMembersValidationKey,createUnsubscribeUrl},
+                t: tFr
+            });
+            const html = '%%{created_at}%%';
+            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
+            assert.equal(replacements.length, 2);
+            assert.equal(replacements[0].token.toString(), '/%%\\{created_at\\}%%/g');
+            assert.equal(replacements[0].id, 'created_at');
+            assert.equal(replacements[0].getValue(member), '13 March 2023');
+        });
+
         it('handles dates when the locale is en (US)', function () {
             emailRenderer = new EmailRenderer({
                 urlUtils: {
                     urlFor: () => 'http://example.com/subdirectory/'
                 },
                 labs: {
-                    isSet: () => labsEnabled
+                    isSet: () => true
                 },
                 settingsCache: {
                     get: (key) => {
@@ -464,7 +492,7 @@ describe('Email renderer', function () {
                     urlFor: () => 'http://example.com/subdirectory/'
                 },
                 labs: {
-                    isSet: () => labsEnabled
+                    isSet: () => true
                 },
                 settingsCache: {
                     get: (key) => {
@@ -493,7 +521,7 @@ describe('Email renderer', function () {
                     urlFor: () => 'http://example.com/subdirectory/'
                 },
                 labs: {
-                    isSet: () => labsEnabled
+                    isSet: () => true
                 },
                 settingsCache: {
                     get: (key) => {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/21573

- We discussed this, and figured we should get this behind the flag for now, even though it's pulled
- This gives us the ability to do a fast revert if we have to later, which is the point of having the labs "GA FEATURES" array
- Note this removes the labsEnabled variable in the tests to make it clearer if the flag is off or on (it was off!)

