### PR TITLE
Removed `dangerouslySetInnerHTML` for attachments

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -307,12 +307,6 @@ const Profile: React.FC<ProfileProps> = ({}) => {
                                 dangerouslySetInnerHTML={{__html: userProfile?.summary ?? ''}}
                                 className='ap-profile-content mt-3 text-[1.5rem] [&>p]:mb-3'
                             />
-                            {attachments.map(attachment => (
-                                <span className='mt-3 line-clamp-1 flex flex-col text-[1.5rem]'>
-                                    <span className={`text-xs font-semibold`}>{attachment.name}</span>
-                                    <span dangerouslySetInnerHTML={{__html: attachment.value}} className='ap-profile-content truncate'/>
-                                </span>
-                            ))}
                             {!isExpanded && isOverflowing && (
                                 <div className='absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white via-white/90 via-60% to-transparent' />
                             )}

--- a/apps/admin-x-activitypub/src/components/global/ViewProfileModal.tsx
+++ b/apps/admin-x-activitypub/src/components/global/ViewProfileModal.tsx
@@ -285,12 +285,6 @@ const ViewProfileModal: React.FC<ViewProfileModalProps> = ({
                                         dangerouslySetInnerHTML={{__html: profile.actor.summary}}
                                         className='ap-profile-content mt-3 text-[1.5rem] [&>p]:mb-3'
                                     />
-                                    {attachments.map((attachment: {name: string, value: string}) => (
-                                        <span className='mt-3 line-clamp-1 flex flex-col text-[1.5rem]'>
-                                            <span className={`text-xs font-semibold`}>{attachment.name}</span>
-                                            <span dangerouslySetInnerHTML={{__html: attachment.value}} className='ap-profile-content truncate'/>
-                                        </span>
-                                    ))}
                                     {!isExpanded && isOverflowing && (
                                         <div className='absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white via-white/90 via-60% to-transparent' />
                                     )}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-585

The `value` of an attachment is not always a string, and can cause crashes in the client. Moreover, we're not sanitizing attachments, so dangerously setting the inner html is not possible at the moment. I've removed the rendering which should fix the bug and close the security hole.
