### PR TITLE
Fixed inbox tab not showing user's own posts in admin-x-activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -20,6 +20,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
 
     const {getActivitiesQuery, updateActivity} = useActivitiesForUser({
         handle: 'index',
+        includeOwn: true,
         excludeNonFollowers: true,
         filter: {
             type: ['Create:Article', 'Create:Note', 'Announce:Note']


### PR DESCRIPTION
refs [AP-588](https://linear.app/ghost/issue/AP-588/inbox-tab-not-showing-users-own-posts)

Fixed inbox tab not showing user's own posts in admin-x-activitypub by ensuring that the `includeOwn` parameter is set to `true` when fetching the activities for the inbox tab