### PR TITLE
Removed inbox feed filtering by `inReplyTo` in admin-x-activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -25,7 +25,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
         includeOwn: true,
         excludeNonFollowers: true,
         filter: {
-            type: ['Create:Article', 'Create:Note', 'Announce:Note']
+            type: ['Create:Article:notReply', 'Create:Note:notReply', 'Announce:Note']
         }
     });
     const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = getActivitiesQuery;
@@ -35,9 +35,7 @@ const Inbox: React.FC<InboxProps> = ({}) => {
     const {suggestedProfilesQuery} = useSuggestedProfiles('index', ['@index@activitypub.ghost.org', '@index@john.onolan.org', '@index@coffeecomplex.ghost.io', '@index@codename-jimmy.ghost.io', '@index@syphoncontinuity.ghost.io']);
     const {data: suggested = [], isLoading: isLoadingSuggested} = suggestedProfilesQuery;
 
-    const activities = (data?.pages.flatMap(page => page.data) ?? []).filter((activity) => {
-        return !activity.object.inReplyTo;
-    });
+    const activities = (data?.pages.flatMap(page => page.data) ?? []);
 
     // Intersection observer to fetch more activities when the user scrolls
     // to the bottom of the page


### PR DESCRIPTION
refs [TryGhost/ActivityPub#166](https://github.com/TryGhost/ActivityPub/pull/166)

Removed the inbox feed filtering by `inReplyTo` in admin-x-activitypub that was put in as a temporary measure when replies were being returned from the API