### PR TITLE
Fixed flaky batch sending tests

### DIFF
--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -109,6 +109,7 @@ describe('Batch sending tests', function () {
             value: false
         }], {context: {internal: true}});
         mockManager.restore();
+        await jobManager.allSettled();
     });
 
     before(async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1749

Batch sending tests were failing with MySQL fairly regularly. It appears to be a race condition where the listener for the batch sending job having completed is returning too early, causing the subsequent Bookshelf data model refresh to happen too soon.

This is a fundamental flaw in the JobManager awaitCompletion handler (and how the batch sending system interacts with it) as there's no way to identify one batch from another - they all use the same name, and we don't pass along any metadata.