### PR TITLE
Added utilities for creating custom prometheus metrics

### DIFF
--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -168,6 +168,7 @@ export class PrometheusClient {
      * Registers a gauge metric
      * @param name - The name of the metric
      * @param help - The help text for the metric
+     * @param collect - The collect function to use for the gauge
      * @returns The gauge metric
      */
     registerGauge({name, help, collect}: {name: string, help: string, collect?: () => void}): client.Gauge {
@@ -183,6 +184,7 @@ export class PrometheusClient {
      * @param name - The name of the metric
      * @param help - The help text for the metric
      * @param percentiles - The percentiles to calculate for the summary
+     * @param collect - The collect function to use for the summary
      * @returns The summary metric
      */
     registerSummary({name, help, percentiles, collect}: {name: string, help: string, percentiles?: number[], collect?: () => void}): client.Summary {
@@ -191,6 +193,22 @@ export class PrometheusClient {
             help,
             percentiles: percentiles || [0.5, 0.9, 0.99],
             collect
+        });
+    }
+
+    /**
+     * Registers a histogram metric
+     * @param name - The name of the metric
+     * @param help - The help text for the metric
+     * @param buckets - The buckets to calculate for the histogram
+     * @param collect - The collect function to use for the histogram
+     * @returns The histogram metric
+     */
+    registerHistogram({name, help, buckets}: {name: string, help: string, buckets: number[], collect?: () => void}): client.Histogram {
+        return new this.client.Histogram({
+            name: `${this.prefix}${name}`,
+            help,
+            buckets: buckets
         });
     }
 

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -1,5 +1,6 @@
 import {Request, Response} from 'express';
 import client from 'prom-client';
+import type {Metric} from 'prom-client';
 import type {Knex} from 'knex';
 import logging from '@tryghost/logging';
 
@@ -112,10 +113,23 @@ export class PrometheusClient {
     }
 
     /**
-     * Returns the metrics from the registry
+     * Returns the metrics from the registry as a string
      */
-    async getMetrics() {
+    async getMetrics(): Promise<string> {
         return this.client.register.metrics();
+    }
+
+    /**
+     * Returns the metrics from the registry as a JSON object
+     * 
+     * Particularly useful for testing
+     */
+    async getMetricsAsJSON(): Promise<object[]> {
+        return this.client.register.getMetricsAsJSON();
+    }
+
+    async getMetricsAsArray(): Promise<object[]> {
+        return this.client.register.getMetricsAsArray();
     }
 
     /**
@@ -123,6 +137,31 @@ export class PrometheusClient {
      */
     getContentType() {
         return this.client.register.contentType;
+    }
+
+    /**
+     * Returns a single metric from the registry
+     * @param name - The name of the metric
+     * @returns The metric
+     */
+    getMetric(name: string): Metric | undefined {
+        if (!name.startsWith(this.prefix)) {
+            name = `${this.prefix}${name}`;
+        }
+        return this.client.register.getSingleMetric(name);
+    }
+
+    /**
+     * Registers a counter metric
+     * @param name - The name of the metric
+     * @param help - The help text for the metric
+     * @returns The counter metric
+     */
+    registerCounter(name: string, help: string) {
+        return new this.client.Counter({
+            name: `${this.prefix}${name}`,
+            help
+        });
     }
 
     // Utility functions for creating custom metrics

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -178,6 +178,22 @@ export class PrometheusClient {
         });
     }
 
+    /**
+     * Registers a summary metric
+     * @param name - The name of the metric
+     * @param help - The help text for the metric
+     * @param percentiles - The percentiles to calculate for the summary
+     * @returns The summary metric
+     */
+    registerSummary({name, help, percentiles, collect}: {name: string, help: string, percentiles?: number[], collect?: () => void}): client.Summary {
+        return new this.client.Summary({
+            name: `${this.prefix}${name}`,
+            help,
+            percentiles: percentiles || [0.5, 0.9, 0.99],
+            collect
+        });
+    }
+
     // Utility functions for creating custom metrics
 
     /**

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -157,10 +157,24 @@ export class PrometheusClient {
      * @param help - The help text for the metric
      * @returns The counter metric
      */
-    registerCounter(name: string, help: string) {
+    registerCounter({name, help}: {name: string, help: string}): client.Counter {
         return new this.client.Counter({
             name: `${this.prefix}${name}`,
             help
+        });
+    }
+
+    /**
+     * Registers a gauge metric
+     * @param name - The name of the metric
+     * @param help - The help text for the metric
+     * @returns The gauge metric
+     */
+    registerGauge({name, help, collect}: {name: string, help: string, collect?: () => void}): client.Gauge {
+        return new this.client.Gauge({
+            name: `${this.prefix}${name}`,
+            help,
+            collect
         });
     }
 

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from 'express';
 import client from 'prom-client';
-import type {Metric} from 'prom-client';
+import type {Metric, MetricObjectWithValues, MetricValue} from 'prom-client';
 import type {Knex} from 'knex';
 import logging from '@tryghost/logging';
 
@@ -150,6 +150,31 @@ export class PrometheusClient {
         }
         return this.client.register.getSingleMetric(name);
     }
+
+    /**
+     * Returns the metric object of a single metric, if it exists
+     * @param name - The name of the metric
+     * @returns The values of the metric
+     */
+    async getMetricObject(name: string): Promise<MetricObjectWithValues<MetricValue<string>> | undefined> {
+        const metric = this.getMetric(name);
+        if (!metric) {
+            return undefined;
+        }
+        return await metric.get();
+    }
+
+    async getMetricValues(name: string): Promise<MetricValue<string>[] | undefined> {
+        const metricObject = await this.getMetricObject(name);
+        if (!metricObject) {
+            return undefined;
+        }
+        return metricObject.values;
+    }
+
+    /**
+     * 
+     */
 
     /**
      * Registers a counter metric

--- a/ghost/prometheus-metrics/test/prometheus-client.test.ts
+++ b/ghost/prometheus-metrics/test/prometheus-client.test.ts
@@ -208,6 +208,44 @@ describe('Prometheus Client', function () {
         });
     });
 
+    describe('getMetricObject', function () {
+        it('should return the values of a metric', async function () {
+            instance = new PrometheusClient();
+            instance.init();
+            const metricObject = await instance.getMetricObject('ghost_process_cpu_seconds_total');
+            assert.ok(metricObject);
+            assert.ok(metricObject.values);
+            assert.ok(Array.isArray(metricObject.values));
+            assert.equal(metricObject.help, 'Total user and system CPU time spent in seconds.');
+            assert.equal(metricObject.type, 'counter');
+            assert.equal(metricObject.name, 'ghost_process_cpu_seconds_total');
+        });
+
+        it('should return undefined if the metric is not found', async function () {
+            instance = new PrometheusClient();
+            instance.init();
+            const metricObject = await instance.getMetricObject('ghost_not_a_metric');
+            assert.equal(metricObject, undefined);
+        });
+    });
+
+    describe('getMetricValues', function () {
+        it('should return the values of a metric', async function () {
+            instance = new PrometheusClient();
+            instance.init();
+            const metricValues = await instance.getMetricValues('ghost_process_cpu_seconds_total');
+            assert.ok(metricValues);
+            assert.ok(Array.isArray(metricValues));
+        });
+
+        it('should return undefined if the metric is not found', async function () {
+            instance = new PrometheusClient();
+            instance.init();
+            const metricValues = await instance.getMetricValues('ghost_not_a_metric');
+            assert.equal(metricValues, undefined);
+        });
+    });
+
     describe('instrumentKnex', function () {
         let knexMock: Knex;
         let eventEmitter: EventEmitterType;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1771/add-utility-functions-to-easily-create-custom-metrics

- Currently adding custom metrics to our prometheus client requires you to directly access the `prometheusClient.client` to create the metrics
- This isn't super convenient, as you then have to either keep the metric in a local variable, or manually get it from the `prometheusClient.client.register`
- This commit exposes some utility functions for registering metrics on the `prometheusClient` class, and for retrieving metrics that have already been recorded