### PR TITLE
Ensured `prometheusClient` is not initialized unless enabled via config

### DIFF
--- a/ghost/core/core/shared/prometheus-client.js
+++ b/ghost/core/core/shared/prometheus-client.js
@@ -3,7 +3,7 @@ const config = require('./config');
 
 let prometheusClient;
 
-if (!prometheusClient) {
+if (!prometheusClient && config.get('prometheus:enabled')) {
     const pushgatewayConfig = config.get('prometheus:pushgateway');
     const prometheusConfig = {pushgateway: pushgatewayConfig};
     prometheusClient = new PrometheusClient(prometheusConfig);

--- a/ghost/core/test/integration/prometheus-client.test.js
+++ b/ghost/core/test/integration/prometheus-client.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert').strict;
+const configUtils = require('../utils/configUtils');
+
+function clearModuleCache() {
+    delete require.cache[require.resolve('../../core/shared/prometheus-client')];
+}
+
+function getFreshPrometheusClient() {
+    clearModuleCache();
+    return require('../../core/shared/prometheus-client');
+}
+
+describe('Integration: prometheus-client', function () {
+    let prometheusClient;
+
+    beforeEach(function () {
+        if (prometheusClient) {
+            prometheusClient.client.register.clear();
+        }
+    });
+
+    it('should export an instance of the prometheus client if it is enabled', async function () {
+        configUtils.set('prometheus:enabled', true);
+        prometheusClient = getFreshPrometheusClient();
+        assert.ok(prometheusClient);
+    });
+
+    it('should not create a new instance if one already exists', async function () {
+        configUtils.set('prometheus:enabled', true);
+        prometheusClient = getFreshPrometheusClient();
+        const prometheusClient2 = require('../../core/shared/prometheus-client');
+        assert.equal(prometheusClient, prometheusClient2);
+    });
+
+    it('should not export an instance of the prometheus client if it is disabled', async function () {
+        configUtils.set('prometheus:enabled', false);
+        prometheusClient = getFreshPrometheusClient();
+        assert.equal(prometheusClient, undefined);
+    });
+});


### PR DESCRIPTION
no issue

- Currently the prometheus client is only initialized on boot if enabled via config, but if it's required in other files (i.e. to create a custom metric) it will be initialized then
- This commit explicitly checks if the prometheus client is enabled via config before initializing it, thus preventing it from being initialized when disabled