### PR TITLE
Added "time to acquire connection" prometheus metric

### DIFF
--- a/.github/scripts/grafana/dashboards/main-dashboard.json
+++ b/.github/scripts/grafana/dashboards/main-dashboard.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -17,7 +20,9 @@
         "type": "dashboard"
       },
       {
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "enable": true,
         "expr": "ghost_process_start_time_seconds{job=~\"$job\", instance=~\"$instance\"} * 1000",
         "hide": false,
@@ -35,12 +40,15 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 14058,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1731033697061,
+  "id": 63,
   "links": [],
   "liveNow": false,
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MFh-a5E4z"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -48,6 +56,15 @@
         "y": 0
       },
       "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MFh-a5E4z"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "type": "row"
     },
@@ -96,7 +113,6 @@
         "y": 1
       },
       "id": 2,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
@@ -110,12 +126,17 @@
           "fields": "/^version$/",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.0",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_version_info{}",
           "format": "table",
@@ -163,7 +184,6 @@
         "y": 1
       },
       "id": 3,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
@@ -177,12 +197,17 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.0",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "sum(changes(ghost_process_start_time_seconds{job=~\"$job\"}[$__range]))",
           "instant": false,
@@ -196,6 +221,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MFh-a5E4z"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -204,6 +233,15 @@
       },
       "id": 4,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MFh-a5E4z"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Process",
       "type": "row"
     },
@@ -219,6 +257,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -230,6 +271,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -272,7 +314,6 @@
         "y": 4
       },
       "id": 5,
-      "interval": "1",
       "options": {
         "legend": {
           "calcs": [
@@ -282,30 +323,50 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
-          "expr": "rate(ghost_process_cpu_user_seconds_total{job=~\"$job\"}[1m]) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "rate(ghost_process_cpu_user_seconds_total{job=~\"$job\"}[$interval]) * 100",
           "interval": "",
           "legendFormat": "User CPU - {{job}}",
+          "range": true,
           "refId": "A"
         },
         {
-          "expr": "rate(ghost_process_cpu_system_seconds_total{job=~\"$job\"}[1m]) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "rate(ghost_process_cpu_system_seconds_total{job=~\"$job\"}[$interval]) * 100",
           "interval": "",
           "legendFormat": "System CPU - {{job}}",
+          "range": true,
           "refId": "B"
         },
         {
-          "expr": "rate(ghost_process_cpu_seconds_total{job=~\"$job\"}[1m]) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "rate(ghost_process_cpu_seconds_total{job=~\"$job\"}[$interval]) * 100",
           "interval": "",
           "legendFormat": "Total CPU - {{job}}",
+          "range": true,
           "refId": "C"
         }
       ],
@@ -324,6 +385,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -335,6 +399,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -377,7 +442,6 @@
         "y": 4
       },
       "id": 6,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -387,15 +451,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "rate(ghost_process_cpu_seconds_total{job=~\"$job\"}[$interval])",
           "interval": "",
@@ -403,6 +473,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "rate(ghost_process_cpu_system_seconds_total{job=~\"$job\"}[$interval])",
           "hide": false,
@@ -411,6 +485,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "rate(ghost_process_cpu_user_seconds_total{job=~\"$job\"}[$interval])",
           "hide": false,
@@ -434,6 +512,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -445,6 +526,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -487,7 +569,6 @@
         "y": 4
       },
       "id": 7,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -497,15 +578,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "process_resident_memory_bytes{job=~\"$job\"}",
           "interval": "",
@@ -513,6 +600,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_heap_size_total_bytes{job=~\"$job\"}",
           "interval": "",
@@ -520,6 +611,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_heap_size_used_bytes{job=~\"$job\"}",
           "interval": "",
@@ -527,6 +622,10 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_external_memory_bytes{job=~\"$job\"}",
           "interval": "",
@@ -549,6 +648,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -560,6 +662,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -602,7 +705,6 @@
         "y": 13
       },
       "id": 8,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -612,15 +714,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_active_handles_total{job=~\"$job\"}",
           "interval": "",
@@ -628,6 +736,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_active_requests_total{job=~\"$job\"}",
           "interval": "",
@@ -650,6 +762,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -661,6 +776,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -703,7 +819,6 @@
         "y": 13
       },
       "id": 9,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -713,15 +828,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_eventloop_lag_seconds{job=~\"$job\"}",
           "hide": false,
@@ -731,6 +852,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_eventloop_lag_p99_seconds{job=~\"$job\"}",
           "interval": "",
@@ -738,6 +863,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_eventloop_lag_p50_seconds{job=~\"$job\"}",
           "interval": "",
@@ -750,6 +879,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MFh-a5E4z"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -758,10 +891,23 @@
       },
       "id": 18,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MFh-a5E4z"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Database: Connection Pool",
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "The number of active connections maintained with the database. These connections can be in use or idle.",
       "fieldConfig": {
         "defaults": {
@@ -769,24 +915,28 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -820,51 +970,58 @@
         "y": 23
       },
       "id": 20,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "ghost_db_connection_pool_max{job=\"$job\"}",
+          "expr": "ghost_db_connection_pool_max{job=~\"$job\"}",
           "interval": "",
           "legendFormat": "Max - {{job}}",
+          "range": true,
           "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "ghost_db_connection_pool_active{job=\"$job\"}",
+          "expr": "ghost_db_connection_pool_active{job=~\"$job\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Active - {{job}}",
+          "range": true,
           "refId": "B"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "ghost_db_connection_pool_min{job=\"$job\"}",
+          "expr": "ghost_db_connection_pool_min{job=~\"$job\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Min - {{job}}",
+          "range": true,
           "refId": "C"
         }
       ],
@@ -872,129 +1029,39 @@
       "type": "timeseries"
     },
     {
-      "description": "The number of connections in the pool in active use (i.e. to run a query).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The percent of active connections out of the pool max.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 23
-      },
-      "id": 23,
-      "interval": "1s",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "ghost_db_connection_pool_max{job=\"$job\"}",
-          "interval": "",
-          "legendFormat": "Max - {{job}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "ghost_db_connection_pool_used{job=\"$job\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Used - {{job}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Used Connections",
-      "type": "timeseries"
-    },
-    {
-      "description": "The percent of active or used connections out of the pool max.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1025,37 +1092,28 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 16,
+        "x": 8,
         "y": 23
       },
       "id": 25,
-      "interval": "1s",
+      "interval": "15s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "ghost_db_connection_pool_used{job=~\"$job\"} / ghost_db_connection_pool_max{job=~\"$job\"}",
-          "interval": "",
-          "legendFormat": "Used - {{job}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "ghost_db_connection_pool_active{job=~\"$job\"} / ghost_db_connection_pool_max{job=~\"$job\"}",
@@ -1065,10 +1123,14 @@
           "refId": "B"
         }
       ],
-      "title": "Utilization",
+      "title": "Pool Utilization",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "The number of queries that are currently waiting for a free connection.",
       "fieldConfig": {
         "defaults": {
@@ -1076,24 +1138,125 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "ghost_db_connection_pool_pending_acquires{job=~\"$job\"}",
+          "interval": "",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Acquires",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The number of connections waiting to be established with the database.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1126,109 +1289,24 @@
         "x": 0,
         "y": 31
       },
-      "id": 24,
-      "interval": "1s",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "ghost_db_connection_pool_pending_acquires{job=~\"$job\"}",
-          "interval": "",
-          "legendFormat": "{{job}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Pending Acquires",
-      "type": "timeseries"
-    },
-    {
-      "description": "The number of connections waiting to be established with the database.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 31
-      },
       "id": 22,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "ghost_db_connection_pool_pending_creates{job=~\"$job\"}",
@@ -1242,6 +1320,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MFh-a5E4z"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1250,10 +1332,23 @@
       },
       "id": 27,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MFh-a5E4z"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Database: Queries",
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1261,24 +1356,28 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1313,22 +1412,23 @@
         "y": 40
       },
       "id": 31,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "ghost_db_query_duration_milliseconds{quantile=\"0.5\", job=~\"$job\"}",
@@ -1339,7 +1439,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "ghost_db_query_duration_milliseconds{quantile=\"0.9\", job=~\"$job\"}",
@@ -1351,7 +1451,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "ghost_db_query_duration_milliseconds{quantile=\"0.99\", job=~\"$job\"}",
@@ -1365,6 +1465,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "The number of queries executed in the trailing 60s.",
       "fieldConfig": {
         "defaults": {
@@ -1372,24 +1476,28 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1424,22 +1532,23 @@
         "y": 40
       },
       "id": 29,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "exemplar": true,
           "expr": "rate(ghost_db_query_count{job=~\"$job\"}[1m])",
@@ -1453,6 +1562,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "MFh-a5E4z"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1461,6 +1574,15 @@
       },
       "id": 10,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "MFh-a5E4z"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Garbage Collector",
       "type": "row"
     },
@@ -1476,6 +1598,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1487,6 +1612,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1509,8 +1635,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1529,7 +1654,6 @@
         "y": 49
       },
       "id": 11,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -1539,15 +1663,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "rate(ghost_nodejs_gc_duration_seconds_sum{job=~\"$job\"}[$interval])",
           "interval": "",
@@ -1570,6 +1700,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1581,6 +1714,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1604,8 +1738,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1624,7 +1757,6 @@
         "y": 49
       },
       "id": 12,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -1634,15 +1766,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_gc_duration_seconds_sum{job=~\"$job\"}",
           "interval": "",
@@ -1665,6 +1803,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1676,6 +1817,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1698,8 +1840,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1718,7 +1859,6 @@
         "y": 49
       },
       "id": 13,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -1728,15 +1868,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_heap_size_total_bytes{job=~\"$job\"}",
           "interval": "",
@@ -1744,6 +1890,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_heap_size_used_bytes{job=~\"$job\"}",
           "interval": "",
@@ -1751,6 +1901,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "process_resident_memory_bytes{job=~\"$job\"}",
           "interval": "",
@@ -1758,6 +1912,10 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_external_memory_bytes{job=~\"$job\"}",
           "interval": "",
@@ -1780,6 +1938,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1791,6 +1952,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1813,8 +1975,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1833,7 +1994,6 @@
         "y": 57
       },
       "id": 14,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -1843,15 +2003,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "rate(ghost_nodejs_gc_duration_seconds_count{job=~\"$job\"}[$interval])",
           "interval": "",
@@ -1874,6 +2040,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1885,6 +2054,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1908,8 +2078,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1928,7 +2097,6 @@
         "y": 57
       },
       "id": 15,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -1938,15 +2106,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_gc_duration_seconds_count{job=~\"$job\"}",
           "interval": "",
@@ -1969,6 +2143,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1980,6 +2157,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2002,8 +2180,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2022,7 +2199,6 @@
         "y": 57
       },
       "id": 16,
-      "interval": "1s",
       "options": {
         "legend": {
           "calcs": [
@@ -2032,15 +2208,21 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "exemplar": true,
           "expr": "ghost_nodejs_heap_space_size_used_bytes{job=~\"$job\"}",
           "interval": "",
@@ -2053,8 +2235,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 33,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "node.js",
     "nodejs"
@@ -2065,7 +2246,7 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "MFh-a5E4z"
         },
         "hide": 0,
         "includeAll": false,
@@ -2082,12 +2263,12 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "ghost-chris-local"
+            "ghost-305496"
           ],
           "value": [
-            "ghost-chris-local"
+            "ghost-305496"
           ]
         },
         "datasource": {
@@ -2115,7 +2296,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -2166,6 +2347,11 @@
           },
           {
             "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
             "text": "10m",
             "value": "10m"
           },
@@ -2210,7 +2396,7 @@
             "value": "30d"
           }
         ],
-        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
         "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
@@ -2219,7 +2405,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -2239,6 +2425,6 @@
   "timezone": "",
   "title": "Ghost Dashboard",
   "uid": "yX2d7k1Gk",
-  "version": 12,
+  "version": 6,
   "weekStart": ""
 }

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -591,6 +591,12 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
         // Step 4 - Load Ghost with all its services
         debug('Begin: Load Ghost Services & Apps');
         await initCore({ghostServer, config, bootLogger, frontend});
+
+        // Instrument the knex instance and connection pool if prometheus is enabled
+        // Needs to be after initCore because the pool is destroyed and recreated in initCore, which removes the event listeners
+        if (prometheusClient) {
+            prometheusClient.instrumentKnex(connection);
+        }
         const {dataService} = await initServicesForFrontend({bootLogger});
 
         if (frontend) {

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -68,10 +68,6 @@ if (!knexInstance && config.get('database') && config.get('database').client) {
         const instrumentation = new ConnectionPoolInstrumentation({knex: knexInstance, logging, metrics, config});
         instrumentation.instrument();
     }
-    if (config.get('prometheus:enabled')) {
-        const prometheusClient = require('../../../shared/prometheus-client');
-        prometheusClient.instrumentKnex(knexInstance);
-    }
 }
 
 module.exports = knexInstance;

--- a/ghost/core/core/server/models/settings.js
+++ b/ghost/core/core/server/models/settings.js
@@ -263,21 +263,9 @@ Settings = ghostBookshelf.Model.extend({
             options.context = internalContext.context;
         }
 
-        // tear down the connection pool and reinitialize it
         // this is required for sqlite to pick up the columns after db init
-        // first get all the listeners on the connection pool so we can reattach them after recreating the pool
-        const events = ghostBookshelf.knex.client.pool.emitter?.eventNames();
-        let listeners = {};
-        events?.forEach((event) => {
-            listeners[event] = ghostBookshelf.knex.client.pool.emitter.listeners(event);
-        });
-        // destroy and reinitialize the pool
         await ghostBookshelf.knex.destroy();
         await ghostBookshelf.knex.initialize();
-        // reattach the listeners
-        events?.forEach((event) => {
-            listeners[event].forEach(listener => ghostBookshelf.knex.client.pool.emitter.on(event, listener));
-        });
 
         const allSettings = await this.findAll(options);
 

--- a/ghost/core/core/server/models/settings.js
+++ b/ghost/core/core/server/models/settings.js
@@ -263,9 +263,21 @@ Settings = ghostBookshelf.Model.extend({
             options.context = internalContext.context;
         }
 
+        // tear down the connection pool and reinitialize it
         // this is required for sqlite to pick up the columns after db init
+        // first get all the listeners on the connection pool so we can reattach them after recreating the pool
+        const events = ghostBookshelf.knex.client.pool.emitter?.eventNames();
+        let listeners = {};
+        events?.forEach((event) => {
+            listeners[event] = ghostBookshelf.knex.client.pool.emitter.listeners(event);
+        });
+        // destroy and reinitialize the pool
         await ghostBookshelf.knex.destroy();
         await ghostBookshelf.knex.initialize();
+        // reattach the listeners
+        events?.forEach((event) => {
+            listeners[event].forEach(listener => ghostBookshelf.knex.client.pool.emitter.on(event, listener));
+        });
 
         const allSettings = await this.findAll(options);
 

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -31,7 +31,7 @@ export class PrometheusClient {
 
     public client;
     public gateway: client.Pushgateway<client.RegistryContentType> | undefined; // public for testing
-    public queries: Map<string, Date> = new Map();
+    public queries: Map<string, () => void> = new Map();
 
     private config: PrometheusClientConfig;
     private prefix;
@@ -305,9 +305,9 @@ export class PrometheusClient {
             help: 'The number of queries executed'
         });
 
-        this.registerSummary({
-            name: `db_query_duration_milliseconds`,
-            help: 'The duration of queries in milliseconds',
+        const queryDurationSummary = this.registerSummary({
+            name: `db_query_duration_seconds`,
+            help: 'The duration of queries in seconds',
             percentiles: [0.5, 0.9, 0.99]
         });
 
@@ -315,15 +315,11 @@ export class PrometheusClient {
             // Increment the query counter
             (this.getMetric(`db_query_count`) as client.Counter).inc();
             // Add the query to the map
-            this.queries.set(query.__knexQueryUid, new Date());
+            this.queries.set(query.__knexQueryUid, queryDurationSummary.startTimer());
         });
 
         knexInstance.on('query-response', (err, query) => {
-            const start = this.queries.get(query.__knexQueryUid);
-            if (start) {
-                const duration = new Date().getTime() - start.getTime();
-                (this.getMetric(`db_query_duration_milliseconds`) as client.Summary).observe(duration);
-            }
+            this.queries.get(query.__knexQueryUid)?.();
         });
     }
 }

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -217,11 +217,14 @@ export class PrometheusClient {
      * @param collect - The collect function to use for the summary
      * @returns The summary metric
      */
-    registerSummary({name, help, percentiles, collect}: {name: string, help: string, percentiles?: number[], collect?: () => void}): client.Summary {
+    registerSummary({name, help, percentiles, collect, maxAgeSeconds, ageBuckets, pruneAgedBuckets}: {name: string, help: string, percentiles?: number[], collect?: () => void, maxAgeSeconds?: number, ageBuckets?: number, pruneAgedBuckets?: boolean}): client.Summary {
         return new this.client.Summary({
             name: `${this.prefix}${name}`,
             help,
             percentiles: percentiles || [0.5, 0.9, 0.99],
+            maxAgeSeconds,
+            ageBuckets,
+            pruneAgedBuckets,
             collect
         });
     }
@@ -315,13 +318,19 @@ export class PrometheusClient {
         this.registerSummary({
             name: `db_query_duration_seconds`,
             help: 'The duration of queries in seconds',
-            percentiles: [0.5, 0.9, 0.99]
+            percentiles: [0.5, 0.9, 0.99],
+            maxAgeSeconds: 60,
+            ageBuckets: 1,
+            pruneAgedBuckets: true
         });
 
         this.registerSummary({
             name: `db_acquire_duration_seconds`,
             help: 'The duration of acquire requests in seconds',
-            percentiles: [0.5, 0.9, 0.99]
+            percentiles: [0.5, 0.9, 0.99],
+            maxAgeSeconds: 60,
+            ageBuckets: 1,
+            pruneAgedBuckets: true
         });
     }
 

--- a/ghost/prometheus-metrics/src/PrometheusClient.ts
+++ b/ghost/prometheus-metrics/src/PrometheusClient.ts
@@ -31,7 +31,6 @@ export class PrometheusClient {
 
     public client;
     public gateway: client.Pushgateway<client.RegistryContentType> | undefined; // public for testing
-    public customMetrics: Map<string, client.Metric> = new Map();
     public queries: Map<string, Date> = new Map();
 
     private config: PrometheusClientConfig;
@@ -245,76 +244,76 @@ export class PrometheusClient {
      */
     instrumentKnex(knexInstance: Knex) {
         // Create some gauges for tracking the connection pool
-        this.customMetrics.set(`${this.prefix}db_connection_pool_max`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_max`,
+        this.registerGauge({
+            name: `db_connection_pool_max`,
             help: 'The maximum number of connections allowed in the pool',
             collect() {
-                this.set(knexInstance.client.pool.max);
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.max);
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_min`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_min`,
+        this.registerGauge({
+            name: `db_connection_pool_min`,
             help: 'The minimum number of connections allowed in the pool',
             collect() {
-                this.set(knexInstance.client.pool.min);
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.min);
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_active`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_active`,
+        this.registerGauge({
+            name: `db_connection_pool_active`,
             help: 'The number of active connections to the database, which can be in use or idle',
             collect() {
-                this.set(knexInstance.client.pool.numUsed() + knexInstance.client.pool.numFree());
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.numUsed() + knexInstance.client.pool.numFree());
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_used`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_used`,
+        this.registerGauge({
+            name: `db_connection_pool_used`,
             help: 'The number of connections currently in use by the database',
             collect() {
-                this.set(knexInstance.client.pool.numUsed());
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.numUsed());
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_idle`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_idle`,
+        this.registerGauge({
+            name: `db_connection_pool_idle`,
             help: 'The number of active connections currently idle in pool',
             collect() {
-                this.set(knexInstance.client.pool.numFree());
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.numFree());
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_pending_acquires`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_pending_acquires`,
+        this.registerGauge({
+            name: `db_connection_pool_pending_acquires`,
             help: 'The number of connections currently waiting to be acquired from the pool',
             collect() {
-                this.set(knexInstance.client.pool.numPendingAcquires());
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.numPendingAcquires());
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_connection_pool_pending_creates`, new this.client.Gauge({
-            name: `${this.prefix}db_connection_pool_pending_creates`,
+        this.registerGauge({
+            name: `db_connection_pool_pending_creates`,
             help: 'The number of connections currently waiting to be created',
             collect() {
-                this.set(knexInstance.client.pool.numPendingCreates());
+                (this as unknown as client.Gauge).set(knexInstance.client.pool.numPendingCreates());
             }
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_query_count`, new this.client.Counter({
-            name: `${this.prefix}db_query_count`,
+        this.registerCounter({
+            name: `db_query_count`,
             help: 'The number of queries executed'
-        }));
+        });
 
-        this.customMetrics.set(`${this.prefix}db_query_duration_milliseconds`, new this.client.Summary({
-            name: `${this.prefix}db_query_duration_milliseconds`,
+        this.registerSummary({
+            name: `db_query_duration_milliseconds`,
             help: 'The duration of queries in milliseconds',
             percentiles: [0.5, 0.9, 0.99]
-        }));
+        });
 
         knexInstance.on('query', (query) => {
             // Increment the query counter
-            (this.customMetrics.get(`${this.prefix}db_query_count`) as client.Counter).inc();
+            (this.getMetric(`db_query_count`) as client.Counter).inc();
             // Add the query to the map
             this.queries.set(query.__knexQueryUid, new Date());
         });
@@ -323,7 +322,7 @@ export class PrometheusClient {
             const start = this.queries.get(query.__knexQueryUid);
             if (start) {
                 const duration = new Date().getTime() - start.getTime();
-                (this.customMetrics.get(`${this.prefix}db_query_duration_milliseconds`) as client.Summary).observe(duration);
+                (this.getMetric(`db_query_duration_milliseconds`) as client.Summary).observe(duration);
             }
         });
     }

--- a/ghost/prometheus-metrics/test/prometheus-client.test.ts
+++ b/ghost/prometheus-metrics/test/prometheus-client.test.ts
@@ -287,40 +287,36 @@ describe('Prometheus Client', function () {
             sinon.restore();
         });
 
-        it('should create all the custom metrics for the connection pool and queries', function () {
+        it('should create all the custom metrics for the connection pool and queries', async function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const metrics = Array.from(instance.customMetrics.keys());
-            assert.deepEqual(metrics, [
-                'ghost_db_connection_pool_max',
-                'ghost_db_connection_pool_min',
-                'ghost_db_connection_pool_active',
-                'ghost_db_connection_pool_used',
-                'ghost_db_connection_pool_idle',
-                'ghost_db_connection_pool_pending_acquires',
-                'ghost_db_connection_pool_pending_creates',
-                'ghost_db_query_count',
-                'ghost_db_query_duration_milliseconds'
-            ]);
+            const metrics = await instance.getMetrics();
+            assert.match(metrics, /ghost_db_connection_pool_max/);
+            assert.match(metrics, /ghost_db_connection_pool_min/);
+            assert.match(metrics, /ghost_db_connection_pool_active/);
+            assert.match(metrics, /ghost_db_connection_pool_used/);
+            assert.match(metrics, /ghost_db_connection_pool_idle/);
+            assert.match(metrics, /ghost_db_connection_pool_pending_acquires/);
+            assert.match(metrics, /ghost_db_connection_pool_pending_creates/);
+            assert.match(metrics, /ghost_db_query_count/);
+            assert.match(metrics, /ghost_db_query_duration_milliseconds/);
         });
 
         it('should collect the connection pool max metric', async function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolMaxGauge = instance.customMetrics.get('ghost_db_connection_pool_max') as Gauge;
-            const result = await connectionPoolMaxGauge.get();
-            assert.equal(result.values[0].value, 10);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_max');
+            assert.deepEqual(metricValues, [{value: 10, labels: {}}]);
         });
 
         it('should collect the connection pool min metric', async function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolMinGauge = instance.customMetrics.get('ghost_db_connection_pool_min') as Gauge;
-            const result = await connectionPoolMinGauge.get();
-            assert.equal(result.values[0].value, 1);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_min');
+            assert.deepEqual(metricValues, [{value: 1, labels: {}}]);
         });
 
         it('should collect the connection pool active metric', async function () {
@@ -329,9 +325,8 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolActiveGauge = instance.customMetrics.get('ghost_db_connection_pool_active') as Gauge;
-            const result = await connectionPoolActiveGauge.get();
-            assert.equal(result.values[0].value, 10);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_active');
+            assert.deepEqual(metricValues, [{value: 10, labels: {}}]);
         });
 
         it('should collect the connection pool used metric', async function () {
@@ -339,9 +334,8 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolUsedGauge = instance.customMetrics.get('ghost_db_connection_pool_used') as Gauge;
-            const result = await connectionPoolUsedGauge.get();
-            assert.equal(result.values[0].value, 3);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_used');
+            assert.deepEqual(metricValues, [{value: 3, labels: {}}]);
         });
 
         it('should collect the connection pool idle metric', async function () {
@@ -349,9 +343,8 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolIdleGauge = instance.customMetrics.get('ghost_db_connection_pool_idle') as Gauge;
-            const result = await connectionPoolIdleGauge.get();
-            assert.equal(result.values[0].value, 7);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_idle');
+            assert.deepEqual(metricValues, [{value: 7, labels: {}}]);
         });
 
         it('should collect the connection pool pending acquires metric', async function () {
@@ -359,9 +352,8 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolPendingAcquiresGauge = instance.customMetrics.get('ghost_db_connection_pool_pending_acquires') as Gauge;
-            const result = await connectionPoolPendingAcquiresGauge.get();
-            assert.equal(result.values[0].value, 3);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_pending_acquires');
+            assert.deepEqual(metricValues, [{value: 3, labels: {}}]);
         });
 
         it('should collect the connection pool pending creates metric', async function () {
@@ -369,28 +361,25 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const connectionPoolPendingCreatesGauge = instance.customMetrics.get('ghost_db_connection_pool_pending_creates') as Gauge;
-            const result = await connectionPoolPendingCreatesGauge.get();
-            assert.equal(result.values[0].value, 3);
+            const metricValues = await instance.getMetricValues('ghost_db_connection_pool_pending_creates');
+            assert.deepEqual(metricValues, [{value: 3, labels: {}}]);
         });
 
         it('should collect the db query count metric', async function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            const dbQueryCountGauge = instance.customMetrics.get('ghost_db_query_count') as Counter;
-            const result = await dbQueryCountGauge.get();
-            assert.equal(result.values[0].value, 0);
+            const metricValues = await instance.getMetricValues('ghost_db_query_count');
+            assert.deepEqual(metricValues, [{value: 0, labels: {}}]);
         });
 
         it('should increment the db query count metric when a query is executed', async function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            eventEmitter.emit('query', {__knexQueryUid: '1', sql: 'SELECT 1'});
-            const dbQueryCountGauge = instance.customMetrics.get('ghost_db_query_count') as Counter;
-            const result = await dbQueryCountGauge.get();
-            assert.equal(result.values[0].value, 1);
+            simulateQuery('1', 0);
+            const metricValues = await instance.getMetricValues('ghost_db_query_count');
+            assert.deepEqual(metricValues, [{value: 1, labels: {}}]);
             assert.equal(instance.queries.size, 1);
             assert.ok(instance.queries.has('1'));
         });
@@ -399,10 +388,15 @@ describe('Prometheus Client', function () {
             instance = new PrometheusClient();
             instance.init();
             instance.instrumentKnex(knexMock);
-            eventEmitter.emit('query', {__knexQueryUid: '1', sql: 'SELECT 1'});
-            const dbQueryDurationSummary = instance.customMetrics.get('ghost_db_query_duration_milliseconds') as Summary;
-            const result = await dbQueryDurationSummary.get();
-            assert.equal(result.values[0].value, 0);
+            simulateQuery('1', 0);
+            const metricValues = await instance.getMetricValues('ghost_db_query_duration_milliseconds');
+            assert.deepEqual(metricValues, [
+                {value: 0, labels: {quantile: 0.5}},
+                {value: 0, labels: {quantile: 0.9}},
+                {value: 0, labels: {quantile: 0.99}},
+                {metricName: 'ghost_db_query_duration_milliseconds_sum', labels: {}, value: 0},
+                {metricName: 'ghost_db_query_duration_milliseconds_count', labels: {}, value: 1}
+            ]);
         });
 
         it('should accurately calculate the query duration of a query', async function () {
@@ -411,9 +405,8 @@ describe('Prometheus Client', function () {
             instance.instrumentKnex(knexMock);
             const durations = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
             simulateQueries(durations);
-            const dbQueryDurationSummary = instance.customMetrics.get('ghost_db_query_duration_milliseconds') as Summary;
-            const result = await dbQueryDurationSummary.get();
-            assert.deepEqual(result.values, [
+            const metricValues = await instance.getMetricValues('ghost_db_query_duration_milliseconds');
+            assert.deepEqual(metricValues, [
                 {labels: {quantile: 0.5}, value: 550},
                 {labels: {quantile: 0.9}, value: 950},
                 {labels: {quantile: 0.99}, value: 1000},

--- a/ghost/prometheus-metrics/test/prometheus-client.test.ts
+++ b/ghost/prometheus-metrics/test/prometheus-client.test.ts
@@ -300,7 +300,7 @@ describe('Prometheus Client', function () {
             assert.match(metrics, /ghost_db_connection_pool_pending_acquires/);
             assert.match(metrics, /ghost_db_connection_pool_pending_creates/);
             assert.match(metrics, /ghost_db_query_count/);
-            assert.match(metrics, /ghost_db_query_duration_milliseconds/);
+            assert.match(metrics, /ghost_db_query_duration_seconds/);
         });
 
         it('should collect the connection pool max metric', async function () {
@@ -389,13 +389,13 @@ describe('Prometheus Client', function () {
             instance.init();
             instance.instrumentKnex(knexMock);
             simulateQuery('1', 0);
-            const metricValues = await instance.getMetricValues('ghost_db_query_duration_milliseconds');
+            const metricValues = await instance.getMetricValues('ghost_db_query_duration_seconds');
             assert.deepEqual(metricValues, [
                 {value: 0, labels: {quantile: 0.5}},
                 {value: 0, labels: {quantile: 0.9}},
                 {value: 0, labels: {quantile: 0.99}},
-                {metricName: 'ghost_db_query_duration_milliseconds_sum', labels: {}, value: 0},
-                {metricName: 'ghost_db_query_duration_milliseconds_count', labels: {}, value: 1}
+                {metricName: 'ghost_db_query_duration_seconds_sum', labels: {}, value: 0},
+                {metricName: 'ghost_db_query_duration_seconds_count', labels: {}, value: 1}
             ]);
         });
 
@@ -405,13 +405,13 @@ describe('Prometheus Client', function () {
             instance.instrumentKnex(knexMock);
             const durations = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
             simulateQueries(durations);
-            const metricValues = await instance.getMetricValues('ghost_db_query_duration_milliseconds');
+            const metricValues = await instance.getMetricValues('ghost_db_query_duration_seconds');
             assert.deepEqual(metricValues, [
-                {labels: {quantile: 0.5}, value: 550},
-                {labels: {quantile: 0.9}, value: 950},
-                {labels: {quantile: 0.99}, value: 1000},
-                {metricName: 'ghost_db_query_duration_milliseconds_sum', labels: {}, value: 5500},
-                {metricName: 'ghost_db_query_duration_milliseconds_count', labels: {}, value: 10}
+                {labels: {quantile: 0.5}, value: 0.55},
+                {labels: {quantile: 0.9}, value: 0.95},
+                {labels: {quantile: 0.99}, value: 1},
+                {metricName: 'ghost_db_query_duration_seconds_sum', labels: {}, value: 5.5},
+                {metricName: 'ghost_db_query_duration_seconds_count', labels: {}, value: 10}
             ]);
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1769/improve-pool-utilization-metric

- The current connection pool metrics collect a point in time sample of the number of active and used connections. With a scraping interval of 15s, these metrics aren't sensitive enough to rapid changes in the pool. This commit adds a metric to track the time to acquire a connection from the pool, and reports percentiles to prometheus.
- This should provide a much more responsive and valuable metric for identifying when there is contention in the database pool — if a query is waiting more than a few milliseconds for a connection to free up, that indicates there is contention in the database pool.
- This commit also makes the `prometheus.instrumentKnex()` method idempotent so it can safely be called on the `knex` instance more than once, and it moves the call to `prometheus.instrumentKnex()` to after the settings service is initialized in the boot process, because the `knex.pool` is torn down and recreated during the settings initialization, which removes the event listeners on the pool used to collect the time to acquire connections.
