### PR TITLE
Stopped HTML cards with fixed width from causing overflow in the drawer

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/articleBodyStyles.ts
+++ b/apps/admin-x-activitypub/src/components/articleBodyStyles.ts
@@ -2122,6 +2122,7 @@ headings, text, images and lists. We deal with cards lower down. */
 .gh-content {
     font-size: var(--content-font-size, 1.7rem);
     letter-spacing: -0.01em;
+    overflow-x: hidden;
 }
 
 /* Default vertical spacing */


### PR DESCRIPTION
close https://linear.app/ghost/issue/AP-557/elements-in-articles-can-cause-horizontal-scrolling

- HTML cards allow users to set a fixed width for HTML elements. This can cause horizontal overflow when the post is viewed in the ActivityPub drawer and `overflow-x: hidden` hides these overflows.
