### PR TITLE
Added e2e test for sending invite to a staff member and user signing up using the invite link

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -23,7 +23,7 @@
                         <div class="gh-user-avatar relative" style={{background-image-style this.session.user.profileImageUrl}}>
                             {{#if (and this.whatsNew.hasNew (not this.whatsNew.hasNewFeatured))}}<span class="absolute dib ba b--white br-100 gh-whats-new-badge-account"></span>{{/if}}
                         </div>
-                        {{svg-jar "arrow-down" class="w3 mr1 fill-darkgrey"}}
+                        {{svg-jar "arrow-down" class="w3 mr1 fill-darkgrey" data-test-nav="arrow-down"}}
                     </div>
                 </dropdown.Trigger>
 

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -46,7 +46,7 @@ test.describe('Portal', () => {
             //signout current user
             await sharedPage.goto('/ghost/#/dashboard');
             await sharedPage.waitForLoadState('networkidle');
-            await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();
+            await sharedPage.getByRole('button', {name: 'arrow-down'}).click();
             await sharedPage.getByRole('link', {name: 'Sign out'}).click();
 
             // Open invite URL

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -44,7 +44,8 @@ test.describe('Portal', () => {
             const inviteUrl = `${adminUrl}/signup/${encodedToken}/`;
 
             //signout current user
-            await sharedPage.goto('/ghost');
+            await sharedPage.goto('/ghost/#/dashboard');
+            await sharedPage.waitForLoadState('networkidle');
             await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();
             await sharedPage.getByRole('link', {name: 'Sign out'}).click();
 

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -1,6 +1,7 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const security = require('@tryghost/security');
+const models = require('../../../core/server/models');
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -13,9 +14,11 @@ test.describe('Portal', () => {
             await sharedPage.locator('[data-test-nav="settings"]').click();
             await sharedPage.waitForLoadState('networkidle');
 
+            const testEmail = 'test@gmail.com';
+
             // Send the invitation
             await sharedPage.getByRole('button', {name: 'Invite people'}).click();
-            await sharedPage.getByPlaceholder('jamie@example.com').fill('x@gmail.com');
+            await sharedPage.getByPlaceholder('jamie@example.com').fill(testEmail);
 
             // Set up response listener just before clicking send
             let inviteResponse = null;
@@ -36,8 +39,10 @@ test.describe('Portal', () => {
             const invitedMessage = sharedPage.getByText('Invitation sent', {exact: true});
             await expect(invitedMessage).toBeVisible({timeout: 5000});
 
-            const token = '45676578';
-            
+            // Get the token from database
+            const invite = await models.Invite.findOne({email: testEmail});
+            const token = invite.get('token');
+
             // Construct the invite URL
             const adminUrl = new URL(sharedPage.url()).origin + '/ghost';
             const encodedToken = security.url.encodeBase64(token);

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -46,7 +46,7 @@ test.describe('Portal', () => {
             //signout current user
             await sharedPage.goto('/ghost/#/dashboard');
             await sharedPage.waitForLoadState('networkidle');
-            await sharedPage.getByRole('button', {name: 'arrow-down'}).click();
+            await sharedPage.locator('[data-test-nav="arrow-down"]').click();
             await sharedPage.getByRole('link', {name: 'Sign out'}).click();
 
             // Open invite URL
@@ -65,7 +65,7 @@ test.describe('Portal', () => {
             await expect(sharedPage.locator('text=Start creating content.')).toBeVisible();
             await expect(sharedPage).toHaveURL('/ghost/#/posts');
 
-            await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();
+            await sharedPage.locator('[data-test-nav="arrow-down"]').click();
             await expect(sharedPage.locator(`text=${testEmail}`)).toBeVisible();
         });
     });

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -35,6 +35,15 @@ test.describe('Portal', () => {
             // Verify the invitation was sent (UI feedback)
             const invitedMessage = sharedPage.getByText('Invitation sent', {exact: true});
             await expect(invitedMessage).toBeVisible({timeout: 5000});
+
+            const token = '45676578';
+            
+            // Construct the invite URL
+            const adminUrl = new URL(sharedPage.url()).origin + '/ghost';
+            const encodedToken = security.url.encodeBase64(token);
+            const inviteUrl = `${adminUrl}/signup/${encodedToken}/`;
+            
+            console.log('Invite URL:', inviteUrl);
         });
     });
 });

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -62,7 +62,6 @@ test.describe('Portal', () => {
             await sharedPage.getByRole('button', {name: 'Create Account →'}).click();
             await sharedPage.waitForLoadState('networkidle');
             await expect(sharedPage.locator('text=Start creating content.')).toBeVisible();
-            await expect(sharedPage.locator('text=Write a new post')).toBeVisible();
             await expect(sharedPage).toHaveURL('/ghost/#/posts');
 
             await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -1,0 +1,33 @@
+const {expect} = require('@playwright/test');
+const test = require('../fixtures/ghost-test');
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+test.describe('Portal', () => {
+    test.describe('Invites', () => {
+        test('Send invitation to a new staff member', async ({sharedPage}) => {
+            await sharedPage.goto('/ghost');
+            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.waitForLoadState('networkidle');
+            
+            //Send invitation to a new staff member
+            await sharedPage.getByRole('button', {name: 'Invite people'}).click();
+            await sharedPage.getByPlaceholder('jamie@example.com').fill('vershwal.princi@gmail.com');
+            await sharedPage.getByRole('button', { name: 'Send invitation' }).click();
+
+            // Wait for the network request to complete
+            await sharedPage.waitForLoadState('networkidle');
+
+            
+            // Check if the invitation was sent
+            const invitedEmail = sharedPage.getByText('Invitation sent', {exact: true});
+            await expect(invitedEmail).toBeVisible({timeout: 5000});
+            
+            // Check for other elements after confirming that the invitation was sent
+            await sharedPage.getByTestId('user-invite').getByText('vershwal.princi@gmail.com').hover();
+            await expect(sharedPage.getByRole('button', {name: 'Revoke'})).toBeVisible();
+            await expect(sharedPage.getByRole('button', {name: 'Resend'})).toBeVisible();
+        });
+    });
+});

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -3,9 +3,6 @@ const test = require('../fixtures/ghost-test');
 const security = require('@tryghost/security');
 const models = require('../../../core/server/models');
 
-/**
- * @param {import('@playwright/test').Page} page
- */
 test.describe('Portal', () => {
     test.describe('Invites', () => {
         test('New staff member can signup using an invite link', async ({sharedPage}) => {
@@ -21,18 +18,17 @@ test.describe('Portal', () => {
             await sharedPage.getByPlaceholder('jamie@example.com').fill(testEmail);
 
             // Set up response listener just before clicking send
-            let inviteResponse = null;
             const responsePromise = sharedPage.waitForResponse(
                 response => response.url().includes('/api/admin/invites/') && 
                            response.request().method() === 'POST'
             );
 
             // Click send invitation
-            await sharedPage.getByRole('button', { name: 'Send invitation' }).click();
+            await sharedPage.getByRole('button', {name: 'Send invitation'}).click();
 
             // Wait for the API response
             const response = await responsePromise;
-            inviteResponse = await response.json();
+            await response.json();
 
             // Verify the invitation was sent (UI feedback)
             const invitedMessage = sharedPage.getByText('Invitation sent', {exact: true});
@@ -49,8 +45,8 @@ test.describe('Portal', () => {
 
             //signout current user
             await sharedPage.goto('/ghost');
-            await sharedPage.getByRole('button', { name: 'arrow-down', exact: true }).click();
-            await sharedPage.getByRole('link', { name: 'Sign out' }).click();
+            await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();
+            await sharedPage.getByRole('link', {name: 'Sign out'}).click();
 
             // Open invite URL
             await sharedPage.goto(inviteUrl);
@@ -69,9 +65,8 @@ test.describe('Portal', () => {
             await expect(sharedPage.locator('text=Write a new post')).toBeVisible();
             await expect(sharedPage).toHaveURL('/ghost/#/posts');
 
-            await sharedPage.getByRole('button', { name: 'arrow-down', exact: true }).click();
+            await sharedPage.getByRole('button', {name: 'arrow-down', exact: true}).click();
             await expect(sharedPage.locator(`text=${testEmail}`)).toBeVisible();
-
         });
     });
 });

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -8,7 +8,7 @@ const models = require('../../../core/server/models');
  */
 test.describe('Portal', () => {
     test.describe('Invites', () => {
-        test('Send invitation to a new staff member', async ({sharedPage}) => {
+        test('Send invitation to a new staff member', async ({sharedPage, browser}) => {
             // Navigate to settings
             await sharedPage.goto('/ghost');
             await sharedPage.locator('[data-test-nav="settings"]').click();
@@ -49,6 +49,27 @@ test.describe('Portal', () => {
             const inviteUrl = `${adminUrl}/signup/${encodedToken}/`;
             
             console.log('Invite URL:', inviteUrl);
+
+            //signout current user
+            await sharedPage.goto('/ghost');
+            await sharedPage.getByRole('button', { name: 'arrow-down', exact: true }).click();
+            await sharedPage.getByRole('link', { name: 'Sign out' }).click();
+
+            // Open invite URL in a new context
+            const newContext = await browser.newContext();
+            const newPage = await newContext.newPage();
+            await newPage.goto(inviteUrl);
+
+            // Verify we're on the signup page
+            await newPage.waitForLoadState('networkidle');
+            await expect(newPage.locator('text=Create your account.')).toBeVisible();
+            
+            // Cleanup
+            await newContext.close();
         });
     });
 });
+// await page.goto('http://localhost:2368/ghost/');
+// await page.goto('http://localhost:2368/ghost/#/dashboard');
+// await page.getByRole('button', { name: 'arrow-down', exact: true }).click();
+// await page.getByRole('link', { name: 'Sign out' }).click();


### PR DESCRIPTION
Fixes https://linear.app/ghost/issue/ENG-1702/add-e2e-browser-test-for-staff-invite-and-accept-flow