### PR TITLE
Updated analytics button logic for disabled newsletter emails

### DIFF
--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -196,8 +196,6 @@ export default Model.extend(Comparable, ValidationEngine, {
         return this.hasBeenEmailed
             && !this.session.user.isContributor
             && this.settings.membersSignupAccess !== 'none'
-            && this.settings.editorDefaultEmailRecipients !== 'disabled'
-            && this.hasBeenEmailed
             && this.email.trackOpens
             && this.settings.emailTrackOpens;
     }),
@@ -206,7 +204,6 @@ export default Model.extend(Comparable, ValidationEngine, {
         return this.hasBeenEmailed
             && !this.session.user.isContributor
             && this.settings.membersSignupAccess !== 'none'
-            && this.settings.editorDefaultEmailRecipients !== 'disabled'
             && (this.isSent || this.isPublished)
             && this.email.trackClicks
             && this.settings.emailTrackClicks;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-594

We had a check to prevent showing the Analytics page link for email-only posts (newsletters) if newsletters were disabled. I don't see a good reason to remove this - users then have to re-enable newsletters just to see the analytics.