### PR TITLE
Fixed missing `in_reply_to_snippet` for replies

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const utils = require('../../..');
 const url = require('../utils/url');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
+const labs = require('../../../../../../../shared/labs');
 
 const commentFields = [
     'id',
@@ -45,8 +46,15 @@ const countFields = [
 const commentMapper = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
 
-    if (jsonModel.inReplyTo && jsonModel.inReplyTo.status === 'published') {
-        jsonModel.in_reply_to_snippet = htmlToPlaintext.commentSnippet(jsonModel.inReplyTo.html);
+    if (labs.isSet('commentImprovements')) {
+        if (jsonModel.inReplyTo && jsonModel.inReplyTo.status === 'published') {
+            jsonModel.in_reply_to_snippet = htmlToPlaintext.commentSnippet(jsonModel.inReplyTo.html);
+        } else {
+            jsonModel.in_reply_to_id = null;
+            jsonModel.in_reply_to_snippet = null;
+        }
+    } else {
+        delete jsonModel.in_reply_to_id;
     }
 
     const response = _.pick(jsonModel, commentFields);

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -258,6 +258,7 @@ const Comment = ghostBookshelf.Model.extend({
         const relationsToLoadIndividually = [
             'replies',
             'replies.member',
+            'replies.inReplyTo',
             'replies.count.likes',
             'replies.count.liked'
         ].filter(relation => withRelated.includes(relation));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -22699,7 +22699,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "17625",
+  "content-length": "17706",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -22867,7 +22867,7 @@ exports[`Activity Feed API Filter splitting Can use NQL OR for type only 2: [hea
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5180",
+  "content-length": "5261",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -23914,7 +23914,7 @@ exports[`Activity Feed API Returns comments in activity feed 2: [headers] 1`] = 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1304",
+  "content-length": "1385",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -12,7 +12,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -32,7 +31,7 @@ exports[`Comments API Tier-only posts Members with access Can comment on a post 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "401",
+  "content-length": "379",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -54,7 +53,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -74,7 +72,7 @@ exports[`Comments API Tier-only posts Members with access Can reply to a comment
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -156,7 +154,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -177,7 +174,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -195,7 +191,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -227,7 +222,7 @@ exports[`Comments API when commenting enabled for all when authenticated Browsin
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1184",
+  "content-length": "1118",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -247,7 +242,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -265,7 +259,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -288,7 +281,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -318,7 +310,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can bro
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1184",
+  "content-length": "1118",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -338,7 +330,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -356,7 +347,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -379,7 +369,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -409,7 +398,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can bro
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1184",
+  "content-length": "1118",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -429,7 +418,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -450,7 +438,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -468,7 +455,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -500,7 +486,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can bro
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1184",
+  "content-length": "1118",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -520,7 +506,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -540,7 +525,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can com
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "401",
+  "content-length": "379",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -562,7 +547,6 @@ Object {
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "html": "Updated comment",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -582,7 +566,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can edi
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "392",
+  "content-length": "370",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -633,7 +617,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -653,7 +636,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can lik
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "389",
+  "content-length": "367",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -683,7 +666,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -703,7 +685,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can lik
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "378",
+  "content-length": "356",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -723,7 +705,6 @@ Object {
       "edited_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "html": "Illegal comment update",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -743,7 +724,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can not
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "399",
+  "content-length": "377",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -833,7 +814,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -853,7 +833,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rem
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "379",
+  "content-length": "357",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -873,7 +853,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -893,7 +872,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rep
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -915,7 +894,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -935,7 +913,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rep
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -957,7 +935,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -977,7 +954,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rep
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -999,7 +976,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1019,7 +995,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can rep
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1049,7 +1025,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1078,7 +1053,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can req
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "436",
+  "content-length": "414",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1097,7 +1072,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1116,7 +1090,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1135,7 +1108,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1154,7 +1126,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1173,7 +1144,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1192,7 +1162,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1211,7 +1180,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1240,7 +1208,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can ret
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2467",
+  "content-length": "2313",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1329,7 +1297,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1347,7 +1314,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -1366,7 +1332,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -1385,7 +1350,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -1407,7 +1371,99 @@ exports[`Comments API when commenting enabled for all when authenticated Limits 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1396",
+  "content-length": "1308",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies can browse comments with replies to replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [
+        Object {
+          "count": Object {
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "edited_at": null,
+          "html": "<p>This is what was replied to</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": Nullable<StringMatching>,
+          "in_reply_to_snippet": null,
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": "Egon Spengler",
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "status": "published",
+        },
+        Object {
+          "count": Object {
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "edited_at": null,
+          "html": "<p>This is a reply to a reply</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": Nullable<StringMatching>,
+          "in_reply_to_snippet": "This is what was replied to",
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "status": "published",
+        },
+      ],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies can browse comments with replies to replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1304",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1470,7 +1526,8 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1490,7 +1547,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "388",
+  "content-length": "415",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1512,7 +1569,8 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1532,7 +1590,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "388",
+  "content-length": "415",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1555,6 +1613,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1574,7 +1633,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "401",
+  "content-length": "406",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1595,6 +1654,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1614,7 +1674,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "401",
+  "content-length": "406",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1635,6 +1695,7 @@ Object {
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1654,7 +1715,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "388",
+  "content-length": "415",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1676,7 +1737,8 @@ Object {
       "edited_at": null,
       "html": "<p>This is a reply to a reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1696,7 +1758,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "388",
+  "content-length": "415",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -1802,7 +1864,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1820,7 +1881,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -1852,7 +1912,7 @@ exports[`Comments API when commenting enabled for all when not authenticated Can
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "808",
+  "content-length": "764",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1872,7 +1932,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1890,7 +1949,6 @@ Object {
           "edited_at": null,
           "html": "<p>This is a reply</p>",
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": Nullable<StringMatching>,
           "liked": Any<Boolean>,
           "member": Object {
             "avatar_image": null,
@@ -1922,7 +1980,7 @@ exports[`Comments API when commenting enabled for all when not authenticated Can
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "808",
+  "content-length": "764",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2092,7 +2150,6 @@ Object {
       "edited_at": null,
       "html": "<p>This is a message</p><p></p><p>New line</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2112,7 +2169,7 @@ exports[`Comments API when paid only commenting Members with access Can comment 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "401",
+  "content-length": "379",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2134,7 +2191,6 @@ Object {
       "edited_at": null,
       "html": "This is a reply",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2154,7 +2210,7 @@ exports[`Comments API when paid only commenting Members with access Can reply to
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "370",
+  "content-length": "348",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -7,6 +7,7 @@ const moment = require('moment-timezone');
 const settingsCache = require('../../../core/shared/settings-cache');
 const sinon = require('sinon');
 const DomainEvents = require('@tryghost/domain-events');
+const {mockLabsEnabled, mockLabsDisabled} = require('../../utils/e2e-framework-mock-manager');
 
 let membersAgent, membersAgent2, postId, postAuthorEmail, postTitle;
 
@@ -102,7 +103,6 @@ const dbFns = {
 
 const commentMatcher = {
     id: anyObjectId,
-    in_reply_to_id: nullable(anyObjectId),
     created_at: anyISODateTime,
     member: {
         id: anyObjectId,
@@ -114,25 +114,28 @@ const commentMatcher = {
     liked: anyBoolean
 };
 
+const labsCommentMatcher = {
+    ...commentMatcher,
+    in_reply_to_id: nullable(anyObjectId)
+};
+
 /**
  * @param {Object} [options]
  * @param {number} [options.replies]
+ * @param {object} [options.commentMatcher]
  * @returns
  */
-function commentMatcherWithReplies(options = {replies: 0}) {
+function commentMatcherWithReplies(options) {
+    const defaultOptions = {replies: 0, commentMatcher};
+    options = {...defaultOptions, ...options};
+
     return {
-        id: anyObjectId,
-        created_at: anyISODateTime,
-        member: {
-            id: anyObjectId,
-            uuid: anyUuid
-        },
-        replies: new Array(options?.replies ?? 0).fill(commentMatcher),
+        ...options.commentMatcher,
+        replies: new Array(options.replies).fill(options.commentMatcher),
         count: {
             likes: anyNumber,
             replies: anyNumber
-        },
-        liked: anyBoolean
+        }
     };
 }
 
@@ -348,6 +351,8 @@ describe('Comments API', function () {
     beforeEach(async function () {
         mockManager.mockMail();
 
+        mockLabsDisabled('commentImprovements');
+
         // ensure we don't have data dependencies across tests
         await dbUtils.truncate('comments');
         await dbUtils.truncate('comment_likes');
@@ -398,42 +403,48 @@ describe('Comments API', function () {
                 ]);
             });
 
-            it('excludes hidden comments', async function () {
-                const hiddenComment = await dbFns.addComment({
-                    post_id: postId,
-                    member_id: fixtureManager.get('members', 2).id,
-                    html: 'This is a hidden comment',
-                    status: 'hidden'
+            describe('when commentImprovements flag is enabled', function () {
+                beforeEach(function () {
+                    mockLabsEnabled('commentImprovements');
                 });
 
-                const data2 = await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200);
+                it('excludes hidden comments', async function () {
+                    const hiddenComment = await dbFns.addComment({
+                        post_id: postId,
+                        member_id: fixtureManager.get('members', 2).id,
+                        html: 'This is a hidden comment',
+                        status: 'hidden'
+                    });
 
-                // check that hiddenComment.id is not in the response
-                should(data2.body.comments.map(c => c.id)).not.containEql(hiddenComment.id);
-                should(data2.body.comments.length).eql(0);
-            });
+                    const data2 = await membersAgent
+                        .get(`/api/comments/post/${postId}/`)
+                        .expectStatus(200);
 
-            it('excludes deleted comments', async function () {
-                // await mockManager.mockLabsEnabled('commentImprovements');
-                await dbFns.addComment({
-                    post_id: postId,
-                    member_id: fixtureManager.get('members', 2).id,
-                    html: 'This is a deleted comment',
-                    status: 'deleted'
+                    // check that hiddenComment.id is not in the response
+                    should(data2.body.comments.map(c => c.id)).not.containEql(hiddenComment.id);
+                    should(data2.body.comments.length).eql(0);
                 });
 
-                const data2 = await membersAgent
-                    .get(`/api/comments/post/${postId}/`)
-                    .expectStatus(200);
+                it('excludes deleted comments', async function () {
+                    // await mockManager.mockLabsEnabled('commentImprovements');
+                    await dbFns.addComment({
+                        post_id: postId,
+                        member_id: fixtureManager.get('members', 2).id,
+                        html: 'This is a deleted comment',
+                        status: 'deleted'
+                    });
 
-                // go through all comments and check if the deleted comment is not there
-                data2.body.comments.forEach((comment) => {
-                    should(comment.html).not.eql('This is a deleted comment');
+                    const data2 = await membersAgent
+                        .get(`/api/comments/post/${postId}/`)
+                        .expectStatus(200);
+
+                    // go through all comments and check if the deleted comment is not there
+                    data2.body.comments.forEach((comment) => {
+                        should(comment.html).not.eql('This is a deleted comment');
+                    });
+
+                    data2.body.comments.length.should.eql(0);
                 });
-
-                data2.body.comments.length.should.eql(0);
             });
 
             it('shows hidden and deleted comment where there is a reply', async function () {
@@ -1145,6 +1156,29 @@ describe('Comments API', function () {
             });
 
             describe('replies to replies', function () {
+                beforeEach(function () {
+                    mockLabsEnabled('commentImprovements');
+                });
+
+                it('can browse comments with replies to replies', async function () {
+                    const {replies: [reply]} = await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 1).id,
+                        replies: [{
+                            member_id: fixtureManager.get('members', 2).id,
+                            html: '<p>This is what was replied to</p>'
+                        }]
+                    });
+
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 1).id,
+                        parent_id: reply.get('parent_id'),
+                        in_reply_to_id: reply.get('id'),
+                        html: '<p>This is a reply to a reply</p>'
+                    });
+
+                    await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 2, commentMatcher: labsCommentMatcher})]);
+                });
+
                 it('can set in_reply_to_id when creating a reply', async function () {
                     const {replies: [reply]} = await dbFns.addCommentWithReplies({
                         member_id: fixtureManager.get('members', 1).id,
@@ -1158,6 +1192,10 @@ describe('Comments API', function () {
                         parent_id: reply.get('parent_id'),
                         in_reply_to_id: reply.get('id'),
                         html: '<p>This is a reply to a reply</p>'
+                    }, {
+                        matchBodySnapshot: {
+                            comments: [labsCommentMatcher]
+                        }
                     });
 
                     // in_reply_to is set
@@ -1245,6 +1283,10 @@ describe('Comments API', function () {
                         parent_id: diffParentComment.get('id'),
                         in_reply_to_id: reply.get('id'),
                         html: '<p>This is a reply to a reply</p>'
+                    }, {
+                        matchBodySnapshot: {
+                            comments: [labsCommentMatcher]
+                        }
                     });
 
                     // in_reply_to is not set
@@ -1266,9 +1308,13 @@ describe('Comments API', function () {
                         parent_id: reply.get('parent_id'),
                         in_reply_to_id: reply.get('id'),
                         html: '<p>This is a reply to a reply</p>'
+                    }, {
+                        matchBodySnapshot: {
+                            comments: [labsCommentMatcher]
+                        }
                     });
 
-                    const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [commentMatcher]);
+                    const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
                     // in_reply_to_snippet is included
                     comment.in_reply_to_snippet.should.eql('This is what was replied to');
@@ -1291,7 +1337,7 @@ describe('Comments API', function () {
                             in_reply_to_id: reply.get('id')
                         });
 
-                        const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [commentMatcher]);
+                        const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
                         should.not.exist(comment.in_reply_to_snippet);
                     });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -8,6 +8,7 @@ const extraAttrsUtils = require('../../../../../../../core/server/api/endpoints/
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
 const memberAttribution = require('../../../../../../../core/server/services/member-attribution');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
+const labs = require('../../../../../../../core/shared/labs');
 
 function createJsonModel(data) {
     return Object.assign(data, {toJSON: sinon.stub().returns(data)});
@@ -611,7 +612,11 @@ describe('Unit: utils/serializers/output/mappers', function () {
         });
     });
 
-    describe('Comment mapper', function () {
+    describe('Comment mapper (commentImprovements flag enabled)', function () {
+        beforeEach(function () {
+            sinon.stub(labs, 'isSet').returns(true);
+        });
+
         it('includes in_reply_to_snippet for published replies-to-replies', function () {
             const frame = {};
 
@@ -640,7 +645,13 @@ describe('Unit: utils/serializers/output/mappers', function () {
                 id: 'comment3',
                 html: '<p>comment 3</p>',
                 member: {id: 'member1'},
-                parent: {id: 'comment1', html: '<p>comment 1</p>', member: {id: 'member1'}},
+                parent: {
+                    id: 'comment1',
+                    html: '<p>comment 1</p>',
+                    member: {id: 'member1'},
+                    in_reply_to_id: null,
+                    in_reply_to_snippet: null
+                },
                 in_reply_to_id: 'comment2',
                 in_reply_to_snippet: 'comment 2'
             });
@@ -668,7 +679,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             });
         });
 
-        it('does not include in_reply_to_snippet for top-level comments', function () {
+        it('includes null in_reply_to attributes for top-level comments', function () {
             const frame = {};
 
             const model = {
@@ -682,7 +693,9 @@ describe('Unit: utils/serializers/output/mappers', function () {
             mapped.should.eql({
                 id: 'comment1',
                 html: '<p>comment 1</p>',
-                member: null
+                member: null,
+                in_reply_to_id: null,
+                in_reply_to_snippet: null
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-230

- the `inReplyTo` relationship was not being loaded for replies which meant the mapper never hit the code which adds `in_reply_to_snippet`
- moved all `in_reply_to` code behind the `commentImprovements` labs flag
- updated tests to correctly disable/enable the flag
- added test for browsing comments with replies-to-replies so `in_reply_to_snippet` is captured in the snapshot
