### PR TITLE
🐛 Fixed scheduled post datepicker marking prior day as selected

### DIFF
--- a/ghost/admin/app/components/gh-date-time-picker.js
+++ b/ghost/admin/app/components/gh-date-time-picker.js
@@ -53,8 +53,7 @@ export default class GhDateTimePicker extends Component {
     
     @computed('_date')
     get localDateValue() {
-        // Convert the selected date to a new date in the local timezone, purely to please PowerDatepicker
-        return new Date(this._date.format(DATE_FORMAT));
+        return this._date.toDate();
     }
 
     @computed('blogTimezone')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-590

When choosing dates to schedule a post in the future, it could end up displaying the wrong selected date because it was accounting for local TZ. This doesn't make sense as we're displaying the site TZ in the picker itself, and that's the real TZ used for scheduling.

In short, this feels confusing and also is often incorrect/misleading, even though the scheduler in the background is correct. This should align those to make it more transparent.