### PR TITLE
Fixed picker for local tz use

### DIFF
--- a/ghost/admin/app/components/gh-date-time-picker.js
+++ b/ghost/admin/app/components/gh-date-time-picker.js
@@ -53,7 +53,10 @@ export default class GhDateTimePicker extends Component {
     
     @computed('_date')
     get localDateValue() {
-        return this._date.toDate();
+        // extract parts so we can build a date object that is strictly the day in the local tz
+        const [year, month, day] = this._date.format(DATE_FORMAT).split('-').map(Number);
+        const date = new Date(year, month - 1, day); // month is 0-indexed in the js date object
+        return date;
     }
 
     @computed('blogTimezone')


### PR DESCRIPTION
ref 47b8161805f5145493b16940a1fa4119be9bf79f

This ended up inverting the behavior, such that TZs far in advance of GMT fouled up. This change builds the date by date components in the local TZ so we should not run into further trouble...