### PR TITLE
Consolidated `compose.yml` files for Dev Container

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -26,10 +26,12 @@ services:
     extends:
       file: ../compose.yml
       service: mysql
+    container_name: ghost-devcontainer-mysql
   redis:
     extends:
       file: ../compose.yml
       service: redis
+    container_name: ghost-devcontainer-redis
 
 volumes:
   mysql-data:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -8,7 +8,7 @@ services:
     image: ghost-devcontainer
     command: ["sleep", "infinity"]
     build:
-      context: ../
+      context: ./
       dockerfile: .docker/Dockerfile
       target: base-devcontainer
       args:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -11,6 +11,8 @@ services:
       context: ../
       dockerfile: .docker/Dockerfile
       target: base-devcontainer
+      args:
+        WORKDIR: /workspaces/ghost
     pull_policy: never
     environment:
       - DEVCONTAINER=true
@@ -20,31 +22,3 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-  mysql:
-    image: mysql:8.0.35
-    # We'll need to look into how we can further fine tune the memory usage/performance here
-    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
-    ports:
-      - "3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: ghost
-    restart: always
-    volumes:
-      - mysql-data:/var/lib/mysql
-    healthcheck:
-      test: "mysql -uroot -proot ghost -e 'select 1'"
-      interval: 1s
-      retries: 120
-  redis:
-    image: redis:7.0
-    ports:
-      - "6379"
-    restart: always
-    healthcheck:
-      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
-      interval: 1s
-      retries: 120
-
-volumes:
-  mysql-data:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -8,7 +8,7 @@ services:
     image: ghost-devcontainer
     command: ["sleep", "infinity"]
     build:
-      context: ./
+      context: ../
       dockerfile: .docker/Dockerfile
       target: base-devcontainer
       args:
@@ -22,3 +22,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+  mysql:
+    extends:
+      file: ../compose.yml
+      service: mysql
+  redis:
+    extends:
+      file: ../compose.yml
+      service: redis
+
+volumes:
+  mysql-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "plugins": "git yarn gh"
         }
     },
-    "dockerComposeFile": ["./compose.yml"],
+    "dockerComposeFile": ["../compose.yml", "./compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "plugins": "git yarn gh"
         }
     },
-    "dockerComposeFile": ["../compose.yml", "../.devcontainer/compose.yml"],
+    "dockerComposeFile": ["./.devcontainer/compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "plugins": "git yarn gh"
         }
     },
-    "dockerComposeFile": ["./.devcontainer/compose.yml"],
+    "dockerComposeFile": ["./compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "plugins": "git yarn gh"
         }
     },
-    "dockerComposeFile": ["./compose.yml", "./.devcontainer/compose.yml"],
+    "dockerComposeFile": ["../compose.yml", "../.devcontainer/compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
             "plugins": "git yarn gh"
         }
     },
-    "dockerComposeFile": ["../compose.yml", "./compose.yml"],
+    "dockerComposeFile": ["./compose.yml", "./.devcontainer/compose.yml"],
     "service": "ghost",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "shutdownAction": "stopCompose",

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,6 @@
 ARG NODE_VERSION=20.15.1
+ARG WORKDIR=/home/ghost
+
 ## Base Image used for all targets
 FROM node:$NODE_VERSION-bullseye-slim AS base
 RUN apt-get update && \
@@ -45,14 +47,14 @@ EXPOSE 7174
 ### This is a full devcontainer with all the code and dependencies installed
 ### Useful in an environment like Github Codespaces where you don't mount your local code into the container
 FROM base-devcontainer AS full-devcontainer
-WORKDIR /workspaces/ghost
+WORKDIR $WORKDIR
 COPY ../../ .
 RUN yarn install --frozen-lockfile --prefer-offline --cache-folder $YARN_CACHE_FOLDER
 
 # Development Stage: alternative entrypoint for development with some caching optimizations
 FROM base-devcontainer AS development
 
-WORKDIR /workspaces/ghost
+WORKDIR $WORKDIR
 
 COPY ../../ .
 

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,10 @@ services:
     ports:
       - "6379:6379"
     restart: always
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 1s
+      retries: 120
   prometheus:
     profiles: [monitoring]
     image: prom/prometheus:v2.30.3


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1785/consolidate-dev-container-composeyml-with-the-root-level-composeyml

- We currently have two compose.yml files:
    - `.devcontainer/compose.yml`: used for the Dev Container
    - `compose.yml`: used for local development with docker compose
- The Dev Container compose file does need some additional configuration, but most of this code is duplicated from the root level compose.yml file
- This commit removes this duplication by using both compose files in the Dev Container setup, so it will base the compose configuration on the root level, and then extend it with the Dev Container specific configuration
- This way any updates to the root level compose file will also be available and reflected in the Dev Container setup without having to make the change twice.