### PR TITLE
Include hidden comments for admins in pagination count

### DIFF
--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -61,6 +61,7 @@ const Comment = ghostBookshelf.Model.extend({
             // Note: this limit is not working
             .query('limit', 3);
     },
+
     customQuery(qb) {
         qb.where(function () {
             this.whereNotIn('comments.status', ['hidden', 'deleted'])
@@ -271,8 +272,8 @@ const Comment = ghostBookshelf.Model.extend({
 
     countRelations() {
         return {
-            replies(modelOrCollection) {
-                if (labs.isSet('commentImprovements')) {
+            replies(modelOrCollection, options) {
+                if (labs.isSet('commentImprovements') && !options.isAdmin) {
                     modelOrCollection.query('columns', 'comments.*', (qb) => {
                         qb.count('replies.id')
                             .from('comments AS replies')
@@ -285,6 +286,16 @@ const Comment = ghostBookshelf.Model.extend({
                         qb.count('replies.id')
                             .from('comments AS replies')
                             .whereRaw('replies.parent_id = comments.id')
+                            .as('count__replies');
+                    });
+                }
+
+                if (options.isAdmin && labs.isSet('commentImprovements')) {
+                    modelOrCollection.query('columns', 'comments.*', (qb) => {
+                        qb.count('replies.id')
+                            .from('comments AS replies')
+                            .whereRaw('replies.parent_id = comments.id')
+                            .whereNotIn('replies.status', ['deleted'])
                             .as('count__replies');
                     });
                 }

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -236,10 +236,39 @@ describe('Admin Comments API', function () {
 
             const hiddenComment = res.body.comments.find(comment => comment.status === 'hidden');
             assert.equal(hiddenComment.html, 'Comment 2');
-            // console.log(res.body);
-            // assert.equal(res.body.comments[0].html, 'Comment 2');
+        });
 
-            // assert.equal(res.body.comments[1].html, 'Comment 1');
+        it('includes hidden replies but not deleted replies in count', async function () {
+            const post = fixtureManager.get('posts', 1);
+            const {parent} = await dbFns.addCommentWithReplies({
+                member_id: fixtureManager.get('members', 0).id,
+                post_id: post.id,
+                html: 'Comment 1',
+                status: 'published',
+                replies: [
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 1',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 2',
+                        status: 'deleted'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 3',
+                        status: 'published'
+                    }
+                ]
+            });
+
+            const res = await adminApi.get('/comments/post/' + post.id + '/');
+
+            const comment = res.body.comments.find(cmt => parent.id === cmt.id);
+
+            assert.equal(comment.replies_count, 2);
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -265,10 +265,8 @@ describe('Admin Comments API', function () {
             });
 
             const res = await adminApi.get('/comments/post/' + post.id + '/');
-
-            const comment = res.body.comments.find(cmt => parent.id === cmt.id);
-
-            assert.equal(comment.replies_count, 2);
+            const item = res.body.comments.find(cmt => parent.id === cmt.id);
+            assert.equal(item.count.replies, 2);
         });
     });
 });


### PR DESCRIPTION
ref PLG-227

- Ensure hidden comments are included in the replies count for admin users to ensure pagination works as expected.
