### PR TITLE
Added new endpoint for loading replies as Admin

### DIFF
--- a/ghost/core/core/server/api/endpoints/comment-replies.js
+++ b/ghost/core/core/server/api/endpoints/comment-replies.js
@@ -1,0 +1,36 @@
+// This is a new endpoint for the admin API to return replies to a comment with pagination
+
+const commentsService = require('../../services/comments');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'comments',
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'include',
+            'page',
+            'limit',
+            'fields',
+            'filter',
+            'order',
+            'debug',
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return commentsService.controller.adminReplies(frame);
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/comments.js
+++ b/ghost/core/core/server/api/endpoints/comments.js
@@ -1,6 +1,5 @@
 const models = require('../../models');
 const commentsService = require('../../services/comments');
-
 function handleCacheHeaders(model, frame) {
     if (model) {
         const postId = model.get('post_id');

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -197,6 +197,10 @@ module.exports = {
         return apiFramework.pipeline(require('./comments'), localUtils);
     },
 
+    get commentReplies() {
+        return apiFramework.pipeline(require('./comment-replies'), localUtils);
+    },
+
     get links() {
         return apiFramework.pipeline(require('./links'), localUtils);
     },

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -333,8 +333,7 @@ const Comment = ghostBookshelf.Model.extend({
      */
     permittedOptions: function permittedOptions(methodName) {
         let options = ghostBookshelf.Model.permittedOptions.call(this, methodName);
-
-        // The comment model additionally supports having a parentId option
+        // The comment model additionally supports having a parentId and isAdmin option
         options.push('parentId');
         options.push('isAdmin');
 

--- a/ghost/core/core/server/services/comments/CommentsController.js
+++ b/ghost/core/core/server/services/comments/CommentsController.js
@@ -85,6 +85,14 @@ module.exports = class CommentsController {
     /**
      * @param {Frame} frame
      */
+    async adminReplies(frame) {
+        frame.options.isAdmin = true;
+        return this.service.getReplies(frame.options.id, _.omit(frame.options, 'id'));
+    }
+
+    /**
+     * @param {Frame} frame
+     */
     async read(frame) {
         return await this.service.getCommentByID(frame.data.id, frame.options);
     }

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -51,6 +51,7 @@ module.exports = function apiRoutes() {
 
     router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
 
+    router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
     router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
     router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
 

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -268,5 +268,192 @@ describe('Admin Comments API', function () {
             const item = res.body.comments.find(cmt => parent.id === cmt.id);
             assert.equal(item.count.replies, 2);
         });
+
+        it('can load additional replies as an admin', async function () {
+            const post = fixtureManager.get('posts', 1);
+            const {parent} = await dbFns.addCommentWithReplies({
+                member_id: fixtureManager.get('members', 0).id,
+                post_id: post.id,
+                html: 'Comment 1',
+                status: 'published',
+                replies: [
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 1',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 2',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 3',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 4',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 5',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 6',
+                        status: 'published'
+                    }
+                ]
+            });
+
+            const res = await adminApi.get('/comments/post/' + post.id + '/');
+            const item = res.body.comments.find(cmt => parent.id === cmt.id);
+            const lastReply = item.replies[item.replies.length - 1];
+            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+            assert.equal(res2.body.comments.length, 3);
+        });
+
+        it('can load additional replies and includes hidden replies as an admin', async function () {
+            const post = fixtureManager.get('posts', 1);
+            const {parent} = await dbFns.addCommentWithReplies({
+                member_id: fixtureManager.get('members', 0).id,
+                post_id: post.id,
+                html: 'Comment 1',
+                status: 'published',
+                replies: [
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 1',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 2',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 3',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 4',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 5',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 6',
+                        status: 'published'
+                    }
+                ]
+            });
+
+            const res = await adminApi.get('/comments/post/' + post.id + '/');
+            const item = res.body.comments.find(cmt => parent.id === cmt.id);
+            const lastReply = item.replies[item.replies.length - 1];
+            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+            assert.equal(res2.body.comments.length, 3);
+        });
+
+        it('does not return deleted replies as an admin', async function () {
+            const post = fixtureManager.get('posts', 1);
+            const {parent} = await dbFns.addCommentWithReplies({
+                member_id: fixtureManager.get('members', 0).id,
+                post_id: post.id,
+                html: 'Comment 1',
+                status: 'published',
+                replies: [
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 1',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 2',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 3',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 4',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 5',
+                        status: 'deleted'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 6',
+                        status: 'deleted'
+                    }
+                ]
+            });
+
+            const res = await adminApi.get('/comments/post/' + post.id + '/');
+            const item = res.body.comments.find(cmt => parent.id === cmt.id);
+            const lastReply = item.replies[item.replies.length - 1];
+            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+            assert.equal(res2.body.comments.length, 1);
+        });
+
+        it('includes html string of replies as an admin', async function () {
+            const post = fixtureManager.get('posts', 1);
+            const {parent} = await dbFns.addCommentWithReplies({
+                member_id: fixtureManager.get('members', 0).id,
+                post_id: post.id,
+                html: 'Comment 1',
+                status: 'published',
+                replies: [
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 1',
+                        status: 'published'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 2',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 3',
+                        status: 'hidden'
+                    },
+                    {
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Reply 4',
+                        status: 'hidden'
+                    }
+                ]
+            });
+
+            const res = await adminApi.get('/comments/post/' + post.id + '/');
+            const item = res.body.comments.find(cmt => parent.id === cmt.id);
+            const lastReply = item.replies[item.replies.length - 1];
+            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+            assert.equal(res2.body.comments.length, 1);
+            assert.equal(res2.body.comments[0].html, 'Reply 4');
+        });
     });
 });


### PR DESCRIPTION
ref PLG-227

- Wired up a new endpoint that would be able to paginate replies as an admin user.
- The difference compared to the members-api endpoint is that this includes hidden comments and includes the html content which is normally hidden from non-admin users

