### PR TITLE
chore: migrate IFrame component to functional component

### DIFF
--- a/apps/signup-form/src/components/Frame.tsx
+++ b/apps/signup-form/src/components/Frame.tsx
@@ -107,14 +107,14 @@ type TailwindFrameProps = ResizableFrameProps & {
 /**
  * Loads all the CSS styles inside an iFrame.
  */
-const TailwindFrame: React.FC<TailwindFrameProps> = ({children, onResize, style, title}) => {
-    const head = (
-        <>
-            <style dangerouslySetInnerHTML={{__html: styles}} />
-            <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0" name="viewport" />
-        </>
-    );
+const head = (
+    <>
+        <style dangerouslySetInnerHTML={{__html: styles}} />
+        <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0" name="viewport" />
+    </>
+);
 
+const TailwindFrame: React.FC<TailwindFrameProps> = ({children, onResize, style, title}) => {
     return (
         <IFrame head={head} style={style} title={title} onResize={onResize}>
             {children}


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)
    - Neither of these commands ran any tasks and `npx nx graph` doesn't show any task graphs either, I wonder if Nx is misconfigured.

We appreciate your contribution!

---------------------

While looking at the codebase, I found:

- An unmemoized `head` element that, on re-render, would wreck havoc on performance thanks to reconstructing all of the CSS styles
- A class component that referenced migration to a functional component
- Missing property typings for the `iframe` component

I figured I'd see if I could help with these issues, so I took a stab at it. I loaded the signup page and did a comparison against both the production tab and the development tab without my changes and it seemed to work fine.

> I still worry about some of the uncleaned up effects. I know the comment mentions that the `iframe` being removed will cleanup the effects, but I'm not entirely certain of this. After all, we're passing an arrow function which the browser's GC might not handle properly.
>
> This isn't a _huge_ deal given the scope of this component, but it's a minimal refactor to handle in a more 'tidy' manner. I could do this refactor as a follow-up if requested.