### PR TITLE
🐛 Fixed missing progress indicator when submitting comments

### DIFF
--- a/apps/comments-ui/src/App.tsx
+++ b/apps/comments-ui/src/App.tsx
@@ -70,13 +70,20 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
         // This is a bit a ugly hack, but only reliable way to make sure we can get the latest state asynchronously
         // without creating infinite rerenders because dispatchAction needs to change on every state change
         // So state shouldn't be a dependency of dispatchAction
-        setState((state) => {
-            ActionHandler({action, data, state, api, adminApi: state.adminApi!, options}).then((updatedState) => {
-                setState({...updatedState});
-            }).catch(console.error); // eslint-disable-line no-console
+        //
+        // Wrapped in a Promise so that callers of `dispatchAction` can await the action completion. setState doesn't
+        // allow for async actions within it's updater function so this is the best option.
+        return new Promise((resolve) => {
+            setState((state) => {
+                ActionHandler({action, data, state, api, adminApi: state.adminApi!, options}).then((updatedState) => {
+                    const newState = {...updatedState};
+                    resolve(newState);
+                    setState(newState);
+                }).catch(console.error); // eslint-disable-line no-console
 
-            // No immediate changes
-            return {};
+                // No immediate changes
+                return {};
+            });
         });
     }, [api, options]); // Do not add state or context as a dependency here -> infinite render loop
 

--- a/apps/comments-ui/src/components/content/forms/Form.tsx
+++ b/apps/comments-ui/src/components/content/forms/Form.tsx
@@ -58,7 +58,7 @@ const FormEditor: React.FC<FormEditorProps> = ({comment, submit, progress, setPr
 
     if (progress === 'sending') {
         submitText = null;
-        buttonIcon = <SpinnerIcon className="h-[24px] w-[24px] fill-white dark:fill-black" />;
+        buttonIcon = <SpinnerIcon className="h-[24px] w-[24px] fill-white dark:fill-black" data-testid="button-spinner" />;
     }
 
     const stopIfFocused = useCallback((event) => {

--- a/apps/comments-ui/test/e2e/actions.test.ts
+++ b/apps/comments-ui/test/e2e/actions.test.ts
@@ -177,8 +177,15 @@ test.describe('Actions', async () => {
 
         await page.keyboard.type('This is a reply to a reply');
 
+        // give time for spinner to show
+        mockedApi.setDelay(100);
+
         const submitButton = parentComment.getByTestId('submit-form-button');
         await submitButton.click();
+
+        // Spinner is shown
+        await expect(frame.getByTestId('button-spinner')).toBeVisible();
+        await expect(frame.getByTestId('button-spinner')).not.toBeVisible();
 
         // Comment gets added and has correct contents
         await expect(frame.getByTestId('comment-component')).toHaveCount(3);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PLG-265

- wrapped the async part of `dispatchAction` in a Promise so code that calls it can await the action completion
  - this was a regression introduced a long time ago when we switched to Typescript and React hooks
- added a `setDelay()` method to our `MockedApi` class to make it easier to test interstitial loading states
