### PR TITLE
🐛 Fixed slug not always updating for draft posts

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -335,7 +335,6 @@ export default class LexicalEditorController extends Controller {
 
     @action
     updateTitleScratch(title) {
-        console.log('updateTitleScratch', title);
         this.set('post.titleScratch', title);
         try {
             this.localRevisions.scheduleSave(this.post.displayName, {...this.post.serialize({includeId: true}), title: title});
@@ -594,12 +593,7 @@ export default class LexicalEditorController extends Controller {
     // _xSave tasks  that will also cancel the autosave task
     @task({group: 'saveTasks'})
     *saveTask(options = {}) {
-        console.log('saveTask');
-        console.log(`this.post.titleScratch: ${this.post.titleScratch}`);
-        console.log(`this.post.title: ${this.post.title}`);
-        console.log(`this.post.slug: ${this.post.slug}`);
         if (this.post.status === 'draft' && this.post.titleScratch !== this.post.title) {
-            console.log(`title mismatch`);
             yield this.generateSlugTask.perform();
         }
 
@@ -767,19 +761,15 @@ export default class LexicalEditorController extends Controller {
         if (!this.post.titleScratch?.trim()) {
             this.set('post.titleScratch', DEFAULT_TITLE);
         }
-        console.log(`beforeSaveTask`);
 
         // Generate a slug if we don't have one or if the title has changed
         if (!this.get('post.slug') || (this.post.status === 'draft' && this.post.titleScratch !== this.post.title)) {
-            console.log(`>title mismatch, generating slug`);
             this.saveTitleTask.cancelAll();
             yield this.generateSlugTask.perform();
         }
 
         // TODO: There's no need for most of these scratch values.
         // Refactor so we're setting model attributes directly
-        console.log(`>this.post.title`, this.post.title);
-        console.log(`>this.post.titleScratch`, this.post.titleScratch);
         this.set('post.title', this.get('post.titleScratch'));
         this.set('post.customExcerpt', this.get('post.customExcerptScratch'));
         this.set('post.footerInjection', this.get('post.footerExcerptScratch'));
@@ -798,7 +788,6 @@ export default class LexicalEditorController extends Controller {
      */
     @task({group: 'saveTasks'})
     *updateSlugTask(_newSlug) {
-        console.log(`updateSlugTask`);
         let slug = this.get('post.slug');
         let newSlug, serverSlug;
 

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -734,7 +734,7 @@ export default class LexicalEditorController extends Controller {
     }
 
     @task
-    *beforeSaveTask(options = {}) {
+    *beforeSaveTask() {
         if (this.post?.isDestroyed || this.post?.isDestroying) {
             return;
         }

--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -623,6 +623,24 @@ describe('Acceptance: Editor', function () {
             expect(find('[data-test-editor-post-status]')).to.contain.text('New');
         });
 
+        it('updates slug when title changes without blur', async function () {
+            let post = this.server.create('post', {authors: [author]});
+
+            await visit(`/editor/post/${post.id}`);
+            await fillIn('[data-test-editor-title-input]', 'Test Title');
+
+            await triggerEvent('[data-test-editor-title-input]', 'keydown', {
+                keyCode: 83, // s
+                metaKey: ctrlOrCmd === 'command',
+                ctrlKey: ctrlOrCmd === 'ctrl'
+            });
+
+            let [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+            let body = JSON.parse(lastRequest.requestBody);
+            expect(body.posts[0].slug).to.equal('test-title');
+            expect(post.slug).to.equal('test-title');
+        });
+
         it('handles TKs in title', async function () {
             let post = this.server.create('post', {authors: [author]});
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-548/

There have been reported cases of the editor not updating the slug for draft posts. The logic should be as follows: for a draft post, if the title was updated and we do not detect a custom slug, update it.

This got out of sync due to actions where the save was triggered but the title onBlur effect (which updates the slug) was not triggered. This has been resolved by evaluating the slug in the before save actions.