### PR TITLE
Removed TTL from tinybird analytics _events datasource

### DIFF
--- a/ghost/tinybird/datasources/analytics_events.datasource
+++ b/ghost/tinybird/datasources/analytics_events.datasource
@@ -13,4 +13,3 @@ SCHEMA >
 ENGINE MergeTree
 ENGINE_PARTITION_KEY toYYYYMM(timestamp)
 ENGINE_SORTING_KEY timestamp
-ENGINE_TTL timestamp + toIntervalDay(60)


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-115/data-retention

- The bad news here is I didn't notice that the tinybird web analytics starter kit included a TTL on the analytics_events datasource of 60 days
- This means any data older than 60days was automatically dropped from the table
- I updated this in the UI when I noticed it a few days ago, this makes sure it can't come back
- The good news is that we don't have to implement anything to make this work when we do get to the point where we want a TTL!
