### PR TITLE
Stopped deleting asset files before regenerating

### DIFF
--- a/ghost/core/core/frontend/services/assets-minification/AdminAuthAssets.js
+++ b/ghost/core/core/frontend/services/assets-minification/AdminAuthAssets.js
@@ -63,7 +63,6 @@ module.exports = class AdminAuthAssets extends AssetsMinificationBase {
     async load() {
         const globs = this.generateGlobs();
         const replacements = this.generateReplacements();
-        await this.clearFiles();
         await this.minify(globs, {replacements});
     }
 };

--- a/ghost/core/core/frontend/services/assets-minification/AssetsMinificationBase.js
+++ b/ghost/core/core/frontend/services/assets-minification/AssetsMinificationBase.js
@@ -1,5 +1,3 @@
-const path = require('path');
-const fs = require('fs').promises;
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 
@@ -28,24 +26,6 @@ module.exports = class AssetsMinificationBase {
         });
     }
 
-    /**
-     * @returns {Promise<void>}
-     */
-    async clearFiles() {
-        const rmFile = async (name) => {
-            await fs.unlink(path.join(this.dest, name));
-        };
-
-        const promises = [];
-        for (const key of Object.keys(this.generateGlobs())) {
-            // @deprecated switch this to use fs.rm when we drop support for Node v12
-            promises.push(rmFile(key));
-        }
-
-        // We don't care if removing these files fails as it's valid for them to not exist
-        await Promise.allSettled(promises);
-    }
-
     async minify(globs, options) {
         try {
             const result = await this.minifier.minify(globs, options);
@@ -57,7 +37,7 @@ module.exports = class AssetsMinificationBase {
                 return;
             }
 
-            throw error;           
+            throw error;
         }
     }
 

--- a/ghost/core/core/frontend/services/assets-minification/CardAssets.js
+++ b/ghost/core/core/frontend/services/assets-minification/CardAssets.js
@@ -82,8 +82,6 @@ module.exports = class CardAssets extends AssetsMinificationBase {
 
         debug('loading with config', this.config);
 
-        await this.clearFiles();
-
         const globs = this.generateGlobs();
 
         debug('globs', globs);

--- a/ghost/core/core/frontend/services/assets-minification/CommentCountsAssets.js
+++ b/ghost/core/core/frontend/services/assets-minification/CommentCountsAssets.js
@@ -27,7 +27,6 @@ module.exports = class CommentCountsAssets extends AssetsMinificationBase {
      * @override
      */
     async load() {
-        await this.clearFiles();
         const globs = this.generateGlobs();
         this.files = await this.minify(globs);
     }

--- a/ghost/core/core/frontend/services/assets-minification/MemberAttributionAssets.js
+++ b/ghost/core/core/frontend/services/assets-minification/MemberAttributionAssets.js
@@ -40,7 +40,6 @@ module.exports = class MemberAttributionAssets extends AssetsMinificationBase {
     async load() {
         const globs = this.generateGlobs();
         const replacements = this.generateReplacements();
-        await this.clearFiles();
         await this.minify(globs, {replacements});
     }
 };

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -65,41 +65,6 @@ describe('Card Asset Service', function () {
         cardAssets.files.should.eql([]);
     });
 
-    it('can clearFiles', async function () {
-        const cardAssets = new CardAssetService({
-            src: srcDir,
-            dest: destDir,
-            config: true
-        });
-
-        await fs.writeFile(path.join(destDir, 'cards.min.css'), 'test-css');
-        await fs.writeFile(path.join(destDir, 'cards.min.js'), 'test-js');
-
-        await cardAssets.clearFiles();
-
-        try {
-            await fs.readFile(path.join(destDir, 'cards.min.css'), 'utf-8');
-            should.fail(cardAssets, 'CSS file should not exist');
-        } catch (error) {
-            if (error instanceof should.AssertionError) {
-                throw error;
-            }
-
-            error.code.should.eql('ENOENT');
-        }
-
-        try {
-            await fs.readFile(path.join(destDir, 'cards.min.js'), 'utf-8');
-            should.fail(cardAssets, 'JS file should not exist');
-        } catch (error) {
-            if (error instanceof should.AssertionError) {
-                throw error;
-            }
-
-            error.code.should.eql('ENOENT');
-        }
-    });
-
     describe('Generate the correct glob strings', function () {
         it('CARD ASSET SERVICE DEFAULT CASE: do nothing', function () {
             const cardAssets = new CardAssetService();


### PR DESCRIPTION
fix https://linear.app/ghost/issue/ONC-619/remove-code-that-deletes-assets-before-regeneration-in-ghost

- in our asset minification code, we delete asset files before regenerating them
- on shared filesystems, we're seeing errors like `Unknown system error -116` where 116 is Stale NFS file handle
- this is probably happening because we delete files right before creating them, and maybe there is some distributed filesystem delay that's causing issues here
- to workaround that, we can just stop deleting the files, which means we can delete code (yay!)