### PR TITLE
Fixed comments-ui tests not properly mocking actions on replies

### DIFF
--- a/apps/comments-ui/src/utils/helpers.test.ts
+++ b/apps/comments-ui/src/utils/helpers.test.ts
@@ -3,6 +3,34 @@ import moment, {DurationInputObject} from 'moment';
 import sinon from 'sinon';
 import {buildAnonymousMember, buildComment, buildDeletedMember} from '../../test/utils/fixtures';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('flattenComments', function () {
+    it('flattens comments and replies', function () {
+        const comments: any[] = [
+            {id: '1', replies: [{id: '2'}]},
+            {id: '3', replies: []}
+        ];
+        expect(helpers.flattenComments(comments)).toEqual([
+            {id: '1', replies: [{id: '2'}]},
+            {id: '2'},
+            {id: '3', replies: []}
+        ]);
+    });
+});
+
+describe('findCommentById', function () {
+    it('finds a top-level comment', function () {
+        const comments: any[] = [{id: '1'}, {id: '2'}, {id: '3'}];
+        expect(helpers.findCommentById(comments, '2')).toEqual({id: '2'});
+    });
+
+    it('finds a reply', function () {
+        const comments: any[] = [{id: '1', replies: [{id: '2'}]}, {id: '3'}];
+        expect(helpers.findCommentById(comments, '2')).toEqual({id: '2'});
+    });
+});
+
 describe('formatNumber', function () {
     it('adds commas to large numbers', function () {
         expect(helpers.formatNumber(1234567)).toEqual('1,234,567');

--- a/apps/comments-ui/src/utils/helpers.ts
+++ b/apps/comments-ui/src/utils/helpers.ts
@@ -1,5 +1,14 @@
 import {Comment, Member, TranslationFunction} from '../AppContext';
 
+export function flattenComments(comments: Comment[]): Comment[] {
+    return comments.flatMap(comment => [comment, ...(comment.replies || [])]);
+}
+
+export function findCommentById(comments: Comment[], id: string): Comment | undefined {
+    return comments.find(comment => comment?.id === id)
+        || comments.flatMap(comment => comment.replies || []).find(reply => reply?.id === id);
+}
+
 export function formatNumber(number: number): string {
     if (number !== 0 && !number) {
         return '';

--- a/apps/comments-ui/test/e2e/actions.test.ts
+++ b/apps/comments-ui/test/e2e/actions.test.ts
@@ -1,4 +1,5 @@
 import {MockedApi, initialize, waitEditorFocused} from '../utils/e2e';
+import {buildReply} from '../utils/fixtures';
 import {expect, test} from '@playwright/test';
 
 test.describe('Actions', async () => {
@@ -70,6 +71,29 @@ test.describe('Actions', async () => {
         const icon2 = likeButton2.locator('svg');
         await expect(icon2).toHaveClass(/fill/);
         await expect(likeButton2).toHaveText('52');
+    });
+
+    test('Can like and unlike a reply', async ({page}) => {
+        mockedApi.addComment({
+            id: '1',
+            html: '<p>This is comment 1</p>',
+            replies: [
+                buildReply({id: '2', html: '<p>This is reply 1</p>'}),
+                buildReply({id: '3', html: '<p>This is reply 2</p>', in_reply_to_id: '2', in_reply_to_snippet: 'This is reply 1'}),
+                buildReply({id: '4', html: '<p>This is reply 3</p>'})
+            ]
+        });
+
+        const {frame} = await initializeTest(page);
+
+        const reply = frame.getByTestId('comment-component').nth(1);
+        const likeButton = reply.getByTestId('like-button');
+
+        await expect(likeButton).toHaveText('0');
+        await likeButton.click();
+        await expect(likeButton).toHaveText('1');
+        await likeButton.click();
+        await expect(likeButton).toHaveText('0');
     });
 
     test('Can reply to a comment', async ({page}) => {


### PR DESCRIPTION
no issue

- `MockedApi.browseComments` only worked on top-level comments, it couldn't find replies when passed `filter:'id:123'` such is used when liking and editing replies
- fixed missing get handler for fetching single comment via Admin API (used after showing a hidden comment)
- added `flattenComments` and `findCommentById` helper functions to facilitate easier finding of a comment or reply within the nested structure
- added tests for liking and hiding replies
