### PR TITLE
Changed in-reply-to snippet to show [hidden/removed]

### DIFF
--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -2112,6 +2112,88 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": "[hidden/removed]",
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "442",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": "[hidden/removed]",
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "442",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated replies to replies in_reply_to_id is ignored id in_reply_to_id has a different parent 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1500,7 +1500,7 @@ describe('Comments API', function () {
                 });
 
                 ['deleted', 'hidden'].forEach((status) => {
-                    it(`does not include in_reply_to_snippet for ${status} comments`, async function () {
+                    it(`has redacted in_reply_to_snippet when referenced comment is ${status}`, async function () {
                         const {replies: [reply]} = await dbFns.addCommentWithReplies({
                             member_id: fixtureManager.get('members', 1).id,
                             replies: [{
@@ -1518,7 +1518,7 @@ describe('Comments API', function () {
 
                         const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
-                        should.not.exist(comment.in_reply_to_snippet);
+                        comment.in_reply_to_snippet.should.eql('[hidden/removed]');
                     });
                 });
             });

--- a/ghost/i18n/locales/af/comments.json
+++ b/ghost/i18n/locales/af/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Voltydse ouer",
     "Head of Marketing at Acme, Inc": "Hoof van Bemarking by Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Versteek",
     "Hide comment": "Versteek kommentaar",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/ar/comments.json
+++ b/ghost/i18n/locales/ar/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "أب بدوام كامل",
     "Head of Marketing at Acme, Inc": "رئيس وحدة التسويق لدى شركة أكمى",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "اخفاء",
     "Hide comment": "اخف التعليق",
     "Jamie Larson": "فلان الفلانى",

--- a/ghost/i18n/locales/bg/comments.json
+++ b/ghost/i18n/locales/bg/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Родител на пълно работно време",
     "Head of Marketing at Acme, Inc": "Директор маркетинг в Компания ООД",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Скриване",
     "Hide comment": "Скриване на коментара",
     "Jamie Larson": "Иван Иванов",

--- a/ghost/i18n/locales/bn/comments.json
+++ b/ghost/i18n/locales/bn/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "পূর্ণকালীন অভিভাবক",
     "Head of Marketing at Acme, Inc": "মার্কেটিং প্রধান @ বাংলাদেশ ট্রেড হাব",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "লুকান",
     "Hide comment": "মন্তব্য লুকান",
     "Jamie Larson": "শাহ নেওয়াজ",

--- a/ghost/i18n/locales/bs/comments.json
+++ b/ghost/i18n/locales/bs/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Full time roditelj",
     "Head of Marketing at Acme, Inc": "Šef marketinga u kompaniji Acme d.o.o",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Sakrij",
     "Hide comment": "Sakrij komentar",
     "Jamie Larson": "Vanja Larsić",

--- a/ghost/i18n/locales/ca/comments.json
+++ b/ghost/i18n/locales/ca/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Pare a temps complert",
     "Head of Marketing at Acme, Inc": "Cap de màrqueting a Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Amaga",
     "Hide comment": "Amaga el comentari",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -307,6 +307,7 @@
     "complimentary": "",
     "edited": "",
     "free": "",
+    "hidden/removed": "",
     "jamie@example.com": "Placeholder for email input field",
     "month": "the subscription interval (monthly), following the /",
     "paid": "",

--- a/ghost/i18n/locales/cs/comments.json
+++ b/ghost/i18n/locales/cs/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Rodič na plný úvazek",
     "Head of Marketing at Acme, Inc": "Vedoucí marketingu v Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Skrýt",
     "Hide comment": "Skrýt komentář",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/da/comments.json
+++ b/ghost/i18n/locales/da/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Forældre på fuld tid",
     "Head of Marketing at Acme, Inc": "Chef for marking hos Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Skjul",
     "Hide comment": "Skjul kommentar",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/de-CH/comments.json
+++ b/ghost/i18n/locales/de-CH/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/de/comments.json
+++ b/ghost/i18n/locales/de/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Vollzeit-Elternteil",
     "Head of Marketing at Acme, Inc": "Leiter Marketing bei Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Verbergen",
     "Hide comment": "Kommentar verbergen",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/el/comments.json
+++ b/ghost/i18n/locales/el/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Γονέας πλήρους απασχόλησης",
     "Head of Marketing at Acme, Inc": "Επικεφαλής Μάρκετινγκ στην Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Απόκρυψη",
     "Hide comment": "Απόκρυψη σχολίου",
     "Jamie Larson": "Τζέιμι Λάρσον",

--- a/ghost/i18n/locales/en/comments.json
+++ b/ghost/i18n/locales/en/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/eo/comments.json
+++ b/ghost/i18n/locales/eo/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/es/comments.json
+++ b/ghost/i18n/locales/es/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Padres de tiempo completo",
     "Head of Marketing at Acme, Inc": "Jefe de Marketing en Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Ocultar",
     "Hide comment": "Ocultar comentario",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/et/comments.json
+++ b/ghost/i18n/locales/et/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Täiskohaga lapsevanem",
     "Head of Marketing at Acme, Inc": "Turundusjuht Acme, Inc-s",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Peida",
     "Hide comment": "Peida kommentaar",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/fa/comments.json
+++ b/ghost/i18n/locales/fa/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": " خانه\u200cدار تمام وقت",
     "Head of Marketing at Acme, Inc": "سرپرست بخش بازاریابی یک شرکت خیالی",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "مخفی کردن",
     "Hide comment": "مخفی کردن دیدگاه",
     "Jamie Larson": "جیمی لارسن",

--- a/ghost/i18n/locales/fi/comments.json
+++ b/ghost/i18n/locales/fi/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Kokoaikainen vanhempi",
     "Head of Marketing at Acme, Inc": "Markkinointijohtaja",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Piilota",
     "Hide comment": "Piilota kommentti",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/fr/comments.json
+++ b/ghost/i18n/locales/fr/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Parent à plein temps",
     "Head of Marketing at Acme, Inc": "Responsable du marketing chez Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Masquer",
     "Hide comment": "Masquer le commentaire",
     "Jamie Larson": "Jean Martin",

--- a/ghost/i18n/locales/gd/comments.json
+++ b/ghost/i18n/locales/gd/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Pàrant làn-ùine",
     "Head of Marketing at Acme, Inc": "Àrd-cheann Margaidheachd aig Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Cuir am falach",
     "Hide comment": "Cuir am beachd am falach",
     "Jamie Larson": "Seamaidh Larson",

--- a/ghost/i18n/locales/he/comments.json
+++ b/ghost/i18n/locales/he/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "הורה במשרה מלאה",
     "Head of Marketing at Acme, Inc": "ראש אגף שיווק ב- Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "הסתר",
     "Hide comment": "הסתר תגובה",
     "Jamie Larson": "ג׳יימי לרסון",

--- a/ghost/i18n/locales/hi/comments.json
+++ b/ghost/i18n/locales/hi/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "पूर्णकालिक माता-पिता",
     "Head of Marketing at Acme, Inc": "Acme, Inc में विपणन प्रमुख",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "छिपाएं",
     "Hide comment": "टिप्पणी छिपाएं",
     "Jamie Larson": "राहुल शर्मा",

--- a/ghost/i18n/locales/hr/comments.json
+++ b/ghost/i18n/locales/hr/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Full-time Roditelj",
     "Head of Marketing at Acme, Inc": "Voditelj marketinga Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Sakrij",
     "Hide comment": "Sakrij komentar",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/hu/comments.json
+++ b/ghost/i18n/locales/hu/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Főállású szülő",
     "Head of Marketing at Acme, Inc": "Marketing vezető —\u00a0Acme Kft.",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Elrejtés",
     "Hide comment": "Hozzászólás elrejtése",
     "Jamie Larson": "Kiss Sára",

--- a/ghost/i18n/locales/id/comments.json
+++ b/ghost/i18n/locales/id/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Orang tua penuh waktu",
     "Head of Marketing at Acme, Inc": "Direktur Pemasaran di Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Sembunyikan",
     "Hide comment": "Sembunyikan komentar",
     "Jamie Larson": "Sutan T. Alisjahbana",

--- a/ghost/i18n/locales/is/comments.json
+++ b/ghost/i18n/locales/is/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/it/comments.json
+++ b/ghost/i18n/locales/it/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Genitore a tempo pieno",
     "Head of Marketing at Acme, Inc": "Ragioniere presso Megaditta",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Nascondi",
     "Hide comment": "Nascondi commento",
     "Jamie Larson": "Andrea Rossi",

--- a/ghost/i18n/locales/ja/comments.json
+++ b/ghost/i18n/locales/ja/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "専業主婦・主夫",
     "Head of Marketing at Acme, Inc": "マーケティング責任者 @ Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "非表示にする",
     "Hide comment": "コメントを非表示にする",
     "Jamie Larson": "ジェイミー・ラーソン",

--- a/ghost/i18n/locales/ko/comments.json
+++ b/ghost/i18n/locales/ko/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "전업 부모",
     "Head of Marketing at Acme, Inc": "Acme Inc 마케팅 책임자",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "숨기기",
     "Hide comment": "댓글 숨기기",
     "Jamie Larson": "제이미 라슨",

--- a/ghost/i18n/locales/kz/comments.json
+++ b/ghost/i18n/locales/kz/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Толық күн жұмыс істейтін ата-ана",
     "Head of Marketing at Acme, Inc": "@ Acme маркетинг жетекшісі ",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Жасыру",
     "Hide comment": "Пікірді жасыру",
     "Jamie Larson": "Пәленше Түгеншиев",

--- a/ghost/i18n/locales/lt/comments.json
+++ b/ghost/i18n/locales/lt/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Vaiką prižiūrintis tėvas",
     "Head of Marketing at Acme, Inc": "Tyrinėtojas",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Paslėpti",
     "Hide comment": "Paslėpti komentarą",
     "Jamie Larson": "Vardenis Pavardenis",

--- a/ghost/i18n/locales/mk/comments.json
+++ b/ghost/i18n/locales/mk/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Родител",
     "Head of Marketing at Acme, Inc": "Раководител на Маркетинг во Примерна Компанија",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Скријте",
     "Hide comment": "Скријте го коментарот",
     "Jamie Larson": "Петар Петровски",

--- a/ghost/i18n/locales/mn/comments.json
+++ b/ghost/i18n/locales/mn/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/ms/comments.json
+++ b/ghost/i18n/locales/ms/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/ne/comments.json
+++ b/ghost/i18n/locales/ne/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/nl/comments.json
+++ b/ghost/i18n/locales/nl/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Full-time ouder",
     "Head of Marketing at Acme, Inc": "Acme BV, Hoofd Marketing",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Verbergen",
     "Hide comment": "Verberg reactie",
     "Jamie Larson": "Jan Jansen",

--- a/ghost/i18n/locales/nn/comments.json
+++ b/ghost/i18n/locales/nn/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/no/comments.json
+++ b/ghost/i18n/locales/no/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Forelder på heltid",
     "Head of Marketing at Acme, Inc": "Markedsføringsleder hos Acme Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Skjul",
     "Hide comment": "Skjul kommentar",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/pl/comments.json
+++ b/ghost/i18n/locales/pl/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "Head of Marketing at Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Ukryj",
     "Hide comment": "Ukryj komentarz",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/pt-BR/comments.json
+++ b/ghost/i18n/locales/pt-BR/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Pai/Mãe em tempo integral",
     "Head of Marketing at Acme, Inc": "Chefe de Marketing na Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Esconder",
     "Hide comment": "Esconder comentário",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/pt/comments.json
+++ b/ghost/i18n/locales/pt/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Pai a tempo inteiro",
     "Head of Marketing at Acme, Inc": "Responsável do Marketing @ Amce, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Esconder",
     "Hide comment": "Esconder comentário",
     "Jamie Larson": "Jane Doe",

--- a/ghost/i18n/locales/ro/comments.json
+++ b/ghost/i18n/locales/ro/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Părinte cu normă întreagă",
     "Head of Marketing at Acme, Inc": "Șef de Marketing la Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Ascunde",
     "Hide comment": "Ascunde comentariul",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/ru/comments.json
+++ b/ghost/i18n/locales/ru/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Родитель, работающий полный рабочий день",
     "Head of Marketing at Acme, Inc": "Руководитель отдела маркетинга в Корпорации «Акме»",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Скрыть",
     "Hide comment": "Скрыть комментарий",
     "Jamie Larson": "Павел Бид",

--- a/ghost/i18n/locales/si/comments.json
+++ b/ghost/i18n/locales/si/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "පූර්ණ කාලීන භාරකරුව\u200bන්",
     "Head of Marketing at Acme, Inc": "Acme, Inc හි අලෙවි ප්\u200dරධානී",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "සඟවන්න",
     "Hide comment": "අදහස සඟවන්න",
     "Jamie Larson": "ජේමි ලාර්සන්",

--- a/ghost/i18n/locales/sk/comments.json
+++ b/ghost/i18n/locales/sk/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Rodič na plný úväzok",
     "Head of Marketing at Acme, Inc": "Vedúci marketingu v spoločnosti Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Skryť",
     "Hide comment": "Skryť komentár",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/sl/comments.json
+++ b/ghost/i18n/locales/sl/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/sq/comments.json
+++ b/ghost/i18n/locales/sq/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/sr-Cyrl/comments.json
+++ b/ghost/i18n/locales/sr-Cyrl/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Родитељ пуним радним временом",
     "Head of Marketing at Acme, Inc": "Шеф маркетинга у Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Сакриј",
     "Hide comment": "Сакриј коментар",
     "Jamie Larson": "Џејми Ларсон",

--- a/ghost/i18n/locales/sr/comments.json
+++ b/ghost/i18n/locales/sr/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/sv/comments.json
+++ b/ghost/i18n/locales/sv/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Hemmaförälder",
     "Head of Marketing at Acme, Inc": "Marknadsföringschef på Företaget AB",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Dölj",
     "Hide comment": "Dölj kommentar",
     "Jamie Larson": "Anders Andersson",

--- a/ghost/i18n/locales/sw/comments.json
+++ b/ghost/i18n/locales/sw/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Mzazi wa muda wote",
     "Head of Marketing at Acme, Inc": "Mkuu wa Masoko katika Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Ficha",
     "Hide comment": "Ficha maoni",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/ta/comments.json
+++ b/ghost/i18n/locales/ta/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "முழுநேர பெற்றோர்",
     "Head of Marketing at Acme, Inc": "Acme Inc நிறுவனத்தின் சந்தைப்படுத்தல் தலைவர்",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "மறைக்கவும்",
     "Hide comment": "கருத்தை மறை",
     "Jamie Larson": "ஜேமி லார்சன்",

--- a/ghost/i18n/locales/th/comments.json
+++ b/ghost/i18n/locales/th/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "ผู้ปกครองเต็มเวลา",
     "Head of Marketing at Acme, Inc": "หัวหน้าฝ่ายการตลาด ณ Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "ซ่อน",
     "Hide comment": "ซ่อนข้อความ",
     "Jamie Larson": "กนกพัฒน์ สัณห์ฤทัย",

--- a/ghost/i18n/locales/tr/comments.json
+++ b/ghost/i18n/locales/tr/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Tam zamanlı ebeveyn",
     "Head of Marketing at Acme, Inc": "Firma, Ünvan'da Pazarlama Müdürü",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Gizle",
     "Hide comment": "Yorumu gizle",
     "Jamie Larson": "Ad Soyad",

--- a/ghost/i18n/locales/uk/comments.json
+++ b/ghost/i18n/locales/uk/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Виховую дітей",
     "Head of Marketing at Acme, Inc": "Голова продажів в Acme, Inc",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "Сховати",
     "Hide comment": "Сховати коментар",
     "Jamie Larson": "Ваше імʼя",

--- a/ghost/i18n/locales/ur/comments.json
+++ b/ghost/i18n/locales/ur/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "پورے وقت کا والد یا والدہ",
     "Head of Marketing at Acme, Inc": "Acme، Inc کے مارکیٹنگ کا سربراہ",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "چھپائیں",
     "Hide comment": "تبادلہ چھپائیں",
     "Jamie Larson": "جیمی لارسن",

--- a/ghost/i18n/locales/uz/comments.json
+++ b/ghost/i18n/locales/uz/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "",
     "Head of Marketing at Acme, Inc": "",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "",
     "Hide comment": "",
     "Jamie Larson": "",

--- a/ghost/i18n/locales/vi/comments.json
+++ b/ghost/i18n/locales/vi/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "Phụ huynh toàn thời gian",
     "Head of Marketing at Acme, Inc": "Trưởng phòng Marketing tại Acme, Inc",
     "Hidden for members": "Ẩn với thành viên",
+    "hidden/removed": "",
     "Hide": "Ẩn",
     "Hide comment": "Ẩn bình luận",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/zh-Hant/comments.json
+++ b/ghost/i18n/locales/zh-Hant/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "全職父母",
     "Head of Marketing at Acme, Inc": "Acme, Inc市場部負責人",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "隱藏",
     "Hide comment": "隱藏留言",
     "Jamie Larson": "Jamie Larson",

--- a/ghost/i18n/locales/zh/comments.json
+++ b/ghost/i18n/locales/zh/comments.json
@@ -30,6 +30,7 @@
     "Full-time parent": "全职父母",
     "Head of Marketing at Acme, Inc": "Acme, Inc市场部负责人",
     "Hidden for members": "",
+    "hidden/removed": "",
     "Hide": "隐藏",
     "Hide comment": "隐藏评论",
     "Jamie Larson": "Jamie Larson",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PLG-263/

When hiding a reply as an Admin, if there were other replies that referenced it then those snippets would still show the hidden content because there was no immediate update in the comments-ui client. This made it look like hidden content would still be visible even though at the API level snippets were entirely removed so no other user would see it.

- added client-side handling so in-reply-to snippets immediately show `[hidden/removed]` which means we don't have to fetch every reply from the API
- updated the API to use `[hidden/removed]` as the snippet when referencing a hidden reply instead of removing all `in_reply_to_` data
  - keeping `in_reply_to_id` and `in_reply_to_snippet` means comments-ui still displays the replied-to reference text (albeit not directly showing the API-supplied string so `[hidden/removed]` can be translated)
  - returns the full `in_reply_to_snippet` text for Admin API requests so that showing a comment that has been loaded from the API can immediately show the contents for any displayed references to the comment
