### PR TITLE
Extracted duplicate comments test dbFns to shared test util

### DIFF
--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -4,67 +4,7 @@ const {
     fixtureManager,
     mockManager
 } = require('../../utils/e2e-framework');
-const models = require('../../../core/server/models');
-let postId;
-const dbFns = {
-    /**
-     * @typedef {Object} AddCommentData
-     * @property {string} [post_id=post_id]
-     * @property {string} member_id
-     * @property {string} [parent_id]
-     * @property {string} [html='This is a comment']
-     * @property {string} [status='published']
-     * @property {date} [created_at]
-     */
-    /**
-     * @typedef {Object} AddCommentReplyData
-     * @property {string} member_id
-     * @property {string} [html='This is a reply']
-     * @property {date} [created_at]
-     */
-    /**
-     * @typedef {AddCommentData & {replies: AddCommentReplyData[]}} AddCommentWithRepliesData
-     */
-
-    /**
-     * @param {AddCommentData} data
-     * @returns {Promise<any>}
-     */
-    addComment: async (data) => {
-        return await models.Comment.add({
-            post_id: data.post_id || postId,
-            member_id: data.member_id,
-            parent_id: data.parent_id,
-            html: data.html || '<p>This is a comment</p>',
-            created_at: data.created_at,
-            status: data.status || 'published'
-        });
-    },
-    /**
-     * @param {AddCommentWithRepliesData}  data
-     * @returns {Promise<any>}
-     */
-    addCommentWithReplies: async (data) => {
-        const {replies, ...commentData} = data;
-
-        const parent = await dbFns.addComment(commentData);
-        const createdReplies = [];
-
-        for (const reply of replies) {
-            const createdReply = await dbFns.addComment({
-                post_id: parent.get('post_id'),
-                member_id: reply.member_id,
-                parent_id: parent.get('id'),
-                html: reply.html || '<p>This is a reply</p>',
-                status: reply.status || 'published',
-                created_at: reply.created_at || new Date()
-            });
-            createdReplies.push(createdReply);
-        }
-
-        return {parent, replies: createdReplies};
-    }
-};
+const dbFns = require('../../utils/db-fns/comments');
 
 describe('Admin Comments API', function () {
     let adminApi;

--- a/ghost/core/test/utils/db-fns/comments.js
+++ b/ghost/core/test/utils/db-fns/comments.js
@@ -1,0 +1,89 @@
+const models = require('../../../core/server/models');
+
+const dbFns = {
+    /**
+    * @typedef {Object} AddCommentData
+    * @property {string} post_id
+    * @property {string} member_id
+    * @property {string} [parent_id]
+    * @property {string} [in_reply_to_id]
+    * @property {string} [html='This is a comment']
+    * @property {string} [status]
+    * @property {Date} [created_at]
+    */
+    /**
+    * @typedef {Object} AddCommentReplyData
+    * @property {string} member_id
+    * @property {string} [html='This is a reply']
+    * @property {Date} [created_at]
+    * @property {string} [status]
+    */
+    /**
+    * @typedef {AddCommentData & {replies: AddCommentReplyData[]}} AddCommentWithRepliesData
+    */
+
+    /**
+    * @param {AddCommentData} data
+    * @returns {Promise<any>}
+    */
+    addComment: async (data) => {
+        return await models.Comment.add({
+            post_id: data.post_id,
+            member_id: data.member_id,
+            parent_id: data.parent_id,
+            html: data.html || '<p>This is a comment</p>',
+            created_at: data.created_at,
+            in_reply_to_id: data.in_reply_to_id,
+            status: data.status || 'published'
+        });
+    },
+    /**
+    * @param {AddCommentWithRepliesData}  data
+    * @returns {Promise<any>}
+    */
+    addCommentWithReplies: async (data) => {
+        const {replies, ...commentData} = data;
+
+        const parent = await dbFns.addComment(commentData);
+        const createdReplies = [];
+
+        for (const reply of replies) {
+            const createdReply = await dbFns.addComment({
+                post_id: parent.get('post_id'),
+                member_id: reply.member_id,
+                parent_id: parent.get('id'),
+                html: reply.html || '<p>This is a reply</p>',
+                status: reply.status
+            });
+            createdReplies.push(createdReply);
+        }
+
+        return {parent, replies: createdReplies};
+    },
+    /**
+    * @param {Object} data
+    * @param {string} data.comment_id
+    * @param {string} data.member_id
+    * @returns {Promise<any>}
+    */
+    addLike: async (data) => {
+        return await models.CommentLike.add({
+            comment_id: data.comment_id,
+            member_id: data.member_id
+        });
+    },
+    /**
+    * @param {Object} data
+    * @param {string} data.comment_id
+    * @param {string} data.member_id
+    * @returns {Promise<any>}
+    */
+    addReport: async (data) => {
+        return await models.CommentReport.add({
+            comment_id: data.comment_id,
+            member_id: data.member_id
+        });
+    }
+};
+
+module.exports = dbFns;


### PR DESCRIPTION
no issue

- we have a `dbFns` object in our e2e test files to facilitate setup for each test
- we have two different APIs that work with comments and so we have two separate tests with the same `dbFns`
- extracted the functions object to a new test utils directory so they can be shared across any test that requires comments db setup and allows the utils to be updated in a single place
