### PR TITLE
Fixed comments APIs incorrectly returning hidden/deleted replies

### DIFF
--- a/ghost/core/core/server/services/comments/CommentsService.js
+++ b/ghost/core/core/server/services/comments/CommentsService.js
@@ -2,7 +2,6 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const {MemberCommentEvent} = require('@tryghost/member-events');
 const DomainEvents = require('@tryghost/domain-events');
-const labs = require('../../../shared/labs');
 
 const messages = {
     commentNotFound: 'Comment could not be found',
@@ -209,28 +208,6 @@ class CommentsService {
             });
         }
 
-        if (labs.isSet('commentImprovements')) {
-            const replies = model.related('replies'); // Get the loaded replies relation
-            await replies.fetch({withRelated: ['member', 'count.likes']}); // Fetch all replies
-
-            if (replies && replies.length > 0) {
-                // Filter out deleted replies for all, and hidden replies for non-admins
-                replies.remove(
-                    replies.filter((reply) => {
-                        const status = reply.get('status');
-                        if (status === 'deleted') {
-                            return true;
-                        } // Always remove deleted replies
-                        if (!options.isAdmin && status === 'hidden') {
-                            return true;
-                        } // Remove hidden replies for non-admins
-                        return false; // Keep others
-                    })
-                );
-            }
-        }
-
-        // this route does not need to handle pagination, so we can remove hidden/deleted replies here
         return model;
     }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Admin Comments API Hide Can hide comments 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API Hide Can hide comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "410",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API Hide Can hide comments 3: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "hidden",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API Hide Can hide comments 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "385",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API Hide Can hide replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a reply</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API Hide Can hide replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "404",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API Hide Can hide replies 3: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "hidden",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API Hide Can hide replies 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "381",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -1,6 +1,162 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Admin Comments API Hide Can hide comments 1: [body] 1`] = `
+exports[`Admin Comments API - commentImprovements off Hide Can hide comments 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "361",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide comments 3: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "hidden",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide comments 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "336",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a reply</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "355",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide replies 3: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "hidden",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API - commentImprovements off Hide Can hide replies 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "332",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Admin Comments API - commentImprovements on Hide Can hide comments 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -29,7 +185,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide comments 2: [headers] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide comments 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -41,7 +197,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide comments 3: [body] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide comments 3: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -70,7 +226,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide comments 4: [headers] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide comments 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -82,7 +238,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide replies 1: [body] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide replies 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -111,7 +267,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide replies 2: [headers] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide replies 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -123,7 +279,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide replies 3: [body] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide replies 3: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -152,7 +308,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Hide Can hide replies 4: [headers] 1`] = `
+exports[`Admin Comments API - commentImprovements on Hide Can hide replies 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -6,7 +6,7 @@ const {
     dbUtils,
     matchers
 } = require('../../utils/e2e-framework');
-const {nullable, anyEtag, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean} = matchers;
+const {anyEtag, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean} = matchers;
 const models = require('../../../core/server/models');
 
 const membersCommentMatcher = {
@@ -20,19 +20,6 @@ const membersCommentMatcher = {
         likes: anyNumber
     },
     liked: anyBoolean
-};
-
-const membersLabsCommentMatcher = {
-    ...membersCommentMatcher,
-    in_reply_to_id: nullable(anyObjectId)
-};
-
-const adminCommentMatcher = {
-    ...membersCommentMatcher
-};
-
-const adminLabsCommentMatcher = {
-    ...membersLabsCommentMatcher
 };
 
 let postId;
@@ -110,553 +97,592 @@ async function getMemberComments(url, commentsMatcher = [membersCommentMatcher])
         });
 }
 
-describe('Admin Comments API', function () {
-    before(async function () {
-        const agents = await agentProvider.getAgentsForMembers();
-        adminApi = agents.adminAgent;
-        membersApi = agents.membersAgent;
+[true, false].forEach((enableCommentImprovements) => {
+    describe(`Admin Comments API - commentImprovements ${enableCommentImprovements ? 'on' : 'off'}`, function () {
+        before(async function () {
+            const agents = await agentProvider.getAgentsForMembers();
+            adminApi = agents.adminAgent;
+            membersApi = agents.membersAgent;
 
-        await fixtureManager.init('users', 'posts', 'members', 'comments');
+            await fixtureManager.init('users', 'posts', 'members', 'comments');
 
-        await adminApi.loginAsOwner();
+            await adminApi.loginAsOwner();
 
-        mockManager.mockSetting('comments_enabled', 'all');
-        postId = fixtureManager.get('posts', 1).id;
-    });
-
-    beforeEach(async function () {
-        // ensure we don't have data dependencies across tests
-        await dbUtils.truncate('comments');
-        await dbUtils.truncate('comment_likes');
-        await dbUtils.truncate('comment_reports');
-    });
-
-    after(function () {
-        mockManager.restore();
-    });
-
-    describe('Hide', function () {
-        it('Can hide comments', async function () {
-            const commentToHide = await dbFns.addComment({member_id: fixtureManager.get('members', 0).id});
-
-            const {body: {comments: [initialState]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
-
-            assert.equal(initialState.status, 'published');
-
-            const res = await adminApi.put(`comments/${commentToHide.id}/`).body({
-                comments: [{
-                    id: commentToHide.id,
-                    status: 'hidden'
-                }]
-            });
-
-            assert.equal(res.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/`);
-
-            const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
-
-            assert.equal(afterHiding.status, 'hidden');
+            mockManager.mockSetting('comments_enabled', 'all');
+            postId = fixtureManager.get('posts', 1).id;
         });
 
-        it('Can hide replies', async function () {
-            const {parent, replies: [commentToHide]} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id
-                }]
-            });
+        beforeEach(async function () {
+            // ensure we don't have data dependencies across tests
+            await dbUtils.truncate('comments');
+            await dbUtils.truncate('comment_likes');
+            await dbUtils.truncate('comment_reports');
 
-            const {body: {comments: [initialState]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
-
-            assert.equal(initialState.status, 'published');
-
-            const res = await adminApi.put(`comments/${commentToHide.id}/`).body({
-                comments: [{
-                    id: commentToHide.id,
-                    status: 'hidden'
-                }]
-            });
-
-            assert.equal(
-                res.headers['x-cache-invalidate'],
-                `/api/members/comments/post/${postId}/, /api/members/comments/${parent.id}/replies/`
-            );
-
-            const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
-
-            assert.equal(afterHiding.status, 'hidden');
-        });
-    });
-
-    describe('browse', function () {
-        it('can browse comments as an admin', async function () {
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published'
-            });
-
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 2',
-                status: 'published'
-            });
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            assert.equal(res.body.comments.length, 2);
-        });
-
-        it('returns hidden comments (with html)', async function () {
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'hidden'
-            });
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-
-            const hiddenComment = res.body.comments[0];
-            assert.equal(hiddenComment.html, 'Comment 1');
-        });
-
-        it('returns hidden replies (with html)', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'hidden'
-                }]
-            });
-
-            const res = await adminApi.get(`/comments/${parent.id}/`);
-
-            const hiddenReply = res.body.comments[0].replies[0];
-            assert.equal(hiddenReply.html, '<p>This is a reply</p>');
-        });
-
-        it('does not return deleted comments', async function () {
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'deleted'
-            });
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 2',
-                status: 'hidden'
-            });
-
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            // check that there is no deleted comments by looping through the returned comments
-            for (const comment of res.body.comments) {
-                assert.notEqual(comment.status, 'deleted');
+            if (!enableCommentImprovements) {
+                mockManager.mockLabsDisabled('commentImprovements');
             }
         });
 
-        it('does not return deleted replies', async function () {
-            await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'deleted'
-                }]
-            });
-
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-
-            res.body.comments[0].replies.should.have.length(0);
+        after(function () {
+            mockManager.restore();
         });
 
-        it('returns deleted comments if they have published replies', async function () {
-            await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'deleted',
-                replies: [{
+        describe('Hide', function () {
+            it('Can hide comments', async function () {
+                const commentToHide = await dbFns.addComment({member_id: fixtureManager.get('members', 0).id});
+
+                const {body: {comments: [initialState]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
+
+                assert.equal(initialState.status, 'published');
+
+                const res = await adminApi.put(`comments/${commentToHide.id}/`).body({
+                    comments: [{
+                        id: commentToHide.id,
+                        status: 'hidden'
+                    }]
+                });
+
+                assert.equal(res.headers['x-cache-invalidate'], `/api/members/comments/post/${postId}/`);
+
+                const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
+
+                assert.equal(afterHiding.status, 'hidden');
+            });
+
+            it('Can hide replies', async function () {
+                const {parent, replies: [commentToHide]} = await dbFns.addCommentWithReplies({
                     member_id: fixtureManager.get('members', 0).id,
-                    html: 'Reply 1',
-                    status: 'published'
-                }]
-            });
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id
+                    }]
+                });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
+                const {body: {comments: [initialState]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
 
-            const deletedComment = res.body.comments[0];
-            assert.equal(deletedComment.html, 'Comment 1');
+                assert.equal(initialState.status, 'published');
 
-            const publishedReply = res.body.comments[0].replies[0];
-            assert.equal(publishedReply.html, 'Reply 1');
-        });
-
-        it('does not return deleted comments without replies', async function () {
-            await dbFns.addComment({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'deleted'
-            });
-
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            assert.equal(res.body.comments.length, 0);
-        });
-
-        it('returns hidden comments and hidden replies', async function () {
-            await dbFns.addCommentWithReplies({
-                status: 'hidden',
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'hidden'
-                }]
-            });
-
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-
-            const hiddenComment = res.body.comments[0];
-            assert.equal(hiddenComment.status, 'hidden');
-
-            const hiddenReply = res.body.comments[0].replies[0];
-            assert.equal(hiddenReply.status, 'hidden');
-        });
-
-        it('includes hidden replies but not deleted replies in count', async function () {
-            await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                replies: [
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 1',
+                const res = await adminApi.put(`comments/${commentToHide.id}/`).body({
+                    comments: [{
+                        id: commentToHide.id,
                         status: 'hidden'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 2',
-                        status: 'deleted'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 3',
-                        status: 'published'
-                    }
-                ]
-            });
+                    }]
+                });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const comment = res.body.comments[0];
-            assert.equal(comment.count.replies, 2);
+                assert.equal(
+                    res.headers['x-cache-invalidate'],
+                    `/api/members/comments/post/${postId}/, /api/members/comments/${parent.id}/replies/`
+                );
+
+                const {body: {comments: [afterHiding]}} = await getMemberComments(`/api/comments/${commentToHide.id}/`);
+
+                assert.equal(afterHiding.status, 'hidden');
+            });
         });
 
-        it('can load additional replies as an admin', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                replies: [
-                    {
+        describe('browse', function () {
+            it('returns comments', async function () {
+                await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published'
+                });
+
+                await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 2',
+                    status: 'published'
+                });
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+                assert.equal(res.body.comments.length, 2);
+            });
+
+            it('returns hidden comments (with html)', async function () {
+                await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'hidden'
+                });
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+
+                const hiddenComment = res.body.comments[0];
+                assert.equal(hiddenComment.html, 'Comment 1');
+            });
+
+            it('returns hidden replies (with html)', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id,
+                        status: 'hidden'
+                    }]
+                });
+
+                const res = await adminApi.get(`/comments/${parent.id}/`);
+
+                const hiddenReply = res.body.comments[0].replies[0];
+                assert.equal(hiddenReply.html, '<p>This is a reply</p>');
+            });
+
+            it('returns hidden comments and hidden replies', async function () {
+                await dbFns.addCommentWithReplies({
+                    status: 'hidden',
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id,
+                        status: 'hidden'
+                    }]
+                });
+
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+
+                const hiddenComment = res.body.comments[0];
+                assert.equal(hiddenComment.status, 'hidden');
+
+                const hiddenReply = res.body.comments[0].replies[0];
+                assert.equal(hiddenReply.status, 'hidden');
+            });
+
+            it('can load additional replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published',
+                    replies: [{
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 1',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 2',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 3',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 4',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 5',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 6',
                         status: 'published'
-                    }
-                ]
+                    }]
+                });
+
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+                const item = res.body.comments.find(cmt => parent.id === cmt.id);
+                const lastReply = item.replies[item.replies.length - 1];
+                const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+                const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+                assert.equal(res2.body.comments.length, 3);
             });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const item = res.body.comments.find(cmt => parent.id === cmt.id);
-            const lastReply = item.replies[item.replies.length - 1];
-            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
-            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
-            assert.equal(res2.body.comments.length, 3);
-        });
-
-        it('can load additional replies and includes hidden replies as an admin', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                replies: [
-                    {
+            it('can load additional replies and includes hidden replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published',
+                    replies: [{
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 1',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 2',
                         status: 'hidden'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 3',
                         status: 'hidden'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 4',
                         status: 'hidden'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 5',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 6',
                         status: 'published'
-                    }
-                ]
+                    }]
+                });
+
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+                const item = res.body.comments.find(cmt => parent.id === cmt.id);
+                const lastReply = item.replies[item.replies.length - 1];
+                const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+                const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+                assert.equal(res2.body.comments.length, 3);
             });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const item = res.body.comments.find(cmt => parent.id === cmt.id);
-            const lastReply = item.replies[item.replies.length - 1];
-            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
-            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
-            assert.equal(res2.body.comments.length, 3);
-        });
-
-        it('does not return deleted replies as an admin', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                replies: [
-                    {
+            it('includes html string of replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published',
+                    replies: [{
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 1',
                         status: 'published'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 2',
                         status: 'hidden'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 3',
                         status: 'hidden'
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 4',
                         status: 'hidden'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 5',
-                        status: 'deleted'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 6',
-                        status: 'deleted'
-                    }
-                ]
+                    }]
+                });
+
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+                const item = res.body.comments.find(cmt => parent.id === cmt.id);
+                const lastReply = item.replies[item.replies.length - 1];
+                const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+                const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
+                assert.equal(res2.body.comments.length, 1);
+                assert.equal(res2.body.comments[0].html, 'Reply 4');
             });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const item = res.body.comments.find(cmt => parent.id === cmt.id);
-            const lastReply = item.replies[item.replies.length - 1];
-            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
-            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
-            assert.equal(res2.body.comments.length, 1);
-        });
-
-        it('includes html string of replies as an admin', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                replies: [
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 1',
+            it('Does return published replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id,
                         status: 'published'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 2',
-                        status: 'hidden'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 3',
-                        status: 'hidden'
-                    },
-                    {
-                        member_id: fixtureManager.get('members', 0).id,
-                        html: 'Reply 4',
-                        status: 'hidden'
-                    }
-                ]
+                    }, {
+                        member_id: fixtureManager.get('members', 2).id,
+                        status: 'published'
+                    }, {
+                        member_id: fixtureManager.get('members', 3).id,
+                        status: 'published'
+                    }]
+                });
+
+                const res = await adminApi.get(`/comments/${parent.get('id')}/`);
+                res.body.comments[0].replies.length.should.eql(3);
+                res.body.comments[0].replies[0].member.should.be.an.Object().with.properties('id', 'uuid', 'name', 'avatar_image');
+                res.body.comments[0].replies[0].should.be.an.Object().with.properties('id', 'html', 'status', 'created_at', 'member', 'count');
             });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const item = res.body.comments.find(cmt => parent.id === cmt.id);
-            const lastReply = item.replies[item.replies.length - 1];
-            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
-            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=5&filter=${filter}`);
-            assert.equal(res2.body.comments.length, 1);
-            assert.equal(res2.body.comments[0].html, 'Reply 4');
-        });
-
-        it('includes in_reply_to references to hidden comments', async function () {
-        });
-
-        it('Does not return deleted replies', async function () {
-            await mockManager.mockLabsEnabled('commentImprovements');
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'hidden'
-                }, {
-                    member_id: fixtureManager.get('members', 2).id,
-                    status: 'deleted'
-                }, {
-                    member_id: fixtureManager.get('members', 3).id,
-                    status: 'hidden'
-                }, {
-                    member_id: fixtureManager.get('members', 4).id,
-                    status: 'published'
-                }]
-            });
-
-            const res = await adminApi.get(`/comments/${parent.get('id')}/`);
-            res.body.comments[0].replies.length.should.eql(3);
-
-            res.body.comments[0].replies[0].member.should.be.an.Object().with.properties('id', 'uuid', 'name', 'avatar_image');
-
-            res.body.comments[0].replies[0].should.be.an.Object().with.properties('id', 'html', 'status', 'created_at', 'member', 'count');
-        });
-
-        it('Does return published replies', async function () {
-            await mockManager.mockLabsEnabled('commentImprovements');
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'published'
-                }, {
-                    member_id: fixtureManager.get('members', 2).id,
-                    status: 'published'
-                }, {
-                    member_id: fixtureManager.get('members', 3).id,
-                    status: 'published'
-                }]
-            });
-
-            const res = await adminApi.get(`/comments/${parent.get('id')}/`);
-            res.body.comments[0].replies.length.should.eql(3);
-            res.body.comments[0].replies[0].member.should.be.an.Object().with.properties('id', 'uuid', 'name', 'avatar_image');
-            res.body.comments[0].replies[0].should.be.an.Object().with.properties('id', 'html', 'status', 'created_at', 'member', 'count');
-        });
-
-        it('Does return published and hidden replies but not deleted', async function () {
-            await mockManager.mockLabsEnabled('commentImprovements');
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                replies: [{
-                    member_id: fixtureManager.get('members', 1).id,
-                    status: 'published'
-                }, {
-                    member_id: fixtureManager.get('members', 2).id,
-                    status: 'published'
-                }, {
-                    member_id: fixtureManager.get('members', 3).id,
-                    status: 'published'
-                }, {
-                    member_id: fixtureManager.get('members', 4).id,
-                    status: 'hidden'
-                }, {
-                    member_id: fixtureManager.get('members', 5).id,
-                    status: 'deleted'
-                }]
-            });
-            const res = await adminApi.get(`/comments/${parent.get('id')}/`);
-            res.body.comments[0].replies.length.should.eql(4);
-            res.body.comments[0].replies[0].member.should.be.an.Object().with.properties('id', 'uuid', 'name', 'avatar_image');
-            res.body.comments[0].replies[0].should.be.an.Object().with.properties('id', 'html', 'status', 'created_at', 'member', 'count');
-        });
-
-        it('ensure replies are always ordered from oldest to newest', async function () {
-            const {parent} = await dbFns.addCommentWithReplies({
-                member_id: fixtureManager.get('members', 0).id,
-                html: 'Comment 1',
-                status: 'published',
-                created_at: new Date('2021-01-01'),
-                replies: [
-                    {
+            it('ensure replies are always ordered from oldest to newest', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published',
+                    created_at: new Date('2021-01-01'),
+                    replies: [{
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 1',
                         status: 'published',
                         created_at: new Date('2022-01-01')
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 2',
                         status: 'published',
                         created_at: new Date('2022-01-02')
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 3',
                         status: 'hidden',
                         created_at: new Date('2022-01-03')
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 4',
                         status: 'hidden',
                         created_at: new Date('2022-01-04')
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 5',
                         status: 'published',
                         created_at: new Date('2022-01-05')
-                    },
-                    {
+                    }, {
                         member_id: fixtureManager.get('members', 0).id,
                         html: 'Reply 6',
                         status: 'published',
                         created_at: new Date('2022-01-06')
-                    }
-                ]
+                    }]
+                });
+
+                const res = await adminApi.get('/comments/post/' + postId + '/');
+                const item = res.body.comments.find(cmt => parent.id === cmt.id);
+                const lastReply = item.replies[item.replies.length - 1];
+                const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
+                const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=10&filter=${filter}`);
+                assert.equal(res2.body.comments.length, 3);
+                assert.equal(res2.body.comments[0].html, 'Reply 4');
+                assert.equal(res2.body.comments[1].html, 'Reply 5');
+                assert.equal(res2.body.comments[2].html, 'Reply 6');
             });
 
-            const res = await adminApi.get('/comments/post/' + postId + '/');
-            const item = res.body.comments.find(cmt => parent.id === cmt.id);
-            const lastReply = item.replies[item.replies.length - 1];
-            const filter = encodeURIComponent(`id:>'${lastReply.id}'`);
-            const res2 = await adminApi.get(`/comments/${parent.id}/replies?limit=10&filter=${filter}`);
-            assert.equal(res2.body.comments.length, 3);
-            assert.equal(res2.body.comments[0].html, 'Reply 4');
-            assert.equal(res2.body.comments[1].html, 'Reply 5');
-            assert.equal(res2.body.comments[2].html, 'Reply 6');
+            if (enableCommentImprovements) {
+                it('does not return deleted comments', async function () {
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'deleted'
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    assert.equal(res.body.comments.length, 0);
+                });
+
+                it('returns deleted comments if they have published replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'deleted',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 1',
+                            status: 'published'
+                        }]
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+
+                    const deletedComment = res.body.comments[0];
+                    assert.equal(deletedComment.html, 'Comment 1');
+
+                    const publishedReply = res.body.comments[0].replies[0];
+                    assert.equal(publishedReply.html, 'Reply 1');
+                });
+
+                it('does not return deleted comments with only deleted replies', async function () {
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'deleted'
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    assert.equal(res.body.comments.length, 0);
+                });
+            } else {
+                it('returns deleted comments', async function () {
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'deleted'
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    assert.equal(res.body.comments.length, 1);
+                });
+            }
+
+            if (enableCommentImprovements) {
+                it('does not return deleted replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'published',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 1',
+                            status: 'deleted'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 2',
+                            status: 'hidden'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 3',
+                            status: 'published'
+                        }]
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    const comment = res.body.comments[0];
+                    assert.equal(comment.replies.length, 2);
+                    assert.notEqual(comment.replies[0].status, 'deleted');
+                    assert.notEqual(comment.replies[1].status, 'deleted');
+                });
+            } else {
+                it('returns deleted replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'published',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 1',
+                            status: 'published'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 2',
+                            status: 'deleted'
+                        }]
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    const comment = res.body.comments[0];
+                    assert.equal(comment.replies.length, 2);
+                });
+            }
+
+            // These tests check changes that only occur
+            // with the commentImprovements flag enabled
+            // - Ensure the opposite behaviour is tested as well
+            if (enableCommentImprovements) {
+                it('includes hidden replies but not deleted replies in count', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'published',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 1',
+                            status: 'hidden'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 2',
+                            status: 'deleted'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 3',
+                            status: 'published'
+                        }]
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    const comment = res.body.comments[0];
+                    assert.equal(comment.count.replies, 2);
+                });
+            } else {
+                it('includes all replies in count', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        html: 'Comment 1',
+                        status: 'published',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 1',
+                            status: 'hidden'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 2',
+                            status: 'deleted'
+                        }, {
+                            member_id: fixtureManager.get('members', 0).id,
+                            html: 'Reply 3',
+                            status: 'published'
+                        }]
+                    });
+
+                    const res = await adminApi.get('/comments/post/' + postId + '/');
+                    const comment = res.body.comments[0];
+                    assert.equal(comment.count.replies, 3);
+                });
+            }
+        });
+
+        describe('get by id', function () {
+            it('can get a published comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'published'
+                });
+
+                const res = await adminApi.get(`/comments/${comment.id}/`);
+                assert.equal(res.body.comments[0].html, 'Comment 1');
+            });
+
+            it('can get a hidden comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'hidden'
+                });
+
+                const res = await adminApi.get(`/comments/${comment.id}/`);
+                assert.equal(res.body.comments[0].html, 'Comment 1');
+            });
+
+            // TODO: Should this be possible?
+            it('can get a deleted comment', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 0).id,
+                    html: 'Comment 1',
+                    status: 'deleted'
+                });
+
+                const res = await adminApi.get(`/comments/${comment.id}/`);
+                assert.equal(res.body.comments[0].html, 'Comment 1');
+            });
+
+            it('includes published replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id,
+                        html: 'Reply 1',
+                        status: 'published'
+                    }]
+                });
+
+                const res = await adminApi.get(`/comments/${parent.id}/`);
+                const reply = res.body.comments[0].replies[0];
+                assert.equal(reply.html, 'Reply 1');
+            });
+
+            it('includes hidden replies', async function () {
+                const {parent} = await dbFns.addCommentWithReplies({
+                    member_id: fixtureManager.get('members', 0).id,
+                    replies: [{
+                        member_id: fixtureManager.get('members', 1).id,
+                        html: 'Reply 1',
+                        status: 'hidden'
+                    }]
+                });
+
+                const res = await adminApi.get(`/comments/${parent.id}/`);
+                const reply = res.body.comments[0].replies[0];
+                assert.equal(reply.html, 'Reply 1');
+            });
+
+            if (enableCommentImprovements) {
+                it('does not include deleted replies', async function () {
+                    const {parent} = await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            html: 'Reply 1',
+                            status: 'deleted'
+                        }]
+                    });
+
+                    const res = await adminApi.get(`/comments/${parent.id}/`);
+                    assert.equal(res.body.comments[0].replies.length, 0);
+                });
+            } else {
+                it('includes deleted replies', async function () {
+                    const {parent} = await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            html: 'Reply 1',
+                            status: 'deleted'
+                        }]
+                    });
+
+                    const res = await adminApi.get(`/comments/${parent.id}/`);
+                    const reply = res.body.comments[0].replies[0];
+                    assert.equal(reply.html, 'Reply 1');
+                });
+            }
         });
     });
 });

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1856,6 +1856,88 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for deleted comments 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for deleted comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "406",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for hidden comments 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": Nullable<StringMatching>,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for hidden comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "406",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1379,7 +1379,119 @@ Object {
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated hidden and deleted replies are not included in the count 1: [body] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted comments 1: [body] 1`] = `
+Object {
+  "comments": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted comments if all replies are hidden or deleted 1: [body] 1`] = `
+Object {
+  "comments": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted comments if all replies are hidden or deleted 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden comments 1: [body] 1`] = `
+Object {
+  "comments": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden comments 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden comments if all replies are hidden or deleted 1: [body] 1`] = `
+Object {
+  "comments": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden comments if all replies are hidden or deleted 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled includes deleted comments if they have published replies 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -1389,7 +1501,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "<p>This is a comment</p>",
+      "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": null,
       "in_reply_to_snippet": null,
@@ -1422,26 +1534,58 @@ Object {
           },
           "status": "published",
         },
-        Object {
-          "count": Object {
-            "likes": Any<Number>,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "<p>This is a reply</p>",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": Any<Boolean>,
-          "member": Object {
-            "avatar_image": null,
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": null,
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "status": "published",
-        },
+      ],
+      "status": "deleted",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled includes deleted comments if they have published replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "838",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled includes hidden comments if they have published replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [
         Object {
           "count": Object {
             "likes": Any<Number>,
@@ -1463,17 +1607,27 @@ Object {
           "status": "published",
         },
       ],
-      "status": "published",
+      "status": "hidden",
     },
   ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated hidden and deleted replies are not included in the count 2: [headers] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled includes hidden comments if they have published replies 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1504",
+  "content-length": "837",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1702,7 +1856,7 @@ Object {
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for deleted comments 1: [body] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -1715,7 +1869,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": null,
+      "in_reply_to_snippet": "[hidden/removed]",
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1731,11 +1885,11 @@ Object {
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for deleted comments 2: [headers] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "406",
+  "content-length": "442",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1743,7 +1897,7 @@ Object {
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for hidden comments 1: [body] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -1756,7 +1910,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": null,
+      "in_reply_to_snippet": "[hidden/removed]",
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -1772,11 +1926,11 @@ Object {
 }
 `;
 
-exports[`Comments API when commenting enabled for all when authenticated replies to replies does not include in_reply_to_snippet for hidden comments 2: [headers] 1`] = `
+exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "406",
+  "content-length": "442",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1379,6 +1379,78 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled doesn't count deleted or hidden comments in replies count 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [
+        Object {
+          "count": Object {
+            "likes": Any<Number>,
+          },
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "edited_at": null,
+          "html": "<p>This is a reply</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "in_reply_to_id": null,
+          "in_reply_to_snippet": null,
+          "liked": Any<Boolean>,
+          "member": Object {
+            "avatar_image": null,
+            "expertise": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "status": "published",
+        },
+      ],
+      "status": "deleted",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled doesn't count deleted or hidden comments in replies count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "838",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted comments 1: [body] 1`] = `
 Object {
   "comments": Array [],
@@ -1435,6 +1507,57 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes deleted replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "498",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden comments 1: [body] 1`] = `
 Object {
   "comments": Array [],
@@ -1484,6 +1607,57 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>This is a comment</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated browse by post when commentImprovements flag is enabled excludes hidden replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "498",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1931,88 +2105,6 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "406",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 0,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "<p>This is a comment</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": "[hidden/removed]",
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "replies": Array [],
-      "status": "published",
-    },
-  ],
-}
-`;
-
-exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is deleted 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "442",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 0,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "<p>This is a comment</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": "[hidden/removed]",
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "replies": Array [],
-      "status": "published",
-    },
-  ],
-}
-`;
-
-exports[`Comments API when commenting enabled for all when authenticated replies to replies has redacted in_reply_to_snippet when referenced comment is hidden 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "442",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -652,6 +652,155 @@ describe('Comments API', function () {
                 should.not.exist(response.body.comments[0].unsubscribe_url);
             });
 
+            describe('browse by post when commentImprovements flag is enabled', function () {
+                beforeEach(function () {
+                    mockLabsEnabled('commentImprovements');
+                });
+
+                it('excludes deleted comments', async function () {
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 2).id,
+                        status: 'deleted'
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, []);
+                    should(result.body.comments.length).eql(0);
+                    should(result.body.meta.pagination.total).eql(0);
+                });
+
+                it('includes deleted comments if they have published replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'deleted',
+                        html: 'This is a deleted comment',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'published'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 1})]);
+                    should(result.body.comments.length).eql(1);
+                    should(result.body.comments[0].html).eql(null);
+                    should(result.body.comments[0].count.replies).eql(1);
+                    should(result.body.meta.pagination.total).eql(1);
+                });
+
+                it('excludes deleted comments if all replies are hidden or deleted', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'deleted',
+                        html: 'This is a deleted comment',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'deleted'
+                        }, {
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'hidden'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, []);
+                    should(result.body.comments.length).eql(0);
+                    should(result.body.meta.pagination.total).eql(0);
+                });
+
+                it('excludes hidden comments', async function () {
+                    await dbFns.addComment({
+                        member_id: fixtureManager.get('members', 2).id,
+                        status: 'hidden'
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, []);
+                    should(result.body.comments.length).eql(0);
+                    should(result.body.meta.pagination.total).eql(0);
+                });
+
+                it('includes hidden comments if they have published replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'hidden',
+                        html: 'This is a hidden comment',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'published'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 1})]);
+                    should(result.body.comments.length).eql(1);
+                    should(result.body.comments[0].html).eql(null);
+                    should(result.body.comments[0].count.replies).eql(1);
+                    should(result.body.meta.pagination.total).eql(1);
+                });
+
+                it('excludes hidden comments if all replies are hidden or deleted', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'hidden',
+                        html: 'This is a hidden comment',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'deleted'
+                        }, {
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'hidden'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, []);
+                    should(result.body.comments.length).eql(0);
+                    should(result.body.meta.pagination.total).eql(0);
+                });
+
+                it('excludes deleted replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'deleted'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0})]);
+                    should(result.body.comments[0].replies.length).eql(0);
+                });
+
+                it('excludes hidden replies', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'hidden'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0})]);
+                    should(result.body.comments[0].replies.length).eql(0);
+                });
+
+                it('doesn\'t count deleted or hidden comments in replies count', async function () {
+                    await dbFns.addCommentWithReplies({
+                        member_id: fixtureManager.get('members', 0).id,
+                        status: 'deleted',
+                        html: 'This is a deleted comment',
+                        replies: [{
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'published'
+                        }, {
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'hidden'
+                        }, {
+                            member_id: fixtureManager.get('members', 1).id,
+                            status: 'deleted'
+                        }]
+                    });
+
+                    const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 1})]);
+                    should(result.body.comments[0].count.replies).eql(1);
+                });
+            });
+
             it('can show most liked comment first when order param = best followed by most recent', async function () {
                 await setupBrowseCommentsData();
                 await dbFns.addComment({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-270/

If the API is returning replies that are not shown in the UI then the comments-ui app isn't able to paginate correctly. This should be true across all comments endpoints with no inconsistency across browse by page or comment, or when fetching individual comments.

- expectations for public comments endpoints:
  - hidden/deleted comments are never returned unless they have published replies
  - hidden/deleted replies are never returned
- expectations for admin comments endpoints:
  - deleted comments are never returned unless they have published replies
  - deleted replies are never returned
  - hidden comments+replies are always returned (necessary to allow hidden comments to be toggled back to visible)

Fixed by:
- using bookshelf `withRelated` callback function for `replies` relation in `defaultRelations` (and again in `findPage` which uses `withRelations` to load relations individually)
- cleaned up now-unnecessary additional filtering in `CommentsService`
- added additional tests to ensure behaviour and lack of regressions