### PR TITLE
Moved `importMemberTier` to beta status

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -31,6 +31,7 @@ const BETA_FEATURES = [
     'webmentions',
     'editorExcerpt',
     'ActivityPub',
+    'importMemberTier',
     'customFonts'
 ];
 
@@ -41,7 +42,6 @@ const ALPHA_FEATURES = [
     'emailCustomization',
     'mailEvents',
     'collectionsCard',
-    'importMemberTier',
     'lexicalIndicators',
     'adminXDemo',
     'contentVisibility',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1802/move-importmembertier-to-beta

- this allows us to enable the flag without needing developer experiments enabled, which is useful for Concierge whilst we're still wanting to keep it in GA