### PR TITLE
🐛 Fixed feedback buttons' layout breaking in different languages, in newsletters

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
@@ -322,10 +322,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -782,7 +779,7 @@ exports[`Email Preview API Read can read post email preview with email card and 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24870",
+  "content-length": "24766",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1018,10 +1015,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -1500,7 +1494,7 @@ exports[`Email Preview API Read can read post email preview with fields 4: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "29650",
+  "content-length": "29546",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1767,10 +1761,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -2234,7 +2225,7 @@ exports[`Email Preview API Read has custom content transformations for email com
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24624",
+  "content-length": "24520",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2830,10 +2821,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -3311,7 +3299,7 @@ exports[`Email Preview API Read uses the newsletter provided through ?newsletter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "25407",
+  "content-length": "25303",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3933,10 +3921,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -4414,7 +4399,7 @@ exports[`Email Preview API Read uses the posts newsletter by default 4: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "25407",
+  "content-length": "25303",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
@@ -215,10 +215,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -900,10 +897,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -1561,10 +1555,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -2222,10 +2213,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -2883,10 +2871,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -3492,10 +3477,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -4153,10 +4135,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -4444,20 +4423,20 @@ table.body h2 span {
                                     <td dir=\\"ltr\\" width=\\"100%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #15212A; background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e5eff5;\\" align=\\"center\\" bgcolor=\\"#ffffff\\" valign=\\"top\\">
                                         <table class=\\"feedback-buttons\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: auto; width: 100%;\\" width=\\"100%\\">
                                             <tr>
-                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" nowrap width=\\"30%\\">
+                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" width=\\"30%\\">
                                                         <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/#/feedback/post-id/1/?uuid=member-uuid&amp;key=xxxxxx\\" target=\\"_blank\\" style=\\"color: #FF1A75; text-decoration: none; overflow-wrap: anywhere;\\">
-                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"More like this\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: inline-block; vertical-align: middle;\\">
-                                                            <p class=\\"feedback-button-text\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; display: inline; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin-bottom: 0; font-size: 13px;\\">More like this</p>
+                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"More like this\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; vertical-align: middle;\\">
+                                                            <p class=\\"feedback-button-text\\" style=\\"display: inline-block; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin: 1em 0 0 0; line-height: 1.4em; word-break: break-word; font-size: 13px;\\">More like this</p>
                                                         </a>
-                                                    </td>                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" nowrap width=\\"30%\\">
+                                                    </td>                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" width=\\"30%\\">
                                                         <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/#/feedback/post-id/0/?uuid=member-uuid&amp;key=xxxxxx\\" target=\\"_blank\\" style=\\"color: #FF1A75; text-decoration: none; overflow-wrap: anywhere;\\">
-                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Less like this\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: inline-block; vertical-align: middle;\\">
-                                                            <p class=\\"feedback-button-text\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; display: inline; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin-bottom: 0; font-size: 13px;\\">Less like this</p>
+                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Less like this\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; vertical-align: middle;\\">
+                                                            <p class=\\"feedback-button-text\\" style=\\"display: inline-block; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin: 1em 0 0 0; line-height: 1.4em; word-break: break-word; font-size: 13px;\\">Less like this</p>
                                                         </a>
-                                                    </td>                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" nowrap width=\\"30%\\">
+                                                    </td>                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" width=\\"30%\\">
                                                         <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/#ghost-comments\\" target=\\"_blank\\" style=\\"color: #FF1A75; text-decoration: none; overflow-wrap: anywhere;\\">
-                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/comment-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Comment\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: inline-block; vertical-align: middle;\\">
-                                                            <p class=\\"feedback-button-text\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; display: inline; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin-bottom: 0; font-size: 13px;\\">Comment</p>
+                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/comment-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Comment\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; vertical-align: middle;\\">
+                                                            <p class=\\"feedback-button-text\\" style=\\"display: inline-block; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin: 1em 0 0 0; line-height: 1.4em; word-break: break-word; font-size: 13px;\\">Comment</p>
                                                         </a>
                                                     </td>                                            </tr>
                                         </table>
@@ -4874,10 +4853,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -5165,10 +5141,10 @@ table.body h2 span {
                                     <td dir=\\"ltr\\" width=\\"100%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #15212A; background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e5eff5;\\" align=\\"center\\" bgcolor=\\"#ffffff\\" valign=\\"top\\">
                                         <table class=\\"feedback-buttons\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: auto; width: 100%;\\" width=\\"100%\\">
                                             <tr>
-                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" nowrap width=\\"30%\\">
+                                                    <td dir=\\"ltr\\" valign=\\"top\\" align=\\"center\\" style=\\"font-size: 18px; color: #15212A; display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;\\" width=\\"30%\\">
                                                         <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-3/#ghost-comments\\" target=\\"_blank\\" style=\\"color: #FF1A75; text-decoration: none; overflow-wrap: anywhere;\\">
-                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/comment-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Comment\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: inline-block; vertical-align: middle;\\">
-                                                            <p class=\\"feedback-button-text\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; display: inline; padding-left: 8px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin-bottom: 0; font-size: 13px;\\">Comment</p>
+                                                            <img src=\\"https://static.ghost.org/v5.0.0/images/comment-mobile.png\\" border=\\"0\\" width=\\"42\\" height=\\"42\\" alt=\\"Comment\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; vertical-align: middle;\\">
+                                                            <p class=\\"feedback-button-text\\" style=\\"display: inline-block; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; color: #15212A; font-weight: 500; margin: 1em 0 0 0; line-height: 1.4em; word-break: break-word; font-size: 13px;\\">Comment</p>
                                                         </a>
                                                     </td>                                            </tr>
                                         </table>
@@ -6931,10 +6907,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -7737,10 +7710,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -8453,10 +8423,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -9169,10 +9136,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -9885,10 +9849,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -10601,10 +10562,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -11317,10 +11275,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -11980,10 +11935,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -215,10 +215,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -876,10 +873,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -1537,10 +1531,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {
@@ -2733,10 +2724,7 @@ table.body .footer a {
   }
 
   table.body .feedback-button-text {
-    display: block !important;
-    padding-top: 4px !important;
-    padding-left: 0px !important;
-    font-size: 13px !important;
+    display: none!important;
   }
 
   table.body .latest-posts-header {

--- a/ghost/email-service/lib/email-templates/partials/feedback-button.hbs
+++ b/ghost/email-service/lib/email-templates/partials/feedback-button.hbs
@@ -1,7 +1,6 @@
-<td dir="ltr" valign="top" align="center" style="display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;" nowrap>
+<td dir="ltr" valign="top" align="center" style="display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;">
     <a href="{{href}}" target="_blank">
         <img src={{iconUrl}} border="0" width={{width}} height={{height}} alt="{{buttonText}}">
         <p class="feedback-button-text">{{t buttonText}}</p>
-        {{!-- Button text possible values:  {{t 'More like this'}} {{t 'Less like this'}} {{t 'Comment'}} --}}
     </a>
 </td>

--- a/ghost/email-service/lib/email-templates/partials/feedback-button.hbs
+++ b/ghost/email-service/lib/email-templates/partials/feedback-button.hbs
@@ -2,5 +2,6 @@
     <a href="{{href}}" target="_blank">
         <img src={{iconUrl}} border="0" width={{width}} height={{height}} alt="{{buttonText}}">
         <p class="feedback-button-text">{{t buttonText}}</p>
+        {{!-- Button text possible values:  {{t 'More like this'}} {{t 'Less like this'}} {{t 'Comment'}} --}}
     </a>
 </td>

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -523,6 +523,7 @@ figure blockquote p {
     font-weight: 500;
     margin: 1em 0 0 0; 
     line-height: 1.4em;
+    word-break: break-word;
 }
 
 /* -------------------------------------

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -510,18 +510,19 @@ figure blockquote p {
 }
 
 .feedback-buttons img {
-    display: inline-block;
+    display: block;
+    margin: 0 auto;
     vertical-align: middle;
 }
 
 .feedback-button-text {
-    display: inline;
-    padding-left: 8px;
+    display: inline-block;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     color: #15212A;
     font-size: 13px !important;
     font-weight: 500;
-    margin-bottom: 0;
+    margin: 1em 0 0 0; 
+    line-height: 1.4em;
 }
 
 /* -------------------------------------
@@ -1490,10 +1491,7 @@ a[data-flickr-embed] img {
     }
 
     table.body .feedback-button-text {
-        display: block !important;
-        padding-top: 4px !important;
-        padding-left: 0px !important;
-        font-size: 13px !important;
+        display: none!important;
     }
 
     table.body .latest-posts-header {

--- a/ghost/i18n/locales/nl/newsletter.json
+++ b/ghost/i18n/locales/nl/newsletter.json
@@ -1,6 +1,6 @@
 {
     "By {authors}": "Door {authors}",
-    "Comment": "Reageren",
+    "Comment": "Opmerking",
     "complimentary": "gratis",
     "Email": "E-mail",
     "free": "gratis",

--- a/ghost/i18n/locales/nl/newsletter.json
+++ b/ghost/i18n/locales/nl/newsletter.json
@@ -1,6 +1,6 @@
 {
     "By {authors}": "Door {authors}",
-    "Comment": "Opmerking",
+    "Comment": "Reageren",
     "complimentary": "gratis",
     "Email": "E-mail",
     "free": "gratis",


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-974/feedback-and-comment-icons-when-translated-cause-overlapping-in-email

- Since we added i18n, the feedback/comment button layout would break in languages where the text is longer. 
- We've revised the button layout to be centred. On smaller (mobile) resolutions, we hide the labels and rely solely on the icons.

**Before**
<img width="679" alt="french-before" src="https://github.com/user-attachments/assets/e3de40a2-7a0a-4317-8ab8-03e285eb9f8a">
<br /><br />


**After**
<img width="720" alt="newsletter-buttons-desktop-french" src="https://github.com/user-attachments/assets/f7fce52d-bb3b-4afd-b8fd-538a2ec9a31e"><br /><br />
<img width="462" alt="newsletter-buttons-mobile" src="https://github.com/user-attachments/assets/9e21c706-8d92-4fc2-804c-ad2aab6b6350">
