### PR TITLE
Updated Dutch translation for "Comment"-button in newsletters

### DIFF
--- a/ghost/i18n/locales/nl/newsletter.json
+++ b/ghost/i18n/locales/nl/newsletter.json
@@ -1,6 +1,6 @@
 {
     "By {authors}": "Door {authors}",
-    "Comment": "Opmerking",
+    "Comment": "Reageer",
     "complimentary": "gratis",
     "Email": "E-mail",
     "free": "gratis",


### PR DESCRIPTION
The Dutch translation of the "Comment"-button in newsletters was very formal. This new translation improves that, and more closely matches Ghost's tone of voice.


