### PR TITLE
Added design system as a dependency to the Admin-X Settings checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
             admin-x-settings:
               - *shared
               - 'apps/admin-x-settings/**'
+              - 'apps/admin-x-design-system/**'
             announcement-bar:
               - *shared
               - 'apps/announcement-bar/**'

--- a/apps/admin-x-design-system/src/global/form/Checkbox.tsx
+++ b/apps/admin-x-design-system/src/global/form/Checkbox.tsx
@@ -31,7 +31,7 @@ const Checkbox: React.FC<CheckboxProps> = ({title, label, value, onChange, disab
                 <label className={`flex cursor-pointer items-start ${title && '-mb-1 mt-1'}`} htmlFor={id}>
                     <CheckboxPrimitive.Root className="mt-0.5 flex h-4 w-4 cursor-pointer appearance-none items-center justify-center rounded-[3px] border border-solid border-grey-500 bg-white outline-none data-[state=checked]:border-black data-[state=indeterminate]:border-black data-[state=checked]:bg-black data-[state=indeterminate]:bg-black" defaultChecked={checked} disabled={disabled} id={id} value={value} onCheckedChange={handleCheckedChange}>
                         <CheckboxPrimitive.Indicator>
-                            <svg fill="none" height="11" viewBox="0 0 10 11" width="11">
+                            <svg fill="none" height="11" viewBox="0 0 10 11" width="10">
                                 <path d="M1 5.88889L4.6 9L9 1" stroke="white" strokeLinecap="round" strokeWidth="2"/>
                             </svg>
                         </CheckboxPrimitive.Indicator>

--- a/apps/admin-x-design-system/src/global/form/Checkbox.tsx
+++ b/apps/admin-x-design-system/src/global/form/Checkbox.tsx
@@ -31,7 +31,7 @@ const Checkbox: React.FC<CheckboxProps> = ({title, label, value, onChange, disab
                 <label className={`flex cursor-pointer items-start ${title && '-mb-1 mt-1'}`} htmlFor={id}>
                     <CheckboxPrimitive.Root className="mt-0.5 flex h-4 w-4 cursor-pointer appearance-none items-center justify-center rounded-[3px] border border-solid border-grey-500 bg-white outline-none data-[state=checked]:border-black data-[state=indeterminate]:border-black data-[state=checked]:bg-black data-[state=indeterminate]:bg-black" defaultChecked={checked} disabled={disabled} id={id} value={value} onCheckedChange={handleCheckedChange}>
                         <CheckboxPrimitive.Indicator>
-                            <svg fill="none" height="11" viewBox="0 0 10 11" width="10">
+                            <svg fill="none" height="11" viewBox="0 0 10 11" width="11">
                                 <path d="M1 5.88889L4.6 9L9 1" stroke="white" strokeLinecap="round" strokeWidth="2"/>
                             </svg>
                         </CheckboxPrimitive.Indicator>


### PR DESCRIPTION
no issues

- when anything is changed in the design system, the Admin-X Settings checks will run now
- they didn't use to run before, and it caused some PRs to be merged without being checked

