### PR TITLE
Fixed WordPress article feature image not showing

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -354,7 +354,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                                     excerpt={object?.preview?.content}
                                     heading={object.name}
                                     html={object.content}
-                                    image={object?.image}
+                                    image={typeof object.image === 'string' ? object.image : object.image?.url}
                                 />
                                 <div className='ml-[-7px]'>
                                     <FeedItemStats

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -85,7 +85,7 @@ export function renderFeedAttachment(object: ObjectProperties, layout: string) {
         </div>;
     default:
         if (object.image) {
-            return <img alt='attachment' className='my-3 max-h-[280px] w-full rounded-md object-cover outline outline-1 -outline-offset-1 outline-black/[0.05]' src={object.image} />;
+            return <img alt='attachment' className='my-3 max-h-[280px] w-full rounded-md object-cover outline outline-1 -outline-offset-1 outline-black/[0.05]' src={typeof object.image === 'string' ? object.image : object.image?.url} />;
         }
         return null;
     }
@@ -137,7 +137,7 @@ function renderInboxAttachment(object: ObjectProperties) {
         );
     default:
         if (object.image) {
-            return <img className={imageAttachmentStyles} src={object.image} />;
+            return <img className={imageAttachmentStyles} src={typeof object.image === 'string' ? object.image : object.image?.url} />;
         }
         return null;
     }

--- a/apps/admin-x-framework/src/api/activitypub.ts
+++ b/apps/admin-x-framework/src/api/activitypub.ts
@@ -14,7 +14,11 @@ export type ObjectProperties = {
     content: string;
     url?: string | undefined;
     attributedTo?: object | string | object[] | undefined;
-    image?: string;
+    image?: string | {
+        url: string;
+        mediaType?: string;
+        type?: string;
+    };
     published?: string;
     preview?: {type: string, content: string};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-619/feature-images-from-wordpress-are-[object-object]

- WordPress puts the feature image into an `image` object, rather than putting the URL directly into an `image` string. We now properly render this.
