### PR TITLE
Change blockquote border color to accent color

### DIFF
--- a/apps/comments-ui/src/styles/iframe.css
+++ b/apps/comments-ui/src/styles/iframe.css
@@ -36,7 +36,7 @@ body {
 
 /* Blockquotes */
 .gh-comment-content blockquote {
-    border-left: 3px solid rgba(13,13,13,.1);
+    border-left: 3px solid var(--gh-accent-color);
     padding-left: 1rem;
     margin: 0 0 1.2rem;
 }


### PR DESCRIPTION
REF https://linear.app/ghost/issue/PLG-291/add-support-for-blockquote-border-in-darkmode
- The border color was invisible in dark mode. Instead of adding a white border for dark mode, it now uses the accent color. This matches link and buttoncolors in comments, and makes it stand out more.