### PR TITLE
Added support for WordPress advanced text formatting in `notes`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -232,7 +232,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
         return (
             <>
                 {object && (
-                    <div className={`group/article relative cursor-pointer pb-[18px] pt-6`} data-layout='feed' data-object-id={object.id} onClick={onClick}>
+                    <div className={`group/article relative -mx-6 -my-px cursor-pointer rounded-lg p-6 pb-[18px]`} data-layout='feed' data-object-id={object.id} onClick={onClick}>
                         {(type === 'Announce' && object.type === 'Note') && <div className='z-10 mb-2 flex items-center gap-3 text-grey-700'>
                             <div className='z-10 flex w-10 justify-end'><Icon colorClass='text-grey-700' name='reload' size={'sm'}></Icon></div>
                             <span className='z-10'>{actor.name} reposted</span>
@@ -254,7 +254,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                     <div className=''>
                                         {(object.type === 'Article') && renderFeedAttachment(object, layout)}
                                         {object.name && <Heading className='my-1 text-pretty leading-tight' level={5} data-test-activity-heading>{object.name}</Heading>}
-                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: object.content})} className='ap-note-content text-pretty leading-[1.4] tracking-[-0.006em] text-grey-900'></div>}
+                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: object.content})} className='ap-note-content text-pretty leading-[1.4285714286] tracking-[-0.006em] text-grey-900'></div>}
                                         {(object.type === 'Note') && renderFeedAttachment(object, layout)}
                                         {(object.type === 'Article') && <Button
                                             className={`mt-3 self-start text-grey-900 transition-all hover:opacity-60`}
@@ -308,7 +308,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col'>
                                         {object.name && <Heading className='mb-1 leading-tight' level={4} data-test-activity-heading>{object.name}</Heading>}
-                                        <div dangerouslySetInnerHTML={({__html: object.content})} className='ap-note-content text-pretty text-[1.6rem] tracking-[-0.011em] text-grey-900'></div>
+                                        <div dangerouslySetInnerHTML={({__html: object.content})} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-grey-900'></div>
                                         {renderFeedAttachment(object, layout)}
                                         <div className='space-between ml-[-7px] mt-3 flex'>
                                             <FeedItemStats

--- a/apps/admin-x-activitypub/src/styles/index.css
+++ b/apps/admin-x-activitypub/src/styles/index.css
@@ -1,67 +1,160 @@
 @import '@tryghost/admin-x-design-system/styles.css';
 
 .admin-x-base.admin-x-activitypub {
-  animation-name: none;
+    animation-name: none;
 }
 
 @keyframes bump {
-  0% {
-    transform: scale(1);
-  }
+    0% {
+        transform: scale(1);
+    }
 
-  50% {
-    transform: scale(1.1);
-  }
+    50% {
+        transform: scale(1.1);
+    }
 
-  100% {
-    transform: scale(1);
-  }
+    100% {
+        transform: scale(1);
+    }
 }
 
 button:active svg {
-  animation: bump 0.3s ease-in-out;
+    animation: bump 0.3s ease-in-out;
 }
 
 .ap-red-heart path {
-  fill: #F50B23;
+    fill: #F50B23;
 }
 
+/* Note and profile content */
+
 .ap-note-content a,
-.ap-profile-content a {
-  color: #2563eb !important;
-  word-break: break-all;
+.ap-profile-content a,
+.ap-note-content-large a {
+    color: #2563eb !important;
+    word-break: break-all;
 }
 
 .ap-note-content a:hover,
-.ap-profile-content a:hover {
-  color: #1d4ed8 !important;
-  text-decoration: underline !important;
+.ap-profile-content a:hover,
+.ap-note-content-large a:hover {
+    color: #1d4ed8 !important;
+    text-decoration: underline !important;
 }
 
 .ap-note-content span.invisible,
-.ap-profile-content span.invisible {
-  display: none;
+.ap-profile-content span.invisible,
+.ap-note-content-large span.invisible {
+    display: none;
 }
 
 .ap-note-content a:not(.hashtag) span.ellipsis:after,
 .ap-profile-content a:not(.hashtag) span.ellipsis:after,
+.ap-note-content-large a:not(.hashtag) span.ellipsis:after,
 .ap-likes .ellipsis::after {
-  content: "…";
+    content: "…";
 }
 
-.ap-note-content p+p {
-  margin-top: 1.2rem !important;
+.ap-note-content > * + * {
+    margin-top: 1.2rem !important;
+}
+
+.ap-note-content-large > * + * {
+    margin-top: 1.6rem !important;
+}
+
+.ap-note-content > h1 + *,
+.ap-note-content > h2 + *,
+.ap-note-content > h3 + * {
+    margin-top: 0.6rem !important;
+}
+
+.ap-note-content-large > h1 + *,
+.ap-note-content-large > h2 + *,
+.ap-note-content-large > h3 + * {
+    margin-top: 0.8rem !important;
+}
+
+.ap-note-content figure,
+.ap-note-content-large figure {
+    display: none;
+}
+
+.ap-note-content ul,
+.ap-note-content-large ul {
+    list-style-type: '-' !important;
+    padding-left: 1rem !important;
+}
+
+.ap-note-content ol,
+.ap-note-content-large ol {
+    list-style: auto !important;
+    padding-left: 1.7rem !important;
+}
+
+.ap-note-content li {
+    font-size: 1.4rem !important;
+    padding-left: 0.4rem !important;
+}
+
+.ap-note-content-large li {
+    font-size: 1.6rem !important;
+    padding-left: 0.4rem !important;
+}
+
+.ap-note-content h2, .ap-note-content h3, .ap-note-content h4, .ap-note-content h5 {
+    font-size: 1.4rem !important;
+    font-weight: 600 !important;
+    line-height: 1.375 !important;
+}
+
+.ap-note-content-large h2, .ap-note-content-large h3, .ap-note-content-large h4, .ap-note-content-large h5 {
+    font-size: 1.6rem !important;
+}
+
+.ap-note-content blockquote,
+.ap-note-content-large blockquote {
+    border-left: 2px solid #E5E9ED;
+    padding-left: 0.8rem;
+    margin: 0.6rem 0 !important;
+}
+
+.ap-note-content blockquote p {
+    font-weight: 400;
+    font-size: 1.4rem;
+}
+
+.ap-note-content-large blockquote p {
+    font-weight: 400;
+    font-size: 1.6rem;
+}
+
+.ap-note-content code,
+.ap-note-content-large code {
+    background-color: #F9FAFB !important;
+    font-size: 1.3rem !important;
+    color: #15171a;
+}
+
+.ap-note-content-large code {
+    font-size: 1.5rem !important;
+}
+
+.ap-note-content mark,
+.ap-note-content-large mark {
+    background-color: transparent !important;
+    color: #15171a;
 }
 
 .ap-likes .invisible {
-  display: inline-block;
-  font-size: 0;
-  height: 0;
-  line-height: 0;
-  position: absolute;
-  width: 0;
+    display: inline-block;
+    font-size: 0;
+    height: 0;
+    line-height: 0;
+    position: absolute;
+    width: 0;
 }
 
 .ap-textarea {
-  field-sizing: content;
+    field-sizing: content;
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-622/add-support-for-rich-text-formatting-of-notes

- Until now we only had plain text with line breaks and links inside `note` objects. But WordPress is very flexible and allows users to put almost all of their blocks inside a `note`, like headings, lists and blockquotes. We now support those in Ghost, but with minimal formatting to keep the feed clean and easy to scan through.
