### PR TITLE
Removed code disabling bluebird debug

### DIFF
--- a/ghost/core/core/server/overrides.js
+++ b/ghost/core/core/server/overrides.js
@@ -1,10 +1,3 @@
-/**
- * If we enable bluebird debug logs we see a huge memory usage.
- * You can reproduce by removing this line and import a big database export into Ghost.
- * `NODE_ENV=development node index.js`
- */
-process.env.BLUEBIRD_DEBUG = 0;
-
 const luxon = require('luxon');
 const moment = require('moment-timezone');
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/14882 ref https://github.com/TryGhost/Ghost/issues/14882#issuecomment-2395498636

- As per the comment on the issue, the last reference to bluebird in Ghost itself was removed over a year ago.
- We added this code blocking bluebird debug over 6 years ago.
- We do still use bluebird through dependencies so we could still have memory issues BUT
- This change only affects development, and really should not be a problem anymore.
- Leaning towards deleting the weird old edge-case code as it should not be an issue, and finding out the hard way if I'm wrong :D


