### PR TITLE
Updated hidden/removed comment copy on API side

### DIFF
--- a/apps/comments-ui/test/e2e/content.test.ts
+++ b/apps/comments-ui/test/e2e/content.test.ts
@@ -41,7 +41,7 @@ test.describe('Deleted and Hidden Content', async () => {
         await expect(comments).toHaveCount(3);
     });
 
-    test('hide and deleted comment shows with hidden/deleted text when it has replies', async ({page}) => {
+    test('hide and deleted comment shows with removed text when it has replies', async ({page}) => {
         const mockedApi = new MockedApi({});
         mockedApi.addComment({
             html: '<p>This is comment 1</p>'

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -52,7 +52,7 @@ const commentMapper = (model, frame) => {
         if (jsonModel.inReplyTo && (jsonModel.inReplyTo.status === 'published' || (!isPublicRequest && jsonModel.inReplyTo.status === 'hidden'))) {
             jsonModel.in_reply_to_snippet = htmlToPlaintext.commentSnippet(jsonModel.inReplyTo.html);
         } else if (jsonModel.inReplyTo && jsonModel.inReplyTo.status !== 'published') {
-            jsonModel.in_reply_to_snippet = '[hidden/removed]';
+            jsonModel.in_reply_to_snippet = '[removed]';
         } else {
             jsonModel.in_reply_to_snippet = null;
         }

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -2125,7 +2125,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": "[hidden/removed]",
+      "in_reply_to_snippet": "[removed]",
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2145,7 +2145,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "442",
+  "content-length": "435",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2166,7 +2166,7 @@ Object {
       "html": "<p>This is a comment</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": Nullable<StringMatching>,
-      "in_reply_to_snippet": "[hidden/removed]",
+      "in_reply_to_snippet": "[removed]",
       "liked": Any<Boolean>,
       "member": Object {
         "avatar_image": null,
@@ -2186,7 +2186,7 @@ exports[`Comments API when commenting enabled for all when authenticated replies
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "442",
+  "content-length": "435",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1518,7 +1518,7 @@ describe('Comments API', function () {
 
                         const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
-                        comment.in_reply_to_snippet.should.eql('[hidden/removed]');
+                        comment.in_reply_to_snippet.should.eql('[removed]');
                     });
                 });
             });

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -307,7 +307,6 @@
     "complimentary": "",
     "edited": "",
     "free": "",
-    "hidden/removed": "",
     "jamie@example.com": "Placeholder for email input field",
     "month": "the subscription interval (monthly), following the /",
     "paid": "",


### PR DESCRIPTION
REF https://linear.app/ghost/issue/PLG-295/change-copy-for-replied-to-[hiddenremoved]
- Updated the copy from hidden/removed to removed on API side and in i18n context.json for consistency