### PR TITLE
Removed unnecessary forUpdate

### DIFF
--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -944,7 +944,7 @@ module.exports = class MemberRepository {
         const subscriptionPriceData = _.get(subscription, 'items.data[0].price');
         let ghostProduct;
         try {
-            ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, {...options, forUpdate: true});
+            ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, options);
             // Use first Ghost product as default product in case of missing link
             if (!ghostProduct) {
                 ghostProduct = await this._productRepository.getDefaultProduct({


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/ENG-1758/product-row-locking-in-linksubscription-causes-slowness-in-high-signup

- The method used a FOR UPDATE query when fetching the Ghost product despite never updating that row. 
- In this case, we're only reading the default product to link it with a subscription - we're not actually modifying the default product itself. The operation is read-only in nature, therefore, the forUpdate lock is unnecessary
- The actual update to the product happens later in the code when we call this._productRepository.update() with the stripe price data, and that operation has its own transaction handling and locking mechanisms