### PR TITLE
Modified `lastSeenAt` updater to use job queue for member link click events

### DIFF
--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -8,6 +8,7 @@ const logging = require('@tryghost/logging');
 const models = require('../../models');
 const sentry = require('../../../shared/sentry');
 const domainEvents = require('@tryghost/domain-events');
+const eventEmitter = require('../../lib/common/events');
 const config = require('../../../shared/config');
 const prometheusClient = require('../../../shared/prometheus-client');
 const errorHandler = (error, workerMeta) => {
@@ -43,7 +44,7 @@ const initTestMode = () => {
     }, 5000);
 };
 
-const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, prometheusClient});
+const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, prometheusClient, eventEmitter});
 
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;

--- a/ghost/core/core/server/services/members-events/jobs/update-member-last-seen-at/index.js
+++ b/ghost/core/core/server/services/members-events/jobs/update-member-last-seen-at/index.js
@@ -27,15 +27,16 @@ module.exports = async function updateMemberLastSeenAt(data) {
                 .first();
 
             // Return data for the job manager to emit the event
-            const events = [{
-                name: 'member.edited',
-                data: updatedMember
-            }];
+            const eventData = {
+                nodeEvents: [{
+                    name: 'member.edited',
+                    data: updatedMember
+                }]
+            };
 
-            return {result: updatedMember, events};
+            return {result: updatedMember, eventData};
         }
         return undefined;
     });
-    console.log(`result of updateMemberLastSeenAt:`, result);
     return result;
 };

--- a/ghost/core/core/server/services/members-events/jobs/updateMemberLastSeenAt/index.js
+++ b/ghost/core/core/server/services/members-events/jobs/updateMemberLastSeenAt/index.js
@@ -1,0 +1,41 @@
+const db = require('../../../../data/db');
+const errors = require('@tryghost/errors');
+const moment = require('moment-timezone');
+module.exports = async function updateMemberLastSeenAt(data) {
+    const result = await db.knex.transaction(async (trx) => {
+        // To avoid a race condition, we lock the member row for update, then the last_seen_at field again to prevent simultaneous updates
+        const currentMember = await trx('members')
+            .where({id: data.memberId})
+            .forUpdate()
+            .first();
+
+        if (!currentMember) {
+            throw new errors.NotFoundError({message: `Member with id ${data.memberId} not found`});
+        }
+
+        const currentMemberLastSeenAt = currentMember.last_seen_at;
+        if (currentMemberLastSeenAt === null || moment(moment.utc(data.timestamp).tz(data.timezone).startOf('day')).isAfter(currentMemberLastSeenAt)) {
+            await trx('members')
+                .where({id: data.memberId})
+                .update({
+                    last_seen_at: moment.utc(data.timestamp).format('YYYY-MM-DD HH:mm:ss')
+                });
+
+            // Fetch the updated member data
+            const updatedMember = await trx('members')
+                .where({id: data.memberId})
+                .first();
+
+            // Return data for the job manager to emit the event
+            const events = [{
+                name: 'member.edited',
+                data: updatedMember
+            }];
+
+            return {result: updatedMember, events};
+        }
+        return undefined;
+    });
+    console.log(`result of updateMemberLastSeenAt:`, result);
+    return result;
+};

--- a/ghost/job-manager/lib/JobManager.js
+++ b/ghost/job-manager/lib/JobManager.js
@@ -49,7 +49,7 @@ class JobManager {
      * @param {Function} [options.errorHandler] - custom job error handler
      * @param {Function} [options.workerMessageHandler] - custom message handler coming from workers
      * @param {Object} [options.JobModel] - a model which can persist job data in the storage
-     * @param {Object} [options.domainEvents] - domain eventEmitter emitter
+     * @param {Object} [options.domainEvents] - domain events emitter
      * @param {Object} [options.eventEmitter] - eventEmitter emitter
      * @param {Object} [options.config] - config
      * @param {boolean} [options.isDuplicate] - if true, the job manager will not initialize the job queue

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -148,9 +148,9 @@ class JobQueueManager {
      * @param {Array<{name: string, data: any}>} events - Array of event objects with name and data
      */
     emitEvents(events) {
-        console.log(`emitting events`);
+        debug(`[emitEvents] Emitting events`);
         events.forEach((e) => {
-            console.log(`emitting event: ${e.name}`);
+            debug(`[emitEvents] Emitting event: ${e.name}`);
             this.eventEmitter.emit(e.name, e.data);
         });
     }
@@ -173,20 +173,20 @@ class JobQueueManager {
             await this.jobsRepository.delete(job.id);
             this.handleMetrics(jobName);
 
-            console.log(`result for job ${jobName}:`, result);
+            debug(`[executeJob] Result for job ${jobName}:`, result);
             if (result && result.eventData) {
                 // Emits domain events
                 // if (result.eventData.domainEvents && result.eventData.domainEvents.length > 0) {
                 //     this.emitDomainEvents(result.eventData.domainEvents);
                 // }
                 // Emits node events
-                console.log(`result.eventData.events:`, result.eventData.events);
-                if (result.eventData.events && result.eventData.events.length > 0) {
-                    this.emitEvents(result.eventData.events);
+                debug(`[executeJob] Emitting node events:`, result.eventData.nodeEvents);
+                if (result.eventData.nodeEvents && result.eventData.nodeEvents.length > 0) {
+                    this.emitEvents(result.eventData.nodeEvents);
                 }
             }
         } catch (error) {
-            console.log(`Error in executeJob: ${error}`);
+            debug(`[executeJob] Error in executeJob: ${error}`);
             await this.handleJobError(job, jobMetadata, error);
         } finally {
             this.state.queuedJobs.delete(jobName);

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -13,5 +13,6 @@ module.exports = {
     SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent'),
     OfferRedemptionEvent: require('./lib/OfferRedemptionEvent'),
     MemberLinkClickEvent: require('./lib/MemberLinkClickEvent'),
-    MemberEmailAnalyticsUpdateEvent: require('./lib/MemberEmailAnalyticsUpdateEvent')
+    MemberEmailAnalyticsUpdateEvent: require('./lib/MemberEmailAnalyticsUpdateEvent'),
+    MemberLastSeenAtJobEvent: require('./lib/MemberLastSeenAtJobEvent')
 };

--- a/ghost/member-events/lib/MemberLastSeenAtJobEvent.js
+++ b/ghost/member-events/lib/MemberLastSeenAtJobEvent.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} MemberLastSeenAtJobEventData
+ * @prop {string} memberId
+ * @prop {Date} timestamp
+ * @prop {string} timezone
+ */
+
+/**
+ * Server-side event firing on page views (page, post, tags...)
+ */
+module.exports = class MemberLastSeenAtJobEvent {
+    /**
+     * @param {MemberLastSeenAtJobEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {MemberLastSeenAtJobEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new MemberLastSeenAtJobEvent(data, timestamp || new Date);
+    }
+};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1815/create-job-queue-entry-for-lastseenatupdater
ref https://linear.app/ghost/issue/ENG-1816/implement-domainevents-in-jobqueuemanager

This change requires a few pieces that I'll likely split out into other PRs to isolate the changes. This is a single PR spike for demonstration purposes.

The `lastSeenAt` update for members after clicking an email link is not a time-sensitive operation. Given that the period following the sending a newsletter is already one of incredibly high activity for Ghost, it makes sense to shift this workload to the job queue where it can be processed in turn with other time-insensitive operations.

Ultimately, we've got a few new patterns here that I'd like to get some feedback on.
- This approach firms up the groundwork laid in the EmailAnalyticsJob-related updates that we introduced the job queue for, where **service wrappers w/in `ghost/core` are the ones listening to `DomainEvents` and submit the jobs to the `JobManager`.**
- Jobs have a new return pattern, if needed, to be able to submit events upon completion (we have two flavors in Ghost, `DomainEvents` and 'Node events', e.g. `site.changed`). In general, the return value is otherwise disregarded, so this is only important if needed to signal other activities like chaining job submissions. In pseudocode typing: `result = {result: <any>, eventData: <domainEvents || nodeEvents>}`
- Jobs should be contained within the `ghost/core/core/services/<service>/jobs` directories.
- Jobs may require new `Events` to be created and subscribed to. These can be created within the appropriate events package, e.g. `members-events`. I don't see a need to create a job-specific bundle of events.
- Jobs should only interact with `knex`/the DB directly, not using models or services. This reduces the overhead and paves the way for creation of standalone services.

Note: I'm not sure if we want to maintain two code paths for 'job queue enabled' vs 'job queue disabled'. Either we should let the `JobManager` route it to the job queue or inline runner on its own, or simply widespread enable the job queue.