### PR TITLE
Add saveRaw method to LocalFilesStorage and LocalMediaStorage classes

### DIFF
--- a/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
@@ -1,16 +1,50 @@
 // # Local File System Storage module
 // The (default) module for storing media, using the local file system
+const fs = require('fs-extra');
+const path = require('path');
 const config = require('../../../shared/config');
+
 const constants = require('@tryghost/constants');
+const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
+
+const messages = {
+    notFound: 'File not found',
+    notFoundWithRef: 'File not found: {file}',
+    cannotRead: 'Could not read File: {file}'
+};
 
 class LocalFilesStorage extends LocalStorageBase {
     constructor() {
         super({
             storagePath: config.getContentPath('files'),
             siteUrl: config.getSiteUrl(),
-            staticFileURLPrefix: constants.STATIC_FILES_URL_PREFIX
+            staticFileURLPrefix: constants.STATIC_FILES_URL_PREFIX,
+            errorMessages: messages
         });
+    }
+
+    /**
+     * Saves a buffer in the targetPath
+     * @param {Buffer} buffer is an instance of Buffer
+     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
+     * @returns {Promise<String>} a URL to retrieve the data
+     */
+    async saveRaw(buffer, targetPath) {
+        const storagePath = path.join(this.storagePath, targetPath);
+        const targetDir = path.dirname(storagePath);
+
+        await fs.mkdirs(targetDir);
+        await fs.writeFile(storagePath, buffer);
+
+        // For local file system storage can use relative path so add a slash
+        const fullUrl = (
+            urlUtils.urlJoin('/', urlUtils.getSubdir(),
+                this.staticFileURLPrefix,
+                targetPath)
+        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
+
+        return fullUrl;
     }
 }
 

--- a/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
@@ -1,11 +1,7 @@
 // # Local File System Storage module
 // The (default) module for storing media, using the local file system
-const fs = require('fs-extra');
-const path = require('path');
 const config = require('../../../shared/config');
-
 const constants = require('@tryghost/constants');
-const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
 const messages = {
@@ -22,29 +18,6 @@ class LocalFilesStorage extends LocalStorageBase {
             staticFileURLPrefix: constants.STATIC_FILES_URL_PREFIX,
             errorMessages: messages
         });
-    }
-
-    /**
-     * Saves a buffer in the targetPath
-     * @param {Buffer} buffer is an instance of Buffer
-     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
-     * @returns {Promise<String>} a URL to retrieve the data
-     */
-    async saveRaw(buffer, targetPath) {
-        const storagePath = path.join(this.storagePath, targetPath);
-        const targetDir = path.dirname(storagePath);
-
-        await fs.mkdirs(targetDir);
-        await fs.writeFile(storagePath, buffer);
-
-        // For local file system storage can use relative path so add a slash
-        const fullUrl = (
-            urlUtils.urlJoin('/', urlUtils.getSubdir(),
-                this.staticFileURLPrefix,
-                targetPath)
-        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
-
-        return fullUrl;
     }
 }
 

--- a/ghost/core/core/server/adapters/storage/LocalImagesStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalImagesStorage.js
@@ -1,10 +1,6 @@
 // # Local File System Image Storage module
 // The (default) module for storing images, using the local file system
-
-const fs = require('fs-extra');
-const path = require('path');
 const config = require('../../../shared/config');
-
 const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
@@ -22,29 +18,6 @@ class LocalImagesStorage extends LocalStorageBase {
             siteUrl: config.getSiteUrl(),
             errorMessages: messages
         });
-    }
-
-    /**
-     * Saves a buffer in the targetPath
-     * @param {Buffer} buffer is an instance of Buffer
-     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
-     * @returns {Promise<String>} a URL to retrieve the data
-     */
-    async saveRaw(buffer, targetPath) {
-        const storagePath = path.join(this.storagePath, targetPath);
-        const targetDir = path.dirname(storagePath);
-
-        await fs.mkdirs(targetDir);
-        await fs.writeFile(storagePath, buffer);
-
-        // For local file system storage can use relative path so add a slash
-        const fullUrl = (
-            urlUtils.urlJoin('/', urlUtils.getSubdir(),
-                this.staticFileURLPrefix,
-                targetPath)
-        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
-
-        return fullUrl;
     }
 }
 

--- a/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
@@ -1,7 +1,11 @@
 // # Local File System Media Storage module
 // The (default) module for storing media, using the local file system
+const fs = require('fs-extra');
+const path = require('path');
 const config = require('../../../shared/config');
+
 const constants = require('@tryghost/constants');
+const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
 const messages = {
@@ -18,6 +22,29 @@ class LocalMediaStorage extends LocalStorageBase {
             siteUrl: config.getSiteUrl(),
             errorMessages: messages
         });
+    }
+
+    /**
+     * Saves a buffer in the targetPath
+     * @param {Buffer} buffer is an instance of Buffer
+     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
+     * @returns {Promise<String>} a URL to retrieve the data
+     */
+    async saveRaw(buffer, targetPath) {
+        const storagePath = path.join(this.storagePath, targetPath);
+        const targetDir = path.dirname(storagePath);
+
+        await fs.mkdirs(targetDir);
+        await fs.writeFile(storagePath, buffer);
+
+        // For local file system storage can use relative path so add a slash
+        const fullUrl = (
+            urlUtils.urlJoin('/', urlUtils.getSubdir(),
+                this.staticFileURLPrefix,
+                targetPath)
+        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
+
+        return fullUrl;
     }
 }
 

--- a/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
@@ -1,11 +1,7 @@
 // # Local File System Media Storage module
 // The (default) module for storing media, using the local file system
-const fs = require('fs-extra');
-const path = require('path');
 const config = require('../../../shared/config');
-
 const constants = require('@tryghost/constants');
-const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
 const messages = {
@@ -22,29 +18,6 @@ class LocalMediaStorage extends LocalStorageBase {
             siteUrl: config.getSiteUrl(),
             errorMessages: messages
         });
-    }
-
-    /**
-     * Saves a buffer in the targetPath
-     * @param {Buffer} buffer is an instance of Buffer
-     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
-     * @returns {Promise<String>} a URL to retrieve the data
-     */
-    async saveRaw(buffer, targetPath) {
-        const storagePath = path.join(this.storagePath, targetPath);
-        const targetDir = path.dirname(storagePath);
-
-        await fs.mkdirs(targetDir);
-        await fs.writeFile(storagePath, buffer);
-
-        // For local file system storage can use relative path so add a slash
-        const fullUrl = (
-            urlUtils.urlJoin('/', urlUtils.getSubdir(),
-                this.staticFileURLPrefix,
-                targetPath)
-        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
-
-        return fullUrl;
     }
 }
 

--- a/ghost/core/core/server/adapters/storage/LocalStorageBase.js
+++ b/ghost/core/core/server/adapters/storage/LocalStorageBase.js
@@ -81,6 +81,29 @@ class LocalStorageBase extends StorageBase {
     }
 
     /**
+     * Saves a buffer in the targetPath
+     * @param {Buffer} buffer is an instance of Buffer
+     * @param {String} targetPath relative path NOT including storage path to which the buffer should be written
+     * @returns {Promise<String>} a URL to retrieve the data
+     */
+    async saveRaw(buffer, targetPath) {
+        const storagePath = path.join(this.storagePath, targetPath);
+        const targetDir = path.dirname(storagePath);
+
+        await fs.mkdirs(targetDir);
+        await fs.writeFile(storagePath, buffer);
+
+        // For local file system storage can use relative path so add a slash
+        const fullUrl = (
+            urlUtils.urlJoin('/', urlUtils.getSubdir(),
+                this.staticFileURLPrefix,
+                targetPath)
+        ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
+
+        return fullUrl;
+    }
+
+    /**
      *
      * @param {String} url full url under which the stored content is served, result of save method
      * @returns {String} path under which the content is stored


### PR DESCRIPTION
ref https://linear.app/ghost/issue/CON-3/external-media-inliner-should-inline-more-file-types

The external media inliner requests each file as a buffer. Saving this works well for images, but not media or files as the `saveRaw` method is not available on those storage adapters.

This PR adds the same `saveRaw` method from `LocalImagesStorage` to two related classes, which enables saving buffers for all other supported file types
