### PR TITLE
Added Sentry logging for email link clicks w/ bad member uuid

### DIFF
--- a/ghost/core/core/server/services/link-tracking/LinkClickRepository.js
+++ b/ghost/core/core/server/services/link-tracking/LinkClickRepository.js
@@ -1,5 +1,7 @@
 const {LinkClick} = require('@tryghost/link-tracking');
 const ObjectID = require('bson-objectid').default;
+const sentry = require('../../../shared/sentry');
+const config = require('../../../shared/config');
 
 module.exports = class LinkClickRepository {
     /** @type {Object} */
@@ -52,6 +54,9 @@ module.exports = class LinkClickRepository {
         // Convert uuid to id
         const member = await this.#Member.findOne({uuid: linkClick.member_uuid});
         if (!member) {
+            if (config.get('captureLinkClickBadMemberUuid')) {
+                sentry.captureMessage('LinkClickTrackingService > Member not found', {extra: {member_uuid: linkClick.member_uuid}});
+            }
             return;
         }
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -243,7 +243,8 @@
             "minDaysSinceLastEmail": 14
         },
     "bulkEmail": {
-        "batchSize": 1000
+        "batchSize": 1000,
+        "captureLinkClickBadMemberUuid": false
     },
     "disableJSBackups": false
 }


### PR DESCRIPTION
no ref

I've discovered email link checkers appear to be using falsified/scrambled uuids when testing links for a given site. It's difficult to check against all sites, so instead we'll log to Sentry to confirm this is the case.

I've put this behind config because I believe it will create a LOT of entries, and may burden an already burdened workflow during peak traffic.