### PR TITLE
Improved grouped notifications UI

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/components/Inbox.tsx
@@ -7,7 +7,6 @@ import NewPostModal from './modals/NewPostModal';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
 import Separator from './global/Separator';
-import ViewProfileModal from './modals/ViewProfileModal';
 import getName from '../utils/get-name';
 import getUsername from '../utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
@@ -19,6 +18,7 @@ import {
     useSuggestedProfiles,
     useUserDataForUser
 } from '../hooks/useActivityPubQueries';
+import {handleProfileClick} from '../utils/handle-profile-click';
 import {handleViewContent} from '../utils/content-handlers';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
@@ -149,9 +149,9 @@ const Inbox: React.FC<InboxProps> = ({layout}) => {
                                                 return (
                                                     <React.Fragment key={actor.id}>
                                                         <li key={actor.id}>
-                                                            <ActivityItem url={actor.url} onClick={() => NiceModal.show(ViewProfileModal, {
-                                                                profile: getUsername(actor)
-                                                            })}>
+                                                            <ActivityItem
+                                                                onClick={() => handleProfileClick(actor)}
+                                                            >
                                                                 <APAvatar author={actor} />
                                                                 <div className='flex min-w-0 flex-col'>
                                                                     <span className='block w-full truncate font-bold text-black'>{getName(actor)}</span>

--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -194,7 +194,6 @@ const FollowingTab: React.FC = () => {
                         <React.Fragment key={item.id}>
                             <ActivityItem
                                 key={item.id}
-                                url={item.url}
                                 onClick={() => handleUserClick(item)}
                             >
                                 <APAvatar author={item} />
@@ -231,7 +230,6 @@ const FollowersTab: React.FC = () => {
                         <React.Fragment key={item.id}>
                             <ActivityItem
                                 key={item.id}
-                                url={item.url}
                                 onClick={() => handleUserClick(item)}
                             >
                                 <APAvatar author={item} />

--- a/apps/admin-x-activitypub/src/components/activities/NotificationIcon.tsx
+++ b/apps/admin-x-activitypub/src/components/activities/NotificationIcon.tsx
@@ -4,7 +4,7 @@ import {Icon} from '@tryghost/admin-x-design-system';
 export type NotificationType = 'like' | 'follow' | 'reply';
 
 interface NotificationIconProps {
-    notificationType: 'like' | 'follow' | 'reply';
+    notificationType: NotificationType;
     className?: string;
 }
 
@@ -32,7 +32,7 @@ const NotificationIcon: React.FC<NotificationIconProps> = ({notificationType, cl
     }
 
     return (
-        <div className={`flex h-10 w-10 items-center justify-center rounded-full ${badgeColor} ${className}`}>
+        <div className={`flex h-10 w-10 items-center justify-center rounded-full ${badgeColor} ${className && className}`}>
             <Icon colorClass={iconColor} name={icon} size='sm' />
         </div>
     );

--- a/apps/admin-x-activitypub/src/components/activities/NotificationItem.tsx
+++ b/apps/admin-x-activitypub/src/components/activities/NotificationItem.tsx
@@ -20,9 +20,12 @@ interface NotificationItemProps {
 const NotificationItem = ({children, onClick, url, className}: NotificationItemProps) => {
     return (
         <NotificationContext.Provider value={{onClick, url}}>
-            <button className={`relative -mx-4 -my-px grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 rounded-lg p-4 text-left hover:bg-grey-75 ${className}`} type='button' onClick={onClick}>
+            <div className={`relative -mx-4 -my-px grid cursor-pointer grid-cols-[auto_1fr] gap-x-3 gap-y-2 rounded-lg p-4 text-left hover:bg-grey-75 ${className}`}
+                role='button'
+                onClick={onClick}
+            >
                 {children}
-            </button>
+            </div>
         </NotificationContext.Provider>
     );
 };

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -10,6 +10,7 @@ import getReadingTime from '../../utils/get-reading-time';
 import getRelativeTimestamp from '../../utils/get-relative-timestamp';
 import getUsername from '../../utils/get-username';
 import stripHtml from '../../utils/strip-html';
+import {handleProfileClick} from '../../utils/handle-profile-click';
 import {renderTimestamp} from '../../utils/render-timestamp';
 
 function getAttachment(object: ObjectProperties) {
@@ -241,9 +242,18 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                             <div className='relative z-30 flex min-w-0 items-center gap-3'>
                                 <APAvatar author={author}/>
                                 <div className='flex min-w-0 flex-col gap-0.5'>
-                                    <span className='min-w-0 truncate break-all font-semibold leading-[normal]' data-test-activity-heading>{author.name}</span>
+                                    <span className='min-w-0 truncate break-all font-semibold leading-[normal] hover:underline'
+                                        data-test-activity-heading
+                                        onClick={e => handleProfileClick(actor, e)}
+                                    >
+                                        {author.name}
+                                    </span>
                                     <div className='flex w-full text-grey-700'>
-                                        <span className='truncate leading-tight'>{getUsername(author)}</span>
+                                        <span className='truncate leading-tight hover:underline'
+                                            onClick={e => handleProfileClick(actor, e)}
+                                        >
+                                            {getUsername(author)}
+                                        </span>
                                         <div className='ml-1 leading-tight before:mr-1 before:content-["·"]' title={`${timestamp}`}>{renderTimestamp(object)}</div>
                                     </div>
                                 </div>
@@ -400,7 +410,12 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                         <div className='min-w-0'>
                             <div className='z-10 mb-1.5 flex w-full min-w-0 items-center gap-1.5 text-sm group-hover/article:border-transparent'>
                                 <APAvatar author={author} size='2xs'/>
-                                <span className='min-w-0 truncate break-all font-semibold text-grey-900' title={getUsername(author)} data-test-activity-heading>{author.name}</span>
+                                <span className='min-w-0 truncate break-all font-semibold text-grey-900 hover:underline'
+                                    title={getUsername(author)}
+                                    data-test-activity-heading
+                                    onClick={e => handleProfileClick(actor, e)}
+                                >{author.name}
+                                </span>
                                 <span className='shrink-0 whitespace-nowrap text-grey-600 before:mr-1 before:content-["·"]' title={`${timestamp}`}>{getRelativeTimestamp(date)}</span>
                             </div>
                             <div className='flex'>

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -1,40 +1,30 @@
+import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
+import ViewProfileModal from '../modals/ViewProfileModal';
 import clsx from 'clsx';
 import getUsername from '../../utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Icon} from '@tryghost/admin-x-design-system';
 
 type AvatarSize = '2xs' | 'xs' | 'sm' | 'lg' | 'notification';
-export type AvatarBadge = 'user-fill' | 'heart-fill' | 'comment-fill' | undefined;
 
 interface APAvatarProps {
-    author?: ActorProperties;
+    author: ActorProperties | undefined;
     size?: AvatarSize;
-    badge?: AvatarBadge;
 }
 
-const APAvatar: React.FC<APAvatarProps> = ({author, size, badge}) => {
+const APAvatar: React.FC<APAvatarProps> = ({author, size}) => {
     let iconSize = 18;
-    let containerClass = 'shrink-0 items-center justify-center relative z-10 flex';
+    let containerClass = `shrink-0 items-center justify-center relative cursor-pointer z-10 flex ${size === 'lg' ? '' : 'hover:opacity-80'}`;
     let imageClass = 'z-10 rounded-md w-10 h-10 object-cover';
-    const badgeClass = `w-6 h-6 z-20 rounded-full absolute -bottom-2 -right-[0.6rem] border-2 border-white content-box flex items-center justify-center`;
-    let badgeColor = '';
     const [iconUrl, setIconUrl] = useState(author?.icon?.url);
 
     useEffect(() => {
         setIconUrl(author?.icon?.url);
     }, [author?.icon?.url]);
 
-    switch (badge) {
-    case 'user-fill':
-        badgeColor = 'bg-blue-500';
-        break;
-    case 'heart-fill':
-        badgeColor = 'bg-red-500';
-        break;
-    case 'comment-fill':
-        badgeColor = 'bg-purple-500';
-        break;
+    if (!author) {
+        return null;
     }
 
     switch (size) {
@@ -69,37 +59,42 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, badge}) => {
         containerClass = clsx(containerClass, 'bg-grey-100');
     }
 
-    const BadgeElement = badge && (
-        <div className={clsx(badgeClass, badgeColor)}>
-            <Icon
-                colorClass='text-white'
-                name={badge}
-                size='xs'
-            />
-        </div>
-    );
+    const onClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        NiceModal.show(ViewProfileModal, {
+            profile: getUsername(author as ActorProperties)
+        });
+    };
+
+    const title = `${author?.name} ${getUsername(author as ActorProperties)}`;
 
     if (iconUrl) {
         return (
-            <a className={containerClass} href={author?.url} rel='noopener noreferrer' target='_blank' title={`${author?.name} ${getUsername(author as ActorProperties)}`}>
+            <div
+                className={containerClass}
+                title={title}
+                onClick={onClick}
+            >
                 <img
                     className={imageClass}
                     src={iconUrl}
                     onError={() => setIconUrl(undefined)}
                 />
-                {BadgeElement}
-            </a>
+            </div>
         );
     }
 
     return (
-        <div className={containerClass} title={author?.name}>
+        <div
+            className={containerClass}
+            title={title}
+            onClick={onClick}
+        >
             <Icon
                 colorClass='text-grey-600'
                 name='user'
                 size={iconSize}
             />
-            {BadgeElement}
         </div>
     );
 };

--- a/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
@@ -16,6 +16,7 @@ import FollowButton from '../global/FollowButton';
 import Separator from '../global/Separator';
 import getName from '../../utils/get-name';
 import getUsername from '../../utils/get-username';
+import {handleProfileClick} from '../../utils/handle-profile-click';
 
 const noop = () => {};
 
@@ -83,7 +84,9 @@ const ActorList: React.FC<ActorListProps> = ({
                         {actors.map(({actor, isFollowing}, index) => {
                             return (
                                 <React.Fragment key={actor.id}>
-                                    <ActivityItem key={actor.id} url={actor.url}>
+                                    <ActivityItem key={actor.id}
+                                        onClick={() => handleProfileClick(actor)}
+                                    >
                                         <APAvatar author={actor} />
                                         <div>
                                             <div className='text-grey-600'>

--- a/apps/admin-x-activitypub/src/utils/handle-profile-click.ts
+++ b/apps/admin-x-activitypub/src/utils/handle-profile-click.ts
@@ -1,0 +1,11 @@
+import NiceModal from '@ebay/nice-modal-react';
+import ViewProfileModal from '../components/modals/ViewProfileModal';
+import getUsername from './get-username';
+import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
+
+export const handleProfileClick = (actor: ActorProperties, e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    NiceModal.show(ViewProfileModal, {
+        profile: getUsername(actor)
+    });
+};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-625/implement-notification-grouping-for-follows-and-likes

- Improved handling for notification clicks of various types: single follower notification opens that follower in the drawer, multiple followers expands the followers list, liked post opens the article in the wide drawer, liked note opens the note in the narrow drawer
- Improved hover and click states for profile names, usernames and avatars. Now it's more obvious what's clickable, and clicking on any of these elements in any context opens that profile in the drawer.
- Created a handleProfileClick utility since we're using it in a lot of places.
- Removed unnecessary types
- Made the HTML structure more semantic