### PR TITLE
Fixed excerpt display in post history modal

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -27,7 +27,9 @@
                     <div class="gh-editor-excerpt" data-test-post-history-preview-excerpt>
                         {{this.selectedRevision.custom_excerpt}}
                     </div>
-                    <hr class="gh-editor-title-divider">
+                    {{#if this.selectedRevision.custom_excerpt}}
+                        <hr class="gh-editor-title-divider">
+                    {{/if}}
                 {{/if}}
                 <KoenigLexicalEditor
                     @lexical={{this.selectedRevision.lexical}}

--- a/ghost/admin/app/styles/layouts/post-history.css
+++ b/ghost/admin/app/styles/layouts/post-history.css
@@ -196,6 +196,19 @@
     color: var(--black);
 }
 
+.gh-post-history .gh-editor-excerpt {
+    max-width: 740px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.gh-post-history .gh-editor-title-divider {
+    width: 100%;
+    max-width: 740px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .gh-post-history-hidden-lexical {
     display: none;
 }


### PR DESCRIPTION
REF https://linear.app/ghost/issue/DES-1026/visual-bug-with-excerpt-in-post-history-modal
- The excerpt was not in line with the rest of the content.
- The excerpt divider was visible even when there was no excerpt.