### PR TITLE
Fixed tinybird tests with versioning

### DIFF
--- a/ghost/tinybird/scripts/branch_and_test.sh
+++ b/ghost/tinybird/scripts/branch_and_test.sh
@@ -17,6 +17,9 @@ for arg in "$@"; do
     fi
 done
 
+# Allow version to be passed in or default to 0
+export TB_VERSION=${TB_VERSION:-0}
+
 # Attempt to create the branch and check for errors
 if ! tb branch create "$BRANCH_NAME"; then
     echo "🚨 ERROR: Failed to create branch $BRANCH_NAME. Exiting."

--- a/ghost/tinybird/scripts/exec_test.sh
+++ b/ghost/tinybird/scripts/exec_test.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 export TB_VERSION_WARNING=0
 
+# Default version if not provided
+export TB_VERSION=${TB_VERSION:-0}
+
 # Get the expected count once, outside of any function
 ndjson_file="./datasources/fixtures/analytics_events.ndjson"
 export expected_count=$(wc -l < "$ndjson_file" || echo "0")

--- a/ghost/tinybird/tests/all_kpis.test
+++ b/ghost/tinybird/tests/all_kpis.test
@@ -1,1 +1,1 @@
-tb pipe data kpis --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data kpis__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/all_top_browsers.test
+++ b/ghost/tinybird/tests/all_top_browsers.test
@@ -1,1 +1,1 @@
- tb pipe data top_browsers --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data top_browsers__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/all_top_devices.test
+++ b/ghost/tinybird/tests/all_top_devices.test
@@ -1,2 +1,1 @@
-
- tb pipe data top_devices --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data top_devices__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/all_top_locations.test
+++ b/ghost/tinybird/tests/all_top_locations.test
@@ -1,2 +1,1 @@
-
- tb pipe data top_locations --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data top_locations__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/all_top_pages.test
+++ b/ghost/tinybird/tests/all_top_pages.test
@@ -1,1 +1,1 @@
-tb pipe data top_pages --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data top_pages__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/all_top_sources.test
+++ b/ghost/tinybird/tests/all_top_sources.test
@@ -1,1 +1,1 @@
-tb pipe data top_sources --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV
+tb pipe data top_sources__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV

--- a/ghost/tinybird/tests/filter_browser_chrome_kpis.test
+++ b/ghost/tinybird/tests/filter_browser_chrome_kpis.test
@@ -1,1 +1,1 @@
-tb pipe data kpis --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome
+tb pipe data kpis__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/tinybird/tests/filter_browser_chrome_top_browsers.test
+++ b/ghost/tinybird/tests/filter_browser_chrome_top_browsers.test
@@ -1,1 +1,1 @@
-tb pipe data top_browsers --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome
+tb pipe data top_browsers__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/tinybird/tests/filter_browser_chrome_top_pages.test
+++ b/ghost/tinybird/tests/filter_browser_chrome_top_pages.test
@@ -1,1 +1,1 @@
-tb pipe data top_pages --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome
+tb pipe data top_pages__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/tinybird/tests/filter_browser_chrome_top_sources.test
+++ b/ghost/tinybird/tests/filter_browser_chrome_top_sources.test
@@ -1,1 +1,1 @@
-tb pipe data top_sources --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome
+tb pipe data top_sources__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/tinybird/tests/filter_source_bing_kpis.test
+++ b/ghost/tinybird/tests/filter_source_bing_kpis.test
@@ -1,1 +1,1 @@
-tb pipe data kpis --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com
+tb pipe data kpis__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/tinybird/tests/filter_source_bing_top_browsers.test
+++ b/ghost/tinybird/tests/filter_source_bing_top_browsers.test
@@ -1,1 +1,1 @@
-tb pipe data top_browsers --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com
+tb pipe data top_browsers__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/tinybird/tests/filter_source_bing_top_pages.test
+++ b/ghost/tinybird/tests/filter_source_bing_top_pages.test
@@ -1,1 +1,1 @@
-tb pipe data top_pages --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com
+tb pipe data top_pages__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/tinybird/tests/filter_source_bing_top_sources.test
+++ b/ghost/tinybird/tests/filter_source_bing_top_sources.test
@@ -1,1 +1,1 @@
-tb pipe data top_sources --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com
+tb pipe data top_sources__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/21794

- This was missed in the PR to add versioning to all the resources - the endpoints are now different, and the tests don't run
- I've been struggling to deploy out my changes, and part of it is because this is a wholesale change to having versions, where previously we didn't
- This change brings the tests into line, so we can be certain that the new endpoints with the versions work the same as the old
- TODO: really must get CI working for tinybird!
