### PR TITLE
Added config flag to disable link click tracking

### DIFF
--- a/ghost/core/core/server/services/link-tracking/index.js
+++ b/ghost/core/core/server/services/link-tracking/index.js
@@ -2,6 +2,7 @@ const LinkClickRepository = require('./LinkClickRepository');
 const PostLinkRepository = require('./PostLinkRepository');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
+const config = require('../../../shared/config');
 
 class LinkTrackingServiceWrapper {
     async init() {
@@ -40,7 +41,8 @@ class LinkTrackingServiceWrapper {
             linkClickRepository: this.linkClickRepository,
             postLinkRepository,
             DomainEvents,
-            urlUtils
+            urlUtils,
+            config
         });
 
         await this.service.init();

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -192,6 +192,7 @@
     "stripeDirect": false,
     "enableStripePromoCodes": false,
     "emailAnalytics": true,
+    "linkClickTracking": true,
     "backgroundJobs": {
         "emailAnalytics": true,
         "clickTrackingLastSeenAtUpdater": true

--- a/ghost/link-tracking/lib/LinkClickTrackingService.js
+++ b/ghost/link-tracking/lib/LinkClickTrackingService.js
@@ -61,6 +61,8 @@ class LinkClickTrackingService {
     #LinkRedirect;
     /** @type {Object} */
     #urlUtils;
+    /** @type {Object} */
+    #config;
 
     /**
      * @param {object} deps
@@ -69,6 +71,7 @@ class LinkClickTrackingService {
      * @param {IPostLinkRepository} deps.postLinkRepository
      * @param {DomainEvents} deps.DomainEvents
      * @param {urlUtils} deps.urlUtils
+     * @param {config} deps.config
      */
     constructor(deps) {
         this.#linkClickRepository = deps.linkClickRepository;
@@ -76,13 +79,17 @@ class LinkClickTrackingService {
         this.#postLinkRepository = deps.postLinkRepository;
         this.#DomainEvents = deps.DomainEvents;
         this.#urlUtils = deps.urlUtils;
+        this.#config = deps.config;
     }
 
     async init() {
         if (this.#initialised) {
             return;
         }
-        this.subscribe();
+
+        if (!this.#config || this.#config.get('linkClickTracking')) {
+            this.subscribe();
+        }
         this.#initialised = true;
     }
 

--- a/ghost/link-tracking/test/LinkClickTrackingService.test.js
+++ b/ghost/link-tracking/test/LinkClickTrackingService.test.js
@@ -13,6 +13,10 @@ describe('LinkClickTrackingService', function () {
     });
 
     describe('init', function () {
+        afterEach(function () {
+            sinon.restore();
+        });
+
         it('initialises only once', function () {
             const subscribe = sinon.stub();
             const service = new LinkClickTrackingService({
@@ -24,6 +28,16 @@ describe('LinkClickTrackingService', function () {
             assert.ok(subscribe.calledOnce);
             service.init();
             assert.ok(subscribe.calledOnce);
+        });
+
+        it('does not subscribe if linkClickTracking is false', function () {
+            const subscribe = sinon.stub();
+            const service = new LinkClickTrackingService({
+                config: {get: sinon.stub().returns(false)},
+                DomainEvents: {subscribe}
+            });
+            service.init();
+            assert.ok(!subscribe.called);
         });
     });
 


### PR DESCRIPTION
no ref

This isn't needed at this time. We're doing some load testing to better assess what piece is doing the most work, and this config flag lets us shut off pieces of the redirect flow.