### PR TITLE
Fixed comment count in comments-ui when logged in as admin

### DIFF
--- a/apps/comments-ui/src/App.tsx
+++ b/apps/comments-ui/src/App.tsx
@@ -121,8 +121,7 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
                         ...state,
                         adminApi: adminApi,
                         comments: adminComments.comments,
-                        pagination: adminComments.meta.pagination,
-                        commentCount: adminComments.meta.pagination.total
+                        pagination: adminComments.meta.pagination
                     });
                 }
             } catch (e) {

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -35,6 +35,8 @@ test.describe('Admin moderation', async () => {
             mockedApi,
             page,
             publication: 'Publisher Weekly',
+            title: 'Member discussion',
+            count: true,
             admin,
             labs: {
                 commentImprovements: options.labs
@@ -326,6 +328,14 @@ test.describe('Admin moderation', async () => {
 
             await expect(inReplyToComment).not.toContainText('[removed]');
             await expect(inReplyToComment).toContainText('This is reply 1');
+        });
+
+        test('has correct comments count', async ({page}) => {
+            mockedApi.addComment({html: '<p>This is comment 1</p>', replies: [buildReply()]});
+            mockedApi.addComment({html: '<p>This is comment 2</p>'});
+
+            const {frame} = await initializeTest(page, {labs: true});
+            await expect(frame.getByTestId('count')).toContainText('3 comments');
         });
     });
 });

--- a/apps/comments-ui/test/utils/MockedApi.ts
+++ b/apps/comments-ui/test/utils/MockedApi.ts
@@ -103,8 +103,11 @@ export class MockedApi {
     }
 
     commentsCounts() {
+        // get total number of published comments and replies in this.comments
+        const count = flattenComments(this.comments).filter(c => c.status === 'published').length;
+
         return {
-            [this.postId]: this.comments.length
+            [this.postId]: count
         };
     }
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PLG-297

- we were setting the comment count Admin API browse comments response meta pagination data which will never be correct because it only counts top-level comments for pagination purposes
- we have a public comment counts endpoint that is already fetched, there's no need to override that when using the Admin API because the overall count doesn't change across API's, even when the Admin API includes hidden comments because those don't impact the visible count
- updated test setup so the title and count is shown so it can be asserted against
- updated mocked api to correctly return count of all published comments+replies
