### PR TITLE
Changed location of built public content to temporary dir

### DIFF
--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+const os = require('os');
 const path = require('path');
 const {URL} = require('url');
 
@@ -64,6 +66,28 @@ const isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
     return this.get('privacy')[privacyFlag] === false;
 };
 
+/** @type {string|null} */
+let processTmpDirPath = null;
+
+/**
+ * Get a tmp dir path for the current process
+ *
+ * @returns {string} - tmp dir path for the current process
+ */
+function getProcessTmpDirPath(config) {
+    // Memoize the computed path to avoid re-computing it on each call - The
+    // value should not change during the lifetime of the process.
+    if (processTmpDirPath === null) {
+        const siteHash = crypto.createHash('md5')
+            .update(config.getSiteUrl())
+            .digest('hex');
+
+        processTmpDirPath = path.join(os.tmpdir(), `ghost_${siteHash}_${process.pid}`);
+    }
+
+    return processTmpDirPath;
+}
+
 /**
  * @callback getContentPathFn
  * @param {string} type - the type of context you want the path for
@@ -88,7 +112,7 @@ const getContentPath = function getContentPath(type) {
     case 'settings':
         return path.join(this.get('paths:contentPath'), 'settings/');
     case 'public':
-        return path.join(this.get('paths:contentPath'), 'public/');
+        return path.join(getProcessTmpDirPath(this), 'public/');
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -74,15 +74,11 @@ let processTmpDirPath = null;
  *
  * @returns {string} - tmp dir path for the current process
  */
-function getProcessTmpDirPath(config) {
+function getProcessTmpDirPath() {
     // Memoize the computed path to avoid re-computing it on each call - The
     // value should not change during the lifetime of the process.
     if (processTmpDirPath === null) {
-        const siteHash = crypto.createHash('md5')
-            .update(config.getSiteUrl())
-            .digest('hex');
-
-        processTmpDirPath = path.join(os.tmpdir(), `ghost_${siteHash}_${process.pid}`);
+        processTmpDirPath = path.join(os.tmpdir(), `ghost_${crypto.randomUUID()}`);
     }
 
     return processTmpDirPath;

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -187,6 +187,6 @@ describe('servePublicFile', function () {
         res.writeHead.called.should.be.true();
         res.writeHead.args[0][0].should.equal(200);
 
-        fileStub.firstCall.args[0].should.endWith('content/public/something.css');
+        fileStub.firstCall.args[0].should.endWith('/public/something.css');
     });
 });

--- a/ghost/core/test/unit/shared/config/helpers.test.js
+++ b/ghost/core/test/unit/shared/config/helpers.test.js
@@ -1,4 +1,8 @@
+const crypto = require('crypto');
+const os = require('os');
+const path = require('path');
 const should = require('should');
+
 const configUtils = require('../../../utils/configUtils');
 
 describe('vhost utils', function () {
@@ -50,5 +54,22 @@ describe('vhost utils', function () {
             configUtils.config.getBackendMountPath().should.eql(/.*/);
             configUtils.config.getFrontendMountPath().should.eql(/.*/);
         });
+    });
+});
+
+describe('getContentPath', function () {
+    it('should return the correct path for type: public', function () {
+        const tmpdir = os.tmpdir();
+        const siteUrl = configUtils.config.getSiteUrl();
+        const siteHash = crypto.createHash('md5')
+            .update(siteUrl)
+            .digest('hex');
+
+        const expectedPath = path.join(tmpdir, `ghost_${siteHash}_${process.pid}`, 'public/');
+
+        configUtils.config.getContentPath('public').should.eql(expectedPath);
+
+        // Call again to ensure the path is deterministic
+        configUtils.config.getContentPath('public').should.eql(expectedPath);
     });
 });


### PR DESCRIPTION
refs [ONC-662](https://linear.app/ghost/issue/ONC-662/fix-file-write-issues-in-ghost-application-related-to-asset-generation)

Changed location of built public content to temporary dir to circumvent file writing issues in some environments (i.e gluster). This is a stop-gap measure until we get to refactoring the generation of the built public content.