### PR TITLE
Added node event support to the job queue

### DIFF
--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -15,6 +15,7 @@ const errorHandler = (error, workerMeta) => {
     logging.error(error);
     sentry.captureException(error);
 };
+const events = require('../../lib/common/events');
 
 const workerMessageHandler = ({name, message}) => {
     if (typeof message === 'string') {
@@ -43,7 +44,7 @@ const initTestMode = () => {
     }, 5000);
 };
 
-const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, prometheusClient});
+const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, prometheusClient, events});
 
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;

--- a/ghost/core/test/integration/jobs/test-job-events.js
+++ b/ghost/core/test/integration/jobs/test-job-events.js
@@ -1,0 +1,19 @@
+/**
+ * A job that simulates an event-driven process.
+ * @returns {Object} An object containing the event data.
+ */
+module.exports = function jobWithEvents() {
+    const num1 = Math.floor(Math.random() * 100);
+    const num2 = Math.floor(Math.random() * 100);
+    const result = num1 + num2;
+
+    return {
+        success: true,
+        data: {
+            result: result
+        },
+        eventData: {
+            events: [{name: 'member.edited', data: {id: '1'}}]
+        }
+    };
+};

--- a/ghost/job-manager/lib/JobManager.js
+++ b/ghost/job-manager/lib/JobManager.js
@@ -42,6 +42,7 @@ class JobManager {
     #jobQueueManager = null;
     #config;
     #JobModel;
+    #events;
 
     /**
      * @param {Object} options
@@ -53,14 +54,16 @@ class JobManager {
      * @param {boolean} [options.isDuplicate] - if true, the job manager will not initialize the job queue
      * @param {JobQueueManager} [options.jobQueueManager] - job queue manager instance (for testing)
      * @param {Object} [options.prometheusClient] - prometheus client instance (for testing)
+     * @param {Object} [options.events] - events instance (for testing)
      */
-    constructor({errorHandler, workerMessageHandler, JobModel, domainEvents, config, isDuplicate = false, jobQueueManager = null, prometheusClient = null}) {
+    constructor({errorHandler, workerMessageHandler, JobModel, domainEvents, config, isDuplicate = false, jobQueueManager = null, prometheusClient = null, events = null}) {
         this.inlineQueue = fastq(this, worker, 3);
         this._jobMessageHandler = this._jobMessageHandler.bind(this);
         this._jobErrorHandler = this._jobErrorHandler.bind(this);
         this.#domainEvents = domainEvents;
         this.#config = config;
         this.#JobModel = JobModel;
+        this.#events = events;
 
         const combinedMessageHandler = workerMessageHandler
             ? ({name, message}) => {
@@ -104,7 +107,7 @@ class JobManager {
 
     #initializeJobQueueManager() {
         if (this.#config?.get('services:jobs:queue:enabled') === true && !this.#jobQueueManager) {
-            this.#jobQueueManager = new JobQueueManager({JobModel: this.#JobModel, config: this.#config, prometheusClient: this.prometheusClient});
+            this.#jobQueueManager = new JobQueueManager({JobModel: this.#JobModel, config: this.#config, prometheusClient: this.prometheusClient, eventEmitter: this.#events});
             this.#jobQueueManager.init();
         }
     }

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -134,7 +134,6 @@ class JobQueueManager {
      */
     emitEvents(events) {
         events.forEach((e) => {
-            console.log('emitting event', e);
             this.eventEmitter.emit(e.name, e.data);
         });
     }
@@ -159,7 +158,6 @@ class JobQueueManager {
              * @returns {Promise<{success?: boolean, eventData?: {events: Array<{name: string, data: any}>}}>}
              */
             const result = await this.pool.exec('executeJob', [jobMetadata.job, jobMetadata.data]);
-            console.log('result', result);
             await this.jobsRepository.delete(job.id);
             this.prometheusClient?.getMetric('job_manager_queue_job_completion_count')?.inc({jobName});
             if (jobName === 'update-member-email-analytics') {

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -5,15 +5,16 @@ const debug = require('@tryghost/debug')('job-manager:JobQueueManager');
 const logging = require('@tryghost/logging');
 
 class JobQueueManager {
-    constructor({JobModel, config, logger = logging, WorkerPool = workerpool, prometheusClient}) {
+    constructor({JobModel, config, logger = logging, WorkerPool = workerpool, prometheusClient, eventEmitter}) {
         this.jobsRepository = new JobsRepository({JobModel});
         this.config = this.initializeConfig(config?.get('services:jobs:queue') || {});
         this.logger = this.createLogger(logger, this.config.logLevel);
         this.WorkerPool = WorkerPool;
         this.pool = this.createWorkerPool();
         this.state = this.initializeState();
+        this.eventEmitter = eventEmitter;
+        
         this.prometheusClient = prometheusClient;
-
         if (prometheusClient) {
             this.prometheusClient.registerCounter({
                 name: 'job_manager_queue_job_completion_count',
@@ -127,6 +128,17 @@ class JobQueueManager {
         }
     }
 
+    /**
+     * Emits events to the Node event emitter
+     * @param {Array<{name: string, data: any}>} events - The events to emit, e.g. member.edited
+     */
+    emitEvents(events) {
+        events.forEach((e) => {
+            console.log('emitting event', e);
+            this.eventEmitter.emit(e.name, e.data);
+        });
+    }
+
     async processJobs(jobs) {
         for (const job of jobs) {
             const jobMetadata = JSON.parse(job.get('metadata'));
@@ -141,11 +153,20 @@ class JobQueueManager {
     async executeJob(job, jobName, jobMetadata) {
         this.state.queuedJobs.add(jobName);
         try {
-            await this.pool.exec('executeJob', [jobMetadata.job, jobMetadata.data]);
+            /**
+             * @param {'executeJob'} jobName - This is the generic job execution fn
+             * @param {Array<{name: string, data: any}>} args - The arguments to pass to the job execution fn
+             * @returns {Promise<{success?: boolean, eventData?: {events: Array<{name: string, data: any}>}}>}
+             */
+            const result = await this.pool.exec('executeJob', [jobMetadata.job, jobMetadata.data]);
+            console.log('result', result);
             await this.jobsRepository.delete(job.id);
             this.prometheusClient?.getMetric('job_manager_queue_job_completion_count')?.inc({jobName});
             if (jobName === 'update-member-email-analytics') {
                 this.prometheusClient?.getMetric('email_analytics_aggregate_member_stats_count')?.inc();
+            }
+            if (result && result.eventData) {
+                this.emitEvents(result.eventData.events); // this is nested within eventData because we may want to support DomainEvents emission as well
             }
         } catch (error) {
             await this.handleJobError(job, jobMetadata, error);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1851/
- added handling so that jobs run by the job queue can emit events on completion
- added tests

Events (both node and our DomainEvents lib) must be emitted on the primary process, so we can't emit these within the worker threads. Instead, we'll return the necessary data with the job's completion in the thread message such that the JobQueueManager can emit whatever events may be needed.