### PR TITLE
Fixed replies line showing after all replies have been deleted

### DIFF
--- a/apps/comments-ui/src/components/content/Comment.tsx
+++ b/apps/comments-ui/src/components/content/Comment.tsx
@@ -439,7 +439,7 @@ const RepliesLine: React.FC<{hasReplies: boolean}> = ({hasReplies}) => {
         return null;
     }
 
-    return (<div className="mb-2 h-full w-px grow rounded bg-gradient-to-b from-neutral-900/10 via-neutral-900/10 to-transparent dark:from-white/10 dark:via-white/10" />);
+    return (<div className="mb-2 h-full w-px grow rounded bg-gradient-to-b from-neutral-900/10 via-neutral-900/10 to-transparent dark:from-white/10 dark:via-white/10" data-testid="replies-line" />);
 };
 
 type CommentLayoutProps = {

--- a/apps/comments-ui/src/components/content/context-menus/AuthorContextMenu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/AuthorContextMenu.tsx
@@ -27,7 +27,7 @@ const AuthorContextMenu: React.FC<Props> = ({comment, close, toggleEdit}) => {
             <button className="w-full rounded px-2.5 py-1.5 text-left text-[14px] transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-700" data-testid="edit" type="button" onClick={toggleEdit}>
                 {t('Edit')}
             </button>
-            <button className="w-full rounded px-2.5 py-1.5 text-left text-[14px] text-red-600 transition-colors hover:bg-neutral-100 dark:text-red-500 dark:hover:bg-neutral-700" type="button" onClick={deleteComment}>
+            <button className="w-full rounded px-2.5 py-1.5 text-left text-[14px] text-red-600 transition-colors hover:bg-neutral-100 dark:text-red-500 dark:hover:bg-neutral-700" data-testid="delete" type="button" onClick={deleteComment}>
                 {t('Delete')}
             </button>
         </div>

--- a/apps/comments-ui/src/components/popups/DeletePopup.tsx
+++ b/apps/comments-ui/src/components/popups/DeletePopup.tsx
@@ -64,7 +64,7 @@ const DeletePopup = ({comment}: {comment: Comment}) => {
     };
 
     return (
-        <div className="shadow-modal relative h-screen w-screen rounded-none bg-white p-[28px] text-center sm:h-auto sm:w-[500px] sm:rounded-xl sm:p-8 sm:text-left" onMouseDown={stopPropagation}>
+        <div className="shadow-modal relative h-screen w-screen rounded-none bg-white p-[28px] text-center sm:h-auto sm:w-[500px] sm:rounded-xl sm:p-8 sm:text-left" data-testid="delete-popup" onMouseDown={stopPropagation}>
             <div className="flex h-full flex-col justify-center pt-10 sm:justify-normal sm:pt-0">
                 <h1 className="mb-1.5 font-sans text-[2.2rem] font-bold tracking-tight text-black">
                     <span>{t('Are you sure?')}</span>
@@ -73,6 +73,7 @@ const DeletePopup = ({comment}: {comment: Comment}) => {
                 <div className="mt-auto flex flex-col items-center justify-start gap-4 sm:mt-8 sm:flex-row">
                     <button
                         className={`text-md flex h-[44px] w-full items-center justify-center rounded-md px-4 font-sans font-medium text-white transition duration-200 ease-linear sm:w-fit ${buttonColor} opacity-100 hover:opacity-90`}
+                        data-testid="delete-popup-confirm"
                         disabled={isSubmitting}
                         type="button"
                         onClick={submit}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-267

- updated delete comment action so it removes comments from local state rather than just updating their status to `'deleted'`
- for deleted comments that have replies, the status updated so the replies remain visible
- matches updated API behaviour where deleted comments are not shown at all
