### PR TITLE
🐛 Fixed mobile navigation for Admin

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -192,3 +192,4 @@ remove|ember-template-lint|no-action|73|76|73|76|7d339c0f3d02ec863651697ad8e8105
 add|ember-template-lint|no-action|5|14|5|14|a90edd9a99596008f60bfcdbc6befe7fe8d26321|1730678400000|1741046400000|1746230400000|app/components/gh-psm-tags-input.hbs
 remove|ember-template-lint|no-action|5|14|5|14|88b11bf43be33d97824ebac071a563affac0b97d|1730678400000|1741046400000|1746230400000|app/components/gh-psm-tags-input.hbs
 add|ember-template-lint|no-action|80|92|80|92|f30d469e4ae668f05aca2f92a124a6b4748847a3|1730678400000|1741046400000|1746230400000|app/components/gh-post-settings-menu.hbs
+remove|ember-template-lint|no-action|8|50|8|50|de589665046a78748832e8f93d2e495d1d259265|1728345600000|1738717200000|1743897600000|app/components/gh-mobile-nav-bar.hbs

--- a/ghost/admin/app/components/gh-mobile-nav-bar.hbs
+++ b/ghost/admin/app/components/gh-mobile-nav-bar.hbs
@@ -5,5 +5,12 @@
     <LinkTo @route="posts">{{svg-jar "content" data-test-mobile-nav="posts"}}Posts</LinkTo>
 {{/if}}
 <LinkTo @route="members" class="gh-nav-main-users" data-test-mobile-nav="members">{{svg-jar "members"}}Members</LinkTo>
-<div role="button" class="gh-mobile-nav-bar-more" {{action "openMobileMenu" target=this.ui data-test-mobile-nav="more"}}>{{svg-jar "icon" class="icon-gh"}}More</div>
+<div 
+    role="button" 
+    class="gh-mobile-nav-bar-more" 
+    {{on "click" (fn this.ui.toggleMobileMenu)}}
+    data-test-mobile-nav="more"
+>
+    {{svg-jar "icon" class="icon-gh"}}More
+</div>
 {{yield}}

--- a/ghost/admin/app/components/gh-mobile-nav-bar.hbs
+++ b/ghost/admin/app/components/gh-mobile-nav-bar.hbs
@@ -8,7 +8,7 @@
 <div 
     role="button" 
     class="gh-mobile-nav-bar-more" 
-    {{on "click" (fn this.ui.toggleMobileMenu)}}
+    {{on "click" this.ui.toggleMobileMenu}}
     data-test-mobile-nav="more"
 >
     {{svg-jar "icon" class="icon-gh"}}More

--- a/ghost/admin/app/services/ui.js
+++ b/ghost/admin/app/services/ui.js
@@ -192,4 +192,9 @@ export default class UiService extends Service {
         document.body.removeEventListener('dragend', this.cancelDrag, {capture: true});
         document.body.removeEventListener('drop', this.cancelDrag, {capture: true});
     }
+
+    @action
+    toggleMobileMenu() {
+        this.showMobileMenu = !this.showMobileMenu;
+    }
 }


### PR DESCRIPTION
Previously, the only way to close the navigation in Ghost Admin on mobile was to tap outside of the menu, on the background behind it. With this change, you can also tap the 'More' button or navigate to any other menu item to have the menu close itself again.

fixes https://linear.app/ghost/issue/DES-993/the-slide-out-panel-inside-ghosts-admin-on-mobile-lacks-intuitive


https://github.com/user-attachments/assets/db48a8cd-db4f-4118-9d6a-7b7b3d5e6236


