### PR TITLE
🐛 Fixed responsive issues with Posts filters

### DIFF
--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -1835,9 +1835,17 @@
     .gh-canvas {
         padding: 0 4vw 4vw;
     }
+    
+    .gh-canvas-header.break.tablet .view-actions {
+        position: absolute;
+        left: 0;
+        width: 100%;
+    }
 
     .gh-canvas-header.break .view-actions-bottom-row {
         max-width: calc(100vw - 56px) !important;
+        min-width: 100%!important;
+        overflow-x: scroll;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -1846,9 +1846,10 @@
         position: relative;
         max-width: calc(100vw - 56px) !important;
         min-width: 100%;
-        overflow-x: scroll;
         display: flex;
-        padding-right: 40px;
+        justify-content: space-between;
+        overflow-x: auto;
+
     }
 
     .gh-canvas-header.break .view-actions .gh-contentfilter {

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -1842,10 +1842,29 @@
         width: 100%;
     }
 
-    .gh-canvas-header.break .view-actions-bottom-row {
+    .gh-canvas-header.break.tablet .view-actions-bottom-row {
+        position: relative;
         max-width: calc(100vw - 56px) !important;
-        min-width: 100%!important;
+        min-width: 100%;
         overflow-x: scroll;
+    }
+
+    .gh-canvas-header.break.tablet .view-actions-bottom-row::after {
+        content: '';
+        position: sticky;
+        top: 0;
+        right: 0;
+        height: 100%;
+        z-index: 1;
+        width: 40px;
+        background: linear-gradient(to right, transparent, var(--main-bg-color));
+        pointer-events: none;
+        float: right;
+        margin-left: -40px;
+    }
+
+    .gh-canvas-header.break .view-actions .gh-contentfilter {
+        border: none;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -1847,20 +1847,8 @@
         max-width: calc(100vw - 56px) !important;
         min-width: 100%;
         overflow-x: scroll;
-    }
-
-    .gh-canvas-header.break.tablet .view-actions-bottom-row::after {
-        content: '';
-        position: sticky;
-        top: 0;
-        right: 0;
-        height: 100%;
-        z-index: 1;
-        width: 40px;
-        background: linear-gradient(to right, transparent, var(--main-bg-color));
-        pointer-events: none;
-        float: right;
-        margin-left: -40px;
+        display: flex;
+        padding-right: 40px;
     }
 
     .gh-canvas-header.break .view-actions .gh-contentfilter {

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -464,6 +464,10 @@ p.gh-members-list-email {
     .gh-members-list-chevron {
         display: none;
     }
+
+    .members-header .view-actions .gh-members-header-search {
+        width: 100%;
+    }
 }
 
 @media (max-width: 450px) {
@@ -2833,6 +2837,10 @@ a.gh-members-emailpreview-subscription-link {
 
     .members-header .gh-canvas-title {
         left: 25px;
+    }
+    
+    .members-header .view-actions .gh-members-header-search {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
When using the Admin on a mobile device, the filters on the Posts screen fell off the screen. They weren't scrollable horizontally, making them difficult to use. These changes address that. 
The Members header uses the same markup, so I addressed a responsive issue there as well (the search bar for Members wasn't behaving accurately across resolutions).

fixes https://linear.app/ghost/issue/DES-1030/filters-for-posts-fall-off-screen-on-mobile-resolutions

**Before / After**

https://github.com/user-attachments/assets/f7d51801-6949-45d0-aea6-054f17d92a19

