### PR TITLE
Added experimental section in Shade

### DIFF
--- a/apps/shade/.storybook/preview.tsx
+++ b/apps/shade/.storybook/preview.tsx
@@ -59,7 +59,7 @@ const preview: Preview = {
 		options: {
 			storySort: {
 				method: 'alphabetical',
-				order: ['Welcome', 'Adding components', 'Component usage', 'Conventions', 'Icons', 'Global', ['Form', 'Chrome', 'Modal', 'Layout', ['View Container', 'Page Header', 'Page'], 'List', 'Table', '*'], 'Settings', ['Setting Section', 'Setting Group', '*'], 'Experimental'],
+				order: ['Welcome', 'Adding components', 'Component usage', 'Conventions', 'Icons', 'Components', 'Meta', 'Experimental'],
 			},
 		},
 		docs: {

--- a/apps/shade/src/components/ui/icon.stories.tsx
+++ b/apps/shade/src/components/ui/icon.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 
 const meta = {
-    title: 'Components / Streamline icons',
+    title: 'Components / Icons',
     component: Icon.Close,
     tags: ['autodocs'],
     argTypes: {

--- a/apps/shade/src/components/ui/lucide-icon.stories.tsx
+++ b/apps/shade/src/components/ui/lucide-icon.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {Smile} from 'lucide-react';
 
 const meta = {
-    title: 'Components / Lucide icons',
+    title: 'Experimental / Lucide icons',
     component: Smile,
     tags: ['autodocs'],
     parameters: {

--- a/apps/shade/src/docs/Icons.mdx
+++ b/apps/shade/src/docs/Icons.mdx
@@ -12,9 +12,9 @@ In Shade we use Streamline icons. They are dynamically loaded from the `src/asse
 <Icon.IconName size="md" />
 ```
 
-If you check out the [Icons](/docs/components-streamline-icons--docs) component here in Storybook, you'll see a grid of all available icons in Shade. This list is dynamically loaded and if you click on an icon then the component code will be copied to your clipboard.
+If you check out the [Icons](/docs/components-icons--docs) component here in Storybook, you'll see a grid of all available icons in Shade. This list is dynamically loaded and if you click on an icon then the component code will be copied to your clipboard.
 
-<a href="/?path=/docs/components-streamline-icons--docs" className="button">Streamline icons in Shade &rarr;</a>
+<a href="/?path=/docs/components-icons--docs" className="button">Streamline icons in Shade &rarr;</a>
 
 
 ## Adding icons


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1033/icon-implementation

The Storybook structure contained Lucide icons under "Components", but it's an experimental component. This commit creates an Experimental component group in Shade and updates the corresponding docs.