### PR TITLE
Fix problems with Tinybird deployment

### DIFF
--- a/ghost/tinybird/datasources/analytics_pages_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_pages_mv.datasource
@@ -16,4 +16,4 @@ SCHEMA >
 
 ENGINE AggregatingMergeTree
 ENGINE_PARTITION_KEY toYYYYMM(date)
-ENGINE_SORTING_KEY date, device, browser, location, source, pathname, post_uuid, site_uuid
+ENGINE_SORTING_KEY date, device, browser, location, source, pathname, post_type, post_uuid, site_uuid

--- a/ghost/tinybird/datasources/analytics_pages_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_pages_mv.datasource
@@ -1,8 +1,9 @@
-VERSION 0
+VERSION 1
 
 SCHEMA >
     `site_uuid` String,
     `post_uuid` String,
+    `post_type` String,
     `date` Date,
     `device` String,
     `browser` String,

--- a/ghost/tinybird/datasources/analytics_sessions_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_sessions_mv.datasource
@@ -1,10 +1,11 @@
-VERSION 0
+VERSION 1
 SCHEMA >
     `site_uuid` String,
     `date` Date,
     `session_id` String,
     `member_status` SimpleAggregateFunction(any, String),
     `post_uuid` SimpleAggregateFunction(any, String),
+    `post_type` SimpleAggregateFunction(any, String),
     `device` SimpleAggregateFunction(any, String),
     `browser` SimpleAggregateFunction(any, String),
     `location` SimpleAggregateFunction(any, String),

--- a/ghost/tinybird/datasources/version_log.datasource
+++ b/ghost/tinybird/datasources/version_log.datasource
@@ -1,0 +1,8 @@
+SCHEMA >
+    `version` LowCardinality(String) `json:$.version`,
+    `timestamp` DateTime64(3) `json:$.timestamp` DEFAULT now64(3),
+    `step_id` Int64 `json:$.step_id`,
+    `message` LowCardinality(String) `json:$.message`
+
+ENGINE "MergeTree"
+ENGINE_SORTING_KEY "version, timestamp"

--- a/ghost/tinybird/pipes/analytics_pages.pipe
+++ b/ghost/tinybird/pipes/analytics_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -34,6 +35,7 @@ SQL >
         member_uuid,
         member_status,
         post_uuid,
+        post_type,
         location,
         domainWithoutWWW(referrer) as source,
         pathname,
@@ -71,6 +73,7 @@ SQL >
         site_uuid,
         toDate(timestamp) AS date,
         post_uuid,
+        post_type,
         device,
         browser,
         location,
@@ -82,8 +85,8 @@ SQL >
         ) AS member_status,
         uniqState(session_id) AS visits,
         countState() AS pageviews
-    FROM analytics_hits_data
-    GROUP BY date, device, browser, location, source, pathname, post_uuid,site_uuid
+    FROM analytics_hits
+        GROUP BY date, device, browser, location, source, pathname, post_uuid, post_type, site_uuid
 
 TYPE MATERIALIZED
-DATASOURCE analytics_pages_mv__v0
+DATASOURCE analytics_pages_mv__v1

--- a/ghost/tinybird/pipes/analytics_pages.pipe
+++ b/ghost/tinybird/pipes/analytics_pages.pipe
@@ -85,7 +85,7 @@ SQL >
         ) AS member_status,
         uniqState(session_id) AS visits,
         countState() AS pageviews
-    FROM analytics_hits
+    FROM analytics_hits_data
         GROUP BY date, device, browser, location, source, pathname, post_uuid, post_type, site_uuid
 
 TYPE MATERIALIZED

--- a/ghost/tinybird/pipes/analytics_sessions.pipe
+++ b/ghost/tinybird/pipes/analytics_sessions.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'

--- a/ghost/tinybird/pipes/analytics_sessions.pipe
+++ b/ghost/tinybird/pipes/analytics_sessions.pipe
@@ -89,4 +89,4 @@ SQL >
     GROUP BY date, session_id, site_uuid
 
 TYPE MATERIALIZED
-DATASOURCE analytics_sessions_mv__v0
+DATASOURCE analytics_sessions_mv__v1

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 1
+VERSION 0
 
 NODE parsed_hits
 DESCRIPTION >

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -93,4 +93,4 @@ SQL >
     HAVING b.source != current_domain
 
 TYPE MATERIALIZED
-DATASOURCE analytics_sources_mv__v1
+DATASOURCE analytics_sources_mv__v0

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -93,4 +93,4 @@ SQL >
     HAVING b.source != current_domain
 
 TYPE MATERIALIZED
-DATASOURCE analytics_sources_mv__v0
+DATASOURCE analytics_sources_mv__v1

--- a/ghost/tinybird/pipes/kpis.pipe
+++ b/ghost/tinybird/pipes/kpis.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Summary with general KPIs per date, including visits, page views, bounce rate and average session duration.

--- a/ghost/tinybird/pipes/kpis.pipe
+++ b/ghost/tinybird/pipes/kpis.pipe
@@ -65,6 +65,69 @@ SQL >
             ) as date
     {% end %}
 
+NODE parsed_hits
+DESCRIPTION >
+    Parse raw page_hit events
+
+SQL >
+    SELECT
+        timestamp,
+        action,
+        version,
+        coalesce(session_id, '0') as session_id,
+        JSONExtractString(payload, 'locale') as locale,
+        JSONExtractString(payload, 'location') as location,
+        JSONExtractString(payload, 'referrer') as referrer,
+        JSONExtractString(payload, 'pathname') as pathname,
+        JSONExtractString(payload, 'href') as href,
+        JSONExtractString(payload, 'site_uuid') as site_uuid,
+        JSONExtractString(payload, 'member_uuid') as member_uuid,
+        JSONExtractString(payload, 'member_status') as member_status,
+        JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
+        lower(JSONExtractString(payload, 'user-agent')) as user_agent
+    FROM analytics_events
+    where action = 'page_hit'
+
+NODE analytics_hits_data
+SQL >
+    SELECT
+        site_uuid,
+        timestamp,
+        action,
+        version,
+        session_id,
+        member_uuid,
+        member_status,
+        post_uuid,
+        location,
+        domainWithoutWWW(referrer) as source,
+        pathname,
+        href,
+        case
+            when match(user_agent, 'wget|ahrefsbot|curl|urllib|bitdiscovery|\+https://|googlebot')
+            then 'bot'
+            when match(user_agent, 'android')
+            then 'mobile-android'
+            when match(user_agent, 'ipad|iphone|ipod')
+            then 'mobile-ios'
+            else 'desktop'
+        END as device,
+        case
+            when match(user_agent, 'firefox')
+            then 'firefox'
+            when match(user_agent, 'chrome|crios')
+            then 'chrome'
+            when match(user_agent, 'opera')
+            then 'opera'
+            when match(user_agent, 'msie|trident')
+            then 'ie'
+            when match(user_agent, 'iphone|ipad|safari')
+            then 'safari'
+            else 'Unknown'
+        END as browser
+    FROM parsed_hits
+
 NODE pageviews
 DESCRIPTION >
     Group by sessions and calculate metrics at that level
@@ -87,7 +150,7 @@ SQL >
             case when min(timestamp) = max(timestamp) then 1 else 0 end as is_bounce,
             max(timestamp) as latest_view_aux,
             min(timestamp) as first_view_aux
-        from analytics_hits
+        from analytics_hits_data
         where toDate(timestamp) = {{ Date(date_from) }}
         group by toStartOfHour(timestamp), session_id, site_uuid, member_status, device, browser, location, source, pathname
     {% else %}

--- a/ghost/tinybird/pipes/top_browsers.pipe
+++ b/ghost/tinybird/pipes/top_browsers.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top Browsers ordered by most visits.

--- a/ghost/tinybird/pipes/top_devices.pipe
+++ b/ghost/tinybird/pipes/top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top Device Types ordered by most visits.

--- a/ghost/tinybird/pipes/top_locations.pipe
+++ b/ghost/tinybird/pipes/top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top visiting Countries ordered by most visits.

--- a/ghost/tinybird/pipes/top_pages.pipe
+++ b/ghost/tinybird/pipes/top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Most visited pages for a given period.

--- a/ghost/tinybird/pipes/top_sources.pipe
+++ b/ghost/tinybird/pipes/top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Top traffic sources (domains), ordered by most visits.
     Accepts `date_from` and `date_to` date filter. Defaults to last 7 days.

--- a/ghost/tinybird/pipes/trend.pipe
+++ b/ghost/tinybird/pipes/trend.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Visits trend over time for the last 30 minutes, filling the blanks.
     Works great for the realtime chart.
@@ -25,6 +25,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'

--- a/ghost/tinybird/scripts/version_upgrade.sh
+++ b/ghost/tinybird/scripts/version_upgrade.sh
@@ -67,18 +67,14 @@ while [ $current_step -le $max_steps ]; do
         # Do stuff...
         step_message="Populate analytics_sessions_mv__v1 with analytics_sessions__v1"
         # Migrate the data
-        output=$(tb pipe populate --truncate --wait analytics_sessions__v1 | tee /dev/tty)
+        output=$(tb pipe populate --truncate --wait analytics_sessions__v1)
 
         # Check that it ran ok
         if [ $? -ne 0 ]; then
             echo "Error in step $current_step"
+            echo $output
             exit 1
         fi
-        # ^ Right now this is broken, on error it does not stop
-        # Suggested approach: parse the output of the job. Output:
-        # ** Populating job url https://api.tinybird.co/v0/jobs/b19bebf2-6d21-435b-ac63-2ab1703fa563
-        # tb job details <job_id>
-
 
         # Log the stuff you've done
         # curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"$ver_from\",\"step_id\":$current_step,\"message\":\"$step_message\"}"
@@ -89,13 +85,15 @@ while [ $current_step -le $max_steps ]; do
         # Do stuff...
         step_message="Populate analytics_pages_mv__v1 with analytics_pages__v1"
         # Migrate the data
-        output=$(tb pipe populate --truncate --wait analytics_pages__v1 | tee /dev/tty)
+        output=$(tb pipe populate --truncate --wait analytics_pages__v1)
 
         # Check that it ran ok
         if [ $? -ne 0 ]; then
             echo "Error in step $current_step"
+            echo $output
             exit 1
         fi
+
         # Log the stuff you've done
         echo "{\"version\":\"$ver_from\",\"step_id\":$current_step,\"message\":\"$step_message\"}" > /tmp/msg.ndjson
         tb datasource append version_log /tmp/msg.ndjson

--- a/ghost/tinybird/scripts/version_upgrade.sh
+++ b/ghost/tinybird/scripts/version_upgrade.sh
@@ -86,6 +86,7 @@ while [ $current_step -le $max_steps ]; do
         # Log the stuff you've done
         curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"$ver_from\",\"step_id\":$current_step,\"message\":\"$step_message\"}"
     else
+        # Empty step for testing
         sleep 1
     fi
     # Go to the next step

--- a/ghost/tinybird/scripts/version_upgrade.sh
+++ b/ghost/tinybird/scripts/version_upgrade.sh
@@ -12,7 +12,7 @@ echo "Current version: $current_ver"
 # TODO: If current_ver = '', the DS is empty, we need to initialize
 # I am going to leave this command as a placeholder initializer for now:
 # tb datasource truncate version_log --yes
-# curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d '{"version":"0.0.0","step_id":-1,"retry":-1,"message":"Initial version statement"}'
+# curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d '{"version":"0.0.0","step_id":-1,"message":"Initial version statement"}'
 
 
 if [ "$ver_from" != "$current_ver" ];
@@ -25,12 +25,9 @@ echo "Upgrading from: \"$ver_from\" to: \"$ver_to\""
 
 
 # Get the highest step done:
-query_result=$(tb sql --format JSON "SELECT max(step_id) last_step, max(retry) last_retry FROM version_log WHERE version = '$current_ver'")
+query_result=$(tb sql --format JSON "SELECT max(step_id) last_step FROM version_log WHERE version = '$current_ver'")
 
 max_step=$(echo "$query_result" | jq -r '.data[0].last_step')
-current_retry=$(echo "$query_result" | jq -r '.data[0].last_retry')
-
-current_retry=$((current_retry+1))
 
 if [ $max_step -lt 0 ]
 then
@@ -53,7 +50,7 @@ while [ $current_step -le $max_steps ]; do
     if [ "$current_step" -le 0 ];then
         # Do stuff...
         # Log the stuff you've done
-        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":$current_step,\"retry\":$current_retry,\"message\":\"Start update to $ver_to\"}"
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":$current_step,\"message\":\"Start update to $ver_to\"}"
     elif [ "$current_step" -le 1 ];
     then
         # Do stuff...
@@ -67,7 +64,7 @@ while [ $current_step -le $max_steps ]; do
         fi
 
         # Log the stuff you've done
-        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":1,\"retry\":$current_retry,\"message\":\"Deploy changes\"}"
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":$current_step,\"message\":\"Deploy changes\"}"
     elif [ "$current_step" -le 2 ];
     then
         # Do stuff...
@@ -79,7 +76,7 @@ while [ $current_step -le $max_steps ]; do
             exit 1
         fi
         # Log the stuff you've done
-        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":1,\"retry\":$current_retry,\"message\":\"Deploy changes\"}"
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":$current_step,\"message\":\"Deploy changes\"}"
     else
         sleep 1
     fi

--- a/ghost/tinybird/scripts/version_upgrade.sh
+++ b/ghost/tinybird/scripts/version_upgrade.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+ver_from="0.0.0"
+ver_to="1.0.0"
+
+
+
+current_ver=$(tb sql --format JSON "SELECT argMax(version, timestamp) version FROM version_log" | jq -r '.data[0].version')
+
+echo "Current version: $current_ver"
+
+# TODO: If current_ver = '', the DS is empty, we need to initialize
+# I am going to leave this command as a placeholder initializer for now:
+# tb datasource truncate version_log --yes
+# curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d '{"version":"0.0.0","step_id":-1,"retry":-1,"message":"Initial version statement"}'
+
+
+if [ "$ver_from" != "$current_ver" ];
+then
+  echo "This script is valid only for version $ver_from"
+  exit 1
+fi
+
+echo "Upgrading from: \"$ver_from\" to: \"$ver_to\""
+
+
+# Get the highest step done:
+query_result=$(tb sql --format JSON "SELECT max(step_id) last_step, max(retry) last_retry FROM version_log WHERE version = '$current_ver'")
+
+max_step=$(echo "$query_result" | jq -r '.data[0].last_step')
+current_retry=$(echo "$query_result" | jq -r '.data[0].last_retry')
+
+current_retry=$((current_retry+1))
+
+if [ $max_step -lt 0 ]
+then
+    # Start at -1
+    current_step=-1
+else
+    current_step=$max_step
+fi
+
+# The idea is that a logged step means that it is done already, so we go to the next
+current_step=$((current_step+1))
+
+echo "Running from step id $current_step"
+
+
+max_steps=5
+while [ $current_step -le $max_steps ]; do
+    echo
+    echo "Running step $current_step"
+    if [ "$current_step" -le 0 ];then
+        # Do stuff...
+        # Log the stuff you've done
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":$current_step,\"retry\":$current_retry,\"message\":\"Start update to $ver_to\"}"
+    elif [ "$current_step" -le 1 ];
+    then
+        # Do stuff...
+        # Deploy changes
+        output=$(tb push --push-deps --only-changes --no-check --yes | tee /dev/tty)
+
+        # If a step fails, the script should stop without logging so it can be retried
+        if [ $? -ne 0 ]; then
+            echo "Error in step $current_step"
+            exit 1
+        fi
+
+        # Log the stuff you've done
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":1,\"retry\":$current_retry,\"message\":\"Deploy changes\"}"
+    elif [ "$current_step" -le 2 ];
+    then
+        # Do stuff...
+        # Migrate the data
+        let
+
+        if [ $? -ne 0 ]; then
+            echo "Error in step $current_step"
+            exit 1
+        fi
+        # Log the stuff you've done
+        curl -X POST 'https://api.tinybird.co/v0/events?name=version_log' -H "Authorization: Bearer $TB_TOKEN" -d "{\"version\":\"0.0.0\",\"step_id\":1,\"retry\":$current_retry,\"message\":\"Deploy changes\"}"
+    else
+        sleep 1
+    fi
+    # Go to the next step
+    current_step=$((current_step+1))
+done
+
+
+# When all runs ok, finish
+


### PR DESCRIPTION
The objective of these changes is to enable running these commands without errors:
- `tb branch use main`
- `tb branch rm  tb_deploy_tinybird_add_column_test`
(Clean up if needed)
- `tb branch create --last-partition --wait tb_deploy_tinybird_add_column_test`
- `tb branch use tb_deploy_tinybird_add_column_test`
- `tb deploy`

This also introduces a tentative "version log" to keep track of the latest deployed version in Tinybird.

I have included the first draft of a "version upgrade script", ~but I think I have gone overboard with stuff we don't really need, and I am going to cut back its complexity and the amount of stuff that it does~. The script has been cut back to a really simple set of commands that perform the necessary data operations.

You can test the version upgrade script with the data migration (after deploying):
First initialize the `version_log` datasource
- `tb datasource truncate version_log --yes`
- `echo "{\"version\":\"0.0.0\",\"step_id\":-1,\"message\":\"Current version statement\"}" > /tmp/msg.ndjson`
- `tb datasource append version_log /tmp/msg.ndjson`
Then run the script:
- `sh scripts/version_upgrade.sh`
