### PR TITLE
Added stale-if-error and fixed bug for frontend cache staleWhileRevaidate config (#21886)

### DIFF
--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -15,7 +15,7 @@ function calculateMemberTier(member, freeTier) {
     const activeSubscriptions = member.subscriptions.filter(sub => sub.status === 'active');
     if (activeSubscriptions.length === 0) {
         return freeTier;
-    } 
+    }
     if (activeSubscriptions.length === 1) {
         return activeSubscriptions[0].tier;
     }
@@ -62,10 +62,14 @@ const getMiddleware = async (getFreeTier = async () => {
             // The member is either on the free tier or has a single active subscription
             // Cache the content based on the member's tier
             res.set({'X-Member-Cache-Tier': memberTier.id});
-            return shared.middleware.cacheControl('public', {maxAge: config.get('caching:frontend:maxAge')})(req, res, next);
         }
+
         // CASE: Site is not private and the request is not made by a member — cache the content
-        return shared.middleware.cacheControl('public', {maxAge: config.get('caching:frontend:maxAge')})(req, res, next);
+        return shared.middleware.cacheControl('public', {
+            maxAge: config.get('caching:frontend:maxAge'),
+            staleWhileRevalidate: config.get('caching:frontend:staleWhileRevalidate'),
+            staleIfError: config.get('caching:frontend:staleIfError')
+        })(req, res, next);
     }
 
     return setFrontendCacheHeadersMiddleware;

--- a/ghost/mw-cache-control/lib/mw-cache-control.js
+++ b/ghost/mw-cache-control/lib/mw-cache-control.js
@@ -13,13 +13,15 @@ const isString = require('lodash/isString');
  * @param {object} [options]
  * @param {number} [options.maxAge] The max-age in seconds to use when profile is "public"
  * @param {number} [options.staleWhileRevalidate] The stale-while-revalidate in seconds to use when profile is "public"
+ * @param {number} [options.staleIfError] The stale-if-error in seconds to use when profile is "public"
  */
 const cacheControl = (profile, options = {maxAge: 0}) => {
-    const isOptionHasProperty = property => Object.prototype.hasOwnProperty.call(options, property);
+    const isOptionHasProperty = property => Object.prototype.hasOwnProperty.call(options, property) && options[property];
     const publicOptions = [
         'public',
         `max-age=${options.maxAge}`,
-        isOptionHasProperty('staleWhileRevalidate') ? `stale-while-revalidate=${options.staleWhileRevalidate}` : ''
+        isOptionHasProperty('staleWhileRevalidate') ? `stale-while-revalidate=${options.staleWhileRevalidate}` : '',
+        isOptionHasProperty('staleIfError') ? `stale-if-error=${options.staleIfError}` : ''
     ];
 
     const profiles = {

--- a/ghost/mw-cache-control/test/cache-control.test.js
+++ b/ghost/mw-cache-control/test/cache-control.test.js
@@ -34,11 +34,56 @@ describe('Cache-Control middleware', function () {
         });
     });
 
+    it('correctly sets the public profile headers with custom maxAge while both staleWhileRevalidate and staleIfError are undefined', function (done) {
+        cacheControl('public', {maxAge: 123456, staleWhileRevalidate: undefined, staleIfError: undefined})(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'public, max-age=123456'}).should.be.true();
+            done();
+        });
+    });
+
     it('correctly sets the public profile headers with staleWhileRevalidate', function (done) {
         cacheControl('public', {maxAge: 1, staleWhileRevalidate: 9})(null, res, function (a) {
             should.not.exist(a);
             res.set.calledOnce.should.be.true();
             res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'}).should.be.true();
+            done();
+        });
+    });
+
+    it('correctly sets the public profile headers with staleWhileRevalidate while staleIfError is undefined', function (done) {
+        cacheControl('public', {maxAge: 1, staleWhileRevalidate: 9, staleIfError: undefined})(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'}).should.be.true();
+            done();
+        });
+    });
+
+    it('correctly sets the public profile headers with staleIfError', function (done) {
+        cacheControl('public', {maxAge: 1, staleIfError: 10})(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-if-error=10'}).should.be.true();
+            done();
+        });
+    });
+
+    it('correctly sets the public profile headers with staleIfError while staleWhileRevalidate is undefined', function (done) {
+        cacheControl('public', {maxAge: 1, staleIfError: 10, staleWhileRevalidate: undefined})(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-if-error=10'}).should.be.true();
+            done();
+        });
+    });
+
+    it('correctly sets the public profile headers with both staleWhileRevalidate and staleIfError', function (done) {
+        cacheControl('public', {maxAge: 1, staleWhileRevalidate: 10, staleIfError: 11})(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-while-revalidate=10, stale-if-error=11'}).should.be.true();
             done();
         });
     });


### PR DESCRIPTION
This PR fixes the `staleWhileRevaidate` config not being passed into the `cacheControl()` middleware if it is set via the frontend caching config. It also adds the `staleIfError` configuration to allow the `stale-if-error` `Cache-Control` header directive.

Tests have also been added for varying cases of the directives including when the Ghost config is not set.

Documentation from https://ghost.org/docs/config/#caching will also need to be updated. Happy to update this given the source.

- [X] There's a clear use-case for this code change, explained above
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

Closes issue https://github.com/TryGhost/Ghost/issues/21886