### PR TITLE
🐛 Fixed post list not displaying correctly with long titles

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -145,42 +145,9 @@
         </LinkTo>
     {{/if}}
 
-    {{!-- Opened / Signups column --}}
-    {{#if (and @post.showEmailOpenAnalytics @post.showEmailClickAnalytics) }}
-        <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
-            <span class="gh-content-email-stats-value">
-                {{#if this.isHovered}}
-                    {{format-number @post.email.openedCount}}
-                {{else}}
-                    {{@post.email.openRate}}<sup>%</sup>
-                {{/if}}
-            </span>
-            <span class="gh-content-email-stats">
-                opened
-            </span>
-        </LinkTo>
-    {{else}}
-        <LinkTo @route={{this.editorRoute}} @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data">
-            {{!-- Empty on purpose --}}
-        </LinkTo>
-    {{/if}}
-
-    {{!-- Clicked / Conversions column --}}
-    {{#if @post.showEmailClickAnalytics }}
-        <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
-            <span class="gh-content-email-stats-value">
-                {{#if this.isHovered}}
-                    {{format-number @post.count.clicks}}
-                {{else}}
-                    {{@post.clickRate}}<sup>%</sup>
-                {{/if}}
-            </span>
-            <span class="gh-content-email-stats">
-                clicked
-            </span>
-        </LinkTo>
-    {{else}}
-        {{#if @post.showEmailOpenAnalytics }}
+    {{!-- Metrics columns --}}
+    <div class="gh-post-list-metrics-container">
+        {{#if (and @post.showEmailOpenAnalytics @post.showEmailClickAnalytics) }}
             <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
                 <span class="gh-content-email-stats-value">
                     {{#if this.isHovered}}
@@ -198,7 +165,41 @@
                 {{!-- Empty on purpose --}}
             </LinkTo>
         {{/if}}
-    {{/if}}
+
+        {{#if @post.showEmailClickAnalytics }}
+            <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
+                <span class="gh-content-email-stats-value">
+                    {{#if this.isHovered}}
+                        {{format-number @post.count.clicks}}
+                    {{else}}
+                        {{@post.clickRate}}<sup>%</sup>
+                    {{/if}}
+                </span>
+                <span class="gh-content-email-stats">
+                    clicked
+                </span>
+            </LinkTo>
+        {{else}}
+            {{#if @post.showEmailOpenAnalytics }}
+                <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
+                    <span class="gh-content-email-stats-value">
+                        {{#if this.isHovered}}
+                            {{format-number @post.email.openedCount}}
+                        {{else}}
+                            {{@post.email.openRate}}<sup>%</sup>
+                        {{/if}}
+                    </span>
+                    <span class="gh-content-email-stats">
+                        opened
+                    </span>
+                </LinkTo>
+            {{else}}
+                <LinkTo @route={{this.editorRoute}} @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data">
+                    {{!-- Empty on purpose --}}
+                </LinkTo>
+            {{/if}}
+        {{/if}}
+    </div>
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -145,8 +145,9 @@
         </LinkTo>
     {{/if}}
 
-    {{!-- Metrics columns --}}
+    {{!-- Metrics columns wrapper --}}
     <div class="gh-post-list-metrics-container">
+        {{!-- Opened / Signups column --}}
         {{#if (and @post.showEmailOpenAnalytics @post.showEmailClickAnalytics) }}
             <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
                 <span class="gh-content-email-stats-value">
@@ -166,6 +167,7 @@
             </LinkTo>
         {{/if}}
 
+        {{!-- Clicked / Conversions column --}}
         {{#if @post.showEmailClickAnalytics }}
             <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
                 <span class="gh-content-email-stats-value">

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -339,6 +339,13 @@
     margin: 0 0 2px;
     font-size: 1.6rem;
     font-weight: 600;
+    max-width: 100%;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    box-orient: vertical;
 }
 
 .gh-content-entry-title a {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -666,7 +666,17 @@
         flex: 1 1 auto;
         max-width: 100%;
         overflow: hidden;
+        padding-right: 0;
     }
+
+    /* .gh-post-list-metrics-container {
+        padding-right: 0!important;
+    } */
+
+    .gh-post-list-metrics-container a {
+        padding: 0!important;
+    }
+
 }
 
 @media (min-width: 901px) {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -346,11 +346,6 @@
     font-weight: 600;
     max-width: 100%;
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    line-clamp: 2;
-    box-orient: vertical;
 }
 
 .gh-content-entry-title a {
@@ -666,6 +661,12 @@
     .gh-contentfilter-menu:last-of-type {
         padding-right: 8px;
     }
+
+    .gh-post-list-title {
+        flex: 1 1 auto;
+        max-width: 100%;
+        overflow: hidden;
+    }
 }
 
 @media (min-width: 901px) {
@@ -765,11 +766,7 @@
     display: block;
     padding: 6px 0 8px;
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: initial;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
 }
 
 @media (max-width: 1280px) {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -285,7 +285,7 @@
 .gh-post-list-title {
     flex: 0 1 auto;
     min-width: 0;
-    max-width: 70%;
+    max-width: 80%;
     overflow: hidden;
 }
 
@@ -668,10 +668,6 @@
         overflow: hidden;
         padding-right: 0;
     }
-
-    /* .gh-post-list-metrics-container {
-        padding-right: 0!important;
-    } */
 
     .gh-post-list-metrics-container a {
         padding: 0!important;
@@ -2150,7 +2146,6 @@ span.dropdown .gh-post-list-cta > span {
 .gh-post-list-metrics-container {
     display: flex;
     flex: 0 0 auto;
-    padding-right: 16px;
 }
 
 .gh-post-list-metrics {
@@ -2158,7 +2153,6 @@ span.dropdown .gh-post-list-cta > span {
     flex-shrink: 0;
     display: grid;
     grid-template-rows: auto auto;
-    text-align: right;
 }
 
 .gh-post-list-button {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -282,6 +282,9 @@
 
 .gh-post-list-title {
     padding-left: 10px;
+    min-width: 0;
+    max-width: 70%;
+    overflow: hidden;
 }
 
 .gh-post-list-title .gh-lexical-indicator {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -2142,12 +2142,13 @@ span.dropdown .gh-post-list-cta > span {
 
 .gh-post-list-metrics-container {
     display: flex;
-    gap: 24px;
     flex: 0 0 auto;
+    padding-right: 16px;
 }
 
 .gh-post-list-metrics {
-    min-width: 100px;
+    width: 100px;
+    flex-shrink: 0;
     display: grid;
     grid-template-rows: auto auto;
     text-align: right;

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -2142,13 +2142,15 @@ span.dropdown .gh-post-list-cta > span {
 
 .gh-post-list-metrics-container {
     display: flex;
-    gap: 24px;  /* Space between metrics */
+    gap: 24px;
     flex: 0 0 auto;
 }
 
 .gh-post-list-metrics {
     min-width: 100px;
-    flex: 0 1 120px;
+    display: grid;
+    grid-template-rows: auto auto;
+    text-align: right;
 }
 
 .gh-post-list-button {

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -1462,7 +1462,7 @@
 }
 
 .gh-post-list-metrics {
-    width: 120px;
+    min-width: 120px;
 }
 
 .gh-content-email-stats,

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -236,7 +236,9 @@
 /* END Temporary styles to move post list to use flex instead of tables */
 
 .gh-posts-list-item {
-    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .gh-posts-list-item a:hover {
@@ -281,7 +283,7 @@
 }
 
 .gh-post-list-title {
-    padding-left: 10px;
+    flex: 0 1 auto;
     min-width: 0;
     max-width: 70%;
     overflow: hidden;
@@ -1461,10 +1463,6 @@
     transition: all 1s ease;
 }
 
-.gh-post-list-metrics {
-    min-width: 120px;
-}
-
 .gh-content-email-stats,
 .gh-post-list-cta {
     margin: 0 0 3px;
@@ -2136,4 +2134,23 @@ span.dropdown .gh-post-list-cta > span {
 
 .gh-post-analytics-mentions .gh-dashboard-list-footer a {
     font-size: 1.3rem;
+}
+
+.gh-post-list-button {
+    flex: 0 0 auto;
+}
+
+.gh-post-list-metrics-container {
+    display: flex;
+    gap: 24px;  /* Space between metrics */
+    flex: 0 0 auto;
+}
+
+.gh-post-list-metrics {
+    min-width: 100px;
+    flex: 0 1 120px;
+}
+
+.gh-post-list-button {
+    flex: 0 0 auto;
 }


### PR DESCRIPTION
Previously, if you had posts with very long titles, the layout of the post list would break, causing the analytics button and the metrics to shift from row to row. 

These changes address that, and make the list render cohesively regardless of the length of a post's title, across resolutions.

fixes https://linear.app/ghost/issue/DES-610/post-list-breaks-with-really-long-titles