### PR TITLE
Fixed theme management menu alignment

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/AdvancedThemeSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/AdvancedThemeSettings.tsx
@@ -161,7 +161,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     return (
         <div className='-mr-3 flex items-center gap-4'>
             {actions}
-            <Menu items={menuItems} position='start' triggerButtonProps={buttonProps} />
+            <Menu items={menuItems} position='end' triggerButtonProps={buttonProps} />
         </div>
     );
 };


### PR DESCRIPTION
ref DES-933

- when three dot buttons are clicked in the theme management modal, the menu alignment was wrong
- this fixes the issue by aligning the button and the menu by the right edge