### PR TITLE
Added 403 errors to the error handler

### DIFF
--- a/apps/admin-x-framework/src/utils/api/handleResponse.ts
+++ b/apps/admin-x-framework/src/utils/api/handleResponse.ts
@@ -20,6 +20,8 @@ const handleResponse = async (response: Response) => {
             throw new VersionMismatchError(response, data);
         } else if (data.errors?.[0]?.type === 'ValidationError') {
             throw new ValidationError(response, data);
+        } else if (data.errors?.[0]?.type === 'NoPermissionError') {
+            throw new ValidationError(response, data);
         } else if (data.errors?.[0]?.type === 'ThemeValidationError') {
             throw new ThemeValidationError(response, data);
         } else if (data.errors?.[0]?.type === 'HostLimitError') {


### PR DESCRIPTION
ref ENG-745

- added permission related errors to list of error types to be handled
- previously, generic error messages were displayed when permission errors are thrown
- this would make it possible to display the actual message returned from the API in toasts