### PR TITLE
Added accept parameter to FileUpload component

### DIFF
--- a/apps/admin-x-design-system/src/global/form/FileUpload.tsx
+++ b/apps/admin-x-design-system/src/global/form/FileUpload.tsx
@@ -16,9 +16,10 @@ export interface FileUploadProps {
     style?: CSSProperties;
     unstyled?: boolean;
     inputRef?: React.RefObject<HTMLInputElement>;
+    accept?: string;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({id, onUpload, children, style, unstyled = false, inputRef, className, dragIndicatorClassName, ...props}) => {
+const FileUpload: React.FC<FileUploadProps> = ({id, onUpload, children, style, unstyled = false, inputRef, className, dragIndicatorClassName, accept, ...props}) => {
     const [fileKey, setFileKey] = useState<number>(Date.now());
     const [isDragging, setIsDragging] = useState(false);
 
@@ -52,7 +53,7 @@ const FileUpload: React.FC<FileUploadProps> = ({id, onUpload, children, style, u
     return (
         <label className={clsx('relative', className)} htmlFor={id} style={style} onDragEnter={handleDragging} onDragLeave={handleStopDragging} onDragOver={handleDragging} onDrop={handleDrop} {...props}>
             <div className={clsx({'absolute inset-1 rounded': true, 'border-2 border-dashed border-grey-400/25': isDragging}, isDragging && [dragIndicatorClassName])} />
-            <input key={fileKey} ref={inputRef || null} id={id} type="file" hidden onChange={handleFileChange} />
+            <input key={fileKey} ref={inputRef || null} accept={accept} id={id} type="file" hidden onChange={handleFileChange} />
             {(typeof children === 'string') ?
                 <div className={!unstyled ? `inline-flex h-[34px] cursor-pointer items-center justify-center rounded px-4 text-sm font-semibold hover:bg-grey-100 dark:text-white dark:hover:bg-grey-900` : ''}>
                     {children}

--- a/apps/admin-x-settings/src/components/settings/advanced/migrationtools/UniversalImportModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migrationtools/UniversalImportModal.tsx
@@ -20,6 +20,7 @@ const UniversalImportModal: React.FC = () => {
         >
             <div className='py-4 leading-9'>
                 <FileUpload
+                    accept="application/json, application/zip"
                     id="import-file"
                     onUpload={async (file) => {
                         setUploading(true);


### PR DESCRIPTION
ref DES-182

- adds `accept` parameter to the file uploads making it possible to define a set of accepted file types
- allows only zip and json files for the universal importer