### PR TITLE
Filtered notifications that show in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Activities.tsx
+++ b/apps/admin-x-activitypub/src/components/Activities.tsx
@@ -224,6 +224,17 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
                 }
 
                 return true;
+            })
+            // Remove our own create activities
+            .filter((activity) => {
+                if (
+                    activity.type === ACTIVITY_TYPE.CREATE &&
+                    activity.actor?.id === userProfile?.id
+                ) {
+                    return false;
+                }
+
+                return true;
             });
 
         return groupActivities(filtered);

--- a/apps/admin-x-activitypub/src/components/Activities.tsx
+++ b/apps/admin-x-activitypub/src/components/Activities.tsx
@@ -198,6 +198,14 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
                 }
 
                 return true;
+            })
+            // Remove follower likes if they are not for our own posts
+            .filter((activity) => {
+                if (activity.type === ACTIVITY_TYPE.LIKE && activity.object?.attributedTo?.id !== userProfile?.id) {
+                    return false;
+                }
+
+                return true;
             });
 
         return groupActivities(filtered);


### PR DESCRIPTION
refs [AP-627](https://linear.app/ghost/issue/AP-627/sanitising-note-content)

Adding client side filtering of the notifications in `admin-x-activitypub` - This is a stop-gap until we have a dedicated endpoint for returning notifications. Filtering includes:

- Do not show our own likes
- Only show `like` notifications when it is on our own posts
- Only show replies to our own posts