### PR TITLE
Added redis data volume to compose setup

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -35,3 +35,4 @@ services:
 
 volumes:
   mysql-data:
+  redis-data:

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,8 @@ services:
     ports:
       - "6379:6379"
     restart: always
+    volumes:
+      - redis-data:/data
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
       interval: 1s
@@ -61,3 +63,4 @@ services:
       - "9091:9091"
 volumes:
   mysql-data:
+  redis-data:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1956/redis-creates-new-anonymous-volume-each-time-it-boots

- Before this commit, the redis service in our docker compose setup would create a new anonymous volume each time it boots, with a non-descriptive, hash-based name. Over time these volumes accumulate and become a pain to clean up, and it's not immediately obvious what they are used for.
- This commit adds a persistent data volume for redis data, so it will reuse the same volume, with a more descriptive title each time it boots. This eliminates the annoying anonymous volumes, and also gives us data persistence across boots for the redis service (which can be easily cleared by deleting the volume). 