### PR TITLE
Fixed intermittent error when posting a note in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -258,13 +258,13 @@ export class ActivityPubAPI {
         };
     }
 
-    async reply(id: string, content: string) {
+    async reply(id: string, content: string): Promise<Activity> {
         const url = new URL(`.ghost/activitypub/actions/reply/${encodeURIComponent(id)}`, this.apiUrl);
         const response = await this.fetchJSON(url, 'POST', {content});
         return response;
     }
 
-    async note(content: string) {
+    async note(content: string): Promise<Activity> {
         const url = new URL('.ghost/activitypub/actions/note', this.apiUrl);
         const response = await this.fetchJSON(url, 'POST', {content});
         return response;

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -356,13 +356,13 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
         updateActivity(activityId, {
             object: {
                 ...object,
-                replyCount: object.replyCount + 1
+                replyCount: (object.replyCount ?? 0) + 1
             }
         } as Partial<Activity>);
 
         // Update the replyCount on the current activity loaded in the modal
         // This is used for when we navigate via the history
-        object.replyCount = object.replyCount + 1;
+        object.replyCount = (object.replyCount ?? 0) + 1;
     }
 
     const replyBoxRef = useRef<HTMLDivElement>(null);

--- a/apps/admin-x-activitypub/src/components/modals/NewPostModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewPostModal.tsx
@@ -17,23 +17,28 @@ const NewPostModal = NiceModal.create(() => {
 
     const handlePost = async () => {
         const trimmedContent = content.trim();
+
         if (!trimmedContent) {
             return;
         }
 
-        await noteMutation.mutate({content: trimmedContent}, {
+        noteMutation.mutate({content: trimmedContent}, {
             onSuccess() {
                 showToast({
                     message: 'Note posted',
                     type: 'success'
                 });
+
                 modal.remove();
             },
-            onError() {
+            onError(error) {
                 showToast({
                     message: 'An error occurred while posting your note.',
                     type: 'error'
                 });
+
+                // eslint-disable-next-line no-console
+                console.error(error);
             }
         });
     };


### PR DESCRIPTION
refs [AP-629](https://linear.app/ghost/issue/AP-629/notes-say-they-error-but-post-correctly)

Fixed intermittent error when posting a note in `admin-x-activitypub`

The error was intermittent due to it only occurring when a specific set of steps occurred, and the query cache being periodically cleared.

The error itself was due to incorrectly expecting the `outbox:${handle}` query to be an array when it was in fact an object.

This PR also resolves and issue where the reply count for new notes would display `NaN` (because the `replyCount` property was not present on newly created notes)