### PR TITLE
🎨 Improved Access card layout in Settings

### DIFF
--- a/apps/admin-x-design-system/src/settings/SettingGroupContent.tsx
+++ b/apps/admin-x-design-system/src/settings/SettingGroupContent.tsx
@@ -14,12 +14,12 @@ export interface SettingGroupContentProps {
 }
 
 const SettingGroupContent: React.FC<SettingGroupContentProps> = ({columns, values, children, className}) => {
-    let styles = 'flex flex-col gap-x-5 gap-y-7';
+    let styles = 'flex flex-col gap-x-5';
     if (columns === 2) {
         styles = 'grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6';
     }
 
-    styles += ` ${className}`;
+    styles += className ? ` ${className}` : ' gap-y-7';
 
     return (
         <div className={styles}>

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -130,23 +130,22 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const form = (
         <SettingGroupContent columns={1}>
+            
             <Select
-                hint='Who should be able to subscribe to your site?'
                 options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
                 selectedOption={MEMBERS_SIGNUP_ACCESS_OPTIONS.find(option => option.value === membersSignupAccess)}
                 testId='subscription-access-select'
-                title="Subscription access"
+                title="Who should be able to subscribe to your site?"
                 onSelect={(option) => {
                     updateSetting('members_signup_access', option?.value || null);
                     handleEditingChange(true);
                 }}
             />
             <Select
-                hint='When a new post is created, who should have access?'
                 options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
                 selectedOption={DEFAULT_CONTENT_VISIBILITY_OPTIONS.find(option => option.value === defaultContentVisibility)}
                 testId='default-post-access-select'
-                title="Default post access"
+                title="Who should have access to new posts?"
                 onSelect={(option) => {
                     updateSetting('default_content_visibility', option?.value || null);
                     handleEditingChange(true);
@@ -167,11 +166,10 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 />
             )}
             <Select
-                hint='Who can comment on posts?'
                 options={COMMENTS_ENABLED_OPTIONS}
                 selectedOption={COMMENTS_ENABLED_OPTIONS.find(option => option.value === commentsEnabled)}
                 testId='commenting-select'
-                title="Commenting"
+                title="Who can comment on posts?"
                 onSelect={(option) => {
                     updateSetting('comments_enabled', option?.value || null);
                     handleEditingChange(true);

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -131,7 +131,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
             <div className="flex content-center items-center gap-4">
-                <div className="w-[320px]">Who should be able to subscribe to your site?</div>
+                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who should be able to subscribe to your site?</div>
                 <div className="flex-1">
                     <Select 
                         options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
@@ -146,7 +146,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             <Separator />
             <div className="flex content-center items-center gap-4">
-                <div className="w-[320px]">Who should have access to new posts?</div>
+                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who should have access to new posts?</div>
                 <div className="flex-1">
                     <Select
                         options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
@@ -161,7 +161,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             {defaultContentVisibility === 'tiers' && (
                 <div className="flex content-center items-center gap-4">
-                    <div className="w-[320px]">Select specific tiers</div>
+                    <div className="w-2/3 min-w-[200px] max-w-[340px]">Select specific tiers</div>
                     <div className="flex-1">
                         <MultiSelect
                             color='black'
@@ -178,7 +178,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             )}
             <Separator />
             <div className="flex content-center items-center gap-4">
-                <div className="w-[320px]">Who can comment on posts?</div>
+                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who can comment on posts?</div>
                 <div className="flex-1">
                     <Select
                         options={COMMENTS_ENABLED_OPTIONS}

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -146,7 +146,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             <Separator />
             <div className="flex content-center items-center gap-4">
-                <div className="w-[320px] pt-1">Who should have access to new posts?</div>
+                <div className="w-[320px]">Who should have access to new posts?</div>
                 <div className="flex-1">
                     <Select
                         options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
@@ -161,7 +161,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             {defaultContentVisibility === 'tiers' && (
                 <div className="flex content-center items-center gap-4">
-                    <div className="w-[320px] pt-1">Select specific tiers</div>
+                    <div className="w-[320px]">Select specific tiers</div>
                     <div className="flex-1">
                         <MultiSelect
                             color='black'
@@ -178,7 +178,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             )}
             <Separator />
             <div className="flex content-center items-center gap-4">
-                <div className="w-[320px] pt-1">Who can comment on posts?</div>
+                <div className="w-[320px]">Who can comment on posts?</div>
                 <div className="flex-1">
                     <Select
                         options={COMMENTS_ENABLED_OPTIONS}

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {GroupBase, MultiValue} from 'react-select';
-import {MultiSelect, MultiSelectOption, Select, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {MultiSelect, MultiSelectOption, Select, Separator, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
 // import {getOptionLabel} from '../../../utils/helpers';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
@@ -129,52 +129,69 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     // );
 
     const form = (
-        <SettingGroupContent columns={1}>
-            
-            <Select
-                options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
-                selectedOption={MEMBERS_SIGNUP_ACCESS_OPTIONS.find(option => option.value === membersSignupAccess)}
-                testId='subscription-access-select'
-                title="Who should be able to subscribe to your site?"
-                onSelect={(option) => {
-                    updateSetting('members_signup_access', option?.value || null);
-                    handleEditingChange(true);
-                }}
-            />
-            <Select
-                options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
-                selectedOption={DEFAULT_CONTENT_VISIBILITY_OPTIONS.find(option => option.value === defaultContentVisibility)}
-                testId='default-post-access-select'
-                title="Who should have access to new posts?"
-                onSelect={(option) => {
-                    updateSetting('default_content_visibility', option?.value || null);
-                    handleEditingChange(true);
-                }}
-            />
+        <SettingGroupContent className='gap-y-4' columns={1}>
+            <div className="flex content-center items-center gap-4">
+                <div className="w-[320px]">Who should be able to subscribe to your site?</div>
+                <div className="flex-1">
+                    <Select 
+                        options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
+                        selectedOption={MEMBERS_SIGNUP_ACCESS_OPTIONS.find(option => option.value === membersSignupAccess)}
+                        testId='subscription-access-select'
+                        onSelect={(option) => {
+                            updateSetting('members_signup_access', option?.value || null);
+                            handleEditingChange(true);
+                        }}
+                    />
+                </div>
+            </div>
+            <Separator />
+            <div className="flex content-center items-center gap-4">
+                <div className="w-[320px] pt-1">Who should have access to new posts?</div>
+                <div className="flex-1">
+                    <Select
+                        options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
+                        selectedOption={DEFAULT_CONTENT_VISIBILITY_OPTIONS.find(option => option.value === defaultContentVisibility)}
+                        testId='default-post-access-select'
+                        onSelect={(option) => {
+                            updateSetting('default_content_visibility', option?.value || null);
+                            handleEditingChange(true);
+                        }}
+                    />
+                </div>
+            </div>
             {defaultContentVisibility === 'tiers' && (
-                <MultiSelect
-                    color='black'
-                    options={tierOptionGroups.filter(group => group.options.length > 0)}
-                    testId='tiers-select'
-                    title='Select tiers'
-                    values={selectedTierOptions}
-                    clearBg
-                    onChange={(selectedOptions) => {
-                        setSelectedTiers(selectedOptions);
-                        handleEditingChange(true);
-                    }}
-                />
+                <div className="flex content-center items-center gap-4">
+                    <div className="w-[320px] pt-1">Select specific tiers</div>
+                    <div className="flex-1">
+                        <MultiSelect
+                            color='black'
+                            options={tierOptionGroups.filter(group => group.options.length > 0)}
+                            testId='tiers-select'
+                            values={selectedTierOptions}
+                            onChange={(selectedOptions) => {
+                                setSelectedTiers(selectedOptions);
+                                handleEditingChange(true);
+                            }}
+                        />
+                    </div>
+                </div>
             )}
-            <Select
-                options={COMMENTS_ENABLED_OPTIONS}
-                selectedOption={COMMENTS_ENABLED_OPTIONS.find(option => option.value === commentsEnabled)}
-                testId='commenting-select'
-                title="Who can comment on posts?"
-                onSelect={(option) => {
-                    updateSetting('comments_enabled', option?.value || null);
-                    handleEditingChange(true);
-                }}
-            />
+            <Separator />
+            <div className="flex content-center items-center gap-4">
+                <div className="w-[320px] pt-1">Who can comment on posts?</div>
+                <div className="flex-1">
+                    <Select
+                        options={COMMENTS_ENABLED_OPTIONS}
+                        selectedOption={COMMENTS_ENABLED_OPTIONS.find(option => option.value === commentsEnabled)}
+                        testId='commenting-select'
+                        title=""
+                        onSelect={(option) => {
+                            updateSetting('comments_enabled', option?.value || null);
+                            handleEditingChange(true);
+                        }}
+                    />
+                </div>
+            </div>
         </SettingGroupContent>
     );
 

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -3,7 +3,7 @@ import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {GroupBase, MultiValue} from 'react-select';
 import {MultiSelect, MultiSelectOption, Select, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {getOptionLabel} from '../../../utils/helpers';
+// import {getOptionLabel} from '../../../utils/helpers';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 
@@ -81,9 +81,9 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
         'members_signup_access', 'default_content_visibility', 'default_content_visibility_tiers', 'comments_enabled'
     ]) as string[];
 
-    const membersSignupAccessLabel = getOptionLabel(MEMBERS_SIGNUP_ACCESS_OPTIONS, membersSignupAccess);
-    const defaultContentVisibilityLabel = getOptionLabel(DEFAULT_CONTENT_VISIBILITY_OPTIONS, defaultContentVisibility);
-    const commentsEnabledLabel = getOptionLabel(COMMENTS_ENABLED_OPTIONS, commentsEnabled);
+    // const membersSignupAccessLabel = getOptionLabel(MEMBERS_SIGNUP_ACCESS_OPTIONS, membersSignupAccess);
+    // const defaultContentVisibilityLabel = getOptionLabel(DEFAULT_CONTENT_VISIBILITY_OPTIONS, defaultContentVisibility);
+    // const commentsEnabledLabel = getOptionLabel(COMMENTS_ENABLED_OPTIONS, commentsEnabled);
 
     const {data: {tiers} = {}} = useBrowseTiers();
 
@@ -106,27 +106,27 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
         updateSetting('default_content_visibility_tiers', JSON.stringify(selectedTiers));
     };
 
-    const values = (
-        <SettingGroupContent
-            values={[
-                {
-                    heading: 'Subscription access',
-                    key: 'subscription-access',
-                    value: membersSignupAccessLabel
-                },
-                {
-                    heading: 'Default post access',
-                    key: 'default-post-access',
-                    value: defaultContentVisibilityLabel
-                },
-                {
-                    heading: 'Commenting',
-                    key: 'commenting',
-                    value: commentsEnabledLabel
-                }
-            ]}
-        />
-    );
+    // const values = (
+    //     <SettingGroupContent
+    //         values={[
+    //             {
+    //                 heading: 'Subscription access',
+    //                 key: 'subscription-access',
+    //                 value: membersSignupAccessLabel
+    //             },
+    //             {
+    //                 heading: 'Default post access',
+    //                 key: 'default-post-access',
+    //                 value: defaultContentVisibilityLabel
+    //             },
+    //             {
+    //                 heading: 'Commenting',
+    //                 key: 'commenting',
+    //                 value: commentsEnabledLabel
+    //             }
+    //         ]}
+    //     />
+    // );
 
     const form = (
         <SettingGroupContent columns={1}>
@@ -138,6 +138,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 title="Subscription access"
                 onSelect={(option) => {
                     updateSetting('members_signup_access', option?.value || null);
+                    handleEditingChange(true);
                 }}
             />
             <Select
@@ -148,6 +149,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 title="Default post access"
                 onSelect={(option) => {
                     updateSetting('default_content_visibility', option?.value || null);
+                    handleEditingChange(true);
                 }}
             />
             {defaultContentVisibility === 'tiers' && (
@@ -158,7 +160,10 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     title='Select tiers'
                     values={selectedTierOptions}
                     clearBg
-                    onChange={setSelectedTiers}
+                    onChange={(selectedOptions) => {
+                        setSelectedTiers(selectedOptions);
+                        handleEditingChange(true);
+                    }}
                 />
             )}
             <Select
@@ -169,6 +174,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 title="Commenting"
                 onSelect={(option) => {
                     updateSetting('comments_enabled', option?.value || null);
+                    handleEditingChange(true);
                 }}
             />
         </SettingGroupContent>
@@ -183,11 +189,12 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             saveState={saveState}
             testId='access'
             title='Access'
+            hideEditButton
             onCancel={handleCancel}
             onEditingChange={handleEditingChange}
             onSave={handleSave}
         >
-            {isEditing ? form : values}
+            {form}
         </TopLevelGroup>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -131,7 +131,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
             <div className="flex flex-col content-center items-center gap-4 md:flex-row">
-                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who should be able to subscribe to your site?</div>
+                <div className="w-full min-w-[160px] max-w-none md:w-2/3 md:max-w-[320px]">Who should be able to subscribe to your site?</div>
                 <div className="w-full md:flex-1">
                     <Select 
                         options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
@@ -146,7 +146,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             <Separator />
             <div className="flex flex-col content-center items-center gap-4 md:flex-row">
-                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who should have access to new posts?</div>
+                <div className="w-full min-w-[160px] max-w-none md:w-2/3 md:max-w-[320px]">Who should have access to new posts?</div>
                 <div className="w-full md:flex-1">
                     <Select
                         options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
@@ -161,7 +161,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             </div>
             {defaultContentVisibility === 'tiers' && (
                 <div className="flex flex-col content-center items-center gap-4 md:flex-row">
-                    <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Select specific tiers</div>
+                    <div className="w-full min-w-[160px] max-w-none md:w-2/3 md:max-w-[320px]">Select specific tiers</div>
                     <div className="w-full md:flex-1">
                         <MultiSelect
                             color='black'
@@ -178,7 +178,7 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
             )}
             <Separator />
             <div className="flex flex-col content-center items-center gap-4 md:flex-row">
-                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who can comment on posts?</div>
+                <div className="w-full min-w-[160px] max-w-none md:w-2/3 md:max-w-[320px]">Who can comment on posts?</div>
                 <div className="w-full md:flex-1">
                     <Select
                         options={COMMENTS_ENABLED_OPTIONS}

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -130,9 +130,9 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>
-            <div className="flex content-center items-center gap-4">
-                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who should be able to subscribe to your site?</div>
-                <div className="flex-1">
+            <div className="flex flex-col content-center items-center gap-4 md:flex-row">
+                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who should be able to subscribe to your site?</div>
+                <div className="w-full md:flex-1">
                     <Select 
                         options={MEMBERS_SIGNUP_ACCESS_OPTIONS}
                         selectedOption={MEMBERS_SIGNUP_ACCESS_OPTIONS.find(option => option.value === membersSignupAccess)}
@@ -145,9 +145,9 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 </div>
             </div>
             <Separator />
-            <div className="flex content-center items-center gap-4">
-                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who should have access to new posts?</div>
-                <div className="flex-1">
+            <div className="flex flex-col content-center items-center gap-4 md:flex-row">
+                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who should have access to new posts?</div>
+                <div className="w-full md:flex-1">
                     <Select
                         options={DEFAULT_CONTENT_VISIBILITY_OPTIONS}
                         selectedOption={DEFAULT_CONTENT_VISIBILITY_OPTIONS.find(option => option.value === defaultContentVisibility)}
@@ -160,9 +160,9 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 </div>
             </div>
             {defaultContentVisibility === 'tiers' && (
-                <div className="flex content-center items-center gap-4">
-                    <div className="w-2/3 min-w-[200px] max-w-[340px]">Select specific tiers</div>
-                    <div className="flex-1">
+                <div className="flex flex-col content-center items-center gap-4 md:flex-row">
+                    <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Select specific tiers</div>
+                    <div className="w-full md:flex-1">
                         <MultiSelect
                             color='black'
                             options={tierOptionGroups.filter(group => group.options.length > 0)}
@@ -177,9 +177,9 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 </div>
             )}
             <Separator />
-            <div className="flex content-center items-center gap-4">
-                <div className="w-2/3 min-w-[200px] max-w-[340px]">Who can comment on posts?</div>
-                <div className="flex-1">
+            <div className="flex flex-col content-center items-center gap-4 md:flex-row">
+                <div className="w-full min-w-[200px] max-w-none md:w-2/3 md:max-w-[340px]">Who can comment on posts?</div>
+                <div className="w-full md:flex-1">
                     <Select
                         options={COMMENTS_ENABLED_OPTIONS}
                         selectedOption={COMMENTS_ENABLED_OPTIONS.find(option => option.value === commentsEnabled)}

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -82,8 +82,6 @@ test.describe('Access settings', async () => {
 
         const section = page.getByTestId('access');
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
         await chooseOptionInSelect(section.getByTestId('default-post-access-select'), 'Specific tiers');
         await section.getByTestId('tiers-select').click();
 

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -90,7 +90,7 @@ test.describe('Access settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByText('Specific tiers')).toHaveCount(1);
+        await expect(section.getByTestId('default-post-access-select')).toHaveValue('tiers');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -21,15 +21,11 @@ test.describe('Access settings', async () => {
         await expect(section.getByText('Public')).toHaveCount(1);
         await expect(section.getByText('Nobody')).toHaveCount(1);
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
         await chooseOptionInSelect(section.getByTestId('subscription-access-select'), 'Only people I invite');
         await chooseOptionInSelect(section.getByTestId('default-post-access-select'), /^Members only$/);
         await chooseOptionInSelect(section.getByTestId('commenting-select'), 'All members');
 
         await section.getByRole('button', {name: 'Save'}).click();
-
-        await expect(section.getByTestId('subscription-access-select')).toHaveCount(0);
 
         await expect(section.getByText('Only people I invite')).toHaveCount(1);
         await expect(section.getByText('Members only')).toHaveCount(1);
@@ -55,8 +51,6 @@ test.describe('Access settings', async () => {
         await page.goto('/');
 
         const section = page.getByTestId('access');
-
-        await section.getByRole('button', {name: 'Edit'}).click();
 
         await chooseOptionInSelect(section.getByTestId('subscription-access-select'), 'Nobody');
 

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -62,7 +62,7 @@ test.describe('Access settings', async () => {
             ]
         });
 
-        await expect(section.getByTestId('subscription-access-select')).toHaveValue('none');
+        await expect(section.getByTestId('subscription-access-select')).toContainText('Nobody');
 
         await expect(page.getByTestId('portal').getByRole('button', {name: 'Customize'})).toBeDisabled();
         await expect(page.getByTestId('enable-newsletters')).toContainText('only existing members will receive newsletters');
@@ -90,7 +90,7 @@ test.describe('Access settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByTestId('default-post-access-select')).toHaveValue('tiers');
+        await expect(section.getByTestId('default-post-access-select')).toContainText('Specific tiers');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -62,7 +62,7 @@ test.describe('Access settings', async () => {
             ]
         });
 
-        await expect(section.getByTestId('subscription-access-select')).toHaveCount(0);
+        await expect(section.getByText('Nobody')).toHaveCount(1);
 
         await expect(page.getByTestId('portal').getByRole('button', {name: 'Customize'})).toBeDisabled();
         await expect(page.getByTestId('enable-newsletters')).toContainText('only existing members will receive newsletters');

--- a/apps/admin-x-settings/test/acceptance/membership/access.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/access.test.ts
@@ -62,7 +62,7 @@ test.describe('Access settings', async () => {
             ]
         });
 
-        await expect(section.getByText('Nobody')).toHaveCount(1);
+        await expect(section.getByTestId('subscription-access-select')).toHaveValue('none');
 
         await expect(page.getByTestId('portal').getByRole('button', {name: 'Customize'})).toBeDisabled();
         await expect(page.getByTestId('enable-newsletters')).toContainText('only existing members will receive newsletters');

--- a/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
@@ -19,68 +19,68 @@ test.describe('Portal Settings', () => {
         test('can open portal on default page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
-            // fetch portal default url from input
             const portalUrl = await modal.getByLabel('Default:').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
 
-            // check portal popup is opened
+            // Wait for frame to be attached and visible
             await expect(portalFrame).toBeVisible();
         });
 
         test('can open portal on signin page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
-            // fetch portal signin url from input
             const portalUrl = await modal.getByLabel('Sign in').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-
-            // check portal popup is opened
+            
+            // Wait for frame to be attached and visible first
             await expect(portalFrame).toBeVisible();
-            // check signin page is opened in portal
-            await expect(portalFrameLocator.getByRole('heading', {name: 'Sign in'})).toBeVisible();
+            
+            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            
+            // Wait for the frame content to be loaded
+            await expect(portalFrameLocator.locator('.gh-portal-signin')).toBeVisible({timeout: 15000});
+            await expect(portalFrameLocator.getByRole('heading', {name: 'Sign in'})).toBeVisible({timeout: 15000});
         });
 
         test('can open portal on signup page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
-            // fetch portal signup url from input
             const portalUrl = await modal.getByLabel('Sign up').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-
-            // check portal popup is opened
+            
+            // Wait for frame to be attached and visible first
             await expect(portalFrame).toBeVisible();
-            // check signup page is opened in portal
-            await expect(portalFrameLocator.locator('.gh-portal-signup')).toBeVisible();
+            
+            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
+            
+            // Wait for the frame content to be loaded
+            await expect(portalFrameLocator.locator('.gh-portal-signup')).toBeVisible({timeout: 15000});
         });
 
         test('can open portal directly on monthly signup', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
-            // fetch and go to portal directly monthly signup url
             const portalUrl = await modal.getByLabel('Signup / Monthly').inputValue();
             await sharedPage.goto(portalUrl);
 
-            // expect stripe checkout to have opeened
-            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/);
+            // Wait longer for Stripe checkout to load
+            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/, {timeout: 15000});
         });
 
         test('can open portal directly on yearly signup', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
-            // fetch and go to portal directly yearly signup url
             const portalUrl = await modal.getByLabel('Signup / Yearly').inputValue();
             await sharedPage.goto(portalUrl);
 
-            // expect stripe checkout to have opeened
-            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/);
+            // Wait longer for Stripe checkout to load
+            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/, {timeout: 15000});
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
@@ -19,68 +19,68 @@ test.describe('Portal Settings', () => {
         test('can open portal on default page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
+            // fetch portal default url from input
             const portalUrl = await modal.getByLabel('Default:').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
 
-            // Wait for frame to be attached and visible
+            // check portal popup is opened
             await expect(portalFrame).toBeVisible();
         });
 
         test('can open portal on signin page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
+            // fetch portal signin url from input
             const portalUrl = await modal.getByLabel('Sign in').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            
-            // Wait for frame to be attached and visible first
-            await expect(portalFrame).toBeVisible();
-            
             const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-            
-            // Wait for the frame content to be loaded
-            await expect(portalFrameLocator.locator('.gh-portal-signin')).toBeVisible({timeout: 15000});
-            await expect(portalFrameLocator.getByRole('heading', {name: 'Sign in'})).toBeVisible({timeout: 15000});
+
+            // check portal popup is opened
+            await expect(portalFrame).toBeVisible();
+            // check signin page is opened in portal
+            await expect(portalFrameLocator.getByRole('heading', {name: 'Sign in'})).toBeVisible();
         });
 
         test('can open portal on signup page', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
+            // fetch portal signup url from input
             const portalUrl = await modal.getByLabel('Sign up').inputValue();
             await sharedPage.goto(portalUrl);
 
             const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            
-            // Wait for frame to be attached and visible first
-            await expect(portalFrame).toBeVisible();
-            
             const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-            
-            // Wait for the frame content to be loaded
-            await expect(portalFrameLocator.locator('.gh-portal-signup')).toBeVisible({timeout: 15000});
+
+            // check portal popup is opened
+            await expect(portalFrame).toBeVisible();
+            // check signup page is opened in portal
+            await expect(portalFrameLocator.locator('.gh-portal-signup')).toBeVisible();
         });
 
         test('can open portal directly on monthly signup', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
+            // fetch and go to portal directly monthly signup url
             const portalUrl = await modal.getByLabel('Signup / Monthly').inputValue();
             await sharedPage.goto(portalUrl);
 
-            // Wait longer for Stripe checkout to load
-            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/, {timeout: 15000});
+            // expect stripe checkout to have opeened
+            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/);
         });
 
         test('can open portal directly on yearly signup', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);
 
+            // fetch and go to portal directly yearly signup url
             const portalUrl = await modal.getByLabel('Signup / Yearly').inputValue();
             await sharedPage.goto(portalUrl);
 
-            // Wait longer for Stripe checkout to load
-            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/, {timeout: 15000});
+            // expect stripe checkout to have opeened
+            await sharedPage.waitForURL(/^https:\/\/checkout.stripe.com/);
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -6,15 +6,19 @@ const changeSubscriptionAccess = async (page, access) => {
     await page.locator('[data-test-nav="settings"]').click();
 
     const section = page.getByTestId('access');
-    await section.getByRole('button', {name: 'Edit'}).click();
-
+    
     const select = section.getByTestId('subscription-access-select');
     await select.click();
     await page.locator(`[data-testid="select-option"][data-value="${access}"]`).click();
 
     // Save settings
     await section.getByRole('button', {name: 'Save'}).click();
-    await expect(select).not.toBeVisible();
+    
+    await expect(select).toContainText(
+        access === 'all' ? 'Anyone can sign up' :
+            access === 'invite' ? 'Only people I invite' :
+                'Nobody'
+    );
 };
 
 const checkPortalScriptLoaded = async (page, loaded = true) => {


### PR DESCRIPTION
As part of our efforts to add more personality to Settings, we've identified areas where we can improve the UX.

This change makes it easier to manipulate Access settings by removing a step from the flow.

fixes https://linear.app/ghost/issue/DES-484/improve-access-card-layout-in-settings

**Before**
<img width="1718" alt="access-card-before" src="https://github.com/user-attachments/assets/8c0f8f14-31b9-4712-93d2-97eb0f05c965" />

**After**
<img width="1718" alt="access-card-after" src="https://github.com/user-attachments/assets/5831a7cc-fbad-4d4b-bccc-6e86be6a8c65" />
