### PR TITLE
Increased the number of notifications retrieved in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -214,12 +214,13 @@ export class ActivityPubAPI {
         includeOwn: boolean = false,
         includeReplies: boolean = false,
         filter: {type?: string[]} | null = null,
+        limit: number = 50,
         cursor?: string
     ): Promise<{data: Activity[], next: string | null}> {
-        const LIMIT = 50;
-
         const url = new URL(this.activitiesApiUrl);
-        url.searchParams.set('limit', LIMIT.toString());
+
+        url.searchParams.set('limit', limit.toString());
+
         if (includeOwn) {
             url.searchParams.set('includeOwn', includeOwn.toString());
         }

--- a/apps/admin-x-activitypub/src/components/Activities.tsx
+++ b/apps/admin-x-activitypub/src/components/Activities.tsx
@@ -185,6 +185,7 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
         filter: {
             type: ['Follow', 'Like', `Create:Note`]
         },
+        limit: 250,
         key: GET_ACTIVITIES_QUERY_KEY_NOTIFICATIONS
     });
 

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -267,12 +267,14 @@ export function useActivitiesForUser({
     includeOwn = false,
     includeReplies = false,
     filter = null,
+    limit = undefined,
     key = null
 }: {
     handle: string;
     includeOwn?: boolean;
     includeReplies?: boolean;
     filter?: {type?: string[]} | null;
+    limit?: number;
     key?: string | null;
 }) {
     const queryKey = [`activities:${handle}`, key, {includeOwn, includeReplies, filter}];
@@ -283,7 +285,7 @@ export function useActivitiesForUser({
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);
-            return api.getActivities(includeOwn, includeReplies, filter, pageParam);
+            return api.getActivities(includeOwn, includeReplies, filter, limit, pageParam);
         },
         getNextPageParam(prevPage) {
             return prevPage.next;


### PR DESCRIPTION
refs [AP-626](https://linear.app/ghost/issue/AP-626/wrong-posts-showing-up-in-notifications)

Increased the number of notifications retrieved in `admin-x-activitypub` to account for notifications being grouped and reduce the amount of time waiting on requests to finish (by making fewer requests)