### PR TITLE
Removed i18n toggle from labs UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -24,10 +24,6 @@ const BetaFeatures: React.FC = () => {
                 detail={<>Enable support for CashApp, iDEAL, Bancontact, and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />
             <LabItem
-                action={<FeatureToggle flag='i18n' />}
-                detail={<>Translate your membership flows into your publication language (<a className='text-green' href="https://github.com/TryGhost/Ghost/tree/main/ghost/i18n/locales" rel="noopener noreferrer" target="_blank">supported languages</a>). Don’t see yours? <a className='text-green' href="https://forum.ghost.org/t/help-translate-ghost-beta/37461" rel="noopener noreferrer" target="_blank">Get involved</a></>}
-                title='Portal translation' />
-            <LabItem
                 action={<div className='flex flex-col items-end gap-1'>
                     <FileUpload
                         id='upload-redirects'

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -6,21 +6,20 @@ const {createPostDraft} = require('../utils');
  * @param {import('@playwright/test').Page} page
  */
 
+async function setLanguage(sharedPage, language) {
+    await sharedPage.goto('/ghost/#/settings/publication-language');
+    const section = sharedPage.getByTestId('publication-language');
+    await section.getByRole('button', {name: 'Edit'}).click();
+    const input = section.getByPlaceholder('Site language');
+    await input.fill(language);
+    await section.getByRole('button', {name: 'Save'}).click();
+}
+
 test.describe('i18n', () => {
     test.describe('Newsletter', () => {
         test('changing the site language immediately translates strings in newsletters', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost/#/settings/publication-language');
-            const section = sharedPage.getByTestId('publication-language');
-            await section.getByRole('button', {name: 'Edit'}).click();
-            const input = section.getByPlaceholder('Site language');
-            await input.fill('fr');
-            await section.getByRole('button', {name: 'Save'}).click();
+            await setLanguage(sharedPage, 'fr');
 
-            const labsSection = sharedPage.getByTestId('labs');
-            await labsSection.getByRole('button', {name: 'Open'}).click();
-            let portalLabel = labsSection.getByText('Portal translation');
-            let portalToggle = portalLabel.locator('..').locator('..').locator('..').getByRole('switch');
-            await portalToggle.click();
 
             const postData = {
                 title: 'Publish and email post',
@@ -41,6 +40,9 @@ test.describe('i18n', () => {
             const metaText = await sharedPage.frameLocator('iframe.gh-pe-iframe').locator('td.post-meta').first().textContent();
             expect(metaText).toContain('Par Joe Bloggs');
             expect(metaText).not.toContain('By Joe Bloggs');
+
+            // Set the language back before the next test!
+            await setLanguage(sharedPage, 'en');
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -20,7 +20,6 @@ test.describe('i18n', () => {
         test('changing the site language immediately translates strings in newsletters', async ({sharedPage}) => {
             await setLanguage(sharedPage, 'fr');
 
-
             const postData = {
                 title: 'Publish and email post',
                 body: 'This is my post body.'


### PR DESCRIPTION
ref bb9a69e

- We promoted i18n to GA several weeks ago now, and it's going fine
- Removing the UI first to reduce confusion
- This is before clearning up all the other references to the flagGot some code for us? Awesome 🎊!


