### PR TITLE
Reduce number of notifications retrieved in `admin-x-activtypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/Activities.tsx
+++ b/apps/admin-x-activitypub/src/components/Activities.tsx
@@ -185,7 +185,7 @@ const Activities: React.FC<ActivitiesProps> = ({}) => {
         filter: {
             type: ['Follow', 'Like', `Create:Note`]
         },
-        limit: 250,
+        limit: 120,
         key: GET_ACTIVITIES_QUERY_KEY_NOTIFICATIONS
     });
 


### PR DESCRIPTION
no refs

`250` takes a bit too long on the server so reducing it down to `120` for now