### PR TITLE
Auto trigger Post analytics refresh

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -35,14 +35,6 @@
                     {{/let}}
                 </div>
                 <div style="display: flex; gap: 8px;">
-                    <GhTaskButton
-                        @buttonText="Refresh"
-                        @task={{this.fetchPostTask}}
-                        @showIcon={{true}}
-                        @idleIcon="reload"
-                        @successText="Refreshed"
-                        @class="gh-btn gh-btn-icon refresh"
-                        @successClass="gh-btn gh-btn-icon refresh" />
                     {{#unless this.post.emailOnly}}
                         <button type="button" class="gh-btn gh-btn-icon share" {{on "click" this.togglePublishFlowModal}}>
                             <span>{{svg-jar "share" title="Share post"}} Share</span>

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -4,6 +4,7 @@ import PostSuccessModal from '../modal-post-success';
 import anime from 'animejs/lib/anime.es.js';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
+import {later} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -51,6 +52,18 @@ export default class Analytics extends Component {
     constructor() {
         super(...arguments);
         this.checkPublishFlowModal();
+        this.setupAutoRefresh();
+    }
+
+    setupAutoRefresh() {
+        later(this, this.triggerRefresh, 5000);
+    }
+
+    triggerRefresh() {
+        if (!this.isDestroyed && !this.isDestroying) {
+            this.fetchPostTask.perform();
+            this.setupAutoRefresh();
+        }
     }
 
     openPublishFlowModal() {

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -20,6 +20,8 @@ const DISPLAY_OPTIONS = [{
     value: 'paid'
 }];
 
+const AUTO_REFRESH_RATE = 10000;
+
 export default class Analytics extends Component {
     @service ajax;
     @service ghostPaths;
@@ -56,7 +58,7 @@ export default class Analytics extends Component {
     }
 
     setupAutoRefresh() {
-        later(this, this.triggerRefresh, 5000);
+        later(this, this.triggerRefresh, AUTO_REFRESH_RATE);
     }
 
     triggerRefresh() {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1041/auto-refresh-post-analytics

At the moment have a Refresh button in Post analytics which requires users manually clicking to see how data updates on the page. This PR is about automatically trigger this "click" every [10 seconds] so that the refresh happens without users having to click.