### PR TITLE
Updated Portal browser test to be less dependent on exact copy

### DIFF
--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -51,7 +51,7 @@ test.describe('Site Settings', () => {
             const portalFrame = sharedPage.frameLocator('#ghost-portal-root div iframe');
 
             // Check sign up is disabled and a message is shown
-            await expect(portalFrame.locator('.gh-portal-invite-only-notification')).toHaveText('This site is invite-only, contact the owner for access.');
+            await expect(portalFrame.locator('.gh-portal-section')).toHaveText(/contact the owner for access/);
 
             // Check free trial message is not shown for invite only
             await expect(portalFrame.locator('.gh-portal-free-trial-notification')).not.toBeVisible();


### PR DESCRIPTION
no issue
- this Portal browser test was relying on a 1-1 text match with text generated in Portal
- this makes changing copy in Portal difficult, as publishing a new version of Portal with copy changes can break browser tests
