### PR TITLE
📦 externalized portal locales

### DIFF
--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -1,7 +1,8 @@
+// @ts-check
 /* eslint-disable no-console */
 import {getCheckoutSessionDataFromPlanAttribute, getUrlHistory} from './utils/helpers';
 import {HumanReadableError, chooseBestErrorMessage} from './utils/errors';
-import i18nLib from '@tryghost/i18n';
+import {getAsyncInstance} from '@tryghost/i18n/browser.mjs';
 
 export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler},
     t = (str) => {
@@ -94,10 +95,7 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
     });
 }
 
-export function planClickHandler({event, el, errorEl, siteUrl, site, member, clickHandler}) {
-    const i18nLanguage = site.locale | 'en';
-    const i18n = i18nLib(i18nLanguage, 'portal');
-    const t = i18n.t;
+export function planClickHandler({event, el, errorEl, siteUrl, site, member, clickHandler, t}) {
     el.removeEventListener('click', clickHandler);
     event.preventDefault();
     let plan = el.dataset.membersPlan;
@@ -178,9 +176,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
 }
 
 export function handleDataAttributes({siteUrl, site, member}) {
-    const i18nLanguage = site.locale | 'en';
-    const i18n = i18nLib(i18nLanguage, 'portal');
-    const t = i18n.t;
+    const {t} = getAsyncInstance('portal');
     if (!siteUrl) {
         return;
     }
@@ -196,7 +192,7 @@ export function handleDataAttributes({siteUrl, site, member}) {
     Array.prototype.forEach.call(document.querySelectorAll('[data-members-plan]'), function (el) {
         let errorEl = el.querySelector('[data-members-error]');
         function clickHandler(event) {
-            planClickHandler({el, event, errorEl, member, site, siteUrl, clickHandler});
+            planClickHandler({el, event, errorEl, member, site, siteUrl, clickHandler, t});
         }
         el.addEventListener('click', clickHandler);
     });

--- a/apps/portal/src/index.js
+++ b/apps/portal/src/index.js
@@ -22,7 +22,18 @@ function getSiteData() {
         const apiKey = scriptTag.dataset.key;
         const apiUrl = scriptTag.dataset.api;
         const locale = scriptTag.dataset.locale; // not providing a fallback here but will do it within the app.
-        return {siteUrl, apiKey, apiUrl, siteI18nEnabled, locale};
+        let localeRoot = scriptTag.dataset.localeRoot ?? './locales';
+
+        // CASE: The root is based on the current script, resolve it
+        if (localeRoot.startsWith('.')) {
+            const currentPath = import.meta.url.slice(0, import.meta.url.lastIndexOf('/'));
+            localeRoot = new URL(localeRoot, currentPath).href;
+        }
+
+        // Remove the trailing slash since it's not needed by our i18n implementation
+        localeRoot = localeRoot.replace(/\/$/, '');
+
+        return {siteUrl, apiKey, apiUrl, siteI18nEnabled, locale, localeRoot};
     }
     return {};
 }
@@ -42,12 +53,12 @@ function setup() {
 
 function init() {
     // const customSiteUrl = getSiteUrl();
-    const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale} = getSiteData();
+    const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale, localeRoot} = getSiteData();
     const siteUrl = customSiteUrl || window.location.origin;
     setup({siteUrl});
     ReactDOM.render(
         <React.StrictMode>
-            <App siteUrl={siteUrl} customSiteUrl={customSiteUrl} apiKey={apiKey} apiUrl={apiUrl} siteI18nEnabled={siteI18nEnabled} locale={locale}/>
+            <App siteUrl={siteUrl} customSiteUrl={customSiteUrl} apiKey={apiKey} apiUrl={apiUrl} siteI18nEnabled={siteI18nEnabled} locale={locale} localeRoot={localeRoot} />
         </React.StrictMode>,
         document.getElementById(ROOT_DIV_ID)
     );

--- a/apps/portal/vite.config.js
+++ b/apps/portal/vite.config.js
@@ -5,10 +5,9 @@ import {defineConfig} from 'vitest/config';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import reactPlugin from '@vitejs/plugin-react';
 import svgrPlugin from 'vite-plugin-svgr';
+import {ghostI18nPlugin} from '@tryghost/i18n/plugin.js';
 
 import pkg from './package.json';
-
-import {SUPPORTED_LOCALES} from '@tryghost/i18n';
 
 export default defineConfig((config) => {
     const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
@@ -30,7 +29,8 @@ export default defineConfig((config) => {
         plugins: [
             cssInjectedByJsPlugin(),
             reactPlugin(),
-            svgrPlugin()
+            svgrPlugin(),
+            ghostI18nPlugin('portal'),
         ],
         esbuild: {
             loader: 'jsx',
@@ -69,11 +69,6 @@ export default defineConfig((config) => {
                 output: {
                     manualChunks: false
                 }
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/portal.json`)
             }
         },
         test: {

--- a/apps/portal/vite.config.js
+++ b/apps/portal/vite.config.js
@@ -30,7 +30,7 @@ export default defineConfig((config) => {
             cssInjectedByJsPlugin(),
             reactPlugin(),
             svgrPlugin(),
-            ghostI18nPlugin('portal'),
+            ghostI18nPlugin('portal', 'opt-in'),
         ],
         esbuild: {
             loader: 'jsx',

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -69,7 +69,7 @@ function getMembersHelper(data, frontendKey, excludeList) {
             attributes['accent-color'] = colorString;
         }
         const dataAttributes = getDataAttributes(attributes);
-        membersHelper += `<script defer src="${scriptUrl}" ${dataAttributes} crossorigin="anonymous"></script>`;
+        membersHelper += `<script type="module" defer src="${scriptUrl}" ${dataAttributes} crossorigin="anonymous"></script>`;
     }
     if (!excludeList.has('cta_styles')) {
         membersHelper += (`<style id="gh-members-styles">${templateStyles}</style>`);

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -67,7 +67,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -779,7 +779,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -894,7 +894,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -1848,7 +1848,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -1962,7 +1962,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2077,7 +2077,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2191,7 +2191,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2357,7 +2357,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2637,7 +2637,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><script async src=\\"https://js.stripe.com/v3/\\"></script>
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><script async src=\\"https://js.stripe.com/v3/\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -2852,7 +2852,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3019,7 +3019,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3249,7 +3249,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3363,7 +3363,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script type=\\"module\\" defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;

--- a/ghost/i18n/browser.mjs
+++ b/ghost/i18n/browser.mjs
@@ -1,0 +1,80 @@
+// @ts-check
+import {createInstance} from 'i18next';
+
+/**
+ * @typedef {'ghost'|'portal'|'test'|'signup-form'|'comments'|'search'|'newsletter'} GhostNamespace
+ */
+
+/**
+ * @type {Partial<Record<GhostNamespace, ReturnType<typeof createInstance>>>}
+ */
+const asyncInstances = {};
+
+/**
+ * @param {GhostNamespace} ns
+ */
+export function getAsyncInstance (ns = 'portal') {
+    if (asyncInstances[ns]) {
+        return asyncInstances[ns];
+    }
+
+    throw new Error(`No cached i18n instance available for ${ns}`);
+}
+
+/**
+ * @param {GhostNamespace} ns
+ * @param {string} lng
+ * @param {string} root The root path where locales are stored, following `${root}/${locale}/${ns}.json`
+ */
+export function createAsyncInstance(ns, lng, root) {
+    const i18nextInstance = createInstance();
+
+    i18nextInstance.use({
+        type: 'backend',
+        async read(locale, namespace, callback) {
+            if (process.env.NODE_ENV !== 'production' && namespace !== ns) {
+                return callback(new Error(`Namespace mismatch! Expected ${ns}, got ${namespace}`), null);
+            }
+
+            // CASE: locale is the default. The text is already translated, so avoid loading a translation file.
+            if (locale === 'en') {
+                callback(null, {});
+                return;
+            }
+
+            try {
+                const response = await fetch(`${root}/${locale}/${ns}.json`);
+                const data = await response.json();
+                callback(null, data);
+            } catch (error) {
+                callback(error, null);
+            }
+        },
+    });
+
+    i18nextInstance.init({
+        lng,
+
+        // allow keys to be phrases having `:`, `.`
+        nsSeparator: false,
+        keySeparator: false,
+
+        // if the value is an empty string, return the key
+        returnEmptyString: false,
+
+        // do not load a fallback
+        fallbackLng: false,
+
+        ns: ns,
+        defaultNS: ns,
+
+        // separators
+        interpolation: ns === 'newsletter' ? {
+            prefix: '{',
+            suffix: '}'
+        } : {},
+    });
+
+    asyncInstances[ns] = i18nextInstance;
+    return i18nextInstance;
+}

--- a/ghost/i18n/browser.mjs
+++ b/ghost/i18n/browser.mjs
@@ -21,6 +21,10 @@ export function getAsyncInstance (ns = 'portal') {
     throw new Error(`No cached i18n instance available for ${ns}`);
 }
 
+// TODO: Remove this when all apps are using async locales
+// Added at build time
+const INLINE_TRANSLATIONS = global.GHOST_INLINE_TRANSLATIONS;
+
 /**
  * @param {GhostNamespace} ns
  * @param {string} lng
@@ -39,6 +43,12 @@ export function createAsyncInstance(ns, lng, root) {
             // CASE: locale is the default. The text is already translated, so avoid loading a translation file.
             if (locale === 'en') {
                 callback(null, {});
+                return;
+            }
+
+            const local = INLINE_TRANSLATIONS[locale];
+            if (local) {
+                callback(null, local);
                 return;
             }
 

--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -1,3 +1,4 @@
+// @ts-check
 const i18next = require('i18next');
 
 const SUPPORTED_LOCALES = [
@@ -85,7 +86,7 @@ function generateResources(locales, ns) {
 
 /**
  * @param {string} [lng]
- * @param {'ghost'|'portal'|'test'|'signup-form'|'comments'|'search'|'newsletter'} ns
+ * @param {import('../browser.mjs').GhostNamespace} ns
  */
 module.exports = (lng = 'en', ns = 'portal') => {
     const i18nextInstance = i18next.createInstance();

--- a/ghost/i18n/plugin.js
+++ b/ghost/i18n/plugin.js
@@ -1,0 +1,126 @@
+// @ts-check
+const {join} = require('node:path');
+const {readdir, readFile, unlink} = require('node:fs/promises');
+
+const LOCALES_PATH = join(__dirname, './locales');
+
+/**
+ * @param {import('./browser.mjs').GhostNamespace} namespace
+ * @param {string} locale
+ * @returns {Promise<{
+    type: 'asset';
+    fileName: string,
+    source: string;
+ }>}
+ */
+async function processTranslation(namespace, locale) {
+    const diskPath = `${LOCALES_PATH}/${locale}/${namespace}.json`;
+    const contents = await readFile(diskPath, 'utf8');
+    return {
+        type: 'asset',
+        fileName: `locales/${locale}/${namespace}.json`,
+        // Since these files don't get processed, minify the contents using `JSON.stringify`
+        source: JSON.stringify(JSON.parse(contents))
+    };
+}
+
+/**
+ * @param {import('./browser.mjs').GhostNamespace} namespace
+ * @param {Set<string> | null} invalidatedLocales [mutated] the set of locales that changed. If not provided, all locales will be loaded from disk.
+ */
+async function loadTranslations(namespace, invalidatedLocales) {
+    /** @type {string[]} */
+    let locales;
+    if (invalidatedLocales) {
+        locales = Array.from(invalidatedLocales);
+
+        // Common path - no locales changed
+        if (locales.length === 0) {
+            return [];
+        }
+
+        invalidatedLocales.clear();
+    } else {
+        locales = await readdir(LOCALES_PATH);
+    }
+
+    /** @type {import('rollup').EmittedAsset[]} */
+    const assets = [];
+
+    await Promise.all(locales.map(async (locale) => {
+        try {
+            assets.push(await processTranslation(namespace, locale));
+        } catch {
+            // Ignore invalid locales, or locales that don't have this namespace
+        }
+    }));
+
+    return assets;
+}
+
+/**
+ * @param {import('./browser.mjs').GhostNamespace} namespace
+ * @returns {import('vite').Plugin}
+ */
+function ghostI18nPlugin(namespace) {
+    const namespaceJson = `${namespace}.json`;
+    let firstRun = true;
+    const localesToBuild = new Set();
+    /**
+     * @description The output directory, used when a locale is deleted in watch mod
+     * @type {string}
+     */
+    let outputRoot;
+
+    return {
+        name: 'vite-plugin-ghost-i18n',
+        configResolved(config) {
+            outputRoot = config.build.outDir;
+        },
+        async buildStart(/* options */) {
+            if (this.meta.watchMode && firstRun) {
+                this.addWatchFile(LOCALES_PATH);
+            }
+
+            // For the first run we want to trigger all translations to be copied.
+            // In consecutive runs we only want changed translations to be copied.
+            const assets = await loadTranslations(namespace, firstRun ? null : localesToBuild);
+            firstRun = false;
+            for (const asset of assets) {
+                this.emitFile(asset);
+            }
+        },
+        /**
+         * @param {string | null} property
+         */
+        resolveImportMeta(property) {
+            // In `umd` mode, rollup synthetically defines `import.meta.url` which breaks path resolution for CDNs
+            if (property === 'url') {
+                return 'import.meta.url';
+            }
+
+            return null;
+        },
+        async watchChange(path, {event}) {
+            // CASE: A file or unrelated namespace was changed, nothing to do
+            if (!path.startsWith(LOCALES_PATH) || !path.endsWith(namespaceJson)) {
+                return;
+            }
+
+            const locale = path.replace(LOCALES_PATH, '')
+                .replace(namespaceJson, '')
+                .replaceAll('/', '');
+
+            // CASE: A file was deleted, try to delete the emitted asset. Fail silently since it's not critical
+            if (event === 'delete') {
+                await unlink(`${outputRoot}/locales/${locale}/${namespaceJson}`).catch(() => {});
+                return;
+            }
+
+            // CASE: A file was created or modified, schedule it to (re)built in the next pass
+            localesToBuild.add(locale);
+        }
+    };
+}
+
+module.exports.ghostI18nPlugin = ghostI18nPlugin;

--- a/ghost/i18n/plugin.js
+++ b/ghost/i18n/plugin.js
@@ -1,34 +1,45 @@
 // @ts-check
 const {join} = require('node:path');
 const {readdir, readFile, unlink} = require('node:fs/promises');
+const MagicString = require('magic-string');
 
 const LOCALES_PATH = join(__dirname, './locales');
+const LOCAL_LOCALES_REPLACEMENT = 'global.GHOST_INLINE_TRANSLATIONS';
 
 /**
  * @param {import('./browser.mjs').GhostNamespace} namespace
  * @param {string} locale
  * @returns {Promise<{
-    type: 'asset';
-    fileName: string,
-    source: string;
+    data: Record<string, string>;
+    asset: {
+        type: 'asset';
+        fileName: string,
+        source: string;
+    };
  }>}
  */
 async function processTranslation(namespace, locale) {
     const diskPath = `${LOCALES_PATH}/${locale}/${namespace}.json`;
     const contents = await readFile(diskPath, 'utf8');
+    const data = JSON.parse(contents);
+
     return {
-        type: 'asset',
-        fileName: `locales/${locale}/${namespace}.json`,
-        // Since these files don't get processed, minify the contents using `JSON.stringify`
-        source: JSON.stringify(JSON.parse(contents))
+        data,
+        asset: {
+            type: 'asset',
+            fileName: `locales/${locale}/${namespace}.json`,
+            // Since these files don't get processed, minify the contents using `JSON.stringify`
+            source: JSON.stringify(data)
+        }
     };
 }
 
 /**
  * @param {import('./browser.mjs').GhostNamespace} namespace
  * @param {Set<string> | null} invalidatedLocales [mutated] the set of locales that changed. If not provided, all locales will be loaded from disk.
+ * @param {Record<string, Record<string, string>>} allTranslations [mutated] all translations loaded from disk
  */
-async function loadTranslations(namespace, invalidatedLocales) {
+async function loadTranslations(namespace, invalidatedLocales, allTranslations) {
     /** @type {string[]} */
     let locales;
     if (invalidatedLocales) {
@@ -49,7 +60,9 @@ async function loadTranslations(namespace, invalidatedLocales) {
 
     await Promise.all(locales.map(async (locale) => {
         try {
-            assets.push(await processTranslation(namespace, locale));
+            const {data, asset} = await processTranslation(namespace, locale);
+            allTranslations[locale] = data;
+            assets.push(asset);
         } catch {
             // Ignore invalid locales, or locales that don't have this namespace
         }
@@ -58,14 +71,43 @@ async function loadTranslations(namespace, invalidatedLocales) {
     return assets;
 }
 
+function generateInlineTranslationsCode(translations) {
+    return `JSON.parse(${JSON.stringify(JSON.stringify(translations))})`;
+}
+
+/**
+ * @param {string} text
+ * @param {string} search
+ * @param {string} replace
+ */
+function magicReplaceOnce(text, search, replace) {
+    const source = new MagicString.default(text);
+    const startingIndex = text.indexOf(search);
+    const endingIndex = startingIndex + search.length;
+
+    source.update(startingIndex, endingIndex, replace);
+
+    return {
+        code: source.toString(),
+        map: source.generateMap()
+    };
+}
+
 /**
  * @param {import('./browser.mjs').GhostNamespace} namespace
+ * @param {'opt-in' | 'opt-out' | 'solo'} stability The stability of external locales for the namespace
+ *   - `opt-in` - A separate external locales bundle (`${namespace}-no-locales.min.js`) will be generated
+ *   - `opt-out` - The primary bundle will have external locales, and `${namespace}-locales.min.js` will have bundled locales
+ *   - `solo` - Only one bundle (external locales) will be generated
+ *  Note: extra bundles will not have source maps
  * @returns {import('vite').Plugin}
  */
-function ghostI18nPlugin(namespace) {
+function ghostI18nPlugin(namespace, stability) {
     const namespaceJson = `${namespace}.json`;
     let firstRun = true;
     const localesToBuild = new Set();
+    /** @type {Record<string, Record<string, string>>} */
+    const allTranslations = {};
     /**
      * @description The output directory, used when a locale is deleted in watch mod
      * @type {string}
@@ -84,11 +126,75 @@ function ghostI18nPlugin(namespace) {
 
             // For the first run we want to trigger all translations to be copied.
             // In consecutive runs we only want changed translations to be copied.
-            const assets = await loadTranslations(namespace, firstRun ? null : localesToBuild);
+            const assets = await loadTranslations(namespace, firstRun ? null : localesToBuild, allTranslations);
             firstRun = false;
             for (const asset of assets) {
                 this.emitFile(asset);
             }
+        },
+        transform(code/* , id */) {
+            if (!code.includes(LOCAL_LOCALES_REPLACEMENT)) {
+                return null;
+            }
+
+            // In `solo` mode, we don't need any translations --> empty object
+            // In `opt-in` mode, translations are bundled separately --> empty object
+            // In `opt-out` mode, translations are bundled with the main bundle --> translations
+            const translations = stability === 'opt-out' || stability === 'solo' ? {} : allTranslations;
+            return magicReplaceOnce(code, LOCAL_LOCALES_REPLACEMENT, generateInlineTranslationsCode(translations));
+        },
+        /**
+         * @description Emits the extra bundle for stability modes that require it.
+         * Note: This bundle is a find/replace version of the main bundle, without sourcemaps.
+         */
+        generateBundle(options, bundle/* , isWrite */) {
+            if (stability === 'solo') {
+                return;
+            }
+
+            /** @type {import('rollup').OutputChunk} */
+            // @ts-expect-error type narrowing isn't working, but it's done in the next line
+            const mainBundle = bundle[`${namespace}.min.js`];
+
+            if (!mainBundle || mainBundle.type !== 'chunk') {
+                this.error(`Chunk ${namespace}.min.js not found for translations`);
+            }
+
+            const localesText = generateInlineTranslationsCode(allTranslations);
+            const noLocalesText = generateInlineTranslationsCode({});
+
+            let fileName;
+            let search;
+            let replace;
+
+            if (stability === 'opt-in') {
+                fileName = `${namespace}-no-locales.min.js`;
+                // The optimizer will rewrite the string to reduce its size, so we're forced to use a regex match.
+                // It's not common to call `JSON.parse` on a constant string, so explicitly match quotes to
+                // avoid matching other calls.
+                search = new RegExp(`JSON.parse\\([\`"'].*?[\`"']\\);`, 'g');
+                replace = noLocalesText;
+            } else {
+                fileName = `${namespace}-locales.min.js`;
+                search = new RegExp(`JSON.parse\\("{}"\\);`, 'g');
+                replace = localesText;
+            }
+
+            const matches = Array.from(mainBundle.code.matchAll(search));
+
+            if (matches.length === 0) {
+                this.error(`Missing marker to inline translations on ${fileName}`);
+            }
+
+            if (matches.length > 1) {
+                this.error(`Multiple markers found when inlining translations on ${fileName}`);
+            }
+
+            this.emitFile({
+                type: 'asset',
+                fileName,
+                source: mainBundle.code.replace(matches[0][0], replace + ';')
+            });
         },
         /**
          * @param {string | null} property


### PR DESCRIPTION
no issue

All locales were previously included in the main bundle, even though at most 1 locale is used.
By separating out the locales, we can reduce the bundle size by ~60%:

|                     | raw             | gzip            |
| ------------------- | --------------- | --------------- |
| Before              | 1,542.72 kB     | 365.86 kB       |
| After               | 546.38 kB       | 156.29 kB       |
| Savings             | 996.34 kB (65%) | 209.57 kB (57%) |
| After (+1 locale)   | 564.48 kB       | 162.54 kB       |
| Savings (+1 locale) | 978.24 kB (63%) | 203.32 kB (56%) |

 - Added an async i18n factory that fetches locales on-demand
   - Implemented in a separate browser entrypoint for tree shaking
 - Created an i18n singleton/cache to avoid downloading the same locale multiple times
 - Allowed the locale fetch root to be overridden via `data-locale-root`
 - Added `vite-plugin-ghost-i18n` (plugin.js) in `@tryghost/i18n` to:
   - Emit each portal locale as a build asset
   - Minify the locales (using `JSON.stringify`)
   - Prevent rewriting `import.meta.url`Got some code for us? Awesome 🎊!

## Backwards Compatibility

The new plugin (`vite-plugin-ghost-i18n`) supports incremental adoption, based on `stability`. Since this hasn't been tested at-scale, Portal's stability is currently `opt-in`.

| Stability Mode | Main Bundle Type           | Secondary Bundle Name    | Secondary Bundle Type |
| -------------- | -------------------------- | ------------------------ | --------------------- |
| opt-in         | No change (inline locales) | `{ns}-no-locales.min.js` | Async locales         |
| opt-out        | Async locales              | `{ns}-locales.min.js`    | Inline locales        |
| solo           | Async locales              | N/A                      | N/A                   |

