### PR TITLE
Fixed member filter dropdown breaking for long post titles

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -82,7 +82,6 @@
     margin: 0;
     padding: 6px 14px;
     color: var(--darkgrey);
-    height: 32px;
 }
 
 .ember-power-select-option[aria-current="true"] {


### PR DESCRIPTION
Previously, if you'd filter members by which page or post they signed up on, if you had very long titles for your posts they wouldn't display properly. This change removes the fixed height set for items within this dropdown, which fixes that.

Fixes https://linear.app/ghost/issue/DES-1057/long-post-titles-get-squashedcut-off-in-members-filter-dropdown
