### PR TITLE
Removed Admin UI for enabling URL cache

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -4,10 +4,6 @@ import React from 'react';
 import {List} from '@tryghost/admin-x-design-system';
 
 const features = [{
-    title: 'URL cache',
-    description: 'Enable URL Caching',
-    flag: 'urlCache'
-},{
     title: 'Webmentions',
     description: 'Allows viewing received mentions on the dashboard.',
     flag: 'webmentions'

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -59,7 +59,6 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
-    @feature('urlCache') urlCache;
     @feature('audienceFeedback') audienceFeedback;
     @feature('webmentions') webmentions;
     @feature('stripeAutomaticTax') stripeAutomaticTax;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1803/remove-url-cache-code

- this was an experimental feature to persist the URL cache to disk so it can be read upon boot, which would save recalculating it and hopefully speed up boot times
- it was never fleshed out and the code is a bit of a hack, so it's not really worth keeping it around
- it's not trivial to delete the backend code because it's hooked into the E2E tests and they fail if you remove the flag (strange), so I'm just removing the UI so no-one can enable it
- I'll remove the backend code in a future commit