### PR TITLE
Disable "Create" button after first click in "Create newsletter" modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/AddNewsletterModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/AddNewsletterModal.tsx
@@ -71,6 +71,7 @@ const AddNewsletterModal: React.FC<RoutingModalProps> = () => {
         }}
         backDropClick={false}
         okColor='black'
+        okDisabled={saveState === 'saving'}
         okLabel='Create'
         okLoading={saveState === 'saving'}
         size='sm'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-505/double-click-on-newsletter-create-button-closes-the-modal

- It was possible to click this button again after the first click, which would close the modal and then open the "Edit newsletter" modal, which is confusing for the user. The button is now both disabled and in the loading state after the first click.
