### PR TITLE
Fixed browser tests running in docker compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - .:/home/ghost
     tty: true
+    env_file:
+      - .env
     depends_on:
       - mysql
       - redis

--- a/ghost/core/test/e2e-browser/fixtures/ghost-test.js
+++ b/ghost/core/test/e2e-browser/fixtures/ghost-test.js
@@ -11,7 +11,8 @@ const Stripe = require('stripe').Stripe;
 const configUtils = require('../../utils/configUtils');
 
 const startWebhookServer = (port) => {
-    const command = `stripe listen --forward-connect-to http://127.0.0.1:${port}/members/webhooks/stripe/ ${process.env.CI ? `--api-key ${process.env.STRIPE_SECRET_KEY}` : ''}`.trim();
+    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+    const command = `stripe listen --forward-connect-to http://127.0.0.1:${port}/members/webhooks/stripe/ ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`.trim();
     const webhookServer = spawn(command.split(' ')[0], command.split(' ').slice(1));
 
     // Adding event listeners here seems to prevent heisenbug where webhooks aren't received
@@ -22,7 +23,8 @@ const startWebhookServer = (port) => {
 };
 
 const getWebhookSecret = async () => {
-    const command = `stripe listen --print-secret ${process.env.CI ? `--api-key ${process.env.STRIPE_SECRET_KEY}` : ''}`.trim();
+    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+    const command = `stripe listen --print-secret ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`.trim();
     const webhookSecret = (await promisify(exec)(command)).stdout;
     return webhookSecret.toString().trim();
 };

--- a/ghost/core/test/e2e-browser/fixtures/ghost-test.js
+++ b/ghost/core/test/e2e-browser/fixtures/ghost-test.js
@@ -11,8 +11,10 @@ const Stripe = require('stripe').Stripe;
 const configUtils = require('../../utils/configUtils');
 
 const startWebhookServer = (port) => {
+    const isCI = process.env.CI;
+    const isDocker = process.env.COMPOSE_PROFILES === 'full';
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-    const command = `stripe listen --forward-connect-to http://127.0.0.1:${port}/members/webhooks/stripe/ ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`.trim();
+    const command = `stripe listen --forward-connect-to http://127.0.0.1:${port}/members/webhooks/stripe/ ${isDocker || isCI ? `--api-key ${stripeSecretKey}` : ''}`.trim();
     const webhookServer = spawn(command.split(' ')[0], command.split(' ').slice(1));
 
     // Adding event listeners here seems to prevent heisenbug where webhooks aren't received
@@ -23,8 +25,10 @@ const startWebhookServer = (port) => {
 };
 
 const getWebhookSecret = async () => {
+    const isCI = process.env.CI;
+    const isDocker = process.env.COMPOSE_PROFILES === 'full';
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-    const command = `stripe listen --print-secret ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`.trim();
+    const command = `stripe listen --print-secret ${isDocker || isCI ? `--api-key ${stripeSecretKey}` : ''}`.trim();
     const webhookSecret = (await promisify(exec)(command)).stdout;
     return webhookSecret.toString().trim();
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1968/get-browser-tests-working-in-docker

- When running browser tests in docker compose, the `stripe listen` command was not outputting the API key from the environment, because it's expecting that you've already run `stripe login` to authenticate with stripe. It only outputs the API key in the command line in CI. 
- This isn't convenient/practical to do in docker, and it's much easier to supply the API key as an environment variable, so this changes the logic to use the API key from the command line when running in docker _or_ CI. 
