### PR TITLE
Removed i18n toggle from labs UI (#21927)

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -24,10 +24,6 @@ const BetaFeatures: React.FC = () => {
                 detail={<>Enable support for CashApp, iDEAL, Bancontact, and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />
             <LabItem
-                action={<FeatureToggle flag='i18n' />}
-                detail={<>Translate your membership flows into your publication language (<a className='text-green' href="https://github.com/TryGhost/Ghost/tree/main/ghost/i18n/locales" rel="noopener noreferrer" target="_blank">supported languages</a>). Don’t see yours? <a className='text-green' href="https://forum.ghost.org/t/help-translate-ghost-beta/37461" rel="noopener noreferrer" target="_blank">Get involved</a></>}
-                title='Portal translation' />
-            <LabItem
                 action={<div className='flex flex-col items-end gap-1'>
                     <FileUpload
                         id='upload-redirects'

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -2,24 +2,18 @@ const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {createPostDraft} = require('../utils');
 
-/**
- * @param {import('@playwright/test').Page} page
- */
+async function setLanguage(sharedPage, language) {
+    await sharedPage.goto('/ghost/#/settings/publication-language');
+    const section = sharedPage.getByTestId('publication-language');
+    const input = section.getByPlaceholder('Site language');
+    await input.fill(language);
+    await section.getByRole('button', {name: 'Save'}).click();
+}
 
 test.describe('i18n', () => {
     test.describe('Newsletter', () => {
         test('changing the site language immediately translates strings in newsletters', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost/#/settings/publication-language');
-            const section = sharedPage.getByTestId('publication-language');
-            const input = section.getByPlaceholder('Site language');
-            await input.fill('fr');
-            await section.getByRole('button', {name: 'Save'}).click();
-
-            const labsSection = sharedPage.getByTestId('labs');
-            await labsSection.getByRole('button', {name: 'Open'}).click();
-            let portalLabel = labsSection.getByText('Portal translation');
-            let portalToggle = portalLabel.locator('..').locator('..').locator('..').getByRole('switch');
-            await portalToggle.click();
+            await setLanguage(sharedPage, 'fr');
 
             const postData = {
                 title: 'Publish and email post',
@@ -40,6 +34,9 @@ test.describe('i18n', () => {
             const metaText = await sharedPage.frameLocator('iframe.gh-pe-iframe').locator('td.post-meta').first().textContent();
             expect(metaText).toContain('Par Joe Bloggs');
             expect(metaText).not.toContain('By Joe Bloggs');
+
+            // Set the language back before the next test!
+            await setLanguage(sharedPage, 'en');
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -2,16 +2,6 @@ const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {createPostDraft} = require('../utils');
 
-// const section = page.getByTestId('publication-language');
-
-//         await expect(section.getByText('en')).toHaveCount(1);
-
-//         await section.getByLabel('Site language').fill('jp');
-
-//         await section.getByRole('button', {name: 'Save'}).click();
-
-//         await expect(section.getByLabel('Site language')).toHaveValue('jp');
-
 async function setLanguage(sharedPage, language) {
     await sharedPage.goto('/ghost/#/settings/publication-language');
     const section = sharedPage.getByTestId('publication-language');
@@ -45,9 +35,6 @@ test.describe('i18n', () => {
 
             await expect(metaText).toContain('Par Joe Bloggs');
             await expect(metaText).not.toContain('By Joe Bloggs');
-
-            // Set the language back before the next test!
-            // await setLanguage(sharedPage, 'en');
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -2,12 +2,24 @@ const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {createPostDraft} = require('../utils');
 
+// const section = page.getByTestId('publication-language');
+
+//         await expect(section.getByText('en')).toHaveCount(1);
+
+//         await section.getByLabel('Site language').fill('jp');
+
+//         await section.getByRole('button', {name: 'Save'}).click();
+
+//         await expect(section.getByLabel('Site language')).toHaveValue('jp');
+
 async function setLanguage(sharedPage, language) {
     await sharedPage.goto('/ghost/#/settings/publication-language');
     const section = sharedPage.getByTestId('publication-language');
-    const input = section.getByPlaceholder('Site language');
-    await input.fill(language);
+    await expect(section.getByText('en')).toHaveCount(1);
+    await section.getByLabel('Site language').fill(language);
     await section.getByRole('button', {name: 'Save'}).click();
+
+    await expect(section.getByLabel('Site language')).toHaveValue(language);
 }
 
 test.describe('i18n', () => {
@@ -29,14 +41,13 @@ test.describe('i18n', () => {
             await sharedPage.waitForSelector('[data-test-button="email-preview"]');
             await sharedPage.locator('[data-test-button="email-preview"]').first().click();
 
-            await sharedPage.waitForTimeout(1000);
-
             const metaText = await sharedPage.frameLocator('iframe.gh-pe-iframe').locator('td.post-meta').first().textContent();
-            expect(metaText).toContain('Par Joe Bloggs');
-            expect(metaText).not.toContain('By Joe Bloggs');
+
+            await expect(metaText).toContain('Par Joe Bloggs');
+            await expect(metaText).not.toContain('By Joe Bloggs');
 
             // Set the language back before the next test!
-            await setLanguage(sharedPage, 'en');
+            // await setLanguage(sharedPage, 'en');
         });
     });
 });


### PR DESCRIPTION
Trying again! 🙈

ref bb9a69e
ref https://linear.app/ghost/issue/ENG-1753/labs-flags-cleanup

- We promoted i18n to GA several weeks ago now, and it's going fine
- Removing the UI first to reduce confusion before cleaning up all the other references to the flag
- Also changed the i18n test to set the language back at the end of the test, to ensure no conflicts



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Removed Feature**
  - Removed the 'Portal translation' feature toggle from the Labs settings.

- **Testing**
  - Introduced a new function for setting the publication language in internationalization (i18n) test cases, enhancing readability and reducing redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->