### PR TITLE
🎨 Made 5 settings quicker to edit at the top-level in Settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/PublicationLanguage.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/PublicationLanguage.tsx
@@ -12,7 +12,6 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleSave,
         handleCancel,
         updateSetting,
-        focusRef,
         errors,
         clearError,
         handleEditingChange
@@ -32,38 +31,16 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const handleLanguageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         updateSetting('locale', e.target.value);
+        if (!isEditing) {
+            handleEditingChange(true);
+        }
     };
-
-    const values = (
-        <SettingGroupContent values={[
-            {
-                heading: 'Site language',
-                key: 'site-language',
-                value: publicationLanguage
-            }
-        ]} />
-    );
 
     const hint = (
         <>
             Default: English (<strong>en</strong>); find out more about
             <a className='text-green-400' href="https://ghost.org/docs/faq/translation/" rel="noopener noreferrer" target="_blank"> using Ghost in other languages</a>
         </>
-    );
-
-    const inputFields = (
-        <SettingGroupContent columns={1}>
-            <TextField
-                error={!!errors.publicationLanguage}
-                hint={errors.publicationLanguage || hint}
-                inputRef={focusRef}
-                placeholder="Site language"
-                title='Site language'
-                value={publicationLanguage}
-                onChange={handleLanguageChange}
-                onKeyDown={() => clearError('password')}
-            />
-        </SettingGroupContent>
     );
 
     return (
@@ -75,11 +52,22 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {
             saveState={saveState}
             testId='publication-language'
             title="Publication Language"
+            hideEditButton
             onCancel={handleCancel}
             onEditingChange={handleEditingChange}
             onSave={handleSave}
         >
-            {isEditing ? inputFields : values}
+            <SettingGroupContent columns={1}>
+                <TextField
+                    error={!!errors.publicationLanguage}
+                    hint={errors.publicationLanguage || hint}
+                    placeholder="Site language"
+                    title='Site language'
+                    value={publicationLanguage}
+                    onChange={handleLanguageChange}
+                    onKeyDown={() => clearError('password')}
+                />
+            </SettingGroupContent>
         </TopLevelGroup>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
@@ -34,22 +34,12 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const handleFacebookChange = (value: string) => {
         setFacebookUrl(value);
-        if (!isEditing) {
-            handleEditingChange(true);
-        }
-    };
-
-    const handleTwitterChange = (value: string) => {
-        setTwitterUrl(value);
-        if (!isEditing) {
-            handleEditingChange(true);
-        }
-    };
-
-    const handleFacebookBlur = () => {
         try {
-            const newUrl = validateFacebookUrl(facebookUrl);
+            const newUrl = validateFacebookUrl(value);
             updateSetting('facebook', facebookUrlToHandle(newUrl));
+            if (!isEditing) {
+                handleEditingChange(true);
+            }
             if (errors.facebook) {
                 setErrors({...errors, facebook: ''});
             }
@@ -61,10 +51,14 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
     };
 
-    const handleTwitterBlur = () => {
+    const handleTwitterChange = (value: string) => {
+        setTwitterUrl(value);
         try {
-            const newUrl = validateTwitterUrl(twitterUrl);
+            const newUrl = validateTwitterUrl(value);
             updateSetting('twitter', twitterUrlToHandle(newUrl));
+            if (!isEditing) {
+                handleEditingChange(true);
+            }
             if (errors.twitter) {
                 setErrors({...errors, twitter: ''});
             }
@@ -130,7 +124,6 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     placeholder="https://www.facebook.com/ghost"
                     title={`URL of your publication's Facebook Page`}
                     value={facebookUrl}
-                    onBlur={handleFacebookBlur}
                     onChange={e => handleFacebookChange(e.target.value)}
                 />
                 <TextField
@@ -139,7 +132,6 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     placeholder="https://x.com/ghost"
                     title="URL of your X (formerly Twitter) profile"
                     value={twitterUrl}
-                    onBlur={handleTwitterBlur}
                     onChange={e => handleTwitterChange(e.target.value)}
                 />
             </SettingGroupContent>

--- a/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
@@ -34,12 +34,22 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const handleFacebookChange = (value: string) => {
         setFacebookUrl(value);
+        if (!isEditing) {
+            handleEditingChange(true);
+        }
+    };
+
+    const handleTwitterChange = (value: string) => {
+        setTwitterUrl(value);
+        if (!isEditing) {
+            handleEditingChange(true);
+        }
+    };
+
+    const handleFacebookBlur = () => {
         try {
-            const newUrl = validateFacebookUrl(value);
+            const newUrl = validateFacebookUrl(facebookUrl);
             updateSetting('facebook', facebookUrlToHandle(newUrl));
-            if (!isEditing) {
-                handleEditingChange(true);
-            }
             if (errors.facebook) {
                 setErrors({...errors, facebook: ''});
             }
@@ -51,14 +61,10 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
     };
 
-    const handleTwitterChange = (value: string) => {
-        setTwitterUrl(value);
+    const handleTwitterBlur = () => {
         try {
-            const newUrl = validateTwitterUrl(value);
+            const newUrl = validateTwitterUrl(twitterUrl);
             updateSetting('twitter', twitterUrlToHandle(newUrl));
-            if (!isEditing) {
-                handleEditingChange(true);
-            }
             if (errors.twitter) {
                 setErrors({...errors, twitter: ''});
             }
@@ -124,6 +130,7 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     placeholder="https://www.facebook.com/ghost"
                     title={`URL of your publication's Facebook Page`}
                     value={facebookUrl}
+                    onBlur={handleFacebookBlur}
                     onChange={e => handleFacebookChange(e.target.value)}
                 />
                 <TextField
@@ -132,6 +139,7 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     placeholder="https://x.com/ghost"
                     title="URL of your X (formerly Twitter) profile"
                     value={twitterUrl}
+                    onBlur={handleTwitterBlur}
                     onChange={e => handleTwitterChange(e.target.value)}
                 />
             </SettingGroupContent>

--- a/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
@@ -54,8 +54,6 @@ const TimeZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
         };
     });
 
-    const publicationTimezoneData = timezoneOptions.find(option => option.value === publicationTimezone);
-
     const handleTimezoneChange = (value?: string) => {
         updateSetting('timezone', value || null);
         handleEditingChange(true);

--- a/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
@@ -58,36 +58,13 @@ const TimeZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const handleTimezoneChange = (value?: string) => {
         updateSetting('timezone', value || null);
+        handleEditingChange(true);
     };
-
-    const viewContent = (
-        <SettingGroupContent values={[
-            {
-                key: 'site-timezone',
-                value: <div className='flex flex-col'>
-                    {publicationTimezoneData?.label || publicationTimezone}
-                    <span className='text-xs'><Hint timezone={publicationTimezone} /></span>
-                </div>
-            }
-        ]} />
-    );
-    const inputFields = (
-        <SettingGroupContent columns={1}>
-            <Select
-                hint={<Hint timezone={publicationTimezone} />}
-                options={timezoneOptions}
-                selectedOption={timezoneOptions.find(option => option.value === publicationTimezone)}
-                testId='timezone-select'
-                title="Site timezone"
-                isSearchable
-                onSelect={option => handleTimezoneChange(option?.value)}
-            />
-        </SettingGroupContent>
-    );
 
     return (
         <TopLevelGroup
             description='Set the time and date of your publication, used for all published posts'
+            hideEditButton={true}
             isEditing={isEditing}
             keywords={keywords}
             navid='timezone'
@@ -98,7 +75,17 @@ const TimeZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
             onEditingChange={handleEditingChange}
             onSave={handleSave}
         >
-            {isEditing ? inputFields : viewContent}
+            <SettingGroupContent columns={1}>
+                <Select
+                    hint={<Hint timezone={publicationTimezone} />}
+                    options={timezoneOptions}
+                    selectedOption={timezoneOptions.find(option => option.value === publicationTimezone)}
+                    testId='timezone-select'
+                    title="Site timezone"
+                    isSearchable
+                    onSelect={option => handleTimezoneChange(option?.value)}
+                />
+            </SettingGroupContent>
         </TopLevelGroup>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
@@ -44,6 +44,15 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [copied, setCopied] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
 
+    // Watch for changes in localSettings and update editing state
+    useEffect(() => {
+        const hasChanges = localSettings.some(setting => setting.dirty);
+        if (hasChanges && !isEditing) {
+            setIsEditing(true);
+            handleEditingChange(true);
+        }
+    }, [localSettings, isEditing, handleEditingChange]);
+
     const copyDonateUrl = () => {
         navigator.clipboard.writeText(donateUrl);
         setCopied(true);
@@ -55,10 +64,6 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     const handleSettingChange = (key: string, value: string) => {
-        if (!isEditing) {
-            setIsEditing(true);
-            handleEditingChange(true);
-        }
         updateSetting(key, value);
     };
 
@@ -91,6 +96,7 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <SettingGroupContent columns={1}>
                 <div className='flex max-w-[180px] items-end gap-[.6rem]'>
                     <CurrencyField
+                        key={donationsSuggestedAmount}
                         error={!!errors.donationsSuggestedAmount}
                         hint={errors.donationsSuggestedAmount}
                         inputRef={focusRef}

--- a/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {Button, CurrencyField, Heading, Select, SettingGroupContent, confirmIfDirty, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {currencySelectGroups, getSymbol, validateCurrencyAmount} from '../../../utils/currency';
+import {currencySelectGroups, validateCurrencyAmount} from '../../../utils/currency';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 
 // Stripe doesn't allow amounts over 10,000 as a preset amount
@@ -13,15 +13,14 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
         localSettings,
         siteData,
         updateSetting,
-        isEditing,
         saveState,
         handleSave,
         handleCancel,
         focusRef,
-        handleEditingChange,
         errors,
         validate,
-        clearError
+        clearError,
+        handleEditingChange
     } = useSettingGroup({
         onValidate: () => {
             return {
@@ -36,7 +35,6 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 
     const suggestedAmountInCents = parseInt(donationsSuggestedAmount);
-    const suggestedAmountInDollars = suggestedAmountInCents / 100;
     const donateUrl = `${siteData?.url.replace(/\/$/, '')}/#/portal/support`;
 
     useEffect(() => {
@@ -44,6 +42,7 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     }, [donationsCurrency]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const [copied, setCopied] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
 
     const copyDonateUrl = () => {
         navigator.clipboard.writeText(donateUrl);
@@ -55,81 +54,25 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
         confirmIfDirty(saveState === 'unsaved', () => window.open(donateUrl, '_blank'));
     };
 
-    const values = (
-        <SettingGroupContent
-            columns={1}
-            values={[
-                {
-                    heading: 'Suggested amount',
-                    key: 'suggested-amount',
-                    value: `${getSymbol(donationsCurrency)}${suggestedAmountInDollars}`,
-                    'data-testid': 'suggested-amount'
-                },
-                {
-                    heading: '',
-                    key: 'shareable-link',
-                    value: (
-                        <div className='w-100'>
-                            <div className='flex items-center gap-2'>
-                                <Heading level={6}>Shareable link</Heading>
-                            </div>
-                            <div className='w-100 group relative mt-0 flex items-center justify-between overflow-hidden border-b border-transparent pb-2 pt-1 hover:border-grey-300 dark:hover:border-grey-600'>
-                                <span data-testid="donate-url">{donateUrl}</span>
-                                <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
-                                    <Button color='clear' data-testid="preview-shareable-link" label={'Preview'} size='sm' onClick={openPreview} />
-                                    <Button color='light-grey' data-testid="copy-shareable-link" label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
-                                </div>
-                            </div>
-                        </div>
-                    )
-                }
-            ]}
-        />
-    );
+    const handleSettingChange = (key: string, value: string) => {
+        if (!isEditing) {
+            setIsEditing(true);
+            handleEditingChange(true);
+        }
+        updateSetting(key, value);
+    };
 
-    const inputFields = (
-        <SettingGroupContent columns={1}>
-            <div className='flex max-w-[180px] items-end gap-[.6rem]'>
-                <CurrencyField
-                    error={!!errors.donationsSuggestedAmount}
-                    hint={errors.donationsSuggestedAmount}
-                    inputRef={focusRef}
-                    placeholder="5"
-                    rightPlaceholder={(
-                        <Select
-                            border={false}
-                            clearBg={true}
-                            containerClassName='w-14'
-                            fullWidth={false}
-                            options={currencySelectGroups()}
-                            selectedOption={currencySelectGroups().flatMap(group => group.options).find(option => option.value === donationsCurrency)}
-                            title='Currency'
-                            hideTitle
-                            isSearchable
-                            onSelect={option => updateSetting('donations_currency', option?.value || 'USD')}
-                        />
-                    )}
-                    title='Suggested amount'
-                    valueInCents={parseInt(donationsSuggestedAmount)}
-                    onBlur={validate}
-                    onChange={cents => updateSetting('donations_suggested_amount', cents.toString())}
-                    onKeyDown={() => clearError('donationsSuggestedAmount')}
-                />
-            </div>
-            <div className='w-100'>
-                <div className='flex items-center gap-2'>
-                    <Heading level={6}>Shareable link</Heading>
-                </div>
-                <div className='w-100 group relative mt-0 flex items-center justify-between overflow-hidden border-b border-transparent pb-2 pt-1 hover:border-grey-300 dark:hover:border-grey-600'>
-                    {donateUrl}
-                    <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
-                        <Button color='clear' label={'Preview'} size='sm' onClick={openPreview} />
-                        <Button color='light-grey' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
-                    </div>
-                </div>
-            </div>
-        </SettingGroupContent>
-    );
+    const handleCancelClick = () => {
+        setIsEditing(false);
+        handleCancel();
+    };
+
+    const handleSaveClick = async () => {
+        const response = await handleSave();
+        if (response) {
+            setIsEditing(false);
+        }
+    };
 
     return (
         <TopLevelGroup
@@ -140,11 +83,52 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
             saveState={saveState}
             testId='tips-and-donations'
             title="Tips & donations"
-            onCancel={handleCancel}
-            onEditingChange={handleEditingChange}
-            onSave={handleSave}
+            hideEditButton
+            onCancel={handleCancelClick}
+            onEditingChange={setIsEditing}
+            onSave={handleSaveClick}
         >
-            {isEditing ? inputFields : values}
+            <SettingGroupContent columns={1}>
+                <div className='flex max-w-[180px] items-end gap-[.6rem]'>
+                    <CurrencyField
+                        error={!!errors.donationsSuggestedAmount}
+                        hint={errors.donationsSuggestedAmount}
+                        inputRef={focusRef}
+                        placeholder="5"
+                        rightPlaceholder={(
+                            <Select
+                                border={false}
+                                clearBg={true}
+                                containerClassName='w-14'
+                                fullWidth={false}
+                                options={currencySelectGroups()}
+                                selectedOption={currencySelectGroups().flatMap(group => group.options).find(option => option.value === donationsCurrency)}
+                                title='Currency'
+                                hideTitle
+                                isSearchable
+                                onSelect={option => handleSettingChange('donations_currency', option?.value || 'USD')}
+                            />
+                        )}
+                        title='Suggested amount'
+                        valueInCents={parseInt(donationsSuggestedAmount)}
+                        onBlur={validate}
+                        onChange={cents => handleSettingChange('donations_suggested_amount', cents.toString())}
+                        onKeyDown={() => clearError('donationsSuggestedAmount')}
+                    />
+                </div>
+                <div className='w-100'>
+                    <div className='flex items-center gap-2'>
+                        <Heading level={6}>Shareable link</Heading>
+                    </div>
+                    <div className='w-100 group relative mt-0 flex items-center justify-between overflow-hidden border-b border-transparent pb-2 pt-1 hover:border-grey-300 dark:hover:border-grey-600'>
+                        {donateUrl}
+                        <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
+                            <Button color='clear' label={'Preview'} size='sm' onClick={openPreview} />
+                            <Button color='light-grey' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
+                        </div>
+                    </div>
+                </div>
+            </SettingGroupContent>
             <div className='items-center-mt-1 flex text-sm'>
                 All tips and donations are subject to Stripe&apos;s <a className='ml-1 text-green' href="https://ghost.org/help/tips-donations/" rel="noopener noreferrer" target="_blank"> tipping policy</a>.
             </div>

--- a/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
@@ -127,10 +127,10 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         <Heading level={6}>Shareable link</Heading>
                     </div>
                     <div className='w-100 group relative mt-0 flex items-center justify-between overflow-hidden border-b border-transparent pb-2 pt-1 hover:border-grey-300 dark:hover:border-grey-600'>
-                        {donateUrl}
+                        <span data-testid='donate-url'>{donateUrl}</span>
                         <div className='invisible flex gap-1 bg-white pl-1 group-hover:visible dark:bg-black'>
-                            <Button color='clear' label={'Preview'} size='sm' onClick={openPreview} />
-                            <Button color='light-grey' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
+                            <Button color='clear' data-testid='preview-shareable-link' label={'Preview'} size='sm' onClick={openPreview} />
+                            <Button color='light-grey' data-testid='copy-shareable-link' label={copied ? 'Copied' : 'Copy link'} size='sm' onClick={copyDonateUrl} />
                         </div>
                     </div>
                 </div>

--- a/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/TipsAndDonations.tsx
@@ -63,8 +63,8 @@ const TipsAndDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     const handleCancelClick = () => {
-        setIsEditing(false);
         handleCancel();
+        setIsEditing(false);
     };
 
     const handleSaveClick = async () => {

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -3,7 +3,6 @@ import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {GroupBase, MultiValue} from 'react-select';
 import {MultiSelect, MultiSelectOption, Select, Separator, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
-// import {getOptionLabel} from '../../../utils/helpers';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 
@@ -86,10 +85,6 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
         'members_signup_access', 'default_content_visibility', 'default_content_visibility_tiers', 'comments_enabled'
     ]) as string[];
 
-    // const membersSignupAccessLabel = getOptionLabel(MEMBERS_SIGNUP_ACCESS_OPTIONS, membersSignupAccess);
-    // const defaultContentVisibilityLabel = getOptionLabel(DEFAULT_CONTENT_VISIBILITY_OPTIONS, defaultContentVisibility);
-    // const commentsEnabledLabel = getOptionLabel(COMMENTS_ENABLED_OPTIONS, commentsEnabled);
-
     const {data: {tiers} = {}} = useBrowseTiers();
 
     const tierOptionGroups: GroupBase<MultiSelectOption>[] = [
@@ -110,28 +105,6 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
         const selectedTiers = selectedOptions.map(option => option.value);
         updateSetting('default_content_visibility_tiers', JSON.stringify(selectedTiers));
     };
-
-    // const values = (
-    //     <SettingGroupContent
-    //         values={[
-    //             {
-    //                 heading: 'Subscription access',
-    //                 key: 'subscription-access',
-    //                 value: membersSignupAccessLabel
-    //             },
-    //             {
-    //                 heading: 'Default post access',
-    //                 key: 'default-post-access',
-    //                 value: defaultContentVisibilityLabel
-    //             },
-    //             {
-    //                 heading: 'Commenting',
-    //                 key: 'commenting',
-    //                 value: commentsEnabledLabel
-    //             }
-    //         ]}
-    //     />
-    // );
 
     const form = (
         <SettingGroupContent className='gap-y-4' columns={1}>

--- a/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
@@ -17,7 +17,7 @@ test.describe('DangerZone', async () => {
 
         await page.getByTestId('confirmation-modal').getByRole('button', {name: 'Delete'}).click();
 
-        await expect(page.getByTestId('toast-success')).toContainText('All content deleted');
+        await expect(page.getByTestId('toast-success')).toContainText('All content deleted from database');
 
         expect(lastApiRequests.deleteAllContent).toBeTruthy();
     });

--- a/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
@@ -38,7 +38,6 @@ test.describe('Default recipient settings', async () => {
             ]
         });
 
-        await section.getByRole('button', {name: 'Edit'}).click();
         await chooseOptionInSelect(section.getByTestId('default-recipients-select'), 'Paid-members only');
         await section.getByRole('button', {name: 'Save'}).click();
 

--- a/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
@@ -28,7 +28,6 @@ test.describe('Default recipient settings', async () => {
             ]
         });
 
-        await section.getByRole('button', {name: 'Edit'}).click();
         await chooseOptionInSelect(section.getByTestId('default-recipients-select'), 'Usually nobody');
         await section.getByRole('button', {name: 'Save'}).click();
 

--- a/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
@@ -18,7 +18,6 @@ test.describe('Default recipient settings', async () => {
 
         await expect(section.getByText('Whoever has access to the post')).toHaveCount(1);
 
-        await section.getByRole('button', {name: 'Edit'}).click();
         await chooseOptionInSelect(section.getByTestId('default-recipients-select'), 'All members');
         await section.getByRole('button', {name: 'Save'}).click();
 
@@ -78,8 +77,6 @@ test.describe('Default recipient settings', async () => {
 
         const section = page.getByTestId('default-recipients');
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
         await chooseOptionInSelect(section.getByTestId('default-recipients-select'), 'Specific people');
         await section.getByLabel('Filter').click();
 
@@ -126,7 +123,6 @@ test.describe('Default recipient settings', async () => {
         await page.goto('/');
 
         const section = page.getByTestId('default-recipients');
-        await section.getByRole('button', {name: 'Edit'}).click();
 
         await expect(section.getByText('Specific people')).toHaveCount(1);
         await expect(section.getByText('Basic Supporter')).toHaveCount(1);

--- a/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/defaultRecipients.test.ts
@@ -41,9 +41,9 @@ test.describe('Default recipient settings', async () => {
         await chooseOptionInSelect(section.getByTestId('default-recipients-select'), 'Paid-members only');
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByTestId('default-recipients-select')).toHaveCount(0);
-
-        await expect(section.getByText('Paid-members only')).toHaveCount(1);
+        const select = section.getByTestId('default-recipients-select');
+        await expect(select).toBeVisible();
+        await expect(select).toHaveText(/Paid-members only/);
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [
@@ -84,7 +84,9 @@ test.describe('Default recipient settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByText('Specific people')).toHaveCount(1);
+        const select = section.getByTestId('default-recipients-select');
+        await expect(select).toBeVisible();
+        await expect(select).toHaveText(/Specific people/);
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/general/publicationLanguage.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/publicationLanguage.test.ts
@@ -21,9 +21,7 @@ test.describe('Publication language settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByLabel('Site language')).toHaveCount(0);
-
-        await expect(section.getByText('jp')).toHaveCount(1);
+        await expect(section.getByLabel('Site language')).toHaveValue('jp');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/general/publicationLanguage.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/publicationLanguage.test.ts
@@ -17,8 +17,6 @@ test.describe('Publication language settings', async () => {
 
         await expect(section.getByText('en')).toHaveCount(1);
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
         await section.getByLabel('Site language').fill('jp');
 
         await section.getByRole('button', {name: 'Save'}).click();

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -16,20 +16,19 @@ test.describe('Social account settings', async () => {
 
         const section = page.getByTestId('social-accounts');
 
-        await expect(section.getByText('https://www.facebook.com/ghost')).toHaveCount(1);
-        await expect(section.getByText('https://x.com/ghost')).toHaveCount(1);
+        // Check initial values in input fields
+        await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/ghost');
+        await expect(section.getByLabel('URL of your X (formerly Twitter) profile')).toHaveValue('https://x.com/ghost');
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
-        await section.getByLabel(`URL of your publication’s Facebook Page`).fill('https://www.facebook.com/fb');
+        // Fill in new values
+        await section.getByLabel(`URL of your publication's Facebook Page`).fill('https://www.facebook.com/fb');
         await section.getByLabel('URL of your X (formerly Twitter) profile').fill('https://x.com/tw');
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByLabel('URL of your X (formerly Twitter) profile')).toHaveCount(0);
-
-        await expect(section.getByText('https://www.facebook.com/fb')).toHaveCount(1);
-        await expect(section.getByText('https://x.com/tw')).toHaveCount(1);
+        // Check updated values in input fields
+        await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/fb');
+        await expect(section.getByLabel('URL of your X (formerly Twitter) profile')).toHaveValue('https://x.com/tw');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [
@@ -48,7 +47,7 @@ test.describe('Social account settings', async () => {
 
         const section = page.getByTestId('social-accounts');
 
-        const facebookInput = section.getByLabel(`URL of your publication’s Facebook Page`);
+        const facebookInput = section.getByLabel(`URL of your publication's Facebook Page`);
 
         await testUrlValidation(
             facebookInput,

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -47,7 +47,6 @@ test.describe('Social account settings', async () => {
         await page.goto('/');
 
         const section = page.getByTestId('social-accounts');
-        await section.getByRole('button', {name: 'Edit'}).click();
 
         const facebookInput = section.getByLabel(`URL of your publication’s Facebook Page`);
 

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -20,7 +20,6 @@ test.describe('Social account settings', async () => {
         await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/ghost');
         await expect(section.getByLabel('URL of your X (formerly Twitter) profile')).toHaveValue('https://x.com/ghost');
 
-        // Fill in new values
         await section.getByLabel(`URL of your publication's Facebook Page`).fill('https://www.facebook.com/fb');
         await section.getByLabel('URL of your X (formerly Twitter) profile').fill('https://x.com/tw');
 
@@ -47,7 +46,9 @@ test.describe('Social account settings', async () => {
 
         const section = page.getByTestId('social-accounts');
 
+        // Wait for the inputs to be visible
         const facebookInput = section.getByLabel(`URL of your publication's Facebook Page`);
+        await expect(facebookInput).toBeVisible();
 
         await testUrlValidation(
             facebookInput,
@@ -94,14 +95,14 @@ test.describe('Social account settings', async () => {
         await testUrlValidation(
             facebookInput,
             'http://github.com/username',
-            'http://github.com/username',
+            '',
             'The URL must be in a format like https://www.facebook.com/yourPage'
         );
 
         await testUrlValidation(
             facebookInput,
             'http://github.com/pages/username',
-            'http://github.com/pages/username',
+            '',
             'The URL must be in a format like https://www.facebook.com/yourPage'
         );
 
@@ -128,7 +129,7 @@ test.describe('Social account settings', async () => {
         await testUrlValidation(
             twitterInput,
             '*(&*(%%))',
-            '*(&*(%%))',
+            '',
             'The URL must be in a format like https://x.com/yourUsername'
         );
 

--- a/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
@@ -23,7 +23,7 @@ test.describe('Time zone settings', async () => {
         await section.getByRole('button', {name: 'Save'}).click();
 
         await expect(select).toBeVisible();
-        await expect(select).toHaveValue('America/Anchorage');
+        await expect(select).toContainText('(GMT -9:00) Alaska');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
@@ -15,7 +15,7 @@ test.describe('Time zone settings', async () => {
 
         const section = page.getByTestId('timezone');
 
-        await expect(section.getByText('(GMT) UTC')).toHaveCount(1);
+        await expect(section.getByLabel('Site timezone')).toBeVisible();
 
         await chooseOptionInSelect(section.getByTestId('timezone-select'), '(GMT -9:00) Alaska');
 
@@ -23,7 +23,7 @@ test.describe('Time zone settings', async () => {
 
         await expect(section.getByTestId('timezone-select')).toHaveCount(0);
 
-        await expect(section.getByText('(GMT -9:00) Alaska')).toHaveCount(1);
+        await expect(section.getByLabel('Site timezone')).toContainText('(GMT -9:00) Alaska');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
@@ -14,16 +14,16 @@ test.describe('Time zone settings', async () => {
         await page.goto('/');
 
         const section = page.getByTestId('timezone');
+        const select = section.getByTestId('timezone-select');
 
-        await expect(section.getByLabel('Site timezone')).toBeVisible();
+        await expect(select).toBeVisible();
 
-        await chooseOptionInSelect(section.getByTestId('timezone-select'), '(GMT -9:00) Alaska');
+        await chooseOptionInSelect(select, '(GMT -9:00) Alaska');
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        await expect(section.getByTestId('timezone-select')).toHaveCount(0);
-
-        await expect(section.getByLabel('Site timezone')).toContainText('(GMT -9:00) Alaska');
+        await expect(select).toBeVisible();
+        await expect(select).toHaveValue('America/Anchorage');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/timeZone.test.ts
@@ -17,8 +17,6 @@ test.describe('Time zone settings', async () => {
 
         await expect(section.getByText('(GMT) UTC')).toHaveCount(1);
 
-        await section.getByRole('button', {name: 'Edit'}).click();
-
         await chooseOptionInSelect(section.getByTestId('timezone-select'), '(GMT -9:00) Alaska');
 
         await section.getByRole('button', {name: 'Save'}).click();

--- a/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
@@ -23,12 +23,18 @@ test.describe('Tips and donations', () => {
         await expect(page.locator('[data-setting-nav-item] #tips-and-donations')).toBeVisible();
         await expect(section).toBeVisible();
 
-        await expect(section.getByTestId('suggested-amount')).toHaveText(/\$5/);
-        await expect(section.getByTestId('donate-url')).toHaveText('http://test.com/#/portal/support');
+        const suggestedAmountInput = section.getByTestId('suggested-amount');
+        await expect(suggestedAmountInput).toBeVisible();
+        await expect(suggestedAmountInput).toHaveValue('5');
+
+        const donateUrl = section.getByTestId('donate-url');
+        await expect(donateUrl).toBeVisible();
+        await expect(donateUrl).toHaveText('http://test.com/#/portal/support');
+
         await expect(section.getByTestId('preview-shareable-link')).not.toBeVisible();
         await expect(section.getByTestId('copy-shareable-link')).not.toBeVisible();
 
-        await section.getByTestId('donate-url').hover();
+        await donateUrl.hover();
 
         await expect(section.getByTestId('preview-shareable-link')).toBeVisible();
         await expect(section.getByTestId('copy-shareable-link')).toBeVisible();

--- a/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
@@ -27,6 +27,8 @@ test.describe('Tips and donations', () => {
         await expect(suggestedAmountInput).toBeVisible();
         await expect(suggestedAmountInput).toHaveValue('5');
 
+        await expect(section.getByRole('combobox')).toBeVisible();
+
         const donateUrl = section.getByTestId('donate-url');
         await expect(donateUrl).toBeVisible();
         await expect(donateUrl).toHaveText('http://test.com/#/portal/support');

--- a/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/tips-and-donations.test.ts
@@ -23,7 +23,7 @@ test.describe('Tips and donations', () => {
         await expect(page.locator('[data-setting-nav-item] #tips-and-donations')).toBeVisible();
         await expect(section).toBeVisible();
 
-        const suggestedAmountInput = section.getByTestId('suggested-amount');
+        const suggestedAmountInput = section.getByRole('textbox', {name: 'Suggested amount'});
         await expect(suggestedAmountInput).toBeVisible();
         await expect(suggestedAmountInput).toHaveValue('5');
 

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -184,8 +184,11 @@ test.describe('Offers Modal', () => {
 
         await page.goto('/');
         const section = page.getByTestId('offers');
-        await section.getByRole('button', {name: 'Manage offers'}).click();
+        const manageButton = section.getByRole('button', {name: 'Manage offers'});
+        await expect(manageButton).toBeVisible();
+        await manageButton.click();
         const modal = page.getByTestId('offers-modal');
+        await expect(modal).toBeVisible();
         await expect(modal.getByText('Active')).toHaveAttribute('aria-selected', 'true');
         await expect(modal).toContainText('First offer');
         await expect(modal).toContainText('Second offer');

--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -11,7 +11,6 @@ test.describe('i18n', () => {
         test('changing the site language immediately translates strings in newsletters', async ({sharedPage}) => {
             await sharedPage.goto('/ghost/#/settings/publication-language');
             const section = sharedPage.getByTestId('publication-language');
-            await section.getByRole('button', {name: 'Edit'}).click();
             const input = section.getByPlaceholder('Site language');
             await input.fill('fr');
             await section.getByRole('button', {name: 'Save'}).click();

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -613,7 +613,6 @@ test.describe('Updating post access', () => {
         await page.locator('[data-test-nav="settings"]').click();
         await expect(page.getByTestId('timezone')).toContainText('UTC');
 
-        await page.getByTestId('timezone').getByRole('button', {name: 'Edit'}).click();
         await page.getByTestId('timezone-select').click();
         await page.locator('[data-testid="select-option"]', {hasText: 'Tokyo'}).click();
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -637,7 +637,6 @@ test.describe('Updating post access', () => {
         await page.locator('[data-testid="select-option"]', {hasText: /Usually nobody/}).click();
         await page.getByTestId('default-recipients').getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('default-recipients-select')).toBeHidden();
         await expect(page.getByTestId('default-recipients')).toContainText('Usually nobody');
 
         await page.goto('/ghost');

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -617,7 +617,6 @@ test.describe('Updating post access', () => {
         await page.locator('[data-testid="select-option"]', {hasText: 'Tokyo'}).click();
 
         await page.getByTestId('timezone').getByRole('button', {name: 'Save'}).click();
-        await expect(page.getByTestId('timezone-select')).toBeHidden();
         await expect(page.getByTestId('timezone')).toContainText('(GMT +9:00) Osaka, Sapporo, Tokyo');
 
         await page.getByTestId('exit-settings').click();

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -634,7 +634,6 @@ test.describe('Updating post access', () => {
     test('default recipient settings - usually nobody', async ({page}) => {
         // switch to "usually nobody" setting
         await page.goto('/ghost/settings/newsletters');
-        await page.getByTestId('default-recipients').getByRole('button', {name: 'Edit'}).click();
         await page.getByTestId('default-recipients-select').click();
         await page.locator('[data-testid="select-option"]', {hasText: /Usually nobody/}).click();
         await page.getByTestId('default-recipients').getByRole('button', {name: 'Save'}).click();

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -58,7 +58,6 @@ test.describe('Portal', () => {
 
             const section = sharedPage.getByTestId('tips-and-donations');
 
-            await section.getByRole('button', {name: 'Edit'}).click();
             await section.getByLabel('Suggested amount').fill('98');
             const select = section.getByLabel('Currency');
             await select.click();

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -63,7 +63,8 @@ test.describe('Portal', () => {
             await select.click();
             await sharedPage.locator(`[data-testid="select-option"][data-value="EUR"]`).click();
             await section.getByRole('button', {name: 'Save'}).click();
-            await expect(select).not.toBeVisible();
+            // Currency selector is now always visible
+            await expect(select).toBeVisible();
 
             // go to website and open portal
             await sharedPage.goto('/#/portal/support');


### PR DESCRIPTION
Based on our changes to the _Access_ and _Analytics_ cards in Settings, we decided to update how we allow edits to a few other settings, too.

These changes allow the following settings to be manipulated at the top-level in Settings, without having to click 'Edit' first. 

- Timezone
- Default recipients for newsletters
- Publication language
- Social accounts
- Tips and donations

fixes https://linear.app/ghost/issue/DES-1062/updates-to-editsave-method-of-settings-cards