### PR TITLE
Fixed Select component catching all ESC keypresses

### DIFF
--- a/apps/admin-x-design-system/src/global/form/Select.tsx
+++ b/apps/admin-x-design-system/src/global/form/Select.tsx
@@ -109,7 +109,7 @@ const Select: React.FC<SelectProps> = ({
     ...props
 }) => {
     const id = useId();
-    const {setFocusState} = useFocusContext();
+    const {setFocusState, isAnyTextFieldFocused} = useFocusContext();
     const handleFocus = () => {
         setFocusState(true);
     };
@@ -119,27 +119,29 @@ const Select: React.FC<SelectProps> = ({
     };
 
     useEffect(() => {
-        const handleEscapeKey = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                // Fix for Safari - if an element in the modal is focused, closing it will jump to
-                // the bottom of the page because Safari tries to focus the "next" element in the DOM
-                if (document.activeElement && document.activeElement instanceof HTMLElement) {
-                    document.activeElement.blur();
+        if (isAnyTextFieldFocused) {
+            const handleEscapeKey = (event: KeyboardEvent) => {
+                if (event.key === 'Escape') {
+                    // Fix for Safari - if an element in the modal is focused, closing it will jump to
+                    // the bottom of the page because Safari tries to focus the "next" element in the DOM
+                    if (document.activeElement && document.activeElement instanceof HTMLElement) {
+                        document.activeElement.blur();
+                    }
+                    setFocusState(false);
+
+                    // Prevent the event from bubbling up to the window level
+                    event.stopPropagation();
                 }
-                setFocusState(false);
+            };
 
-                // Prevent the event from bubbling up to the window level
-                event.stopPropagation();
-            }
-        };
+            document.addEventListener('keydown', handleEscapeKey);
 
-        document.addEventListener('keydown', handleEscapeKey);
-
-        // Clean up the event listener when the modal is closed
-        return () => {
-            document.removeEventListener('keydown', handleEscapeKey);
-        };
-    }, [setFocusState]);
+            // Clean up the event listener when the modal is closed
+            return () => {
+                document.removeEventListener('keydown', handleEscapeKey);
+            };
+        }
+    }, [setFocusState, isAnyTextFieldFocused]);
 
     let containerClasses = '';
     if (!unstyled) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/DES-1075/regression-esc-doesnt-close-admin-settings

- Hitting ESC in Admin/Settings while nothing is in focus should close Settings and navigate back to the Dashboard — instead, right now nothing happens when `ESC` is hit. The problem was that the `Select` component in the current Design System caught `ESC` keystrokes and stopped propagating them even if they were not in focus. This issue wasn't apparent so far because no `Select` components were rendered directly on the Settings page. However, in a [recent change](https://github.com/TryGhost/Ghost/commit/ab2c7f18e25bd127ee344f4f9dc11ab508877e04) we moved out some select components from Access settings to the main Settings view, which immediately stopped propagating `ESC` keystrokes to the main component. This fix adds a check if the `Select` (or any other) component is in focus and stops propagation only if that's true.