### PR TITLE
Improved member filter display by clamping long post titles

### DIFF
--- a/ghost/admin/app/components/gh-resource-select.hbs
+++ b/ghost/admin/app/components/gh-resource-select.hbs
@@ -15,5 +15,5 @@
     @searchPlaceholder={{this.searchPlaceholderText}}
   as |resource|
 >
-  {{resource.title}}
+  <span>{{resource.title}}</span>
 </PowerSelect>

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -101,6 +101,18 @@
 
 .ember-power-select-options li {
     margin-bottom: 0;
+    padding: 0;
+}
+
+.ember-power-select-options li span {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: 1.3em;
+    overflow: hidden;
+    /* padding: 7px 12px; */
 }
 
 .ember-power-select-search input {
@@ -133,7 +145,7 @@
     display: inline-block;
     width: 100%;
     margin-top: 6px;
-    padding: 10px 12px 8px;
+    padding: 10px 12px 8px 0px;
     cursor: default;
     border-top: 1px solid var(--list-color-divider);
     text-transform: uppercase;
@@ -175,9 +187,9 @@
 }
 
 .ember-power-select-group .ember-power-select-option {
-    padding: 7px 12px;
     cursor: pointer;
     font-size: 1.4rem;
+    padding-left: 0;
 }
 
 .ember-power-select-group .ember-power-select-option span {

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -79,8 +79,6 @@
 }
 
 .ember-power-select-option {
-    margin: 0;
-    padding: 6px 14px;
     color: var(--darkgrey);
 }
 
@@ -97,6 +95,8 @@
 
 .ember-power-select-options:not([role="group"]) {
     max-height: 50vh;
+    width: 100%;
+    overflow-x: hidden;
 }
 
 .ember-power-select-options li {
@@ -175,11 +175,19 @@
 }
 
 .ember-power-select-group .ember-power-select-option {
-    overflow: hidden;
     padding: 7px 12px;
-    line-height: 1.35em;
     cursor: pointer;
     font-size: 1.4rem;
+}
+
+.ember-power-select-group .ember-power-select-option span {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: 1.3em;
+    overflow: hidden;
 }
 
 .ember-power-select-group .ember-power-select-option .highlight {

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -80,15 +80,8 @@
 
 .ember-power-select-option {
     margin: 0;
+    padding: 6px 14px;
     color: var(--darkgrey);
-    -webkit-line-clamp: 2;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    word-break: break-word;
-    line-height: 1.3;
-    max-height: 3.45em;
 }
 
 .ember-power-select-option[aria-current="true"] {

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -80,8 +80,15 @@
 
 .ember-power-select-option {
     margin: 0;
-    padding: 6px 14px;
     color: var(--darkgrey);
+    -webkit-line-clamp: 2;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: 1.3;
+    max-height: 3.45em;
 }
 
 .ember-power-select-option[aria-current="true"] {

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -99,9 +99,10 @@
     overflow-x: hidden;
 }
 
-.ember-power-select-options li {
+.ember-power-select-group .ember-power-select-options li,
+.ember-power-select-options li.ember-power-select-option {
     margin-bottom: 0;
-    padding: 0;
+    padding: 7px 12px;
 }
 
 .ember-power-select-options li span {
@@ -112,7 +113,6 @@
     word-break: break-word;
     line-height: 1.3em;
     overflow: hidden;
-    /* padding: 7px 12px; */
 }
 
 .ember-power-select-search input {
@@ -145,7 +145,7 @@
     display: inline-block;
     width: 100%;
     margin-top: 6px;
-    padding: 10px 12px 8px 0px;
+    padding: 12px 0 0 12px;
     cursor: default;
     border-top: 1px solid var(--list-color-divider);
     text-transform: uppercase;
@@ -174,8 +174,7 @@
 
 .ember-power-select-group:first-of-type .ember-power-select-group-name {
     margin: 8px 0;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0 0 0 12px;
 }
 
 .ember-power-select-group:first-of-type .ember-power-select-group-name:after {


### PR DESCRIPTION
[Previously](https://github.com/TryGhost/Ghost/commit/98306d2337d39729a0539f2f0aebe06209fc9263), we improved the way the member filter looks when it needs to display long titles. Extremely long titles, however, would be a little hard to read.

Now, extremely long titles will be clamped after two lines, making the filter easier to scan.

No issue.