### PR TITLE
Fixed dark mode separator in Analytics settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -59,7 +59,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     handleToggleChange('email_track_opens', e);
                 }}
             />
-            <Separator />
+            <Separator className="border-grey-200 dark:border-grey-900" />
             <Toggle
                 checked={trackEmailClicks}
                 direction='rtl'
@@ -70,7 +70,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     handleToggleChange('email_track_clicks', e);
                 }}
             />
-            <Separator />
+            <Separator className="border-grey-200 dark:border-grey-900" />
             <Toggle
                 checked={trackMemberSources}
                 direction='rtl'
@@ -81,7 +81,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     handleToggleChange('members_track_sources', e);
                 }}
             />
-            <Separator />
+            <Separator className="border-grey-200 dark:border-grey-900" />
             <Toggle
                 checked={outboundLinkTagging}
                 direction='rtl'


### PR DESCRIPTION
The separator in Analytics settings wasn't showing in the right colour in dark mode. This change fixes that. 

Fixes https://linear.app/ghost/issue/DES-1077/analytics-separators-have-wrong-colour-in-dark-mode