### PR TITLE
Fixed power select trigger styles in post preview

### DIFF
--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -220,8 +220,8 @@
     grid-template-columns: 65px 1fr;
 }
 
-.gh-preview-newsletter-trigger,
-.gh-preview-newsletter-trigger:focus {
+.ember-power-select-trigger.gh-preview-newsletter-trigger,
+.ember-power-select-trigger.gh-preview-newsletter-trigger:focus {
     padding: 0;
     border: none;
     cursor: pointer;

--- a/ghost/admin/app/styles/patterns/forms.css
+++ b/ghost/admin/app/styles/patterns/forms.css
@@ -301,6 +301,7 @@ textarea {
 
 textarea.gh-input-x {
     padding-block: 8px;
+    max-width: unset;
 }
 
 


### PR DESCRIPTION
No issue
- The css specificity had changed due to adding `:not(gh-input-x)`, which led to an unintended border around the free/paid dropdown in the email preview
- The description field on the tag page had an unintended `max-width`.