### PR TITLE
🎨 Made custom_excerpt searchable via Sodo Search

### DIFF
--- a/apps/sodo-search/src/search-index.js
+++ b/apps/sodo-search/src/search-index.js
@@ -15,7 +15,7 @@ export default class SearchIndex {
             rtl: rtl,
             document: {
                 id: 'id',
-                index: ['title', 'excerpt'],
+                index: ['title', 'excerpt', 'custom_excerpt'],
                 store: true
             },
             ...this.#getEncodeOptions()
@@ -66,7 +66,7 @@ export default class SearchIndex {
     async init() {
         let posts = await this.api.posts.browse({
             limit: '10000',
-            fields: 'id,slug,title,excerpt,url,updated_at,visibility',
+            fields: 'id,slug,title,excerpt,custom_excerpt,url,updated_at,visibility',
             order: 'updated_at DESC'
         });
 
@@ -143,7 +143,7 @@ export default class SearchIndex {
 
     #getEncodeOptions() {
         const regex = new RegExp(
-            `[\u{4E00}-\u{9FFF}\u{3040}-\u{309F}\u{30A0}-\u{30FF}\u{AC00}-\u{D7A3}\u{3400}-\u{4DBF}\u{20000}-\u{2A6DF}\u{2A700}-\u{2B73F}\u{2B740}-\u{2B81F}\u{2B820}-\u{2CEAF}\u{2CEB0}-\u{2EBEF}\u{30000}-\u{3134F}\u{31350}-\u{323AF}\u{2EBF0}-\u{2EE5F}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]|[0-9A-Za-zа-я\u00C0-\u017F\u0400-\u04FF\u0600-\u06FF\u0980-\u09FF\u1E00-\u1EFF]+`,
+            `[\u{4E00}-\u{9FFF}\u{3040}-\u{309F}\u{30A0}-\u{30FF}\u{AC00}-\u{D7A3}\u{3400}-\u{4DBF}\u{20000}-\u{2A6DF}\u{2A700}-\u{2B73F}\u{2B740}-\u{2B81F}\u{2B820}-\u{2CEAF}\u{2CEB0}-\u{2EBEF}\u{30000}-\u{3134F}\u{31350}-\u{323AF}\u{2EBF0}-\u{2EE5F}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]|[0-9A-Za-zа-я\u00C0-\u017F\u0400-\u04FF\u0600-\u06FF\u0980-\u09FF\u1E00-\u1EFF#_]+`,
             'mug'
         );
 


### PR DESCRIPTION
no issue
When custom excerpt was defined in the posts, it was currently non-searchable, which is confusing UX-wise. On top of that hash symbols (#) or underscores (_) were not searchable

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

P.S. I couldn't run `yarn test:all`, got command not found, but nothing should fail with this small of a change.
