### PR TITLE
Added additional test routes

### DIFF
--- a/ghost/core/core/server/web/api/testmode/routes.js
+++ b/ghost/core/core/server/web/api/testmode/routes.js
@@ -91,5 +91,27 @@ module.exports = function testRoutes() {
         res.sendStatus(202);
     });
 
+    function blockForSeconds(seconds) {
+        const end = Date.now() + seconds * 1000;
+        while (Date.now() < end) {
+            // Busy-wait loop to block the event loop
+        }
+    }
+
+    router.get('/block/:seconds', (req, res) => {
+        const seconds = parseInt(req.params.seconds, 10);
+        if (isNaN(seconds) || seconds <= 0) {
+            return res.status(400).send('Invalid number of seconds');
+        }
+
+        console.log(`Blocking for ${seconds} seconds`);
+        blockForSeconds(seconds);
+        res.send(`Blocked for ${seconds} seconds`);
+    });
+
+    router.get('/drop', () => { // do nothing and wait for request to drop
+        console.log('Request received but not responding');
+    });
+
     return router;
 };

--- a/ghost/core/core/server/web/api/testmode/routes.js
+++ b/ghost/core/core/server/web/api/testmode/routes.js
@@ -104,12 +104,14 @@ module.exports = function testRoutes() {
             return res.status(400).send('Invalid number of seconds');
         }
 
+        // eslint-disable-next-line no-console
         console.log(`Blocking for ${seconds} seconds`);
         blockForSeconds(seconds);
         res.send(`Blocked for ${seconds} seconds`);
     });
 
     router.get('/drop', () => { // do nothing and wait for request to drop
+        // eslint-disable-next-line no-console
         console.log('Request received but not responding');
     });
 


### PR DESCRIPTION
no ref

Added a couple new routes for testing purposes. server:testmode config must be set to true to access.
- {ghostUrl}/ghost/api/block/:seconds will block the node process for the given duration
- {ghostUrl}/ghost/api/drop will simply hold the connection until client timeout by doing nothing with it, helpful for saturating connections