### PR TITLE
🐛 Fixed CustomView not showing edit in bad state

### DIFF
--- a/ghost/admin/app/services/custom-views.js
+++ b/ghost/admin/app/services/custom-views.js
@@ -196,16 +196,34 @@ export default class CustomViewsService extends Service {
         if (!this.router.currentRoute) {
             return undefined;
         }
-        return this.findView(this.router.currentRouteName, this.router.currentRoute.queryParams);
+        const found = this.findView(this.router.currentRouteName, this.router.currentRoute.queryParams);
+        return found;
     }
 
     findView(routeName, queryParams) {
         let _routeName = routeName.replace(/_loading$/, '');
-
         return this.viewList.find((view) => {
             return view.route === _routeName
-                && isFilterEqual(view.filter, queryParams);
+                && isFilterEqual(this.cleanFilter(view.filter), queryParams);
         });
+    }
+
+    cleanFilter(filter) {
+        // Remove keys where the value is null or undefined using native JS methods
+        return Object.fromEntries(
+            Object.entries(filter).filter(([, value]) => value !== null)
+        );
+    }
+
+    isFilterEqual(filterA, filterB) {
+        const keysA = Object.keys(filterA);
+        const keysB = Object.keys(filterB);
+
+        if (keysA.length !== keysB.length) {
+            return false;
+        }
+
+        return keysA.every(key => filterA[key] === filterB[key]);
     }
 
     newView() {

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -766,7 +766,6 @@ describe('Acceptance: Posts / Pages', function () {
                     });
                 });
             });
-
             it('can add and edit custom views', async function () {
                 // actions are not visible when there's no filter
                 await visit('/posts');
@@ -848,6 +847,27 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(currentURL()).to.equal('/posts?type=scheduled');
                 expect(find('[data-test-nav-custom="posts-Scheduled"]')).to.have.class('active');
                 expect(find('[data-test-screen-title]').innerText).to.match(/Scheduled/);
+            });
+
+            it('Shows edit view if order is null, which indicates a bad state', async function () {
+                this.server.schema.settings.findBy({key: 'shared_views'}).update({
+                    group: 'site',
+                    key: 'shared_views',
+                    value: JSON.stringify([{
+                        route: 'posts',
+                        name: 'My posts',
+                        filter: {
+                            author: admin.slug,
+                            order: null
+                        }
+                    }])
+                });
+
+                await visit('/posts');
+                expect(find('[data-test-nav-custom="posts-My posts"]'), 'my posts nav').to.exist;
+                // click on the custom view
+                await click('[data-test-nav-custom="posts-My posts"]');
+                expect(find('[data-test-button="edit-view"]'), 'edit-view button (on existing view)').to.exist;
             });
         });
     });


### PR DESCRIPTION
ref ONC-715

- A customer reported an issue where one of their custom views doesn't have the edit button appearing.
- The issue stems to a bad state in the database where `order` has `null` as a value, however this should never be possible.
- To fix this, we allow the filtering which compares the routes with the view query to ignore nulled keys in order for the edit button to be populated.
- also added tests

