### PR TITLE
Changed profile modal to always remote load in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/src/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/components/Profile.tsx
@@ -177,9 +177,7 @@ const LikesTab: React.FC = () => {
 };
 
 const handleAccountClick = (handle: string) => {
-    NiceModal.show(ViewProfileModal, {
-        profile: handle
-    });
+    NiceModal.show(ViewProfileModal, {handle});
 };
 
 const FollowingTab: React.FC = () => {

--- a/apps/admin-x-activitypub/src/components/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/Search.tsx
@@ -48,7 +48,7 @@ const SearchResult: React.FC<SearchResultProps> = ({result, update}) => {
         <ActivityItem
             key={result.actor.id}
             onClick={() => {
-                NiceModal.show(ViewProfileModal, {profile: result, onFollow, onUnfollow});
+                NiceModal.show(ViewProfileModal, {handle: result.handle, onFollow, onUnfollow});
             }}
         >
             <APAvatar author={result.actor}/>

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -69,9 +69,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size}) => {
 
     const onClick = (e: React.MouseEvent) => {
         e.stopPropagation();
-        NiceModal.show(ViewProfileModal, {
-            profile: handle
-        });
+        NiceModal.show(ViewProfileModal, {handle});
     };
 
     const title = `${author?.name} ${handle}`;

--- a/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect, useRef, useState} from 'react';
 
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 
 import {Button, Heading, Icon, List, LoadingIndicator, Modal, NoValueLabel, Tab,TabView} from '@tryghost/admin-x-design-system';
 import {UseInfiniteQueryResult} from '@tanstack/react-query';
@@ -217,13 +216,7 @@ const FollowersTab: React.FC<{handle: string}> = ({handle}) => {
 };
 
 interface ViewProfileModalProps {
-    profile: {
-        actor: ActorProperties;
-        handle: string;
-        followerCount: number;
-        followingCount: number;
-        isFollowing: boolean;
-    } | string;
+    handle: string;
     onFollow?: () => void;
     onUnfollow?: () => void;
 }
@@ -231,20 +224,14 @@ interface ViewProfileModalProps {
 type ProfileTab = 'posts' | 'following' | 'followers';
 
 const ViewProfileModal: React.FC<ViewProfileModalProps> = ({
-    profile: initialProfile,
+    handle,
     onFollow = noop,
     onUnfollow = noop
 }) => {
     const modal = useModal();
     const [selectedTab, setSelectedTab] = useState<ProfileTab>('posts');
 
-    const willLoadProfile = typeof initialProfile === 'string';
-    let {data: profile, isInitialLoading: isLoading} = useProfileForUser('index', initialProfile as string, willLoadProfile);
-
-    if (!willLoadProfile) {
-        profile = initialProfile;
-        isLoading = false;
-    }
+    const {data: profile, isLoading} = useProfileForUser('index', handle);
 
     const attachments = (profile?.actor.attachment || []);
 

--- a/apps/admin-x-activitypub/src/utils/handle-profile-click.ts
+++ b/apps/admin-x-activitypub/src/utils/handle-profile-click.ts
@@ -6,6 +6,6 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 export const handleProfileClick = (actor: ActorProperties, e?: React.MouseEvent) => {
     e?.stopPropagation();
     NiceModal.show(ViewProfileModal, {
-        profile: getUsername(actor)
+        handle: getUsername(actor)
     });
 };


### PR DESCRIPTION
no refs

Changed profile modal to always remote load in `admin-x-activitypub` instead of both accepting an object or a string. This will allow for easier refactoring of the modal when we switch this area of the app to use `accounts` instead of `profiles`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
    - Simplified profile modal data structure across multiple components
    - Updated profile-related function calls to use `handle` directly instead of nested profile objects

- **Bug Fixes**
    - Streamlined profile data passing mechanism to improve consistency and reduce complexity

The changes focus on standardizing how profile information is handled and displayed throughout the application, making the code more straightforward and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->