### PR TITLE
Improved how we represent unusual article heading structures

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-634/table-of-contents-in-reader-view

- Sometimes publishers use headings in unusual ways (for example, using just `h3`s). This means we can't rely on headings always being structured in the expected way (`h1`, `h2`, `h3`...) Now after we scan the article for headings, we find the highest level heading and then calculate normalized levels for all other headings. This helps the widget look good even in these edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Bumped package version from `0.3.46` to `0.3.47`

- **Improvements**
	- Enhanced table of contents functionality in article modal
	- Refined heading extraction and normalization in article body
	- Updated styling for table of contents components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->