### PR TITLE
🐛 Fixed degraded database performance when using the Post Analytics screen

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -35,6 +35,14 @@
                     {{/let}}
                 </div>
                 <div style="display: flex; gap: 8px;">
+                    <GhTaskButton
+                        @buttonText="Refresh"
+                        @task={{this.fetchPostTask}}
+                        @showIcon={{true}}
+                        @idleIcon="reload"
+                        @successText="Refreshed"
+                        @class="gh-btn gh-btn-icon refresh"
+                        @successClass="gh-btn gh-btn-icon refresh" />
                     {{#unless this.post.emailOnly}}
                         <button type="button" class="gh-btn gh-btn-icon share" {{on "click" this.togglePublishFlowModal}}>
                             <span>{{svg-jar "share" title="Share post"}} Share</span>

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -3,7 +3,7 @@ import DeletePostModal from '../modals/delete-post';
 import PostSuccessModal from '../modal-post-success';
 import anime from 'animejs/lib/anime.es.js';
 import {action} from '@ember/object';
-import {didCancel, task, timeout} from 'ember-concurrency';
+import {didCancel, task} from 'ember-concurrency';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -18,8 +18,6 @@ const DISPLAY_OPTIONS = [{
     name: 'Paid conversions',
     value: 'paid'
 }];
-
-const AUTO_REFRESH_RATE = 7500;
 
 export default class Analytics extends Component {
     @service ajax;
@@ -53,8 +51,6 @@ export default class Analytics extends Component {
     constructor() {
         super(...arguments);
         this.checkPublishFlowModal();
-        this.fetchPostTask.perform();
-        this.autoRefreshTask.perform();
     }
 
     openPublishFlowModal() {
@@ -392,13 +388,6 @@ export default class Analytics extends Component {
         yield this.fetchLinks();
 
         return true;
-    }
-
-    @task
-    *autoRefreshTask() {
-        yield timeout(AUTO_REFRESH_RATE);
-        yield this.fetchPostTask.perform();
-        this.autoRefreshTask.perform();
     }
 
     @action


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-717/support-escalation-re-dashboard-unresponsive

This reverts commit 9082a9f1db1d44026013a8cc8f0dee27e06e1486, which introduced an automatic refresh interval on the Post Analytics screen in Admin. This change led to an increase in the number of requests to the `/ghost/api/admin/members/events/` endpoint, which is a particularly database intensive endpoint. Ultimately this led to significantly higher load on the database which degraded performance for sites with a large `email_recipients` table.