### PR TITLE
Fixed reading progress indicator for very short articles

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.52",
+  "version": "0.3.53",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -538,6 +538,8 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
     // Add debounced version of setReadingProgress
     const [debouncedSetReadingProgress] = useDebounce(setReadingProgress, 100);
 
+    const PROGRESS_INCREMENT = 5; // Progress is shown in 5% increments (0%, 5%, 10%, etc.)
+
     useEffect(() => {
         const container = document.querySelector('.overflow-y-auto');
         const article = document.getElementById('object-content');
@@ -565,7 +567,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             const totalHeight = (article as HTMLElement).offsetHeight - (container as HTMLElement).offsetHeight;
 
             const rawProgress = Math.min(Math.max((scrolledPast / totalHeight) * 100, 0), 100);
-            const progress = Math.round(rawProgress / 5) * 5;
+            const progress = Math.round(rawProgress / PROGRESS_INCREMENT) * PROGRESS_INCREMENT;
 
             debouncedSetReadingProgress(progress);
         };

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -18,6 +18,7 @@ import APAvatar from '../global/APAvatar';
 import APReplyBox from '../global/APReplyBox';
 import TableOfContents, {TOCItem} from './TableOfContents';
 import getReadingTime from '../../utils/get-reading-time';
+import {useDebounce} from 'use-debounce';
 
 interface ArticleModalProps {
     activityId: string;
@@ -532,8 +533,10 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
     const currentGridWidth = `${parseInt(currentMaxWidth) - 64}px`;
 
     const [readingProgress, setReadingProgress] = useState(0);
-
     const [isLoading, setIsLoading] = useState(true);
+
+    // Add debounced version of setReadingProgress
+    const [debouncedSetReadingProgress] = useDebounce(setReadingProgress, 100);
 
     useEffect(() => {
         const container = document.querySelector('.overflow-y-auto');
@@ -550,7 +553,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             const isContentShorterThanViewport = articleRect.height <= containerRect.height;
 
             if (isContentShorterThanViewport) {
-                setReadingProgress(100);
+                debouncedSetReadingProgress(100);
                 return;
             }
 
@@ -560,7 +563,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             const rawProgress = Math.min(Math.max((scrolledPast / totalHeight) * 100, 0), 100);
             const progress = Math.round(rawProgress / 5) * 5;
 
-            setReadingProgress(progress);
+            debouncedSetReadingProgress(progress);
         };
 
         if (isLoading) {
@@ -583,7 +586,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             container?.removeEventListener('scroll', handleScroll);
             observer.disconnect();
         };
-    }, [isLoading]);
+    }, [isLoading, debouncedSetReadingProgress]);
 
     const [tocItems, setTocItems] = useState<TOCItem[]>([]);
     const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -543,7 +543,11 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
         const article = document.getElementById('object-content');
 
         const handleScroll = () => {
-            if (!container || !article || isLoading) {
+            if (isLoading) {
+                return;
+            }
+
+            if (!container || !article) {
                 return;
             }
 

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -547,7 +547,6 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             const articleRect = article.getBoundingClientRect();
             const containerRect = container.getBoundingClientRect();
 
-            // Calculate if content is shorter than viewport
             const isContentShorterThanViewport = articleRect.height <= containerRect.height;
 
             if (isContentShorterThanViewport) {
@@ -555,7 +554,6 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                 return;
             }
 
-            // Existing progress calculation for longer content
             const scrolledPast = Math.max(0, containerRect.top - articleRect.top);
             const totalHeight = (article as HTMLElement).offsetHeight - (container as HTMLElement).offsetHeight;
 
@@ -565,25 +563,26 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
             setReadingProgress(progress);
         };
 
-        // Only set up observers and listeners once content is loaded
-        if (!isLoading) {
-            const observer = new MutationObserver(handleScroll);
-            if (article) {
-                observer.observe(article, {
-                    childList: true,
-                    subtree: true,
-                    characterData: true
-                });
-            }
-
-            container?.addEventListener('scroll', handleScroll);
-            handleScroll();
-
-            return () => {
-                container?.removeEventListener('scroll', handleScroll);
-                observer.disconnect();
-            };
+        if (isLoading) {
+            return;
         }
+
+        const observer = new MutationObserver(handleScroll);
+        if (article) {
+            observer.observe(article, {
+                childList: true,
+                subtree: true,
+                characterData: true
+            });
+        }
+
+        container?.addEventListener('scroll', handleScroll);
+        handleScroll();
+
+        return () => {
+            container?.removeEventListener('scroll', handleScroll);
+            observer.disconnect();
+        };
     }, [isLoading]);
 
     const [tocItems, setTocItems] = useState<TOCItem[]>([]);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-653/scroll-percentage-remains-at-0percent-when-no-content-to-scroll

- When an entire article fits into the viewport height, we used to show`0%` in the reading progress indicator. Now we check if that's the case, and then show `100%` if it is.


