### PR TITLE
🐛 Fixed newsletters not rendering in Portal Email Preferences

### DIFF
--- a/apps/portal/src/components/pages/AccountEmailPage.test.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.test.js
@@ -134,4 +134,28 @@ describe('Account Email Page', () => {
         expect(unsubscribeBtns).toHaveLength(1);
         expect(unsubscribeBtns[0].textContent).toContain('Get notified when someone replies to your comment');
     });
+
+    test('newsletters are visible when editor default email recipients is set to visibility', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            editorDefaultEmailRecipients: 'visibility',
+            member: getMemberData({newsletters: newsletterData})
+        });
+        const {getAllByTestId} = setup({site: siteData});
+        const unsubscribeBtns = getAllByTestId(`toggle-wrapper`);
+        expect(unsubscribeBtns).toHaveLength(3);
+    });
+
+    test('newsletters are visible when editor default email recipients is set to filter', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            editorDefaultEmailRecipients: 'filter',
+            member: getMemberData({newsletters: newsletterData})
+        });
+        const {getAllByTestId} = setup({site: siteData});
+        const unsubscribeBtns = getAllByTestId(`toggle-wrapper`);
+        expect(unsubscribeBtns).toHaveLength(3);
+    });
 });

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -87,7 +87,7 @@ export function getNewsletterFromUuid({site, uuid}) {
 }
 
 export function hasNewsletterSendingEnabled({site}) {
-    return site?.editor_default_email_recipients === 'visibility';
+    return site?.editor_default_email_recipients !== 'disabled';
 }
 
 export function allowCompMemberUpgrade({member}) {

--- a/apps/portal/src/utils/helpers.test.js
+++ b/apps/portal/src/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import {hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast} from './helpers';
+import {hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast, hasNewsletterSendingEnabled} from './helpers';
 import * as Fixtures from './fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from '../utils/test-fixtures';
 import {isComplimentaryMember} from '../utils/helpers';
@@ -537,6 +537,23 @@ describe('Helpers - ', () => {
 
             expect(isInThePast(pastDate)).toEqual(true);
             expect(isInThePast(futureDate)).toEqual(false);
+        });
+    });
+
+    describe('hasNewsletterSendingEnabled', () => {
+        test('returns true when editor default email recipients is set to visibility', () => {
+            const site = {editor_default_email_recipients: 'visibility'};
+            expect(hasNewsletterSendingEnabled({site})).toBe(true);
+        });
+
+        test('returns false when editor default email recipients is set to disabled', () => {
+            const site = {editor_default_email_recipients: 'disabled'};
+            expect(hasNewsletterSendingEnabled({site})).toBe(false);
+        });
+
+        test('returns true when editor default email recipients is set to filter', () => {
+            const site = {editor_default_email_recipients: 'filter'};
+            expect(hasNewsletterSendingEnabled({site})).toBe(true);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-723/support-escalation-re-fwd-email-preferences

- On sites where the Default recipients setting was set to anything other than "Whoever has access to the post", the list of newsletters and the toggle to subscribe/unsubscribe would not be rendered on the Portal "Email Preferences" page.
- The bug was introduced in v5.106.0, and intended to hide the newsletter list if Newsletter sending were disabled completely, but there was bug in the logic
- This commit has a breaking test to prevent this in the future, and fixes the logic to only hide the newsletter list if `editor_default_email_recipients` is explicitly set to 'disabled'.