### PR TITLE
Added `contentVisibilityAlpha` flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -40,10 +40,14 @@ const features = [{
     description: '(Highly) Experimental support for ActivityPub.',
     flag: 'ActivityPub'
 },{
-    title: 'Content Visibility',
-    description: 'Enables content visibility in Emails',
+    title: 'Content Visibility (Beta)',
+    description: 'Enables content visibility in Emails - Changes already released to beta testers',
     flag: 'contentVisibility'
-}, {
+},{
+    title: 'Content Visibility (Alpha)',
+    description: 'Enables content visibility in Emails - Additional changes for internal testing. NOTE: requires `contentVisibility` to also be enabled',
+    flag: 'contentVisibilityAlpha'
+},{
     title: 'Post analytics redesign',
     description: 'Enables redesigned Post analytics page',
     flag: 'postsX'

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -441,7 +441,8 @@ export default class KoenigLexicalEditor extends Component {
             renderLabels: !this.session.user.isContributor,
             feature: {
                 collectionsCard: this.feature.collectionsCard,
-                contentVisibility: this.feature.contentVisibility
+                contentVisibility: this.feature.contentVisibility,
+                contentVisibilityAlpha: this.feature.contentVisibilityAlpha
             },
             deprecated: { // todo fix typo
                 headerV1: true // if false, shows header v1 in the menu

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -74,6 +74,7 @@ export default class FeatureService extends Service {
     @feature('ActivityPub') ActivityPub;
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
+    @feature('contentVisibilityAlpha') contentVisibilityAlpha;
     @feature('postsX') postsX;
 
     _user = null;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -51,7 +51,8 @@ const ALPHA_FEATURES = [
     'lexicalIndicators',
     'adminXDemo',
     'postsX',
-    'captcha'
+    'captcha',
+    'contentVisibilityAlpha'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -18,6 +18,7 @@ Object {
       "captcha": true,
       "collectionsCard": true,
       "contentVisibility": true,
+      "contentVisibilityAlpha": true,
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,


### PR DESCRIPTION
no issue

- flag to allow internal testing of content visibility developments without unintentional early release to beta testers
