### PR TITLE
Added missing error message handler for the integrity token endpoint

### DIFF
--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -254,7 +254,6 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             if (res.ok) {
                 return res.text();
             } else {
-                // Try to read body error message that is human readable and should be shown to the user
                 const humanError = await HumanReadableError.fromApiResponse(res);
                 if (humanError) {
                     throw humanError;
@@ -295,7 +294,6 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             if (res.ok) {
                 return 'Success';
             } else {
-                // Try to read body error message that is human readable and should be shown to the user
                 const humanError = await HumanReadableError.fromApiResponse(res);
                 if (humanError) {
                     throw humanError;

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -254,6 +254,11 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             if (res.ok) {
                 return res.text();
             } else {
+                // Try to read body error message that is human readable and should be shown to the user
+                const humanError = await HumanReadableError.fromApiResponse(res);
+                if (humanError) {
+                    throw humanError;
+                }
                 throw new Error('Failed to start a members session');
             }
         },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1349

- the integrity token endpoint can return a json response with an error message, when rate limited
- added the standard response handler to the integrity token endpoint in Portal