### PR TITLE
Added new setting in the database: blocked_email_domains [migration]

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -74,7 +74,8 @@ const EDITABLE_SETTINGS = [
     'donations_suggested_amount',
     'recommendations_enabled',
     'body_font',
-    'heading_font'
+    'heading_font',
+    'blocked_email_domains'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/migrations/versions/5.108/2025-01-23-02-51-10-add-blocked-email-domains-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.108/2025-01-23-02-51-10-add-blocked-email-domains-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'blocked_email_domains',
+    value: '[]',
+    type: 'array',
+    group: 'members'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -315,6 +315,10 @@
                 "isIn": [["true", "false"]]
             },
             "type": "boolean"
+        },
+        "blocked_email_domains": {
+            "defaultValue": "[]",
+            "type": "array"
         }
     },
     "portal": {

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 88;
+            const allowedKeysLength = 89;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'b26690fb57ffd0edbddb4cd9e02b17d6';
     const currentFixturesHash = '80e79d1efd5da275e19cb375afb4ad04';
-    const currentSettingsHash = '80387fdbda0102ab4995660d5d98007c';
+    const currentSettingsHash = '05366d793079c93b87477ec0404301c6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1973
ref https://app.incident.io/ghost/incidents/132

- added a new database setting: `blocked_email_domains` (array, default: `[]`)
- this setting will allow publishers to block additional email domains during member signups, on top of the ones blocklisted at a config level  (follow-up PR)