### PR TITLE
🐛 Fixed tags and authors not fitting in the input field

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -309,7 +309,8 @@
 }
 
 .ember-power-select-status-icon {
-    top: -4px;
+    position: absolute;
+    top: 11px;
     right: 13px;
     border: solid var(--midlightgrey);
     border-width: 0 1px 1px 0;

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -310,7 +310,7 @@
 
 .ember-power-select-status-icon {
     position: absolute;
-    top: 11px;
+    top: 13px;
     right: 13px;
     border: solid var(--midlightgrey);
     border-width: 0 1px 1px 0;

--- a/ghost/admin/app/styles/patterns/forms.css
+++ b/ghost/admin/app/styles/patterns/forms.css
@@ -306,28 +306,34 @@ textarea.gh-input-x {
 }
 
 .ember-power-select-multiple-trigger {
-    padding-left: 4px;
-    padding-right: 32px;
-    height: auto;
+    padding: 4px;
     min-height: 38px;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: 4px;
+    display: grid;
+    grid-template-columns: 1fr 24px;
     position: relative;
 }
 
+.ember-power-select-multiple-options {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+}
+
 .ember-power-select-trigger-multiple-input {
-    width: auto !important;
-    max-width: 100%;
+    margin: 2px;
+    padding: 0;
+    border: 0;
+    background: none;
+    min-width: 60px;
 }
 
 .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon,
 .ember-power-select-status-icon {
-    position: absolute;
-    right: 12px;
-    top: 16px;
-    transform: translateY(-50%);
+    margin: 0 auto;
+    transform: none;
 }
 
 

--- a/ghost/admin/app/styles/patterns/forms.css
+++ b/ghost/admin/app/styles/patterns/forms.css
@@ -282,7 +282,8 @@ textarea {
 
 .gh-input-x {
     width: 100%;
-    height: 38px;
+    min-height: 38px;
+    height: auto;
     padding: 4px 12px;
     font-size: 1.4rem;
     color: var(--black);
@@ -306,6 +307,27 @@ textarea.gh-input-x {
 
 .ember-power-select-multiple-trigger {
     padding-left: 4px;
+    padding-right: 32px;
+    height: auto;
+    min-height: 38px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 4px;
+    position: relative;
+}
+
+.ember-power-select-trigger-multiple-input {
+    width: auto !important;
+    max-width: 100%;
+}
+
+.ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon,
+.ember-power-select-status-icon {
+    position: absolute;
+    right: 12px;
+    top: 16px;
+    transform: translateY(-50%);
 }
 
 


### PR DESCRIPTION
Input fields for tags and authors in the post sidebar were hard to use; they became scrollable if you added more than one line of either. 

This fix addresses that; the input field now grows in size to accommodate for the number of tags or authors you enter.

fixes https://linear.app/ghost/issue/DES-1087/overflow-on-boxes-in-post-settings-too-small, https://linear.app/ghost/issue/DES-1084/tag-field-in-post-settings-menu-is-difficult-to-work-now-with-when