### PR TITLE
Fixed double ESC press to close the preview

### DIFF
--- a/ghost/admin/app/components/editor/publish-management.js
+++ b/ghost/admin/app/components/editor/publish-management.js
@@ -124,6 +124,9 @@ export default class PublishManagement extends Component {
     // triggered by ctrl/cmd+p
     @action
     togglePreview(event) {
+        if (event?.defaultPrevented) {
+            return;
+        }
         event?.preventDefault();
 
         if (!this.previewModal || this.previewModal.isClosing) {


### PR DESCRIPTION
ref DES-549

- togglePreview() function was called twice when the key combination CMD+P is pressed
- added a guard in the function to prevent it from being called twice