### PR TITLE
Disabled nx daemon in docker container

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
         default-mysql-client && \
     npx -y playwright@1.46.1 install --with-deps
 
-ENV NX_DAEMON=true
+ENV NX_DAEMON=false
 ENV YARN_CACHE_FOLDER=$WORKDIR/.yarncache
 
 EXPOSE 2368


### PR DESCRIPTION
no issue

- When the nx daemon is enabled and using docker for local development, we periodically get an error like the following, which crashes `yarn dev` and requires a manual restart:

```
Daemon process terminated and closed the connection

Please rerun the command, which will restart the daemon.
If you get this error again, check for any errors in the daemon process logs found in: /home/ghost/.nx/workspace-data/d/daemon.log
```

- Disabling the daemon in docker prevents these errors, and so far I haven't noticed any performance degradation from disabling it.