### PR TITLE
Revert "Disabled nx daemon in docker container (#22066)"

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
         default-mysql-client && \
     npx -y playwright@1.46.1 install --with-deps
 
-ENV NX_DAEMON=false
+ENV NX_DAEMON=true
 ENV YARN_CACHE_FOLDER=$WORKDIR/.yarncache
 
 EXPOSE 2368


### PR DESCRIPTION
This reverts commit 38d377d434747ff252b14b1271faadbbeb678997.

- Disabling the daemon led to more problems than it solved with `yarn dev` running in Docker