### PR TITLE
Added ability to override settings via config

### DIFF
--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -8,6 +8,7 @@ export type SettingValue = string | boolean | null;
 export type Setting = {
     key: string;
     value: SettingValue;
+    override?: boolean;
 }
 
 export type SettingsResponseMeta = Meta & {
@@ -80,6 +81,14 @@ export function getSettingValue<ValueType = SettingValue>(settings: Setting[] | 
     }
     const setting = settings.find(d => d.key === key);
     return setting?.value as ValueType || null;
+}
+
+export function isSettingReadOnly(settings: Setting[] | null | undefined, key: string): boolean | null {
+    if (!settings) {
+        return null;
+    }
+    const setting = settings.find(d => d.key === key);
+    return setting?.override || false;
 }
 
 export function checkStripeEnabled(settings: Setting[], config: Config) {

--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -83,9 +83,9 @@ export function getSettingValue<ValueType = SettingValue>(settings: Setting[] | 
     return setting?.value as ValueType || null;
 }
 
-export function isSettingReadOnly(settings: Setting[] | null | undefined, key: string): boolean | null {
+export function isSettingReadOnly(settings: Setting[] | null | undefined, key: string): boolean | undefined {
     if (!settings) {
-        return null;
+        return undefined;
     }
     const setting = settings.find(d => d.key === key);
     return setting?.override || false;

--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -211,13 +211,17 @@ export async function mockApi<Requests extends Record<string, MockRequestConfig>
     return {lastApiRequests};
 }
 
-export function updatedSettingsResponse(newSettings: Array<{ key: string, value: string | boolean | null }>) {
+export function updatedSettingsResponse(newSettings: Array<{ key: string, value: string | boolean | null, override?: boolean }>) {
     return {
         ...responseFixtures.settings,
         settings: responseFixtures.settings.settings.map((setting) => {
             const newSetting = newSettings.find(({key}) => key === setting.key);
 
-            return {key: setting.key, value: newSetting?.value || setting.value};
+            return {
+                key: setting.key,
+                value: newSetting?.value !== undefined ? newSetting.value : setting.value,
+                ...(newSetting?.override ? {override: true} : {})
+            };
         })
     };
 }

--- a/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
@@ -50,10 +50,10 @@ describe('settings utils', function () {
             expect(value).toEqual(false);
         });
 
-        it('returns null if settings is null', function () {
+        it('returns undefined if settings is falsy', function () {
             const settings = undefined;
             const value = isSettingReadOnly(settings, 'test_key');
-            expect(value).toEqual(null);
+            expect(value).toEqual(undefined);
         });
     });
 });

--- a/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
@@ -1,0 +1,59 @@
+import {getSettingValue, getSettingValues, isSettingReadOnly} from '../../../../src/api/settings';
+
+describe('settings utils', function () {
+    describe('getSettingValue', function () {
+        it('returns the value of a setting', function () {
+            const settings = [
+                {key: 'test_key', value: 'test_value'}
+            ];
+            const value = getSettingValue(settings, 'test_key');
+            expect(value).toEqual('test_value');
+        });
+
+        it('returns null if settings is null', function () {
+            const settings = undefined;
+            const value = getSettingValue(settings, 'test_key');
+            expect(value).toEqual(null);
+        });
+    });
+
+    describe('getSettingValues', function () {
+        it('returns the values of multiple settings', function () {
+            const settings = [
+                {key: 'test_key', value: 'test_value'},
+                {key: 'test_key_2', value: 'test_value_2'}
+            ];
+            const values = getSettingValues(settings, ['test_key', 'test_key_2']);
+            expect(values).toEqual(['test_value', 'test_value_2']);
+        });
+
+        it('returns undefined for missing keys', function () {
+            const values = getSettingValues([], ['test_key', 'test_key_2']);
+            expect(values).toEqual([undefined, undefined]);
+        });
+    });
+
+    describe('isSettingReadOnly', function () {
+        it('returns true if the setting has an override', function () {
+            const settings = [
+                {key: 'test_key', override: true, value: 'test_value'}
+            ];
+            const value = isSettingReadOnly(settings, 'test_key');
+            expect(value).toEqual(true);
+        });
+
+        it('returns false if the setting does not have an override', function () {
+            const settings = [
+                {key: 'test_key', override: false, value: 'test_value'}
+            ];
+            const value = isSettingReadOnly(settings, 'test_key');
+            expect(value).toEqual(false);
+        });
+
+        it('returns null if settings is null', function () {
+            const settings = undefined;
+            const value = isSettingReadOnly(settings, 'test_key');
+            expect(value).toEqual(null);
+        });
+    });
+});

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {getSettingValues, isSettingReadOnly} from '@tryghost/admin-x-framework/api/settings';
 import {usePostsExports} from '@tryghost/admin-x-framework/api/posts';
 
 const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
@@ -19,6 +19,8 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging] = getSettingValues(localSettings, [
         'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging'
     ]) as boolean[];
+
+    const isEmailTrackClicksReadOnly = isSettingReadOnly(localSettings, 'email_track_clicks');
 
     const handleToggleChange = (key: string, e: React.ChangeEvent<HTMLInputElement>) => {
         updateSetting(key, e.target.checked);
@@ -63,6 +65,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <Toggle
                 checked={trackEmailClicks}
                 direction='rtl'
+                disabled={isEmailTrackClicksReadOnly}
                 gap='gap-0'
                 label='Newsletter clicks'
                 labelClasses='py-4 w-full'

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -57,4 +57,28 @@ test.describe('Analytics settings', async () => {
         const hasDownloadUrl = lastApiRequests.postsExport?.url?.includes('/posts/export/?limit=1000');
         expect(hasDownloadUrl).toBe(true);
     });
+
+    test('Supports read only settings', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {method: 'GET', path: /^\/settings\/\?group=/, response: updatedSettingsResponse([
+                {key: 'members_track_sources', value: false},
+                {key: 'email_track_opens', value: false},
+                {key: 'email_track_clicks', value: false, override: true},
+                {key: 'outbound_link_tagging', value: false}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('analytics');
+
+        await expect(section).toBeVisible();
+
+        const newsletterClicksToggle = await section.getByLabel(/Newsletter clicks/);
+
+        await expect(newsletterClicksToggle).not.toBeChecked();
+
+        await expect(newsletterClicksToggle).toBeDisabled();
+    });
 });

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/settings.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 module.exports = (attrs) => {
     if (Array.isArray(attrs)) {
         return attrs.map((setting) => {
-            return _.pick(setting, ['key', 'value']);
+            return _.pick(setting, ['key', 'value', 'override']);
         });
     }
 

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -5,6 +5,7 @@
 const events = require('../../lib/common/events');
 const models = require('../../models');
 const labs = require('../../../shared/labs');
+const config = require('../../../shared/config');
 const adapterManager = require('../adapter-manager');
 const SettingsCache = require('../../../shared/settings-cache');
 const SettingsBREADService = require('./SettingsBREADService');
@@ -71,7 +72,8 @@ module.exports = {
     async init() {
         const cacheStore = adapterManager.getAdapter('cache:settings');
         const settingsCollection = await models.Settings.populateDefaults();
-        SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore);
+        const settingsOverrides = config.get('hostSettings:settingsOverrides') || {};
+        SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore, settingsOverrides);
     },
 
     /**

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -55,12 +55,17 @@ class CacheManager {
         if (!this.settingsCache) {
             return;
         }
-
-        let cacheEntry;
+        
+        let override;
         if (this.settingsOverrides && Object.keys(this.settingsOverrides).includes(key)) {
-            cacheEntry = this.settingsOverrides[key];
-        } else {
-            cacheEntry = this.settingsCache.get(key);
+            // Wrap the override value in an object in case it's a boolean
+            override = {value: this.settingsOverrides[key]};
+        }
+
+        const cacheEntry = this.settingsCache.get(key);
+
+        if (override) {
+            cacheEntry.value = override.value;
         }
 
         if (!cacheEntry) {

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -66,6 +66,7 @@ class CacheManager {
 
         if (override) {
             cacheEntry.value = override.value;
+            cacheEntry.override = true;
         }
 
         if (!cacheEntry) {

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -62,7 +62,7 @@ class CacheManager {
         } else {
             cacheEntry = this.settingsCache.get(key);
         }
-        
+
         if (!cacheEntry) {
             return;
         }
@@ -150,7 +150,7 @@ class CacheManager {
         const all = {};
 
         keys.forEach((key) => {
-            all[key] = _.cloneDeep(this.settingsCache.get(key));
+            all[key] = _.cloneDeep(this.get(key, {resolve: false}));
         });
 
         return all;

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -69,7 +69,8 @@ class CacheManager {
             cacheEntry.override = true;
         }
 
-        if (!cacheEntry) {
+        // Return if the cacheEntry is undefined, but continue if it's null or false
+        if (cacheEntry === undefined) {
             return;
         }
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -15,13 +15,11 @@ class CacheManager {
     /**
      * @prop {Object} options
      * @prop {Object} options.publicSettings - key/value pairs of settings which are publicly accessible
-     * @prop {Object} options.settingsOverrides - key/value pairs of settings which are overridden via config
      */
-    constructor({publicSettings, settingsOverrides}) {
+    constructor({publicSettings}) {
         // settingsCache holds cached settings, keyed by setting.key, contains the JSON version of the model
         this.settingsCache;
         this.publicSettings = publicSettings;
-        this.settingsOverrides = settingsOverrides;
         this.calculatedFields = [];
 
         this.get = this.get.bind(this);
@@ -54,10 +52,6 @@ class CacheManager {
         //       it is decoupled from the model layer
         if (!this.settingsCache) {
             return;
-        }
-
-        if (this.settingsOverrides && Object.keys(this.settingsOverrides).includes(key)) {
-            return this.settingsOverrides[key];
         }
 
         const cacheEntry = this.settingsCache.get(key);

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -15,11 +15,13 @@ class CacheManager {
     /**
      * @prop {Object} options
      * @prop {Object} options.publicSettings - key/value pairs of settings which are publicly accessible
+     * @prop {Object} options.settingsOverrides - key/value pairs of settings which are overridden via config
      */
-    constructor({publicSettings}) {
+    constructor({publicSettings, settingsOverrides}) {
         // settingsCache holds cached settings, keyed by setting.key, contains the JSON version of the model
         this.settingsCache;
         this.publicSettings = publicSettings;
+        this.settingsOverrides = settingsOverrides;
         this.calculatedFields = [];
 
         this.get = this.get.bind(this);
@@ -52,6 +54,10 @@ class CacheManager {
         //       it is decoupled from the model layer
         if (!this.settingsCache) {
             return;
+        }
+
+        if (this.settingsOverrides && Object.keys(this.settingsOverrides).includes(key)) {
+            return this.settingsOverrides[key];
         }
 
         const cacheEntry = this.settingsCache.get(key);

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -69,8 +69,7 @@ class CacheManager {
             cacheEntry.override = true;
         }
 
-        // Return if the cacheEntry is undefined, but continue if it's null or false
-        if (cacheEntry === undefined) {
+        if (!cacheEntry) {
             return;
         }
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -15,13 +15,12 @@ class CacheManager {
     /**
      * @prop {Object} options
      * @prop {Object} options.publicSettings - key/value pairs of settings which are publicly accessible
-     * @prop {Object} options.settingsOverrides - key/value pairs of settings which are overridden via config
      */
-    constructor({publicSettings, settingsOverrides}) {
+    constructor({publicSettings}) {
         // settingsCache holds cached settings, keyed by setting.key, contains the JSON version of the model
         this.settingsCache;
+        this.settingsOverrides;
         this.publicSettings = publicSettings;
-        this.settingsOverrides = settingsOverrides;
         this.calculatedFields = [];
 
         this.get = this.get.bind(this);
@@ -186,10 +185,12 @@ class CacheManager {
      * @param {Bookshelf.Collection<Settings>} settingsCollection
      * @param {Array} calculatedFields
      * @param {Object} cacheStore - cache storage instance base on Cache Base Adapter
+     * @param {Object} settingsOverrides - key/value pairs of settings which are overridden (i.e. via config)
      * @return {Object} - filled out instance for Cache Base Adapter
      */
-    init(events, settingsCollection, calculatedFields, cacheStore) {
+    init(events, settingsCollection, calculatedFields, cacheStore, settingsOverrides) {
         this.settingsCache = cacheStore;
+        this.settingsOverrides = settingsOverrides;
         // First, reset the cache and
         this.reset(events);
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -15,11 +15,13 @@ class CacheManager {
     /**
      * @prop {Object} options
      * @prop {Object} options.publicSettings - key/value pairs of settings which are publicly accessible
+     * @prop {Object} options.settingsOverrides - key/value pairs of settings which are overridden via config
      */
-    constructor({publicSettings}) {
+    constructor({publicSettings, settingsOverrides}) {
         // settingsCache holds cached settings, keyed by setting.key, contains the JSON version of the model
         this.settingsCache;
         this.publicSettings = publicSettings;
+        this.settingsOverrides = settingsOverrides;
         this.calculatedFields = [];
 
         this.get = this.get.bind(this);
@@ -54,7 +56,13 @@ class CacheManager {
             return;
         }
 
-        const cacheEntry = this.settingsCache.get(key);
+        let cacheEntry;
+        if (this.settingsOverrides && Object.keys(this.settingsOverrides).includes(key)) {
+            cacheEntry = this.settingsOverrides[key];
+        } else {
+            cacheEntry = this.settingsCache.get(key);
+        }
+        
         if (!cacheEntry) {
             return;
         }

--- a/ghost/core/core/shared/settings-cache/index.js
+++ b/ghost/core/core/shared/settings-cache/index.js
@@ -1,7 +1,6 @@
 const CacheManager = require('./CacheManager');
 const publicSettings = require('./public');
-const config = require('../config');
 
-const cacheManager = new CacheManager({publicSettings, settingsOverrides: config.get('hostSettings:settingsOverrides')});
+const cacheManager = new CacheManager({publicSettings});
 
 module.exports = cacheManager;

--- a/ghost/core/core/shared/settings-cache/index.js
+++ b/ghost/core/core/shared/settings-cache/index.js
@@ -1,6 +1,7 @@
 const CacheManager = require('./CacheManager');
 const publicSettings = require('./public');
+const config = require('../config');
 
-const cacheManager = new CacheManager({publicSettings});
+const cacheManager = new CacheManager({publicSettings, settingsOverrides: config.get('hostSettings:settingsOverrides')});
 
 module.exports = cacheManager;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -5749,6 +5749,380 @@ Object {
 }
 `;
 
+exports[`Settings API Settings overrides respects settings overrides defined in hostSettings:settingsOverrides 1: [body] 1`] = `
+Object {
+  "meta": Object {},
+  "settings": Array [
+    Object {
+      "key": "members_track_sources",
+      "value": true,
+    },
+    Object {
+      "key": "title",
+      "value": null,
+    },
+    Object {
+      "key": "description",
+      "value": "Thoughts, stories and ideas",
+    },
+    Object {
+      "key": "logo",
+      "value": "",
+    },
+    Object {
+      "key": "cover_image",
+      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    },
+    Object {
+      "key": "icon",
+      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
+    },
+    Object {
+      "key": "accent_color",
+      "value": "#FF1A75",
+    },
+    Object {
+      "key": "locale",
+      "value": "ua",
+    },
+    Object {
+      "key": "timezone",
+      "value": "Pacific/Auckland",
+    },
+    Object {
+      "key": "codeinjection_head",
+      "value": null,
+    },
+    Object {
+      "key": "codeinjection_foot",
+      "value": "",
+    },
+    Object {
+      "key": "facebook",
+      "value": "ghost",
+    },
+    Object {
+      "key": "twitter",
+      "value": "@ghost",
+    },
+    Object {
+      "key": "navigation",
+      "value": "[{\\"label\\":\\"label1\\"}]",
+    },
+    Object {
+      "key": "secondary_navigation",
+      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
+    },
+    Object {
+      "key": "meta_title",
+      "value": "SEO title",
+    },
+    Object {
+      "key": "meta_description",
+      "value": "SEO description",
+    },
+    Object {
+      "key": "og_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
+    },
+    Object {
+      "key": "og_title",
+      "value": "facebook title",
+    },
+    Object {
+      "key": "og_description",
+      "value": "facebook description",
+    },
+    Object {
+      "key": "twitter_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
+    },
+    Object {
+      "key": "twitter_title",
+      "value": "twitter title",
+    },
+    Object {
+      "key": "twitter_description",
+      "value": "twitter description",
+    },
+    Object {
+      "key": "active_theme",
+      "value": "source",
+    },
+    Object {
+      "key": "is_private",
+      "value": false,
+    },
+    Object {
+      "key": "password",
+      "value": "",
+    },
+    Object {
+      "key": "public_hash",
+      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
+    },
+    Object {
+      "key": "default_content_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "default_content_visibility_tiers",
+      "value": "[]",
+    },
+    Object {
+      "key": "members_signup_access",
+      "value": "all",
+    },
+    Object {
+      "key": "members_support_address",
+      "value": "default@email.com",
+    },
+    Object {
+      "key": "stripe_secret_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_publishable_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_plans",
+      "value": "[]",
+    },
+    Object {
+      "key": "stripe_connect_publishable_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_secret_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_livemode",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_display_name",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_account_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_monthly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_yearly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "portal_name",
+      "value": true,
+    },
+    Object {
+      "key": "portal_button",
+      "value": true,
+    },
+    Object {
+      "key": "portal_plans",
+      "value": "[\\"free\\"]",
+    },
+    Object {
+      "key": "portal_default_plan",
+      "value": "yearly",
+    },
+    Object {
+      "key": "portal_products",
+      "value": "[]",
+    },
+    Object {
+      "key": "portal_button_style",
+      "value": "icon-and-text",
+    },
+    Object {
+      "key": "portal_button_icon",
+      "value": null,
+    },
+    Object {
+      "key": "portal_button_signup_text",
+      "value": "Subscribe",
+    },
+    Object {
+      "key": "portal_signup_terms_html",
+      "value": null,
+    },
+    Object {
+      "key": "portal_signup_checkbox_required",
+      "value": false,
+    },
+    Object {
+      "key": "mailgun_domain",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_api_key",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
+      "override": true,
+      "value": false,
+    },
+    Object {
+      "key": "email_verification_required",
+      "value": false,
+    },
+    Object {
+      "key": "amp",
+      "value": false,
+    },
+    Object {
+      "key": "amp_gtag_id",
+      "value": null,
+    },
+    Object {
+      "key": "firstpromoter",
+      "value": false,
+    },
+    Object {
+      "key": "firstpromoter_id",
+      "value": null,
+    },
+    Object {
+      "key": "labs",
+      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
+    },
+    Object {
+      "key": "slack_url",
+      "value": "",
+    },
+    Object {
+      "key": "slack_username",
+      "value": "New Slack Username",
+    },
+    Object {
+      "key": "unsplash",
+      "value": false,
+    },
+    Object {
+      "key": "shared_views",
+      "value": "[]",
+    },
+    Object {
+      "key": "editor_default_email_recipients",
+      "value": "visibility",
+    },
+    Object {
+      "key": "editor_default_email_recipients_filter",
+      "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": "<p>Great news coming soon!</p>",
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
+      "key": "comments_enabled",
+      "value": "off",
+    },
+    Object {
+      "key": "outbound_link_tagging",
+      "value": true,
+    },
+    Object {
+      "key": "pintura",
+      "value": true,
+    },
+    Object {
+      "key": "pintura_js_url",
+      "value": null,
+    },
+    Object {
+      "key": "pintura_css_url",
+      "value": null,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "500",
+    },
+    Object {
+      "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "members_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "members_invite_only",
+      "value": false,
+    },
+    Object {
+      "key": "allow_self_signup",
+      "value": true,
+    },
+    Object {
+      "key": "paid_members_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "firstpromoter_account",
+      "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "default@email.com",
+    },
+    Object {
+      "key": "all_blocked_email_domains",
+      "value": Array [],
+    },
+  ],
+}
+`;
+
+exports[`Settings API Settings overrides respects settings overrides defined in hostSettings:settingsOverrides 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Settings API deprecated can do updateMembersEmail 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -968,7 +968,7 @@ describe('Members API', function () {
         await agent.delete(`/members/${memberFailVerification.id}`);
 
         await configUtils.restore();
-        settingsCache.set('email_verification_required', false);
+        settingsCache.set('email_verification_required', {value: false});
     });
 
     it('Can add and send a signup confirmation email', async function () {

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -659,4 +659,27 @@ describe('Settings API', function () {
             mockManager.assert.sentEmailCount(0);
         });
     });
+
+    describe('Settings overrides', function () {
+        this.beforeEach(async function () {
+            const settingsOverrides = {
+                email_track_clicks: false
+            };
+            configUtils.set('hostSettings:settingsOverrides', settingsOverrides);
+            await fixtureManager.init();
+        });
+
+        it('respects settings overrides defined in hostSettings:settingsOverrides', async function () {
+            await agent.get('settings/')
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    settings: matchSettingsArray(CURRENT_SETTINGS_COUNT)
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    'content-length': anyContentLength,
+                    etag: anyEtag
+                });
+        });
+    });
 });

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -16,7 +16,10 @@ describe('UNIT: settings cache', function () {
     beforeEach(function () {
         let cacheStore = new InMemoryCache();
         cache = new CacheManager({
-            publicSettings
+            publicSettings,
+            settingsOverrides: {
+                test_override_key: {value: true}
+            }
         });
         cache.init(events, {}, [], cacheStore);
     });
@@ -91,6 +94,10 @@ describe('UNIT: settings cache', function () {
         should(cache.get('stringfalse')).eql(false);
         should(cache.get('stringobj')).eql({});
         should(cache.get('stringarr')).eql([]);
+    });
+
+    it('.get() respects settingsOverrides', function () {
+        should(cache.get('test_override_key')).eql(true);
     });
 
     it('.getAll() returns all values', function () {

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -117,8 +117,20 @@ describe('UNIT: settings cache', function () {
         cache = createCacheManager({
             email_track_clicks: {value: false}
         });
-        cache.set('email_track_clicks', {value: true});
-        cache.getAll().should.eql({email_track_clicks: {value: false}});
+        cache.set('email_track_clicks', {
+            id: '67996cef430e5905ab385357', 
+            group: 'email', 
+            key: 'email_track_clicks', 
+            value: true, 
+            type: 'boolean'
+        });
+        cache.getAll().should.eql({email_track_clicks: {
+            id: '67996cef430e5905ab385357', 
+            group: 'email', 
+            key: 'email_track_clicks', 
+            value: false, 
+            type: 'boolean'
+        }});
     });
 
     it('.getPublic() correctly filters and formats public values', function () {

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -108,6 +108,10 @@ describe('UNIT: settings cache', function () {
         should(cache.get('email_track_clicks', {resolve: false})).eql({value: false, override: true});
     });
 
+    it('.get() only returns an override if the key is set to begin with', function () {
+        should(cache.get('email_track_clicks', {resolve: false})).eql(undefined);
+    });
+
     it('.getAll() returns all values', function () {
         cache.set('key1', {value: '1'});
         cache.get('key1').should.eql('1');

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -105,6 +105,7 @@ describe('UNIT: settings cache', function () {
         });
         cache.set('email_track_clicks', {value: true});
         should(cache.get('email_track_clicks')).eql(false);
+        should(cache.get('email_track_clicks', {resolve: false})).eql({value: false, override: true});
     });
 
     it('.getAll() returns all values', function () {
@@ -118,17 +119,18 @@ describe('UNIT: settings cache', function () {
             email_track_clicks: false
         });
         cache.set('email_track_clicks', {
-            id: '67996cef430e5905ab385357', 
-            group: 'email', 
-            key: 'email_track_clicks', 
-            value: true, 
+            id: '67996cef430e5905ab385357',
+            group: 'email',
+            key: 'email_track_clicks',
+            value: true,
             type: 'boolean'
         });
         cache.getAll().should.eql({email_track_clicks: {
-            id: '67996cef430e5905ab385357', 
-            group: 'email', 
-            key: 'email_track_clicks', 
-            value: false, 
+            id: '67996cef430e5905ab385357',
+            group: 'email',
+            key: 'email_track_clicks',
+            value: false,
+            override: true,
             type: 'boolean'
         }});
     });

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -13,10 +13,9 @@ should.equal(true, true);
 function createCacheManager(settingsOverrides = {}) {
     const cacheStore = new InMemoryCache();
     const cache = new CacheManager({
-        publicSettings,
-        settingsOverrides
+        publicSettings
     });
-    cache.init(events, {}, [], cacheStore);
+    cache.init(events, {}, [], cacheStore, settingsOverrides);
     return cache;
 }
 

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -101,7 +101,7 @@ describe('UNIT: settings cache', function () {
 
     it('.get() respects settingsOverrides', function () {
         cache = createCacheManager({
-            email_track_clicks: {value: false}
+            email_track_clicks: false
         });
         cache.set('email_track_clicks', {value: true});
         should(cache.get('email_track_clicks')).eql(false);
@@ -115,7 +115,7 @@ describe('UNIT: settings cache', function () {
 
     it('.getAll() respects settingsOverrides', function () {
         cache = createCacheManager({
-            email_track_clicks: {value: false}
+            email_track_clicks: false
         });
         cache.set('email_track_clicks', {
             id: '67996cef430e5905ab385357', 

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -106,6 +106,10 @@ describe('UNIT: settings cache', function () {
         cache.getAll().should.eql({key1: {value: '1'}});
     });
 
+    it('.getAll() respects settingsOverrides', function () {
+        cache.getAll().should.eql({test_override_key: {value: true}});
+    });
+
     it('.getPublic() correctly filters and formats public values', function () {
         cache.set('key1', {value: 'something'});
         cache.set('title', {value: 'hello world'});

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -10,18 +10,21 @@ const InMemoryCache = require('../../../core/server/adapters/cache/MemoryCache')
 
 should.equal(true, true);
 
+function createCacheManager(settingsOverrides = {}) {
+    let cacheStore = new InMemoryCache();
+    let cache = new CacheManager({
+        publicSettings,
+        settingsOverrides
+    });
+    cache.init(events, {}, [], cacheStore);
+    return cache;
+}
+
 describe('UNIT: settings cache', function () {
     let cache;
 
     beforeEach(function () {
-        let cacheStore = new InMemoryCache();
-        cache = new CacheManager({
-            publicSettings,
-            settingsOverrides: {
-                test_override_key: {value: true}
-            }
-        });
-        cache.init(events, {}, [], cacheStore);
+        cache = createCacheManager();
     });
 
     afterEach(function () {

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -11,8 +11,8 @@ const InMemoryCache = require('../../../core/server/adapters/cache/MemoryCache')
 should.equal(true, true);
 
 function createCacheManager(settingsOverrides = {}) {
-    let cacheStore = new InMemoryCache();
-    let cache = new CacheManager({
+    const cacheStore = new InMemoryCache();
+    const cache = new CacheManager({
         publicSettings,
         settingsOverrides
     });
@@ -100,7 +100,11 @@ describe('UNIT: settings cache', function () {
     });
 
     it('.get() respects settingsOverrides', function () {
-        should(cache.get('test_override_key')).eql(true);
+        cache = createCacheManager({
+            email_track_clicks: {value: false}
+        });
+        cache.set('email_track_clicks', {value: true});
+        should(cache.get('email_track_clicks')).eql(false);
     });
 
     it('.getAll() returns all values', function () {
@@ -110,7 +114,11 @@ describe('UNIT: settings cache', function () {
     });
 
     it('.getAll() respects settingsOverrides', function () {
-        cache.getAll().should.eql({test_override_key: {value: true}});
+        cache = createCacheManager({
+            email_track_clicks: {value: false}
+        });
+        cache.set('email_track_clicks', {value: true});
+        cache.getAll().should.eql({email_track_clicks: {value: false}});
     });
 
     it('.getPublic() correctly filters and formats public values', function () {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker:setup": "git submodule update --init && node .github/scripts/setup-docker.js",
     "docker:dev": "COMPOSE_PROFILES=full docker compose up --attach=ghost --no-log-prefix",
+    "docker:shell": "COMPOSE_PROFILES=full docker compose run --rm -it ghost /bin/bash",
     "docker:test:unit": "COMPOSE_PROFILES=full docker compose run --rm --no-deps ghost yarn test:unit",
     "docker:test:browser": "COMPOSE_PROFILES=full docker compose run --rm ghost yarn test:browser",
     "docker:test:all": "COMPOSE_PROFILES=full docker compose run --rm ghost yarn nx run ghost:test:all",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1974/create-config-option-to-forcibly-disable-email-track-clicks

- We want to be able to disable the `email_track_clicks` setting forcibly via config, such that it is turned off and the user is unable to change it in the UI.
- This commit passes a `settingsOverrides` object into the settings cache, which is passed in from the `hostSettings:settingsOverride` configuration key, and overrides both `settingsCache.get()` and `settingsCache.getAll()` to override the value of the setting that's returned with whatever is defined via configuration.
