### PR TITLE
🐛 Fixed dropdowns in Members filters

### DIFF
--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -1102,6 +1102,12 @@ input:focus,
     border-color: var(--midlightgrey);
 }
 
+.ember-power-select-trigger:not(.gh-input-x) {
+    background: var(--lightgrey);
+    border-color: var(--lightgrey);
+}
+
+
 kbd {
     color: #394047;
 }

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -308,14 +308,23 @@
     margin: 2px;
 }
 
+.ember-power-select-trigger {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-height: 33px;
+}
+
 .ember-power-select-status-icon {
     position: absolute;
-    top: 13px;
-    right: 13px;
+    right: 12px;
+    /* Calculate vertical center position: 50% - (icon height + border width) / 2 */
+    top: calc(50% - 4px);
     border: solid var(--midlightgrey);
     border-width: 0 1px 1px 0;
     padding: 3px;
     transform: rotate(45deg);
+    pointer-events: none;
 }
 
 .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -318,7 +318,7 @@
 .ember-power-select-status-icon {
     position: absolute;
     right: 12px;
-    top: 13px;
+    top: 12px;
     border: solid var(--midlightgrey);
     border-width: 0 1px 1px 0;
     padding: 3px;

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -318,13 +318,16 @@
 .ember-power-select-status-icon {
     position: absolute;
     right: 12px;
-    /* Calculate vertical center position: 50% - (icon height + border width) / 2 */
-    top: calc(50% - 4px);
+    top: 13px;
     border: solid var(--midlightgrey);
     border-width: 0 1px 1px 0;
     padding: 3px;
     transform: rotate(45deg);
     pointer-events: none;
+}
+
+.ember-power-select-trigger:not(.ember-power-select-multiple-trigger) .ember-power-select-status-icon {
+    top: calc(50% - 4px);
 }
 
 .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {
@@ -532,4 +535,28 @@
 .gh-btn-create-snippet svg {
     width: 1.2rem;
     height: 1.2rem;
+}
+
+.ember-power-select-multiple-trigger {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 2px 28px 2px 2px !important;
+    min-height: 33px;
+}
+
+.ember-power-select-multiple-options {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.ember-power-select-trigger-multiple-input {
+    width: auto !important;
+    padding: 0;
+    margin: 2px;
+    border: none;
+    font-size: 1.4rem;
+    line-height: 1.35em;
+    background: none;
 }

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -245,7 +245,7 @@
     background: #fff;
     padding: 4px;
     border: var(--input-border);
-    border-radius: 3px;
+    border-radius: var(--border-radius);
     outline: none;
 }
 

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -2,7 +2,7 @@
     padding: 0 12px;
     border: var(--input-border);
     border-radius: var(--border-radius);
-    background: transparent;
+    background: var(--main-bg-color);
 }
 
 .ember-power-select-trigger.gh-btn {

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -182,7 +182,7 @@ p.gh-members-list-email {
 .gh-member-actions-menu {
     top: calc(100% + 6px);
     left: auto;
-    right: 10px;
+    right: 0;
 }
 
 .gh-member-actions-menu.fade-out {

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2998,7 +2998,3 @@ a.gh-members-emailpreview-subscription-link {
     font-weight: 500;
     font-size: 1.3rem;
 }
-
-.ember-basic-dropdown-content-wormhole-origin {
-    position: absolute !important;
-}

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2998,3 +2998,7 @@ a.gh-members-emailpreview-subscription-link {
     font-weight: 500;
     font-size: 1.3rem;
 }
+
+.ember-basic-dropdown-content-wormhole-origin {
+    position: absolute !important;
+}

--- a/ghost/admin/app/styles/patterns/forms.css
+++ b/ghost/admin/app/styles/patterns/forms.css
@@ -307,7 +307,6 @@ textarea.gh-input-x {
 
 .ember-power-select-multiple-trigger {
     padding: 4px;
-    min-height: 38px;
     display: grid;
     grid-template-columns: 1fr 24px;
     position: relative;


### PR DESCRIPTION
A few of the dropdowns within the Members filter were displaying incorrectly (wrong background colour, sizing, border radius, and dark mode styling).

These changes address that. 

Fixes https://linear.app/ghost/issue/DES-1093/the-filter-for-selecting-an-email-has-a-grey-background-rather-than, https://linear.app/ghost/issue/DES-1094/the-label-field-is-taller-than-other-fields, https://linear.app/ghost/issue/DES-1095/the-label-field-changes-border-radius-on-focus, https://linear.app/ghost/issue/DES-1096/label-and-email-fields-display-incorrectly-in-dark-mode