### PR TITLE
Removed lodash from data-manipulation and sanitize model plugins

### DIFF
--- a/ghost/core/core/frontend/helpers/foreach.js
+++ b/ghost/core/core/frontend/helpers/foreach.js
@@ -31,7 +31,7 @@ module.exports = function foreach(items, options) {
         if (Object.values(items).length > 0 && checks.isPost(Object.values(items)[0])) {
             visibility = visibility || 'all';
         }
-    } 
+    }
 
     if (_.isArray(items) && items.length > 0 && checks.isNewsletter(items[0])) {
         visibility = visibility || 'all';

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -8,11 +8,10 @@ const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
  * @returns {void} - modifies attrs
  */
 module.exports.forPost = (options, model, attrs) => {
-    const _ = require('lodash');
     // This function is split up in 3 conditions for 3 different purposes:
     // 1. Gets excerpt from post's plaintext. If custom_excerpt exists, it overrides the excerpt but the key remains excerpt.
-    if (Object.prototype.hasOwnProperty.call(options, 'columns') || _.includes(options.columns, 'excerpt') || _.includes(options.columns, 'excerpt') && options.formats && options.formats.includes('plaintext')) {
-        if (_.includes(options.columns, 'excerpt')) {
+    if (Object.prototype.hasOwnProperty.call(options, 'columns') || options.columns?.includes('excerpt') || (options.columns?.includes('excerpt') && options.formats?.includes('plaintext'))) {
+        if (options.columns?.includes('excerpt')) {
             if (!attrs.custom_excerpt || attrs.custom_excerpt === null) {
                 let plaintext = model.get('plaintext');
                 if (plaintext) {
@@ -25,7 +24,7 @@ module.exports.forPost = (options, model, attrs) => {
                 }
             } else {
                 attrs.excerpt = attrs.custom_excerpt;
-                if (!_.includes(options.columns, 'custom_excerpt')) {
+                if (!options.columns?.includes('custom_excerpt')) {
                     delete attrs.custom_excerpt;
                 }
             }
@@ -33,7 +32,7 @@ module.exports.forPost = (options, model, attrs) => {
     }
 
     // 2. Displays plaintext if requested by user as a field. Also works if used as format.
-    if (_.includes(options.columns, 'plaintext') || options.formats && options.formats.includes('plaintext')) {
+    if (options.columns?.includes('plaintext') || options.formats?.includes('plaintext')) {
         let plaintext = model.get('plaintext');
         if (plaintext) {
             attrs.plaintext = plaintext;
@@ -62,7 +61,7 @@ module.exports.forPost = (options, model, attrs) => {
     // reading_time still only works when used along with formats=html.
 
     if (!Object.prototype.hasOwnProperty.call(options, 'columns') ||
-        (options.columns.includes('reading_time'))) {
+        (options.columns?.includes('reading_time'))) {
         if (attrs.html) {
             let additionalImages = 0;
 

--- a/ghost/core/core/server/models/base/plugins/data-manipulation.js
+++ b/ghost/core/core/server/models/base/plugins/data-manipulation.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const moment = require('moment');
 
 const schema = require('../../../data/schema');
@@ -25,18 +24,18 @@ module.exports = function (Bookshelf) {
         /**
          * before we insert dates into the database, we have to normalize
          * date format is now in each db the same
+         *
+         * @param {object} attrs - attributes to convert
+         * @returns {object} attrs - converted attributes
          */
         fixDatesWhenSave: function fixDatesWhenSave(attrs) {
-            const self = this;
+            const tableDef = schema.tables[this.tableName];
 
-            _.each(attrs, function each(value, key) {
-                if (value !== null
-                && Object.prototype.hasOwnProperty.call(schema.tables, self.tableName)
-                && Object.prototype.hasOwnProperty.call(schema.tables[self.tableName], key)
-                && schema.tables[self.tableName][key].type === 'dateTime') {
-                    attrs[key] = moment(value).format('YYYY-MM-DD HH:mm:ss');
+            for (const key in attrs) {
+                if (attrs[key] && tableDef?.[key]?.type === 'dateTime') {
+                    attrs[key] = moment(attrs[key]).format('YYYY-MM-DD HH:mm:ss');
                 }
-            });
+            }
 
             return attrs;
         },
@@ -48,11 +47,14 @@ module.exports = function (Bookshelf) {
          *   - knex returns a UTC String (2018-04-12 20:50:35)
          * mysql:
          *   - knex wraps the UTC value into a local JS Date
+         *
+         * @param {object} attrs - attributes to convert
+         * @returns {object} attrs - converted attributes
          */
         fixDatesWhenFetch: function fixDatesWhenFetch(attrs) {
             const tableDef = schema.tables[this.tableName];
 
-            Object.keys(attrs).forEach((key) => {
+            for (const key in attrs) {
                 if (attrs[key] && tableDef?.[key]?.type === 'dateTime') {
                     const dateMoment = moment(attrs[key]);
 
@@ -64,20 +66,25 @@ module.exports = function (Bookshelf) {
                         attrs[key] = moment().startOf('seconds').toDate();
                     }
                 }
-            });
+            }
 
             return attrs;
         },
 
-        // Convert integers to real booleans
+        /**
+         * Convert integers to real booleans
+         *
+         * @param {object} attrs - attributes to convert
+         * @returns {object} attrs - converted attributes
+         */
         fixBools: function fixBools(attrs) {
             const tableDef = schema.tables[this.tableName];
 
-            Object.keys(attrs).forEach((key) => {
+            for (const key in attrs) {
                 if (tableDef?.[key]?.type === 'boolean') {
                     attrs[key] = !!attrs[key];
                 }
-            });
+            }
 
             return attrs;
         }

--- a/ghost/core/core/server/models/base/plugins/overrides.js
+++ b/ghost/core/core/server/models/base/plugins/overrides.js
@@ -81,11 +81,11 @@ module.exports = function (Bookshelf) {
              * removes null relations coming from `hasOne` - https://bookshelfjs.org/api.html#Model-instance-hasOne
              * Based on https://github.com/bookshelf/bookshelf/issues/72#issuecomment-25164617
              */
-            _.each(this.relations, (value, key) => {
-                if (_.isEmpty(value)) {
+            for (const key in this.relations) {
+                if (_.isEmpty(this.relations[key])) {
                     delete this.relations[key];
                 }
-            });
+            }
             // CASE: get JSON of previous attrs
             if (options.previous) {
                 const clonedModel = _.cloneDeep(this);

--- a/ghost/core/core/server/models/base/plugins/sanitize.js
+++ b/ghost/core/core/server/models/base/plugins/sanitize.js
@@ -17,7 +17,7 @@ module.exports = function (Bookshelf) {
     Bookshelf.Model = Bookshelf.Model.extend({
         // Ghost option handling - get permitted attributes from server/data/schema.js, where the DB schema is defined
         permittedAttributes: function permittedAttributes() {
-            return _.keys(schema.tables[this.tableName])
+            return Object.keys(schema.tables[this.tableName] || {})
                 .filter(key => key.indexOf('@@') === -1);
         }
     }, {


### PR DESCRIPTION
- only some small micro-optimizations but we can remove lodash from a sanitize plugin method (needs an empty object fallback because Object.keys is less forgiving than _.keys and there are some tests which don't fully initialize the model)
- also converts the data-manipulation plugins into for-loops because there are more native than using lodash, and it means we can remove lodash from this file too
- lodash is a bit of a perf burn on extreme hotpaths, so it's good to clean it up where it's not needed
- adds a bit of JSDoc to help with editor autocomplete