### PR TITLE
Removed unused sentry profiling integration

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -1,5 +1,4 @@
 const config = require('./config');
-const logging = require('@tryghost/logging');
 const SentryKnexTracingIntegration = require('./SentryKnexTracingIntegration');
 const sentryConfig = config.get('sentry');
 const errors = require('@tryghost/errors');
@@ -126,22 +125,6 @@ if (sentryConfig && !sentryConfig.disabled) {
     if (sentryConfig.tracing?.enabled === true) {
         sentryInitConfig.integrations.push(new Sentry.Integrations.Http({tracing: true}));
         sentryInitConfig.tracesSampleRate = parseFloat(sentryConfig.tracing.sampleRate) || 0.0;
-        // Enable profiling, if configured, only if tracing is also configured
-        if (sentryConfig.profiling?.enabled === true) {
-            // Import Sentry's profiling integration if available
-            let ProfilingIntegration;
-            try {
-                ({ProfilingIntegration} = require('@sentry/profiling-node'));
-            } catch (err) {
-                logging.warn('Sentry Profiling Integration not available');
-                ProfilingIntegration = null;
-            }
-
-            if (ProfilingIntegration) {
-                sentryInitConfig.integrations.push(new ProfilingIntegration());
-                sentryInitConfig.profilesSampleRate = parseFloat(sentryConfig.profiling.sampleRate) || 0.0;
-            }
-        }
     }
     Sentry.init(sentryInitConfig);
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -223,7 +223,6 @@
     "xml": "1.0.1"
   },
   "optionalDependencies": {
-    "@sentry/profiling-node": "7.119.2",
     "@tryghost/html-to-mobiledoc": "3.1.2",
     "sqlite3": "5.1.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,14 +5213,6 @@
     "@sentry/types" "7.119.2"
     "@sentry/utils" "7.119.2"
 
-"@sentry/profiling-node@7.119.2":
-  version "7.119.2"
-  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-7.119.2.tgz#969d05c43e037c02918d1d4c7a6e52b66ce78e95"
-  integrity sha512-c2eR//qqydnLacxBy3ufRba0GFkfa3VS7ZG7b6pChkEzNmP6ObBVRdNCQ5FhyeJ6dPyi7x+wy8rI0d5aWhU23Q==
-  dependencies:
-    detect-libc "^2.0.2"
-    node-abi "^3.61.0"
-
 "@sentry/react@7.119.2":
   version "7.119.2"
   resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.119.2.tgz#b950b7ecfb18df4b5910655d05e888b18e7c543f"
@@ -24452,7 +24444,7 @@ nock@^14.0.0-beta.6:
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
 
-node-abi@^3.3.0, node-abi@^3.61.0:
+node-abi@^3.3.0:
   version "3.62.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.62.0.tgz#017958ed120f89a3a14a7253da810f5d724e3f36"
   integrity sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1731006713718679

- This code and dependency isn't currently in use anywhere so it's currently just adding cruft to `node_modules` and making our Sentry code more complex for no real benefit.
