### PR TITLE
Moved gated content block processing behind labs flag

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/post-gating.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/post-gating.js
@@ -1,4 +1,5 @@
 const membersService = require('../../../../../../services/members');
+const labs = require('../../../../../../../shared/labs');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 
 const {PERMIT_ACCESS} = membersService.contentGating;
@@ -106,11 +107,13 @@ const forPost = (attrs, frame) => {
         }
     }
 
-    const hasGatedBlocks = HAS_GATED_BLOCKS_REGEX.test(attrs.html);
-    if (hasGatedBlocks) {
-        attrs.html = module.exports.stripGatedBlocks(attrs.html, frame.original.context.member);
-        _updatePlaintext(attrs);
-        _updateExcerpt(attrs);
+    if (labs.isSet('contentVisibility')) {
+        const hasGatedBlocks = HAS_GATED_BLOCKS_REGEX.test(attrs.html);
+        if (hasGatedBlocks) {
+            attrs.html = module.exports.stripGatedBlocks(attrs.html, frame.original.context.member);
+            _updatePlaintext(attrs);
+            _updateExcerpt(attrs);
+        }
     }
 
     if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') || (frame.options.columns.includes('access'))) {


### PR DESCRIPTION
ref https://app.incident.io/ghost/incidents/137

- some sites make use of the Content API to fetch all posts in a single request with high traffic volumes which results in a lot of data processing to check for gated content that may cause higher CPU usage and slowdown
- under an abundance of caution we're moving the related code behind a labs flag whilst further performance testing is performed
- it should be noted that whilst this flag-conditional is in place, any content that has already used gated blocks as part of alpha testing will become visible if the flag is subsequently disabled
