### PR TITLE
Changed tags input to use autosave instead of save

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -70,7 +70,7 @@
                         {{#unless this.session.user.isContributor}}
                         <div class="form-group">
                             <label for="tag-input">Tags</label>
-                            <GhPsmTagsInput @triggerClass="gh-input-x" @post={{this.post}} @savePostOnChange={{action "savePost"}} @triggerId="tag-input" />
+                            <GhPsmTagsInput @triggerClass="gh-input-x" @post={{this.post}} @savePostOnChange={{action "autosavePost"}} @triggerId="tag-input" />
                         </div>
                         {{/unless}}
 

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -630,6 +630,14 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     @action
+    autosavePost() {
+        this.autosavePostTask.perform().catch((error) => {
+            this.showError(error);
+            this.post.rollbackAttributes();
+        });
+    }
+
+    @action
     deletePostInternal() {
         if (this.deletePost) {
             this.deletePost();

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -843,6 +843,25 @@ export default class LexicalEditorController extends Controller {
         }
     }
 
+    @task({group: 'saveTasks'})
+    *autosavePostTask() {
+        try {
+            return yield this._autosaveTask.perform();
+        } catch (error) {
+            if (error === undefined) {
+                // validation error
+                return;
+            }
+
+            if (error) {
+                let status = this.get('post.status');
+                this._showErrorAlert(status, status, error);
+            }
+
+            throw error;
+        }
+    }
+
     // convenience method for saving the post and performing post-save cleanup
     @task
     *_savePostTask(options = {}) {

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -136,7 +136,8 @@
                 @post={{this.post}}
                 @deletePost={{this.openDeletePostModal}}
                 @updateSlugTask={{this.updateSlugTask}}
-                @savePostTask={{this.autosavePostTask}}
+                @savePostTask={{this.savePostTask}}
+                @autosavePostTask={{this.autosavePostTask}}
                 @editorAPI={{this.editorAPI}}
                 @secondaryEditorAPI={{this.secondaryEditorAPI}}
                 @toggleSettingsMenu={{this.toggleSettingsMenu}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -136,7 +136,7 @@
                 @post={{this.post}}
                 @deletePost={{this.openDeletePostModal}}
                 @updateSlugTask={{this.updateSlugTask}}
-                @savePostTask={{this.savePostTask}}
+                @savePostTask={{this.autosavePostTask}}
                 @editorAPI={{this.editorAPI}}
                 @secondaryEditorAPI={{this.secondaryEditorAPI}}
                 @toggleSettingsMenu={{this.toggleSettingsMenu}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-756/reduce-api-calls-made-when-addingremoving-tags
ref https://github.com/TryGhost/Ghost/commit/d91869e6406b7b1f0790cb34c92d2b8c992f3465

- This is just a proof of concept — no tests yet because I'm not really sure how to test this. 
- The linked commit above added functionality to save the post (and relations) every time a tag is added or removed from a post. This commit modifies that behavior to use the _autosave_ task rather than the save task, which has some additional logic to sort of "debounce" saves. The end result of this is that if you add or remove a couple tags in quick succession, it will only send 1 API call to the server, rather than sending 1 for each change you make.