### PR TITLE
Removed env_file from compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,8 +14,6 @@ services:
     volumes:
       - .:/home/ghost
     tty: true
-    env_file:
-      - .env
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
no issue

- With the `package.json` commands specifying the `COMPOSE_PROFILES` environment variable, this `env_file` block is no longer needed. 
- Worse yet, it throws an error if the `.env` file it points to does not exist, which is really annoying.
