### PR TITLE
Wired Repost button to the new ActivityPub endpoint

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -219,6 +219,11 @@ export class ActivityPubAPI {
         await this.fetchJSON(url, 'POST');
     }
 
+    async repost(id: string): Promise<void> {
+        const url = new URL(`.ghost/activitypub/actions/repost/${encodeURIComponent(id)}`, this.apiUrl);
+        await this.fetchJSON(url, 'POST');
+    }
+
     get activitiesApiUrl() {
         return new URL(`.ghost/activitypub/activities/${this.handle}`, this.apiUrl);
     }

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {useLikeMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
+import {useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
 
 interface FeedItemStatsProps {
     object: ObjectProperties;
@@ -21,8 +21,10 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     onCommentClick
 }) => {
     const [isLiked, setIsLiked] = useState(object.liked);
+    const [isReposted, setIsReposted] = useState(object.reposted);
     const likeMutation = useLikeMutationForUser('index');
     const unlikeMutation = useUnlikeMutationForUser('index');
+    const repostMutation = useRepostMutationForUser('index');
 
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -66,6 +68,22 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();
                 onCommentClick();
+            }}
+        />
+        <Button
+            className={buttonClassName}
+            icon='reload'
+            iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green'}`}
+            id='repost'
+            size='md'
+            unstyled={true}
+            onClick={(e?: React.MouseEvent<HTMLElement>) => {
+                e?.stopPropagation();
+
+                if (!isReposted) {
+                    repostMutation.mutate(object.id);
+                    setIsReposted(true);
+                }
             }}
         />
     </div>);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-699

- wired the frontend to the new Create Repost API endpoint (POST /actions/repost/:id)
- the UX/UI is yet to be worked on by Djordje
- the frontend activity-pub app is currently missing acceptance tests altogether. A follow-up commit will set up and add a basic acceptance test to the FE app, so that we can add tests as we ship new changes
