### PR TITLE
Removed autosaving of tags from gh-post-settings-menu

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -204,3 +204,5 @@ remove|ember-template-lint|no-invalid-link-title|27|24|27|24|17a357b69040eb9e19a
 add|ember-template-lint|no-invalid-interactive|41|26|41|26|da9f7c0f319619ff98a53fd679c47841cfaa3c1d|1736380800000|1746745200000|1751929200000|app/components/gh-nav-menu/main.hbs
 add|ember-template-lint|no-redundant-fn|5|70|5|70|d8c5269c9b4ca3aec0fc5b8e3d6a997e115dbc92|1736380800000|1746745200000|1751929200000|app/components/gh-nav-menu/main.hbs
 remove|ember-template-lint|no-invalid-interactive|34|26|34|26|0c04fbca90264398b6b5033632f3170c73d1769b|1734307200000|1744671600000|1749855600000|app/components/gh-nav-menu/main.hbs
+add|ember-template-lint|no-action|73|109|73|109|ea929ac6dd30568030605712131db607b4762a26|1738713600000|1749081600000|1754265600000|app/components/gh-post-settings-menu.hbs
+remove|ember-template-lint|no-action|73|82|73|82|f30d469e4ae668f05aca2f92a124a6b4748847a3|1730678400000|1741046400000|1746230400000|app/components/gh-post-settings-menu.hbs

--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -70,7 +70,7 @@
                         {{#unless this.session.user.isContributor}}
                         <div class="form-group">
                             <label for="tag-input">Tags</label>
-                            <GhPsmTagsInput @triggerClass="gh-input-x" @post={{this.post}} @savePostOnChange={{action "savePost"}} @triggerId="tag-input" />
+                            <GhPsmTagsInput @triggerClass="gh-input-x" @post={{this.post}} @savePostOnChange={{action "saveTags"}} @triggerId="tag-input" />
                         </div>
                         {{/unless}}
 

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -625,7 +625,6 @@ export default class GhPostSettingsMenu extends Component {
     saveTags() {
         this.saveTagsTask.perform().catch((error) => {
             this.showError(error);
-            this.post.rollbackAttributes();
         });
     }
 

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -622,6 +622,14 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     @action
+    saveTags() {
+        this.saveTagsTask.perform().catch((error) => {
+            this.showError(error);
+            this.post.rollbackAttributes();
+        });
+    }
+
+    @action
     savePost() {
         this.savePostTask.perform().catch((error) => {
             this.showError(error);

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -843,6 +843,11 @@ export default class LexicalEditorController extends Controller {
         }
     }
 
+    @task({group: 'saveTasks'})
+    *saveTagsTask() {
+        return yield this._autosaveTask.perform();
+    }
+
     // convenience method for saving the post and performing post-save cleanup
     @task
     *_savePostTask(options = {}) {

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -137,6 +137,7 @@
                 @deletePost={{this.openDeletePostModal}}
                 @updateSlugTask={{this.updateSlugTask}}
                 @savePostTask={{this.savePostTask}}
+                @saveTagsTask={{this.saveTagsTask}}
                 @editorAPI={{this.editorAPI}}
                 @secondaryEditorAPI={{this.secondaryEditorAPI}}
                 @toggleSettingsMenu={{this.toggleSettingsMenu}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-756
ref d91869e6406b7b1f0790cb34c92d2b8c992f3465

Rather than forcing a save on every tag change, we want to defer to the autosave functionality which will debounce saves, reducing the number of API calls when modifying tags on a post. This does mean that changing tags for existing posts will require an explicit save, as the autosave functionality does not run for published posts.
