### PR TITLE
Added `title` tags to icon buttons

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.57",
+  "version": "0.3.58",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -48,6 +48,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             id='like'
             label={new Intl.NumberFormat().format(likeCount)}
             size='md'
+            title='Like'
             unstyled={true}
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();
@@ -64,6 +65,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             id='comment'
             label={new Intl.NumberFormat().format(commentCount)}
             size='md'
+            title='Reply'
             unstyled={true}
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();
@@ -76,6 +78,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green'}`}
             id='repost'
             size='md'
+            title='Repost'
             unstyled={true}
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-708/add-title-tags-to-icon-buttons

- This will help users figure out what our icon buttons (like/reply/repost) do, since they don't have labels.
