### PR TITLE
Added `service_healthy` condition for mysql and redis

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,8 +15,10 @@ services:
       - .:/home/ghost
     tty: true
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   mysql:
     image: mysql:8.0.35
     container_name: ghost-mysql


### PR DESCRIPTION
no issue

- Ghost would sometimes crash because it was booting before the database service was ready (even if the container had already started). This commit tells `docker compose` to only start the ghost service once the `mysql` and `redis` services have passed their health checks