### PR TITLE
Fixed flaky browser tests for scheduling posts

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,9 @@ services:
       - DEBUG=${DEBUG:-}
       - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
       - GHOST_DEV_MODE=${GHOST_DEV_MODE:-}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
+      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
   mysql:
     image: mysql:8.0.35
     container_name: ghost-mysql

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -148,10 +148,12 @@ const publishPost = async (page, {type = 'publish', time, date} = {}) => {
 
     if (date) {
         await page.locator('[data-test-date-time-picker-date-input]').fill(date);
+        await page.locator('[data-test-date-time-picker-date-input]').blur();
     }
 
     if (time) {
         await page.locator('[data-test-date-time-picker-time-input]').fill(time);
+        await page.locator('[data-test-date-time-picker-time-input]').blur();
     }
 
     // TODO: set other publish options


### PR DESCRIPTION
no issue

- The browser tests for scheduling posts were flaking/failing because the time was set to `00:00`, which is invalid and should reset the time to "a few seconds from now", but the test was sometimes able to "Continue" before the validation logic could run on blur. This left the actual scheduled time set to `00:00`, which then caused the following assertions to fail.
- I've tried to replicate this race condition manually to confirm it's not a bug that a user could actually reach, but I haven't been able to. I suspect that playwright's `.fill()` and/or `.click()` method behave slightly differently than expected, which creates this race condition.