### PR TITLE
Fixed publish and email post flaky browser test

### DIFF
--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -429,7 +429,8 @@ const createPostDraft = async (page, {title = 'Hello world', body = 'This is my 
     // Continue to the body by pressing enter
     await page.keyboard.press('Enter');
 
-    await page.waitForTimeout(100); // allow new->draft switch to occur fully, without this some initial typing events can be missed
+    const postStatus = await page.locator('[data-test-editor-post-status]');
+    await expect(postStatus).toHaveText('Draft - Saved');
     await page.keyboard.type(body);
 };
 


### PR DESCRIPTION
no issue

- The publish and email post browser test was flaking often due to a race condition — if the Publish button is clicked before the post has saved, the slug isn't updated yet. When we then visit the published post with the expected slug, we get a 404.
- This change will wait for the post to finish saving before publishing the post, rather than arbitrarily waiting 100ms and hoping it's fully saved by then.