### PR TITLE
Wired 'Undo Repost' action with the backend API endpoint

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -224,6 +224,11 @@ export class ActivityPubAPI {
         await this.fetchJSON(url, 'POST');
     }
 
+    async depost(id: string): Promise<void> {
+        const url = new URL(`.ghost/activitypub/actions/depost/${encodeURIComponent(id)}`, this.apiUrl);
+        await this.fetchJSON(url, 'POST');
+    }
+
     get activitiesApiUrl() {
         return new URL(`.ghost/activitypub/activities/${this.handle}`, this.apiUrl);
     }

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -224,8 +224,8 @@ export class ActivityPubAPI {
         await this.fetchJSON(url, 'POST');
     }
 
-    async depost(id: string): Promise<void> {
-        const url = new URL(`.ghost/activitypub/actions/depost/${encodeURIComponent(id)}`, this.apiUrl);
+    async derepost(id: string): Promise<void> {
+        const url = new URL(`.ghost/activitypub/actions/derepost/${encodeURIComponent(id)}`, this.apiUrl);
         await this.fetchJSON(url, 'POST');
     }
 

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
+import {useDepostMutationForUser, useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
 
 interface FeedItemStatsProps {
     object: ObjectProperties;
@@ -25,6 +25,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const likeMutation = useLikeMutationForUser('index');
     const unlikeMutation = useUnlikeMutationForUser('index');
     const repostMutation = useRepostMutationForUser('index');
+    const depostMutation = useDepostMutationForUser('index');
 
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -78,15 +79,18 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green'}`}
             id='repost'
             size='md'
-            title='Repost'
+            title={`${isReposted ? 'Undo repost' : 'Repost'}`}
             unstyled={true}
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();
 
                 if (!isReposted) {
                     repostMutation.mutate(object.id);
-                    setIsReposted(true);
+                } else {
+                    depostMutation.mutate(object.id);
                 }
+
+                setIsReposted(!isReposted);
             }}
         />
     </div>);

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {useDepostMutationForUser, useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
+import {useDerepostMutationForUser, useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
 
 interface FeedItemStatsProps {
     object: ObjectProperties;
@@ -25,7 +25,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const likeMutation = useLikeMutationForUser('index');
     const unlikeMutation = useUnlikeMutationForUser('index');
     const repostMutation = useRepostMutationForUser('index');
-    const depostMutation = useDepostMutationForUser('index');
+    const derepostMutation = useDerepostMutationForUser('index');
 
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -87,7 +87,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
                 if (!isReposted) {
                     repostMutation.mutate(object.id);
                 } else {
-                    depostMutation.mutate(object.id);
+                    derepostMutation.mutate(object.id);
                 }
 
                 setIsReposted(!isReposted);

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -241,7 +241,7 @@ export function useDerepostMutationForUser(handle: string) {
             }
             if (previousReposted) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`resposted:${handle}`], (old?: any[]) => {
+                queryClient.setQueryData([`reposted:${handle}`], (old?: any[]) => {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     return old?.filter((item: any) => item.object.id !== id);
                 });

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -208,14 +208,14 @@ export function useRepostMutationForUser(handle: string) {
     });
 }
 
-export function useDepostMutationForUser(handle: string) {
+export function useDerepostMutationForUser(handle: string) {
     const queryClient = useQueryClient();
     return useMutation({
         async mutationFn(id: string) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);
 
-            return api.depost(id);
+            return api.derepost(id);
         },
         onMutate: async (id) => {
             const previousInbox = queryClient.getQueryData([`inbox:${handle}`]);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-699

- when the user clicks again on the Repost icon, we undo the Repost action, by calling the corresponding API endpoint `POST /actions/derepost/:id`
- UX/UI and copy are still WIP
- at this stage, we're still missing acceptance tests in the frontend app. We will be starting acceptance testing in a separate commit

