### PR TITLE
Removed stdout from logging

### DIFF
--- a/ghost/core/core/shared/config/env/config.production.json
+++ b/ghost/core/core/shared/config/env/config.production.json
@@ -16,6 +16,6 @@
         "rotation": {
             "enabled": true
         },
-        "transports": ["file", "stdout"]
+        "transports": ["file"]
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1359

- Load tests showed a performance improvement of 35% by turning off stdout logging. The usage of PrettyStream causes write performance on high traffic conditions to degrade.