### PR TITLE
Added nice transition when stats counter changes

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.3.59",
+  "version": "0.3.60",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -283,7 +283,7 @@ const FeedItem: React.FC<FeedItemProps> = ({actor, object, layout, type, comment
                                                     className='ap-note-content line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-grey-900'
                                                 ></div>
                                                 {isTruncated && (
-                                                    <button className='mt-1 text-[#2563EB]' type='button'>Show more</button>
+                                                    <button className='mt-1 text-blue-600' type='button'>Show more</button>
                                                 )}
                                                 {renderFeedAttachment(object, layout)}
                                             </div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {useAnimatedCounter} from '../../hooks/useAnimatedCounter';
@@ -25,6 +25,24 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
 }) => {
     const [isLiked, setIsLiked] = useState(object.liked);
     const [isReposted, setIsReposted] = useState(object.reposted);
+
+    // Sync with external changes - Update the liked / reposted state when the object changes
+    useEffect(() => {
+        setIsLiked(object.liked);
+        setIsReposted(object.reposted);
+    }, [object.liked, object.reposted]);
+
+    // Sync with external changes - Update the repost count when the initialRepostCount changes
+    useEffect(() => {
+        if (repostCount !== initialRepostCount) {
+            if (initialRepostCount > repostCount) {
+                incrementReposts();
+            } else if (initialRepostCount < repostCount) {
+                decrementReposts();
+            }
+        }
+    }, [initialRepostCount]); // eslint-disable-line react-hooks/exhaustive-deps
+
     const likeMutation = useLikeMutationForUser('index');
     const unlikeMutation = useUnlikeMutationForUser('index');
     const repostMutation = useRepostMutationForUser('index');

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -30,7 +30,8 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const repostMutation = useRepostMutationForUser('index');
     const derepostMutation = useDerepostMutationForUser('index');
     const {
-        displayValue: repostValue,
+        displayValue: repostCountDisplay,
+        currentValue: repostCountNumber,
         increment: incrementReposts,
         decrement: decrementReposts
     } = useAnimatedCounter(repostCount);
@@ -46,12 +47,12 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
         onLikeClick();
     };
 
-    const buttonClassName = `transition-color flex p-2 items-center justify-center rounded-full bg-white leading-none hover:bg-grey-100`;
+    const buttonClassName = `transition-color flex p-2 ap-action-button items-center justify-center rounded-full bg-white leading-none hover:bg-grey-100`;
 
     return (<div className={`flex ${(layout === 'inbox') ? 'flex-col' : 'gap-1'}`}>
         <Button
             className={`${buttonClassName} ${isLiked ? 'text-red-600' : 'text-grey-900'}`}
-            hideLabel={!isLiked || (layout === 'inbox')}
+            hideLabel={true}
             icon='heart'
             iconColorClass={`w-[18px] h-[18px] ${isLiked && 'ap-red-heart text-red-600 *:!fill-red-600 hover:text-red-600'}`}
             id='like'
@@ -83,11 +84,11 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
         />
         <Button
             className={`${buttonClassName} ${isReposted ? 'text-green-500' : 'text-grey-900'}`}
-            hideLabel={repostCount === 0 || (layout === 'inbox')}
+            hideLabel={(repostCount === 0 && !isReposted) || repostCountNumber === 0 || (layout === 'inbox')}
             icon='reload'
             iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green-500'}`}
             id='repost'
-            label={repostValue}
+            label={repostCountDisplay}
             size='md'
             title={`${isReposted ? 'Undo repost' : 'Repost'}`}
             unstyled={true}

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import {Button} from '@tryghost/admin-x-design-system';
 import {ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
+import {useAnimatedCounter} from '../../hooks/useAnimatedCounter';
 import {useDerepostMutationForUser, useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '../../hooks/useActivityPubQueries';
 
 interface FeedItemStatsProps {
@@ -28,6 +29,11 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const unlikeMutation = useUnlikeMutationForUser('index');
     const repostMutation = useRepostMutationForUser('index');
     const derepostMutation = useDerepostMutationForUser('index');
+    const {
+        displayValue: repostValue,
+        increment: incrementReposts,
+        decrement: decrementReposts
+    } = useAnimatedCounter(repostCount);
 
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -40,18 +46,18 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
         onLikeClick();
     };
 
-    const buttonClassName = `transition-color flex p-2 items-center justify-center rounded-full bg-white leading-none text-grey-900 hover:bg-grey-100`;
+    const buttonClassName = `transition-color flex p-2 items-center justify-center rounded-full bg-white leading-none hover:bg-grey-100`;
 
     return (<div className={`flex ${(layout === 'inbox') ? 'flex-col' : 'gap-1'}`}>
         <Button
-            className={buttonClassName}
+            className={`${buttonClassName} ${isLiked ? 'text-red-600' : 'text-grey-900'}`}
             hideLabel={!isLiked || (layout === 'inbox')}
             icon='heart'
-            iconColorClass={`w-[18px] h-[18px] ${isLiked && 'ap-red-heart text-red *:!fill-red hover:text-red'}`}
+            iconColorClass={`w-[18px] h-[18px] ${isLiked && 'ap-red-heart text-red-600 *:!fill-red-600 hover:text-red-600'}`}
             id='like'
             label={new Intl.NumberFormat().format(likeCount)}
             size='md'
-            title='Like'
+            title={`${isLiked ? 'Undo like' : 'Like'}`}
             unstyled={true}
             onClick={(e?: React.MouseEvent<HTMLElement>) => {
                 e?.stopPropagation();
@@ -76,12 +82,12 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
             }}
         />
         <Button
-            className={buttonClassName}
+            className={`${buttonClassName} ${isReposted ? 'text-green-500' : 'text-grey-900'}`}
             hideLabel={repostCount === 0 || (layout === 'inbox')}
             icon='reload'
-            iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green'}`}
+            iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green-500'}`}
             id='repost'
-            label={new Intl.NumberFormat().format(repostCount)}
+            label={repostValue}
             size='md'
             title={`${isReposted ? 'Undo repost' : 'Repost'}`}
             unstyled={true}
@@ -90,8 +96,10 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
 
                 if (!isReposted) {
                     repostMutation.mutate(object.id);
+                    incrementReposts();
                 } else {
                     derepostMutation.mutate(object.id);
+                    decrementReposts();
                 }
 
                 setIsReposted(!isReposted);

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -18,7 +18,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     object,
     likeCount,
     commentCount,
-    repostCount,
+    repostCount: initialRepostCount,
     layout,
     onLikeClick,
     onCommentClick
@@ -30,11 +30,11 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const repostMutation = useRepostMutationForUser('index');
     const derepostMutation = useDerepostMutationForUser('index');
     const {
-        displayValue: repostCountDisplay,
-        currentValue: repostCountNumber,
+        Counter: RepostCounter,
+        currentValue: repostCount,
         increment: incrementReposts,
         decrement: decrementReposts
-    } = useAnimatedCounter(repostCount);
+    } = useAnimatedCounter(initialRepostCount);
 
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -84,11 +84,11 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
         />
         <Button
             className={`${buttonClassName} ${isReposted ? 'text-green-500' : 'text-grey-900'}`}
-            hideLabel={(repostCount === 0 && !isReposted) || repostCountNumber === 0 || (layout === 'inbox')}
+            hideLabel={(initialRepostCount === 0 && !isReposted) || repostCount === 0 || (layout === 'inbox')}
             icon='reload'
             iconColorClass={`w-[18px] h-[18px] ${isReposted && 'text-green-500'}`}
             id='repost'
-            label={repostCountDisplay}
+            label={RepostCounter}
             size='md'
             title={`${isReposted ? 'Undo repost' : 'Repost'}`}
             unstyled={true}

--- a/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
+++ b/apps/admin-x-activitypub/src/hooks/useActivityPubQueries.ts
@@ -78,37 +78,33 @@ export function useLikeMutationForUser(handle: string) {
             const api = createActivityPubAPI(handle, siteUrl);
             return api.like(id);
         },
-        onMutate: (id) => {
-            const previousInbox = queryClient.getQueryData([`inbox:${handle}`]);
-            if (previousInbox) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`inbox:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.map((item: any) => {
-                        if (item.object.id === id) {
-                            return {
-                                ...item,
-                                object: {
-                                    ...item.object,
-                                    liked: true
-                                }
-                            };
-                        }
-                        return item;
-                    });
-                });
-            }
+        onMutate: async (id) => {
+            queryClient.setQueriesData([`activities:${handle}`], (current?: {pages: {data: Activity[]}[]}) => {
+                if (current === undefined) {
+                    return current;
+                }
 
-            // This sets the context for the onError handler
-            return {previousInbox};
-        },
-        onError: (_err, _id, context) => {
-            if (context?.previousInbox) {
-                queryClient.setQueryData([`inbox:${handle}`], context?.previousInbox);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({queryKey: [`liked:${handle}`]});
+                return {
+                    ...current,
+                    pages: current.pages.map((page: {data: Activity[]}) => {
+                        return {
+                            ...page,
+                            data: page.data.map((item: Activity) => {
+                                if (item.object.id === id) {
+                                    return {
+                                        ...item,
+                                        object: {
+                                            ...item.object,
+                                            liked: true
+                                        }
+                                    };
+                                }
+                                return item;
+                            })
+                        };
+                    })
+                };
+            });
         }
     });
 }
@@ -122,45 +118,32 @@ export function useUnlikeMutationForUser(handle: string) {
             return api.unlike(id);
         },
         onMutate: async (id) => {
-            const previousInbox = queryClient.getQueryData([`inbox:${handle}`]);
-            const previousLiked = queryClient.getQueryData([`liked:${handle}`]);
+            queryClient.setQueriesData([`activities:${handle}`], (current?: {pages: {data: Activity[]}[]}) => {
+                if (current === undefined) {
+                    return current;
+                }
 
-            if (previousInbox) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`inbox:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.map((item: any) => {
-                        if (item.object.id === id) {
-                            return {
-                                ...item,
-                                object: {
-                                    ...item.object,
-                                    liked: false
+                return {
+                    ...current,
+                    pages: current.pages.map((page: {data: Activity[]}) => {
+                        return {
+                            ...page,
+                            data: page.data.map((item: Activity) => {
+                                if (item.object.id === id) {
+                                    return {
+                                        ...item,
+                                        object: {
+                                            ...item.object,
+                                            liked: false
+                                        }
+                                    };
                                 }
-                            };
-                        }
-                        return item;
-                    });
-                });
-            }
-            if (previousLiked) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`liked:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.filter((item: any) => item.object.id !== id);
-                });
-            }
-
-            // This sets the context for the onError handler
-            return {previousInbox, previousLiked};
-        },
-        onError: (_err, _id, context) => {
-            if (context?.previousInbox) {
-                queryClient.setQueryData([`inbox:${handle}`], context?.previousInbox);
-            }
-            if (context?.previousLiked) {
-                queryClient.setQueryData([`liked:${handle}`], context?.previousLiked);
-            }
+                                return item;
+                            })
+                        };
+                    })
+                };
+            });
         }
     });
 }
@@ -173,37 +156,34 @@ export function useRepostMutationForUser(handle: string) {
             const api = createActivityPubAPI(handle, siteUrl);
             return api.repost(id);
         },
-        onMutate: (id) => {
-            const previousInbox = queryClient.getQueryData([`inbox:${handle}`]);
-            if (previousInbox) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`inbox:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.map((item: any) => {
-                        if (item.object.id === id) {
-                            return {
-                                ...item,
-                                object: {
-                                    ...item.object,
-                                    reposted: true
-                                }
-                            };
-                        }
-                        return item;
-                    });
-                });
-            }
+        onMutate: async (id) => {
+            queryClient.setQueriesData([`activities:${handle}`], (current?: {pages: {data: Activity[]}[]}) => {
+                if (current === undefined) {
+                    return current;
+                }
 
-            // This sets the context for the onError handler
-            return {previousInbox};
-        },
-        onError: (_err, _id, context) => {
-            if (context?.previousInbox) {
-                queryClient.setQueryData([`inbox:${handle}`], context?.previousInbox);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({queryKey: [`reposted:${handle}`]});
+                return {
+                    ...current,
+                    pages: current.pages.map((page: {data: Activity[]}) => {
+                        return {
+                            ...page,
+                            data: page.data.map((item: Activity) => {
+                                if (item.object.id === id) {
+                                    return {
+                                        ...item,
+                                        object: {
+                                            ...item.object,
+                                            reposted: true,
+                                            repostCount: item.object.repostCount + 1
+                                        }
+                                    };
+                                }
+                                return item;
+                            })
+                        };
+                    })
+                };
+            });
         }
     });
 }
@@ -218,45 +198,33 @@ export function useDerepostMutationForUser(handle: string) {
             return api.derepost(id);
         },
         onMutate: async (id) => {
-            const previousInbox = queryClient.getQueryData([`inbox:${handle}`]);
-            const previousReposted = queryClient.getQueryData([`reposted:${handle}`]);
+            queryClient.setQueriesData([`activities:${handle}`], (current?: {pages: {data: Activity[]}[]}) => {
+                if (current === undefined) {
+                    return current;
+                }
 
-            if (previousInbox) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`inbox:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.map((item: any) => {
-                        if (item.object.id === id) {
-                            return {
-                                ...item,
-                                object: {
-                                    ...item.object,
-                                    reposted: false
+                return {
+                    ...current,
+                    pages: current.pages.map((page: {data: Activity[]}) => {
+                        return {
+                            ...page,
+                            data: page.data.map((item: Activity) => {
+                                if (item.object.id === id) {
+                                    return {
+                                        ...item,
+                                        object: {
+                                            ...item.object,
+                                            reposted: false,
+                                            repostCount: item.object.repostCount - 1 < 0 ? 0 : item.object.repostCount - 1
+                                        }
+                                    };
                                 }
-                            };
-                        }
-                        return item;
-                    });
-                });
-            }
-            if (previousReposted) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueryData([`reposted:${handle}`], (old?: any[]) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return old?.filter((item: any) => item.object.id !== id);
-                });
-            }
-
-            // This sets the context for the onError handler
-            return {previousInbox, previousReposted};
-        },
-        onError: (_err, _id, context) => {
-            if (context?.previousInbox) {
-                queryClient.setQueryData([`inbox:${handle}`], context?.previousInbox);
-            }
-            if (context?.previousReposted) {
-                queryClient.setQueryData([`reposted:${handle}`], context?.previousReposted);
-            }
+                                return item;
+                            })
+                        };
+                    })
+                };
+            });
         }
     });
 }

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -1,0 +1,61 @@
+import {useEffect, useState} from 'react';
+
+interface AnimatedCounterResult {
+    displayValue: React.ReactNode;
+    increment: () => void;
+    decrement: () => void;
+}
+
+const splitNumber = (num: number): string[] => num.toString().split('');
+
+export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult => {
+    const [value, setValue] = useState(initialValue);
+    const [digits, setDigits] = useState(splitNumber(initialValue));
+    const [animatingDigits, setAnimatingDigits] = useState<Set<number>>(new Set());
+    const [isDecrementing, setIsDecrementing] = useState(false);
+
+    useEffect(() => {
+        const newDigits = splitNumber(value);
+        const changedPositions = new Set(
+            [...Array(Math.max(digits.length, newDigits.length))].map(
+                (_, i) => digits[i] !== newDigits[i] ? i : -1
+            ).filter(i => i !== -1)
+        );
+
+        if (changedPositions.size > 0) {
+            setAnimatingDigits(changedPositions);
+
+            const timeout = setTimeout(() => {
+                setDigits(newDigits);
+                setAnimatingDigits(new Set());
+                setIsDecrementing(false);
+            }, 300);
+
+            return () => clearTimeout(timeout);
+        }
+    }, [value, digits]);
+
+    const updateValue = (delta: number) => {
+        setValue(prev => prev + delta);
+        setIsDecrementing(delta < 0);
+    };
+
+    return {
+        displayValue: (
+            <span className="flex">
+                {digits.map((digit, position) => (
+                    <span
+                        key={`${digits.length - position}-${digit}`}
+                        className={animatingDigits.has(position)
+                            ? isDecrementing ? 'animate-slide-down' : 'animate-slide-up'
+                            : ''}
+                    >
+                        {digit}
+                    </span>
+                ))}
+            </span>
+        ),
+        increment: () => updateValue(1),
+        decrement: () => updateValue(-1)
+    };
+};

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
 
 interface AnimatedCounterResult {
-    displayValue: React.ReactNode;
+    Counter: React.ReactNode;
     currentValue: number;
     increment: () => void;
     decrement: () => void;
@@ -43,7 +43,7 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
     };
 
     return {
-        displayValue: (
+        Counter: (
             <span className="flex">
                 {digits.map((digit, position) => (
                     <span

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -17,8 +17,9 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
 
     useEffect(() => {
         const newDigits = splitNumber(value);
+        const maxLength = Math.max(digits.length, newDigits.length);
         const changedPositions = new Set(
-            [...Array(Math.max(digits.length, newDigits.length))].map((_, i) => {
+            Array.from({ length: maxLength }, (_, i) => {
                 return digits[i] !== newDigits[i] ? i : -1;
             }).filter(i => i !== -1)
         );

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -46,6 +46,9 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
                 {digits.map((digit, position) => (
                     <span
                         key={`${digits.length - position}-${digit}`}
+                        role='text'
+                        aria-atomic='true'
+                        aria-live='polite'
                         className={animatingDigits.has(position)
                             ? isDecrementing ? 'animate-slide-down' : 'animate-slide-up'
                             : ''}

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -17,9 +17,9 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
     useEffect(() => {
         const newDigits = splitNumber(value);
         const changedPositions = new Set(
-            [...Array(Math.max(digits.length, newDigits.length))].map(
-                (_, i) => digits[i] !== newDigits[i] ? i : -1
-            ).filter(i => i !== -1)
+            [...Array(Math.max(digits.length, newDigits.length))].map((_, i) => {
+                return digits[i] !== newDigits[i] ? i : -1;
+            }).filter(i => i !== -1)
         );
 
         if (changedPositions.size > 0) {

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -19,7 +19,7 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
         const newDigits = splitNumber(value);
         const maxLength = Math.max(digits.length, newDigits.length);
         const changedPositions = new Set(
-            Array.from({ length: maxLength }, (_, i) => {
+            Array.from({length: maxLength}, (_, i) => {
                 return digits[i] !== newDigits[i] ? i : -1;
             }).filter(i => i !== -1)
         );

--- a/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
+++ b/apps/admin-x-activitypub/src/hooks/useAnimatedCounter.tsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react';
 
 interface AnimatedCounterResult {
     displayValue: React.ReactNode;
+    currentValue: number;
     increment: () => void;
     decrement: () => void;
 }
@@ -46,18 +47,19 @@ export const useAnimatedCounter = (initialValue: number): AnimatedCounterResult 
                 {digits.map((digit, position) => (
                     <span
                         key={`${digits.length - position}-${digit}`}
-                        role='text'
                         aria-atomic='true'
                         aria-live='polite'
                         className={animatingDigits.has(position)
                             ? isDecrementing ? 'animate-slide-down' : 'animate-slide-up'
                             : ''}
+                        role='text'
                     >
                         {digit}
                     </span>
                 ))}
             </span>
         ),
+        currentValue: value,
         increment: () => updateValue(1),
         decrement: () => updateValue(-1)
     };

--- a/apps/admin-x-activitypub/src/styles/index.css
+++ b/apps/admin-x-activitypub/src/styles/index.css
@@ -21,49 +21,51 @@
 @keyframes slideUp {
     0% {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate3d(0, 0, 0);
     }
     50% {
         opacity: 0;
-        transform: translateY(-100%);
+        transform: translate3d(0, -100%, 0);
     }
     51% {
         opacity: 0;
-        transform: translateY(100%);
+        transform: translate3d(0, 100%, 0);
     }
     100% {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate3d(0, 0, 0);
     }
 }
 
 @keyframes slideDown {
     0% {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate3d(0, 0, 0);
     }
     50% {
         opacity: 0;
-        transform: translateY(100%);
+        transform: translate3d(0, 100%, 0);
     }
     51% {
         opacity: 0;
-        transform: translateY(-100%);
+        transform: translate3d(0, -100%, 0);
     }
     100% {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate3d(0, 0, 0);
     }
 }
 
 .animate-slide-up {
     animation: slideUp 0.3s ease-in-out;
     display: inline-block;
+    will-change: transform, opacity;
 }
 
 .animate-slide-down {
     animation: slideDown 0.3s ease-in-out;
     display: inline-block;
+    will-change: transform, opacity;
 }
 
 button.ap-like-button:active svg {

--- a/apps/admin-x-activitypub/src/styles/index.css
+++ b/apps/admin-x-activitypub/src/styles/index.css
@@ -18,6 +18,54 @@
     }
 }
 
+@keyframes slideUp {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    50% {
+        opacity: 0;
+        transform: translateY(-100%);
+    }
+    51% {
+        opacity: 0;
+        transform: translateY(100%);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes slideDown {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    50% {
+        opacity: 0;
+        transform: translateY(100%);
+    }
+    51% {
+        opacity: 0;
+        transform: translateY(-100%);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.animate-slide-up {
+    animation: slideUp 0.3s ease-in-out;
+    display: inline-block;
+}
+
+.animate-slide-down {
+    animation: slideDown 0.3s ease-in-out;
+    display: inline-block;
+}
+
 button.ap-like-button:active svg {
     animation: bump 0.3s ease-in-out;
 }

--- a/apps/admin-x-activitypub/src/styles/index.css
+++ b/apps/admin-x-activitypub/src/styles/index.css
@@ -68,7 +68,7 @@
     will-change: transform, opacity;
 }
 
-button.ap-like-button:active svg {
+button.ap-action-button:active svg {
     animation: bump 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-706/add-repost-count-so-that-the-ui-can-display-the-count

- When you repost (or derepost) a post, the stats counter will now nicely animate into a larger (or smaller) number, with only the relevant digits animating and the others staying in place. We’re using a reusable hook for this.
- Updated stat counter numbers to also change the color when the post is liked or reposted by the currently logged in user
