### PR TITLE
Expand external media inliner to handle srcset images

### DIFF
--- a/ghost/external-media-inliner/lib/ExternalMediaInliner.js
+++ b/ghost/external-media-inliner/lib/ExternalMediaInliner.js
@@ -139,9 +139,9 @@ class ExternalMediaInliner {
      */
     async inlineContent(content, domains) {
         for (const domain of domains) {
-            // NOTE: the src could end with a quote, apostrophe or double-backslash. backlashes are added to content
+            // NOTE: the src could end with a quote, bracket, apostrophe, double-backslash, or encoded quote. backlashes are added to content
             //       as an escape character
-            const srcTerminationSymbols = `"|'|\\\\`;
+            const srcTerminationSymbols = `"|\\)|'| |,|<|\\\\|&quot;`;
             const regex = new RegExp(`(${domain}.*?)(${srcTerminationSymbols})`, 'igm');
             const matches = content.matchAll(regex);
 


### PR DESCRIPTION
no issue

The external media inliner currently fails to process images in a `srcset` attribute.

This PR extends the regexp to detect more valid URLs, `srcset` attributes is a common example, and background image URLs in quotes is another.