### PR TITLE
Fixed some flaky portal browser tests

### DIFF
--- a/ghost/core/test/e2e-browser/admin/i18n.spec.js
+++ b/ghost/core/test/e2e-browser/admin/i18n.spec.js
@@ -12,6 +12,15 @@ async function setLanguage(sharedPage, language) {
     await expect(section.getByLabel('Site language')).toHaveValue(language);
 }
 
+async function resetLanguage(sharedPage) {
+    await sharedPage.goto('/ghost/#/settings/publication-language');
+    const section = sharedPage.getByTestId('publication-language');
+    await section.getByLabel('Site language').fill('en');
+    await section.getByRole('button', {name: 'Save'}).click();
+
+    await expect(section.getByLabel('Site language')).toHaveValue('en');
+}
+
 test.describe('i18n', () => {
     test.describe('Newsletter', () => {
         test('changing the site language immediately translates strings in newsletters', async ({sharedPage}) => {
@@ -35,6 +44,11 @@ test.describe('i18n', () => {
 
             await expect(metaText).toContain('Par Joe Bloggs');
             await expect(metaText).not.toContain('By Joe Bloggs');
+
+            // close the email preview modal
+            await sharedPage.keyboard.press('Escape');
+            // reset language to en
+            await resetLanguage(sharedPage);
         });
     });
 });


### PR DESCRIPTION
no issue

- The i18n browser test was setting the site language to 'fr', and this state was carrying over to other tests which broke assertions based on the english text in portal. This caused portal tests to generally be flaky, since it would break a somewhat random test based on the order they are executed in.
- This resets the language back to english, so we are in a consistent state for future tests.