### PR TITLE
Add more terminations to external media inliner

### DIFF
--- a/ghost/external-media-inliner/lib/ExternalMediaInliner.js
+++ b/ghost/external-media-inliner/lib/ExternalMediaInliner.js
@@ -129,6 +129,24 @@ class ExternalMediaInliner {
         }
     }
 
+    static findMatches(content, domain) {
+        // NOTE: the src could end with a quote, bracket, apostrophe, double-backslash, or encoded quote.
+        //     Backlashes are added to content as an escape character
+        const srcTerminationSymbols = `("|\\)|'|(?=(?:,https?))| |<|\\\\|&quot;|$)`;
+        const regex = new RegExp(`(${domain}.*?)(${srcTerminationSymbols})`, 'igm');
+        const matches = content.matchAll(regex);
+
+        // Simplify the matches so we only get the result needed
+        let matchesArray = Array.from(matches, m => m[1]);
+
+        // Trim trailing commas from each match
+        matchesArray = matchesArray.map((item) => {
+            return item.replace(/,$/, '');
+        });
+
+        return matchesArray;
+    }
+
     /**
      * Find & inline external media from a JSON sting.
      * This works with both Lexical & Mobiledoc, so no separate methods are needed here.
@@ -139,13 +157,9 @@ class ExternalMediaInliner {
      */
     async inlineContent(content, domains) {
         for (const domain of domains) {
-            // NOTE: the src could end with a quote, bracket, apostrophe, double-backslash, or encoded quote. backlashes are added to content
-            //       as an escape character
-            const srcTerminationSymbols = `"|\\)|'| |,|<|\\\\|&quot;`;
-            const regex = new RegExp(`(${domain}.*?)(${srcTerminationSymbols})`, 'igm');
-            const matches = content.matchAll(regex);
+            const matches = this.constructor.findMatches(content, domain);
 
-            for (const [,src] of matches) {
+            for (const src of matches) {
                 const response = await this.getRemoteMedia(src);
 
                 let media;

--- a/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
+++ b/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
@@ -898,6 +898,15 @@ describe('ExternalMediaInliner', function () {
             assert.equal(matches[0], 'https://example.com/image.jpg');
         });
 
+        it('Finds with full domain, http and https', function () {
+            const html = '<img src="http://example.com/image.jpg" /><img src="https://example.com/another-image.jpg" />';
+            const matches = ExternalMediaInliner.findMatches(html, 'https?://example.com');
+
+            assert.equal(matches.length, 2);
+            assert.equal(matches[0], 'http://example.com/image.jpg');
+            assert.equal(matches[1], 'https://example.com/another-image.jpg');
+        });
+
         it('Finds in with comma in string', function () {
             const html = `<img src="https://example.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7303a336-fa0e-4377-9378-123456abcdef_640x640.png
 " />`;

--- a/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
+++ b/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
@@ -898,18 +898,6 @@ describe('ExternalMediaInliner', function () {
             assert.equal(matches[0], 'https://example.com/image.jpg');
         });
 
-        it('Finds with glob pattern', function () {
-            const html = `<img src="https://example.com/wp-content/uploads/2025/02/image.jpg" />
-                <img src="https://anotherexample.com/wp-content/uploads/2025/02/image.jpg" />
-                <img src="https://example.com/photo.jpg" />`;
-            const matches = ExternalMediaInliner.findMatches(html, 'https://.*wp-content');
-
-            // Will only match the two paths with `/wp-content` in them
-            assert.equal(matches.length, 2);
-            assert.equal(matches[0], 'https://example.com/wp-content/uploads/2025/02/image.jpg');
-            assert.equal(matches[1], 'https://anotherexample.com/wp-content/uploads/2025/02/image.jpg');
-        });
-
         it('Finds in with comma in string', function () {
             const html = `<img src="https://example.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7303a336-fa0e-4377-9378-123456abcdef_640x640.png
 " />`;

--- a/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
+++ b/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
@@ -888,5 +888,93 @@ describe('ExternalMediaInliner', function () {
             assert.equal(fileData.extension, '.gif');
         });
     });
-});
 
+    describe('Find matches', function () {
+        it('Finds with full domain', function () {
+            const html = '<img src="https://example.com/image.jpg" /><img src="https://anotherexample.com/image.jpg" />';
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image.jpg');
+        });
+
+        it('Finds with glob pattern', function () {
+            const html = `<img src="https://example.com/wp-content/uploads/2025/02/image.jpg" />
+                <img src="https://anotherexample.com/wp-content/uploads/2025/02/image.jpg" />
+                <img src="https://example.com/photo.jpg" />`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://.*wp-content');
+
+            // Will only match the two paths with `/wp-content` in them
+            assert.equal(matches.length, 2);
+            assert.equal(matches[0], 'https://example.com/wp-content/uploads/2025/02/image.jpg');
+            assert.equal(matches[1], 'https://anotherexample.com/wp-content/uploads/2025/02/image.jpg');
+        });
+
+        it('Finds in with comma in string', function () {
+            const html = `<img src="https://example.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7303a336-fa0e-4377-9378-123456abcdef_640x640.png
+" />`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7303a336-fa0e-4377-9378-123456abcdef_640x640.png');
+        });
+
+        it('Finds when seperatd by a comma', function () {
+            const html = `<img srcsct="https://example.com/image/fetch,one.png 1x, https://example.com/image/fetch,two.png 2x,https://example.com/image/fetch,three.png 3x" />`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 3);
+            assert.equal(matches[0], 'https://example.com/image/fetch,one.png');
+            assert.equal(matches[1], 'https://example.com/image/fetch,two.png');
+            assert.equal(matches[2], 'https://example.com/image/fetch,three.png');
+        });
+
+        it('Finds with parenthesis terminator', function () {
+            const html = `(https://example.com/image/one.png)`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+
+        it('Finds with apostrophe terminator', function () {
+            const html = `'https://example.com/image/one.png'`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+
+        it('Finds with space terminator', function () {
+            const html = ` https://example.com/image/one.png `;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+
+        it('Finds with less than terminator', function () {
+            const html = ` https://example.com/image/one.png<`;
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+
+        it('Finds with encoded &quot; terminator', function () {
+            const html = '&quot;https://example.com/image/one.png&quot;';
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+
+        it('Finds end of string terminator', function () {
+            const html = 'https://example.com/image/one.png';
+            const matches = ExternalMediaInliner.findMatches(html, 'https://example.com');
+
+            assert.equal(matches.length, 1);
+            assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+    });
+});


### PR DESCRIPTION
Builds on top of 9dd48f9d83b751f24722b5eb2c68adcf3781849f

This adds more terminations, which means more URLs are matched. Also added tests.
