### PR TITLE
🌵 SPIKE: Replace dev.js script with declarative NX target

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
         zsh \
         procps \
         default-mysql-client && \
-    npx -y playwright@1.46.1 install --with-deps
+    npx -y playwright@1.50.1 install --with-deps
 
 ENV NX_DAEMON=true
 ENV YARN_CACHE_FOLDER=$WORKDIR/.yarncache
@@ -53,7 +53,6 @@ ARG WORKDIR=/home/ghost
 WORKDIR $WORKDIR
 COPY . .
 RUN yarn install --frozen-lockfile --prefer-offline --cache-folder $YARN_CACHE_FOLDER
-RUN yarn nx run-many -t build:ts && yarn nx run ghost-admin:build
 
 FROM base-devcontainer AS development
 ARG WORKDIR=/home/ghost

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -53,6 +53,7 @@ ARG WORKDIR=/home/ghost
 WORKDIR $WORKDIR
 COPY . .
 RUN yarn install --frozen-lockfile --prefer-offline --cache-folder $YARN_CACHE_FOLDER
+RUN yarn nx run-many -t build:ts && yarn nx run ghost-admin:build
 
 FROM base-devcontainer AS development
 ARG WORKDIR=/home/ghost

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -38,6 +38,9 @@
     "ts-jest": "29.1.5"
   },
   "nx": {
+    "tags": [
+      "type:admin-x-app"
+    ],
     "targets": {
       "build": {
         "dependsOn": [

--- a/apps/admin-x-demo/package.json
+++ b/apps/admin-x-demo/package.json
@@ -34,6 +34,9 @@
     "react-dom": "18.3.1"
   },
   "nx": {
+    "tags": [
+      "type:admin-x-app"
+    ],
     "targets": {
       "dev": {
         "dependsOn": [

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -64,6 +64,9 @@
     "vitest": "0.34.3"
   },
   "nx": {
+    "tags": [
+      "type:admin-x-app"
+    ],
     "targets": {
       "dev": {
         "dependsOn": [

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -15,6 +15,9 @@
     "main": "./dist/posts.umd.cjs",
     "module": "./dist/posts.js",
     "private": true,
+    "tags": [
+      "type:admin-x-app"
+    ],
     "scripts": {
         "dev": "vite build --watch",
         "dev:start": "vite",

--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,7 @@ services:
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
-      target: full-devcontainer
-    command: ["yarn", "nx", "dev"]
+      target: development
     ports:
       - "2368:2368" # Ghost
       - "4200:4200" # Admin
@@ -21,28 +20,8 @@ services:
       - "7173:7173" # Comments
       - "7174:7174" # Comments HTTPS
     profiles: [full]
-    develop:
-      watch:
-        - action: sync+restart
-          path: ./ghost
-          target: /home/ghost/ghost
-          ignore:
-            - node_modules
-            - .git
-            - .docker
-        - action: sync
-          path: ./apps
-          target: /home/ghost/apps
-          ignore:
-            - node_modules
-            - .git
-            - .docker
-        - action: rebuild
-          path: package.json
-          target: /home/ghost/package.json
-        - action: rebuild
-          path: yarn.lock
-          target: /home/ghost/yarn.lock
+    volumes:
+      - .:/home/ghost
     tty: true
     depends_on:
       mysql:

--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,8 @@ services:
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
-      target: development
+      target: full-devcontainer
+    command: ["yarn", "dev"]
     ports:
       - "2368:2368" # Ghost
       - "4200:4200" # Admin
@@ -20,8 +21,22 @@ services:
       - "7173:7173" # Comments
       - "7174:7174" # Comments HTTPS
     profiles: [full]
-    volumes:
-      - .:/home/ghost
+    develop:
+      watch:
+        - action: sync
+          path: ./ghost
+          target: /home/ghost/ghost
+          ignore:
+            - node_modules
+            - .git
+            - .docker
+        - action: sync
+          path: ./apps
+          target: /home/ghost/apps
+          ignore:
+            - node_modules
+            - .git
+            - .docker
     tty: true
     depends_on:
       mysql:

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: ./.docker/Dockerfile
       target: full-devcontainer
-    command: ["yarn", "dev"]
+    command: ["yarn", "nx", "dev"]
     ports:
       - "2368:2368" # Ghost
       - "4200:4200" # Admin
@@ -23,7 +23,7 @@ services:
     profiles: [full]
     develop:
       watch:
-        - action: sync
+        - action: sync+restart
           path: ./ghost
           target: /home/ghost/ghost
           ignore:
@@ -37,6 +37,12 @@ services:
             - node_modules
             - .git
             - .docker
+        - action: rebuild
+          path: package.json
+          target: /home/ghost/package.json
+        - action: rebuild
+          path: yarn.lock
+          target: /home/ghost/yarn.lock
     tty: true
     depends_on:
       mysql:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reset:data:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm -it ghost",
-    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose up --watch --attach=ghost --no-log-prefix",
+    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose up --attach=ghost --no-log-prefix",
     "docker:build": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose build",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm -it ghost /bin/bash",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm --no-deps ghost yarn test:unit",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reset:data:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm -it ghost",
-    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose up --attach=ghost --no-log-prefix",
+    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose up --watch --attach=ghost --no-log-prefix",
     "docker:build": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose build",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm -it ghost /bin/bash",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-full} docker compose run --rm --no-deps ghost yarn test:unit",
@@ -136,5 +136,62 @@
     "rimraf": "5.0.10",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
+  },
+  "nx": {
+    "targets": {
+      "dev": {
+        "executor": "nx:run-commands",
+        "options": {
+          "commands": [
+            {
+              "description": "Start Ghost",
+              "command": "nx run ghost:dev",
+              "prefix": "[ghost]"
+            },
+            {
+              "description": "Build Ghost Dependencies",
+              "command": "nx watch --projects=ghost --includeDependentProjects -- nx run-many -t build:ts -p \\$NX_PROJECT_NAME --exclude=ghost",
+              "prefix": "[ts]"
+            },
+            {
+              "description": "Build Admin X Dependencies",
+              "command": "nx watch --projects=tag:type:admin-x-app --includeDependentProjects -- nx run-many -t build -p \\$NX_PROJECT_NAME --exclude=tag:type:admin-x-app",
+              "prefix": "[adminX]"
+            },
+            {
+              "description": "Start Admin X",
+              "command": "nx run-many -t dev --projects=tag:type:admin-x-app",
+              "prefix": "[adminX]"
+            },
+            {
+              "description": "Start Portal",
+              "command": "nx run @tryghost/portal:dev",
+              "prefix": "[portal]"
+            },
+            {
+              "description": "Start Announcement Bar",
+              "command": "nx run @tryghost/announcement-bar:dev",
+              "prefix": "[announcement-bar]"
+            },
+            {
+              "description": "Start Signup Form",
+              "command": "nx run @tryghost/signup-form:dev",
+              "prefix": "[signup-form]"
+            },
+            {
+              "description": "Start Comments",
+              "command": "nx run @tryghost/comments-ui:dev",
+              "prefix": "[comments]"
+            },
+            {
+              "description": "Start Search",
+              "command": "nx run @tryghost/sodo-search:dev",
+              "prefix": "[search]"
+            }
+          ],
+          "tty": true
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
WIP

- This is an experiment that uses `nx` to run all the various commands that are run in the `.github/scripts/dev.js` script
- Theoretically this method could accomplish the same thing as the `.github/scripts/dev.js` script but more efficiently (since it will take full advantage of the `nx` cache and graph) and it's (arguably) a bit "cleaner"
- The original motivation for this was to lean more heavily on `nx` for file watching because it seems to be more compatible with docker compose's `--watch` flag than the native `node --watch` or `tsc --watch` are