### PR TITLE
Added metric logging for the `JobQueueManager`

### DIFF
--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -9,7 +9,6 @@ const models = require('../../models');
 const sentry = require('../../../shared/sentry');
 const domainEvents = require('@tryghost/domain-events');
 const config = require('../../../shared/config');
-const prometheusClient = require('../../../shared/prometheus-client');
 const errorHandler = (error, workerMeta) => {
     logging.info(`Capturing error for worker during execution of job: ${workerMeta.name}`);
     logging.error(error);
@@ -44,7 +43,7 @@ const initTestMode = () => {
     }, 5000);
 };
 
-const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, prometheusClient, events});
+const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, events});
 
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -212,9 +212,17 @@ class JobQueueManager {
 
     reportStats() {
         setInterval(() => {
-            this.logger.info('-- job queue stats --');
-            this.logger.info(JSON.stringify(this.pool.stats(), null, 2));
+            this._doReportStats();
         }, this.config.reportInterval);
+    }
+
+    _doReportStats() {
+        const poolStats = this.pool.stats();
+        const stats = {
+            ...poolStats
+        };
+        const statsString = JSON.stringify(stats, null, 2);
+        this.logger.info(statsString);
     }
 
     async shutdown() {

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -222,7 +222,7 @@ class JobQueueManager {
             ...poolStats
         };
         const statsString = JSON.stringify(stats, null, 2);
-        this.logger.info(statsString);
+        this.logger.info(`Job Queue Stats: ${statsString}`);
     }
 
     async shutdown() {

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -231,6 +231,7 @@ class JobQueueManager {
         };
         const statsString = JSON.stringify(stats, null, 2);
         this.logger.info(`Job Queue Stats: ${statsString}`);
+        this.metricLogger.metric('job_manager_queue', stats);
     }
 
     async shutdown() {

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -9,11 +9,8 @@ describe('JobQueueManager', function () {
     let mockLogger;
     let mockMetricLogger;
     let mockWorkerPool;
-    let mockPrometheusClient;
-    let metricIncStub;
     let mockEventEmitter;
     beforeEach(function () {
-        metricIncStub = sinon.stub();
         mockJobModel = {};
         mockConfig = {
             get: sinon.stub().returns({})
@@ -25,14 +22,6 @@ describe('JobQueueManager', function () {
         };
         mockMetricLogger = {
             metric: sinon.stub()
-        };
-        mockPrometheusClient = {
-            getMetric: sinon.stub().returns({
-                set: sinon.stub(),
-                inc: metricIncStub
-            }),
-            registerCounter: sinon.stub(),
-            registerGauge: sinon.stub()
         };
         mockWorkerPool = {
             pool: sinon.stub().returns({
@@ -56,7 +45,6 @@ describe('JobQueueManager', function () {
             logger: mockLogger,
             metricLogger: mockMetricLogger,
             WorkerPool: mockWorkerPool,
-            prometheusClient: mockPrometheusClient,
             eventEmitter: mockEventEmitter
         });
     });
@@ -320,28 +308,14 @@ describe('JobQueueManager', function () {
             expect(jobQueueManager.state.queuedJobs.has('testJob')).to.be.false;
         });
 
-        it('should increment the job_manager_queue_job_completion_count metric', async function () {
-            const job = {id: '1', get: sinon.stub().returns('{"job": "testJob", "data": {}}')};
-            sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
-            await jobQueueManager.executeJob(job, 'testJob', {job: 'testJob', data: {}});
-            expect(metricIncStub.calledOnce).to.be.true;
-        });
-
-        it('should increment the email_analytics_aggregate_member_stats_count metric', async function () {
-            const job = {id: '1', get: sinon.stub().returns('{"job": "update-member-email-analytics", "data": {}}')};
-            sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
-            await jobQueueManager.executeJob(job, 'update-member-email-analytics', {job: 'update-member-email-analytics', data: {}});
-            expect(metricIncStub.calledTwice).to.be.true;
-        });
-
-        it('should increment the metricCache.jobCompletionCount', async function () {
+        it('should increment the metricCache.jobCompletionCount metric', async function () {
             const job = {id: '1', get: sinon.stub().returns('{"job": "testJob", "data": {}}')};
             sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
             await jobQueueManager.executeJob(job, 'testJob', {job: 'testJob', data: {}});
             expect(jobQueueManager.metricCache.jobCompletionCount).to.equal(1);
         });
 
-        it('should increment the metricCache.emailAnalyticsAggregateMemberStatsCount', async function () {
+        it('should increment the metricCache.emailAnalyticsAggregateMemberStatsCount metric', async function () {
             const job = {id: '1', get: sinon.stub().returns('{"job": "update-member-email-analytics", "data": {}}')};
             sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
             await jobQueueManager.executeJob(job, 'update-member-email-analytics', {job: 'update-member-email-analytics', data: {}});

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -7,6 +7,7 @@ describe('JobQueueManager', function () {
     let mockJobModel;
     let mockConfig;
     let mockLogger;
+    let mockMetricLogger;
     let mockWorkerPool;
     let mockPrometheusClient;
     let metricIncStub;
@@ -21,6 +22,9 @@ describe('JobQueueManager', function () {
             debug: sinon.stub(),
             info: sinon.stub(),
             error: sinon.stub()
+        };
+        mockMetricLogger = {
+            metric: sinon.stub()
         };
         mockPrometheusClient = {
             getMetric: sinon.stub().returns({
@@ -50,6 +54,7 @@ describe('JobQueueManager', function () {
             JobModel: mockJobModel,
             config: mockConfig,
             logger: mockLogger,
+            metricLogger: mockMetricLogger,
             WorkerPool: mockWorkerPool,
             prometheusClient: mockPrometheusClient,
             eventEmitter: mockEventEmitter
@@ -415,7 +420,10 @@ describe('JobQueueManager', function () {
                 totalWorkers: 1,
                 busyWorkers: 0,
                 idleWorkers: 1,
-                activeTasks: 0
+                activeTasks: 0,
+                jobCompletionCount: 0,
+                queueDepth: 0,
+                emailAnalyticsAggregateMemberStatsCount: 0
             }, null, 2);
             const expectedLog = `Job Queue Stats: ${expectedStats}`;
             expect(loggerInfoStub.calledOnce).to.be.true;

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -152,6 +152,7 @@ describe('JobQueueManager', function () {
             expect(jobQueueManager.jobsRepository.getQueuedJobs.calledOnce).to.be.true;
             expect(jobQueueManager.updatePollInterval.calledOnceWith(mockJobs)).to.be.true;
             expect(jobQueueManager.processJobs.calledOnceWith(mockJobs)).to.be.true;
+            expect(jobQueueManager.metricCache.queueDepth).to.equal(mockJobs.length);
         });
     });
 
@@ -331,6 +332,20 @@ describe('JobQueueManager', function () {
             sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
             await jobQueueManager.executeJob(job, 'update-member-email-analytics', {job: 'update-member-email-analytics', data: {}});
             expect(metricIncStub.calledTwice).to.be.true;
+        });
+
+        it('should increment the metricCache.jobCompletionCount', async function () {
+            const job = {id: '1', get: sinon.stub().returns('{"job": "testJob", "data": {}}')};
+            sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
+            await jobQueueManager.executeJob(job, 'testJob', {job: 'testJob', data: {}});
+            expect(jobQueueManager.metricCache.jobCompletionCount).to.equal(1);
+        });
+
+        it('should increment the metricCache.emailAnalyticsAggregateMemberStatsCount', async function () {
+            const job = {id: '1', get: sinon.stub().returns('{"job": "update-member-email-analytics", "data": {}}')};
+            sinon.stub(jobQueueManager.jobsRepository, 'delete').resolves();
+            await jobQueueManager.executeJob(job, 'update-member-email-analytics', {job: 'update-member-email-analytics', data: {}});
+            expect(jobQueueManager.metricCache.emailAnalyticsAggregateMemberStatsCount).to.equal(1);
         });
 
         it('should emit events if present in result', async function () {

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -33,7 +33,12 @@ describe('JobQueueManager', function () {
         mockWorkerPool = {
             pool: sinon.stub().returns({
                 exec: sinon.stub(),
-                stats: sinon.stub().returns({}),
+                stats: sinon.stub().returns({
+                    totalWorkers: 1,
+                    busyWorkers: 0,
+                    idleWorkers: 1,
+                    activeTasks: 0
+                }),
                 terminate: sinon.stub()
             })
         };
@@ -377,6 +382,28 @@ describe('JobQueueManager', function () {
                 }
             });
             expect(calledUpdateData.finished_at).to.be.instanceOf(Date);
+        });
+    });
+
+    describe('reportStats', function () {
+        it('should log the stats every reportInterval', async function () {
+            const clock = sinon.useFakeTimers();
+            const reportStatsStub = sinon.stub(jobQueueManager, '_doReportStats');
+            jobQueueManager.config.reportInterval = 1000;
+            jobQueueManager.reportStats();
+            await clock.tickAsync(1000);
+            expect(reportStatsStub.calledOnce).to.be.true;
+            clock.restore();
+        });
+
+        it('should not log the stats if reportStats is false', async function () {
+            const clock = sinon.useFakeTimers();
+            jobQueueManager.config.reportStats = false;
+            const reportStatsStub = sinon.stub(jobQueueManager, '_doReportStats');
+            jobQueueManager.reportStats();
+            await clock.tickAsync(2000);
+            expect(reportStatsStub.called).to.be.false;
+            clock.restore();
         });
     });
 });

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -406,4 +406,20 @@ describe('JobQueueManager', function () {
             clock.restore();
         });
     });
+
+    describe('_doReportStats', function () {
+        it('should log the stats', function () {
+            const loggerInfoStub = sinon.stub(jobQueueManager.logger, 'info');
+            jobQueueManager._doReportStats();
+            const expectedStats = JSON.stringify({
+                totalWorkers: 1,
+                busyWorkers: 0,
+                idleWorkers: 1,
+                activeTasks: 0
+            }, null, 2);
+            const expectedLog = `Job Queue Stats: ${expectedStats}`;
+            expect(loggerInfoStub.calledOnce).to.be.true;
+            expect(loggerInfoStub.calledWith(expectedLog)).to.be.true;
+        });
+    });
 });

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -413,10 +413,10 @@ describe('JobQueueManager', function () {
     });
 
     describe('_doReportStats', function () {
-        it('should log the stats', function () {
+        it('should log the stats using the logger', function () {
             const loggerInfoStub = sinon.stub(jobQueueManager.logger, 'info');
             jobQueueManager._doReportStats();
-            const expectedStats = JSON.stringify({
+            const expectedStats = {
                 totalWorkers: 1,
                 busyWorkers: 0,
                 idleWorkers: 1,
@@ -424,10 +424,27 @@ describe('JobQueueManager', function () {
                 jobCompletionCount: 0,
                 queueDepth: 0,
                 emailAnalyticsAggregateMemberStatsCount: 0
-            }, null, 2);
-            const expectedLog = `Job Queue Stats: ${expectedStats}`;
+            };
+            const expectedLog = `Job Queue Stats: ${JSON.stringify(expectedStats, null, 2)}`;
             expect(loggerInfoStub.calledOnce).to.be.true;
             expect(loggerInfoStub.calledWith(expectedLog)).to.be.true;
+        });
+
+        it('should log the stats using the metricLogger', function () {
+            jobQueueManager._doReportStats();
+            const expectedStats = {
+                totalWorkers: 1,
+                busyWorkers: 0,
+                idleWorkers: 1,
+                activeTasks: 0,
+                jobCompletionCount: 0,
+                queueDepth: 0,
+                emailAnalyticsAggregateMemberStatsCount: 0
+            };
+            expect(mockMetricLogger.metric.calledOnce).to.be.true;
+            const args = mockMetricLogger.metric.args[0];
+            expect(args[0]).to.equal('job_manager_queue');
+            expect(args[1]).to.deep.equal(expectedStats);
         });
     });
 });


### PR DESCRIPTION
refs https://linear.app/ghost/issue/ENG-1987/monitor-email-analytics-via-ghost-logging-in-some-form

- Since we decided not to fully roll out prometheus for metrics collection, we need an alternative method to collect metrics from the `JobQueueManager`
- This commit removes the prometheus-based metrics from the `JobQueueManager` in favor of `@tryghost/metrics`