### PR TITLE
:art: Added classes to tags helper output

### DIFF
--- a/ghost/core/core/frontend/helpers/tags.js
+++ b/ghost/core/core/frontend/helpers/tags.js
@@ -6,10 +6,18 @@
 //
 // Note that the standard {{#each tags}} implementation is unaffected by this helper
 const {urlService} = require('../services/proxy');
-const {SafeString, escapeExpression, templates} = require('../services/handlebars');
-
-const isString = require('lodash/isString');
+const {SafeString, escapeExpression} = require('../services/handlebars');
+const _ = require('lodash');
+const isString = _.isString;
 const ghostHelperUtils = require('@tryghost/helpers').utils;
+
+const tagLink = _.template('<a class="<%= tag_class %>" href="<%= url %>"><%= text %></a>');
+const tagSpan = _.template('<span class="<%= tag_class %>"><%= text %></span>');
+
+const tagClass = 'post-tag';
+const prefixClass = 'post-tag-prefix';
+const sepratorClass = 'post-tag-separator';
+const suffixClass = 'post-tag-suffix';
 
 module.exports = function tags(options) {
     options = options || {};
@@ -17,19 +25,24 @@ module.exports = function tags(options) {
 
     const autolink = !(isString(options.hash.autolink) && options.hash.autolink === 'false');
     const separator = isString(options.hash.separator) ? options.hash.separator : ', ';
-    const prefix = isString(options.hash.prefix) ? options.hash.prefix : '';
-    const suffix = isString(options.hash.suffix) ? options.hash.suffix : '';
     const limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined;
+
     let output = '';
     let from = options.hash.from ? parseInt(options.hash.from, 10) : 1;
     let to = options.hash.to ? parseInt(options.hash.to, 10) : undefined;
+    let prefix = isString(options.hash.prefix) ? options.hash.prefix : '';
+    let suffix = isString(options.hash.suffix) ? options.hash.suffix : '';
 
     function createTagList(tagsList) {
         function processTag(tag) {
-            return autolink ? templates.link({
+            return autolink ? tagLink({
                 url: urlService.getUrlByResourceId(tag.id, {withSubdirectory: true}),
-                text: escapeExpression(tag.name)
-            }) : escapeExpression(tag.name);
+                text: escapeExpression(tag.name),
+                tag_class: tagClass
+            }) : tagSpan({
+                text: escapeExpression(tag.name),
+                tag_class: tagClass
+            });
         }
 
         return ghostHelperUtils.visibility.filter(tagsList, options.hash.visibility, processTag);
@@ -39,10 +52,27 @@ module.exports = function tags(options) {
         output = createTagList(this.tags);
         from -= 1; // From uses 1-indexed, but array uses 0-indexed.
         to = to || limit + from || output.length;
-        output = output.slice(from, to).join(separator);
+        output = output.slice(from, to).join(tagSpan({
+            tag_class: sepratorClass,
+            text: separator
+        }));
     }
 
     if (output) {
+        if (prefix) {
+            prefix = tagSpan({
+                text: prefix,
+                tag_class: prefixClass
+            });
+        }
+
+        if (suffix) {
+            suffix = tagSpan({
+                text: suffix,
+                tag_class: suffixClass
+            });
+        }
+
         output = prefix + output + suffix;
     }
 

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -27,7 +27,10 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('foo, bar');
+        String(rendered).should.equal(
+            '<span class="post-tag">foo</span>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<span class="post-tag">bar</span>');
     });
 
     it('can use a different separator', function () {
@@ -39,7 +42,10 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {separator: '|', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted|ghost');
+        String(rendered).should.equal(
+            '<span class="post-tag">haunted</span>' +
+            '<span class="post-tag-separator">|</span>' +
+            '<span class="post-tag">ghost</span>');
     });
 
     it('can add a single prefix to multiple tags', function () {
@@ -51,7 +57,11 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost');
+        String(rendered).should.equal(
+            '<span class="post-tag-prefix">on </span>' +
+            '<span class="post-tag">haunted</span>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<span class="post-tag">ghost</span>');
     });
 
     it('can add a single suffix to multiple tags', function () {
@@ -63,7 +73,11 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted, ghost forever');
+        String(rendered).should.equal(
+            '<span class="post-tag">haunted</span>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<span class="post-tag">ghost</span>' +
+            '<span class="post-tag-suffix"> forever</span>');
     });
 
     it('can add a prefix and suffix to multiple tags', function () {
@@ -75,7 +89,12 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost forever');
+        String(rendered).should.equal(
+            '<span class="post-tag-prefix">on </span>' +
+            '<span class="post-tag">haunted</span>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<span class="post-tag">ghost</span>' +
+            '<span class="post-tag-suffix"> forever</span>');
     });
 
     it('can add a prefix and suffix with HTML', function () {
@@ -87,7 +106,12 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('&hellip; haunted, ghost &bull;');
+        String(rendered).should.equal(
+            '<span class="post-tag-prefix">&hellip; </span>' +
+            '<span class="post-tag">haunted</span>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<span class="post-tag">ghost</span>' +
+            '<span class="post-tag-suffix"> &bull;</span>');
     });
 
     it('does not add prefix or suffix if no tags exist', function () {
@@ -109,7 +133,10 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 1">foo</a>, <a href="tag url 2">bar</a>');
+        String(rendered).should.equal(
+            '<a class="post-tag" href="tag url 1">foo</a>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<a class="post-tag" href="tag url 2">bar</a>');
     });
 
     it('can limit no. tags output to 1', function () {
@@ -123,7 +150,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 1">foo</a>');
+        String(rendered).should.equal('<a class="post-tag" href="tag url 1">foo</a>');
     });
 
     it('can list tags from a specified no.', function () {
@@ -137,7 +164,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 2">bar</a>');
+        String(rendered).should.equal('<a class="post-tag" href="tag url 2">bar</a>');
     });
 
     it('can list tags to a specified no.', function () {
@@ -151,7 +178,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {to: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url x">foo</a>');
+        String(rendered).should.equal('<a class="post-tag" href="tag url x">foo</a>');
     });
 
     it('can list tags in a range', function () {
@@ -167,7 +194,10 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', to: '3'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
+        String(rendered).should.equal(
+            '<a class="post-tag" href="tag url b">bar</a>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<a class="post-tag" href="tag url c">baz</a>');
     });
 
     it('can limit no. tags and output from 2', function () {
@@ -182,7 +212,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url b">bar</a>');
+        String(rendered).should.equal('<a class="post-tag" href="tag url b">bar</a>');
     });
 
     it('can list tags in a range (ignore limit)', function () {
@@ -199,7 +229,12 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url a">foo</a>, <a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
+        String(rendered).should.equal(
+            '<a class="post-tag" href="tag url a">foo</a>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<a class="post-tag" href="tag url b">bar</a>' +
+            '<span class="post-tag-separator">, </span>' +
+            '<a class="post-tag" href="tag url c">baz</a>');
     });
 
     describe('Internal tags', function () {
@@ -228,10 +263,13 @@ describe('{{tags}} helper', function () {
             const rendered = tagsHelper.call({tags: tags});
 
             String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
+                '<a class="post-tag" href="1">foo</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="3">bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="4">baz</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="5">buzz</a>'
             );
         });
 
@@ -239,8 +277,9 @@ describe('{{tags}} helper', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '2'}});
 
             String(rendered).should.equal(
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>'
+                '<a class="post-tag" href="3">bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="4">baz</a>'
             );
         });
 
@@ -248,11 +287,15 @@ describe('{{tags}} helper', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'all'}});
 
             String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="2">#bar</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
+                '<a class="post-tag" href="1">foo</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="2">#bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="3">bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="4">baz</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="5">buzz</a>'
             );
         });
 
@@ -261,11 +304,15 @@ describe('{{tags}} helper', function () {
             should.exist(rendered);
 
             String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="2">#bar</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
+                '<a class="post-tag" href="1">foo</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="2">#bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="3">bar</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="4">baz</a>' +
+                '<span class="post-tag-separator">, </span>' +
+                '<a class="post-tag" href="5">buzz</a>'
             );
         });
 
@@ -273,7 +320,7 @@ describe('{{tags}} helper', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'internal'}});
             should.exist(rendered);
 
-            String(rendered).should.equal('<a href="2">#bar</a>');
+            String(rendered).should.equal('<a class="post-tag" href="2">#bar</a>');
         });
 
         it('should output nothing if all tags are internal', function () {


### PR DESCRIPTION
no issue

- Far easier to customize the tags helper output when the parts have CSS classes
- Avoids the need to write custom code to customize how tags look - unless you really want to
