### PR TITLE
🐛 Fixed invalid `routes.yaml` filter preventing Ghost from booting

### DIFF
--- a/ghost/core/core/server/services/url/UrlGenerator.js
+++ b/ghost/core/core/server/services/url/UrlGenerator.js
@@ -167,8 +167,20 @@ class UrlGenerator {
         }
 
         // CASE 1: route has no custom filter, it will own the resource for sure
+        let shouldReserve = !this.filter;
+
         // CASE 2: find out if my filter matches the resource
-        if ((!this.filter) || (this.nql.queryJSON(resource.data))) {
+        if (!shouldReserve) {
+            try {
+                shouldReserve = this.nql.queryJSON(resource.data);
+            } catch (err) {
+                debug(`Failed to queryJSON with filter "${this.filter}"`, err);
+
+                return false;
+            }
+        }
+
+        if (shouldReserve) {
             const url = this._generateUrl(resource);
             this.urls.add({
                 url: url,

--- a/ghost/core/test/unit/server/services/url/UrlGenerator.test.js
+++ b/ghost/core/test/unit/server/services/url/UrlGenerator.test.js
@@ -294,6 +294,30 @@ describe('Unit: services/url/UrlGenerator', function () {
                 resource.reserve.called.should.be.false();
                 urlGenerator.nql.queryJSON.called.should.be.false();
             });
+
+            it('filter is malformed', function () {
+                resource.isReserved.returns(false);
+
+                const malformedFilter = 'tag:-foo,-bar';
+
+                const urlGenerator = new UrlGenerator({
+                    router,
+                    filter: malformedFilter,
+                    resourceType: 'posts',
+                    queue,
+                    resources,
+                    urls
+                });
+
+                const queryJSONSpy = sinon.spy(urlGenerator.nql, 'queryJSON');
+
+                // When the filter is malformed, the resource should not be reserved
+                urlGenerator._try(resource).should.be.false();
+
+                // Ensure the above false return is due to the malformed filter
+                queryJSONSpy.should.throw(new RegExp('Query Error: unexpected character in filter'));
+                queryJSONSpy.should.throw(new RegExp(malformedFilter));
+            });
         });
     });
 


### PR DESCRIPTION
refs [ONC-776](https://linear.app/ghost/issue/ONC-776/invalid-routesyaml-nql-filter-can-prevent-ghost-from-booting)

If the `routes.yaml` has a definition containing a malformed filter, i.e:

```yaml
collections:
  /foo/:
    permalink: /foo/
    template: foo
    filter: tags:-foo,-bar
```

(`tags:-foo,-bar` invalid because there should be a property directly after the ',`)

then it is possible for the URL service to fail to start due to an unhandled error being thrown when the filter is parsed during URL generation.

This commit handles the error and returns `false` when the filter cannot be parsed, allowing the URL service to still start