### PR TITLE
🐛 Prevent premature deletion of complimentary subscriptions on SQLite installs.

### DIFF
--- a/ghost/core/core/server/services/members/jobs/clean-expired-comped.js
+++ b/ghost/core/core/server/services/members/jobs/clean-expired-comped.js
@@ -5,7 +5,6 @@ const debug = require('@tryghost/debug')('jobs:clean-expired-comped');
 const moment = require('moment');
 const DatabaseInfo = require('@tryghost/database-info');
 
-
 // recurring job to clean expired complimentary subscriptions
 
 // Exit early when cancelled to prevent stalling shutdown. No cleanup needed when cancelling as everything is idempotent and will pick up


### PR DESCRIPTION
closes #22176

Development installs with SQLite store dates as epoch milliseconds.   MySQL stores ISOStrings.  The clean-expired-comps job, which is supposed to detect complimentary subscriptions that have expired, was erroneously comparing an ISOString to the SQLite field, which was epoch milliseconds.  The result was premature removal of comp subscription that had not yet expired, but only on SQLite sites.

Kudos to Ravn on the Ghost forum for helping to identify the behavior!  (Ref: https://forum.ghost.org/t/bulk-creation-of-comped-users-via-admin-api-expiration-issue-after-approx-15-hours/55244/7 )
