### PR TITLE
Enabled Job Queue by default

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -268,5 +268,19 @@
         "batchSize": 1000,
         "captureLinkClickBadMemberUuid": false
     },
-    "disableJSBackups": false
+    "disableJSBackups": false,
+    "services": {
+        "jobs": {
+            "queue": {
+                "enabled": true,
+                "reportStats": true,
+                "maxWorkers": 1,
+                "logLevel": "info",
+                "pollMinInterval": 1000,
+                "pollMaxInterval": 60000,
+                "queueCapacity": 500,
+                "fetchCount": 500
+            }
+        }
+    }
 }

--- a/ghost/job-manager/lib/JobManager.js
+++ b/ghost/job-manager/lib/JobManager.js
@@ -104,7 +104,7 @@ class JobManager {
     }
 
     #initializeJobQueueManager() {
-        if (this.#config?.get('services:jobs:queue:enabled') === true && !this.#jobQueueManager) {
+        if (this.#config?.get('services:jobs:queue:enabled') === true && !this.#jobQueueManager && this.#JobModel) {
             this.#jobQueueManager = new JobQueueManager({JobModel: this.#JobModel, config: this.#config, eventEmitter: this.#events, metricLogger: metrics});
             this.#jobQueueManager.init();
         }

--- a/ghost/job-manager/lib/JobQueueManager.js
+++ b/ghost/job-manager/lib/JobQueueManager.js
@@ -220,7 +220,7 @@ class JobQueueManager {
             ...this.metricCache
         };
         const statsString = JSON.stringify(stats, null, 2);
-        this.logger.info(`Job Queue Stats: ${statsString}`);
+        this.logger.debug(`Job Queue Stats: ${statsString}`);
         this.metricLogger.metric('job_manager_queue', stats);
     }
 

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -403,7 +403,7 @@ describe('JobQueueManager', function () {
 
     describe('_doReportStats', function () {
         it('should log the stats using the logger', function () {
-            const loggerInfoStub = sinon.stub(jobQueueManager.logger, 'info');
+            const loggerDebugStub = sinon.stub(jobQueueManager.logger, 'debug');
             jobQueueManager._doReportStats();
             const expectedStats = {
                 totalWorkers: 1,
@@ -415,8 +415,8 @@ describe('JobQueueManager', function () {
                 emailAnalyticsAggregateMemberStatsCount: 0
             };
             const expectedLog = `Job Queue Stats: ${JSON.stringify(expectedStats, null, 2)}`;
-            expect(loggerInfoStub.calledOnce).to.be.true;
-            expect(loggerInfoStub.calledWith(expectedLog)).to.be.true;
+            expect(loggerDebugStub.calledOnce).to.be.true;
+            expect(loggerDebugStub.calledWith(expectedLog)).to.be.true;
         });
 
         it('should log the stats using the metricLogger', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2001/enable-the-job-queue-in-defaultsjson-once-its-rolled-out-to-all-of-pro

WIP - raising this PR so we can merge when ready, but currently monitoring the impact of the job queue on the database.