### PR TITLE
Removed `linkClickTracking` config

### DIFF
--- a/ghost/core/core/server/services/link-tracking/index.js
+++ b/ghost/core/core/server/services/link-tracking/index.js
@@ -2,7 +2,6 @@ const LinkClickRepository = require('./LinkClickRepository');
 const PostLinkRepository = require('./PostLinkRepository');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
-const config = require('../../../shared/config');
 
 class LinkTrackingServiceWrapper {
     async init() {
@@ -41,8 +40,7 @@ class LinkTrackingServiceWrapper {
             linkClickRepository: this.linkClickRepository,
             postLinkRepository,
             DomainEvents,
-            urlUtils,
-            config
+            urlUtils
         });
 
         await this.service.init();

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -193,7 +193,6 @@
     "stripeDirect": false,
     "enableStripePromoCodes": false,
     "emailAnalytics": true,
-    "linkClickTracking": true,
     "linkClickTrackingCacheMemberUuid": false,
     "backgroundJobs": {
         "emailAnalytics": true,

--- a/ghost/link-tracking/lib/LinkClickTrackingService.js
+++ b/ghost/link-tracking/lib/LinkClickTrackingService.js
@@ -61,8 +61,6 @@ class LinkClickTrackingService {
     #LinkRedirect;
     /** @type {Object} */
     #urlUtils;
-    /** @type {Object} */
-    #config;
 
     /**
      * @param {object} deps
@@ -71,7 +69,6 @@ class LinkClickTrackingService {
      * @param {IPostLinkRepository} deps.postLinkRepository
      * @param {DomainEvents} deps.DomainEvents
      * @param {urlUtils} deps.urlUtils
-     * @param {config} deps.config
      */
     constructor(deps) {
         this.#linkClickRepository = deps.linkClickRepository;
@@ -79,17 +76,13 @@ class LinkClickTrackingService {
         this.#postLinkRepository = deps.postLinkRepository;
         this.#DomainEvents = deps.DomainEvents;
         this.#urlUtils = deps.urlUtils;
-        this.#config = deps.config;
     }
 
     async init() {
         if (this.#initialised) {
             return;
         }
-
-        if (!this.#config || this.#config.get('linkClickTracking')) {
-            this.subscribe();
-        }
+        this.subscribe();
         this.#initialised = true;
     }
 

--- a/ghost/link-tracking/test/LinkClickTrackingService.test.js
+++ b/ghost/link-tracking/test/LinkClickTrackingService.test.js
@@ -13,10 +13,6 @@ describe('LinkClickTrackingService', function () {
     });
 
     describe('init', function () {
-        afterEach(function () {
-            sinon.restore();
-        });
-
         it('initialises only once', function () {
             const subscribe = sinon.stub();
             const service = new LinkClickTrackingService({
@@ -28,16 +24,6 @@ describe('LinkClickTrackingService', function () {
             assert.ok(subscribe.calledOnce);
             service.init();
             assert.ok(subscribe.calledOnce);
-        });
-
-        it('does not subscribe if linkClickTracking is false', function () {
-            const subscribe = sinon.stub();
-            const service = new LinkClickTrackingService({
-                config: {get: sinon.stub().returns(false)},
-                DomainEvents: {subscribe}
-            });
-            service.init();
-            assert.ok(!subscribe.called);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2002/remove-linkclicktracking-config-in-lieu-of

- This was introduced as a way to disable `linkClickTracking` as a last resort for sites that weren't handling email link redirects well, but since we've introduced a more comprehensive config in `hostSettings:settingsOverrides` that allows us to accomplish the same thing.
- Now this `linkClickTracking` config isn't in use or really doing anything, so this commit cleans it up. 