### PR TITLE
🐛 Fixed subscription attribution not getting set for upgrading members

### DIFF
--- a/ghost/core/core/server/models/subscription-created-event.js
+++ b/ghost/core/core/server/models/subscription-created-event.js
@@ -3,6 +3,7 @@ const ghostBookshelf = require('./base');
 
 const SubscriptionCreatedEvent = ghostBookshelf.Model.extend({
     tableName: 'members_subscription_created_events',
+    hasTimestamps: false, // if true (default), requires an updated_at column and schema changes
 
     member() {
         return this.belongsTo('Member', 'member_id', 'id');

--- a/ghost/core/test/utils/stripe-mocker.js
+++ b/ghost/core/test/utils/stripe-mocker.js
@@ -214,7 +214,7 @@ class StripeMocker {
                         mode: 'subscription',
                         customer: customer.id,
                         metadata: {
-                            checkoutType: 'signup',
+                            checkoutType: 'signup'
                         },
                         subscription: subscription.id
                     }

--- a/ghost/core/test/utils/stripe-mocker.js
+++ b/ghost/core/test/utils/stripe-mocker.js
@@ -214,8 +214,9 @@ class StripeMocker {
                         mode: 'subscription',
                         customer: customer.id,
                         metadata: {
-                            checkoutType: 'signup'
-                        }
+                            checkoutType: 'signup',
+                        },
+                        subscription: subscription.id
                     }
                 }
             });

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -9,6 +9,7 @@ module.exports = {
     MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
     MemberCommentEvent: require('./lib/MemberCommentEvent'),
     SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
+    SubscriptionAttributionEvent: require('./lib/SubscriptionAttributionEvent'),
     SubscriptionActivatedEvent: require('./lib/SubscriptionActivatedEvent'),
     SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent'),
     OfferRedemptionEvent: require('./lib/OfferRedemptionEvent'),

--- a/ghost/member-events/lib/SubscriptionAttributionEvent.js
+++ b/ghost/member-events/lib/SubscriptionAttributionEvent.js
@@ -1,0 +1,26 @@
+/**
+ * Fired when we receive attribution data for a subscription
+ *
+ * @typedef {object} SubscriptionAttributionEventData
+ * @prop {string} subscriptionId
+ * @prop {import('@tryghost/member-attribution/lib/Attribution').Attribution} attribution
+ */
+
+module.exports = class SubscriptionAttributionEvent {
+    /**
+     * @param {SubscriptionAttributionEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {SubscriptionCreatedEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new SubscriptionAttributionEvent(data, timestamp ?? new Date);
+    }
+};

--- a/ghost/member-events/lib/SubscriptionAttributionEvent.js
+++ b/ghost/member-events/lib/SubscriptionAttributionEvent.js
@@ -17,7 +17,7 @@ module.exports = class SubscriptionAttributionEvent {
     }
 
     /**
-     * @param {SubscriptionCreatedEventData} data
+     * @param {SubscriptionAttributionEventData} data
      * @param {Date} [timestamp]
      */
     static create(data, timestamp) {

--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -3,7 +3,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const DomainEvents = require('@tryghost/domain-events');
-const {SubscriptionActivatedEvent, MemberCreatedEvent, SubscriptionCreatedEvent, MemberSubscribeEvent, SubscriptionCancelledEvent, OfferRedemptionEvent} = require('@tryghost/member-events');
+const {SubscriptionActivatedEvent, MemberCreatedEvent, SubscriptionCreatedEvent, SubscriptionAttributionEvent, MemberSubscribeEvent, SubscriptionCancelledEvent, OfferRedemptionEvent} = require('@tryghost/member-events');
 const ObjectId = require('bson-objectid').default;
 const {NotFoundError} = require('@tryghost/errors');
 const validator = require('@tryghost/validator');
@@ -883,6 +883,18 @@ module.exports = class MemberRepository {
         }, options);
 
         return subscription;
+    }
+
+    /**
+     * @param {string} subscriptionId - The stripe subscription id
+     * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} attribution
+     * @returns {Promise<void>}
+     */
+    async updateSubscriptionAttribution(subscriptionId, attribution) {
+        const event = SubscriptionAttributionEvent.create({
+            subscriptionId, attribution
+        });
+        DomainEvents.dispatch(event);
     }
 
     /**

--- a/ghost/members-events-service/lib/EventStorage.js
+++ b/ghost/members-events-service/lib/EventStorage.js
@@ -68,14 +68,14 @@ class EventStorage {
 
             const original = subscriptionCreatedEvent.toJSON();
 
-            await this.models.SubscriptionCreatedEvent.edit({
+            await subscriptionCreatedEvent.save({
                 attribution_id: attribution?.id ?? original.attribution_id,
                 attribution_url: attribution?.url ?? original.attribution_url,
                 attribution_type: attribution?.type ?? original.attribution_type,
                 referrer_source: attribution?.referrerSource ?? original.referrer_source,
                 referrer_medium: attribution?.referrerMedium ?? original.referrer_medium,
-                referrer_url: attribution?.referrerUrl ?? original.referrer_url,
-            }, {id: subscriptionCreatedEvent.id});
+                referrer_url: attribution?.referrerUrl ?? original.referrer_url
+            }, {patch: true});
         });
     }
 }

--- a/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
+++ b/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
@@ -192,7 +192,7 @@ module.exports = class CheckoutSessionEventService {
                     await memberRepository.linkSubscription({
                         id: member.id,
                         subscription,
-                        offerId,
+                        offerId
                     });
                 } catch (err) {
                     if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
@@ -204,7 +204,8 @@ module.exports = class CheckoutSessionEventService {
                 }
             }
 
-            await memberRepository.updateSubscriptionAttribution(session.subscription, attribution);
+            const subscriptionModel = await memberRepository.getSubscriptionByStripeId(session.subscription);
+            await memberRepository.updateSubscriptionAttribution(subscriptionModel.id, attribution);
         }
 
         if (checkoutType !== 'upgrade') {

--- a/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
+++ b/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
@@ -204,7 +204,7 @@ module.exports = class CheckoutSessionEventService {
                 }
             }
 
-            const subscriptionModel = await memberRepository.getSubscriptionByStripeId(session.subscription);
+            const subscriptionModel = await memberRepository.getSubscriptionByStripeID(session.subscription);
             await memberRepository.updateSubscriptionAttribution(subscriptionModel.id, attribution);
         }
 

--- a/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
+++ b/ghost/stripe/lib/services/webhook/CheckoutSessionEventService.js
@@ -193,7 +193,6 @@ module.exports = class CheckoutSessionEventService {
                         id: member.id,
                         subscription,
                         offerId,
-                        attribution
                     });
                 } catch (err) {
                     if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
@@ -204,6 +203,8 @@ module.exports = class CheckoutSessionEventService {
                     });
                 }
             }
+
+            await memberRepository.updateSubscriptionAttribution(session.subscription, attribution);
         }
 
         if (checkoutType !== 'upgrade') {

--- a/ghost/stripe/test/unit/lib/services/webhooks/CheckoutSessionEventService.test.js
+++ b/ghost/stripe/test/unit/lib/services/webhooks/CheckoutSessionEventService.test.js
@@ -19,7 +19,9 @@ describe('CheckoutSessionEventService', function () {
             create: sinon.stub(),
             update: sinon.stub(),
             linkSubscription: sinon.stub(),
-            upsertCustomer: sinon.stub()
+            upsertCustomer: sinon.stub(),
+            getSubscriptionByStripeId: sinon.stub().callsFake(id => ({id})),
+            updateSubscriptionAttribution: sinon.stub().resolves()
         };
 
         donationRepository = {
@@ -634,6 +636,15 @@ describe('CheckoutSessionEventService', function () {
             assert.equal(memberData.email, 'customer@example.com');
             assert.equal(memberData.name, 'Metadata Name');
             assert.equal(memberData.newsletters, undefined);
+        });
+
+        it('should update subscription attribution for an existing member', async function () {
+            api.getCustomer.resolves(customer);
+            memberRepository.get.resolves(member);
+
+            await service.handleSubscriptionEvent(session);
+
+            assert(memberRepository.updateSubscriptionAttribution.calledOnce);
         });
 
         it('should update member if found', async function () {

--- a/ghost/stripe/test/unit/lib/services/webhooks/CheckoutSessionEventService.test.js
+++ b/ghost/stripe/test/unit/lib/services/webhooks/CheckoutSessionEventService.test.js
@@ -20,7 +20,7 @@ describe('CheckoutSessionEventService', function () {
             update: sinon.stub(),
             linkSubscription: sinon.stub(),
             upsertCustomer: sinon.stub(),
-            getSubscriptionByStripeId: sinon.stub().callsFake(id => ({id})),
+            getSubscriptionByStripeID: sinon.stub().callsFake(id => ({id})),
             updateSubscriptionAttribution: sinon.stub().resolves()
         };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1561/

When updating existing members' subscriptions (e.g. free member upgrading to paid), the attribution was not being set on the subscription. This should resolve that by adding a code path to the `checkout.session.completed` to update the already-linked subscription.