### PR TITLE
Moved the rest of the page components to views directory in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/MainContent.tsx
+++ b/apps/admin-x-activitypub/src/MainContent.tsx
@@ -1,7 +1,7 @@
 import Inbox from '@views/Inbox';
-import Notifications from './components/Notifications';
-import Profile from './components/Profile';
-import Search from './components/Search';
+import Notifications from '@views/Notifications';
+import Profile from '@views/Profile';
+import Search from '@views/Search';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const MainContent = () => {

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -5,22 +5,22 @@ import NiceModal from '@ebay/nice-modal-react';
 import {Activity, ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LoadingIndicator, NoValueLabel} from '@tryghost/admin-x-design-system';
 
-import APAvatar from './global/APAvatar';
-import ArticleModal from './feed/ArticleModal';
-import MainNavigation from './navigation/MainNavigation';
-import NotificationItem from './activities/NotificationItem';
-import Separator from './global/Separator';
+import APAvatar from '@components/global/APAvatar';
+import ArticleModal from '@components/feed/ArticleModal';
+import MainNavigation from '@components/navigation/MainNavigation';
+import NotificationItem from '@components/activities/NotificationItem';
+import Separator from '@components/global/Separator';
 
-import getUsername from '../utils/get-username';
-import stripHtml from '../utils/strip-html';
-import truncate from '../utils/truncate';
+import getUsername from '@utils/get-username';
+import stripHtml from '@utils/strip-html';
+import truncate from '@utils/truncate';
 import {
     GET_ACTIVITIES_QUERY_KEY_NOTIFICATIONS,
     useActivitiesForUser,
     useUserDataForUser
-} from '../hooks/useActivityPubQueries';
-import {type NotificationType} from './activities/NotificationIcon';
-import {handleProfileClick} from '../utils/handle-profile-click';
+} from '@hooks/useActivityPubQueries';
+import {type NotificationType} from '@components/activities/NotificationIcon';
+import {handleProfileClick} from '@utils/handle-profile-click';
 
 interface NotificationsProps {}
 

--- a/apps/admin-x-activitypub/src/views/Notifications/index.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/index.tsx
@@ -1,0 +1,1 @@
+export {default} from './Notifications';

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -12,17 +12,17 @@ import {
     useAccountForUser,
     useLikedForUser,
     useOutboxForUser
-} from '../hooks/useActivityPubQueries';
-import {FollowAccount} from '../api/activitypub';
-import {handleViewContent} from '../utils/content-handlers';
+} from '@hooks/useActivityPubQueries';
+import {FollowAccount} from '../../api/activitypub';
+import {handleViewContent} from '@utils/content-handlers';
 
-import APAvatar from './global/APAvatar';
-import ActivityItem from './activities/ActivityItem';
-import FeedItem from './feed/FeedItem';
-import FollowButton from './global/FollowButton';
-import MainNavigation from './navigation/MainNavigation';
-import Separator from './global/Separator';
-import ViewProfileModal from './modals/ViewProfileModal';
+import APAvatar from '@components/global/APAvatar';
+import ActivityItem from '@components/activities/ActivityItem';
+import FeedItem from '@components/feed/FeedItem';
+import FollowButton from '@components/global/FollowButton';
+import MainNavigation from '@components/navigation/MainNavigation';
+import Separator from '@components/global/Separator';
+import ViewProfileModal from '@components/modals/ViewProfileModal';
 
 interface UseInfiniteScrollTabProps<TData> {
     useDataHook: (key: string) => ActivityPubCollectionQueryResult<TData> | AccountFollowsQueryResult;

--- a/apps/admin-x-activitypub/src/views/Profile/index.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/index.tsx
@@ -1,0 +1,1 @@
+export {default} from './Profile';

--- a/apps/admin-x-activitypub/src/views/Search/Search.tsx
+++ b/apps/admin-x-activitypub/src/views/Search/Search.tsx
@@ -5,15 +5,15 @@ import NiceModal from '@ebay/nice-modal-react';
 import {Button, Icon, LoadingIndicator, NoValueLabel, TextField} from '@tryghost/admin-x-design-system';
 import {useDebounce} from 'use-debounce';
 
-import APAvatar from './global/APAvatar';
-import ActivityItem from './activities/ActivityItem';
-import FollowButton from './global/FollowButton';
-import MainNavigation from './navigation/MainNavigation';
-import Separator from './global/Separator';
-import ViewProfileModal from './modals/ViewProfileModal';
+import APAvatar from '@components/global/APAvatar';
+import ActivityItem from '@components/activities/ActivityItem';
+import FollowButton from '@components/global/FollowButton';
+import MainNavigation from '@components/navigation/MainNavigation';
+import Separator from '@components/global/Separator';
+import ViewProfileModal from '@components/modals/ViewProfileModal';
 
-import {type Profile} from '../api/activitypub';
-import {useSearchForUser, useSuggestedProfilesForUser} from '../hooks/useActivityPubQueries';
+import {type Profile} from '../../api/activitypub';
+import {useSearchForUser, useSuggestedProfilesForUser} from '@hooks/useActivityPubQueries';
 
 interface AccountSearchResult {
     id: string;

--- a/apps/admin-x-activitypub/src/views/Search/index.tsx
+++ b/apps/admin-x-activitypub/src/views/Search/index.tsx
@@ -1,0 +1,1 @@
+export {default} from './Search';


### PR DESCRIPTION
ref AP-744

- moved Notifications, Profile, and Search components to views directory as they're all page components
- updated the imports with path aliases