### PR TITLE
Moved NewPostModal component to the Feed page

### DIFF
--- a/apps/admin-x-activitypub/src/views/Feed/components/NewPostModal.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/NewPostModal.tsx
@@ -1,9 +1,9 @@
 import * as FormPrimitive from '@radix-ui/react-form';
-import APAvatar from '../global/APAvatar';
+import APAvatar from '@components/global/APAvatar';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Modal, showToast} from '@tryghost/admin-x-design-system';
-import {useNoteMutationForUser, useUserDataForUser} from '../../hooks/useActivityPubQueries';
+import {useNoteMutationForUser, useUserDataForUser} from '@hooks/useActivityPubQueries';
 import {useState} from 'react';
 
 const NewPostModal = NiceModal.create(() => {

--- a/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
@@ -3,7 +3,7 @@ import ActivityItem from '@components/activities/ActivityItem';
 import ActivityPubWelcomeImage from '@assets/images/ap-welcome.png';
 import FeedItem from '@components/feed/FeedItem';
 import MainNavigation from '@components/navigation/MainNavigation';
-import NewPostModal from '@components/modals/NewPostModal';
+import NewPostModal from '@views/Feed/components/NewPostModal';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
 import Separator from '@components/global/Separator';


### PR DESCRIPTION
ref AP-744

- NewPostModal component is only used in Feed
- For that reason, this should be placed with the Feed component itself in view directory
- Inbox and Feed components are still in a single file at the moment as the separation isn't in the context of file structure updates
- Once componets are separated into smaller ones, Feed directory will be populated with the corresponding files
