### PR TITLE
✨ Added support for Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
     if: needs.job_setup.outputs.changed_any_code == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1', '20.11.1' ]
+        node: [ '18.12.1', '20.11.1', '22.13.1' ]
     name: Unit tests (Node ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4
@@ -473,7 +473,7 @@ jobs:
     if: needs.job_setup.outputs.changed_core == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1', '20.11.1' ]
+        node: [ '18.12.1', '20.11.1', '22.13.1' ]
         env:
           - DB: mysql8
             NODE_ENV: testing-mysql

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:js && yarn lint:hbs"
   },
   "engines": {
-    "node": "^18.12.1 || ^20.11.1"
+    "node": "^18.12.1 || ^20.11.1 || ^22.13.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.23.3",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -53,8 +53,8 @@
     "prepack": "node monobundle.js"
   },
   "engines": {
-    "node": "^18.12.1 || ^20.11.1",
-    "cli": "^1.26.0"
+    "node": "^18.12.1 || ^20.11.1 || ^22.13.1",
+    "cli": "^1.27.0"
   },
   "dependencies": {
     "@extractus/oembed-extractor": "3.2.1",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2013/add-node-22-support-to-ghost

- we're adding support for Node 22 because it's now LTS
- this adds the current latest Node 22 version to the package.json for Ghost + Admin, and adds Node 22 testing to CI