### PR TITLE
Removed use of deprecated email mock util

### DIFF
--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -42,7 +42,7 @@ const matchSettingsArray = (length) => {
 
 describe('Settings API', function () {
     let agent;
-
+    let emailMockReceiver;
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init();
@@ -50,7 +50,7 @@ describe('Settings API', function () {
     });
 
     beforeEach(function () {
-        mockManager.mockMail();
+        emailMockReceiver = mockManager.mockMail();
     });
 
     afterEach(function () {
@@ -195,7 +195,7 @@ describe('Settings API', function () {
                     etag: anyEtag
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('removes image size prefixes when setting the icon', async function () {
@@ -230,7 +230,7 @@ describe('Settings API', function () {
             const afterValue = settingsCache.get('icon');
             assert.equal(afterValue, 'http://127.0.0.1:2369/content/images/2019/07/icon.png');
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('cannot edit uneditable settings', async function () {
@@ -252,7 +252,7 @@ describe('Settings API', function () {
                     const emailVerificationRequired = body.settings.find(setting => setting.key === 'email_verification_required');
                     assert.equal(emailVerificationRequired.value, false);
                 });
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('does not trigger email verification flow if members_support_address remains the same', async function () {
@@ -282,7 +282,7 @@ describe('Settings API', function () {
                     assert.deepEqual(body.meta, {});
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('fails to edit setting with unsupported announcement_visibility value', async function () {
@@ -371,7 +371,7 @@ describe('Settings API', function () {
                     assert.equal(membersSupportAddress.value, 'support@example.com');
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('cannot update invalid keys via token', async function () {
@@ -502,7 +502,7 @@ describe('Settings API', function () {
                     });
                 });
 
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
             mockManager.assert.sentEmail({
                 subject: 'Verify email address',
                 to: 'othersupport@example.com'
@@ -525,7 +525,7 @@ describe('Settings API', function () {
                     'content-version': anyContentVersion
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 
@@ -563,7 +563,7 @@ describe('Settings API', function () {
                     });
                 });
 
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
             mockManager.assert.sentEmail({
                 subject: 'Verify email address',
                 to: 'othersupport@example.com'
@@ -589,7 +589,7 @@ describe('Settings API', function () {
                     'content-version': anyContentVersion
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('editing members_support_address equaling default does not trigger verification flow', async function () {
@@ -608,7 +608,7 @@ describe('Settings API', function () {
                     'content-version': anyContentVersion
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 
@@ -637,7 +637,7 @@ describe('Settings API', function () {
                     'content-version': anyContentVersion
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('editing members_support_address equaling default does not trigger verification flow', async function () {
@@ -656,7 +656,7 @@ describe('Settings API', function () {
                     'content-version': anyContentVersion
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 

--- a/ghost/core/test/e2e-server/services/recommendation-emails.test.js
+++ b/ghost/core/test/e2e-server/services/recommendation-emails.test.js
@@ -143,7 +143,7 @@ describe('Incoming Recommendation Emails', function () {
 
         await DomainEvents.allSettled();
 
-        mockManager.assert.sentEmailCount(0);
+        emailMockReceiver.assertSentEmailCount(0);
     });
 
     it('Does not send an email for an unverified webmention', async function () {
@@ -171,6 +171,6 @@ describe('Incoming Recommendation Emails', function () {
 
         await DomainEvents.allSettled();
 
-        mockManager.assert.sentEmailCount(0);
+        emailMockReceiver.assertSentEmailCount(0);
     });
 });

--- a/ghost/core/test/regression/api/admin/authentication.test.js
+++ b/ghost/core/test/regression/api/admin/authentication.test.js
@@ -536,7 +536,7 @@ describe('Authentication API', function () {
             const sessions = await models.Session.fetchAll();
             assert.equal(sessions.length, 0, 'There should be no sessions left in the DB');
 
-            mockManager.assert.sentEmailCount(2);
+            emailMockReceiver.assertSentEmailCount(2);
 
             mockManager.assert.sentEmail({
                 subject: 'Reset Password',

--- a/ghost/core/test/regression/api/admin/members-importer.test.js
+++ b/ghost/core/test/regression/api/admin/members-importer.test.js
@@ -13,6 +13,7 @@ const {mockManager} = require('../../../utils/e2e-framework');
 const assert = require('assert/strict');
 
 let request;
+let emailMockReceiver;
 
 describe('Members Importer API', function () {
     before(async function () {
@@ -22,7 +23,7 @@ describe('Members Importer API', function () {
     });
 
     beforeEach(function () {
-        mockManager.mockMail();
+        emailMockReceiver = mockManager.mockMail();
     });
 
     afterEach(function () {
@@ -300,7 +301,7 @@ describe('Members Importer API', function () {
         assert(!!settingsCache.get('email_verification_required'), 'Email verification should now be required');
 
         // Don't send another email
-        mockManager.assert.sentEmailCount(0);
+        emailMockReceiver.assertSentEmailCount(0);
     });
 
     it('Can import members with host emailVerification limits for large imports', async function () {

--- a/ghost/core/test/unit/server/services/newsletters/service.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/service.test.js
@@ -25,6 +25,7 @@ describe('NewslettersService', function () {
     let newsletterService, getStub, tokenProvider;
     /** @type {NewslettersService.ILimitService} */
     let limitService;
+    let emailMockReceiver;
 
     before(function () {
         models.init();
@@ -73,7 +74,7 @@ describe('NewslettersService', function () {
         getStub.withArgs('id').returns('test');
         sinon.spy(tokenProvider, 'create');
         sinon.spy(tokenProvider, 'validate');
-        mockManager.mockMail();
+        emailMockReceiver = mockManager.mockMail();
     });
 
     afterEach(function () {
@@ -193,7 +194,7 @@ describe('NewslettersService', function () {
             });
 
             sinon.assert.calledOnceWithExactly(addStub, {name: 'hello world', sort_order: 1}, options);
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
             sinon.assert.calledOnce(fetchMembersStub);
             sinon.assert.calledOnceWithExactly(findOneStub, {id: 'test'}, {opt_in_existing: true, transacting: options.transacting, require: true});
         });
@@ -211,7 +212,7 @@ describe('NewslettersService', function () {
             });
 
             sinon.assert.calledOnceWithExactly(addStub, {name: 'hello world', sort_order: 1}, options);
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
             sinon.assert.calledOnceWithExactly(fetchMembersStub, {transacting: 'foo'});
             sinon.assert.calledOnceWithExactly(subscribeStub, fakeMemberIds, options);
         });

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -9,12 +9,14 @@ const {SubscriptionCancelledEvent, MemberCreatedEvent, SubscriptionActivatedEven
 const {MilestoneCreatedEvent} = require('@tryghost/milestones');
 
 describe('Staff Service:', function () {
+    let emailMockReceiver;
+
     before(function () {
         models.init();
     });
 
     beforeEach(function () {
-        mockManager.mockMail();
+        emailMockReceiver = mockManager.mockMail();
         mockManager.mockSlack();
         mockManager.mockSetting('title', 'The Weekly Roundup');
 
@@ -89,7 +91,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /🥳 Free member signup: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('sends email for api source', async function () {
@@ -105,7 +107,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /🥳 Free member signup: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('does not send email for importer source', async function () {
@@ -117,7 +119,7 @@ describe('Staff Service:', function () {
 
             // Wait for the dispatched events (because this happens async)
             await DomainEvents.allSettled();
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 
@@ -146,7 +148,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /💸 Paid subscription started: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('sends email for api source', async function () {
@@ -162,7 +164,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /💸 Paid subscription started: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('does not send email for importer source', async function () {
@@ -174,7 +176,7 @@ describe('Staff Service:', function () {
 
             // Wait for the dispatched events (because this happens async)
             await DomainEvents.allSettled();
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 
@@ -198,7 +200,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /⚠️ Cancellation: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('sends email for api source', async function () {
@@ -214,7 +216,7 @@ describe('Staff Service:', function () {
                 to: 'owner@ghost.org',
                 subject: /⚠️ Cancellation: Jamie/
             });
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('does not send email for importer source', async function () {
@@ -226,7 +228,7 @@ describe('Staff Service:', function () {
 
             // Wait for the dispatched events (because this happens async)
             await DomainEvents.allSettled();
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 
@@ -249,7 +251,7 @@ describe('Staff Service:', function () {
             // Wait for the dispatched events (because this happens async)
             await DomainEvents.allSettled();
 
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
 
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
@@ -291,7 +293,7 @@ describe('Staff Service:', function () {
             // Wait for the dispatched events (because this happens async)
             await DomainEvents.allSettled();
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 });

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -164,20 +164,6 @@ const mockWebhookRequests = () => {
     return mocks.webhookMockReceiver;
 };
 
-/**
- * @deprecated use emailMockReceiver.assertSentEmailCount(count) instead
- * @param {Number} count number of emails sent
- */
-const sentEmailCount = (count) => {
-    if (!mocks.mail) {
-        throw new errors.IncorrectUsageError({
-            message: 'Cannot assert on mail when mail has not been mocked'
-        });
-    }
-
-    mocks.mockMailReceiver.assertSentEmailCount(count);
-};
-
 const sentEmail = (matchers) => {
     if (!mocks.mail) {
         throw new errors.IncorrectUsageError({
@@ -334,7 +320,6 @@ module.exports = {
     restore,
     stripeMocker,
     assert: {
-        sentEmailCount,
         sentEmail,
         emittedEvent
     },


### PR DESCRIPTION
- this util has been deprecated for a while so this commit cleans up all uses of it and replaces it with the `emailMockReceiver` assertion function