### PR TITLE
Updated CTA card bg and link styles

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/cta.css
+++ b/ghost/core/core/frontend/src/cards/css/cta.css
@@ -34,6 +34,14 @@
     background: rgba(209, 46, 46, 0.11);
 }
 
+.kg-cta-bg-pink {
+    background: rgba(225, 71, 174, 0.11);
+}
+
+.kg-cta-bg-purple {
+    background: rgba(135, 85, 236, 0.12);
+}
+
 .kg-cta-sponsor-label {
     margin: 0 2.4rem;
     padding: 1.2rem 0;
@@ -47,6 +55,10 @@
 
 .kg-cta-bg-none .kg-cta-sponsor-label {
     margin: 0;
+}
+
+.kg-cta-sponsor-label a {
+    color: rgba(0, 0, 0);
 }
 
 .kg-cta-content {
@@ -103,6 +115,10 @@
 
 .kg-cta-text p + p {
     margin-top: 2rem;
+}
+
+.kg-cta-text a {
+    color: currentColor;
 }
 
 a.kg-cta-button {

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -941,6 +941,14 @@ a[data-flickr-embed] img {
     background: #FBE9E9;
 }
 
+.kg-cta-bg-pink {
+    background: #FCEEF8;
+}
+
+.kg-cta-bg-purple {
+    background: #F2EDFC;
+}
+
 .kg-cta-sponsor-label {
     padding: 12px 0;
     border-bottom: 1px solid #dddedf;
@@ -953,6 +961,10 @@ a[data-flickr-embed] img {
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
+}
+
+.kg-cta-sponsor-label a {
+    color: rgba(0, 0, 0);
 }
 
 table.kg-cta-content-wrapper {
@@ -984,6 +996,10 @@ img.kg-cta-image {
 
 .post-content .kg-cta-text {
     font-family: Georgia, serif;
+}
+
+.kg-cta-text a {
+    color: currentColor;
 }
 
 .post-content-sans-serif .kg-cta-text {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-355/improve-cta-card-settings-panel
- Added pink and purple as background colors to the CTA card.
- Changed CTA card link styles to currentColor instead of accent color – both for the label and the body text.