### PR TITLE
Added attribution to subscription metadata

### DIFF
--- a/ghost/members-api/lib/repositories/MemberRepository.js
+++ b/ghost/members-api/lib/repositories/MemberRepository.js
@@ -1177,13 +1177,22 @@ module.exports = class MemberRepository {
             const context = options?.context || {};
             const source = this._resolveContextSource(context);
 
+            const attribution = {
+                id: data.attribution?.id ?? subscription.metadata?.attribution_id ?? null,
+                url: data.attribution?.url ?? subscription.metadata?.attribution_url ?? null,
+                type: data.attribution?.type ?? subscription.metadata?.attribution_type ?? null,
+                referrerSource: data.attribution?.referrerSource ?? subscription.metadata?.referrer_source ?? null,
+                referrerMedium: data.attribution?.referrerMedium ?? subscription.metadata?.referrer_medium ?? null,
+                referrerUrl: data.attribution?.referrerUrl ?? subscription.metadata?.referrer_url ?? null
+            };
+
             const subscriptionCreatedEvent = SubscriptionCreatedEvent.create({
                 source,
                 tierId: ghostProduct?.get('id'),
                 memberId: member.id,
                 subscriptionId: subscriptionModel.get('id'),
                 offerId: offerId,
-                attribution: data.attribution,
+                attribution: attribution,
                 batchId: options.batch_id
             });
 

--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -456,7 +456,15 @@ module.exports = class StripeAPI {
             trial_from_plan: true,
             items: [{
                 plan: priceId
-            }]
+            }],
+            metadata: {
+                attribution_id: metadata.attribution_id || null,
+                attribution_url: metadata.attribution_url || null,
+                attribution_type: metadata.attribution_type || null,
+                referrer_source: metadata.referrer_source || null,
+                referrer_medium: metadata.referrer_medium || null,
+                referrer_url: metadata.referrer_url || null
+            }
         };
 
         /**


### PR DESCRIPTION
🚧

This PR does two things:
1. When creating the checkout session, it [adds the attribution data to the _subscription's_ metadata](https://github.com/TryGhost/Ghost/pull/22213/files#diff-68107e2f31cf6c5654724cc9e00bd7a92f2ba6da86c25265e03c05528f1d3273R460-R467) (in addition to the session's metadata as it already does)
2. In `linkSubscription` when creating the `SubscriptionCreatedEvent`, it will [look for the attribution data in the subscription's metadata](https://github.com/TryGhost/Ghost/pull/22213/files#diff-597e2ed47ae1eb6311168a990e291022df08253ba9b8cec9638357535c0953e8R1180-R1187). 

This way, regardless of the order of events, the attribution data should always be available, and therefore it should always get added to the `SubscriptionCreatedEvent`.