### PR TITLE
Fixed NaN values when logging metrics to stdout

### DIFF
--- a/ghost/activitypub/package.json
+++ b/ghost/activitypub/package.json
@@ -23,7 +23,7 @@
   ],
   "devDependencies": {
     "@tryghost/identity-token-service": "0.0.0",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "c8": "10.1.2",
     "knex": "3.1.0",
     "mocha": "10.8.2",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -114,7 +114,7 @@
     "@tryghost/link-redirects": "0.0.0",
     "@tryghost/link-replacer": "0.0.0",
     "@tryghost/link-tracking": "0.0.0",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/magic-link": "0.0.0",
     "@tryghost/mail-events": "0.0.0",
     "@tryghost/mailgun-client": "0.0.0",
@@ -128,7 +128,7 @@
     "@tryghost/members-ssr": "0.0.0",
     "@tryghost/members-stripe-service": "0.0.0",
     "@tryghost/mentions-email-report": "0.0.0",
-    "@tryghost/metrics": "1.0.34",
+    "@tryghost/metrics": "1.0.37",
     "@tryghost/milestones": "0.0.0",
     "@tryghost/minifier": "0.0.0",
     "@tryghost/mw-api-version-mismatch": "0.0.0",
@@ -259,7 +259,7 @@
   },
   "resolutions": {
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "jackspeak": "2.1.1",
     "moment": "2.24.0",
     "moment-timezone": "0.5.45"

--- a/ghost/domain-events/package.json
+++ b/ghost/domain-events/package.json
@@ -19,7 +19,7 @@
     "lib"
   ],
   "devDependencies": {
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "c8": "8.0.1",
     "mocha": "10.2.0",
     "should": "13.2.3"

--- a/ghost/email-service/package.json
+++ b/ghost/email-service/package.json
@@ -30,7 +30,7 @@
     "@tryghost/errors": "1.3.5",
     "@tryghost/html-to-plaintext": "0.0.0",
     "@tryghost/kg-default-cards": "10.1.0",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/tpl": "0.1.32",
     "@tryghost/validator": "0.2.14",
     "bson-objectid": "2.0.4",

--- a/ghost/job-manager/package.json
+++ b/ghost/job-manager/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@breejs/later": "4.2.0",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "bree": "6.5.0",
     "cron-validate": "1.4.5",
     "fastq": "1.19.0",

--- a/ghost/mailgun-client/package.json
+++ b/ghost/mailgun-client/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@tryghost/debug": "0.1.32",
-    "@tryghost/logging": "2.4.20",
-    "@tryghost/metrics": "1.0.34",
+    "@tryghost/logging": "2.4.21",
+    "@tryghost/metrics": "1.0.37",
     "form-data": "4.0.0",
     "lodash": "4.17.21",
     "mailgun.js": "10.4.0"

--- a/ghost/members-api/package.json
+++ b/ghost/members-api/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@tryghost/domain-events": "0.0.0",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/magic-link": "0.0.0",
     "@tryghost/member-events": "0.0.0",
     "@tryghost/members-payments": "0.0.0",

--- a/ghost/members-events-service/package.json
+++ b/ghost/members-events-service/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@tryghost/domain-events": "0.0.0",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/member-events": "0.0.0",
     "moment-timezone": "0.5.34"
   }

--- a/ghost/members-importer/package.json
+++ b/ghost/members-importer/package.json
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/members-csv": "0.0.0",
-    "@tryghost/metrics": "1.0.34",
+    "@tryghost/metrics": "1.0.37",
     "@tryghost/tpl": "0.1.32",
     "moment-timezone": "0.5.45"
   }

--- a/ghost/oembed-service/package.json
+++ b/ghost/oembed-service/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@extractus/oembed-extractor": "3.2.1",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/tpl": "0.1.32",
     "charset": "1.0.1",
     "cheerio": "0.22.0",

--- a/ghost/prometheus-metrics/package.json
+++ b/ghost/prometheus-metrics/package.json
@@ -34,7 +34,7 @@
     "typescript": "5.6.2"
   },
   "dependencies": {
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "express": "4.21.2",
     "prom-client": "15.1.3",
     "stoppable": "1.1.0"

--- a/ghost/stripe/package.json
+++ b/ghost/stripe/package.json
@@ -28,7 +28,7 @@
     "@tryghost/debug": "0.1.32",
     "@tryghost/domain-events": "0.0.0",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/member-events": "0.0.0",
     "leaky-bucket": "2.2.0",
     "lodash": "4.17.21",

--- a/ghost/update-check-service/package.json
+++ b/ghost/update-check-service/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@tryghost/debug": "0.1.32",
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "@tryghost/tpl": "0.1.32",
     "lodash": "4.17.21",
     "moment": "2.24.0"

--- a/ghost/webmentions/package.json
+++ b/ghost/webmentions/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "cheerio": "0.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "resolutions": {
     "@tryghost/errors": "1.3.5",
-    "@tryghost/logging": "2.4.20",
+    "@tryghost/logging": "2.4.21",
     "jackspeak": "2.1.1",
     "moment": "2.24.0",
     "moment-timezone": "0.5.45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7642,7 +7642,7 @@
     "@tryghost/root-utils" "^0.3.32"
     debug "^4.3.1"
 
-"@tryghost/elasticsearch@^3.0.21", "@tryghost/elasticsearch@^3.0.23":
+"@tryghost/elasticsearch@^3.0.23":
   version "3.0.23"
   resolved "https://registry.yarnpkg.com/@tryghost/elasticsearch/-/elasticsearch-3.0.23.tgz#45563fdaa8969cd153bacae7b8538b45681d467c"
   integrity sha512-6j5plnUmdPtOqX8FpwEf5jDWx2MeojvOXhCLViD5DxiOFtG0PSQENNBFpKywHuiabNFTc7rcHkX4PUhOYimBWg==
@@ -7895,15 +7895,15 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/logging@2.4.18", "@tryghost/logging@2.4.19", "@tryghost/logging@2.4.20", "@tryghost/logging@^2.4.7":
-  version "2.4.20"
-  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.20.tgz#251cff0911014829816d865667104fcd4ac25b7f"
-  integrity sha512-7fpg8xuJHrgAgGhtJjY9nH5vAj8RY2SvcPLkOvD/7leou47ZdSu15l+bUBNFAsx9mAI7AdozDRCAv3WuTkV7cw==
+"@tryghost/logging@2.4.18", "@tryghost/logging@2.4.19", "@tryghost/logging@2.4.21", "@tryghost/logging@^2.4.7":
+  version "2.4.21"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.21.tgz#3fd922c19fe8ea0950d83554a8c68ff338700e13"
+  integrity sha512-9Yzkzl1k81b0kEAWUfR3Lc8RQtWrX7SYGy/b3brUthhsigjacCENo7tMGOhMIG/ZKVDbtwa39T7Rnvk5qR6Asg==
   dependencies:
     "@tryghost/bunyan-rotating-filestream" "^0.0.7"
     "@tryghost/elasticsearch" "^3.0.23"
     "@tryghost/http-stream" "^0.1.35"
-    "@tryghost/pretty-stream" "^0.1.28"
+    "@tryghost/pretty-stream" "^0.1.29"
     "@tryghost/root-utils" "^0.3.32"
     bunyan "^1.8.15"
     bunyan-loggly "^1.4.2"
@@ -7912,14 +7912,14 @@
     json-stringify-safe "^5.0.1"
     lodash "^4.17.21"
 
-"@tryghost/metrics@1.0.34":
-  version "1.0.34"
-  resolved "https://registry.npmjs.org/@tryghost/metrics/-/metrics-1.0.34.tgz#b223b21a61e4e116904872c3860e7e1d1bb1f481"
-  integrity sha512-e45Chvl7RRjzX0MfuEYJrlpVZF1Eh4hjkSxtfzhFitP8zk+43K8sxTJRMUPoOk6HfMN4ac3T+46TFgSk4KMpiA==
+"@tryghost/metrics@1.0.37":
+  version "1.0.37"
+  resolved "https://registry.yarnpkg.com/@tryghost/metrics/-/metrics-1.0.37.tgz#a7e0a998ade991d21c76a57341469080d09897cf"
+  integrity sha512-nxi3WMvjlDtneOirtvN9Prf5aekxJfVhvERcr76XKHsRJi9i9A77WGvR5DlJQe6r73FcIOu8k8kDtZ//3BGpFQ==
   dependencies:
-    "@tryghost/elasticsearch" "^3.0.21"
-    "@tryghost/pretty-stream" "^0.1.26"
-    "@tryghost/root-utils" "^0.3.30"
+    "@tryghost/elasticsearch" "^3.0.23"
+    "@tryghost/pretty-stream" "^0.1.29"
+    "@tryghost/root-utils" "^0.3.32"
     json-stringify-safe "^5.0.1"
 
 "@tryghost/mobiledoc-kit@^0.12.4-ghost.1":
@@ -7992,10 +7992,10 @@
     chalk "^4.1.0"
     sywac "^1.3.0"
 
-"@tryghost/pretty-stream@^0.1.26", "@tryghost/pretty-stream@^0.1.28":
-  version "0.1.28"
-  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.28.tgz#2cff88b3a6cb6f1c1b7dd08c27fb9f6351da487e"
-  integrity sha512-iA3Jxw4ltiHKPBZMnvYN3TP26O2RdQBH051BNY+qrSJjx8DhLVverjXlwCC3fxfOTTiPDtx1aMMLlW4RkACtlQ==
+"@tryghost/pretty-stream@^0.1.29":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.29.tgz#e0bbab7333a6cac38fdfa19d3da86aeaaded7f02"
+  integrity sha512-HByPoCd5R63bRg34wZ4D7bfCeBsLTP3gLCi5xVsOnETxB4GiHHo31/vm+kI8pZd7mnWMre3nnDdVR0Sf72U0eQ==
   dependencies:
     date-format "^4.0.14"
     lodash "^4.17.21"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2022/fix-nan-timestamps-in-stdout-logging

- there was a bug in @tryghost/pretty-stream, which was fixed and so this commit bumps all the relevant packages to ensure we get the fix here