### PR TITLE
Switched `prepareContentFolder` in legacy E2E utils to async-await

### DIFF
--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -132,7 +132,7 @@ const prepareContentFolder = async ({contentFolder, redirectsFile = true, routes
     );
 
     if (redirectsFile) {
-        redirectsUtils.setupFile(contentFolderForTests, '.yaml');
+        await redirectsUtils.setupFile(contentFolderForTests, '.yaml');
     }
 
     if (routesFile) {

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -57,7 +57,7 @@ const exposeFixtures = async () => {
         });
 };
 
-const prepareContentFolder = (options) => {
+const prepareContentFolder = async (options) => {
     const contentFolderForTests = options.contentFolder;
 
     /**
@@ -66,36 +66,36 @@ const prepareContentFolder = (options) => {
      */
     configUtils.set('paths:contentPath', contentFolderForTests);
 
-    fs.ensureDirSync(contentFolderForTests);
-    fs.ensureDirSync(path.join(contentFolderForTests, 'data'));
-    fs.ensureDirSync(path.join(contentFolderForTests, 'themes'));
-    fs.ensureDirSync(path.join(contentFolderForTests, 'images'));
-    fs.ensureDirSync(path.join(contentFolderForTests, 'logs'));
-    fs.ensureDirSync(path.join(contentFolderForTests, 'adapters'));
-    fs.ensureDirSync(path.join(contentFolderForTests, 'settings'));
+    await fs.ensureDir(contentFolderForTests);
+    await fs.ensureDir(path.join(contentFolderForTests, 'data'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'themes'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'images'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'logs'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'adapters'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'settings'));
 
     if (options.copyThemes) {
         // Copy all themes into the new test content folder. Default active theme is always source. If you want to use a different theme, you have to set the active theme (e.g. stub)
-        fs.copySync(path.join(__dirname, 'fixtures', 'themes'), path.join(contentFolderForTests, 'themes'));
+        await fs.copy(path.join(__dirname, 'fixtures', 'themes'), path.join(contentFolderForTests, 'themes'));
     }
 
     // Copy theme even if frontend is disabled, as admin can use source when viewing themes section
-    fs.copySync(path.join(__dirname, 'fixtures', 'themes', 'source'), path.join(contentFolderForTests, 'themes', 'source'));
+    await fs.copy(path.join(__dirname, 'fixtures', 'themes', 'source'), path.join(contentFolderForTests, 'themes', 'source'));
 
     if (options.redirectsFile) {
-        redirects.setupFile(contentFolderForTests, options.redirectsFileExt);
+        await redirects.setupFile(contentFolderForTests, options.redirectsFileExt);
     }
 
     if (options.routesFilePath) {
-        fs.copySync(options.routesFilePath, path.join(contentFolderForTests, 'settings', 'routes.yaml'));
+        await fs.copy(options.routesFilePath, path.join(contentFolderForTests, 'settings', 'routes.yaml'));
     } else if (options.copySettings) {
-        fs.copySync(path.join(__dirname, 'fixtures', 'settings', 'routes.yaml'), path.join(contentFolderForTests, 'settings', 'routes.yaml'));
+        await fs.copy(path.join(__dirname, 'fixtures', 'settings', 'routes.yaml'), path.join(contentFolderForTests, 'settings', 'routes.yaml'));
     }
 
     // Used by newsletter fixtures
-    fs.ensureDirSync(path.join(contentFolderForTests, 'images', '2022', '05'));
+    await fs.ensureDir(path.join(contentFolderForTests, 'images', '2022', '05'));
     const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
-    fs.writeFileSync(path.join(contentFolderForTests, 'images', '2022', '05', 'test.jpg'), GIF1x1);
+    await fs.writeFile(path.join(contentFolderForTests, 'images', '2022', '05', 'test.jpg'), GIF1x1);
 };
 
 // CASE: Ghost Server is Running
@@ -218,7 +218,7 @@ const startGhost = async (options) => {
     }, options);
 
     // @TODO: tidy up the tmp folders after tests
-    prepareContentFolder(options);
+    await prepareContentFolder(options);
 
     if (ghostServer && ghostServer.httpServer && !options.forceStart) {
         await restartModeGhostStart(options);

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -15,7 +15,6 @@ const e2eUtils = require('./e2e-utils');
 const APIUtils = require('./api');
 const dbUtils = require('./db-utils');
 const fixtureUtils = require('./fixture-utils');
-const redirects = require('./redirects');
 const cacheRules = require('./fixtures/cache-rules');
 const context = require('./fixtures/context');
 const DataGenerator = require('./fixtures/data-generator');
@@ -136,7 +135,6 @@ module.exports = {
 
     initFixtures: initFixtures,
     initData: dbUtils.initData,
-    setupRedirectsFile: redirects.setupFile,
 
     fixtures: fixtureUtils.fixtures,
 

--- a/ghost/core/test/utils/redirects.js
+++ b/ghost/core/test/utils/redirects.js
@@ -4,7 +4,7 @@ const path = require('path');
 /**
 * Set up the redirects file with the extension you want.
 */
-module.exports.setupFile = (contentFolderForTests, ext) => {
+module.exports.setupFile = async (contentFolderForTests, ext) => {
     const yamlPath = path.join(contentFolderForTests, 'data', 'redirects.yaml');
     const jsonPath = path.join(contentFolderForTests, 'data', 'redirects.json');
 
@@ -12,14 +12,14 @@ module.exports.setupFile = (contentFolderForTests, ext) => {
         if (fs.existsSync(yamlPath)) {
             fs.removeSync(yamlPath);
         }
-        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), jsonPath);
+        await fs.copy(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), jsonPath);
     }
 
     if (ext === '.yaml') {
         if (fs.existsSync(jsonPath)) {
             fs.removeSync(jsonPath);
         }
-        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.yaml'), yamlPath);
+        await fs.copy(path.join(__dirname, 'fixtures', 'data', 'redirects.yaml'), yamlPath);
     }
 
     if (ext === null) {


### PR DESCRIPTION
- this is slightly faster than the sync methods and brings it inline with that we have in the E2E framework, so it'll be easier to switch down the line