### PR TITLE
Removed git submodule update from Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -152,9 +152,6 @@ RUN yarn install --frozen-lockfile --prefer-offline
 ## Copy the rest of the code
 COPY . .
 
-## Initialize submodules
-RUN git submodule update --init --recursive
-
 ## Build typescript packages
 RUN yarn nx run-many -t build:ts
 


### PR DESCRIPTION
no issue

- Doing the submodule update doesn't work if you cloned Ghost via ssh, because the Docker container doesn't have access to your ssh keys.