### PR TITLE
Removed knex-migrator init from Docker entrypoint

### DIFF
--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -3,8 +3,5 @@
 # Adjust local configuration
 node /home/ghost/.github/scripts/setup-docker.js
 
-# Run migrations
-yarn knex-migrator init
-
 # Execute the CMD
 exec "$@"


### PR DESCRIPTION
no issue

- This fails when running the Ghost container alone (i.e. for unit tests) since there is no database available.
- The database will be initialized when running `yarn dev` for the first time anyhow, so this isn't really necessary here.
