### PR TITLE
Added force recreate option to `yarn docker:dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "reset:data:empty": "cd ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123",
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost",
-    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --no-log-prefix",
+    "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
     "docker:build": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose build",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm --no-deps ghost yarn test:unit",


### PR DESCRIPTION
no issue

- There is still some flaky behavior with the docker setup that seems to be caused by the container not shutting down or cleaning up properly. Sometimes `yarn dev` just hangs, or sometimes it only runs some of the commands required. This seems to only happen when running `docker compose up` after having previously run it and stopped it.
- Passing the `--force-recreate` option to docker compose recreates all the containers, which seems to avoid this problem without incurring a noticeable performance penalty.