### PR TITLE
Configured ssh agent forwarding for docker compose

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -37,6 +37,11 @@ FROM development-base AS development
 ARG WORKDIR=/home/ghost
 WORKDIR $WORKDIR
 
+## Add github to known hosts
+### Without this, git submodule updates fail inside the container
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts
+
 # Enable the NX Daemon
 ENV NX_DAEMON=true
 

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# Update git submodules
-git submodule update --init --recursive
-
 # Execute the CMD
 exec "$@"

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# Update git submodules
+git submodule update --init --recursive
+
 # Execute the CMD
 exec "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,12 @@ services:
     volumes:
       # Mount the source code
       - .:/home/ghost
+
+      ## SSH Agent forwarding
       - ${SSH_AUTH_SOCK}:/ssh-agent
+
+      ## Git config
+      - ${HOME}/.gitconfig:/root/.gitconfig:ro
 
       # Volume exclusions:
       ## Prevent collisions between host and container node_modules

--- a/compose.yml
+++ b/compose.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       # Mount the source code
       - .:/home/ghost
+      - ${SSH_AUTH_SOCK}:/ssh-agent
 
       # Volume exclusions:
       ## Prevent collisions between host and container node_modules
@@ -131,6 +132,7 @@ services:
         condition: service_healthy
     environment:
       - DEBUG=${DEBUG:-}
+      - SSH_AUTH_SOCK=/ssh-agent
       - GHOST_DEV_IS_DOCKER=true
       - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}


### PR DESCRIPTION
no issue

- Currently running any `git` commands in the docker container (i.e. updating submodules) that use ssh are failing because the container can't see your ssh keys. This commit adds a volume & environment variable to enable forwarding your local ssh agent into the container. As long as you've got an ssh agent running locally with your keys enabled, this will allow you to e.g. push to a remote over ssh from inside the container.
- It also mounts your local `.gitconfig` file into the container, so your git configuration (i.e. name & email address) will also work inside the container
- Finally, it adds githubs ssh keys to known_hosts in the development target of the Dockerfile to avoid the prompt, which only works in interactive environments and fails in any kind of script (like `yarn main:submodules`).