### PR TITLE
Ensured only one XMLRPC handler is listening

### DIFF
--- a/ghost/core/core/server/services/stripe/service.js
+++ b/ghost/core/core/server/services/stripe/service.js
@@ -63,15 +63,20 @@ module.exports = new StripeService({
     staffService
 });
 
+function stripeSettingsChanged(model) {
+    if (['stripe_publishable_key', 'stripe_secret_key', 'stripe_connect_publishable_key', 'stripe_connect_secret_key'].includes(model.get('key'))) {
+        debouncedConfigureApi();
+    }
+}
+
 module.exports.init = async function init() {
     try {
         await configureApi();
     } catch (err) {
         logging.error(err);
     }
-    events.on('settings.edited', function (model) {
-        if (['stripe_publishable_key', 'stripe_secret_key', 'stripe_connect_publishable_key', 'stripe_connect_secret_key'].includes(model.get('key'))) {
-            debouncedConfigureApi();
-        }
-    });
+
+    events
+        .removeListener('settings.edited', stripeSettingsChanged)
+        .on('settings.edited', stripeSettingsChanged);
 };

--- a/ghost/core/core/server/services/xmlrpc.js
+++ b/ghost/core/core/server/services/xmlrpc.js
@@ -113,7 +113,7 @@ function ping(post) {
     });
 }
 
-function listener(model, options) {
+function xmlrpcListener(model, options) {
     // CASE: do not rpc ping if we import a database
     // TODO: refactor post.published events to never fire on importing
     if (options && options.importing) {
@@ -124,7 +124,9 @@ function listener(model, options) {
 }
 
 function listen() {
-    events.on('post.published', listener);
+    events
+        .removeListener('post.published', xmlrpcListener)
+        .on('post.published', xmlrpcListener);
 }
 
 module.exports = {

--- a/ghost/core/test/unit/server/services/xmlrpc.test.js
+++ b/ghost/core/test/unit/server/services/xmlrpc.test.js
@@ -26,7 +26,7 @@ describe('XMLRPC', function () {
     it('listen() should initialise event correctly', function () {
         xmlrpc.listen();
         eventStub.calledOnce.should.be.true();
-        eventStub.calledWith('post.published', xmlrpc.__get__('listener')).should.be.true();
+        eventStub.calledWith('post.published', xmlrpc.__get__('xmlrpcListener')).should.be.true();
     });
 
     it('listener() calls ping() with toJSONified model', function () {
@@ -40,7 +40,7 @@ describe('XMLRPC', function () {
 
         const pingStub = sinon.stub();
         const resetXmlRpc = xmlrpc.__set__('ping', pingStub);
-        const listener = xmlrpc.__get__('listener');
+        const listener = xmlrpc.__get__('xmlrpcListener');
 
         listener(testModel);
 
@@ -62,7 +62,7 @@ describe('XMLRPC', function () {
 
         const pingStub = sinon.stub();
         const resetXmlRpc = xmlrpc.__set__('ping', pingStub);
-        const listener = xmlrpc.__get__('listener');
+        const listener = xmlrpc.__get__('xmlrpcListener');
 
         listener(testModel, {importing: true});
 


### PR DESCRIPTION
- due to our testing framework, we run the boot over and over, but this means we constantly add new xmlrpc listeners
- from profiling, this accounts for ~3% of the total test time, which is minimal, but given it's an easy fix, this commit performs that
- ideally our test framework would reset the events between runs, or keep them completely separate, but that's a while away yet without a big refactor