### PR TITLE
Added dark mode class to the root element of the Admin

### DIFF
--- a/apps/admin-x-design-system/src/DesignSystemApp.tsx
+++ b/apps/admin-x-design-system/src/DesignSystemApp.tsx
@@ -11,7 +11,6 @@ export interface DesignSystemAppProps extends React.HTMLProps<HTMLDivElement> {
 const DesignSystemApp: React.FC<DesignSystemAppProps> = ({darkMode, fetchKoenigLexical, className, children, ...props}) => {
     const appClassName = clsx(
         'admin-x-base',
-        darkMode && 'dark',
         className
     );
 

--- a/apps/admin-x-design-system/styles.css
+++ b/apps/admin-x-design-system/styles.css
@@ -96,15 +96,15 @@ Used to be for fixed bottom mobile menu bar
     }
 } */
 
-.admin-x-base.dark {
+.dark .admin-x-base {
     color: #FAFAFB;
 }
 
-.admin-x-base.dark .gh-loading-orb-container {
+.dark .admin-x-base .gh-loading-orb-container {
     background-color: #000000;
 }
 
-.admin-x-base.dark .gh-loading-orb {
+.dark .admin-x-base .gh-loading-orb {
     filter: invert(100%);
 }
 
@@ -121,4 +121,3 @@ Used to be for fixed bottom mobile menu bar
 .gh-prose-links a {
     color: #30CF43;
 }
-

--- a/apps/shade/src/ShadeApp.tsx
+++ b/apps/shade/src/ShadeApp.tsx
@@ -12,7 +12,6 @@ export interface ShadeAppProps extends React.HTMLProps<HTMLDivElement> {
 const ShadeApp: React.FC<ShadeAppProps> = ({darkMode, fetchKoenigLexical, className, children, ...props}) => {
     const appClassName = clsx(
         'shade',
-        darkMode && 'dark',
         className
     );
 

--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -204,3 +204,5 @@ remove|ember-template-lint|no-invalid-link-title|27|24|27|24|17a357b69040eb9e19a
 add|ember-template-lint|no-invalid-interactive|41|26|41|26|da9f7c0f319619ff98a53fd679c47841cfaa3c1d|1736380800000|1746745200000|1751929200000|app/components/gh-nav-menu/main.hbs
 add|ember-template-lint|no-redundant-fn|5|70|5|70|d8c5269c9b4ca3aec0fc5b8e3d6a997e115dbc92|1736380800000|1746745200000|1751929200000|app/components/gh-nav-menu/main.hbs
 remove|ember-template-lint|no-invalid-interactive|34|26|34|26|0c04fbca90264398b6b5033632f3170c73d1769b|1734307200000|1744671600000|1749855600000|app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-action|113|83|113|83|40a33b8afd29e93eebeaccdb49d729c06f755e1f|1728345600000|1738717200000|1743897600000|app/components/gh-nav-menu/footer.hbs
+remove|ember-template-lint|no-invalid-interactive|113|83|113|83|91111b837d1217ec9988076f5263b0e32df72604|1728345600000|1738717200000|1743897600000|app/components/gh-nav-menu/footer.hbs

--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -266,7 +266,7 @@ export default class AdminXComponent extends Component {
             </div>
         );
         return (
-            <div className={['admin-x-settings-container-', (this.feature.nightShift && 'dark'), this.args.className].filter(Boolean).join(' ')}>
+            <div className={['admin-x-settings-container-', this.args.className].filter(Boolean).join(' ')}>
                 <ErrorHandler>
                     <Suspense fallback={fallback}>
                         <this.AdminXApp

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -110,7 +110,7 @@
                 <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings" title="Settings (CTRL/⌘ + ,)"}}</LinkTo>
             {{/if}}
             <div class="nightshift-toggle-container">
-                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{action this.toggleNightShift}}>
+                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{on "click" this.toggleNightShift}} role="button">
                     <div class="sun">{{svg-jar "sun"}}</div>
                     <div class="moon">{{svg-jar "moon"}}</div>
                     <div class="thumb"></div>

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -110,7 +110,7 @@
                 <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings" title="Settings (CTRL/⌘ + ,)"}}</LinkTo>
             {{/if}}
             <div class="nightshift-toggle-container">
-                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{action (toggle "nightShift" this.feature)}}>
+                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{action this.toggleNightShift}}>
                     <div class="sun">{{svg-jar "sun"}}</div>
                     <div class="moon">{{svg-jar "moon"}}</div>
                     <div class="thumb"></div>

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -66,4 +66,11 @@ export default class Footer extends Component {
     openWhatsNew() {
         return this.modals.open(WhatsNew);
     }
+
+    @action
+    toggleNightShift() {
+        const newValue = !this.feature.nightShift;
+        this.feature.nightShift = newValue;
+        document.documentElement.classList.toggle('dark', newValue);
+    }
 }

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -152,11 +152,14 @@ export default class FeatureService extends Service {
             nightShift = enabled || this.nightShift;
         }
 
+        document.documentElement.classList.toggle('dark', nightShift);
+
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);
         }).catch(() => {
             //TODO: Also disable toggle from settings and Labs hover
             $('link[title=dark]').prop('disabled', true);
+            document.documentElement.classList.remove('dark');
         });
     }
 }


### PR DESCRIPTION
ref AP-755

- this adds `dark` class to the root <html> element, so it acts as the source of truth for the apps embedded in the admin
- this also gets rid of the `dark` class from the current design system and Shade, so the apps wrapped within the corresponding providers don't output nested `dark` classes