### PR TITLE
Fixed collection of URL service init time metrics

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -78,10 +78,9 @@ async function initDatabase({config}) {
  * @param {object} options
  * @param {object} options.ghostServer
  * @param {object} options.config
- * @param {object} options.bootLogger
  * @param {boolean} options.frontend
  */
-async function initCore({ghostServer, config, bootLogger, frontend}) {
+async function initCore({ghostServer, config, frontend}) {
     debug('Begin: initCore');
 
     // URL Utils is a bit slow, put it here so the timing is visible separate from models
@@ -110,15 +109,10 @@ async function initCore({ghostServer, config, bootLogger, frontend}) {
     // The URLService is a core part of Ghost, which depends on models.
     debug('Begin: Url Service');
     const urlService = require('./server/services/url');
-    const urlServiceStart = Date.now();
     // Note: there is no await here, we do not wait for the url service to finish
     // We can return, but the site will remain in maintenance mode until this finishes
     // This is managed on request: https://github.com/TryGhost/Ghost/blob/main/core/app.js#L10
     urlService.init({
-        onFinished: () => {
-            bootLogger.metric('url-service', urlServiceStart);
-            bootLogger.log('URL Service Ready');
-        },
         urlCache: !frontend // hacky parameter to make the cache initialization kick in as we can't initialize labs before the boot
     });
     debug('End: Url Service');
@@ -563,7 +557,7 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
 
         // Step 4 - Load Ghost with all its services
         debug('Begin: Load Ghost Services & Apps');
-        await initCore({ghostServer, config, bootLogger, frontend});
+        await initCore({ghostServer, config, frontend});
 
         // Instrument the knex instance and connection pool if prometheus is enabled
         // Needs to be after initCore because the pool is destroyed and recreated in initCore, which removes the event listeners

--- a/ghost/core/core/server/services/url/UrlService.js
+++ b/ghost/core/core/server/services/url/UrlService.js
@@ -1,6 +1,8 @@
 const debug = require('@tryghost/debug')('services:url:service');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const metrics = require('@tryghost/metrics');
 const labs = require('../../../shared/labs');
 const UrlGenerator = require('./UrlGenerator');
 const Queue = require('./Queue');
@@ -15,6 +17,8 @@ const resourcesConfig = require('./config');
  * It will tell you if the url generation is in progress or not.
  */
 class UrlService {
+    lastInitStartTime = null;
+
     /**
      *
      * @param {Object} [options]
@@ -25,7 +29,6 @@ class UrlService {
     constructor({cache} = {}) {
         this.utils = urlUtils;
         this.cache = cache;
-        this.onFinished = null;
         this.finished = false;
         this.urlGenerators = [];
 
@@ -65,6 +68,7 @@ class UrlService {
      */
     _onQueueStarted(event) {
         if (event === 'init') {
+            this.lastInitStartTime = Date.now();
             this.finished = false;
         }
     }
@@ -77,9 +81,10 @@ class UrlService {
     _onQueueEnded(event) {
         if (event === 'init') {
             this.finished = true;
-            if (this.onFinished) {
-                this.onFinished();
-            }
+
+            const now = Date.now();
+            logging.info(`URL Service ready in ${now - this.lastInitStartTime}ms`);
+            metrics.metric('url-service', now - this.lastInitStartTime);
         }
     }
 
@@ -303,12 +308,9 @@ class UrlService {
     /**
      * @description Initializes components needed for the URL Service to function
      * @param {Object} options
-     * @param {Function} [options.onFinished] - callback when url generation is finished
      * @param {Boolean} [options.urlCache] - whether to init using url cache or not
      */
-    async init({onFinished, urlCache} = {}) {
-        this.onFinished = onFinished;
-
+    async init({urlCache} = {}) {
         let persistedUrls;
         let persistedResources;
 


### PR DESCRIPTION
- the original implementation of this was wrong in that it would calculate the init time from a static point in the boot process until "now", which would be fine for the boot process
- however, if someone uploads a routes.yaml file much later, it would still call `onFinished` and compare itself to the static time in the boot process, resulting in huge "url service init" metrics
- to fix that, we can just collect the timestamp from `_onQueueStarted`, calculate the diff in `_onQueueEnded` and then do logging/metrics
- as a result, we can then remove the `onFinished` function, as it's no longer necessary