### PR TITLE
Improved stripe listen command in dev.js script

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -205,11 +205,12 @@ async function handleStripe() {
 
         let stripeSecret;
         const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+        const apiKeyFlag = stripeSecretKey ? `--api-key ${stripeSecretKey}` : '';
         try {
-            const stripeListenCommand = `stripe listen --print-secret ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`;
+            const stripeListenCommand = `stripe listen --print-secret ${apiKeyFlag}`;
             stripeSecret = await exec(stripeListenCommand);
         } catch (err) {
-            console.error('Failed to fetch Stripe secret token, do you need to connect Stripe CLI?', err);
+            console.error('Failed to fetch Stripe secret token. Please ensure either STRIPE_SECRET_KEY is set or you are logged in to Stripe CLI by running `stripe login`.', err);
             return;
         }
 
@@ -221,7 +222,7 @@ async function handleStripe() {
         COMMAND_GHOST.env['WEBHOOK_SECRET'] = stripeSecret.stdout.trim();
         commands.push({
             name: 'stripe',
-            command: `stripe listen --forward-to ${siteUrl}members/webhooks/stripe/ ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`,
+            command: `stripe listen --forward-to ${siteUrl}members/webhooks/stripe/ ${apiKeyFlag}`,
             prefixColor: 'yellow',
             env: {}
         });

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -204,8 +204,10 @@ async function handleStripe() {
         }
 
         let stripeSecret;
+        const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
         try {
-            stripeSecret = await exec('stripe listen --print-secret');
+            const stripeListenCommand = `stripe listen --print-secret ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`;
+            stripeSecret = await exec(stripeListenCommand);
         } catch (err) {
             console.error('Failed to fetch Stripe secret token, do you need to connect Stripe CLI?', err);
             return;
@@ -219,7 +221,7 @@ async function handleStripe() {
         COMMAND_GHOST.env['WEBHOOK_SECRET'] = stripeSecret.stdout.trim();
         commands.push({
             name: 'stripe',
-            command: `stripe listen --forward-to ${siteUrl}members/webhooks/stripe/`,
+            command: `stripe listen --forward-to ${siteUrl}members/webhooks/stripe/ ${stripeSecretKey ? `--api-key ${stripeSecretKey}` : ''}`,
             prefixColor: 'yellow',
             env: {}
         });

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -2,21 +2,27 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
+const debug = require('debug')('ghost:dev');
 
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
 // check we're running on Node 18 and above
+debug('checking node version');
 const nodeVersion = parseInt(process.versions.node.split('.')[0]);
 if (nodeVersion < 18) {
     console.error('`yarn dev` requires Node v18 or above. Please upgrade your version of Node.');
     process.exit(1);
 }
+debug('node version check passed');
 
+debug('loading config');
 const config = require('../../ghost/core/core/shared/config/loader').loadNconf({
     customConfigPath: path.join(__dirname, '../../ghost/core')
 });
+debug('config loaded');
 
+debug('loading ts packages');
 const tsPackages = fs.readdirSync(path.resolve(__dirname, '../../ghost'), {withFileTypes: true})
     .filter(dirent => dirent.isDirectory())
     .map(dirent => dirent.name)
@@ -30,15 +36,24 @@ const tsPackages = fs.readdirSync(path.resolve(__dirname, '../../ghost'), {withF
     })
     .map(packageFolder => `ghost/${packageFolder}`)
     .join(',');
+debug('ts packages loaded');
 
+debug('loading live reload base url');
 const liveReloadBaseUrl = config.getSubdir() || '/ghost/';
+debug('live reload base url loaded');
+
+debug('loading site url');
 const siteUrl = config.getSiteUrl();
+debug('site url loaded');
 
 // Pass flags using GHOST_DEV_APP_FLAGS env var or --flag
+debug('loading app flags')
 const DASH_DASH_ARGS = process.argv.filter(a => a.startsWith('--')).map(a => a.slice(2));
 const ENV_ARGS = process.env.GHOST_DEV_APP_FLAGS?.split(',') || [];
 const GHOST_APP_FLAGS = [...ENV_ARGS, ...DASH_DASH_ARGS];
+debug('app flags loaded');
 
+debug('loading commands');
 let commands = [];
 
 const COMMAND_GHOST = {
@@ -199,23 +214,31 @@ if (GHOST_APP_FLAGS.includes('comments') || GHOST_APP_FLAGS.includes('all')) {
 
 async function handleStripe() {
     if (GHOST_APP_FLAGS.includes('stripe') || GHOST_APP_FLAGS.includes('all')) {
+        debug('stripe flag found');
         if (GHOST_APP_FLAGS.includes('offline') || GHOST_APP_FLAGS.includes('browser-tests')) {
+            debug('offline or browser-tests flag found, skipping stripe');
             return;
         }
+        debug('stripe flag found, proceeding');
 
         let stripeSecret;
         const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
         const apiKeyFlag = stripeSecretKey ? `--api-key ${stripeSecretKey}` : '';
         try {
+            debug('fetching stripe secret');
             const stripeListenCommand = `stripe listen --print-secret ${apiKeyFlag}`;
+            debug('stripe listen command', stripeListenCommand);
             stripeSecret = await exec(stripeListenCommand);
+            debug('stripe secret fetched');
         } catch (err) {
             console.error('Failed to fetch Stripe secret token. Please ensure either STRIPE_SECRET_KEY is set or you are logged in to Stripe CLI by running `stripe login`.', err);
             return;
         }
 
         if (!stripeSecret || !stripeSecret.stdout) {
+            debug('no stripe secret found');
             console.error('No Stripe secret was present');
+            console.error('Please ensure either STRIPE_SECRET_KEY is set or you are logged in to Stripe CLI by running `stripe login`.');
             return;
         }
 
@@ -230,19 +253,28 @@ async function handleStripe() {
 }
 
 (async () => {
+    debug('starting with commands', commands);
+    debug('handling stripe');
     await handleStripe();
-
+    debug('stripe handled');
+    
     if (!commands.length) {
+        debug('no commands provided');
         console.log(`No commands provided`);
         process.exit(0);
     }
+    debug('at least one command provided');
 
+    debug('resetting nx');
     process.env.NX_DISABLE_DB = "true";
     await exec("yarn nx reset --onlyDaemon");
+    debug('nx reset');
     await exec("yarn nx daemon --start");
+    debug('nx daemon started');
 
     console.log(`Running projects: ${commands.map(c => chalk.green(c.name)).join(', ')}`);
 
+    debug('creating concurrently promise');
     const {result} = concurrently(commands, {
         prefix: 'name',
         killOthers: ['failure', 'success'],
@@ -250,8 +282,11 @@ async function handleStripe() {
     });
 
     try {
+        debug('running commands concurrently');
         await result;
+        debug('commands completed');
     } catch (err) {
+        debug('concurrently result error', err);
         console.error();
         console.error(chalk.red(`Executing dev command failed:`) + `\n`);
         console.error(chalk.red(`If you've recently done a \`yarn main\`, dependencies might be out of sync. Try running \`${chalk.green('yarn fix')}\` to fix this.`));


### PR DESCRIPTION
no issue

Problem:
- Running `yarn dev` with `--stripe` runs the `stripe listen ...` command in a subprocess to forward webhook events to your local instance of Ghost in development.
- Currently, you have to run `stripe login` manually before this will work. If you fail to do so, the `yarn dev` script simply hangs indefinitely without any logging to indicate why.
- Running `stripe login` manually is also a non-starter in Docker since you'd have to do this for each new container instance, which isn't practical.

Solution:
- Luckily the `stripe listen ...` command accepts an `--api-key` argument, which expects your stripe secret key. This change updates the `dev.js` script to read your stripe API key from the `STRIPE_SECRET_KEY` environment variable if it's present. As long as `STRIPE_SECRET_KEY` exists, you won't need to run `stripe login` anymore.
- It also adds a timeout of 5 seconds to the initial `stripe listen` command and will exit the process if this step fails, indicating with a clear log message that you need to either set the `STRIPE_SECRET_KEY` variable or run `stripe login`
- I also added a bunch of debug statements to the dev script which were useful in debugging this, and may prove useful for similar issues in the future, so I'll leave them in there.