### PR TITLE
Added persistence helpers to the jobs service

### DIFF
--- a/ghost/job-manager/lib/JobManager.js
+++ b/ghost/job-manager/lib/JobManager.js
@@ -473,6 +473,55 @@ class JobManager {
 
         logging.warn('Inline job queue finished');
     }
+
+    /**
+     * Gets job data from the repository
+     * @param {string} name - The name of the job to retrieve
+     * @returns {Promise<Object|null>} The job data if found, null otherwise
+     */
+    async getJobData(name) {
+        if (!this._jobsRepository) {
+            return null;
+        }
+        return await this._jobsRepository.read(name);
+    }
+
+    /**
+     * Gets the timestamp of the last time a job was run
+     * @param {string} name - The name of the job
+     * @returns {Promise<Date|null>} The timestamp of the last run (finished_at or started_at), null if job not found
+     */
+    async getLastJobRunTimestamp(name) {
+        if (!this._jobsRepository) {
+            return null;
+        }
+        return await this._jobsRepository.getLastRunTimestamp(name);
+    }
+
+    /**
+     * Updates or creates a job's timestamp
+     * @param {string} name - The name of the job
+     * @param {'started_at'|'finished_at'} field - The timestamp field to update
+     * @param {Date} date - The timestamp value
+     */
+    async setJobTimestamp(name, field, date) {
+        if (!this._jobsRepository) {
+            return;
+        }
+        await this._jobsRepository.setTimestamp(name, field, date);
+    }
+
+    /**
+     * Updates or creates a job's status
+     * @param {string} name - The name of the job
+     * @param {string} status - The status to set
+     */
+    async setJobStatus(name, status) {
+        if (!this._jobsRepository) {
+            return;
+        }
+        await this._jobsRepository.setStatus(name, status);
+    }
 }
 
 module.exports = JobManager;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2027/

The email analytics job has had a one-off/custom implementation of using the jobs table to persist `started_at` and `finished_at` timestamps for the analytics jobs. This would be helpful for other scheduled/recurring jobs, so this adds helper fns to the JobsService to do so.

The intent is for an entry in the `jobs` table to simply hold the last started/finished times so we don't need to schedule a random time on Ghost boot. This ensures jobs are run daily, etc, in the event of frequent reboots.

This also expands the unit test coverage to ~95% for the job manager lib.