### PR TITLE
Added `.env.example` file to simplify getting started with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Environment variables for Ghost development with docker compose
+## Use this file by running `cp .env.example .env` and then editing the values as needed
+
+# Docker Compose profiles to enable
+## Run `docker compose config --profiles` to see all available profiles
+## See https://docs.docker.com/compose/how-tos/profiles/ for more information
+COMPOSE_PROFILES=ghost
+
+# Debug level to pass to Ghost
+# DEBUG=
+
+# App flags to pass to the dev command
+## Run `yarn dev --show-flags` to see all available app flags
+
+# GHOST_DEV_APP_FLAGS=
+
+# Stripe keys - used to forward Stripe webhooks to the Ghost instance in `dev.js` script
+## Stripe Secret Key: sk_test_*******
+# STRIPE_SECRET_KEY=
+## Stripe Publishable Key: pk_test_*******
+#STRIPE_PUBLISHABLE_KEY=
+## Stripe Account ID: acct_1*******
+#STRIPE_ACCOUNT_ID=

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -48,9 +48,54 @@ debug('site url loaded');
 
 // Pass flags using GHOST_DEV_APP_FLAGS env var or --flag
 debug('loading app flags')
+const availableAppFlags = {
+    'show-flags': 'Show available app flags, then exit',
+    stripe: 'Run `stripe listen` to forward Stripe webhooks to the Ghost instance',
+    all: 'Run all apps',
+    ghost: 'Run only Ghost',
+    admin: 'Run only Admin',
+    'browser-tests': 'Run browser tests',
+    announcementBar: 'Run Announcement Bar',
+    announcementbar: 'Run Announcement Bar',
+    'announcement-bar': 'Run Announcement Bar',
+    portal: 'Run Portal',
+    signup: 'Run Signup Form',
+    search: 'Run Sodo Search',
+    lexical: 'Use your local instance of the Lexical editor running in a separate process',
+    comments: 'Run Comments UI',
+    https: 'Serve apps using HTTPS',
+    offline: 'Run in offline mode (no Stripe webhooks will be forwarded)'
+}
 const DASH_DASH_ARGS = process.argv.filter(a => a.startsWith('--')).map(a => a.slice(2));
 const ENV_ARGS = process.env.GHOST_DEV_APP_FLAGS?.split(',') || [];
-const GHOST_APP_FLAGS = [...ENV_ARGS, ...DASH_DASH_ARGS];
+const GHOST_APP_FLAGS = [...ENV_ARGS, ...DASH_DASH_ARGS].filter(flag => flag.trim().length > 0);
+
+function showAvailableAppFlags() {
+    console.log(chalk.blue('App flags can be enabled by setting the GHOST_DEV_APP_FLAGS environment variable to a comma separated list of flags.'));
+    console.log(chalk.blue('Alternatively, flags can be passed directly to `yarn dev`, i.e. `yarn dev --portal'));
+    console.log(chalk.blue('Note: the `yarn docker:dev` command only supports the GHOST_DEV_APP_FLAGS environment variable, as --flags cannot be passed to the docker container.\n'));
+    console.log(chalk.blue('Available app flags:'));
+    for (const [flag, description] of Object.entries(availableAppFlags)) {
+        console.log(chalk.blue(`  ${flag}: ${description}`));
+    }
+}
+
+if (GHOST_APP_FLAGS.includes('show-flags')) {
+    showAvailableAppFlags();
+    process.exit(0);
+}
+
+// Check for invalid flags
+debug('checking for invalid flags', GHOST_APP_FLAGS);
+const invalidFlags = GHOST_APP_FLAGS.filter(flag => !Object.keys(availableAppFlags).includes(flag));
+if (invalidFlags.length > 0) {
+    console.error(chalk.red(`Error: Invalid app flag(s): ${invalidFlags.join(', ')}`));
+    showAvailableAppFlags();
+    process.exit(1);
+}
+debug('invalid flags check passed');
+
+
 debug('app flags loaded');
 
 debug('loading commands');


### PR DESCRIPTION
no issue

- To run Ghost itself in docker compose, you need to enable the `ghost` profile by setting `COMPOSE_PROFILES=ghost`.
- This is done for you if you use the `yarn docker:*` commands, but if you run any other `docker compose ...` commands manually, the `ghost` profile won't be enabled by default.
- The easiest way to set `COMPOSE_PROFILES` is with a `.env` file in the root of the repo. This `.env.example` file is a template than can be easily copied to `.env` by running `cp .env.example .env`, which will in turn enable the `ghost` profile.
- It also includes commented out environment variables that are useful when running Ghost in Docker compose, such as stripe keys, app flags (for running e.g. portal), and `DEBUG` modes.

This commit also includes some minor changes to the `dev.js` script:
- Adds a list of `availableFlags`, including all the app flags that it will accept
- Adds validation to log an error and exit if any invalid flags are passed. This will force us to keep this list up to date if/when we add more app flags
- Adds a `show-flags` flag, which will print all the available flags, along with a description, then immediately exit. 

Ultimately this makes getting started with docker compose more straight forward:
- Clone the repo
- Run `cp .env.example .env` to enable the `ghost` profile
- Run `docker compose up`