### PR TITLE
Fixed dark mode in ActivityPub article view

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -5,7 +5,6 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import articleBodyStyles from '../articleBodyStyles';
 import getUsername from '../../utils/get-username';
 import {OptionProps, SingleValueProps, components} from 'react-select';
-import {useDesignSystem} from '@tryghost/admin-x-design-system';
 
 import {Activity, ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, Icon, LoadingIndicator, Modal, Popover, Select, SelectOption} from '@tryghost/admin-x-design-system';
@@ -380,7 +379,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
 
     const modalSize = width === 'narrow' ? MODAL_SIZE_SM : MODAL_SIZE_LG;
     const modal = useModal();
-    const {darkMode} = useDesignSystem();
+    const darkMode = document.documentElement.classList.contains('dark');
 
     const canNavigateBack = history.length > 0;
     const navigateBack = () => {

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -69,7 +69,7 @@ const ArticleBody: React.FC<{
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [iframeHeight, setIframeHeight] = useState('0px');
-    const {darkMode} = useDesignSystem();
+    const darkMode = document.documentElement.classList.contains('dark');
 
     const cssContent = articleBodyStyles(siteData?.url.replace(/\/$/, ''));
 

--- a/apps/admin-x-activitypub/src/components/feed/TableOfContents.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/TableOfContents.tsx
@@ -49,7 +49,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({items, onItemClick}) =
                 position='center'
                 side='right'
                 trigger={
-                    <div className='flex cursor-pointer flex-col items-end gap-2 rounded-md bg-white p-2 hover:bg-gray-75'>
+                    <div className='flex cursor-pointer flex-col items-end gap-2 rounded-md bg-white p-2 hover:bg-gray-75 dark:bg-black dark:hover:bg-gray-950'>
                         {items.map(item => (
                             <div
                                 key={item.id}
@@ -68,7 +68,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({items, onItemClick}) =
                         {items.map(item => (
                             <button
                                 key={item.id}
-                                className={`block w-full cursor-pointer truncate rounded py-1 text-left text-gray-700 hover:bg-gray-75 hover:text-gray-900 ${getHeadingPadding(item.level)}`}
+                                className={`block w-full cursor-pointer truncate rounded py-1 text-left text-gray-700 hover:bg-gray-75 hover:text-gray-900 dark:text-gray-600 dark:hover:bg-grey-925 dark:hover:text-gray-400 ${getHeadingPadding(item.level)}`}
                                 title={item.text}
                                 type='button'
                                 onClick={() => onItemClick(item.id)}


### PR DESCRIPTION
no issues

- the dark mode used to be applied only when refreshed — now it doesn't require a refresh anymore
- also added dark mode support to the table of contents