### PR TITLE
Reader improvements in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -739,7 +739,6 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                             </div>
                         </div>)}
                         <div className='col-[3/4] flex items-center justify-end gap-2'>
-                            {/* {modalSize === MODAL_SIZE_LG && object.type === 'Article' && <Popover position='end' trigger={ <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='typography' size='sm' unstyled onClick={() => {}}/> */}
                             {modalSize === MODAL_SIZE_LG && object.type === 'Article' && <Popover modal={false}>
                                 <PopoverTrigger asChild>
                                     <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='typography' size='sm' unstyled />

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -5,9 +5,10 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import articleBodyStyles from '../articleBodyStyles';
 import getUsername from '../../utils/get-username';
 import {OptionProps, SingleValueProps, components} from 'react-select';
+import {Popover, PopoverContent, PopoverTrigger, Skeleton} from '@tryghost/shade';
 
 import {Activity, ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {Button, Icon, LoadingIndicator, Modal, Popover, Select, SelectOption} from '@tryghost/admin-x-design-system';
+import {Button, Icon, LoadingIndicator, Modal, Select, SelectOption} from '@tryghost/admin-x-design-system';
 import {renderTimestamp} from '../../utils/render-timestamp';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useModal} from '@ebay/nice-modal-react';
@@ -282,8 +283,14 @@ const ArticleBody: React.FC<{
         <div className='w-full pb-6'>
             <div className='relative'>
                 {isLoading && (
-                    <div className='absolute inset-0 flex items-center justify-center bg-white/60'>
-                        <LoadingIndicator />
+                    <div className='mt-6'>
+                        <div className='mb-6 flex flex-col gap-2'>
+                            <Skeleton className='h-8' />
+                            <Skeleton className='h-8 w-full max-w-md' />
+                        </div>
+                        <Skeleton className='mt-2 h-4' count={4} randomize={true} />
+                        <Skeleton className='mt-8 h-[400px]' />
+                        <Skeleton className='mt-2 h-4' containerClassName='block mt-7 mb-4' count={8} randomize={true} />
                     </div>
                 )}
                 <iframe
@@ -732,104 +739,110 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                             </div>
                         </div>)}
                         <div className='col-[3/4] flex items-center justify-end gap-2'>
-                            {modalSize === MODAL_SIZE_LG && object.type === 'Article' && <Popover position='end' trigger={ <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='typography' size='sm' unstyled onClick={() => {}}/>
-                            }>
-                                <div className='flex min-w-[300px] flex-col p-5'>
-                                    <Select
-                                        className='mb-3'
-                                        components={{Option, SingleValue}}
-                                        controlClasses={{control: '!min-h-[40px] !py-0 !pl-1 dark:!bg-grey-925', option: '!pl-1 !py-[4px]'}}
-                                        options={[
-                                            {
+                            {/* {modalSize === MODAL_SIZE_LG && object.type === 'Article' && <Popover position='end' trigger={ <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='typography' size='sm' unstyled onClick={() => {}}/> */}
+                            {modalSize === MODAL_SIZE_LG && object.type === 'Article' && <Popover modal={false}>
+                                <PopoverTrigger asChild>
+                                    <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='typography' size='sm' unstyled />
+                                </PopoverTrigger>
+                                <PopoverContent align='end' className='w-[300px]' onCloseAutoFocus={e => e.preventDefault()} onOpenAutoFocus={e => e.preventDefault()}>
+                                    <div className='flex flex-col'>
+                                        <Select
+                                            className='mb-3'
+                                            components={{Option, SingleValue}}
+                                            controlClasses={{control: '!min-h-[40px] !py-0 !pl-1 dark:!bg-grey-925', option: '!pl-1 !py-[4px]'}}
+                                            options={[
+                                                {
+                                                    value: FONT_SANS,
+                                                    label: 'Clean sans-serif',
+                                                    className: 'font-sans'
+                                                },
+                                                {
+                                                    value: 'Georgia, Times, serif',
+                                                    label: 'Elegant serif',
+                                                    className: 'font-serif'
+                                                }
+                                            ]}
+                                            title='Typeface'
+                                            value={fontFamily}
+                                            onFocus={() => {}}
+                                            onSelect={option => setFontFamily(option || {
                                                 value: FONT_SANS,
                                                 label: 'Clean sans-serif',
                                                 className: 'font-sans'
-                                            },
-                                            {
-                                                value: 'Georgia, Times, serif',
-                                                label: 'Elegant serif',
-                                                className: 'font-serif'
-                                            }
-                                        ]}
-                                        title='Typeface'
-                                        value={fontFamily}
-                                        onSelect={option => setFontFamily(option || {
-                                            value: FONT_SANS,
-                                            label: 'Clean sans-serif',
-                                            className: 'font-sans'
-                                        })}
-                                    />
-                                    <div className='mb-2 flex items-center justify-between'>
-                                        <span className='text-sm font-medium text-gray-900 dark:text-white'>Font size</span>
-                                        <div className='flex items-center'>
-                                            <Button
-                                                className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white dark:bg-grey-900 dark:hover:bg-grey-925 ${currentFontSizeIndex === 0 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
-                                                disabled={currentFontSizeIndex === 0}
-                                                hideLabel={true}
-                                                icon='substract'
-                                                iconSize='xs'
-                                                label='Decrease font size'
-                                                unstyled={true}
-                                                onClick={decreaseFontSize}
-                                            />
-                                            <Button
-                                                className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentFontSizeIndex === FONT_SIZES.length - 1 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
-                                                disabled={currentFontSizeIndex === FONT_SIZES.length - 1}
-                                                hideLabel={true}
-                                                icon='add'
-                                                iconSize='xs'
-                                                label='Increase font size'
-                                                unstyled={true}
-                                                onClick={increaseFontSize}
-                                            />
+                                            })}
+                                        />
+                                        <div className='mb-2 flex items-center justify-between'>
+                                            <span className='text-sm font-medium text-gray-900 dark:text-white'>Font size</span>
+                                            <div className='flex items-center'>
+                                                <Button
+                                                    className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white dark:bg-grey-900 dark:hover:bg-grey-925 ${currentFontSizeIndex === 0 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
+                                                    disabled={currentFontSizeIndex === 0}
+                                                    hideLabel={true}
+                                                    icon='substract'
+                                                    iconSize='xs'
+                                                    label='Decrease font size'
+                                                    unstyled={true}
+                                                    onClick={decreaseFontSize}
+                                                />
+                                                <Button
+                                                    className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentFontSizeIndex === FONT_SIZES.length - 1 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
+                                                    disabled={currentFontSizeIndex === FONT_SIZES.length - 1}
+                                                    hideLabel={true}
+                                                    icon='add'
+                                                    iconSize='xs'
+                                                    label='Increase font size'
+                                                    unstyled={true}
+                                                    onClick={increaseFontSize}
+                                                />
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div className='mb-5 flex items-center justify-between'>
-                                        <span className='text-sm font-medium text-gray-900 dark:text-white'>Line spacing</span>
-                                        <div className='flex items-center'>
-                                            <Button
-                                                className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentLineHeightIndex === 0 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
-                                                disabled={currentLineHeightIndex === 0}
-                                                hideLabel={true}
-                                                icon='substract'
-                                                iconSize='xs'
-                                                label='Decrease line spacing'
-                                                unstyled={true}
-                                                onClick={decreaseLineHeight}
-                                            />
-                                            <Button
-                                                className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentLineHeightIndex === LINE_HEIGHTS.length - 1 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
-                                                disabled={currentLineHeightIndex === LINE_HEIGHTS.length - 1}
-                                                hideLabel={true}
-                                                icon='add'
-                                                iconSize='xs'
-                                                label='Increase line spacing'
-                                                unstyled={true}
-                                                onClick={increaseLineHeight}
-                                            />
+                                        <div className='mb-5 flex items-center justify-between'>
+                                            <span className='text-sm font-medium text-gray-900 dark:text-white'>Line spacing</span>
+                                            <div className='flex items-center'>
+                                                <Button
+                                                    className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentLineHeightIndex === 0 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
+                                                    disabled={currentLineHeightIndex === 0}
+                                                    hideLabel={true}
+                                                    icon='substract'
+                                                    iconSize='xs'
+                                                    label='Decrease line spacing'
+                                                    unstyled={true}
+                                                    onClick={decreaseLineHeight}
+                                                />
+                                                <Button
+                                                    className={`transition-color flex h-8 w-8 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-grey-900 dark:hover:bg-grey-925 ${currentLineHeightIndex === LINE_HEIGHTS.length - 1 ? 'opacity-20 hover:bg-white' : 'hover:bg-gray-100'}`}
+                                                    disabled={currentLineHeightIndex === LINE_HEIGHTS.length - 1}
+                                                    hideLabel={true}
+                                                    icon='add'
+                                                    iconSize='xs'
+                                                    label='Increase line spacing'
+                                                    unstyled={true}
+                                                    onClick={increaseLineHeight}
+                                                />
+                                            </div>
                                         </div>
+                                        <Button
+                                            className="text-sm text-gray-600 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-600"
+                                            label="Reset to default"
+                                            link={true}
+                                            onClick={() => {
+                                                setCurrentFontSizeIndex(1); // Default font size
+                                                setCurrentLineHeightIndex(1); // Default line height
+                                                setFontFamily({
+                                                    value: FONT_SANS,
+                                                    label: 'Clean sans-serif'
+                                                });
+                                            }}
+                                        />
                                     </div>
-                                    <Button
-                                        className="text-sm text-gray-600 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-600"
-                                        label="Reset to default"
-                                        link={true}
-                                        onClick={() => {
-                                            setCurrentFontSizeIndex(1); // Default font size
-                                            setCurrentLineHeightIndex(1); // Default line height
-                                            setFontFamily({
-                                                value: FONT_SANS,
-                                                label: 'Clean sans-serif'
-                                            });
-                                        }}
-                                    />
-                                </div>
+                                </PopoverContent>
                             </Popover>}
                             <Button className='transition-color flex h-10 w-10 items-center justify-center rounded-full bg-white hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950' icon='close' size='sm' unstyled onClick={() => modal.remove()}/>
                         </div>
                     </div>
                 </div>
                 <div className='relative flex-1'>
-                    {modalSize === MODAL_SIZE_LG && object.type === 'Article' && tocItems.length > 0 && (
+                    {modalSize === MODAL_SIZE_LG && object.type === 'Article' && tocItems.length > 1 && (
                         <div className="!visible absolute inset-y-0 right-7 z-40 hidden lg:!block">
                             <div className="sticky top-1/2 -translate-y-1/2">
                                 <TableOfContents

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -70,7 +70,7 @@
         "@radix-ui/react-dialog": "1.1.4",
         "@radix-ui/react-dropdown-menu": "2.1.3",
         "@radix-ui/react-form": "0.0.3",
-        "@radix-ui/react-popover": "1.1.1",
+        "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-radio-group": "1.2.0",
         "@radix-ui/react-separator": "1.1.1",
         "@radix-ui/react-slot": "1.1.1",

--- a/apps/shade/src/components/ui/popover.stories.tsx
+++ b/apps/shade/src/components/ui/popover.stories.tsx
@@ -1,0 +1,34 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Popover, PopoverTrigger, PopoverContent} from './popover';
+import {Button} from './button';
+
+const meta = {
+    title: 'Components / Popover',
+    component: Popover,
+    tags: ['autodocs']
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+    args: {
+        children: [
+            <div style={{height: 400}}>
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <Button variant="outline">Open popover</Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-80">
+                        <div className="grid gap-4">
+                            <div className="space-y-2">
+                                <h4 className="font-medium leading-none">Dimensions</h4>
+                                <p className="text-sm text-muted-foreground">Set the dimensions for the layer.</p>
+                            </div>
+                        </div>
+                    </PopoverContent>
+                </Popover>
+            </div>
+        ]
+    }
+};

--- a/apps/shade/src/components/ui/popover.tsx
+++ b/apps/shade/src/components/ui/popover.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import {cn} from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({className, align = 'center', sideOffset = 4, ...props}, ref) => (
+    <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        className={cn(
+            'z-50 rounded-md bg-white bg-popover p-5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            className
+        )}
+        sideOffset={sideOffset}
+        {...props}
+    />
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export {Popover, PopoverTrigger, PopoverContent, PopoverAnchor};

--- a/apps/shade/src/components/ui/skeleton.tsx
+++ b/apps/shade/src/components/ui/skeleton.tsx
@@ -1,23 +1,50 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {cn} from '@/lib/utils';
 
 interface SkeletonProps extends React.HTMLAttributes<HTMLSpanElement> {
     containerClassName?: string;
     count?: number;
+    randomize?: boolean;
+    minWidth?: number;
+    maxWidth?: number;
 }
 
 function Skeleton({
     containerClassName,
     count = 1,
+    randomize = false,
+    minWidth = 70,
+    maxWidth = 100,
     className,
     ...props
 }: SkeletonProps) {
+    const {randomWidths, keys} = useMemo(() => {
+        const widths = [];
+        const uniqueKeys = [];
+
+        for (let i = 0; i < count; i++) {
+            if (randomize) {
+                const steps = Math.floor((maxWidth - minWidth) / 5);
+                const randomStep = Math.floor(Math.random() * (steps + 1));
+                const randomWidth = minWidth + (randomStep * 5);
+                widths.push(`${randomWidth}%`);
+            }
+            uniqueKeys.push(`skeleton-${crypto.randomUUID()}`);
+        }
+
+        return {
+            randomWidths: widths,
+            keys: uniqueKeys
+        };
+    }, [count, randomize, minWidth, maxWidth]);
+
     return (
         <span className={containerClassName}>
-            {Array.from({length: count}).map(() => (
-                <React.Fragment key={`skeleton-${crypto.randomUUID()}`}>
+            {Array.from({length: count}).map((_, index) => (
+                <React.Fragment key={keys[index]}>
                     <span
                         className={cn('inline-flex w-full leading-none animate-pulse rounded-[2px] bg-primary/10', className)}
+                        style={randomize ? {width: randomWidths[index]} : undefined}
                         {...props}
                     >&zwnj;</span>
                     <br />

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -8,6 +8,7 @@ export * from './components/ui/chart';
 export * from './components/ui/dialog';
 export * from './components/ui/dropdown-menu';
 export * from './components/ui/input';
+export * from './components/ui/popover';
 export * from './components/ui/separator';
 export * from './components/ui/sheet';
 export * from './components/ui/sidebar';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,6 +4275,13 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.1"
 
+"@radix-ui/react-arrow@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz#30c0d574d7bb10eed55cd7007b92d38b03c6b2ab"
+  integrity sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
+
 "@radix-ui/react-avatar@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-avatar/-/react-avatar-1.1.0.tgz#457c81334c93f4608df15f081e7baa286558d6a2"
@@ -4441,6 +4448,17 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
+"@radix-ui/react-dismissable-layer@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz#96dde2be078c694a621e55e047406c58cd5fe774"
+  integrity sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
 "@radix-ui/react-dropdown-menu@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.3.tgz#02665f99bfdcefc33a8a15dc130e9b98ebdf7671"
@@ -4497,6 +4515,15 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
     "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-focus-scope@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz#c0a4519cd95c772606a82fc5b96226cd7fdd2602"
+  integrity sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
 "@radix-ui/react-form@0.0.3":
@@ -4580,6 +4607,27 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.7"
 
+"@radix-ui/react-popover@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.6.tgz#699634dbc7899429f657bb590d71fb3ca0904087"
+  integrity sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.5"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.2"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.2"
+    "@radix-ui/react-portal" "1.1.4"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-slot" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
 "@radix-ui/react-popper@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.2.tgz#4c0b96fcd188dc1f334e02dba2d538973ad842e9"
@@ -4629,6 +4677,22 @@
     "@radix-ui/react-use-size" "1.1.0"
     "@radix-ui/rect" "1.1.0"
 
+"@radix-ui/react-popper@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.2.tgz#d2e1ee5a9b24419c5936a1b7f6f472b7b412b029"
+  integrity sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-rect" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+    "@radix-ui/rect" "1.1.0"
+
 "@radix-ui/react-portal@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.3.tgz#ffb961244c8ed1b46f039e6c215a6c4d9989bda1"
@@ -4651,6 +4715,14 @@
   integrity sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==
   dependencies:
     "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-portal@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.4.tgz#ff5401ff63c8a825c46eea96d3aef66074b8c0c8"
+  integrity sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
 "@radix-ui/react-presence@1.1.0":
@@ -4690,6 +4762,13 @@
   integrity sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==
   dependencies:
     "@radix-ui/react-slot" "1.1.1"
+
+"@radix-ui/react-primitive@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz#ac8b7854d87b0d7af388d058268d9a7eb64ca8ef"
+  integrity sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.2"
 
 "@radix-ui/react-radio-group@1.2.0":
   version "1.2.0"
@@ -4822,6 +4901,13 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.1.tgz#ab9a0ffae4027db7dc2af503c223c978706affc3"
   integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-slot@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.2.tgz#daffff7b2bfe99ade63b5168407680b93c00e1c6"
+  integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
 
@@ -9884,6 +9970,13 @@ aria-hidden@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
   integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
+
+aria-hidden@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.4.tgz#b78e383fdbc04d05762c78b4a25a501e736c4522"
+  integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
   dependencies:
     tslib "^2.0.0"
 
@@ -27617,6 +27710,17 @@ react-remove-scroll@^2.6.1:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
+react-remove-scroll@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz#df02cde56d5f2731e058531f8ffd7f9adec91ac2"
+  integrity sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
+
 react-router@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.2.0.tgz#a8f2729d39f634a7a870d14dd906a1b406f39d6f"
@@ -27656,7 +27760,7 @@ react-string-replace@1.1.1:
   resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-1.1.1.tgz#8413a598c60e397fe77df3464f2889f00ba25989"
   integrity sha512-26TUbLzLfHQ5jO5N7y3Mx88eeKo0Ml0UjCQuX4BMfOd/JX+enQqlKpL1CZnmjeBRvQE8TR+ds9j1rqx9CxhKHQ==
 
-react-style-singleton@^2.2.1, react-style-singleton@^2.2.2:
+react-style-singleton@^2.2.1, react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
   integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
@@ -31672,6 +31776,14 @@ use-sidecar@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
   integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"


### PR DESCRIPTION
ref AP-751

- Fixed the close button not working after typography settings opened
- Show table of contents only when there's more than one heading
- Added skeleton loader to the article to make it consistent with the main screens
- Added `randomize` property to Skeleton component for easier random placeholders
- Added Popover component to Shade and replaced the current one with that