### PR TITLE
Fixed the initial state of the dark mode

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -152,7 +152,7 @@ export default class FeatureService extends Service {
             nightShift = enabled || this.nightShift;
         }
 
-        document.documentElement.classList.toggle('dark', nightShift);
+        document.documentElement.classList.toggle('dark', nightShift ?? false);
 
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);


### PR DESCRIPTION
no issues

- when nightShift doesn't exist in the db, it defaulted to dark mode by default
- this changes the initial state to light by default

