### PR TITLE
Fix search line breaks issue

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -202,6 +202,7 @@
 }
 
 .ember-power-select-group .ember-power-select-option .highlight {
+    display: inline;
     background: #fff6b8;
     border-radius: 1px;
     color: color-mod(var(--darkgrey) l(-10%));


### PR DESCRIPTION
closes DES-1103

- Due to a regression of line-clamping the titles in members filter search (https://github.com/TryGhost/Ghost/commit/31fcedd13ba1de926aab79809dffb48e5dc41ad7), the layout of the main search in Admin was breaking in a way that highlights were not inline anymore.