### PR TITLE
🐛 Fixed comment reference snippet overflowing

### DIFF
--- a/apps/comments-ui/src/components/content/Comment.tsx
+++ b/apps/comments-ui/src/components/content/Comment.tsx
@@ -293,7 +293,7 @@ export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
 
     const linkToReply = inReplyToComment && inReplyToComment.status === 'published';
 
-    const className = 'font-medium text-neutral-900/60 transition-colors dark:text-white/70';
+    const className = 'font-medium text-neutral-900/60 break-all transition-colors dark:text-white/70';
 
     return (
         linkToReply


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1106/support-escalation-re-ghostpro-comments-formatting-bug
- The `Replied to: comment..` snippet can contain links that can overflow their container when they span multiple lines. Added `break-all` CSS to force text wrapping, ensuring links stay within boundaries.