### PR TITLE
Added api versions dropdown to stats page

### DIFF
--- a/ghost/admin/app/components/stats/charts/kpis.hbs
+++ b/ghost/admin/app/components/stats/charts/kpis.hbs
@@ -1,1 +1,1 @@
-<div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected)}}></div>
+<div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected apiVersion=@apiVersion)}}></div>

--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -13,7 +13,7 @@ export default class KpisComponent extends Component {
     @inject config;
 
     ReactComponent = (props) => {
-        const {chartRange, selected} = props;
+        const {chartRange, selected, apiVersion} = props;
 
         const params = getStatsParams(
             this.config,
@@ -21,10 +21,12 @@ export default class KpisComponent extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/kpis__v${TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/kpis__v${apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });
+
+        console.log(`chart render kpi ${apiVersion}`);
 
         const LINE_COLOR = statsStaticColors[0];
         const INDEX = 'date';

--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -26,8 +26,6 @@ export default class KpisComponent extends Component {
             params
         });
 
-        console.log(`chart render kpi ${apiVersion}`);
-
         const LINE_COLOR = statsStaticColors[0];
         const INDEX = 'date';
         const CATEGORY = selected === 'unique_visits' ? 'visits' : selected;

--- a/ghost/admin/app/components/stats/charts/technical.hbs
+++ b/ghost/admin/app/components/stats/charts/technical.hbs
@@ -1,1 +1,1 @@
-<div class="gh-stats-technical-data" {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected)}}></div>
+<div class="gh-stats-technical-data" {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected apiVersion=@apiVersion)}}></div>

--- a/ghost/admin/app/components/stats/charts/technical.js
+++ b/ghost/admin/app/components/stats/charts/technical.js
@@ -40,14 +40,15 @@ export default class TechnicalComponent extends Component {
         let endpoint;
         let indexBy;
         let tableHead;
+
         switch (selected) {
         case 'browsers':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_browsers__v${TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_browsers__v${props.apiVersion || TB_VERSION}.json`;
             indexBy = 'browser';
             tableHead = 'Browser';
             break;
         default:
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_devices__v${TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_devices__v${props.apiVersion || TB_VERSION}.json`;
             indexBy = 'device';
             tableHead = 'Device';
         }

--- a/ghost/admin/app/components/stats/charts/top-locations.hbs
+++ b/ghost/admin/app/components/stats/charts/top-locations.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="gh-stats-metric-header"><h5 class="gh-stats-metric-label">Locations</h5></div>
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
 </div>
 
 {{#if this.showSeeAll}}

--- a/ghost/admin/app/components/stats/charts/top-locations.js
+++ b/ghost/admin/app/components/stats/charts/top-locations.js
@@ -61,7 +61,7 @@ export default class TopLocations extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_locations__v${TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_locations__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-pages.hbs
+++ b/ghost/admin/app/components/stats/charts/top-pages.hbs
@@ -18,7 +18,7 @@
             </PowerSelect>
         </div> --}}
     </div>
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
 </div>
 
 {{#if this.showSeeAll}}

--- a/ghost/admin/app/components/stats/charts/top-pages.js
+++ b/ghost/admin/app/components/stats/charts/top-pages.js
@@ -60,7 +60,7 @@ export default class TopPages extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_pages__v${TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_pages__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-sources.hbs
+++ b/ghost/admin/app/components/stats/charts/top-sources.hbs
@@ -19,7 +19,7 @@
         </div> --}}
     </div>
 
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
 </div>
 
 {{#if this.showSeeAll}}

--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -55,7 +55,7 @@ export default class TopSources extends Component {
 
     ReactComponent = (props) => {
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_sources__v${TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_sources__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params: getStatsParams(
                 this.config,

--- a/ghost/admin/app/components/stats/kpis-overview.hbs
+++ b/ghost/admin/app/components/stats/kpis-overview.hbs
@@ -1,5 +1,5 @@
 
-<div class="gh-stats-tabs-header" {{did-update this.fetchDataIfNeeded @chartRange @audience @device @browser @location @source @pathname}}>
+<div class="gh-stats-tabs-header" {{did-update this.fetchDataIfNeeded @chartRange @audience @device @browser @location @source @pathname @apiVersion}}>
     <div class="gh-stats-tabs">
         <button type="button" class="gh-stats-tab min-width {{if this.uniqueVisitsTabSelected 'is-selected'}}" {{on "click" this.changeTabToUniqueVisits}}>
             <Stats::Parts::Metric
@@ -54,5 +54,6 @@
         @source={{@source}}
         @pathname={{@pathname}}
         @selected={{this.selected}}
+        @apiVersion={{@apiVersion}}
     />
 </div>

--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -59,7 +59,9 @@ export default class KpisOverview extends Component {
                 args
             ));
 
-            const response = yield fetch(`${this.config.stats.endpoint}/v0/pipes/kpis__v${TB_VERSION}.json?${params}`, {
+            const endpoint = `${this.config.stats.endpoint}/v0/pipes/kpis__v${args.apiVersion || TB_VERSION}.json?${params}`;
+
+            const response = yield fetch(endpoint, {
                 method: 'GET',
                 headers: {
                     'Content-Type': 'application/json',
@@ -75,6 +77,7 @@ export default class KpisOverview extends Component {
 
             this.totals = this.processData(rawData.data);
         } catch (error) {
+            this.totals = null; // reset totals if the endpoint doesn't exist/fails
             // console.error('Error fetching KPI data:', error);
             // Handle error (e.g., set an error state, show a notification)
         }

--- a/ghost/admin/app/components/stats/technical-overview.hbs
+++ b/ghost/admin/app/components/stats/technical-overview.hbs
@@ -27,5 +27,6 @@
         @source={{@source}}
         @pathname={{@pathname}}
         @selected={{this.selected}}
+        @apiVersion={{@apiVersion}}
     />
 </div>

--- a/ghost/admin/app/controllers/stats.js
+++ b/ghost/admin/app/controllers/stats.js
@@ -1,23 +1,25 @@
 import Controller from '@ember/controller';
 import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
-import {AUDIENCE_TYPES, RANGE_OPTIONS} from 'ghost-admin/utils/stats';
+import {API_VERSION_OPTIONS, AUDIENCE_TYPES, RANGE_OPTIONS} from 'ghost-admin/utils/stats';
 import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 
 countries.registerLocale(enLocale);
 
 export default class StatsController extends Controller {
-    queryParams = ['device', 'browser', 'location', 'source', 'pathname'];
+    queryParams = ['device', 'browser', 'location', 'source', 'pathname', 'apiVersion'];
 
     @tracked device = null;
     @tracked browser = null;
     @tracked location = null;
     @tracked source = null;
     @tracked pathname = null;
+    @tracked apiVersion = 0;
 
     rangeOptions = RANGE_OPTIONS;
     audienceOptions = AUDIENCE_TYPES;
+    apiVersionOptions = API_VERSION_OPTIONS;
     /**
      * @type {number|'all'}
      * Date range to load for member count and MRR related charts
@@ -35,6 +37,11 @@ export default class StatsController extends Controller {
     @action
     onRangeChange(selected) {
         this.chartRange = selected.value;
+    }
+
+    @action
+    onApiVersionChange(selected) {
+        this.apiVersion = selected.value;
     }
 
     @action
@@ -75,5 +82,9 @@ export default class StatsController extends Controller {
 
     get humanReadableLocation() {
         return this.location ? (countries.getName(this.location, 'en') || 'Unknown') : null;
+    }
+
+    get selectedApiVersionOption() {
+        return this.apiVersionOptions.find(option => option.value === this.apiVersion) || this.apiVersionOptions[0];
     }
 }

--- a/ghost/admin/app/templates/stats.hbs
+++ b/ghost/admin/app/templates/stats.hbs
@@ -2,6 +2,21 @@
     <GhCanvasHeader class="gh-canvas-header gh-stats-header sticky break tablet post-header">
         <GhCustomViewTitle @title="Stats" />
         <div class="view-actions">
+            <PowerSelect
+                @selected={{this.selectedApiVersionOption}}
+                @options={{this.apiVersionOptions}}
+                @searchEnabled={{false}}
+                @onChange={{this.onApiVersionChange}}
+                @triggerComponent={{component "gh-power-select/trigger"}}
+                @triggerClass="gh-btn"
+                @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
+                @matchTriggerWidth={{false}}
+                @horizontalPosition="right"
+                as |option|
+            >
+                {{#if option.name}}{{option.name}}{{else}}<span class="red">Unknown option</span>{{/if}}
+            </PowerSelect>
+
             <Stats::Parts::AudienceFilter
                 @excludedAudiences={{this.excludedAudiences}}
                 @onChange={{this.onAudienceChange}}
@@ -71,7 +86,9 @@
                 @browser={{this.browser}}
                 @location={{this.location}}
                 @source={{this.source}}
-                @pathname={{this.pathname}}/>
+                @pathname={{this.pathname}}
+                @apiVersion={{this.apiVersion}}
+            />
         </section>
 
         <section class="gh-stats-grid cols-2">
@@ -84,6 +101,7 @@
                     @location={{this.location}}
                     @source={{this.source}}
                     @pathname={{this.pathname}}
+                    @apiVersion={{this.apiVersion}}
                 />
             </div>
             <div class="gh-stats-container">
@@ -95,6 +113,7 @@
                     @location={{this.location}}
                     @source={{this.source}}
                     @pathname={{this.pathname}}
+                    @apiVersion={{this.apiVersion}}
                 />
             </div>
         </section>
@@ -109,6 +128,7 @@
                     @location={{this.location}}
                     @source={{this.source}}
                     @pathname={{this.pathname}}
+                    @apiVersion={{this.apiVersion}}
                 />
             </div>
             <div class="gh-stats-container">
@@ -120,6 +140,7 @@
                         @location={{this.location}}
                         @source={{this.source}}
                         @pathname={{this.pathname}}
+                        @apiVersion={{this.apiVersion}}
                     />
             </div>
         </section>

--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -2,6 +2,20 @@ import moment from 'moment-timezone';
 
 export const TB_VERSION = 0;
 
+export const API_VERSION_OPTIONS = [
+    {name: 'v0', value: 0},
+    {name: 'v1', value: 1},
+    {name: 'v2', value: 2},
+    {name: 'v3', value: 3},
+    {name: 'v4', value: 4},
+    {name: 'v5', value: 5},
+    {name: 'v6', value: 6},
+    {name: 'v7', value: 7},
+    {name: 'v8', value: 8},
+    {name: 'v9', value: 9},
+    {name: 'v10', value: 10}
+];
+
 export const RANGE_OPTIONS = [
     {name: 'Last 24 hours', value: 1},
     {name: 'Last 7 days', value: 7},


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-123/

This is intended to help with iterating on tinybird API testing. On the `/stats/` page we now have a dropdown for the API version that applies to all fetched endpoints. This was easier than hard-coding to config, which we aren't even certain is the correct approach here.

The default is v0 which is the current behavior.