### PR TITLE
Added open events for transactional emails

### DIFF
--- a/ghost/core/core/server/services/newsletters/NewslettersService.js
+++ b/ghost/core/core/server/services/newsletters/NewslettersService.js
@@ -23,11 +23,12 @@ class NewslettersService {
      * @param {Object} options.mail
      * @param {Object} options.singleUseTokenProvider
      * @param {Object} options.urlUtils
+     * @param {Object} options.settingsCache
      * @param {ILimitService} options.limitService
      * @param {Object} options.emailAddressService
      * @param {Object} options.labs
      */
-    constructor({NewsletterModel, MemberModel, mail, singleUseTokenProvider, urlUtils, limitService, labs, emailAddressService}) {
+    constructor({NewsletterModel, MemberModel, mail, singleUseTokenProvider, urlUtils, settingsCache, limitService, labs, emailAddressService}) {
         this.NewsletterModel = NewsletterModel;
         this.MemberModel = MemberModel;
         this.urlUtils = urlUtils;
@@ -84,6 +85,7 @@ class NewslettersService {
             tokenProvider: singleUseTokenProvider,
             getSigninURL,
             getText,
+            getOpenTrackingEnabled: () => settingsCache.get('email_track_opens'),
             getHTML,
             getSubject,
             sentry

--- a/ghost/core/core/server/services/newsletters/index.js
+++ b/ghost/core/core/server/services/newsletters/index.js
@@ -6,6 +6,7 @@ const urlUtils = require('../../../shared/url-utils');
 const limitService = require('../limits');
 const labs = require('../../../shared/labs');
 const emailAddressService = require('../email-address');
+const settingsCache = require('../../../shared/settings-cache');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
@@ -22,6 +23,7 @@ module.exports = new NewslettersService({
         maxUsageCount: MAGIC_LINK_TOKEN_MAX_USAGE_COUNT
     }),
     urlUtils,
+    settingsCache,
     limitService,
     labs,
     emailAddressService: emailAddressService

--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -79,6 +79,7 @@ class SettingsBREADService {
             transporter,
             tokenProvider: singleUseTokenProvider,
             getSigninURL,
+            getOpenTrackingEnabled: () => settingsCache.get('email_track_opens'),
             getText,
             getHTML,
             getSubject,

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -413,5 +413,46 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
         });
     });
-});
 
+    describe('Open tracking', function () {
+        it('Can enable open tracking', async function () {
+            settingsCache.set('email_track_opens', {value: true});
+
+            const email = 'open-tracking-enabled@test.com';
+            await membersAgent.post('/api/send-magic-link')
+                .body({
+                    email,
+                    emailType: 'signup'
+                })
+                .expectEmptyBody()
+                .expectStatus(201);
+
+            // Check email is sent
+            mockManager.assert.sentEmail({
+                to: email,
+                subject: /Complete your sign up to Ghost!/,
+                'o:tracking-opens': true
+            });
+        });
+
+        it('Can disable open tracking', async function () {
+            settingsCache.set('email_track_opens', {value: false});
+
+            const email = 'open-tracking-enabled@test.com';
+            await membersAgent.post('/api/send-magic-link')
+                .body({
+                    email,
+                    emailType: 'signup'
+                })
+                .expectEmptyBody()
+                .expectStatus(201);
+
+            // Check email is sent without open tracking enabled
+            // TODO: This does not validate that `o:tracking-opens` is unset
+            mockManager.assert.sentEmail({
+                to: email,
+                subject: /Complete your sign up to Ghost!/
+            });
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -192,6 +192,7 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost at 127.0.0.1\\" <noreply@example.com>",
   "generateTextFromHTML": false,
+  "o:tracking-opens": true,
   "replyTo": null,
   "subject": "Verify email address",
   "to": "support@example.com",

--- a/ghost/magic-link/test/index.test.js
+++ b/ghost/magic-link/test/index.test.js
@@ -59,7 +59,8 @@ describe('MagicLink', function () {
                 },
                 config: {
                     get: sandbox.stub().resolves()
-                }
+                },
+                getOpenTrackingEnabled: sandbox.stub().resolves(true)
             };
             const service = new MagicLink(options);
 
@@ -105,7 +106,8 @@ describe('MagicLink', function () {
                 },
                 config: {
                     get: sandbox.stub().resolves()
-                }
+                },
+                getOpenTrackingEnabled: sandbox.stub().resolves(true)
             };
             const service = new MagicLink(options);
 

--- a/ghost/members-api/lib/members-api.js
+++ b/ghost/members-api/lib/members-api.js
@@ -156,6 +156,7 @@ module.exports = function MembersAPI({
         tokenProvider,
         getSigninURL,
         getText,
+        getOpenTrackingEnabled: () => settingsCache.get('email_track_opens'),
         getHTML,
         getSubject,
         sentry


### PR DESCRIPTION
ref BAE-383

Uses the Ghost Setting to determine whether these are tracked. These are not used in Ghost Admin but just within Mailgun. For self-hosters, this allows for better analytics in the Mailgun interface.