### PR TITLE
Loading message in ActivityPub notifications

### DIFF
--- a/apps/admin-x-activitypub/src/components/layout/Layout.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import {Header} from './Header';
 
 const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
-        <div className='mx-auto flex h-screen w-full max-w-page flex-col overflow-y-auto' {...props}>
+        <div className='relative mx-auto flex h-screen w-full max-w-page flex-col overflow-y-auto' {...props}>
             <Header />
             <div className='grid grid-cols-[auto_292px] items-start gap-8 px-8'>
                 <div className='z-0'>

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -1,5 +1,5 @@
-import React, {useEffect, useRef} from 'react';
-import {Skeleton} from '@tryghost/shade';
+import React, {useEffect, useRef, useState} from 'react';
+import {LucideIcon, Skeleton} from '@tryghost/shade';
 
 import NiceModal from '@ebay/nice-modal-react';
 import {Activity, ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
@@ -264,6 +264,24 @@ const Notifications: React.FC<NotificationsProps> = () => {
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+    const [showLoadingMessage, setShowLoadingMessage] = useState(false);
+
+    useEffect(() => {
+        let timeoutID: number;
+
+        if (isLoading) {
+            timeoutID = setTimeout(() => {
+                setShowLoadingMessage(true);
+            }, 3000);
+        } else {
+            setShowLoadingMessage(false);
+        }
+
+        return () => {
+            clearTimeout(timeoutID);
+        };
+    }, [isLoading]);
+
     const handleActivityClick = (group: GroupedActivity, index: number) => {
         switch (group.type) {
         case ACTIVITY_TYPE.CREATE:
@@ -303,6 +321,12 @@ const Notifications: React.FC<NotificationsProps> = () => {
 
     return (
         <Layout>
+            {isLoading && showLoadingMessage && (
+                <div className='absolute bottom-8 left-8 right-[calc(292px+64px)] flex animate-fade-in items-start justify-center rounded-md bg-grey-100 px-3 py-2 font-medium backdrop-blur-md'>
+                    <LucideIcon.Gauge className='mr-1.5 min-w-5 text-purple' size={20} strokeWidth={1.5} />
+                    Notifications are a little slow at the moment, we&apos;re working on improving the performance.
+                </div>
+            )}
             <div className='z-0 flex w-full flex-col items-center'>
                 {
                     isLoading === false && groupedActivities.length === 0 && (

--- a/apps/shade/tailwind.config.cjs
+++ b/apps/shade/tailwind.config.cjs
@@ -83,7 +83,7 @@ module.exports = {
                 100: '#EDE0FF',
                 400: '#A366FF',
                 500: '#8E42FF',
-                600: '7B1FFF',
+                600: '#7B1FFF',
                 DEFAULT: '#8E42FF'
             },
             pink: {


### PR DESCRIPTION
closes AP-783

- Notifications load quite slow in ActivityPub. We're working on improving it but until it gets faster we'll display a short message after 3 seconds of loading to reassure users that the app is not broken.
