### PR TITLE
Added `top_os.pipe` to tinybird and bumped all pipes to version 1

### DIFF
--- a/ghost/tinybird-dedicated/pipes/analytics_pages.pipe
+++ b/ghost/tinybird-dedicated/pipes/analytics_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -60,7 +60,18 @@ SQL >
             when match(user_agent, 'iphone|ipad|safari')
             then 'safari'
             else 'Unknown'
-        END as browser
+        END as browser,
+        case
+            when match(user_agent, 'windows')
+            then 'windows'
+            when match(user_agent, 'mac')
+            then 'mac'
+            when match(user_agent, 'ios')
+            then 'ios'
+            when match(user_agent, 'android')
+            then 'android'
+            else 'Unknown'
+        END as os
     FROM parsed_hits
 
 NODE analytics_pages_1
@@ -74,6 +85,7 @@ SQL >
         post_uuid,
         device,
         browser,
+        os,
         location,
         source,
         pathname,
@@ -84,4 +96,4 @@ SQL >
         uniqState(session_id) AS visits,
         countState() AS pageviews
     FROM analytics_hits_data
-    GROUP BY date, device, browser, location, source, pathname, post_uuid,site_uuid
+    GROUP BY date, device, browser, os, location, source, pathname, post_uuid,site_uuid

--- a/ghost/tinybird-dedicated/pipes/analytics_sessions.pipe
+++ b/ghost/tinybird-dedicated/pipes/analytics_sessions.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 TOKEN "analytics_sessions__v0_endpoint_read_2877" READ
 
 NODE parsed_hits
@@ -64,7 +64,18 @@ SQL >
             when match(user_agent, 'iphone|ipad|safari')
             then 'safari'
             else 'Unknown'
-        END as browser
+        END as browser,
+        case
+            when match(user_agent, 'windows')
+            then 'windows'
+            when match(user_agent, 'mac')
+            then 'mac'
+            when match(user_agent, 'ios')
+            then 'ios'
+            when match(user_agent, 'android')
+            then 'android'
+            else 'Unknown'
+        END as os
     FROM parsed_hits
 
 
@@ -86,6 +97,7 @@ SQL >
         anySimpleState(post_uuid) AS post_uuid,
         anySimpleState(device) AS device,
         anySimpleState(browser) AS browser,
+        anySimpleState(os) AS os,
         anySimpleState(location) AS location,
         anySimpleState(source) AS source,
         anySimpleState(pathname) AS pathname,

--- a/ghost/tinybird-dedicated/pipes/analytics_sources.pipe
+++ b/ghost/tinybird-dedicated/pipes/analytics_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -59,7 +59,18 @@ SQL >
             when match(user_agent, 'iphone|ipad|safari')
             then 'safari'
             else 'Unknown'
-        END as browser
+        END as browser,
+        case
+            when match(user_agent, 'windows')
+            then 'windows'
+            when match(user_agent, 'mac')
+            then 'mac'
+            when match(user_agent, 'ios')
+            then 'ios'
+            when match(user_agent, 'android')
+            then 'android'
+            else 'Unknown'
+        END as os
     FROM parsed_hits
 
 NODE analytics_sources_1
@@ -80,6 +91,7 @@ SQL >
         toDate(a.timestamp) AS date,
         a.device,
         a.browser,
+        a.os,
         a.location,
         b.source AS source,
         a.pathname,
@@ -88,5 +100,5 @@ SQL >
         countState() AS pageviews
     FROM analytics_hits_data as a
     INNER JOIN sessions AS b ON a.session_id = b.session_id
-    GROUP BY a.site_uuid, toDate(a.timestamp), a.device, a.browser, a.location, b.member_status, b.source, a.pathname
+    GROUP BY a.site_uuid, toDate(a.timestamp), a.device, a.browser, a.os, a.location, b.member_status, b.source, a.pathname
     HAVING b.source != current_domain

--- a/ghost/tinybird-dedicated/pipes/kpis.pipe
+++ b/ghost/tinybird-dedicated/pipes/kpis.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Summary with general KPIs per date, including visits, page views, bounce rate and average session duration.
@@ -124,7 +124,18 @@ SQL >
             when match(user_agent, 'iphone|ipad|safari')
             then 'safari'
             else 'Unknown'
-        END as browser
+        END as browser,
+        case
+            when match(user_agent, 'windows')
+            then 'windows'
+            when match(user_agent, 'mac')
+            then 'mac'
+            when match(user_agent, 'ios')
+            then 'ios'
+            when match(user_agent, 'android')
+            then 'android'
+            else 'Unknown'
+        END as os
     FROM parsed_hits
 
 NODE pageviews
@@ -141,6 +152,7 @@ SQL >
             member_status,
             device,
             browser,
+            os,
             location,
             source,
             pathname,
@@ -159,6 +171,7 @@ SQL >
             member_status,
             device,
             browser,
+            os,
             location,
             source,
             pathname,
@@ -176,7 +189,7 @@ SQL >
             {% if defined(date_to) %} and date <= {{ Date(date_to) }}
             {% else %} and date <= today()
             {% end %}
-        group by date, session_id, site_uuid, member_status, device, browser, location, source, pathname
+        group by date, session_id, site_uuid, member_status, device, browser, os, location, source, pathname
     {% end %}
 
 NODE data
@@ -198,6 +211,7 @@ SQL >
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+        {% if defined(os) %} and os = {{ String(os, description="Operating System to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}

--- a/ghost/tinybird-dedicated/pipes/top_browsers.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_browsers.pipe
@@ -35,6 +35,7 @@ SQL >
             {% end %}
             {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
             {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating System to filter on", required=False) }} {% end %}
             {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}

--- a/ghost/tinybird-dedicated/pipes/top_devices.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top Device Types ordered by most visits.

--- a/ghost/tinybird-dedicated/pipes/top_devices.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_devices.pipe
@@ -36,6 +36,7 @@ SQL >
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+        {% if defined(os) %} and os = {{ String(os, description="Operating System to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}

--- a/ghost/tinybird-dedicated/pipes/top_locations.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top visiting Countries ordered by most visits.

--- a/ghost/tinybird-dedicated/pipes/top_os.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_os.pipe
@@ -35,7 +35,7 @@ SQL >
             {% end %}
             {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
             {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-            {% if defined(os) %} and os = {{ String(os, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}

--- a/ghost/tinybird-dedicated/pipes/top_os.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_os.pipe
@@ -1,6 +1,6 @@
 VERSION 1
 DESCRIPTION >
-	Top Browsers ordered by most visits.
+	Top Operating Systems ordered by most visits.
     Accepts `date_from` and `date_to` date filter. Defaults to last 7 days.
     Also `skip` and `limit` parameters for pagination.
 
@@ -11,12 +11,12 @@ TOKEN "stats page" READ
 
 NODE endpoint
 DESCRIPTION >
-    Group by browser and calculate views and visits
+    Group by os and calculate views and visits
 
 SQL >
 
     %
-        select browser, uniq(session_id) as visits, countMerge(pageviews) as pageviews
+        select os, uniq(session_id) as visits, countMerge(pageviews) as pageviews
         from analytics_sessions
         where
             site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
@@ -35,11 +35,11 @@ SQL >
             {% end %}
             {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
             {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Browser to filter on", required=False) }} {% end %}
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-        group by browser
+        group by os
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
 

--- a/ghost/tinybird-dedicated/pipes/top_pages.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Most visited pages for a given period.

--- a/ghost/tinybird-dedicated/pipes/top_pages.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_pages.pipe
@@ -39,6 +39,7 @@ SQL >
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+        {% if defined(os) %} and os = {{ String(os, description="Operating System to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}

--- a/ghost/tinybird-dedicated/pipes/top_sources.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Top traffic sources (domains), ordered by most visits.
     Accepts `date_from` and `date_to` date filter. Defaults to last 7 days.

--- a/ghost/tinybird-dedicated/pipes/top_sources.pipe
+++ b/ghost/tinybird-dedicated/pipes/top_sources.pipe
@@ -35,6 +35,7 @@ SQL >
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+        {% if defined(os) %} and os = {{ String(os, description="Operating System to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-128/experiment-update-the-implementation-to-also-store-os-for-each-event

- This commit is an experiment to learn more about how change control works with Tinybird.
- It bumps the version of all existing pipes from version 0 to version 1
- It adds a new `top_os.json` pipe to aggregate pageviews by operating system, and updates all other relevant pipes so they can be filtered/grouped by operating system
- The actual implementation of parsing the operating system from the user-agent is super naive and doesn't really matter for this experiment, since we're mainly trying to learn how change management works.
- These changes have already been deployed manually to TB, so this commit doesn't really do anything (yet), apart from keeping our source datafiles in sync with Tinybird. 