### PR TITLE
Added `ctaMinimal` image size to `overrides` for email rendering.

### DIFF
--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -126,6 +126,9 @@
             "email-latest-posts-image": {"width": 200, "height": 200},
             "email-latest-posts-image-mobile": {"width": 1200, "height": 960},
             "social-image": {"width": 1200}
+        },
+        "emailSizes" : {
+            "ctaMinimal": {"width": 64, "height": 64}
         }
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-361/fix-image-distortion-quirk-in-outlook

- Added a new `emailSizes` property to the `imageOptimization` configuration in our `overrides.json` config.
- The change is required to support proper image sizing in email rendering, specifically for the minimal Call to Action (CTA) layout.