### PR TITLE
Move email CTA image size to internalImageSizes

### DIFF
--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -122,13 +122,11 @@
         "internalImageSizes": {
             "icon": {"width": 256, "height": 256},
             "signup-form-icon": {"width": 192, "height": 192},
+            "email-cta-card": {"width": 64, "height": 64},
             "email-header-image": {"width": 1200},
             "email-latest-posts-image": {"width": 200, "height": 200},
             "email-latest-posts-image-mobile": {"width": 1200, "height": 960},
             "social-image": {"width": 1200}
-        },
-        "emailSizes" : {
-            "ctaMinimal": {"width": 64, "height": 64}
         }
     }
 }

--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -126,6 +126,9 @@
             "email-latest-posts-image": {"width": 200, "height": 200},
             "email-latest-posts-image-mobile": {"width": 1200, "height": 960},
             "social-image": {"width": 1200}
+        },
+        "emailSizes" : {
+            "ctaMinimal": {"width": 64, "height": 64}
         }
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-361/fix-image-distortion-quirk-in-outlook

- Removed the `emailSizes` key from `imageOptimization`, as Ghost only reads from `contentImageSizes` and `internalImageSizes`.
- Moved the `ctaMinimal` image size under `internalImageSizes` as `email-cta-minimal-image` (64x64).