### PR TITLE
Removed setTimeout from scheduling adapter unit tests

### DIFF
--- a/ghost/core/test/unit/server/adapters/scheduling/SchedulingDefault.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/SchedulingDefault.test.js
@@ -9,7 +9,11 @@ const logging = require('@tryghost/logging');
 describe('Scheduling Default Adapter', function () {
     const scope = {};
 
+    /** @type {import('sinon').SinonFakeTimers} */
+    let clock;
+
     beforeEach(function () {
+        clock = sinon.useFakeTimers();
         scope.adapter = new SchedulingDefault();
     });
 
@@ -90,10 +94,10 @@ describe('Scheduling Default Adapter', function () {
                 }
             });
 
-            setTimeout(() => {
-                scope.adapter._pingUrl.calledOnce.should.eql(true);
-                done();
-            }, 50);
+            clock.tick(50);
+
+            scope.adapter._pingUrl.calledOnce.should.eql(true);
+            done();
         });
 
         it('reschedule: simulate restart', function (done) {
@@ -119,10 +123,9 @@ describe('Scheduling Default Adapter', function () {
                 }
             });
 
-            setTimeout(() => {
-                scope.adapter._pingUrl.calledOnce.should.eql(true);
-                done();
-            }, 50);
+            clock.tick(50);
+            scope.adapter._pingUrl.calledOnce.should.eql(true);
+            done();
         });
 
         it('run', function (done) {
@@ -147,6 +150,8 @@ describe('Scheduling Default Adapter', function () {
             scope.adapter.runTimeoutInMs = 100;
             scope.adapter.offsetInMinutes = 1;
             scope.adapter.run();
+
+            clock.runAll();
         });
 
         it('ensure recursive run works', function (done) {
@@ -157,10 +162,10 @@ describe('Scheduling Default Adapter', function () {
             scope.adapter.offsetInMinutes = 1;
             scope.adapter.run();
 
-            setTimeout(function () {
-                scope.adapter._execute.callCount.should.be.greaterThan(1);
-                done();
-            }, 200);
+            clock.tick(200);
+
+            scope.adapter._execute.callCount.should.be.greaterThan(1);
+            done();
         });
 
         it('execute', function (done) {
@@ -186,7 +191,8 @@ describe('Scheduling Default Adapter', function () {
 
             (function retry() {
                 if (pinged !== jobs) {
-                    return setTimeout(retry, 50);
+                    clock.tick(50);
+                    return retry();
                 }
 
                 done();
@@ -224,7 +230,8 @@ describe('Scheduling Default Adapter', function () {
 
             (function retry() {
                 if (pinged !== 2) {
-                    return setTimeout(retry, 50);
+                    clock.tick(50);
+                    return retry();
                 }
 
                 Object.keys(scope.adapter.deletedJobs).length.should.eql(2);
@@ -240,6 +247,12 @@ describe('Scheduling Default Adapter', function () {
 
         describe('pingUrl', function () {
             it('pingUrl (PUT)', function (done) {
+                // TODO: remove this once we figure out how to make this work with fake timers
+                sinon.restore();
+                sinon.useFakeTimers({
+                    shouldAdvanceTime: true
+                });
+
                 const ping = nock('http://localhost:1111')
                     .put('/ping')
                     .query({})
@@ -276,6 +289,7 @@ describe('Scheduling Default Adapter', function () {
                     }
                 });
 
+                clock.runToLast();
                 ping.isDone().should.be.true();
             });
 
@@ -293,6 +307,7 @@ describe('Scheduling Default Adapter', function () {
                     }
                 });
 
+                clock.runToLast();
                 ping.isDone().should.be.true();
             });
 
@@ -310,10 +325,17 @@ describe('Scheduling Default Adapter', function () {
                     }
                 });
 
+                clock.runToLast();
                 ping.isDone().should.be.true();
             });
 
             it('pingUrl, but blog returns 503', function (done) {
+                // TODO: remove this once we figure out how to make this work with fake timers
+                sinon.restore();
+                sinon.useFakeTimers({
+                    shouldAdvanceTime: true
+                });
+
                 scope.adapter.retryTimeoutInMs = 50;
 
                 const loggingStub = sinon.stub(logging, 'error');


### PR DESCRIPTION
- our scheduling adapter uses internal timeouts for retries etc
- to check this functionality in tests, we're using setTimeout, which causes real-world waits, which slows down tests
- we can avoid that my mocking the clock using sinon and ticking the clock manually
- note: this doesn't remove all of the setTimeouts, but most of them until I can figure out why the others don't yet pass
