### PR TITLE
Updated email analytics jobs to change `completed` status to `finished`

### DIFF
--- a/ghost/email-analytics-service/lib/EmailAnalyticsService.js
+++ b/ghost/email-analytics-service/lib/EmailAnalyticsService.js
@@ -274,7 +274,7 @@ module.exports = class EmailAnalyticsService {
             };
         }
 
-        this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'completed', this.#fetchScheduledData.lastEventTimestamp);
+        this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp);
         return count;
     }
     /**
@@ -374,13 +374,13 @@ module.exports = class EmailAnalyticsService {
         if (!error && eventCount > 0 && eventCount < maxEvents && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
             logging.info('[EmailAnalytics] Reached end of new events, increasing lastEventTimestamp with one second');
             // set the data on the db so we can store it for fetching after reboot
-            await this.queries.setJobTimestamp(fetchData.jobName, 'completed', new Date(fetchData.lastEventTimestamp.getTime()));
+            await this.queries.setJobTimestamp(fetchData.jobName, 'finished', new Date(fetchData.lastEventTimestamp.getTime()));
             // increment and store in local memory
             fetchData.lastEventTimestamp = new Date(fetchData.lastEventTimestamp.getTime() + 1000);
         } else {
             logging.info('[EmailAnalytics] No new events found');
             // set job status to finished
-            await this.queries.setJobStatus(fetchData.jobName, 'completed');
+            await this.queries.setJobStatus(fetchData.jobName, 'finished');
         }
 
         fetchData.running = false;

--- a/ghost/email-analytics-service/test/email-analytics-service.test.js
+++ b/ghost/email-analytics-service/test/email-analytics-service.test.js
@@ -227,6 +227,7 @@ describe('EmailAnalyticsService', function () {
 
                 result.should.equal(10);
                 setJobStatusStub.calledOnce.should.be.true();
+                setJobStatusStub.getCall(0).args[1].should.equal('finished');
                 processEventBatchStub.calledOnce.should.be.true();
             });
 


### PR DESCRIPTION
no issue

- Currently the email analytics jobs record their status in the `jobs` table when they are finished. They are currently using `completed` as their status, but this is not an accepted option in the DB schema — it should be `finished`. 
- The status is set using raw `knex` queries, which bypasses the schema/model validation layer. It doesn't create any problems for the email analytics jobs themselves, but other areas of the codebase query the `jobs` table using the bookshelf models, and this can create an error since the table contains invalid data.
