### PR TITLE
🎨 Added ability to vertically resize the Spam Filters text area

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/SpamFilters.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/SpamFilters.tsx
@@ -67,6 +67,7 @@ const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     error={!!errors.blockedEmailDomains}
                     hint={errors.blockedEmailDomains || hint}
                     placeholder={`spam.xyz\njunk.com`}
+                    resize="vertical"
                     title='Blocked email domains'
                     value={blockedEmailDomains}
                     onChange={updateBlockedEmailDomainsSetting}


### PR DESCRIPTION
- [X] There's a clear use-case for this code change, explained below
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test:all` and `yarn lint`)

In Ghost Admin, the Spam Filters text area was not resizable, which made it difficult to work with for sites with more than 4 rows of blocked domains. This change makes the text area vertically resizable so, if desired, users can see more domains at the same time.

### Before
The Spam Filters text area is not resizable, which makes it difficult to work with longer lists of spam domains.
![image](https://github.com/user-attachments/assets/b3db38d6-dc4f-41cc-8023-5f64d086be38)

### After
Here's what the Spam Filters text area now looks like by default in Firefox - same size as before, but note the resize indicator in the bottom right corner.
![image](https://github.com/user-attachments/assets/7c97ee9f-d73f-4822-9d1f-826ecd80c3d6)

And here's what it looks like when you manually resize the Spam Filters text area (note that it can only be resized vertically, which I think makes the most sense for this use case).
![image](https://github.com/user-attachments/assets/23961da5-c652-40eb-a831-e2e9014f95aa)