### PR TITLE
Improved the cta card rendering

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/cta.css
+++ b/ghost/core/core/frontend/src/cards/css/cta.css
@@ -66,7 +66,7 @@
 
 
 .kg-cta-sponsor-label p span:not(a span) {
-    color: color-mix(in srgb, currentColor 40%, transparent);
+    color: color-mix(in srgb, currentColor 45%, transparent);
 }
 
 .kg-cta-sponsor-label a {
@@ -170,15 +170,23 @@ a.kg-cta-button {
     display: flex;
     position: static;
     align-items: center;
-    padding: 0 2rem;
-    height: 2.4em;
     justify-content: center;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-    font-size: 0.95em;
-    font-weight: 600;
+    font-weight: 500;
+    line-height: 1.65;
     text-decoration: none;
     border-radius: 6px;
     transition: opacity 0.2s ease-in-out;
+}
+
+.kg-cta-minimal a.kg-cta-button {
+    padding: 0 2rem;
+    height: 2.4em;
+    font-size: 0.95em;
+}
+
+.kg-cta-immersive a.kg-cta-button {
+    padding: .8rem 2rem;
 }
 
 a.kg-cta-button:hover {

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -984,6 +984,7 @@ a[data-flickr-embed] img {
 }
 
 .kg-cta-bg-yellow .kg-cta-sponsor-label {
+    color: #e3d9c4;
     border-bottom: 1px solid #e3d9c4;
 }
 
@@ -1006,6 +1007,30 @@ a[data-flickr-embed] img {
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
+}
+
+.kg-cta-bg-blue .kg-cta-sponsor-label p {
+    color: #97A0A3;
+}
+
+.kg-cta-bg-green .kg-cta-sponsor-label p {
+    color: #97A198;
+}
+
+.kg-cta-bg-yellow .kg-cta-sponsor-label p {
+    color: #A49F94;
+}
+
+.kg-cta-bg-red .kg-cta-sponsor-label p {
+    color: #A39797;
+}
+
+.kg-cta-bg-pink .kg-cta-sponsor-label p {
+    color: #A49BA1;
+}
+
+.kg-cta-bg-purple .kg-cta-sponsor-label p {
+    color: #9D9AA4;
 }
 
 .kg-cta-sponsor-label a {
@@ -1057,6 +1082,7 @@ img.kg-cta-image {
 
 .post-content-sans-serif .kg-cta-text {
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+    font-size: 17px;
 }
 
 .kg-cta-text p {
@@ -1104,6 +1130,7 @@ img.kg-cta-image {
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
     font-size: 0.85em;
     font-weight: 600;
+    font-weight: 500;
     text-decoration: none;
 }
 
@@ -1115,8 +1142,9 @@ img.kg-cta-image {
 .kg-cta-immersive a.kg-cta-button {
     display: inline-block; 
     width: 100%;
-    font-size: 0.85em;
+    font-size: 0.9em;
     font-weight: 600;
+    font-weight: 500;
     text-align: center;
     text-decoration: none;
     border-radius: 6px;


### PR DESCRIPTION
No ref
- Updated sponsor label color in email to better match the background color
- Fixed font size for sans-serif newsletters to be the same as the body text
- Fixed button font size and padding for immersive layout