### PR TITLE
Enforced sans-serif font for video player

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/video.css
+++ b/ghost/core/core/frontend/src/cards/css/video.css
@@ -85,6 +85,7 @@
     width: 100%;
     z-index: 9999;
     padding: 12px 16px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
 .kg-video-current-time {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1141/video-player-inherits-body-font
- The video player would unintentionally inherit the body font. Now it will always use sans-serif.