### PR TITLE
Fixed search modal not closing when avatar is clicked

### DIFF
--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -19,9 +19,10 @@ interface APAvatarProps {
     } | undefined;
     size?: AvatarSize;
     isLoading?: boolean;
+    onClick?: () => void;
 }
 
-const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false}) => {
+const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, onClick}) => {
     let iconSize = 18;
     let containerClass = `shrink-0 items-center justify-center rounded-full overflow-hidden relative z-10 flex ${size === 'lg' ? '' : 'hover:opacity-80 cursor-pointer'}`;
     let imageClass = 'z-10 object-cover';
@@ -71,9 +72,10 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false}) =>
 
     const handle = author?.handle || getUsername(author as ActorProperties);
 
-    const onClick = (e: React.MouseEvent) => {
+    const handleClick = (e: React.MouseEvent) => {
         e.stopPropagation();
         NiceModal.show(ViewProfileModal, {handle});
+        onClick?.();
     };
 
     const title = `${author?.name} ${handle}`;
@@ -83,7 +85,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false}) =>
             <div
                 className={containerClass}
                 title={title}
-                onClick={size === 'lg' ? undefined : onClick}
+                onClick={size === 'lg' ? undefined : handleClick}
             >
                 <img
                     className={imageClass}
@@ -98,7 +100,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false}) =>
         <div
             className={containerClass}
             title={title}
-            onClick={onClick}
+            onClick={handleClick}
         >
             <Icon
                 colorClass='text-gray-600'

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -129,7 +129,7 @@ const SuggestedProfile: React.FC<SuggestedProfileProps & {
                 NiceModal.show(ViewProfileModal, {handle: profile.handle, onFollow, onUnfollow});
             }}
         >
-            <APAvatar author={profile.actor}/>
+            <APAvatar author={profile.actor} onClick={() => onOpenChange?.(false)} />
             <div className='flex grow flex-col'>
                 <span className='font-semibold text-black dark:text-white'>{!isLoading ? profile.actor.name : <Skeleton className='w-full max-w-64' />}</span>
                 <span className='text-sm text-gray-700 dark:text-gray-600'>{!isLoading ? profile.handle : <Skeleton className='w-24' />}</span>


### PR DESCRIPTION
ref AP-815

- added `onClick` prop to APAvatar component, so that we can run additional function when avatars are clicked
- passed search modal closing function to the new prop
