### PR TITLE
🐛 Fixed email domain blocklist not being checked when a member updates their email address

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -483,11 +483,13 @@ async function updateProfile({data, state, api}) {
         const action = emailUpdate.success ? 'updateProfile:success' : 'updateProfile:failed';
         const status = emailUpdate.success ? 'success' : 'error';
         let message = '';
-        if (emailUpdate.error.message === 'Memberships from this email domain are currently restricted.') {
-            message = chooseBestErrorMessage(emailUpdate.error, t('Memberships from this email domain are currently restricted.'), t);
+
+        if (emailUpdate.error) {
+            message = chooseBestErrorMessage(emailUpdate.error, t('Failed to send verification email'), t);
         } else {
-            message = emailUpdate.success ? t('Check your inbox to verify email update') : t('Failed to send verification email');
+            message = t('Check your inbox to verify email update');
         }
+
         return {
             action,
             ...(emailUpdate.success ? {page: 'accountHome'} : {}),

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -458,8 +458,8 @@ async function updateProfile({data, state, api}) {
                 })
             };
         }
-        const message = !dataUpdate.success ? t('Failed to update account data') : t('Failed to send verification email');
 
+        const message = !dataUpdate.success ? t('Failed to update account data') : t('Failed to send verification email');
         return {
             action: 'updateProfile:failed',
             ...(dataUpdate.success ? {member: dataUpdate.member} : {}),
@@ -482,7 +482,12 @@ async function updateProfile({data, state, api}) {
     } else if (emailUpdate) {
         const action = emailUpdate.success ? 'updateProfile:success' : 'updateProfile:failed';
         const status = emailUpdate.success ? 'success' : 'error';
-        const message = !emailUpdate.success ? t('Failed to send verification email') : t('Check your inbox to verify email update');
+        let message = '';
+        if (emailUpdate.error.message === 'Memberships from this email domain are currently restricted.') {
+            message = chooseBestErrorMessage(emailUpdate.error, t('Memberships from this email domain are currently restricted.'), t);
+        } else {
+            message = emailUpdate.success ? t('Check your inbox to verify email update') : t('Failed to send verification email');
+        }
         return {
             action,
             ...(emailUpdate.success ? {page: 'accountHome'} : {}),

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -381,11 +381,13 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(body)
-            }).then(function (res) {
+            }).then(async function (res) {
                 if (res.ok) {
                     return 'Success';
                 } else {
-                    throw new Error('Failed to send email address verification email');
+                    const errData = await res.json();
+                    const errMssg = errData?.errors?.[0]?.message || 'Failed to send email address verification email';
+                    throw new Error(errMssg);
                 }
             });
         },

--- a/apps/portal/src/utils/errors.js
+++ b/apps/portal/src/utils/errors.js
@@ -61,7 +61,7 @@ export function chooseBestErrorMessage(error, alreadyTranslatedDefaultMessage, t
             t('This site only accepts paid members.');
             t('Signups from this email domain are currently restricted.');
             t('Too many sign-up attempts, try again later');
-            t('Emails from this domain are currently restricted.');
+            t('Memberships from this email domain are currently restricted.');
         }
     };
 

--- a/apps/portal/src/utils/errors.js
+++ b/apps/portal/src/utils/errors.js
@@ -61,6 +61,7 @@ export function chooseBestErrorMessage(error, alreadyTranslatedDefaultMessage, t
             t('This site only accepts paid members.');
             t('Signups from this email domain are currently restricted.');
             t('Too many sign-up attempts, try again later');
+            t('Emails from this domain are currently restricted.');
         }
     };
 

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -61,7 +61,7 @@ module.exports = function setupMembersApp() {
     }
     
     membersApp.put('/api/member', bodyParser.json({limit: '50mb'}), middleware.updateMemberData);
-    membersApp.post('/api/member/email', bodyParser.json({limit: '50mb'}), (req, res) => membersService.api.middleware.updateEmailAddress(req, res));
+    membersApp.post('/api/member/email', bodyParser.json({limit: '50mb'}), (req, res, next) => membersService.api.middleware.updateEmailAddress(req, res, next));
 
     // Remove email from suppression list
     membersApp.delete('/api/member/suppression', middleware.deleteSuppression);

--- a/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
@@ -108,6 +108,24 @@ Object {
 }
 `;
 
+exports[`sendMagicLink blocked email domains blocks changing email to a blocked domain 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Memberships from this email domain are currently restricted.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
 exports[`sendMagicLink blocked email domains blocks signups from blocked email domains in config 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -387,7 +387,15 @@ describe('sendMagicLink', function () {
                     email: 'hello@blocked-domain-setting.com',
                     identity: '12345678'
                 })
-                .expectStatus(400); // blocked emails return 400
+                .expectStatus(400)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId,
+                        // Add this here because it is easy to be overlooked (we need a human readable error!)
+                        // 'Please sign up first' should be included only when invite only is disabled.
+                        message: 'Memberships from this email domain are currently restricted.'
+                    }]
+                });
         });
     });
 });

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -376,6 +376,19 @@ describe('sendMagicLink', function () {
                 .expectEmptyBody()
                 .expectStatus(201);
         });
+
+        it('blocks changing email to a blocked domain', async function () {
+            settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
+            const email = 'hello@cool-domain-setting.com';
+            await membersService.api.members.create({email, name: 'Member Test'});
+
+            await membersAgent.post('/api/member/email/')
+                .body({
+                    email: 'hello@blocked-domain-setting.com',
+                    identity: '12345678'
+                })
+                .expectStatus(400); // blocked emails return 400
+        });
     });
 });
 

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Maak seker dat e-posse nie per ongeluk in die Spam of Promosies vouers van u posbus beland nie. As dit wel is, kliek op \"Mark as not spam\" en/of \"Move to inbox\".",
     "Manage": "Bestuur",
     "Maybe later": "Dalk later",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Lidmaatskap nie beskikbaar nie, kontak die eienaar vir toegang.",
     "month": "",
     "Monthly": "Maandeliks",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": ".(تأكد من أن الرسائل الإلكترونية لا تنتهي في مجلدات البريد المزعج أو العروض في صندوق الوارد الخاص بك عن طريق الخطأ. إذا كانت كذلك (انقر على علامة كغير مزعج) و/أو (نقل إلى صندوق الوارد",
     "Manage": "إدارة",
     "Maybe later": "ربما لاحقًا",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": ".العضويات غير متاحة، يرجى الاتصال بالمالك للحصول على الوصول",
     "month": "شهر",
     "Monthly": "شهري",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Уверете се, че имейлите не попадат случайно в папките за спам и промоции на входящата ви поща. Ако това е така, щракнете върху \"Не е спам\" и/или \"Премести във входяща поща\".",
     "Manage": "Управление",
     "Maybe later": "Може би по-късно",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Няма възможност за абонамент, свържете се със собственика на сайта за достъп.",
     "month": "месец",
     "Monthly": "Месечно",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "নিশ্চিত করুন যে ইমেলগুলি দুর্ঘটনাক্রমে আপনার ইনবক্সের স্প্যাম বা প্রমোশন ফোল্ডারে শেষ হচ্ছে না। যদি তারা হয়, তাহলে \"স্প্যাম নয়\" চিহ্নিত করুন এবং/অথবা \"ইনবক্সে সরান\" ক্লিক করুন।",
     "Manage": "পরিচালনা করুন",
     "Maybe later": "সম্ভবত পরে",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "সদস্যতা অপ্রাপ্য, প্রবেশাধিকার পেতে মালিকের সাথে যোগাযোগ করুন।",
     "month": "",
     "Monthly": "মাসিক",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Provjeri jesu li se Email poruke slučajno završile u spam folderu ili promocijama vašeg poštanskog sandučića. Ako jesu, označite ih kao sigurne i/ili ih premjestite u glavni sandučić.",
     "Manage": "Upravljaj",
     "Maybe later": "Možda kasnije",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Članstvo nije dostupno, kontaktiraj vlasnika za pristup.",
     "month": "",
     "Monthly": "Mjesečno",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Assegura't que els correus electrònics no acabin accidentalment a les carpetes Correu brossa o Promocions de la teva safata d'entrada. Si això passa, fes clic a \"Marca com a NO correu brossa\" i/o a \"Mou a la safata d'entrada\".",
     "Manage": "Gestiona",
     "Maybe later": "Potser més tard",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Membresies no disponibles. Posa't en contacte amb el propietari per accedir-hi.",
     "month": "mes",
     "Monthly": "Mensual",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Ujistěte se, že e-maily nekončí omylem ve složkách Spam nebo Propagace ve vaší schránce. Pokud ano, klikněte na \"Označit jako ne spam\" a/nebo \"Přesunout do doručené pošty\".",
     "Manage": "Spravovat",
     "Maybe later": "Možná později",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Členství není k dispozici, kontaktujte vlastníka pro přístup.",
     "month": "",
     "Monthly": "Měsíčně",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Sørg for, at e-mails ikke ender i Spam eller Kampagner mapper i din indbakke. Hvis de gør, skal du klikke på \"Markér som ikke spam\" og/eller \"Flyt til indbakke\".",
     "Manage": "Administrer",
     "Maybe later": "Måske senere",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Medlemskaber er ikke tilgængelige. Kontakt ejeren for at få adgang.",
     "month": "måned",
     "Monthly": "Månedlig",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Stellen Sie sicher, dass E-Mails nicht unbeabsichtigt im Spam-Ordner. Wenn das der Fall sein sollte, klicken Sie auf  \"Kein Spam\" und/oder \"In den Posteingang bewegen\".",
     "Manage": "Verwalten",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Keine Abonnements verfügbar, bitte wenden Sie sich an {{supportAddress}}, um für einen Zugang anzufragen.",
     "month": "",
     "Monthly": "Monatlich",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Stelle sicher, dass E-Mails nicht unbeabsichtigt im Spam-Ordner deines Posteingangs landen. Wenn das der Fall sein sollte, klicke auf \"Kein Spam\" und/oder \"In den Posteingang bewegen\".",
     "Manage": "Verwalten",
     "Maybe later": "Vielleicht später",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Mitgliedschaft nicht verfügbar. Kontaktiere den/die Besitzer*in für Zugang.",
     "month": "Monat",
     "Monthly": "Monatlich",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Βεβαιωθείτε ότι τα emails δεν καταλήγουν κατά λάθος στους φακέλους Ανεπιθύμητη αλληλογραφία ή Προσφορές των εισερχομένων σας. Αν είναι εκεί, κάντε κλικ στο \"Σήμανση ως μη ανεπιθύμητη αλληλογραφία\" και/ή \"Μεταφορά στα εισερχόμενα\".",
     "Manage": "Διαχείριση",
     "Maybe later": "Ίσως αργότερα",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Τα μέλη δεν είναι διαθέσιμα, επικοινωνήστε με τον ιδιοκτήτη για πρόσβαση.",
     "month": "",
     "Monthly": "Μηνιαία",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "Administru",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Monate",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Asegúrate de que los correos electrónicos no terminen accidentalmente en las carpetas de correo no deseado o promociones de su bandeja de entrada. Si lo son, haz clic en \"Marcar como no spam\" y/o \"Mover a la bandeja de entrada\".",
     "Manage": "Administrar",
     "Maybe later": "Tal vez más tarde",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Membresía no disponible, contacta al propietario para obtener acceso.",
     "month": "mes",
     "Monthly": "Mensual",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Veenduge, et e-kirjad ei satuks kogemata teie postkasti rämpsposti või reklaamide kausta. Kui need on seal, klõpsake \"Märgi mitte-rämpspostiks\" ja/või \"Liiguta postkasti\".",
     "Manage": "Halda",
     "Maybe later": "Võib-olla hiljem",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Liikmestaatus pole saadaval, võtke juurdepääsu saamiseks ühendust omanikuga.",
     "month": "kuu",
     "Monthly": "Igakuine",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "اطمینان حاصل کنید که ایمیل\u200cها به صورت اتفاقی در پوشه اسپم یا تبلیغاتی شما قرار نگرفته\u200cاند. در صورتی که آنجا باشند، برروی «اسپم نیست» و/یا «انتقال به صندوق ورودی» کلیک کنید.",
     "Manage": "مدیریت",
     "Maybe later": "شاید بعداً",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "عضویت غیرقابل دسترس است، با مالک برای دسترسی تماس بگیرید.",
     "month": "",
     "Monthly": "ماهانه",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Varmista, että sähköpostit eivät mene Spam- tai roskapostikansioihin, Jos näin käy, klikkaa \"Mark as not spam\" ja/tai \"Move to inbox\".",
     "Manage": "Hallitse",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Kuukausittainen",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Assurez-vous que les e-mails ne finissent pas accidentellement dans le dossier Indésirables ou Publicité de votre boîte de réception. Si c'était le cas, cliquez sur \"Marquer en tant que désirable\" et/ou \"Déplacer vers la boîte de réception\".",
     "Manage": "Gérer",
     "Maybe later": "Peut-être plus tard",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Abonnements non disponibles. Veuillez prendre contact avec le propriétaire pour y accéder.",
     "month": "mois",
     "Monthly": "Mensuel",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Dh’fhaodadh gu bheil puist-d a’ dol dhan phasgan spama / margaidheachd agad. Ma tha, Comharraich \"nach e spama\" a th’ annta no briog air \"gluais dhan bhogsa a-steach\".",
     "Manage": "Rianaich",
     "Maybe later": "’S mathaid an ceann greis",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Leig fios dhan rianaire airson cothrom fhaighinn air na ballrachdan.",
     "month": "mìos",
     "Monthly": "Gach mìos",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "ודאו שהמיילים לא מגיעים בטעות לתיקיית הספאם או הפרסומות בתיבת המייל שלכם. אם הם מגיעים, לחצו על \"סמן כלא ספאם\" ו/או \"העבר לתיקיית הנכנסות\".",
     "Manage": "ניהול",
     "Maybe later": "אולי מאוחר יותר",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "מנויים לא זמינים, פנו לבעל האתר לגישה.",
     "month": "חודש",
     "Monthly": "חודשי",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "सुनिश्चित करें कि ईमेल गलती से आपके इनबॉक्स के स्पैम या प्रचार फ़ोल्डरों में समाप्त नहीं हो रहे हैं। यदि वे हैं, तो \"स्पैम नहीं\" और/या \"इनबॉक्स में ले जाएं\" पर क्लिक करें।",
     "Manage": "प्रबंधित करें",
     "Maybe later": "शायद बाद में",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "सदस्यता उपलब्ध नहीं है, पहुँच के लिए मालिक से संपर्क करें।",
     "month": "",
     "Monthly": "मासिक",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Pobrinite se da e-poruke slučajno ne završe u mapi Spam ili Promocije u vašoj pristigloj pošti. Ako jesu, kliknite \"Označi da nije neželjena pošta\" i/ili \"Premjesti u pristiglu poštu\".",
     "Manage": "Upravljanje",
     "Maybe later": "Možda kasnije",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Pretplate nisu dostupne, kontaktirajte vlasnika za pristup.",
     "month": "",
     "Monthly": "Mjesečno",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Győződjön meg róla, hogy az e-mailek véletlenül nem kerülnek-e a Spam vagy Promóciók mappába az email fiókjában. Ha igen, kattintson a 'Nem spam' és/vagy az 'Áthelyezés a beérkezők közé' lehetőségekre.",
     "Manage": "Kezelés",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "A feliratkozás nem elérhető! Kérjük lépjen kapcsolatba a tulajdonossal a hozzáférésért.",
     "month": "",
     "Monthly": "Havi",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Pastikan email tidak berakhir di kotak masuk Spam atau Promosi Anda secara tidak sengaja. Jika ya, klik \"Tandai sebagai bukan spam\" dan/atau \"Pindahkan ke kotak masuk\".",
     "Manage": "Kelola",
     "Maybe later": "Mungkin nanti",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Keanggotaan tidak tersedia, hubungi pemilik situs untuk mendapatkan akses.",
     "month": "bulan",
     "Monthly": "Bulanan",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Gakktu úr skugga um að tölvupóstanir endi ekki í möppum fyrir ruslpósta eða kynningarefni. Ef svo er skaltu smella á \"Mark as not spam\" og/eða \"Move to inbox\"",
     "Manage": "Stjórna",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Mánaðarlega",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Assicurati che le email non finiscano per sbaglio nello spam. Se ce ne sono, clicca su \"Segnala come non spam\" e/o \"Sposta nella cartella Posta in arrivo\".",
     "Manage": "Impostazioni",
     "Maybe later": "Magari più tardi",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Iscrizione non disponibile, contatta il proprietario per accedere.",
     "month": "mese",
     "Monthly": "Mensile",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "メールがスパムまたはプロモーションフォルダに誤って入っていないか確認してください。もしそうなら、\"スパムではない\"とマークするか、\"受信トレイに移動\"を選択してください。",
     "Manage": "管理",
     "Maybe later": "たぶん後で",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "メンバーシップが利用できません。アクセスについては管理者に連絡してください。",
     "month": "",
     "Monthly": "月額",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "이메일이 스팸이나 프로모션 폴더에 실수로 들어가지 않도록 해 주세요. 만약 들어가 있다면 \"스팸이 아님\" 또는 \"받은 편지함으로 이동\"을 클릭해 주세요.",
     "Manage": "관리",
     "Maybe later": "나중에 하기",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "멤버십을 이용할 수 없어요. 접근 권한을 위해 관리자에게 문의해 주세요.",
     "month": "월",
     "Monthly": "월간",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Хаттардың кездейсоқ Спам немесе Жарнамалар қалтасына түсіп кетпеуін қадағалаңыз. Егер олар сол жерге түссе, \"Спам емес\" және/немесе \"Кіріс жәшігіне көшіру\" түймесін басыңыз.",
     "Manage": "Басқару",
     "Maybe later": "Мүмкін кейінірек",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Аккаунт қосу мүмкін емес, қолжетімділік үшін иесіне хабарласыңыз.",
     "month": "",
     "Monthly": "Ай сайын",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Įsitikinkite, kad el. laiškai netyčia nepatenka į pašto dėžutės aplankus „Šlamštas“ arba „Reklamos“. Jei taip įvyko, spustelėkite \"Žymėti kaip ne šlamštą\" ir (arba) \"Perkelti į gautuosius\".",
     "Manage": "Tvarkyti",
     "Maybe later": "Galbūt vėliau",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Narystės negalimos, susisiekite su savininku dėl prieigos.",
     "month": "",
     "Monthly": "Mėnesinis",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Pārliecinieties, vai e-pasta ziņojumi nejauši nenonāk jūsu iesūtnes mapē Mēstules vai Reklāmas. Ja tie ir, noklikšķiniet uz \"Atzīmēt kā ne surogātpastu\" un/vai \"Pārvietot uz iesūtni\".",
     "Manage": "Pārvaldīt",
     "Maybe later": "Varbūt vēlāk",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Dalība nav pieejama. Lai iegūtu piekļuvi, sazinieties ar īpašnieku.",
     "month": "mēnesis",
     "Monthly": "Ikmēneša",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Осигурајте се дека пораките не завршуваат несакано во папките за спам или промоции од вашиот email. Доколку тоа се случува, обележете ги дека не се спам и префрлете ги во главното поштенско сандаче.",
     "Manage": "Управувајте",
     "Maybe later": "Можеби подоцна",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Зачленувањето не е достапно. За пристап контактирајте го сопственикот.",
     "month": "",
     "Monthly": "Месечно",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "Удирдах",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Сарын",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Pastikan e-mel tidak tiba-tiba masuk ke dalam folder Spam atau Promosi peti masuk anda. Jika ya, klik pada \"Tandakan sebagai bukan spam\" dan/atau \"Alih ke peti masuk\".",
     "Manage": "Urus",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Bulanan",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Zorg ervoor dat e-mails niet per ongeluk in je spam- of promotie-mappen belanden. Klik op 'Markeer als geen spam' en/of 'Verplaatsen naar inbox' als dat wel het geval is.",
     "Manage": "Beheer",
     "Maybe later": "Misschien later",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Lidmaatschappen niet beschikbaar, neem contact op met de eigenaar.",
     "month": "maand",
     "Monthly": "Maandelijks",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Pass på at e-postane ikkje ender opp i spam-mappa. Viss dei gjer, marker dei anten som \"Dette er ikkje spam\" og/eller \"Flytt til innboks\".",
     "Manage": "Innstillinger",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Månadleg",

--- a/ghost/i18n/locales/no/portal.json
+++ b/ghost/i18n/locales/no/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Sørg for at e-poster ikke ender opp i spam- eller reklame-mappene ved en feil. Hvis de gjør det, klikk \"Merk som ikke søppel\" eller \"Flytt til innboks\".",
     "Manage": "Administrer",
     "Maybe later": "Kanskje senere",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Medlemskap ikke tilgjengelig, ta kontakt for tilgang.",
     "month": "måned",
     "Monthly": "Månedlig",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Upewnij się, że emaile nie trafiają przypadkowo do folderów spam w skrzynce odbiorczej. Jeśli tak jest, kliknij na \"Oznacz jako nie spam\" i/lub \"Przenieś do skrzynki odbiorczej\".",
     "Manage": "Zarządzaj",
     "Maybe later": "Może później",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Dostęp niemożliwy, skontaktuj się z właścielem strony w celu uzyskania dostępu.",
     "month": "",
     "Monthly": "Miesięcznie",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Verifique se os e-mails não estão indo parar acidentalmente nas pastas Spam ou Promoções da sua caixa de entrada. Se estiverem, clique em \"Marcar como não spam\" e/ou \"Mover para a caixa de entrada\".",
     "Manage": "Gerenciar",
     "Maybe later": "Talvez mais tarde",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Assinaturas indisponíveis, entre em contato para obter acesso.",
     "month": "mês",
     "Monthly": "Mensal",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Certifique-se de que os emails não estão a acabar acidentalmente nas pastas de Spam ou das promoções da sua caixa de entrada. Se estiverem, clique em \"Marcar como não spam\" e/ou \"Mover para a caixa de entrada\".",
     "Manage": "Gerir",
     "Maybe later": "Talvez mais tarde",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Adesões indisponíveis, entre em contacto com o reponsável do site para aceder.",
     "month": "",
     "Monthly": "Mensalmente",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Asigurați-vă că emailurile nu ajung accidental în folderele Spam sau Promoții ale inbox-ului dvs. Dacă da, faceți clic pe \"Marchează ca fiind nesolicitat\" și/sau \"Mută în inbox\".",
     "Manage": "Administrează",
     "Maybe later": "Poate mai târziu",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Membriile nu sunt disponibile, contactați proprietarul pentru acces.",
     "month": "",
     "Monthly": "Lunar",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Убедитесь, что письма случайно не попадают в папки «Спам» или «Промоакции» вашего почтового ящика. Если это так, нажмите «Не спам!» и/или «Отметить как не спам» и/или «Переместить во входящие».",
     "Manage": "Управление",
     "Maybe later": "Может быть позже",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Членство недоступно, свяжитесь с владельцем сайта для получения доступа.",
     "month": "месяц",
     "Monthly": "Ежемесячно",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Spam හෝ inbox එකෙහි ඇති Promotions folder වලට emails අත්වැරදීමකින් හෝ ළඟා වන්නේ ද යන්න සහතික කරගන්න. එසේ වන්නේ නම්, \"Mark as not spam\" සහ/හෝ \"Move to inbox\" යන්නෙහි click කරන්න.",
     "Manage": "කළමනාකරණය කරන්න",
     "Maybe later": "සමහර විට පසුව",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "සාමාජිකත්වයන් නොමැත, ප්\u200dරවේශය සඳහා වෙබ් අඩ\u200bවි හිමිකරු සම්බන්ධ කරගන්\u200bන.",
     "month": "",
     "Monthly": "මාසිකව",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Uistite sa, že e-maily omylom nekončia v priečinkoch Spam alebo Reklamy. Ak sa tak deje, kliknite na „Toto nie je spam“ a/alebo „Presunúť do doručenej pošty“.",
     "Manage": "Spravovať",
     "Maybe later": "Možno neskôr",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Členstvá nie sú k dispozícii, pre prístup kontaktujte vlastníka stránky.",
     "month": "mesiac",
     "Monthly": "Mesačne",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Prepričajte se, da e-pošta ne konča v mapi za vsiljeno pošto ali promocije. Če se to zgodi, kliknite na \"Ni vsiljena pošta\" in/ali \"Premakni v nabiralnik\".",
     "Manage": "Upravljanje",
     "Maybe later": "Morda kasneje",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Članstva niso na voljo, obrnite se na lastnika za dostop.",
     "month": "mesec",
     "Monthly": "Mesečno",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Sigurohuni që emailet të mos përfundojnë aksidentalisht në dosjet e postës së padëshiruar ose të promovimeve të kutisë suaj hyrëse. Nëse janë, klikoni në \"Shëno si jo të padëshiruar\" dhe/ose \"Lëviz te kutia hyrëse\".",
     "Manage": "Menaxho",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Mujore",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Уверите се да мејлови случајно не завршавају у фасциклама за нежељену пошту или промоције у вашем сандучету. Ако јесу, кликните на „Означи као да није нежељено“ и/или „Премести у пријемно сандуче“.",
     "Manage": "Управљајте",
     "Maybe later": "Можда касније",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Чланства нису доступна, контактирајте власника ради приступа.",
     "month": "",
     "Monthly": "Месечно",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "Podešavanja",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Mesečno",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Verifiera att e-postmeddelandena inte hamnat i skräppostmappen. Om de gjort det, flytta dem till inkorgen och/eller markera som \"Ej skräppost\".",
     "Manage": "Hantera",
     "Maybe later": "Kanske senare",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Medlemskap inte tillgängligt. Kontakta ansvarig för webplatsen för tillgång.",
     "month": "månad",
     "Monthly": "Månadsvis",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Hakikisha barua pepe hazijakosekana kufikia folda za Spam au Matangazo ya kikasha chako. Ikiwa ziko, bonyeza \"Alama kama si spam\" na/au \"Hamisha kwenye kikasha\".",
     "Manage": "Dhibiti",
     "Maybe later": "Labda baadaye",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Uanachama haupatikani, wasiliana na mmiliki kupata ufikiaji.",
     "month": "",
     "Monthly": "Kila mwezi",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "மின்னஞ்சல்கள் தற்செயலாக உங்கள் உள்பெட்டியின் ஸ்பாம் அல்லது விளம்பரங்கள் கோப்புறைகளில் முடிவடையவில்லை என்பதை உறுதிப்படுத்தவும். அவை இருந்தால், \"ஸ்பாம் அல்ல என குறி\" மற்றும்/அல்லது \"உள்பெட்டிக்கு நகர்த்து\" என்பதைக் கிளிக் செய்யவும்.",
     "Manage": "நிர்வகி",
     "Maybe later": "ஒருவேளை பிறகு",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "உறுப்பினர்கள் கிடைக்கவில்லை, அணுகலுக்கு உரிமையாளரைத் தொடர்பு கொள்ளவும்.",
     "month": "மாதம்",
     "Monthly": "மாதாந்திர",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "ตรวจสอบให้แน่ใจว่าอีเมลไม่ได้ไปอยู่ในโฟลเดอร์สแปมหรือโปรโมชั่นในกล่องจดหมายของคุณโดยไม่ได้ตั้งใจ หากเป็นเช่นนั้น ให้คลิก \"ทำเครื่องหมายว่าไม่ใช่สแปม\" และ/หรือ \"ย้ายไปที่กล่องจดหมาย\"",
     "Manage": "จัดการ",
     "Maybe later": "ไว้ก่อน",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "การเป็นสมาชิกไม่พร้อมใช้งาน, โปรดติดต่อเจ้าของเพื่อขอสิทธิ์ในการเข้าถึง",
     "month": "",
     "Monthly": "รายเดือน",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "E-postaların yanlışlıkla gelen kutunuzun Spam veya Promosyonlar klasörlerine düşmediğinden emin olun. Varsa, \"Spam değil olarak işaretle\" ve/veya \"Gelen kutusuna taşı\"yı tıklayın.",
     "Manage": "Yönet",
     "Maybe later": "Belki daha sonra",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Üyelikler müsait değil, erişim için sahibe başvurun.",
     "month": "ay",
     "Monthly": "Aylık",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Переконайтеся, що електронні листи випадково не потрапляють у папку \"Спам\" або \"Реклама\" вашої папки \"Вхідні\". Якщо вони так і є, натисніть \"Позначити як не спам\" і/або \"Перемістити до вхідних\".",
     "Manage": "Керувати",
     "Maybe later": "Можливо пізніше",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Членство недоступне, зв’яжіться з власником, щоб отримати доступ.",
     "month": "Місяць",
     "Monthly": "Щомісяця",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "یہ یہ سنجیدہ ہو کہ ای میلز اتفاقی طور پر آپکے ان باکس کے اسپیم یا پروموشن فولڈرز میں ختم نہیں ہو رہے ہیں۔ اگر ہیں تو \"غیر فعال ہے\" پر کلک کریں اور/یا \"ان باکس میں منتقل کریں\"۔",
     "Manage": "منظم کریں",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "ہر مہینے",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "Boshqarmoq",
     "Maybe later": "",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "",
     "month": "",
     "Monthly": "Oylik",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Hãy chắc rằng email không đang trong hộp thư Spam hoặc Quảng cáo. Nếu đang vậy, chọn \"Đánh dấu không phải spam\" hoặc \"Chuyển tới Hộp thư đến\".",
     "Manage": "Quản lý",
     "Maybe later": "Để sau",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "Chưa phải là thành viên, liên hệ với chủ sở hữu để truy cập.",
     "month": "tháng",
     "Monthly": "Hàng tháng",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "請確保郵件沒有意外地被歸類為垃圾郵件或促銷郵件。如果發生這類情形，請點擊「標記為非垃圾郵件」或「移至收件匣」。",
     "Manage": "管理",
     "Maybe later": "晚點再說",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "無法存取你的會員資訊，請聯絡客服或是網站的所有人。",
     "month": "月",
     "Monthly": "每月",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -104,6 +104,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "确保邮件没有被意外标记为垃圾或者促销邮件。如果是，点击“非垃圾邮件”或者“移动到收件箱”。",
     "Manage": "管理",
     "Maybe later": "之后再说",
+    "Memberships from this email domain are currently restricted.": "",
     "Memberships unavailable, contact the owner for access.": "会员资格不可用，请联系网站所有者获取访问权限。",
     "month": "",
     "Monthly": "月付",

--- a/ghost/members-api/lib/controllers/MemberController.js
+++ b/ghost/members-api/lib/controllers/MemberController.js
@@ -1,4 +1,9 @@
 const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    blockedEmailDomain: 'Signups from this email domain are currently restricted.'
+};
 
 module.exports = class MemberController {
     /**
@@ -10,6 +15,7 @@ module.exports = class MemberController {
      * @param {any} deps.StripePrice
      * @param {any} deps.tokenService
      * @param {any} deps.sendEmailWithMagicLink
+     * @param {any} deps.settingsCache
      */
     constructor({
         memberRepository,
@@ -18,7 +24,8 @@ module.exports = class MemberController {
         tiersService,
         StripePrice,
         tokenService,
-        sendEmailWithMagicLink
+        sendEmailWithMagicLink,
+        settingsCache
     }) {
         this._memberRepository = memberRepository;
         this._productRepository = productRepository;
@@ -27,6 +34,7 @@ module.exports = class MemberController {
         this._StripePrice = StripePrice;
         this._tokenService = tokenService;
         this._sendEmailWithMagicLink = sendEmailWithMagicLink;
+        this._settingsCache = settingsCache;
     }
 
     async updateEmailAddress(req, res) {
@@ -39,6 +47,13 @@ module.exports = class MemberController {
         if (!identity) {
             res.writeHead(403);
             return res.end('No Permission.');
+        }
+
+        const blockedEmailDomains = this._settingsCache.get('all_blocked_email_domains');
+        const emailDomain = req.body.email.split('@')[1]?.toLowerCase();
+        if (emailDomain && blockedEmailDomains.includes(emailDomain)) {
+            res.writeHead(400);
+            return res.end(tpl(messages.blockedEmailDomain));
         }
 
         let tokenData = {};

--- a/ghost/members-api/lib/controllers/MemberController.js
+++ b/ghost/members-api/lib/controllers/MemberController.js
@@ -2,7 +2,7 @@ const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    blockedEmailDomain: 'Signups from this email domain are currently restricted.'
+    blockedEmailDomain: 'Memberships from this email domain are currently restricted.'
 };
 
 module.exports = class MemberController {
@@ -52,8 +52,9 @@ module.exports = class MemberController {
         const blockedEmailDomains = this._settingsCache.get('all_blocked_email_domains');
         const emailDomain = req.body.email.split('@')[1]?.toLowerCase();
         if (emailDomain && blockedEmailDomains.includes(emailDomain)) {
-            res.writeHead(400);
-            return res.end(tpl(messages.blockedEmailDomain));
+            throw new errors.BadRequestError({
+                message: tpl(messages.blockedEmailDomain)
+            });
         }
 
         let tokenData = {};

--- a/ghost/members-api/lib/members-api.js
+++ b/ghost/members-api/lib/members-api.js
@@ -179,7 +179,8 @@ module.exports = function MembersAPI({
         tiersService,
         StripePrice,
         tokenService,
-        sendEmailWithMagicLink
+        sendEmailWithMagicLink,
+        settingsCache
     });
 
     const routerController = new RouterController({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-797/spam-filter-not-applied-when-updating-an-email-address

With this change, we extend the email domain blocklist to member's email update feature (previously: only on signups)

- Added logic in `MemberController.js` to validate email domains against a list of blocked domains from`settingsCache (all_blocked_email_domains)` before allowing updates.
- Enhanced error messaging in `api.js` and `actions.js` in Portal to return a specific error ("Memberships from this email domain are currently restricted.") when a blocked domain error from API is detected.
- Added a new E2E test to verify that changing an email to a blocked domain is prevented (status 400 with appropriate error message) and that changing an email to a allowed domain is still allowed (status 201)
- Added the new error message to localisation files (portal.json) across multiple languages for consistent user feedback.