### PR TITLE
Updated placeholder text for add tags modal

### DIFF
--- a/ghost/admin/app/components/posts-list/modals/add-tag.hbs
+++ b/ghost/admin/app/components/posts-list/modals/add-tag.hbs
@@ -18,7 +18,7 @@
                     @selected={{this.selectedTags}}
                     @showCreateWhen={{this.shouldAllowCreate}}
                     @triggerId={{this.triggerId}}
-                    @placeholder="Select tags or start typing"
+                    @placeholder="Select or enter tags..."
                 />
                 <GhErrorMessage @errors={{this.errors}} @property="tags" />
             </GhFormGroup>


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C025584CA/p1741000480576029
- Placeholder text got cut off due to the width of the input field. Due to the nature of it being multiselect, making it full width is undesired because it'll instantly break onto the next line after adding a single tag. Instead, made the placeholder text shorter and more concise.