### PR TITLE
Improved branch naming for Tinybird test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,8 +859,10 @@ jobs:
           fetch-depth: 300
       - name: Check secrets
         if: github.event_name == 'pull_request'
+        env:
+          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
         run: |
-          if [ -z "${{ secrets.TB_ADMIN_TOKEN }}" ]; then
+          if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
             echo "Tinybird admin token is not available. Did you open the PR from a fork?"
             echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,6 +852,11 @@ jobs:
           echo "Current permission level is ${{ steps.get-user-permission.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
+      - name: Checkout current commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 300
       - name: Check if PR is from fork
         if: github.event_name == 'pull_request'
         run: |
@@ -860,11 +865,6 @@ jobs:
             echo "Please re-open the PR from a branch in the TryGhost/Ghost repository."
             exit 1
           fi
-      - name: Checkout current commit
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 300
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,6 +852,14 @@ jobs:
           echo "Current permission level is ${{ steps.get-user-permission.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
+      - name: Check if PR is from fork
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "${{ github.repository }}" != "${{ github.event.pull_request.head.repo.full_name }}" ]; then
+            echo "PR is from a forked repository. Tinybird tests require secrets from the main repository."
+            echo "Please re-open the PR from a branch in the TryGhost/Ghost repository."
+            exit 1
+          fi
       - name: Checkout current commit
         uses: actions/checkout@v4
         with:
@@ -865,11 +873,15 @@ jobs:
       - name: Set environment variables
         run: |
           _ENV_FLAGS="${ENV_FLAGS:=--wait}"
-          _NORMALIZED_BRANCH_NAME=$(echo $DATA_PROJECT_DIR | rev | cut -d "/" -f 1 | rev | tr '.-' '_')
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            TB_BRANCH_NAME="tmp_ci_pr_${{ github.event.pull_request.number }}"
+          else
+            TB_BRANCH_NAME="tmp_ci_main_$(echo ${{ github.sha }} | cut -c1-7)"
+          fi
           GIT_BRANCH=${GITHUB_HEAD_REF}
           echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
           echo "_ENV_FLAGS=$_ENV_FLAGS" >> $GITHUB_ENV
-          echo "_NORMALIZED_BRANCH_NAME=$_NORMALIZED_BRANCH_NAME" >> $GITHUB_ENV
+          echo "TB_BRANCH_NAME=$TB_BRANCH_NAME" >> $GITHUB_ENV
       - name: Install Tinybird CLI
         run: |
           if [ -f "requirements.txt" ]; then
@@ -886,23 +898,22 @@ jobs:
       - name: Try to delete previous Branch
         run: |
           output=$(tb --host ${{ secrets.TB_HOST }} --token ${{ secrets.TB_ADMIN_TOKEN }} branch ls)
-          BRANCH_NAME="tmp_ci_${_NORMALIZED_BRANCH_NAME}_${{ github.event.pull_request.number }}"
           # Check if the branch name exists in the output
-          if echo "$output" | grep -q "\b$BRANCH_NAME\b"; then
+          if echo "$output" | grep -q "\b$TB_BRANCH_NAME\b"; then
             tb \
             --host ${{ secrets.TB_HOST }} \
             --token ${{ secrets.TB_ADMIN_TOKEN }} \
-            branch rm $BRANCH_NAME \
+            branch rm $TB_BRANCH_NAME \
             --yes
           else
-            echo "Skipping clean up: The Branch '$BRANCH_NAME' does not exist."
+            echo "Skipping clean up: The Branch '$TB_BRANCH_NAME' does not exist."
           fi
       - name: Create new test Branch with data
         run: |
           tb \
           --host ${{ secrets.TB_HOST }} \
           --token ${{ secrets.TB_ADMIN_TOKEN }} \
-          branch create tmp_ci_${_NORMALIZED_BRANCH_NAME}_${{ github.event.pull_request.number }} \
+          branch create $TB_BRANCH_NAME \
           ${_ENV_FLAGS}
       - name: Deploy changes to the test Branch
         run: |
@@ -910,7 +921,7 @@ jobs:
           DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
           if [ ! -f "$DEPLOY_FILE" ]; then
             echo "$DEPLOY_FILE not found, running default tb deploy command"
-            tb deploy ${CI_FLAGS}
+            tb deploy
             tb release ls
           fi
       - name: Custom deployment to the test Branch
@@ -942,16 +953,15 @@ jobs:
       - name: Try to delete previous Branch
         run: |
           output=$(tb --host ${{ secrets.TB_HOST }} --token ${{ secrets.TB_ADMIN_TOKEN }} branch ls)
-          BRANCH_NAME="tmp_ci_${_NORMALIZED_BRANCH_NAME}_${{ github.event.pull_request.number }}"
           # Check if the branch name exists in the output
-          if echo "$output" | grep -q "\b$BRANCH_NAME\b"; then
+          if echo "$output" | grep -q "\b$TB_BRANCH_NAME\b"; then
             tb \
                 --host ${{ secrets.TB_HOST }} \
                 --token ${{ secrets.TB_ADMIN_TOKEN }} \
-                branch rm $BRANCH_NAME \
+                branch rm $TB_BRANCH_NAME \
                 --yes
           else
-            echo "Skipping clean up: The Branch '$BRANCH_NAME' does not exist."
+            echo "Skipping clean up: The Branch '$TB_BRANCH_NAME' does not exist."
           fi
 
   job_ghost-cli:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,12 +857,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 300
-      - name: Check if PR is from fork
+      - name: Check secrets
         if: github.event_name == 'pull_request'
         run: |
-          if [ "${{ github.repository }}" != "${{ github.event.pull_request.head.repo.full_name }}" ]; then
-            echo "PR is from a forked repository. Tinybird tests require secrets from the main repository."
-            echo "Please re-open the PR from a branch in the TryGhost/Ghost repository."
+          if [ -z "${{ secrets.TB_ADMIN_TOKEN }}" ]; then
+            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
+            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
             exit 1
           fi
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,16 +857,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 300
-      - name: Check secrets
-        if: github.event_name == 'pull_request'
-        env:
-          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
-        run: |
-          if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
-            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
-            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
-            exit 1
-          fi
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-137/experiment-develop-an-mvp-of-our-cicd-workflows

- The initial implementation of this job creates a TB branch using the default heuristic provided by Tinybird, and results in some slightly weird/imperfect branch names.
- In particular, the `_NORMALIZED_BRANCH_NAME` evaluates to an empty string, so there's a weird `__` in the branch name. More importantly, when the workflow runs on `main`, there is no PR number so the result is just `tmp_ci__` which won't work if we have multiple commits merged to main, running this job simultaneously.
- This commit updates the logic for the branch name to be either `tmp_ci_pr_{PR number}` if the workflow was triggered by PR, or `tmp_ci_main_{first 7 chars of commit sha}` if triggered by a push to main.
- It also DRY's up the logic for generating the branch name, so we only have to change it in one place.
