### PR TITLE
Added a check for secrets with a clear error message if it fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,8 @@ jobs:
         STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
       run: |
         if [ -z "${{ env.STRIPE_PUBLISHABLE_KEY }}" ]; then
-          echo "Stripe Publishable Key is not available. Did you open the PR from a fork?"
-          echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+          echo "Stripe Publishable Key is not available. Did you open this PR from a fork?"
+          echo "If so, please re-open the PR from a branch in the upstream TryGhost/Ghost repository."
           exit 1
         fi
     - uses: actions/setup-node@v4
@@ -873,8 +873,8 @@ jobs:
           TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
         run: |
           if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
-            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
-            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+            echo "Tinybird admin token is not available. Did you open this PR from a fork?"
+            echo "If so, please re-open the PR from a branch in the upstream TryGhost/Ghost repository."
             exit 1
           fi
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,16 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Check secrets
+      if: github.event_name == 'pull_request'
+      env:
+        STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+      run: |
+        if [ -z "${{ env.STRIPE_PUBLISHABLE_KEY }}" ]; then
+          echo "Stripe Publishable Key is not available. Did you open the PR from a fork?"
+          echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+          exit 1
+        fi
     - uses: actions/setup-node@v4
       env:
         FORCE_COLOR: 0
@@ -857,6 +867,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 300
+      - name: Check secrets
+        if: github.event_name == 'pull_request'
+        env:
+          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
+        run: |
+          if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
+            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
+            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+            exit 1
+          fi
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-137/experiment-develop-an-mvp-of-our-cicd-workflows

- When opening a PR from a fork, secrets aren't available in the Github Actions runs. Certain jobs (tinybird tests, browser tests) require access to secrets to run, and will fail otherwise.
- This commit adds checks to confirm secrets are available. If they are, execution continues. If they aren't, a user friendly error message is output, directing the user to re-open their PR from the upstream repo.