### PR TITLE
Improved error message if secrets are missing in CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,8 @@ jobs:
         STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
       run: |
         if [ -z "${{ env.STRIPE_PUBLISHABLE_KEY }}" ]; then
-          echo "Stripe Publishable Key is not available. Did you open the PR from a fork?"
-          echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+          echo "Stripe Publishable Key is not available. Did you open this PR from a fork?"
+          echo "If so, please re-open the PR from a branch in the upstream TryGhost/Ghost repository."
           exit 1
         fi
     - uses: actions/setup-node@v4
@@ -873,8 +873,8 @@ jobs:
           TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
         run: |
           if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
-            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
-            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+            echo "Tinybird admin token is not available. Did you open this PR from a fork?"
+            echo "If so, please re-open the PR from a branch in the upstream TryGhost/Ghost repository."
             exit 1
           fi
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,16 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Check secrets
+      if: github.event_name == 'pull_request'
+      env:
+        STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+      run: |
+        if [ -z "${{ env.STRIPE_PUBLISHABLE_KEY }}" ]; then
+          echo "Stripe Publishable Key is not available. Did you open the PR from a fork?"
+          echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+          exit 1
+        fi
     - uses: actions/setup-node@v4
       env:
         FORCE_COLOR: 0
@@ -857,6 +867,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 300
+      - name: Check secrets
+        if: github.event_name == 'pull_request'
+        env:
+          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
+        run: |
+          if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
+            echo "Tinybird admin token is not available. Did you open the PR from a fork?"
+            echo "If so, please re-open the PR from a branch in the TryGhost/Ghost repository."
+            exit 1
+          fi
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-137/experiment-develop-an-mvp-of-our-cicd-workflows

- Github Actions doesn't allow repository secrets to be accessed in CI runs when the PR is opened from a fork. This is an intentional design "feature" for security purposes, so there aren't any legitimate / risk-free workarounds.
- This results in some frustratingly vague error messages if you open a PR from a fork and it fails, usually in the form of some "authentication failed" message, which doesn't immediately point to a solution.
- This commit adds an explicit check for access to the required secrets for both the browser tests and the tinybird tests (the only two jobs that I'm aware of that depend on secrets being available), and outputs a user-friendly error message if it fails, directing the user to re-open the PR from the upstream TryGhost/Ghost repo