### PR TITLE
Adjusted spacing of activity items in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/activities/ActivityItem.tsx
+++ b/apps/admin-x-activitypub/src/components/activities/ActivityItem.tsx
@@ -15,7 +15,7 @@ const ActivityItem: React.FC<ActivityItemProps> = ({children, url = null, onClic
                 onClick();
             }
         }}>
-            <div className='relative z-10 flex w-full items-center gap-3 py-4'>
+            <div className='relative z-10 flex w-full items-center gap-3 py-3'>
                 {childrenArray[0]}
                 {childrenArray[1]}
                 {childrenArray[2]}

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -161,7 +161,7 @@ const SuggestedProfiles: React.FC<SuggestedProfilesProps & {
     onOpenChange?: (open: boolean) => void;
 }> = ({profiles, isLoading, onUpdate, onOpenChange}) => {
     return (
-        <div className='mb-[-15px] flex flex-col gap-2 pt-2'>
+        <div className='mb-[-15px] flex flex-col gap-3 pt-2'>
             <H4>Suggested accounts</H4>
             <div className='flex flex-col'>
                 {profiles.map((profile) => {

--- a/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/ViewProfileModal.tsx
@@ -73,7 +73,7 @@ const ActorList: React.FC<ActorListProps> = ({
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     return (
-        <div>
+        <div className='pt-3'>
             {
                 hasNextPage === false && actors.length === 0 ? (
                     <NoValueLabel icon='user-add'>
@@ -81,7 +81,7 @@ const ActorList: React.FC<ActorListProps> = ({
                     </NoValueLabel>
                 ) : (
                     <List>
-                        {actors.map(({actor, isFollowing}, index) => {
+                        {actors.map(({actor, isFollowing}) => {
                             return (
                                 <React.Fragment key={actor.id}>
                                     <ActivityItem key={actor.id}
@@ -101,7 +101,6 @@ const ActorList: React.FC<ActorListProps> = ({
                                             type='secondary'
                                         />
                                     </ActivityItem>
-                                    {index < actors.length - 1 && <Separator />}
                                 </React.Fragment>
                             );
                         })}

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -215,7 +215,7 @@ const FollowingTab: React.FC = () => {
         <>
             <EmptyState />
             {
-                <List>
+                <List className='pt-3'>
                     {accounts.map((account, index) => (
                         <React.Fragment key={account.id}>
                             <ActivityItem
@@ -263,7 +263,7 @@ const FollowersTab: React.FC = () => {
         <>
             <EmptyState />
             {
-                <List>
+                <List className='pt-3'>
                     {accounts.map((account, index) => (
                         <React.Fragment key={account.id}>
                             <ActivityItem

--- a/apps/admin-x-design-system/src/global/TabView.tsx
+++ b/apps/admin-x-design-system/src/global/TabView.tsx
@@ -39,7 +39,7 @@ export const TabButton: React.FC<TabButtonProps> = ({
     return (
         <TabsPrimitive.Trigger
             className={clsx(
-                '-m-b-px cursor-pointer appearance-none whitespace-nowrap py-1 text-md font-medium text-grey-700 transition-all after:invisible after:block after:h-px after:overflow-hidden after:font-bold after:text-transparent after:content-[attr(title)] data-[state=active]:font-bold data-[state=active]:text-black dark:text-white [&>span]:data-[state=active]:text-black [&>span]:data-[state=active]:dark:text-white',
+                '-m-b-px cursor-pointer appearance-none whitespace-nowrap py-1 text-md font-semibold text-grey-700 transition-all after:invisible after:block after:h-px after:overflow-hidden after:font-bold after:text-transparent after:content-[attr(title)] data-[state=active]:text-black dark:text-white [&>span]:data-[state=active]:text-black [&>span]:data-[state=active]:dark:text-white',
                 border && 'border-b-2 border-transparent hover:border-grey-500 data-[state=active]:border-black data-[state=active]:dark:border-white data-[state=active]:dark:text-white'
             )}
             id={id}


### PR DESCRIPTION
no issues

- the spacing is tighter in areas that contain activity items such as suggested accounts and following/followers tab
- no more layout shift when switching tabs
