### PR TITLE
Added MVP of Tinybird deployment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1325,4 +1325,3 @@ jobs:
                   $DEPLOY_FILE
               fi
             fi
-    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,7 +1281,7 @@ jobs:
     ]
     name: Deploy Tinybird
     runs-on: ubuntu-latest
-    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1272,3 +1272,57 @@ jobs:
         uses: gacts/purge-jsdelivr-cache@v1
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
+  deploy_tinybird:
+    needs: [
+      job_setup,
+      job_lint,
+      job_unit-tests,
+      job_tinybird
+    ]
+    name: Deploy Tinybird
+    runs-on: ubuntu-latest
+    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 300
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: "x64"
+          cache: "pip"
+      - name: Install Tinybird CLI
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
+      - name: Tinybird version
+        run: tb --version
+      - name: Check auth
+        run: tb --host=${{ secrets.TB_HOST }} --token=${{ secrets.TB_ADMIN_TOKEN }} auth info
+      - name: Deploy changes to the main Workspace
+        run: |
+          DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
+          if [ ! -f "$DEPLOY_FILE" ]; then
+            echo "$DEPLOY_FILE not found, running default tb push command"
+            tb deploy
+          fi
+      - name: Custom deployment to the main Workspace
+        run: |
+            DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
+            if [ -f "$DEPLOY_FILE" ]; then
+              echo "$DEPLOY_FILE found"
+              if ! [ -x "$DEPLOY_FILE" ]; then
+                  echo "Error: You don't have permission to execute '$DEPLOY_FILE'. Run:"
+                  echo "> chmod +x $DEPLOY_FILE"
+                  echo "and commit your changes"
+                  exit 1
+              else
+                  $DEPLOY_FILE
+              fi
+            fi
+    


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-137/experiment-develop-an-mvp-of-our-cicd-workflows

- This commit adds automated deployment to Tinybird whenever a commit is merged to main
- It is configured to only run on `main` (not in PRs) and only if the `job_tinybird` job succeeds
- This is a minimal MVP based on the examples provided by Tinybird.

