### PR TITLE
Improved Tinybird CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1283,7 +1283,7 @@ jobs:
     defaults:
       run:
         working-directory: ghost/tinybird-dedicated
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
               - *shared
               - 'apps/sodo-search/**'
             tinybird:
-              - *shared
               - 'ghost/tinybird-dedicated/**'
               - '!ghost/tinybird-dedicated/**/*.md'
             any-code:
@@ -1281,7 +1280,7 @@ jobs:
     ]
     name: Deploy Tinybird
     runs-on: ubuntu-latest
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1309,6 +1308,8 @@ jobs:
           DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
           if [ ! -f "$DEPLOY_FILE" ]; then
             echo "$DEPLOY_FILE not found, running default tb push command"
+            tb workspace current
+            tb branch current
             tb deploy
           fi
       - name: Custom deployment to the main Workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,6 +1280,9 @@ jobs:
     ]
     name: Deploy Tinybird
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ghost/tinybird-dedicated
     if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1311,7 +1311,6 @@ jobs:
           DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
           if [ ! -f "$DEPLOY_FILE" ]; then
             echo "$DEPLOY_FILE not found, running default tb push command"
-            tb workspace current
             tb branch current
             tb deploy
           fi

--- a/ghost/tinybird-dedicated/pipes/chris_test.pipe
+++ b/ghost/tinybird-dedicated/pipes/chris_test.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Test pipe
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-137/experiment-develop-an-mvp-of-our-cicd-workflows

- The tinybird deploy job wasn't working because it was running `tb deploy` from the root of the repo, instead of in the `ghost/tinybird-dedicated` folder. 
- This commit also modifies the trigger for the `job_tinybird` job so it will _only_ run if the files in `ghost/tinybird-dedicated` change
- Finally, it increments the version on a test pipe as a test to confirm it's working now.