### PR TITLE
Moved CTA card from alpha to private beta

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -50,7 +50,7 @@
     "@tryghost/helpers": "1.1.90",
     "@tryghost/kg-clean-basic-html": "4.2.0",
     "@tryghost/kg-converters": "1.1.0",
-    "@tryghost/koenig-lexical": "1.6.1",
+    "@tryghost/koenig-lexical": "1.6.2",
     "@tryghost/limit-service": "1.2.14",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.7",

--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -191,7 +191,7 @@ describe('Can send cards via email', function () {
             'extended-text', // not a card
             'extended-quote', // not a card
             'extended-heading', // not a card
-            'call-to-action', // behind the contentVisibilityAlpha labs flag
+            'call-to-action', // behind the contentVisibility labs flag
             // not a card and shouldn't be present in published posts / emails
             'tk',
             'at-link',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8092,10 +8092,10 @@
   dependencies:
     semver "^7.7.0"
 
-"@tryghost/koenig-lexical@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.6.1.tgz#13ec7fc78e812ca73a3f2d916151eb23e8c7c5a2"
-  integrity sha512-47mScaOHs9DRFWMMYW6XMGLkuLr5Njw5Mkzh4L0y8zjwtQzt09ghJ8oLRAjvsSXK4S3yc6Uzjfmq8oO4ZBYPtA==
+"@tryghost/koenig-lexical@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.6.2.tgz#56a8f9fff146880488e4576dc4517c5d635bee9d"
+  integrity sha512-Q5ChN3wGHT4LRRGokJrr9126e2pFpCwZo5HbZJNS/kiC3QdPUExEBLal/4OyHYXrMAij2hrT8lLDAzWgOJRAwQ==
 
 "@tryghost/limit-service@1.2.14":
   version "1.2.14"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-365

- bumps Koenig packages to bring the CTA card behind the private beta labs flag
