### PR TITLE
Added CI timeout for MySQL action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,7 @@ jobs:
 
       - uses: daniellockyer/mysql-action@main
         if: matrix.env.DB == 'mysql8'
+        timeout-minutes: 3
         with:
           authentication plugin: 'caching_sha2_password'
           mysql version: '8.0'
@@ -645,6 +646,7 @@ jobs:
 
       - uses: daniellockyer/mysql-action@main
         if: matrix.env.DB == 'mysql8'
+        timeout-minutes: 3
         with:
           authentication plugin: 'caching_sha2_password'
           mysql version: '8.0'


### PR DESCRIPTION
- in the event MySQL does not start, we don't want to be waiting around forever
- 3 minutes is kinda arbitrary and in reality, still way too long, but it's better than infinity