### PR TITLE
Deprecated `models.init` pattern for initializing models

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -88,6 +88,12 @@ async function initCore({ghostServer, config, frontend}) {
     require('./shared/url-utils');
     debug('End: Load urlUtils');
 
+    // Models are the heart of Ghost - we want to explicitly load them here so their require time
+    // isn't hidden in other steps
+    debug('Begin: models');
+    require('./server/models');
+    debug('End: models');
+
     // Settings are a core concept we use settings to store key-value pairs used in critical pathways as well as public data like the site title
     debug('Begin: settings');
     const settings = require('./server/services/settings/settings-service');

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -88,12 +88,6 @@ async function initCore({ghostServer, config, frontend}) {
     require('./shared/url-utils');
     debug('End: Load urlUtils');
 
-    // Models are the heart of Ghost - this is a syncronous operation
-    debug('Begin: models');
-    const models = require('./server/models');
-    models.init();
-    debug('End: models');
-
     // Settings are a core concept we use settings to store key-value pairs used in critical pathways as well as public data like the site title
     debug('Begin: settings');
     const settings = require('./server/services/settings/settings-service');

--- a/ghost/core/core/cli/generate-data.js
+++ b/ghost/core/core/cli/generate-data.js
@@ -21,8 +21,6 @@ module.exports = class DataGeneratorCommand extends Command {
         const models = require('../server/models');
         const knex = require('../server/data/db/connection');
 
-        models.init();
-
         context.models = models;
         context.m = models;
         context.knex = knex;

--- a/ghost/core/core/cli/repl.js
+++ b/ghost/core/core/cli/repl.js
@@ -12,8 +12,6 @@ module.exports = class REPL extends Command {
         const models = require('../server/models');
         const knex = require('../server/data/db/connection');
 
-        models.init();
-
         context.models = models;
         context.m = models;
         context.knex = knex;

--- a/ghost/core/core/server/data/migrations/hooks/init/before.js
+++ b/ghost/core/core/server/data/migrations/hooks/init/before.js
@@ -1,6 +1,3 @@
-const models = require('../../../../models');
-
 module.exports = function before() {
-    models.init();
     return Promise.resolve();
 };

--- a/ghost/core/core/server/models/index.js
+++ b/ghost/core/core/server/models/index.js
@@ -1,10 +1,4 @@
-/**
- * Dependencies
- */
-
-const _ = require('lodash');
-const debug = require('@tryghost/debug')('models');
-const glob = require('glob');
+/* eslint-disable max-lines */
 
 // enable event listeners
 require('./base/listeners');
@@ -12,24 +6,82 @@ require('./base/listeners');
 /**
  * Expose all models
  */
-exports = module.exports;
+module.exports = {
+    // `base` file does not export a Base model
+    Base: require('./base'),
 
-function init() {
-    const baseNow = Date.now();
-    exports.Base = require('./base');
-    debug(`${Date.now() - baseNow}ms - Base.js require`);
-
-    let modelsFiles = glob.sync('!(index).js', {cwd: __dirname});
-    modelsFiles.forEach((model) => {
-        const name = model.replace(/.js$/, '');
-        const modelNow = Date.now();
-        _.extend(exports, require('./' + name));
-        debug(`${Date.now() - modelNow}ms - ${model} require`);
-    });
-}
+    ...require('./action'),
+    ...require('./author'),
+    ...require('./api-key'),
+    ...require('./benefit'),
+    ...require('./collection-post'),
+    ...require('./collection'),
+    ...require('./comment-like'),
+    ...require('./comment-report'),
+    ...require('./comment'),
+    ...require('./custom-theme-setting'),
+    ...require('./donation-payment-event'),
+    ...require('./email-batch'),
+    ...require('./email-recipient-failure'),
+    ...require('./email-recipient'),
+    ...require('./email-spam-complaint-event'),
+    ...require('./email'),
+    ...require('./integration'),
+    ...require('./invite'),
+    ...require('./job'),
+    ...require('./label'),
+    ...require('./mail-event'),
+    ...require('./member-cancel-event'),
+    ...require('./member-click-event'),
+    ...require('./member-created-event'),
+    ...require('./member-email-change-event'),
+    ...require('./member-feedback'),
+    ...require('./member-login-event'),
+    ...require('./member-newsletter'),
+    ...require('./member-paid-subscription-event'),
+    ...require('./member-payment-event'),
+    ...require('./member-product-event'),
+    ...require('./member-status-event'),
+    ...require('./member-stripe-customer'),
+    ...require('./member-subscribe-event'),
+    ...require('./member'),
+    ...require('./mention'),
+    ...require('./milestone'),
+    ...require('./mobiledoc-revision'),
+    ...require('./newsletter'),
+    ...require('./offer-redemption'),
+    ...require('./offer'),
+    ...require('./permission'),
+    ...require('./post-revision'),
+    ...require('./post'),
+    ...require('./posts-meta'),
+    ...require('./product'),
+    ...require('./recommendation-click-event'),
+    ...require('./recommendation-subscribe-event'),
+    ...require('./recommendation'),
+    ...require('./redirect'),
+    ...require('./role'),
+    ...require('./session'),
+    ...require('./settings'),
+    ...require('./single-use-token'),
+    ...require('./snippet'),
+    ...require('./stripe-customer-subscription'),
+    ...require('./stripe-price'),
+    ...require('./stripe-product'),
+    ...require('./subscription-created-event'),
+    ...require('./suppression'),
+    ...require('./tag-public'),
+    ...require('./tag'),
+    ...require('./user'),
+    ...require('./webhook')
+};
 
 /**
- * Expose `init`
+ * @deprecated: remove this once we've removed it from everywhere
  */
-
-exports.init = init;
+module.exports.init = function init() {
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('@deprecated: models.init() is deprecated. Models are now automatically required.');
+    }
+};

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -8,7 +8,6 @@ const errors = require('@tryghost/errors');
 const security = require('@tryghost/security');
 const {pipeline} = require('@tryghost/promise');
 const validatePassword = require('../lib/validate-password');
-const permissions = require('../services/permissions');
 const urlUtils = require('../../shared/url-utils');
 const {setIsRoles} = require('./role-utils');
 const activeStates = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'];
@@ -918,6 +917,7 @@ User = ghostBookshelf.Model.extend({
                         // @NOTE: your role is not the same than the role you try to change (!)
                         // e.g. admin can assign admin role to a user, but not owner
 
+                        const permissions = require('../services/permissions');
                         return permissions.canThis(context).assign.role(role)
                             .then(() => {
                                 if (hasUserPermission && hasApiKeyPermission) {

--- a/ghost/core/core/server/services/update-check/run-update-check.js
+++ b/ghost/core/core/server/services/update-check/run-update-check.js
@@ -31,10 +31,6 @@ if (parentPort) {
 (async () => {
     const updateCheck = require('./');
 
-    // INIT required services
-    const models = require('../../models');
-    models.init();
-
     const permissions = require('../permissions');
     await permissions.init();
 

--- a/ghost/core/core/server/web/api/testmode/jobs/graceful-job.js
+++ b/ghost/core/core/server/web/api/testmode/jobs/graceful-job.js
@@ -25,8 +25,6 @@ const internalContext = {context: {internal: true}};
 (async () => {
     const models = require('../../../../models');
 
-    await models.init();
-
     postParentPortMessage(`Fetching tags`);
     const tags = await models.Tag.findPage(internalContext);
 

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -15,7 +15,7 @@
         "port": 9417
     },
     "logging": {
-        "level": "fatal"
+        "level": "info"
     },
     "spam": {
         "user_login": {

--- a/ghost/core/test/integration/url_service.test.js
+++ b/ghost/core/test/integration/url_service.test.js
@@ -2,15 +2,10 @@ const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../utils');
 const configUtils = require('../utils/configUtils');
-const models = require('../../core/server/models');
 const UrlService = require('../../core/server/services/url/UrlService');
 
 describe('Integration: services/url/UrlService', function () {
     let urlService;
-
-    before(function () {
-        models.init();
-    });
 
     before(testUtils.teardownDb);
     before(testUtils.setup('users:roles', 'posts'));

--- a/ghost/core/test/regression/api/admin/schedules.test.js
+++ b/ghost/core/test/regression/api/admin/schedules.test.js
@@ -15,8 +15,6 @@ describe('Schedules API', function () {
     let request;
 
     before(function () {
-        models.init();
-
         // @NOTE: mock the post scheduler, otherwise it will auto publish the post
         sinon.stub(SchedulingDefault.prototype, '_pingUrl').resolves();
     });

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -8,7 +8,6 @@ const models = require('../../../core/server/models');
 const SETTINGS_LENGTH = 94;
 
 describe('Settings Model', function () {
-    before(models.init);
     afterEach(testUtils.teardownDb);
 
     describe('defaults', function () {

--- a/ghost/core/test/unit/api/cache-invalidation.test.js
+++ b/ghost/core/test/unit/api/cache-invalidation.test.js
@@ -3,15 +3,8 @@ const path = require('path');
 
 const glob = require('glob');
 
-const models = require('../../../core/server/models');
-
 describe('API', function () {
     describe('Cache Invalidation', function () {
-        before(async function () {
-            // Initialise models - Utilised by various endpoints to reference static fields (i.e models.Post.allowedFormats) when required in
-            models.init();
-        });
-
         it('Controller actions explicitly declare cacheInvalidate header', async function () {
             const controllersRootPath = path.join(__dirname, '../../../core/server/api/endpoints');
             const controllerPaths = glob.sync('*.js', {

--- a/ghost/core/test/unit/api/canary/session.test.js
+++ b/ghost/core/test/unit/api/canary/session.test.js
@@ -8,10 +8,6 @@ const sessionController = require('../../../../core/server/api/endpoints/session
 const sessionServiceMiddleware = require('../../../../core/server/services/auth/session');
 
 describe('Session controller', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
@@ -5,10 +5,6 @@ const validators = require('../../../../../../../core/server/api/endpoints/utils
 const models = require('../../../../../../../core/server/models');
 
 describe('Unit: endpoints/utils/validators/input/pages', function () {
-    before(function () {
-        return models.init();
-    });
-
     beforeEach(function () {
         const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
         memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());

--- a/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
@@ -5,10 +5,6 @@ const validators = require('../../../../../../../core/server/api/endpoints/utils
 const models = require('../../../../../../../core/server/models');
 
 describe('Unit: endpoints/utils/validators/input/posts', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
         memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -2,14 +2,9 @@ const should = require('should');
 const sinon = require('sinon');
 const urlService = require('../../../../core/server/services/url');
 const authorsHelper = require('../../../../core/frontend/helpers/authors');
-const models = require('../../../../core/server/models');
 const testUtils = require('../../../utils');
 
 describe('{{authors}} helper', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(urlService, 'getUrlByResourceId');
     });

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -7,7 +7,6 @@ const loggingLib = require('@tryghost/logging');
 
 // Stuff we are testing
 const get = require('../../../../core/frontend/helpers/get');
-const models = require('../../../../core/server/models');
 const proxy = require('../../../../core/frontend/services/proxy');
 const api = require('../../../../core/server/api').endpoints;
 
@@ -16,10 +15,6 @@ describe('{{#get}} helper', function () {
     let inverse;
     let locals = {};
     let logging;
-
-    before(function () {
-        models.init();
-    });
 
     beforeEach(function () {
         fn = sinon.spy();

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 const moment = require('moment');
 const testUtils = require('../../../utils');
 const configUtils = require('../../../utils/configUtils');
-const models = require('../../../../core/server/models');
 const imageLib = require('../../../../core/server/lib/image');
 const routing = require('../../../../core/frontend/services/routing');
 const urlService = require('../../../../core/server/services/url');
@@ -358,9 +357,6 @@ describe('{{ghost_head}} helper', function () {
     };
 
     before(function () {
-        // @TODO: remove when visibility is refactored out of models
-        models.init();
-
         keyStub = sinon.stub().resolves('xyz');
         const dataService = {
             getFrontendKey: keyStub

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
 const api = require('../../../../core/server/api').endpoints;
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/configUtils');
@@ -21,8 +20,6 @@ describe('{{#recommendations}} helper', function () {
     let logging;
 
     before(function () {
-        models.init();
-
         hbs.express4({
             partialsDir: [configUtils.config.get('paths').helperTemplates]
         });

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -2,14 +2,9 @@ const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
 const urlService = require('../../../../core/server/services/url');
-const models = require('../../../../core/server/models');
 const tagsHelper = require('../../../../core/frontend/helpers/tags');
 
 describe('{{tags}} helper', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(urlService, 'getUrlByResourceId');
     });

--- a/ghost/core/test/unit/frontend/meta/keywords.test.js
+++ b/ghost/core/test/unit/frontend/meta/keywords.test.js
@@ -1,13 +1,8 @@
 const should = require('should');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
 const getKeywords = require('../../../../core/frontend/meta/keywords');
 
 describe('getKeywords', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -14,10 +14,6 @@ const nock = require('nock');
 describe('Scheduling: Post Scheduler', function () {
     let adapter;
 
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         adapter = new SchedulingDefault();
 

--- a/ghost/core/test/unit/server/data/db/backup.test.js
+++ b/ghost/core/test/unit/server/data/db/backup.test.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
-const models = require('../../../../../core/server/models');
 const exporter = require('../../../../../core/server/data/exporter');
 const dbBackup = require('../../../../../core/server/data/db/backup');
 const configUtils = require('../../../../utils/configUtils');
@@ -10,10 +9,6 @@ describe('Backup', function () {
     let exportStub;
     let filenameStub;
     let fsStub;
-
-    before(function () {
-        models.init();
-    });
 
     afterEach(function () {
         sinon.restore();

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -13,10 +13,6 @@ describe('Exporter', function () {
     let queryMock;
     let knexMock;
 
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -9,10 +9,6 @@ const fixtures = require('../../../../../utils/fixtures/fixtures.json');
 const fixtureManager = new FixtureManager(fixtures);
 
 describe('Migration Fixture Utils', function () {
-    beforeEach(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/data/schema/validator.test.js
+++ b/ghost/core/test/unit/server/data/schema/validator.test.js
@@ -7,10 +7,6 @@ const models = require('../../../../../core/server/models');
 const validateSchema = require('../../../../../core/server/data/schema/validator');
 
 describe('Validate Schema', function () {
-    before(function () {
-        models.init();
-    });
-
     describe('models.add', function () {
         it('blank model', function () {
             // NOTE: Fields with `defaultTo` are getting ignored. This is handled on the DB level.

--- a/ghost/core/test/unit/server/models/api-key.test.js
+++ b/ghost/core/test/unit/server/models/api-key.test.js
@@ -3,8 +3,6 @@ const should = require('should');
 const sinon = require('sinon');
 
 describe('Unit: models/api_key', function () {
-    before(models.init);
-
     describe('fn: refreshSecret', function () {
         it('returns a call to edit passing a new admin secret', function () {
             const editStub = sinon.stub(models.ApiKey, 'edit').resolves();

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -4,10 +4,6 @@ const sinon = require('sinon');
 const models = require('../../../../../core/server/models');
 
 describe('Models: crud', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -6,10 +6,6 @@ const urlUtils = require('../../../../../core/shared/url-utils');
 const testUtils = require('../../../../utils');
 
 describe('Models: base', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -4,10 +4,6 @@ const models = require('../../../../../core/server/models');
 const assert = require('assert/strict');
 
 describe('Models: getLazyRelation', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -3,10 +3,6 @@ const models = require('../../../../core/server/models');
 const testUtils = require('../../../utils');
 
 describe('Unit: models/comment', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/custom-theme-setting.test.js
+++ b/ghost/core/test/unit/server/models/custom-theme-setting.test.js
@@ -2,10 +2,6 @@ const should = require('should');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/custom-theme-setting', function () {
-    before(function () {
-        models.init();
-    });
-
     describe('parse', function () {
         it('ensure correct parsing when fetching from db', function () {
             const setting = models.CustomThemeSetting.forge();

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -4,10 +4,6 @@ const models = require('../../../../core/server/models');
 const {knex} = require('../../../../core/server/data/db');
 
 describe('Unit: models/integration', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -4,10 +4,6 @@ const models = require('../../../../core/server/models');
 const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('Unit: models/invite', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(settingsCache, 'get').withArgs('db_hash').returns('12345678');
     });

--- a/ghost/core/test/unit/server/models/member-click-event.test.js
+++ b/ghost/core/test/unit/server/models/member-click-event.test.js
@@ -2,10 +2,6 @@ const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/MemberClickEvent', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/member-created-event.test.js
+++ b/ghost/core/test/unit/server/models/member-created-event.test.js
@@ -4,10 +4,6 @@ const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/MemberCreatedEvent', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/member-feedback.test.js
+++ b/ghost/core/test/unit/server/models/member-feedback.test.js
@@ -4,10 +4,6 @@ const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/MemberFeedback', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/member-paid-subscription-event.test.js
+++ b/ghost/core/test/unit/server/models/member-paid-subscription-event.test.js
@@ -2,10 +2,6 @@ const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/MemberPaidSubscriptionEvent', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/member-subscribe-event.test.js
+++ b/ghost/core/test/unit/server/models/member-subscribe-event.test.js
@@ -4,10 +4,6 @@ const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/MemberSubscribeEvent', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -7,10 +7,6 @@ const labs = require('../../../../core/shared/labs');
 const config = configUtils.config;
 
 describe('Unit: models/member', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         config.set('assetHash', '1');
     });

--- a/ghost/core/test/unit/server/models/milestone.test.js
+++ b/ghost/core/test/unit/server/models/milestone.test.js
@@ -3,10 +3,6 @@ const assert = require('assert/strict');
 const errors = require('@tryghost/errors');
 
 describe('Unit: models/milestone', function () {
-    before(function () {
-        models.init();
-    });
-
     describe('validation', function () {
         describe('blank', function () {
             it('throws validation error for mandatory fields', function () {

--- a/ghost/core/test/unit/server/models/newsletter.test.js
+++ b/ghost/core/test/unit/server/models/newsletter.test.js
@@ -5,10 +5,6 @@ const should = require('should');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/newsletter', function () {
-    before(function () {
-        models.init();
-    });
-
     after(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/permission.test.js
+++ b/ghost/core/test/unit/server/models/permission.test.js
@@ -4,10 +4,6 @@ const models = require('../../../../core/server/models');
 const configUtils = require('../../../utils/configUtils');
 
 describe('Unit: models/permission', function () {
-    before(function () {
-        models.init();
-    });
-
     after(async function () {
         sinon.restore();
         await configUtils.restore();

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -13,7 +13,6 @@ describe('Unit: models/post', function () {
     let tracker;
 
     before(function () {
-        models.init();
         mockDb.mock(knex);
         tracker = mockDb.getTracker();
     });
@@ -355,10 +354,6 @@ describe('Unit: models/post', function () {
 });
 
 describe('Unit: models/post: uses database (@TODO: fix me)', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
         sinon.stub(urlService, 'getUrlByResourceId');

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -3,10 +3,6 @@ const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/session', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -7,10 +7,6 @@ const events = require('../../../../core/server/lib/common/events');
 const errors = require('@tryghost/errors');
 
 describe('Unit: models/settings', function () {
-    before(function () {
-        models.init();
-    });
-
     describe('events', function () {
         let tracker;
         let eventSpy;

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -8,7 +8,6 @@ let sandbox;
 
 describe('Unit: models/single-use-token', function () {
     before(function () {
-        models.init();
         sandbox = sinon.createSandbox();
         clock = sandbox.useFakeTimers();
     });

--- a/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
+++ b/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
@@ -3,10 +3,6 @@ const should = require('should');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/stripe-customer-subscription', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/subscription-created-event.test.js
+++ b/ghost/core/test/unit/server/models/subscription-created-event.test.js
@@ -4,10 +4,6 @@ const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/SubscriptionCreatedEvent', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -4,10 +4,6 @@ const models = require('../../../../core/server/models');
 const {knex} = require('../../../../core/server/data/db');
 
 describe('Unit: models/tag', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -8,10 +8,6 @@ const security = require('@tryghost/security');
 const testUtils = require('../../../utils');
 
 describe('Unit: models/user', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -9,8 +9,6 @@ describe('Admin API Key Auth', function () {
     const ADMIN_API_URL_VERSIONED = '/ghost/api/v4/admin/';
     const ADMIN_API_URL_NON_VERSIONED = '/ghost/api/admin/';
 
-    before(models.init);
-
     beforeEach(function () {
         const fakeApiKey = {
             id: '1234',

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -5,8 +5,6 @@ const should = require('should');
 const sinon = require('sinon');
 
 describe('Content API Key Auth', function () {
-    before(models.init);
-
     this.beforeEach(function () {
         const fakeApiKey = {
             id: '1234',

--- a/ghost/core/test/unit/server/services/auth/session/middleware.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/middleware.test.js
@@ -6,10 +6,6 @@ const should = require('should');
 const labs = require('../../../../../../core/shared/labs');
 
 describe('Session Service', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -6,9 +6,6 @@ const sinon = require('sinon');
 const should = require('should');
 
 describe('Auth Service SessionStore', function () {
-    before(function () {
-        models.init();
-    });
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/services/frontend-data-service/frontend-data-service.test.js
+++ b/ghost/core/test/unit/server/services/frontend-data-service/frontend-data-service.test.js
@@ -10,10 +10,6 @@ const logging = require('@tryghost/logging');
 describe('Frontend Data Service', function () {
     let service, modelStub, fakeModel;
 
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         fakeModel = {
             toJSON: () => {

--- a/ghost/core/test/unit/server/services/frontend-data-service/index.test.js
+++ b/ghost/core/test/unit/server/services/frontend-data-service/index.test.js
@@ -1,12 +1,7 @@
-const models = require('../../../../../core/server/models');
 const assert = require('assert/strict');
 
 describe('Frontend Data Service', function () {
     let frontendDataService;
-
-    before(function () {
-        models.init();
-    });
 
     it('Provides expected public API', async function () {
         frontendDataService = require('../../../../../core/server/services/frontend-data-service');

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -14,10 +14,6 @@ describe('Members Service Middleware', function () {
         let res;
         let next;
 
-        before(function () {
-            models.init();
-        });
-
         beforeEach(function () {
             req = {};
             res = {};
@@ -197,10 +193,6 @@ describe('Members Service Middleware', function () {
         // let oldMembersService;
         let req;
         let res;
-
-        before(function () {
-            models.init();
-        });
 
         beforeEach(function () {
             req = {body: {newsletters: [], enable_comment_notifications: null}};

--- a/ghost/core/test/unit/server/services/newsletters/index.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/index.test.js
@@ -1,12 +1,7 @@
-const models = require('../../../../../core/server/models');
 const assert = require('assert/strict');
 
 describe('Newsletters Service', function () {
     let newslettersService;
-
-    before(function () {
-        models.init();
-    });
 
     describe('Newsletter Service', function () {
         it('Provides expected public API', async function () {

--- a/ghost/core/test/unit/server/services/newsletters/service.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/service.test.js
@@ -28,8 +28,6 @@ describe('NewslettersService', function () {
     let emailMockReceiver;
 
     before(function () {
-        models.init();
-
         tokenProvider = new TestTokenProvider();
 
         limitService = {

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -11,10 +11,6 @@ describe('Permissions', function () {
     let findPostSpy;
     let findTagSpy;
 
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -9,10 +9,6 @@ const permissions = require('../../../../../core/server/services/permissions');
 describe('Permissions', function () {
     let fakePermissions = [];
 
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         sinon.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -5,10 +5,6 @@ const models = require('../../../../../core/server/models');
 const providers = require('../../../../../core/server/services/permissions/providers');
 
 describe('Permission Providers', function () {
-    before(function () {
-        models.init();
-    });
-
     afterEach(function () {
         sinon.restore();
     });

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -11,10 +11,6 @@ const MilestoneCreatedEvent = require('../../../../../core/server/services/miles
 describe('Staff Service:', function () {
     let emailMockReceiver;
 
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         emailMockReceiver = mockManager.mockMail();
         mockManager.mockSlack();

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -10,10 +10,6 @@ const tiersService = require('../../../../../core/server/services/tiers');
 const {fixtureManager} = require('../../../../utils/e2e-framework');
 
 describe('WebhookService - Serialize', function () {
-    before(function () {
-        models.init();
-    });
-
     beforeEach(function () {
         tiersService.api = {
             browse() {

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -8,7 +8,6 @@ const _ = require('lodash');
 
 // Ghost Internals
 const models = require('../../core/server/models');
-models.init();
 
 // Other Test Utilities
 const e2eUtils = require('./e2e-utils');
@@ -48,7 +47,6 @@ const setup = function setup() {
 
     return function innerSetup() {
         debug('Setup start');
-        models.init();
         return initFixtures
             .apply(self, args)
             .finally(() => {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1740997729615089 ref https://linear.app/ghost/issue/ENG-2071/remove-modelsinit-pattern

- `models.init` will dynamically require all the files in the folder and re-export them
- this is useful in that you can add a model, but the downside is that it breaks all editor autocomplete because we don't know the exports until runtime
- more generally, this pattern is super annoying and we always have to remember to do `models.init` in unit tests
- to fix that, we can deprecate the use of this (there are some other places outside of this codebase we need to remove it from too) and explicit export all the files
- this means you have to add your new model to this file, but that's better than not having any types available
