### PR TITLE
Updated router in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/routes.tsx
+++ b/apps/admin-x-activitypub/src/routes.tsx
@@ -1,7 +1,7 @@
 import Inbox from '@views/Inbox';
 import Notifications from '@views/Notifications';
 import Profile from '@views/Profile';
-import {RouteObject, redirect} from '@tryghost/admin-x-framework';
+import {Navigate, RouteObject} from '@tryghost/admin-x-framework';
 
 export const APP_ROUTE_PREFIX = '/activitypub';
 
@@ -12,28 +12,27 @@ type CustomRouteObject = RouteObject & {
 export const routes: CustomRouteObject[] = [
     {
         path: '',
-        loader: () => redirect('inbox'),
         index: true,
-        pageTitle: 'Inbox'
+        element: <Navigate to="inbox" replace />
     },
     {
         path: 'inbox',
-        Component: Inbox,
+        element: <Inbox />,
         pageTitle: 'Inbox'
     },
     {
         path: 'feed',
-        Component: Inbox,
+        element: <Inbox />,
         pageTitle: 'Feed'
     },
     {
         path: 'notifications',
-        Component: Notifications,
+        element: <Notifications />,
         pageTitle: 'Notifications'
     },
     {
         path: 'profile',
-        Component: Profile,
+        element: <Profile />,
         pageTitle: 'Profile'
     }
 ];

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -7,7 +7,7 @@ export type {RouteObject} from 'react-router';
 export type {RouterProviderProps} from './providers/RouterProvider';
 export {RouterProvider, useNavigate} from './providers/RouterProvider';
 export {useNavigationStack} from './providers/NavigationStackProvider';
-export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes} from 'react-router';
+export {Link, NavLink, Navigate, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes} from 'react-router';
 
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';

--- a/apps/admin-x-framework/src/providers/RouterProvider.tsx
+++ b/apps/admin-x-framework/src/providers/RouterProvider.tsx
@@ -1,8 +1,8 @@
-import {ErrorPage} from '@tryghost/shade';
 import React, {useCallback, useMemo} from 'react';
 import {createHashRouter, RouteObject, RouterProvider as ReactRouterProvider, NavigateOptions as ReactRouterNavigateOptions, useNavigate as useReactRouterNavigate, Outlet} from 'react-router';
 import {useFramework} from './FrameworkProvider';
 import {NavigationStackProvider} from './NavigationStackProvider';
+import {ErrorPage} from '@tryghost/shade';
 
 /**
  * This provider uses React Router to provide a router context to React apps

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -20,7 +20,7 @@ export * from './components/ui/tooltip';
 
 // Layout components
 export * from './components/layout/page';
-export * from './components/layout/error-page';
+export {ErrorPage} from './components/layout/error-page';
 export * from './components/layout/heading';
 
 // Third party components


### PR DESCRIPTION
ref AP-830

- In live environment the router rendered an empty component when navigating to `/activitypub/` instead of redirecting to `/activitypub/inbox`.