### PR TITLE
Added ActivityPub soft feature flags

### DIFF
--- a/apps/admin-x-activitypub/src/App.tsx
+++ b/apps/admin-x-activitypub/src/App.tsx
@@ -1,6 +1,7 @@
 import {APP_ROUTE_PREFIX, routes} from '@src/routes';
 import {DesignSystemApp, DesignSystemAppProps} from '@tryghost/admin-x-design-system';
-import {FrameworkProvider, RouterProvider, TopLevelFrameworkProps} from '@tryghost/admin-x-framework';
+import {FeatureFlagsProvider} from './lib/feature-flags';
+import {FrameworkProvider, Outlet, RouterProvider, TopLevelFrameworkProps} from '@tryghost/admin-x-framework';
 import {ShadeApp} from '@tryghost/shade';
 
 interface AppProps {
@@ -13,7 +14,11 @@ const App: React.FC<AppProps> = ({framework, designSystem}) => {
         <FrameworkProvider {...framework}>
             <DesignSystemApp className='shade' {...designSystem}>
                 <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
-                    <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes} />
+                    <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
+                        <FeatureFlagsProvider>
+                            <Outlet />
+                        </FeatureFlagsProvider>
+                    </RouterProvider>
                 </ShadeApp>
             </DesignSystemApp>
         </FrameworkProvider>

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -4,8 +4,11 @@ import NiceModal from '@ebay/nice-modal-react';
 import Recommendations from './Recommendations';
 import SidebarMenuLink from './SidebarMenuLink';
 import {Button, LucideIcon, Separator} from '@tryghost/shade';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 
 const Sidebar: React.FC = () => {
+    const {allFlags, flags} = useFeatureFlags();
+
     return (
         <div className='sticky top-[102px] flex min-h-[calc(100vh-102px-32px)] w-[294px] flex-col border-l border-gray-200 dark:border-gray-950'>
             <div className='flex grow flex-col justify-between'>
@@ -36,6 +39,22 @@ const Sidebar: React.FC = () => {
                     <Separator />
 
                     <Recommendations />
+
+                    <div className="space-y-2 p-3">
+                        {allFlags.map((flag) => {
+                            if (flags[flag]) {
+                                return (
+                                    <div key={flag} className="flex items-center justify-between gap-1">
+                                        <span className="font-mono text-xs">{flag}</span>
+                                        <span className='text-green-800 inline-flex items-center rounded bg-green-100 px-1 py-0.5 text-xs font-medium'>
+                                            ON
+                                        </span>
+                                    </div>
+                                );
+                            }
+                            return (<></>);
+                        })}
+                    </div>
                 </div>
                 <div className='flex items-center gap-2 pl-7 pt-4 text-xs text-gray-400'>
                     <a className='text-xs font-medium text-gray-700 hover:text-black dark:text-gray-800 dark:hover:text-white' href="https://forum.ghost.org/t/activitypub-beta-start-here/51780" rel="noreferrer" target="_blank">Feedback</a>

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -1,0 +1,90 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import {useLocation} from '@tryghost/admin-x-framework';
+
+// Define all available feature flags here
+export const FEATURE_FLAGS = ['deleteButton'] as const;
+
+// ---
+export type FeatureFlag = typeof FEATURE_FLAGS[number];
+
+type FeatureFlagsState = Record<FeatureFlag, boolean>;
+
+type FeatureFlagsContextType = {
+    isEnabled: (flag: FeatureFlag) => boolean;
+    flags: FeatureFlagsState;
+    allFlags: typeof FEATURE_FLAGS;
+};
+
+const FeatureFlagsContext = createContext<FeatureFlagsContextType | undefined>(undefined);
+
+export const FeatureFlagsProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+    const location = useLocation();
+    const [flags, setFlags] = useState<FeatureFlagsState>(() => {
+        // Try to load from localStorage first
+        const savedFlags = localStorage.getItem('featureFlags');
+        if (savedFlags) {
+            return JSON.parse(savedFlags);
+        }
+        return getDefaultState();
+    });
+
+    useEffect(() => {
+        const urlFlags = parseUrlParams(location.search);
+        if (Object.keys(urlFlags).length > 0) {
+            setFlags((currentFlags) => {
+                const newFlags = {
+                    ...currentFlags,
+                    ...urlFlags
+                };
+                // Save to localStorage for persistence
+                localStorage.setItem('featureFlags', JSON.stringify(newFlags));
+                return newFlags;
+            });
+        }
+    }, [location.search]);
+
+    const isEnabled = (flag: FeatureFlag): boolean => flags[flag];
+
+    const value = {
+        isEnabled,
+        flags,
+        allFlags: FEATURE_FLAGS
+    };
+
+    return (
+        <FeatureFlagsContext.Provider value={value}>
+            {children}
+        </FeatureFlagsContext.Provider>
+    );
+};
+
+const getDefaultState = (): FeatureFlagsState => {
+    return FEATURE_FLAGS.reduce((acc, flag) => ({
+        ...acc,
+        [flag]: false
+    }), {} as FeatureFlagsState);
+};
+
+const parseUrlParams = (search: string): Partial<FeatureFlagsState> => {
+    const params = new URLSearchParams(search);
+    const state: Partial<FeatureFlagsState> = {};
+
+    FEATURE_FLAGS.forEach((flag) => {
+        const value = params.get(flag);
+        if (value === 'ON') {
+            state[flag] = true;
+        } else if (value === 'OFF') {
+            state[flag] = false;
+        }
+    });
+
+    return state;
+};
+
+export const useFeatureFlags = () => {
+    const context = useContext(FeatureFlagsContext);
+    if (context === undefined) {
+        throw new Error('useFeatureFlags must be used within a FeatureFlagsProvider');
+    }
+    return context;
+};

--- a/apps/admin-x-framework/src/providers/RouterProvider.tsx
+++ b/apps/admin-x-framework/src/providers/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {createHashRouter, RouteObject, RouterProvider as ReactRouterProvider, NavigateOptions as ReactRouterNavigateOptions, useNavigate as useReactRouterNavigate, Outlet} from 'react-router';
+import {createHashRouter, RouteObject, RouterProvider as ReactRouterProvider, NavigateOptions as ReactRouterNavigateOptions, useNavigate as useReactRouterNavigate} from 'react-router';
 import {useFramework} from './FrameworkProvider';
 import {NavigationStackProvider} from './NavigationStackProvider';
 import {ErrorPage} from '@tryghost/shade';
@@ -21,12 +21,14 @@ export interface RouterProviderProps {
 
     // Custom routing props
     errorElement?: React.ReactNode;
+    children?: React.ReactNode;
 }
 
 export function RouterProvider({
     routes,
     prefix,
-    errorElement
+    errorElement,
+    children
 }: RouterProviderProps) {
     // Memoize the router to avoid re-creating it on every render
     const router = useMemo(() => {
@@ -34,11 +36,11 @@ export function RouterProvider({
         const normalizedPrefix = `/${prefix?.replace(/\/+/g, '/').replace(/^\/|\/$/g, '')}`;
 
         // Create a root route that wraps all routes with NavigationStackProvider
-        // so navigation stack is available by default.
+        // and any additional children (providers) so they have access to routing
         const rootRoute: RouteObject = {
             element: (
                 <NavigationStackProvider>
-                    <Outlet />
+                    {children}
                 </NavigationStackProvider>
             ),
             children: routes.map(route => ({
@@ -47,13 +49,10 @@ export function RouterProvider({
             }))
         };
 
-        // Add default error element if not provided
-        // const finalRoutes = routes.map();
-
         return createHashRouter([rootRoute], {
             basename: normalizedPrefix
         });
-    }, [routes, prefix, errorElement]);
+    }, [routes, prefix, errorElement, children]);
 
     return (
         <ReactRouterProvider router={router} />


### PR DESCRIPTION
ref AP-832

- In order to be able to ship small, in progress ActivityPub related features without exposing them to the public, we need a lightweight and fast feature flag subsystem. The current alpha feature flag system is too big for some of the tasks we're working on.