### PR TITLE
Modified CI flow to ignore changes to Tinybird files for core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
               - *shared
               - 'ghost/**'
               - '!ghost/admin/**'
+              - '!ghost/tinybird-dedicated/**'
+              - '!ghost/tinybird/**'
             admin:
               - *shared
               - 'ghost/admin/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1287,7 +1287,7 @@ jobs:
     defaults:
       run:
         working-directory: ghost/tinybird-dedicated
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
no ref

- Ghost core doesn't depend on the files in `ghost/tinybird` or `ghost/tinybird-dedicated`, but currently CI will run all the database/unit/etc tests even if you only change tinybird files.
- This commit ignores changes to Tinybird files when calculating which tests to run on `core`, so if you only change Tinybird files it will not run all database tests, unit tests, etc.
