### PR TITLE
Enable router hooks in the whole ActiviPub app

### DIFF
--- a/apps/admin-x-activitypub/src/App.tsx
+++ b/apps/admin-x-activitypub/src/App.tsx
@@ -12,15 +12,16 @@ interface AppProps {
 const App: React.FC<AppProps> = ({framework, designSystem}) => {
     return (
         <FrameworkProvider {...framework}>
-            <DesignSystemApp className='shade' {...designSystem}>
-                <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
-                    <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
+            <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
+                <DesignSystemApp className='shade' {...designSystem}>
+                    {/* TODO: remove className='' from ShadeApp once DesignSystemApp is removed to apply 'shade' to the main container */}
+                    <ShadeApp className='' darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
                         <FeatureFlagsProvider>
                             <Outlet />
                         </FeatureFlagsProvider>
-                    </RouterProvider>
-                </ShadeApp>
-            </DesignSystemApp>
+                    </ShadeApp>
+                </DesignSystemApp>
+            </RouterProvider>
         </FrameworkProvider>
     );
 };


### PR DESCRIPTION
ref AP-835

- In the main App component of ActivityPub the `RouterProvider` is at the deepest level of the stack. This means that other providers can't access router related hooks which would be essential. To fix this, we need to move the router provider up to the topmost of the stack.