### PR TITLE
Removed unneeded conditions for `deploy_tinybird` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1278,8 +1278,6 @@ jobs:
   deploy_tinybird:
     needs: [
       job_setup,
-      job_lint,
-      job_unit-tests,
       job_tinybird
     ]
     name: Deploy Tinybird


### PR DESCRIPTION
no issue

- The `deploy_tinybird` job currently depends on unit tests and linting, but these jobs aren't actually needed for the Tinybird deploy job to run