### PR TITLE
Copied scripts from previous tinybird implementation into new one

### DIFF
--- a/ghost/tinybird-dedicated/scripts/branch_and_test.sh
+++ b/ghost/tinybird-dedicated/scripts/branch_and_test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Create a branch and test it
+
+# Create a variable with a timestamp to use as a random name for the branch
+BRANCH_NAME="TEST_$(date +%s)"
+
+# Check for -y flag
+force_delete=false
+for arg in "$@"; do
+    if [[ "$arg" == "-y" ]]; then
+        force_delete=true
+        break
+    fi
+done
+
+# Allow version to be passed in or default to 0
+export TB_VERSION=${TB_VERSION:-0}
+
+# Attempt to create the branch and check for errors
+if ! tb branch create "$BRANCH_NAME"; then
+    echo "🚨 ERROR: Failed to create branch $BRANCH_NAME. Exiting."
+    exit 1
+fi
+
+# Run the scripts using their full paths
+"$SCRIPT_DIR/append_fixtures.sh"
+"$SCRIPT_DIR/exec_test.sh"
+
+# Conditional deletion based on the -y flag or user prompt
+if [ "$force_delete" = true ]; then
+    tb branch rm "$BRANCH_NAME" --yes
+    echo "Branch $BRANCH_NAME removed without prompt."
+else
+    read -p "Do you want to delete the branch $BRANCH_NAME? (y/n): " choice
+    if [[ "$choice" == "y" || "$choice" == "Y" ]]; then
+        tb branch rm "$BRANCH_NAME" --yes
+        echo "Branch $BRANCH_NAME removed."
+    else
+        echo "Branch $BRANCH_NAME kept."
+    fi
+fi

--- a/ghost/tinybird-dedicated/scripts/exec_test.sh
+++ b/ghost/tinybird-dedicated/scripts/exec_test.sh
@@ -1,8 +1,50 @@
-
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 export TB_VERSION_WARNING=0
+
+# Default version if not provided
+export TB_VERSION=${TB_VERSION:-0}
+
+# Get the expected count once, outside of any function
+ndjson_file="./datasources/fixtures/analytics_events.ndjson"
+export expected_count=$(wc -l < "$ndjson_file" || echo "0")
+
+check_sum() {
+    local file=$1
+    local expected_count=$2
+
+    # Only perform the check if the file starts with "all_"
+    if [[ ! $(basename "$file") =~ ^all_ ]]; then
+        return 0
+    fi
+
+    local sum=0
+    local column_name=""
+
+    # Determine if the file has a 'pageviews' column
+    if head -n1 "$file" | grep -q 'pageviews'; then
+        column_name="pageviews"
+    else
+        echo "No 'pageviews' column found in $file"
+        return 0  # No relevant column found, skip the check
+    fi
+
+    # Get the column number
+    local column_num=$(head -n1 "$file" | tr ',' '\n' | grep -n "$column_name" | cut -d: -f1)
+
+    # Sum the values in the column
+    sum=$(tail -n +2 "$file" | cut -d',' -f"$column_num" | awk '{s+=$1} END {print s}')
+
+    # Check if the sum equals the number of lines in the NDJSON file
+    if [ "$sum" -eq "$expected_count" ]; then
+        echo "✅ Sanity check passed: Sum of $column_name is $sum (matches NDJSON line count)"
+        return 0
+    else
+        echo "⚠️  WARNING: Sanity check failed: Sum of $column_name is $sum, expected $expected_count (NDJSON line count)"
+        return 1  # Return 1 to indicate a warning, but not a failure
+    fi
+}
 
 run_test() {
     t=$1
@@ -15,15 +57,15 @@ run_test() {
     # When appending fixtures, we need to retry in case of the data is not replicated in time
     while [ $retries -lt $TOTAL_RETRIES ]; do
         # Run the test and store the output in a temporary file
-        bash $t $2 >$tmpfile
+        bash "$t" >"$tmpfile"
         exit_code=$?
         if [ "$exit_code" -eq 0 ]; then
             # If the test passed, break the loop
-            if diff -B ${t}.result $tmpfile >/dev/null 2>&1; then
+            if diff -B "${t}.result" "$tmpfile" >/dev/null 2>&1; then
                 break
             # If the test failed, increment the retries counter and try again
             else
-                retries=$((retries+1))
+                retries=$((retries + 1))
             fi
         # If the bash command failed, print an error message and break the loop
         else
@@ -31,28 +73,47 @@ run_test() {
         fi
     done
 
-    if diff -B ${t}.result $tmpfile >/dev/null 2>&1; then
+    if diff -B "${t}.result" "$tmpfile" >/dev/null 2>&1; then
         echo "✅ Test $t passed"
-        rm $tmpfile
+        check_sum "${t}.result" "$expected_count" || echo "⚠️  Warning: Sanity check did not pass."
+        rm "$tmpfile"
         return 0
     elif [ $retries -eq $TOTAL_RETRIES ]; then
-        echo "🚨 ERROR: Test $t failed, diff:";
-        diff -B ${t}.result $tmpfile
-        rm $tmpfile
+        echo "🚨 ERROR: Test $t failed, showing differences:"
+        diff -B -u --color -U3 "${t}.result" "$tmpfile"  # Use unified diff format with 3 lines of context
+        rm "$tmpfile"
         return 1
     else
         echo "🚨 ERROR: Test $t failed with bash command exit code $?"
-        cat $tmpfile
-        rm $tmpfile
+        cat "$tmpfile"
+        rm "$tmpfile"
         return 1
     fi
     echo ""
 }
+
 export -f run_test
+export -f check_sum
 
 fail=0
-find ./tests -name "*.test" -print0 | xargs -0 -I {} -P 4 bash -c 'run_test "$@"' _ {} || fail=1
+
+# Check if a test name was provided as an argument
+if [ $# -eq 1 ]; then
+    test_name=$1
+    # Find the test file that matches the provided name
+    test_file=$(find ./tests -name "${test_name}*.test")
+    if [ -n "$test_file" ]; then
+        run_test "$test_file" || fail=1
+    else
+        echo "🚨 ERROR: No test found matching name: $test_name"
+        fail=1
+    fi
+else
+    # If no test name provided, run all tests
+    find ./tests -name "*.test" -print0 | xargs -0 -I {} bash -c 'run_test "$@"' _ {} || fail=1
+fi
 
 if [ $fail == 1 ]; then
-  exit -1;
+    echo "🚨 ERROR: Some tests failed"
+    exit 1
 fi

--- a/ghost/tinybird-dedicated/scripts/gen_test_results.sh
+++ b/ghost/tinybird-dedicated/scripts/gen_test_results.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory containing the test files
+TEST_DIR="./tests"
+
+# Function to execute a test and update its result file
+execute_and_update() {
+    local test_file="$1"
+    local result_file="${test_file%.test}.test.result"
+
+    echo "Executing test: $test_file"
+
+    # Execute the test command and capture the output
+    output=$(bash "$test_file")
+
+    # Write the output to the result file, overwriting existing content
+    echo "$output" > "$result_file"
+
+    echo "Updated result file: $result_file"
+    echo "------------------------"
+}
+
+# Main execution
+echo "Starting test result regeneration..."
+
+# Find all .test files and process them
+find "$TEST_DIR" -name "*.test" -type f | while read -r test_file; do
+    execute_and_update "$test_file"
+done
+
+echo "Test result regeneration complete."

--- a/ghost/tinybird-dedicated/scripts/unsafe_redeploy.sh
+++ b/ghost/tinybird-dedicated/scripts/unsafe_redeploy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if --force flag is provided
+force=false
+if [[ "$@" == *"--force"* ]]; then
+    force=true
+fi
+
+# Get current branch info
+branch_info=$(tb branch current)
+
+# Check if 'main' and 'production_stats' are both present in the output
+if echo "$branch_info" | grep -q "main" && echo "$branch_info" | grep -q "production_stats"; then
+    if [ "$force" = false ]; then
+        echo "🚨 ERROR: Attempting to run unsafe_redeploy on main branch in production_stats workspace."
+        echo "If you're sure you want to do this, run the script with the --force flag."
+        exit 1
+    else
+        echo "⚠️  WARNING: Running unsafe_redeploy on main branch in production_stats workspace with --force flag."
+    fi
+fi
+
+echo "Proceeding with unsafe redeploy..."
+
+# Store the lists to avoid multiple calls
+datasources=$(tb datasource ls)
+pipes=$(tb pipe ls)
+
+# Define arrays for each type of resource
+materialized_views=(
+    "analytics_pages_mv"
+    "analytics_sessions_mv"
+    "analytics_sources_mv"
+)
+
+data_pipes=(
+    "analytics_pages"
+    "analytics_sessions"
+    "analytics_sources"
+    "analytics_hits"
+)
+
+endpoint_pipes=(
+    "kpis"
+    "top_browsers"
+    "top_devices"
+    "top_locations"
+    "top_pages"
+    "top_sources"
+    "trend"
+)
+
+# Remove materialized views
+for mv in "${materialized_views[@]}"; do
+    if echo "$datasources" | grep -q "$mv"; then
+        tb datasource rm "$mv" --yes
+    fi
+done
+
+# Remove data pipes
+for pipe in "${data_pipes[@]}"; do
+    if echo "$pipes" | grep -q "$pipe"; then
+        tb pipe rm "$pipe" --yes
+    fi
+done
+
+# Remove endpoint pipes
+for pipe in "${endpoint_pipes[@]}"; do
+    if echo "$pipes" | grep -q "$pipe"; then
+        tb pipe rm "$pipe" --yes
+    fi
+done
+
+# Push all the changes
+tb push --force --populate


### PR DESCRIPTION
no issue

- The shell scripts in `ghost/tinybird` had some nice additional logging that hasn't been copied over to the new `ghost/tinybird-dedicated` implementation yet, and a few additional scripts that also hadn't been copied over.
- This commit just copies the files from `ghost/tinybird` to `ghost/tinybird-dedicated`