### PR TITLE
Updated stats api endpoints

### DIFF
--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -21,7 +21,7 @@ export default class KpisComponent extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/kpis__v${apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_kpis__v${apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/technical.js
+++ b/ghost/admin/app/components/stats/charts/technical.js
@@ -48,17 +48,17 @@ export default class TechnicalComponent extends Component {
 
         switch (effectiveSelected) {
         case 'browsers':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_browsers__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_browsers__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'browser';
             tableHead = 'Browser';
             break;
         case 'os':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_os__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_os__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'os';
             tableHead = 'OS';
             break;
         default:
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_devices__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_devices__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'device';
             tableHead = 'Device';
         }

--- a/ghost/admin/app/components/stats/charts/top-locations.js
+++ b/ghost/admin/app/components/stats/charts/top-locations.js
@@ -61,7 +61,7 @@ export default class TopLocations extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_locations__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_locations__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-pages.js
+++ b/ghost/admin/app/components/stats/charts/top-pages.js
@@ -60,7 +60,7 @@ export default class TopPages extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_pages__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_pages__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -55,7 +55,7 @@ export default class TopSources extends Component {
 
     ReactComponent = (props) => {
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_sources__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_sources__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params: getStatsParams(
                 this.config,

--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -59,7 +59,7 @@ export default class KpisOverview extends Component {
                 args
             ));
 
-            const endpoint = `${this.config.stats.endpoint}/v0/pipes/kpis__v${args.apiVersion || TB_VERSION}.json?${params}`;
+            const endpoint = `${this.config.stats.endpoint}/v0/pipes/api_kpis__v${args.apiVersion || TB_VERSION}.json?${params}`;
 
             const response = yield fetch(endpoint, {
                 method: 'GET',

--- a/ghost/admin/app/components/stats/modal-stats-all.js
+++ b/ghost/admin/app/components/stats/modal-stats-all.js
@@ -81,19 +81,19 @@ export default class AllStatsModal extends Component {
         let unknownOption = 'Unknown';
         switch (type) {
         case 'top-sources':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_sources__v${TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_sources__v${TB_VERSION}.json`;
             labelText = 'Source';
             indexBy = 'source';
             unknownOption = 'Direct';
             break;
         case 'top-locations':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_locations__v${TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_locations__v${TB_VERSION}.json`;
             labelText = 'Country';
             indexBy = 'location';
             unknownOption = 'Unknown';
             break;
         default:
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_pages__v${TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_pages__v${TB_VERSION}.json`;
             labelText = 'Post or page';
             indexBy = 'pathname';
             break;

--- a/ghost/tinybird-dedicated/datasources/_mv_pages.datasource
+++ b/ghost/tinybird-dedicated/datasources/_mv_pages.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 SCHEMA >
     `site_uuid` String,

--- a/ghost/tinybird-dedicated/datasources/_mv_sessions.datasource
+++ b/ghost/tinybird-dedicated/datasources/_mv_sessions.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 SCHEMA >
     `site_uuid` String,
     `date` Date,

--- a/ghost/tinybird-dedicated/datasources/_mv_sources.datasource
+++ b/ghost/tinybird-dedicated/datasources/_mv_sources.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 SCHEMA >
     `site_uuid` String,

--- a/ghost/tinybird-dedicated/pipes/_hits.pipe
+++ b/ghost/tinybird-dedicated/pipes/_hits.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE parsed_hits
 SQL >
 
@@ -17,10 +17,8 @@ SQL >
         toString(payload.member_status) as member_status,
         toString(payload.post_uuid) as post_uuid,
         lower(toString(getSubcolumn(payload,'user-agent'))) as user_agent
-    FROM analytics_events_json_m
+    FROM analytics_events_json_s
     where action = 'page_hit'
-
-
 
 NODE _hits
 SQL >

--- a/ghost/tinybird-dedicated/pipes/api_kpis.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_kpis.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE timeseries
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/api_top_browsers.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_browsers.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _top_browsers_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/api_top_devices.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _top_devices_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/api_top_locations.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _top_locations_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/api_top_os.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_os.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
 	Top Operating Systems ordered by most visits.
     Accepts `date_from` and `date_to` date filter. Defaults to last 7 days.

--- a/ghost/tinybird-dedicated/pipes/api_top_pages.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _top_pages_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/api_top_sources.pipe
+++ b/ghost/tinybird-dedicated/pipes/api_top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 TOKEN "_top_sources_endpoint_read_1325" READ
 
 NODE _top_sources_0

--- a/ghost/tinybird-dedicated/pipes/mv_pages.pipe
+++ b/ghost/tinybird-dedicated/pipes/mv_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _pages_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/mv_sessions.pipe
+++ b/ghost/tinybird-dedicated/pipes/mv_sessions.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _sessions_0
 SQL >
 

--- a/ghost/tinybird-dedicated/pipes/mv_sources.pipe
+++ b/ghost/tinybird-dedicated/pipes/mv_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 NODE _sources_0
 SQL >
 


### PR DESCRIPTION
no ref

We published new endpoints (and a new naming convention for tinybird assets), so we need to update where Admin's Stats page is pointing.

This also includes a change to the data source for all of the metrics to use a smaller one with better performance for testing.