### PR TITLE
Bumped admin stats to v1 as starting version

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -1,9 +1,8 @@
 import moment from 'moment-timezone';
 
-export const TB_VERSION = 0;
+export const TB_VERSION = 1;
 
 export const API_VERSION_OPTIONS = [
-    {name: 'v0', value: 0},
     {name: 'v1', value: 1},
     {name: 'v2', value: 2},
     {name: 'v3', value: 3},


### PR DESCRIPTION
no ref

v0 does not have data and it makes more intuitive sense to have v1 as the default, anyways.