### PR TITLE
Fixed some article needs scrolling to be loaded

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -122,9 +122,9 @@ const ArticleBody: React.FC<{
 
                 function initializeResize() {
                     resizeIframe();
+                    isFullyLoaded = true;
 
                     waitForImages().then(() => {
-                        isFullyLoaded = true;
                         resizeIframe();
                     });
                 }


### PR DESCRIPTION
ref AP-788

- articles needed `isFullyLoaded` to be true to switch from the loading state
- `isFullyLoaded` only set to true when all images in the articles fully loaded
- that caused infinite loading for some content when they contain lazy loaded images 
- this fixes by moving `isFullyLoaded = true` out of the image loading logic, so that it doesn't wait for lazy loaded images
- also it still resizes the iframe after images are loaded, so the content wouldn't be cut half
