### PR TITLE
Fixed ability to deploy to staging on non-org owned PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
         id: check_user_org_membership
         if: github.event_name == 'pull_request'
         run: |
-          echo "Looking up: ${{ github.event.pull_request.user.login }}"
-          ENCODED_USERNAME=$(printf '%s' '${{ github.event.pull_request.user.login }}' | jq -sRr @uri)
+          echo "Looking up: ${{ github.triggering_actor }}"
+          ENCODED_USERNAME=$(printf '%s' '${{ github.triggering_actor }}' | jq -sRr @uri)
 
           LOOKUP_USER=$(curl --write-out "%{http_code}" --silent --output /dev/null --location "https://api.github.com/orgs/tryghost/members/$ENCODED_USERNAME" --header "Authorization: Bearer ${{ secrets.CANARY_DOCKER_BUILD }}")
 


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1741180349448869

- in the event a non-org user opens a PR, such as Renovate, we want org users to be able to label the PR to deploy it to staging
- previously, we were just looking up the owner of the PR, which would fail in this case
- now we look up the triggering actor of the event, so we can check whether it was an org user who labelled the PR
