### PR TITLE
Allowed Renovate PRs to trigger deploy to staging workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1154,7 +1154,10 @@ jobs:
         needs.job_setup.outputs.is_main == 'true'
         || (
           github.event_name == 'pull_request'
-          && needs.job_setup.outputs.member_is_in_org == 'true'
+          && (
+            needs.job_setup.outputs.member_is_in_org == 'true'
+            || github.event.pull_request.user.login == 'renovate[bot]'
+          )
           && contains(github.event.pull_request.labels.*.name, 'deploy-to-staging')
         )
       )


### PR DESCRIPTION
- another edge-case was present where we had the label applied and then Renovate bot would push updates to the repo, hence failing the in-org check and not deploying to staging
- this fixes that by explicitly letting renovate-bot through
