### PR TITLE
Tinybird add column UI + OG workspace switch code

### DIFF
--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -21,7 +21,7 @@ export default class KpisComponent extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_kpis__v${apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/kpis__v${apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/technical.hbs
+++ b/ghost/admin/app/components/stats/charts/technical.hbs
@@ -1,1 +1,1 @@
-<div class="gh-stats-technical-data" {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected apiVersion=@apiVersion)}}></div>
+<div class="gh-stats-technical-data" {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname selected=@selected apiVersion=@apiVersion postType=@postType)}}></div>

--- a/ghost/admin/app/components/stats/charts/technical.js
+++ b/ghost/admin/app/components/stats/charts/technical.js
@@ -48,17 +48,17 @@ export default class TechnicalComponent extends Component {
 
         switch (effectiveSelected) {
         case 'browsers':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_browsers__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_browsers__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'browser';
             tableHead = 'Browser';
             break;
         case 'os':
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_os__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_os__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'os';
             tableHead = 'OS';
             break;
         default:
-            endpoint = `${this.config.stats.endpoint}/v0/pipes/api_top_devices__v${apiVersion || TB_VERSION}.json`;
+            endpoint = `${this.config.stats.endpoint}/v0/pipes/top_devices__v${apiVersion || TB_VERSION}.json`;
             indexBy = 'device';
             tableHead = 'Device';
         }

--- a/ghost/admin/app/components/stats/charts/top-locations.hbs
+++ b/ghost/admin/app/components/stats/charts/top-locations.hbs
@@ -1,11 +1,11 @@
 <div>
     <div class="gh-stats-metric-header"><h5 class="gh-stats-metric-label">Locations</h5></div>
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion postType=@postType)}}></div>
 </div>
 
 {{#if this.showSeeAll}}
 <div class="gh-stats-see-all-container">
-    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname)}}>
+    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname @postType)}}>
         <span>See all &rarr;</span>
     </button>
 </div>

--- a/ghost/admin/app/components/stats/charts/top-locations.js
+++ b/ghost/admin/app/components/stats/charts/top-locations.js
@@ -61,7 +61,7 @@ export default class TopLocations extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_locations__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_locations__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-pages.hbs
+++ b/ghost/admin/app/components/stats/charts/top-pages.hbs
@@ -18,12 +18,12 @@
             </PowerSelect>
         </div> --}}
     </div>
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion postType=@postType)}}></div>
 </div>
 
 {{#if this.showSeeAll}}
 <div class="gh-stats-see-all-container">
-    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname)}}>
+    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname @postType)}}>
         <span>See all &rarr;</span>
     </button>
 </div>

--- a/ghost/admin/app/components/stats/charts/top-pages.js
+++ b/ghost/admin/app/components/stats/charts/top-pages.js
@@ -60,7 +60,7 @@ export default class TopPages extends Component {
         );
 
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_pages__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_pages__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params
         });

--- a/ghost/admin/app/components/stats/charts/top-sources.hbs
+++ b/ghost/admin/app/components/stats/charts/top-sources.hbs
@@ -19,12 +19,12 @@
         </div> --}}
     </div>
 
-    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion)}}></div>
+    <div {{react-render this.ReactComponent props=(hash chartRange=@chartRange audience=@audience device=@device browser=@browser location=@location source=@source pathname=@pathname apiVersion=@apiVersion postType=@postType)}}></div>
 </div>
 
 {{#if this.showSeeAll}}
 <div class="gh-stats-see-all-container">
-    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname)}}>
+    <button type="button" class="gh-btn gh-btn-link gh-stats-see-all-btn" {{on "click" (fn this.openSeeAll @chartRange @audience @device @browser @location @source @pathname @postType)}}>
         <span>See all &rarr;</span>
     </button>
 </div>

--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -55,7 +55,7 @@ export default class TopSources extends Component {
 
     ReactComponent = (props) => {
         const {data, meta, error, loading} = useQuery({
-            endpoint: `${this.config.stats.endpoint}/v0/pipes/api_top_sources__v${props.apiVersion || TB_VERSION}.json`,
+            endpoint: `${this.config.stats.endpoint}/v0/pipes/top_sources__v${props.apiVersion || TB_VERSION}.json`,
             token: this.config.stats.token,
             params: getStatsParams(
                 this.config,

--- a/ghost/admin/app/controllers/stats.js
+++ b/ghost/admin/app/controllers/stats.js
@@ -1,14 +1,24 @@
 import Controller from '@ember/controller';
 import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
-import {API_VERSION_OPTIONS, AUDIENCE_TYPES, RANGE_OPTIONS} from 'ghost-admin/utils/stats';
+import {API_VERSION_OPTIONS, AUDIENCE_TYPES, POST_TYPE_OPTIONS, RANGE_OPTIONS} from 'ghost-admin/utils/stats';
 import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 
 countries.registerLocale(enLocale);
 
 export default class StatsController extends Controller {
-    queryParams = ['device', 'browser', 'location', 'source', 'pathname', 'os'];
+    queryParams = [
+        'range',
+        'audience',
+        'device',
+        'browser',
+        'location',
+        'source',
+        'pathname',
+        'os',
+        'postType'
+    ];
 
     @tracked device = null;
     @tracked browser = null;
@@ -16,11 +26,13 @@ export default class StatsController extends Controller {
     @tracked source = null;
     @tracked pathname = null;
     @tracked os = null;
+    @tracked postType = null;
     @tracked apiVersion = 0;
 
     rangeOptions = RANGE_OPTIONS;
     audienceOptions = AUDIENCE_TYPES;
     apiVersionOptions = API_VERSION_OPTIONS;
+    postTypeOptions = POST_TYPE_OPTIONS;
     /**
      * @type {number|'all'}
      * Date range to load for member count and MRR related charts
@@ -69,7 +81,13 @@ export default class StatsController extends Controller {
     }
 
     @action
+    onPostTypeChange(option) {
+        this.postType = option.value === 'all' ? null : option.value;
+    }
+
+    @action
     clearFilters() {
+        this.postType = null;
         this.device = null;
         this.browser = null;
         this.location = null;
@@ -88,5 +106,9 @@ export default class StatsController extends Controller {
 
     get selectedApiVersionOption() {
         return this.apiVersionOptions.find(option => option.value === this.apiVersion) || this.apiVersionOptions[0];
+    }
+
+    get selectedPostTypeOption() {
+        return this.postTypeOptions.find(option => option.value === this.postType) || this.postTypeOptions[0];
     }
 }

--- a/ghost/admin/app/templates/stats.hbs
+++ b/ghost/admin/app/templates/stats.hbs
@@ -17,6 +17,22 @@
                 {{#if option.name}}{{option.name}}{{else}}<span class="red">Unknown option</span>{{/if}}
             </PowerSelect>
 
+            <PowerSelect
+                @selected={{this.selectedPostTypeOption}}
+                @options={{this.postTypeOptions}}
+                @searchEnabled={{false}}
+                @onChange={{this.onPostTypeChange}}
+                @triggerComponent={{component "gh-power-select/trigger"}}
+                @triggerClass="gh-btn"
+                @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
+                @matchTriggerWidth={{false}}
+                @horizontalPosition="right"
+                as |option|
+            >
+                {{#if option.name}}{{option.name}}{{else}}<span class="red">Unknown option</span>{{/if}}
+            </PowerSelect>
+
+
             <Stats::Parts::AudienceFilter
                 @excludedAudiences={{this.excludedAudiences}}
                 @onChange={{this.onAudienceChange}}
@@ -82,6 +98,7 @@
             <Stats::KpisOverview
                 @chartRange={{this.chartRange}}
                 @audience={{this.audience}}
+                @postType={{this.postType}}
                 @device={{this.device}}
                 @browser={{this.browser}}
                 @location={{this.location}}
@@ -97,6 +114,7 @@
                 <Stats::Charts::TopPages
                     @chartRange={{this.chartRange}}
                     @audience={{this.audience}}
+                    @postType={{this.postType}}
                     @device={{this.device}}
                     @browser={{this.browser}}
                     @location={{this.location}}
@@ -110,6 +128,7 @@
                 <Stats::Charts::TopSources
                     @chartRange={{this.chartRange}}
                     @audience={{this.audience}}
+                    @postType={{this.postType}}
                     @device={{this.device}}
                     @browser={{this.browser}}
                     @location={{this.location}}
@@ -126,6 +145,7 @@
                     <Stats::Charts::TopLocations
                     @chartRange={{this.chartRange}}
                     @audience={{this.audience}}
+                    @postType={{this.postType}}
                     @device={{this.device}}
                     @browser={{this.browser}}
                     @location={{this.location}}
@@ -139,6 +159,7 @@
                     <Stats::TechnicalOverview
                         @chartRange={{this.chartRange}}
                         @audience={{this.audience}}
+                        @postType={{this.postType}}
                         @device={{this.device}}
                         @browser={{this.browser}}
                         @location={{this.location}}

--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -1,8 +1,9 @@
 import moment from 'moment-timezone';
 
-export const TB_VERSION = 1;
+export const TB_VERSION = 0;
 
 export const API_VERSION_OPTIONS = [
+    {name: 'v0', value: 0},
     {name: 'v1', value: 1},
     {name: 'v2', value: 2},
     {name: 'v3', value: 3},
@@ -187,6 +188,7 @@ export function getStatsParams(config, props, additionalParams = {}) {
     if (os) {
         params.os = os;
     }
+
     if (postType) {
         params.post_type = postType;
     }

--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -15,6 +15,12 @@ export const API_VERSION_OPTIONS = [
     {name: 'v10', value: 10}
 ];
 
+export const POST_TYPE_OPTIONS = [
+    {name: 'All', value: 'all'},
+    {name: 'Posts', value: 'post'},
+    {name: 'Pages', value: 'page'}
+];
+
 export const RANGE_OPTIONS = [
     {name: 'Last 24 hours', value: 1},
     {name: 'Last 7 days', value: 7},
@@ -144,7 +150,7 @@ export function getDateRange(chartRange) {
 }
 
 export function getStatsParams(config, props, additionalParams = {}) {
-    const {chartRange, audience, device, browser, location, source, pathname, os} = props;
+    const {chartRange, audience, device, browser, location, source, pathname, os, postType} = props;
     const {startDate, endDate} = getDateRange(chartRange);
 
     const params = {
@@ -180,6 +186,9 @@ export function getStatsParams(config, props, additionalParams = {}) {
 
     if (os) {
         params.os = os;
+    }
+    if (postType) {
+        params.post_type = postType;
     }
 
     return params;

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -158,6 +158,7 @@ function getTinybirdTrackerScript(dataRoot) {
     const tbParams = _.map({
         site_uuid: config.get('tinybird:tracker:id'),
         post_uuid: dataRoot.post?.uuid,
+        post_type: dataRoot.context.includes('post') ? 'post' : dataRoot.context.includes('page') ? 'page' : null,
         member_uuid: dataRoot.member?.uuid,
         member_status: dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -163,7 +163,7 @@ function getTinybirdTrackerScript(dataRoot) {
         member_status: dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');
 
-    return `<script defer src="/public/tracker.js" data-stringify-payload="false" ${datasource ? `data-datasource="${datasource}"` : ''} data-storage="localStorage" data-host="${endpoint}" data-token="${token}" ${tbParams}></script>`;
+    return `<script defer src="${config.get('tinybird:tracker:scriptUrl')}" data-stringify-payload="true" ${datasource ? `data-datasource="${datasource}"` : ''} data-storage="localStorage" data-host="${endpoint}" data-token="${token}" ${tbParams}></script>`;
 }
 
 function getHCaptchaScript() {

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -1729,7 +1729,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"post_uuid\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
@@ -1781,7 +1781,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
@@ -1833,7 +1833,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
@@ -1903,7 +1903,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"post_uuid\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"free\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"free\\"></script>",
 }
 `;
 
@@ -1955,7 +1955,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\"></script>",
 }
 `;
 
@@ -2007,7 +2007,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/tracker.js\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events_json_v1\\" data-storage=\\"localStorage\\" data-host=\\"https://api.tinybird.co\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"tb_test_site_uuid\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 

--- a/ghost/tinybird/datasources/analytics_pages_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_pages_mv.datasource
@@ -1,8 +1,9 @@
-VERSION 0
+VERSION 1
 
 SCHEMA >
     `site_uuid` String,
     `post_uuid` String,
+    `post_type` String,
     `date` Date,
     `device` String,
     `browser` String,
@@ -15,4 +16,4 @@ SCHEMA >
 
 ENGINE AggregatingMergeTree
 ENGINE_PARTITION_KEY toYYYYMM(date)
-ENGINE_SORTING_KEY date, device, browser, location, source, pathname, post_uuid, site_uuid
+ENGINE_SORTING_KEY date, device, browser, location, source, pathname, post_uuid, post_type, site_uuid

--- a/ghost/tinybird/datasources/analytics_sessions_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_sessions_mv.datasource
@@ -1,10 +1,11 @@
-VERSION 0
+VERSION 1
 SCHEMA >
     `site_uuid` String,
     `date` Date,
     `session_id` String,
     `member_status` SimpleAggregateFunction(any, String),
     `post_uuid` SimpleAggregateFunction(any, String),
+    `post_type` SimpleAggregateFunction(any, String),
     `device` SimpleAggregateFunction(any, String),
     `browser` SimpleAggregateFunction(any, String),
     `location` SimpleAggregateFunction(any, String),

--- a/ghost/tinybird/datasources/analytics_sources_mv.datasource
+++ b/ghost/tinybird/datasources/analytics_sources_mv.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 SCHEMA >
     `site_uuid` String,
@@ -9,6 +9,8 @@ SCHEMA >
     `source` String,
     `pathname` String,
     `member_status` SimpleAggregateFunction(any, String),
+    `post_uuid` SimpleAggregateFunction(any, String),
+    `post_type` SimpleAggregateFunction(any, String),
     `visits` AggregateFunction(uniq, String),
     `pageviews` AggregateFunction(count)
 

--- a/ghost/tinybird/pipes/analytics_pages.pipe
+++ b/ghost/tinybird/pipes/analytics_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -34,6 +35,7 @@ SQL >
         member_uuid,
         member_status,
         post_uuid,
+        post_type,
         location,
         domainWithoutWWW(referrer) as source,
         pathname,
@@ -71,6 +73,7 @@ SQL >
         site_uuid,
         toDate(timestamp) AS date,
         post_uuid,
+        post_type,
         device,
         browser,
         location,
@@ -83,7 +86,7 @@ SQL >
         uniqState(session_id) AS visits,
         countState() AS pageviews
     FROM analytics_hits_data
-    GROUP BY date, device, browser, location, source, pathname, post_uuid,site_uuid
+    GROUP BY date, device, browser, location, source, pathname, post_uuid, post_type, site_uuid
 
 TYPE MATERIALIZED
 DATASOURCE analytics_pages_mv

--- a/ghost/tinybird/pipes/analytics_sessions.pipe
+++ b/ghost/tinybird/pipes/analytics_sessions.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -34,6 +35,7 @@ SQL >
         member_uuid,
         member_status,
         post_uuid,
+        post_type,
         location,
         domainWithoutWWW(referrer) as source,
         pathname,

--- a/ghost/tinybird/pipes/analytics_sources.pipe
+++ b/ghost/tinybird/pipes/analytics_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 NODE parsed_hits
 DESCRIPTION >
@@ -19,6 +19,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -34,6 +35,7 @@ SQL >
         member_uuid,
         member_status,
         post_uuid,
+        post_type,
         location,
         domainWithoutWWW(referrer) as source,
         pathname,

--- a/ghost/tinybird/pipes/kpis.pipe
+++ b/ghost/tinybird/pipes/kpis.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Summary with general KPIs per date, including visits, page views, bounce rate and average session duration.
@@ -84,6 +84,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -99,6 +100,7 @@ SQL >
         member_uuid,
         member_status,
         post_uuid,
+        post_type,
         location,
         domainWithoutWWW(referrer) as source,
         pathname,
@@ -139,6 +141,7 @@ SQL >
             toStartOfHour(timestamp) as date,
             session_id,
             member_status,
+            post_type,
             device,
             browser,
             location,
@@ -151,12 +154,13 @@ SQL >
             min(timestamp) as first_view_aux
         from analytics_hits_data
         where toDate(timestamp) = {{ Date(date_from) }}
-        group by toStartOfHour(timestamp), session_id, site_uuid, member_status, device, browser, location, source, pathname
+        group by toStartOfHour(timestamp), session_id, site_uuid, member_status, post_type, device, browser, location, source, pathname
     {% else %}
         select
             site_uuid,
             date,
             member_status,
+            post_type,
             device,
             browser,
             location,
@@ -176,7 +180,7 @@ SQL >
             {% if defined(date_to) %} and date <= {{ Date(date_to) }}
             {% else %} and date <= today()
             {% end %}
-        group by date, session_id, site_uuid, member_status, device, browser, location, source, pathname
+        group by date, session_id, site_uuid, member_status, post_type, device, browser, location, source, pathname
     {% end %}
 
 NODE data
@@ -196,6 +200,7 @@ SQL >
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+        {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/top_browsers.pipe
+++ b/ghost/tinybird/pipes/top_browsers.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top Browsers ordered by most visits.
@@ -34,6 +34,7 @@ SQL >
         {% end %}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+                {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/top_devices.pipe
+++ b/ghost/tinybird/pipes/top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top Device Types ordered by most visits.
@@ -34,6 +34,7 @@ SQL >
         {% end %}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+                {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/top_locations.pipe
+++ b/ghost/tinybird/pipes/top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Top visiting Countries ordered by most visits.
@@ -34,6 +34,7 @@ SQL >
         {% end %}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+                {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/top_pages.pipe
+++ b/ghost/tinybird/pipes/top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 DESCRIPTION >
     Most visited pages for a given period.
@@ -37,6 +37,7 @@ SQL >
         {% end %}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+        {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/top_sources.pipe
+++ b/ghost/tinybird/pipes/top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Top traffic sources (domains), ordered by most visits.
     Accepts `date_from` and `date_to` date filter. Defaults to last 7 days.
@@ -33,6 +33,7 @@ SQL >
         {% end %}
 
         {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+        {% if defined(post_type) %} and post_type IN {{ Array(post_type, "'undefined', 'post', 'page'", description="Post type to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
         {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}

--- a/ghost/tinybird/pipes/trend.pipe
+++ b/ghost/tinybird/pipes/trend.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 DESCRIPTION >
     Visits trend over time for the last 30 minutes, filling the blanks.
     Works great for the realtime chart.
@@ -25,6 +25,7 @@ SQL >
         JSONExtractString(payload, 'member_uuid') as member_uuid,
         JSONExtractString(payload, 'member_status') as member_status,
         JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'


### PR DESCRIPTION
This PR contains two commits:

1. To add the UI for post_type. It goes hand-in-hand with https://github.com/TryGhost/Ghost/commit/324850a1a9c499908b39fd471e43a65ccfbdc1bc, and is how I verified my change really truly worked for _users_.
2. Some code I needed to switch the stats page so that it worked for the old staging_stats workspace instead of the new dedicated_staging_stats workspace. The major difference between these two being A) JSON data type and B) better named endpoints in the new one!

I don't want to merge commit 1 right now, as the dedicated instance doesn't have post_type properly yet. Commit 2 would only ever be merged if we go back to the old workspace.

I didn't want to lose this code though, so thought I'd make a PR so its easier to find in future