### PR TITLE
Modified tinybird job to deploy to staging and production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
               - *shared
               - 'apps/sodo-search/**'
             tinybird:
+              - *shared
               - 'ghost/tinybird-dedicated/**'
               - '!ghost/tinybird-dedicated/**/*.md'
             any-code:
@@ -1315,10 +1316,10 @@ jobs:
         run: tb --version
       - name: Check auth (staging)
         if: matrix.environment == 'staging'
-        run: tb --host=${{ secrets.TB_HOST_STAGING }} --token=${{ secrets.TB_ADMIN_TOKEN_STAGING }} auth info
+        run: tb --host=${{ secrets.TB_HOST }} --token=${{ secrets.TB_ADMIN_TOKEN_STAGING }} auth info
       - name: Check auth (production)
         if: matrix.environment == 'production'
-        run: tb --host=${{ secrets.TB_HOST_PRODUCTION }} --token=${{ secrets.TB_ADMIN_TOKEN_PRODUCTION }} auth info
+        run: tb --host=${{ secrets.TB_HOST }} --token=${{ secrets.TB_ADMIN_TOKEN_PRODUCTION }} auth info
       - name: Deploy changes to the main Workspace
         run: |
           DEPLOY_FILE=./deploy/${VERSION}/deploy.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
               - *shared
               - 'apps/sodo-search/**'
             tinybird:
-              - *shared
               - 'ghost/tinybird-dedicated/**'
               - '!ghost/tinybird-dedicated/**/*.md'
             any-code:
@@ -1286,7 +1285,7 @@ jobs:
       job_setup,
       job_tinybird
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird.result == 'success'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     strategy:
       matrix:
         environment: [ 'staging', 'production']
@@ -1326,7 +1325,7 @@ jobs:
           if [ ! -f "$DEPLOY_FILE" ]; then
             echo "$DEPLOY_FILE not found, running default tb push command"
             tb branch current
-            tb deploy --dry-run
+            tb deploy
           fi
       - name: Custom deployment to the main Workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,7 @@ jobs:
               - *shared
               - 'ghost/**'
               - '!ghost/admin/**'
-              - '!ghost/tinybird-dedicated/**'
-              - '!ghost/tinybird/**'
+              - '!ghost/web-analytics/**'
             admin:
               - *shared
               - 'ghost/admin/**'
@@ -122,8 +121,8 @@ jobs:
               - *shared
               - 'apps/sodo-search/**'
             tinybird:
-              - 'ghost/tinybird-dedicated/**'
-              - '!ghost/tinybird-dedicated/**/*.md'
+              - 'ghost/web-analytics/**'
+              - '!ghost/web-analytics/**/*.md'
             any-code:
               - '!**/*.md'
 
@@ -846,7 +845,7 @@ jobs:
     ]
     defaults:
       run:
-        working-directory: ghost/tinybird-dedicated
+        working-directory: ghost/web-analytics
     if: needs.job_setup.outputs.changed_tinybird == 'true'
     steps:
       - name: Get User Permission
@@ -1292,7 +1291,7 @@ jobs:
     name: Deploy Tinybird
     defaults:
       run:
-        working-directory: ghost/tinybird-dedicated
+        working-directory: ghost/web-analytics
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,16 +1280,19 @@ jobs:
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
   deploy_tinybird:
+    runs-on: ubuntu-latest
     needs: [
       job_setup,
       job_tinybird
     ]
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird.result == 'success'
+    strategy:
+      matrix:
+        environment: [ 'staging', 'production']
     name: Deploy Tinybird
-    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ghost/tinybird-dedicated
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1310,8 +1313,12 @@ jobs:
           fi
       - name: Tinybird version
         run: tb --version
-      - name: Check auth
-        run: tb --host=${{ secrets.TB_HOST }} --token=${{ secrets.TB_ADMIN_TOKEN }} auth info
+      - name: Check auth (staging)
+        if: matrix.environment == 'staging'
+        run: tb --host=${{ secrets.TB_HOST_STAGING }} --token=${{ secrets.TB_ADMIN_TOKEN_STAGING }} auth info
+      - name: Check auth (production)
+        if: matrix.environment == 'production'
+        run: tb --host=${{ secrets.TB_HOST_PRODUCTION }} --token=${{ secrets.TB_ADMIN_TOKEN_PRODUCTION }} auth info
       - name: Deploy changes to the main Workspace
         run: |
           DEPLOY_FILE=./deploy/${VERSION}/deploy.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,7 +874,7 @@ jobs:
       - name: Check secrets
         if: github.event_name == 'pull_request'
         env:
-          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN }}
+          TB_ADMIN_TOKEN: ${{ secrets.TB_ADMIN_TOKEN_STAGING }}
         run: |
           if [ -z "${{ env.TB_ADMIN_TOKEN }}" ]; then
             echo "Tinybird admin token is not available. Did you open this PR from a fork?"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1325,7 +1325,7 @@ jobs:
           if [ ! -f "$DEPLOY_FILE" ]; then
             echo "$DEPLOY_FILE not found, running default tb push command"
             tb branch current
-            tb deploy
+            tb deploy --dry-run
           fi
       - name: Custom deployment to the main Workspace
         run: |


### PR DESCRIPTION
no issue

- We've been using a single workspace in Tinybird for both staging and production, and we want to start using a separate workspace for each environment. 
- We've also have two Tinybird directories - `ghost/tinybird` and `ghost/tinybird-dedicated`, and we're planning to clean both of those up and start fresh in `ghost/web-analytics`.
- This PR keeps the Tinybird tests running against our staging workspace, and modifies the deploy job to deploy to both staging and production when merging to main (at least for now)