### PR TITLE
Refined Delete confirmation copy in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -253,7 +253,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
     }
 
     const UserMenuTrigger = (
-        <Button className={`relative z-10 h-[34px] w-[34px] rounded-full ${layout === 'inbox' || layout === 'modal' ? 'text-gray-900 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-600' : 'text-gray-500 hover:text-gray-500'} dark:bg-black dark:hover:bg-gray-950 [&_svg]:size-5`} variant='ghost'>
+        <Button className={`relative z-10 h-[34px] w-[34px] rounded-md ${layout === 'inbox' || layout === 'modal' ? 'text-gray-900 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-600' : 'text-gray-500 hover:text-gray-500'} dark:bg-black dark:hover:bg-gray-950 [&_svg]:size-5`} variant='ghost'>
             <LucideIcon.Ellipsis />
         </Button>
     );
@@ -293,6 +293,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </div>
                                 <FeedItemMenu
                                     allowDelete={allowDelete}
+                                    layout='feed'
                                     trigger={UserMenuTrigger}
                                     onCopyLink={handleCopyLink}
                                     onDelete={handleDelete}
@@ -425,6 +426,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     </div>
                                     <FeedItemMenu
                                         allowDelete={allowDelete}
+                                        layout='reply'
                                         trigger={UserMenuTrigger}
                                         onCopyLink={handleCopyLink}
                                         onDelete={handleDelete}
@@ -521,6 +523,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     />
                                     <FeedItemMenu
                                         allowDelete={allowDelete}
+                                        layout='inbox'
                                         trigger={UserMenuTrigger}
                                         onCopyLink={handleCopyLink}
                                         onDelete={handleDelete}

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -75,9 +75,9 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
             </Popover>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Are you sure you want to delete this post?</AlertDialogTitle>
+                    <AlertDialogTitle>Delete this post?</AlertDialogTitle>
                     <AlertDialogDescription>
-                        You&apos;re about to delete this post. This is permanent! We warned you, k?
+                        {layout === 'inbox' ? 'This will remove the post from the Fediverse, but it will remain on your website.' : <>If you delete this post, you won&apos;t be able to restore it.</>}
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -65,7 +65,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
         onLikeClick();
     };
 
-    const buttonClassName = `transition-color flex p-2 ap-action-button items-center justify-center rounded-full bg-white text-gray-900 leading-none hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950 dark:text-gray-600`;
+    const buttonClassName = `transition-color flex p-2 ap-action-button items-center justify-center rounded-md bg-white text-gray-900 leading-none hover:bg-gray-100 dark:bg-black dark:hover:bg-gray-950 dark:text-gray-600`;
 
     return (<div className={`flex ${layout !== 'inbox' && 'gap-1'}`}>
         <Button


### PR DESCRIPTION
ref AP-842

- Delete confirmation dialog copy for Inbox was misleading: users could have thought that their posts on the website would also be deleted which is not the case (deleted posts are only deleted from ActivityPub)