### PR TITLE
Refined deleted post indicator in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/DeletedFeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/DeletedFeedItem.tsx
@@ -7,12 +7,12 @@ interface DeletedFeedItemProps {
 
 const DeletedFeedItem: React.FC<DeletedFeedItemProps> = ({last}) => {
     return (
-        <div className='relative py-5'>
-            <div className='flex h-10 grow items-center gap-2 rounded-lg border border-gray-200 p-2 px-[10px] text-center text-sm text-gray-600'>
-                <LucideIcon.Trash size={16} strokeWidth={1.25} />
+        <div className='relative mt-[-5px] py-5'>
+            <div className='flex h-12 grow items-center gap-2 rounded-lg border border-gray-200 p-2 px-[10px] text-gray-600'>
+                <LucideIcon.Trash size={18} strokeWidth={1.25} />
                 This post has been deleted
             </div>
-            {!last && <div className="absolute bottom-0 left-[18px] top-[62px] z-0 mb-[-13px] w-[2px] rounded-sm bg-gray-200"></div>}
+            {!last && <div className="absolute bottom-0 left-[18px] top-[70px] z-0 mb-[-13px] w-[2px] rounded-sm bg-gray-200"></div>}
         </div>
     );
 };


### PR DESCRIPTION
ref AP-786

- The deleted post indicator wasn't really matching the size and typography of the reply thread