### PR TITLE
Ensured reposts do not show the option to delete in `admin-x-actvitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -124,7 +124,7 @@ const useInfiniteScrollTab = <TData,>({useDataHook, emptyStateLabel, emptyStateI
     return {items, EmptyState, LoadingState};
 };
 
-const PostsTab: React.FC = () => {
+const PostsTab: React.FC<{currentUserAccount: Account | undefined}> = ({currentUserAccount}) => {
     const {items, EmptyState, LoadingState} = useInfiniteScrollTab<Activity>({
         useDataHook: useOutboxForUser,
         emptyStateLabel: 'You haven\'t posted anything yet.',
@@ -139,23 +139,33 @@ const PostsTab: React.FC = () => {
             {
                 posts.length > 0 && (
                     <ul className='mx-auto flex max-w-[640px] flex-col'>
-                        {posts.map((activity, index) => (
-                            <li
-                                key={activity.id}
-                                data-test-view-article
-                            >
-                                <FeedItem
-                                    actor={activity.actor}
-                                    allowDelete={true}
-                                    layout='feed'
-                                    object={activity.object}
-                                    type={activity.type}
-                                    onClick={() => handleViewContent(activity, false)}
-                                    onCommentClick={() => handleViewContent(activity, true)}
-                                />
-                                {index < posts.length - 1 && <Separator />}
-                            </li>
-                        ))}
+                        {posts.map((activity, index) => {
+                            let canDelete = false;
+
+                            const attributedTo = activity.object?.attributedTo;
+
+                            if (typeof attributedTo === 'object' && 'id' in attributedTo) {
+                                canDelete = currentUserAccount?.id === attributedTo.id;
+                            }
+
+                            return (
+                                <li
+                                    key={activity.id}
+                                    data-test-view-article
+                                >
+                                    <FeedItem
+                                        actor={activity.actor}
+                                        allowDelete={canDelete}
+                                        layout='feed'
+                                        object={activity.object}
+                                        type={activity.type}
+                                        onClick={() => handleViewContent(activity, false)}
+                                        onCommentClick={() => handleViewContent(activity, true)}
+                                    />
+                                    {index < posts.length - 1 && <Separator />}
+                                </li>
+                            );
+                        })}
                     </ul>
                 )
             }
@@ -327,7 +337,7 @@ const Profile: React.FC<ProfileProps> = ({}) => {
             title: 'Posts',
             contents: (
                 <div className='ap-posts'>
-                    <PostsTab />
+                    <PostsTab currentUserAccount={account} />
                 </div>
             )
         },


### PR DESCRIPTION
refs [AP-852](https://linear.app/ghost/issue/AP-852/fix-issue-where-reposts-erroneously-show-the-option-to-delete-in-the)

Reposts in the posts tab of the profile were showing the option to delete due to allowing all posts in the posts tab to be deleted. This change checks that the author of the post is actually the user doing the deleting before showing the option to delete