### PR TITLE
Added Captcha setting to Ghost Admin

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/SpamFilters.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/SpamFilters.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
-import {SettingGroupContent, TextArea, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {Separator, SettingGroupContent, TextArea, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 
 const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -25,6 +25,14 @@ const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const initialBlockedEmailDomains = JSON.parse(initialBlockedEmailDomainsJSON || '[]') as string[];
     const [blockedEmailDomains, setBlockedEmailDomains] = React.useState(initialBlockedEmailDomains.join('\n'));
 
+    const [captchaEnabled] = getSettingValues(localSettings, ['captcha_enabled']) as boolean[];
+    const handleToggleChange = (key: string, e: React.ChangeEvent<HTMLInputElement>) => {
+        updateSetting(key, e.target.checked);
+        handleEditingChange(true);
+    };
+
+    const labs = JSON.parse(getSettingValue<string>(localSettings, 'labs') || '{}');
+
     const updateBlockedEmailDomainsSetting = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const input = e.target.value;
         setBlockedEmailDomains(input);
@@ -44,6 +52,12 @@ const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const hint = (
         <>
             Prevent unwanted signups by blocking email domains. Add one domain per line, e.g., <code>spam.xyz</code> to block signups from email addresses like <code>hello@spam.xyz</code>.
+        </>
+    );
+
+    const captchaHint = (
+        <>
+            Use <a className="text-green hover:text-green-400" href="https://www.hcaptcha.com/" rel="noreferrer" target="_blank">hCaptcha</a> validation on signup when spam patterns are detected.
         </>
     );
 
@@ -72,6 +86,20 @@ const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     onChange={updateBlockedEmailDomainsSetting}
                     onKeyDown={() => clearError('spam-filters')}
                 />
+                {labs.captcha && (<>
+                    <Separator className="border-grey-200 dark:border-grey-900" />
+                    <Toggle
+                        checked={captchaEnabled}
+                        direction='rtl'
+                        gap='gap-0'
+                        hint={captchaHint}
+                        label='Enable strict signup security'
+                        labelClasses='block text-sm font-medium tracking-normal text-grey-900 w-full mt-[-10px]'
+                        onChange={(e) => {
+                            handleToggleChange('captcha_enabled', e);
+                        }}
+                    />
+                </>)}
             </SettingGroupContent>
         </TopLevelGroup>
     );

--- a/ghost/core/core/server/api/endpoints/settings-public.js
+++ b/ghost/core/core/server/api/endpoints/settings-public.js
@@ -7,11 +7,12 @@ const labs = require('../../../shared/labs');
 const getCaptchaSettings = () => {
     if (labs.isSet('captcha')) {
         return {
-            captcha_enabled: config.get('captcha:enabled'),
             captcha_sitekey: config.get('captcha:siteKey')
         };
     } else {
-        return {};
+        return {
+            captcha_enabled: false
+        };
     }
 };
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -75,7 +75,8 @@ const EDITABLE_SETTINGS = [
     'recommendations_enabled',
     'body_font',
     'heading_font',
-    'blocked_email_domains'
+    'blocked_email_domains',
+    'captcha_enabled'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/migrations/versions/5.111/2025-03-05-16-36-39-add-captcha-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.111/2025-03-05-16-36-39-add-captcha-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'captcha_enabled',
+    value: 'false',
+    type: 'boolean',
+    group: 'members'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -319,6 +319,14 @@
         "blocked_email_domains": {
             "defaultValue": "[]",
             "type": "array"
+        },
+        "captcha_enabled": {
+            "defaultValue": "false",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
         }
     },
     "portal": {

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -127,7 +127,8 @@
             "lifetime": 3600,
             "freeRetries": 10
         },
-        "blocked_email_domains": []
+        "blocked_email_domains": [],
+        "captcha_enabled": false
     },
     "caching": {
         "301": {

--- a/ghost/core/core/shared/settings-cache/public.js
+++ b/ghost/core/core/shared/settings-cache/public.js
@@ -48,5 +48,6 @@ module.exports = {
     default_email_address: 'default_email_address',
     support_email_address: 'support_email_address',
     editor_default_email_recipients: 'editor_default_email_recipients',
+    captcha_enabled: 'captcha_enabled',
     labs: 'labs'
 };

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -112,7 +112,7 @@ Object {
   "settings": Object {
     "accent_color": "#FF1A75",
     "allow_self_signup": true,
-    "captcha_enabled": true,
+    "captcha_enabled": null,
     "captcha_sitekey": "testkey",
     "codeinjection_foot": null,
     "codeinjection_head": null,

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -6,6 +6,7 @@ Object {
   "settings": Object {
     "accent_color": "#FF1A75",
     "allow_self_signup": true,
+    "captcha_enabled": null,
     "codeinjection_foot": null,
     "codeinjection_head": null,
     "comments_enabled": "off",

--- a/ghost/core/test/e2e-api/content/settings.test.js
+++ b/ghost/core/test/e2e-api/content/settings.test.js
@@ -51,7 +51,6 @@ describe('Settings Content API', function () {
                 })
                 .matchBodySnapshot({
                     settings: Object.assign({}, settingsMatcher, {
-                        captcha_enabled: true,
                         captcha_sitekey: 'testkey'
                     })
                 });

--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -1358,6 +1358,7 @@ Object {
   "settings": Object {
     "accent_color": "#FF1A75",
     "allow_self_signup": true,
+    "captcha_enabled": null,
     "codeinjection_foot": null,
     "codeinjection_head": null,
     "comments_enabled": "off",
@@ -1463,6 +1464,7 @@ Object {
   "settings": Object {
     "accent_color": "#FF1A75",
     "allow_self_signup": true,
+    "captcha_enabled": null,
     "codeinjection_foot": null,
     "codeinjection_head": null,
     "comments_enabled": "off",

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 89;
+            const allowedKeysLength = 90;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'b26690fb57ffd0edbddb4cd9e02b17d6';
     const currentFixturesHash = '80e79d1efd5da275e19cb375afb4ad04';
-    const currentSettingsHash = '05366d793079c93b87477ec0404301c6';
+    const currentSettingsHash = 'e3d52cd56b896a110318a975332e2092';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref BAE-400

This is only enabled when the lab setting is at the moment.

We should be able configure the keys from the front end too for self-hosters, we can add that next.