### PR TITLE
Fix empty feature flags in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -5,9 +5,9 @@ import {useLocation} from '@tryghost/admin-x-framework';
 export const FEATURE_FLAGS = ['deleteButton'] as const;
 
 // ---
-export type FeatureFlag = typeof FEATURE_FLAGS[number];
+export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;
 
-type FeatureFlagsState = Record<FeatureFlag, boolean>;
+type FeatureFlagsState = Partial<Record<FeatureFlag, boolean>>;
 
 type FeatureFlagsContextType = {
     isEnabled: (flag: FeatureFlag) => boolean;
@@ -43,7 +43,7 @@ export const FeatureFlagsProvider: React.FC<{children: React.ReactNode}> = ({chi
         }
     }, [location.search]);
 
-    const isEnabled = (flag: FeatureFlag): boolean => flags[flag];
+    const isEnabled = (flag: FeatureFlag): boolean => flags[flag] ?? false;
 
     const value = {
         isEnabled,


### PR DESCRIPTION
ref AP-865

- Having the soft feature flag array empty in ActivityPub breaks unit tests