### PR TITLE
Fixed incorrect time in SLOW_GET_HELPER logs

### DIFF
--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -338,11 +338,10 @@ module.exports = async function get(resource, options) {
                     errorDetails: {
                         api: `${controllerName}.${action}`,
                         apiOptions,
+                        time: totalMs,
                         returnedRows: returnedRowsCount
                     }
-                }), {
-                    time: totalMs
-                });
+                }));
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/22312

- we were passing `time` as a field to the logging library, but that library will interpret it as the time that the log occured
- instead, we can just pass it into the errorDetails to avoid this
