### PR TITLE
Revert "Moved ActivityPub flag to public beta (#22381)"

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -36,6 +36,10 @@ const features = [{
     description: 'Wires up the Ghost NestJS App to the Admin API (also needs GHOST_ENABLE_NEST_FRAMEWORK=1 env var)',
     flag: 'NestPlayground'
 },{
+    title: 'ActivityPub',
+    description: '(Highly) Experimental support for ActivityPub.',
+    flag: 'ActivityPub'
+},{
     title: 'Content Visibility (Beta)',
     description: 'Enables content visibility in Emails - Changes already released to beta testers',
     flag: 'contentVisibility'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -24,10 +24,6 @@ const BetaFeatures: React.FC = () => {
                 detail={<>Enable support for CashApp, iDEAL, Bancontact, and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />
             <LabItem
-                action={<FeatureToggle flag="ActivityPub" />}
-                detail={<>Federate your Ghost publication over ActivityPub. <a className='text-green' href="https://activitypub.ghost.org/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
-                title='ActivityPub' />
-            <LabItem
                 action={<div className='flex flex-col items-end gap-1'>
                     <FileUpload
                         id='upload-redirects'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-853/move-alpha-flag-to-beta

- This reverts commit 6539b56d830a1c0c52116f231d78f4c4ac5cdb03.
- We'll move the AP flag from alpha to beta early next week instead