### PR TITLE
Released @tryghost/portal v2.50.4

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.50.3",
+  "version": "2.50.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no ref

It seems the changes in the previous version didn't get carried through. I'm not certain if this was a timing issue as the substantive commit followed shortly behind, so we're trying this again.