### PR TITLE
Fixed multi-image attachments handling in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -53,12 +53,12 @@ export function renderFeedAttachment(object: ObjectProperties, layout: string) {
         const attachmentCount = attachment.length;
 
         let gridClass = '';
-        if (layout === 'modal') {
+        if (attachmentCount === 1) {
             gridClass = 'grid-cols-1'; // Single image, full width
-        } else if (attachmentCount === 2) {
-            gridClass = 'grid-cols-2 auto-rows-[150px]'; // Two images, side by side
-        } else if (attachmentCount === 3 || attachmentCount === 4) {
-            gridClass = 'grid-cols-2 auto-rows-[150px]'; // Three or four images, two per row
+        } else if (attachmentCount >= 2 && attachmentCount <= 4) {
+            gridClass = 'grid-cols-2 auto-rows-[150px]'; // 2-4 images, two per row
+        } else if (attachmentCount > 4) {
+            gridClass = 'grid-cols-3 auto-rows-[150px]'; // >4 images, three per row
         }
 
         return (

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -42,7 +42,7 @@ function getAttachment(object: ObjectProperties) {
     return attachment;
 }
 
-export function renderFeedAttachment(object: ObjectProperties, layout: string) {
+export function renderFeedAttachment(object: ObjectProperties) {
     const attachment = getAttachment(object);
 
     if (!attachment) {
@@ -303,7 +303,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className='flex flex-col'>
                                     <div className=''>
                                         {(object.type === 'Article') ? <div className='rounded-md border border-gray-150 transition-colors hover:bg-gray-75 dark:border-gray-950 dark:hover:bg-gray-950'>
-                                            {renderFeedAttachment(object, layout)}
+                                            {renderFeedAttachment(object)}
                                             <div className='p-4'>
                                                 <Heading className='mb-1 text-pretty leading-tight' level={5} data-test-activity-heading>{object.name}</Heading>
                                                 <div className='line-clamp-3 leading-tight'>{object.preview?.content}</div>
@@ -322,7 +322,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                 {isTruncated && (
                                                     <button className='mt-1 text-blue-600' type='button'>Show more</button>
                                                 )}
-                                                {renderFeedAttachment(object, layout)}
+                                                {renderFeedAttachment(object)}
                                             </div>
                                         }
                                     </div>
@@ -374,7 +374,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='flex flex-col items-start'>
                                         {object.name && <Heading className='mb-1 leading-tight' level={4} data-test-activity-heading>{object.name}</Heading>}
                                         <div dangerouslySetInnerHTML={({__html: object.content ?? ''})} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 dark:text-gray-600'></div>
-                                        {renderFeedAttachment(object, layout)}
+                                        {renderFeedAttachment(object)}
                                         <div className='space-between ml-[-7px] mt-3 flex'>
                                             <FeedItemStats
                                                 commentCount={commentCount}
@@ -434,10 +434,10 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </div>
                                 <div className={`relative z-10 col-start-2 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col'>
-                                        {(object.type === 'Article') && renderFeedAttachment(object, layout)}
+                                        {(object.type === 'Article') && renderFeedAttachment(object)}
                                         {object.name && <Heading className='my-1 text-pretty leading-tight' level={5} data-test-activity-heading>{object.name}</Heading>}
                                         {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: object.content ?? ''})} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 dark:text-gray-600'></div>}
-                                        {(object.type === 'Note') && renderFeedAttachment(object, layout)}
+                                        {(object.type === 'Note') && renderFeedAttachment(object)}
                                         {(object.type === 'Article') && <ButtonX
                                             className={`mt-3 self-start text-gray-900 transition-all hover:opacity-60`}
                                             color='grey'


### PR DESCRIPTION
ref AP-875

- fixed the logic for one-image attachment — previously it was checking if the layout is "modal" for this which caused stacked images in the drawer
- notes with more than four images wasn't being handled, now it displays them three per row
