### PR TITLE
Improved performance when importing posts via JSON file

### DIFF
--- a/ghost/core/core/server/services/url/Resources.js
+++ b/ghost/core/core/server/services/url/Resources.js
@@ -446,7 +446,11 @@ class Resources {
      * @returns {Object}
      */
     getByIdAndType(type, id) {
-        return _.find(this.data[type], {data: {id: id}});
+        if (!this.data[type]) {
+            return undefined;
+        }
+
+        return this.data[type].find(r => r.data.id === id);
     }
 
     /**


### PR DESCRIPTION
- when we import posts, we have to update our internal URL service state to reflect the new posts
- somewhere in this flow, we call `getByIdAndType`, which uses a lodash `_.find` call to find the resource
- however, if you have a large number of posts, and you're importing a lot of posts, `_.find` becomes chronically slow (~92% of the CPU time from profiling)
- lodash can become a real bottleneck, and it's proving to be so here
- to fix this, we can just switch this out with the native JS find function, which avoids all of the overhead of the internal lodash functions
- from testing, this dramatically speeds up data imports
