### PR TITLE
Put new replies on top when they are added in a thread in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -448,7 +448,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
         // Add the new reply to the thread
         activity.object.authored = true;
         activity.id = activity.object.id;
-        addToThread(activity);
+        addToThread(activity, true);
 
         // Update the replyCount on the activity outside of the context
         // of this component

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -448,7 +448,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
         // Add the new reply to the thread
         activity.object.authored = true;
         activity.id = activity.object.id;
-        addToThread(activity, true);
+        addToThread(activity);
 
         // Update the replyCount on the activity outside of the context
         // of this component

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -610,26 +610,22 @@ export function useThreadForUser(handle: string, id: string) {
         }
     });
 
-    const addToThread = (activity: Activity, addToTop: boolean = false) => {
+    const addToThread = (activity: Activity) => {
         // Add the activity to the thread stored in the thread query cache
         queryClient.setQueryData(queryKey, (current: {posts: Activity[]} | undefined) => {
             if (!current) {
                 return current;
             }
 
-            if (addToTop) {
-                // Find the parent post index
-                const parentIndex = current.posts.findIndex(post => post.object.id === id);
-                // Create a new array with the activity inserted after the parent
-                const newPosts = [...current.posts];
-                newPosts.splice(parentIndex + 1, 0, activity);
-                return {
-                    posts: newPosts
-                };
-            }
+            // Find the parent post index
+            const parentIndex = current.posts.findIndex(post => post.object.id === id);
+
+            // Create a new array with the activity inserted after the parent
+            const newPosts = [...current.posts];
+            newPosts.splice(parentIndex + 1, 0, activity);
 
             return {
-                posts: [...current.posts, activity]
+                posts: newPosts
             };
         });
     };

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -610,11 +610,22 @@ export function useThreadForUser(handle: string, id: string) {
         }
     });
 
-    const addToThread = (activity: Activity) => {
+    const addToThread = (activity: Activity, addToTop: boolean = false) => {
         // Add the activity to the thread stored in the thread query cache
         queryClient.setQueryData(queryKey, (current: {posts: Activity[]} | undefined) => {
             if (!current) {
                 return current;
+            }
+
+            if (addToTop) {
+                // Find the parent post index
+                const parentIndex = current.posts.findIndex(post => post.object.id === id);
+                // Create a new array with the activity inserted after the parent
+                const newPosts = [...current.posts];
+                newPosts.splice(parentIndex + 1, 0, activity);
+                return {
+                    posts: newPosts
+                };
             }
 
             return {


### PR DESCRIPTION
ref AP-874

- currently, new replies are added to the bottom of the thread when they're added
- this adds a new parameter `addToTop` to `addToThread()` function, so that new replies are placed on top
- it still maintains the default old to new order when the thread is opened later
