### PR TITLE
Updated the client AP app to render nothing when flag is off

### DIFF
--- a/apps/admin-x-activitypub/src/App.tsx
+++ b/apps/admin-x-activitypub/src/App.tsx
@@ -7,9 +7,14 @@ import {ShadeApp} from '@tryghost/shade';
 interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: DesignSystemAppProps;
+    activityPubEnabled: boolean;
 }
 
-const App: React.FC<AppProps> = ({framework, designSystem}) => {
+const App: React.FC<AppProps> = ({framework, designSystem, activityPubEnabled}) => {
+    if (!activityPubEnabled) {
+        return null;
+    }
+
     return (
         <FrameworkProvider {...framework}>
             <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>

--- a/apps/admin-x-activitypub/src/standalone.tsx
+++ b/apps/admin-x-activitypub/src/standalone.tsx
@@ -2,4 +2,6 @@ import './styles/index.css';
 import App from './App.tsx';
 import renderStandaloneApp from '@tryghost/admin-x-framework/test/render';
 
-renderStandaloneApp(App, {});
+renderStandaloneApp(App, {
+    activityPubEnabled: false
+});

--- a/ghost/admin/app/components/admin-x/activitypub.js
+++ b/ghost/admin/app/components/admin-x/activitypub.js
@@ -3,6 +3,11 @@ import {inject as service} from '@ember/service';
 
 export default class AdminXActivityPub extends AdminXComponent {
     @service upgradeStatus;
+    @service feature;
 
     static packageName = '@tryghost/admin-x-activitypub';
+
+    additionalProps = () => ({
+        activityPubEnabled: this.feature.ActivityPub
+    });
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-836

- passed the ActivityPub flag to the client AP app
- if the ActivityPub flag is disabled, skipped rendering the AP client app
