### PR TITLE
🐛 Fixed free sign up url not working w/o free plan available

### DIFF
--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -476,7 +476,7 @@ class SignupPage extends React.Component {
     }
 
     getSelectedPriceId(prices = [], selectedPriceId) {
-        if (!prices || prices.length === 0) {
+        if (!prices || prices.length === 0 || selectedPriceId === 'free') {
             return 'free';
         }
         const hasSelectedPlan = prices.some((p) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-687/

There is supposed to be a few options for signups:
- only paid
- hide free in portal but allow free signups via url
- show free in portal

In this case, the #/portal/signup/free url was not working as it was redirecting to Stripe unless the free tier was shown in Portal.