### PR TITLE
Cleaned up early return using optional chaining

### DIFF
--- a/ghost/core/core/server/services/url/Resources.js
+++ b/ghost/core/core/server/services/url/Resources.js
@@ -446,11 +446,7 @@ class Resources {
      * @returns {Object}
      */
     getByIdAndType(type, id) {
-        if (!this.data[type]) {
-            return undefined;
-        }
-
-        return this.data[type].find(r => r.data.id === id);
+        return this.data[type]?.find(r => r.data.id === id);
     }
 
     /**


### PR DESCRIPTION
refs https://x.com/Kikobeats/status/1899560168826040465

- instead of having an early return, we can just use optional chaining for the case where there is no data available (this is the case in some specific tests)