### PR TITLE
Fixed nock URL scheme in ExternalMediaInliner tests

### DIFF
--- a/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
+++ b/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
@@ -790,7 +790,7 @@ describe('ExternalMediaInliner', function () {
 
         it('Handles URLs with no scheme', async function () {
             const imageURL = '//img.stockfresh.com/files/f/ghost-logo.png';
-            const requestMock = nock('https://img.stockfresh.com')
+            const requestMock = nock('http://img.stockfresh.com')
                 .get('/files/f/ghost-logo.png')
                 .reply(200, ghostLogoPng);
 


### PR DESCRIPTION
- this test checks that the ExternalMediaInliner can handle URLs with no scheme
- it does this by providing a URL with no scheme, setting up `nock` for `https://...` and then checking the output
- however, there's a bug in this test because ExternalMediaInliner only prepends `http://` if there is no scheme, which does not match nock
- the reason this test passes here is because img.stockfresh.com is a real URL, and actually redirects our request to HTTPS, which _then_ gets picked up by nock
- when I move the test to Ghost core, where we have network disabled in unit tests, the test fails because there is no http -> https redirect
- to fix this, we can just change the nock mock to http
- when this test is in Ghost core, network will be disabled, so we can skip doing it here now
