### PR TITLE
🐛 Fixed incorrect job status for email analytics jobs

### DIFF
--- a/ghost/core/core/server/services/email-analytics/jobs/update-member-email-analytics/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/update-member-email-analytics/index.js
@@ -1,0 +1,13 @@
+const queries = require('../../lib/queries');
+ 
+/**
+ * Updates email analytics for a specific member
+ * 
+ * @param {Object} options - The options object
+ * @param {string} options.memberId - The ID of the member to update analytics for
+ * @returns {Promise<Object>} The result of the aggregation query (1/0)
+ */
+module.exports = async function updateMemberEmailAnalytics({memberId}) {
+    const result = await queries.aggregateMemberStats(memberId);
+    return result;
+};

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -99,7 +99,7 @@ module.exports = {
     /**
      * Sets the timestamp of the last seen event for the specified email analytics events.
      * @param {EmailAnalyticsJobName} jobName - The name of the job to update.
-     * @param {'completed'|'started'} field - The field to update.
+     * @param {'finished'|'started'} field - The field to update.
      * @param {Date} date - The timestamp of the last seen event.
      * @returns {Promise<void>}
      * @description
@@ -110,8 +110,8 @@ module.exports = {
         // Convert string dates to Date objects for SQLite compatibility
         try {
             debug(`Setting ${field} timestamp for job ${jobName} to ${date}`);
-            const updateField = field === 'completed' ? 'finished_at' : 'started_at';
-            const status = field === 'completed' ? 'finished' : 'started';
+            const updateField = field === 'finished' ? 'finished_at' : 'started_at';
+            const status = field === 'finished' ? 'finished' : 'started';
             const result = await db.knex('jobs').update({[updateField]: date, updated_at: new Date(), status: status}).where('name', jobName);
             if (result === 0) {
                 await db.knex('jobs').insert({

--- a/ghost/email-analytics-service/lib/EmailAnalyticsService.js
+++ b/ghost/email-analytics-service/lib/EmailAnalyticsService.js
@@ -274,7 +274,7 @@ module.exports = class EmailAnalyticsService {
             };
         }
 
-        this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'completed', this.#fetchScheduledData.lastEventTimestamp);
+        this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp);
         return count;
     }
     /**
@@ -374,13 +374,13 @@ module.exports = class EmailAnalyticsService {
         if (!error && eventCount > 0 && eventCount < maxEvents && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
             logging.info('[EmailAnalytics] Reached end of new events, increasing lastEventTimestamp with one second');
             // set the data on the db so we can store it for fetching after reboot
-            await this.queries.setJobTimestamp(fetchData.jobName, 'completed', new Date(fetchData.lastEventTimestamp.getTime()));
+            await this.queries.setJobTimestamp(fetchData.jobName, 'finished', new Date(fetchData.lastEventTimestamp.getTime()));
             // increment and store in local memory
             fetchData.lastEventTimestamp = new Date(fetchData.lastEventTimestamp.getTime() + 1000);
         } else {
             logging.info('[EmailAnalytics] No new events found');
             // set job status to finished
-            await this.queries.setJobStatus(fetchData.jobName, 'completed');
+            await this.queries.setJobStatus(fetchData.jobName, 'finished');
         }
 
         fetchData.running = false;

--- a/ghost/job-manager/test/job-queue-manager.test.js
+++ b/ghost/job-manager/test/job-queue-manager.test.js
@@ -369,11 +369,11 @@ describe('JobQueueManager', function () {
             
             expect(calledId).to.equal('1');
             expect(calledUpdateData).to.deep.include({
-                status: 'error',
-                metadata: {
-                    error: 'Test error',
-                    retries: 1
-                }
+                status: 'failed',
+                metadata: JSON.stringify({
+                    retries: 1,
+                    error: 'Test error'
+                })
             });
             expect(calledUpdateData.finished_at).to.be.instanceOf(Date);
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2075

This was using a status of 'completed' which was not in the allowed list in the schema, causing unnecessary logs.