### PR TITLE
Fixed ActivityPub reply button enabled condition

### DIFF
--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -113,8 +113,7 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
         className
     );
 
-    // We disable the button if either the textbox isn't focused, or the reply is currently being sent.
-    const buttonDisabled = !isFocused || replyMutation.isLoading;
+    const buttonDisabled = !textValue || replyMutation.isLoading;
 
     let placeholder = 'Reply...';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
closes AP-873

- When the textarea for a reply is populated, but not focused, the "post" button goes grey. The user expectation is that if there's content in the textarea then the button stays black to indicate it's possible to click on it to post