### PR TITLE
Removed "Copy link" action of feed items

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -385,13 +385,6 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                 onCommentClick={onCommentClick}
                                                 onLikeClick={onLikeClick}
                                             />
-                                            <FeedItemMenu
-                                                allowDelete={allowDelete}
-                                                layout='modal'
-                                                trigger={UserMenuTrigger}
-                                                onCopyLink={handleCopyLink}
-                                                onDelete={handleDelete}
-                                            />
                                         </div>
                                     </div>
                                 </div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -49,11 +49,13 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                 </PopoverTrigger>
                 <PopoverContent align={`${layout === 'modal' ? 'start' : 'end'}`} alignOffset={layout === 'modal' ? -12 : 0} className='p-2'>
                     <div className='flex w-48 flex-col'>
-                        <PopoverClose asChild>
-                            <Button className='justify-start' variant='ghost' onClick={handleCopyLinkClick}>
-                                Copy link
-                            </Button>
-                        </PopoverClose>
+                        {(!allowDelete || layout === 'inbox') &&
+                            <PopoverClose asChild>
+                                <Button className='justify-start' variant='ghost' onClick={handleCopyLinkClick}>
+                                    Copy link
+                                </Button>
+                            </PopoverClose>
+                        }
                         {allowDelete &&
                             <AlertDialogTrigger asChild>
                                 <PopoverClose asChild>


### PR DESCRIPTION
closes AP-889

- Currently all links of a feed item in ActivityPub results in a 404 which is not an expected behavior. As for now links to feed items is not a requirement we're removing the copy link function for feed items.