### PR TITLE
Updated ActivityPub client app to not render when flag is off

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/App.tsx
+++ b/apps/admin-x-activitypub/src/App.tsx
@@ -7,9 +7,14 @@ import {ShadeApp} from '@tryghost/shade';
 interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: DesignSystemAppProps;
+    activityPubEnabled?: boolean;
 }
 
-const App: React.FC<AppProps> = ({framework, designSystem}) => {
+const App: React.FC<AppProps> = ({framework, designSystem, activityPubEnabled}) => {
+    if (activityPubEnabled === false) {
+        return null;
+    }
+
     return (
         <FrameworkProvider {...framework}>
             <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-836

- if the `ActivityPub` feature flag is off, the client app should not render anything
- this PR does not include Ghost Admin changes, to make sure we can ship `@tryghost/admin-x-activitypub` changes independently without breaking current behaviour
