### PR TITLE
Refactored UrlService.owns for readability

### DIFF
--- a/ghost/core/core/server/services/url/UrlService.js
+++ b/ghost/core/core/server/services/url/UrlService.js
@@ -263,17 +263,7 @@ class UrlService {
     owns(routerId, id) {
         debug('owns', routerId, id);
 
-        let urlGenerator;
-
-        this.urlGenerators.every((_urlGenerator) => {
-            if (_urlGenerator.identifier === routerId) {
-                urlGenerator = _urlGenerator;
-                return false;
-            }
-
-            return true;
-        });
-
+        const urlGenerator = this.urlGenerators.find(g => g.identifier === routerId);
         if (!urlGenerator) {
             return false;
         }


### PR DESCRIPTION
- the use of the .every message is a little janky and difficult to read when we ultimately just want to find the url generator for the router ID and early return if it doesn't exist
- to clean this up, we can use `.find`