### PR TITLE
Passed ActivityPub feature flag to the client app

### DIFF
--- a/ghost/admin/app/components/admin-x/activitypub.js
+++ b/ghost/admin/app/components/admin-x/activitypub.js
@@ -3,6 +3,11 @@ import {inject as service} from '@ember/service';
 
 export default class AdminXActivityPub extends AdminXComponent {
     @service upgradeStatus;
+    @service feature;
 
     static packageName = '@tryghost/admin-x-activitypub';
+
+    additionalProps = () => ({
+        activityPubEnabled: this.feature.ActivityPub
+    });
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-836

- the activityPubEnabled flag is used by the client ActivityPub app to decide whether to render the app or not

