### PR TITLE
✨ Beta feature: Editors can manage comments and members.

### DIFF
--- a/apps/comments-ui/src/App.tsx
+++ b/apps/comments-ui/src/App.tsx
@@ -16,6 +16,8 @@ type AppProps = {
     scriptTag: HTMLElement;
 };
 
+const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
+
 const App: React.FC<AppProps> = ({scriptTag}) => {
     const options = useOptions(scriptTag);
     const [state, setFullState] = useState<EditableAppContext>({
@@ -112,6 +114,12 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
             let admin = null;
             try {
                 admin = await adminApi.getUser();
+
+                // remove 'admin' for any roles (author, contributor, editor) who can't moderate comments
+                if (!admin || !(admin.roles.some(role => ALLOWED_MODERATORS.includes(role.name)))) {
+                    admin = null;
+                }
+                
                 if (admin) {
                     // this is a bit of a hack, but we need to fetch the comments fully populated if the user is an admin
                     const adminComments = await adminApi.browse({page: 1, postId: options.postId, order: state.order, memberUuid: state.member?.uuid});

--- a/apps/comments-ui/test/utils/MockedApi.ts
+++ b/apps/comments-ui/test/utils/MockedApi.ts
@@ -489,7 +489,8 @@ export class MockedApi {
                 status: 200,
                 body: JSON.stringify({
                     users: [{
-                        id: '1'
+                        id: '1',
+                        roles: [{name: 'Owner'}]
                     }]
                 })
             });

--- a/ghost/core/core/frontend/src/admin-auth/message-handler.js
+++ b/ghost/core/core/frontend/src/admin-auth/message-handler.js
@@ -63,7 +63,7 @@ window.addEventListener('message', async function (event) {
     if (data.action === 'getUser') {
         try {
             const res = await fetch(
-                adminUrl + '/users/me/'
+                adminUrl + '/users/me/?include=roles'
             );
             const json = await res.json();
             respond(null, json);

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const validator = require('@tryghost/validator');
 const ObjectId = require('bson-objectid').default;
 const ghostBookshelf = require('./base');
@@ -77,7 +76,7 @@ User = ghostBookshelf.Model.extend({
     },
 
     format(options) {
-        if (!_.isEmpty(options.website) &&
+        if (options.website && 
             !validator.isURL(options.website, {
                 require_protocol: true,
                 protocols: ['http', 'https']
@@ -130,7 +129,7 @@ User = ghostBookshelf.Model.extend({
     onDestroyed: function onDestroyed(model, options) {
         ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
-        if (_.includes(activeStates, model.previous('status'))) {
+        if (activeStates.includes(model.previous('status'))) {
             model.emitChange('deactivated', options);
         }
 
@@ -143,7 +142,7 @@ User = ghostBookshelf.Model.extend({
         model.emitChange('added', options);
 
         // active is the default state, so if status isn't provided, this will be an active user
-        if (!model.get('status') || _.includes(activeStates, model.get('status'))) {
+        if (!model.get('status') || activeStates.includes(model.get('status'))) {
             model.emitChange('activated', options);
         }
     },
@@ -152,7 +151,7 @@ User = ghostBookshelf.Model.extend({
         ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.statusChanging = model.get('status') !== model.previous('status');
-        model.isActive = _.includes(activeStates, model.get('status'));
+        model.isActive = activeStates.includes(model.get('status'));
 
         if (model.statusChanging) {
             model.emitChange(model.isActive ? 'activated' : 'deactivated', options);
@@ -456,18 +455,16 @@ User = ghostBookshelf.Model.extend({
         const options = this.filterOptions(unfilteredOptions, 'findOne');
         let query;
         let status;
-        let data = _.cloneDeep(dataToClone);
+        let data = JSON.parse(JSON.stringify(dataToClone));
         const lookupRole = data.role;
 
         // Ensure only valid fields/columns are added to query
         if (options.columns) {
-            options.columns = _.intersection(options.columns, this.prototype.permittedAttributes());
+            options.columns = options.columns.filter(col => this.prototype.permittedAttributes().includes(col));
         }
 
         delete data.role;
-        data = _.defaults(data || {}, {
-            status: 'all'
-        });
+        data = Object.assign({}, {status: 'all'}, data || {});
 
         status = data.status;
         delete data.status;
@@ -476,7 +473,7 @@ User = ghostBookshelf.Model.extend({
 
         // Support finding by role
         if (lookupRole) {
-            options.withRelated = _.union(options.withRelated, ['roles']);
+            options.withRelated = [...new Set([...(options.withRelated || []), 'roles'])];
             query = this.forge(data);
 
             query.query('join', 'roles_users', 'users.id', '=', 'roles_users.user_id');
@@ -520,7 +517,7 @@ User = ghostBookshelf.Model.extend({
         } else if (type === 'recommendation-received') {
             filter += '+recommendation_notifications:true';
         }
-        const updatedOptions = _.merge({}, options, {filter, withRelated: ['roles']});
+        const updatedOptions = Object.assign({}, options, {filter, withRelated: ['roles']});
         return this.findAll(updatedOptions).then((users) => {
             return users.toJSON().filter((user) => {
                 return user?.roles?.some((role) => {
@@ -641,7 +638,7 @@ User = ghostBookshelf.Model.extend({
     add: function add(dataToClone, unfilteredOptions) {
         const options = this.filterOptions(unfilteredOptions, 'add');
         const self = this;
-        const data = _.cloneDeep(dataToClone);
+        const data = JSON.parse(JSON.stringify(dataToClone));
         let userData = this.filterData(data);
         let roles;
 
@@ -653,7 +650,7 @@ User = ghostBookshelf.Model.extend({
         }
 
         function getAuthorRole() {
-            return ghostBookshelf.model('Role').findOne({name: 'Author'}, _.pick(options, 'transacting'))
+            return ghostBookshelf.model('Role').findOne({name: 'Author'}, {transacting: options.transacting})
                 .then(function then(authorRole) {
                     return [authorRole.get('id')];
                 });
@@ -684,7 +681,7 @@ User = ghostBookshelf.Model.extend({
                 roles = _roles;
 
                 // CASE: it is possible to add roles by name, by id or by object
-                if (_.isString(roles[0]) && !ObjectId.isValid(roles[0])) {
+                if (typeof roles[0] === 'string' && !ObjectId.isValid(roles[0])) {
                     const rolePromises = roles.map((roleName) => {
                         return ghostBookshelf.model('Role').findOne({
                             name: roleName
@@ -781,6 +778,23 @@ User = ghostBookshelf.Model.extend({
         });
     },
 
+    /**
+     * Checks if a user has permission to perform an action on another user
+     * 
+     * @param {Object|string|number} userModelOrId - The user model or ID being acted upon
+     * @param {'edit'|'destroy'} action - The action being performed:
+     *                                     - 'edit': Edit user details, status, or role
+     *                                     - 'destroy': Delete a user (Owner cannot be deleted)
+     * @param {Object} context - The context of the request, containing the current user's ID
+     * @param {Object} unsafeAttrs - The attributes being modified in the action
+     * @param {Object} loadedPermissions - The permissions of the user making the request
+     * @param {boolean} hasUserPermission - Whether the user has permission based on user roles
+     * @param {boolean} hasApiKeyPermission - Whether the user has permission based on API key
+     * @returns {Promise<boolean>} Resolves if the action is permitted, rejects with NoPermissionError if not
+     * @throws {errors.NotFoundError} When the target user is not found
+     * @throws {errors.NoPermissionError} When the action is not permitted
+     * @throws {errors.ValidationError} When role changes are invalid
+     */
     permissible: async function permissible(userModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
         const self = this;
         const userModel = userModelOrId;
@@ -788,13 +802,13 @@ User = ghostBookshelf.Model.extend({
         const {isOwner, isEitherEditor} = setIsRoles(loadedPermissions);
 
         // If we passed in a model without its related roles, we need to fetch it again
-        if (_.isObject(userModelOrId) && !_.isObject(userModelOrId.related('roles'))) {
+        if (typeof userModelOrId === 'object' && !(typeof userModelOrId.related('roles') === 'object')) {
             userModelOrId = userModelOrId.id;
         }
         // If we passed in an id instead of a model get the model first
-        if (_.isNumber(userModelOrId) || _.isString(userModelOrId)) {
+        if (typeof userModelOrId === 'number' || typeof userModelOrId === 'string') {
             // Grab the original args without the first one
-            origArgs = _.toArray(arguments).slice(1);
+            origArgs = Array.from(arguments).slice(1);
 
             // Get the actual user model
             return this.findOne({
@@ -822,9 +836,6 @@ User = ghostBookshelf.Model.extend({
         }
 
         if (action === 'edit') {
-            // Users with the role 'Editor', 'Author', and 'Contributor' have complex permissions when the action === 'edit'
-            // We now have all the info we need to construct the permissions
-
             if (context.user === userModel.get('id')) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = true;
@@ -1058,7 +1069,7 @@ User = ghostBookshelf.Model.extend({
 
                 // check if user has the owner role
                 const currentRoles = contextUser.toJSON(options).roles;
-                if (!_.some(currentRoles, {id: ownerRole.id})) {
+                if (!currentRoles.some(role => role.id === ownerRole.id)) {
                     return Promise.reject(new errors.NoPermissionError({
                         message: tpl(messages.onlyOwnerCanTransferOwnerRole)
                     }));
@@ -1081,7 +1092,7 @@ User = ghostBookshelf.Model.extend({
 
                 const {roles: currentRoles, status} = user.toJSON(options);
 
-                if (!_.some(currentRoles, {id: adminRole.id})) {
+                if (!currentRoles.some(role => role.id === adminRole.id)) {
                     return Promise.reject(new errors.ValidationError({
                         message: tpl(messages.onlyAdmCanBeAssignedOwnerRole)
                     }));

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -11,9 +11,9 @@ const {pipeline} = require('@tryghost/promise');
 const validatePassword = require('../lib/validate-password');
 const permissions = require('../services/permissions');
 const urlUtils = require('../../shared/url-utils');
+const {setIsRoles} = require('./role-utils');
 const activeStates = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'];
 const ASSIGNABLE_ROLES = ['Administrator', 'Super Editor', 'Editor', 'Author', 'Contributor'];
-const {setIsRoles} = require('./role-utils');
 
 const messages = {
     valueCannotBeBlank: 'Value in [{tableName}.{columnKey}] cannot be blank.',
@@ -828,9 +828,9 @@ User = ghostBookshelf.Model.extend({
             if (context.user === userModel.get('id')) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = true;
-            } else if (isOwner) {
+            } else if (loadedPermissions.user && userModel.hasRole('Owner')) {
                 // Owner can only be edited by owner
-                hasUserPermission = loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Owner'});
+                hasUserPermission = isOwner;
             } else if (isEitherEditor) {
                 // If the user we are trying to edit is an Author or Contributor, allow it
                 hasUserPermission = userModel.hasRole('Author') || userModel.hasRole('Contributor');

--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -5,6 +5,7 @@ const tpl = require('@tryghost/tpl');
 const providers = require('./providers');
 const parseContext = require('./parse-context');
 const actionsMap = require('./actions-map-cache');
+const {setIsRoles} = require('../../models/role-utils');
 
 const messages = {
     noPermissionToAction: 'You do not have permission to perform this action',
@@ -66,8 +67,8 @@ class CanThisResult {
 
                         return true;
                     };
-
-                    if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Owner'})) {
+                    const {isOwner} = setIsRoles(loadedPermissions);
+                    if (isOwner) {
                         hasUserPermission = true;
                     } else if (!_.isEmpty(userPermissions)) {
                         hasUserPermission = _.some(userPermissions, checkPermission);

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -1614,7 +1614,7 @@ describe('Post Model', function () {
             const staffCount = testUtils.DataGenerator.forKnex.users.length;
 
             const preReassignPosts = await models.Post.findAll({context: {internal: true}});
-            // There are 10 posts created by posts:mu fixture
+            // The posts:mu fixture creates two posts per staff member.
             preReassignPosts.length.should.equal(2 * staffCount);
 
             const preReassignOwnerWithPosts = await models.Post.findAll({
@@ -1626,7 +1626,7 @@ describe('Post Model', function () {
             await models.Post.reassignByAuthor(authorData);
 
             const postReassignPosts = await models.Post.findAll({context: {internal: true}});
-            // All 10 should remain
+            // All posts should remain
             postReassignPosts.length.should.equal(2 * staffCount);
 
             const postReassignOwnerWithPosts = await models.Post.findAll({


### PR DESCRIPTION
The current Ghost permissions system gives Editors the ability to publish posts and newsletters and to invite new authors and contributors, but does not give them any abilities in terms of member management, such as creating new members, providing complimentary access, viewing subscription status, or cancelling member subscriptions. Currently, that functionality is reserved for the Administrator level, but this access level includes substantial additional permissions, that the site owner may not want to grant to the person in their organization doing "member support".

The situation is similar for comments. Only administrators can moderate comments, even though a busy site might have a lot of staffing need in this area to keep things under control.

This PR creates a "Super Editor" role that can also do user management and comments moderation, controlled by a beta feature flag.

Note: changes to the feature flag toggle do not take effect on individual editors until their roles are individually updated.

While I was there, I closed https://github.com/TryGhost/Ghost/issues/22328

I also added some refactoring of the role-based part of the permissions system to improve readability.

**This is a multi-part PR.**  
#22487 this PR (comments, plus permissions bug fix (from 22450) and some clean-up )
#22453 (admin area)
#22452 (admin-x)
#22450 (migrations & associated)
#22448 (permissions refactoring and utility function)
#22444 (labs flag)
#22443 (updated fixtures and tests)


Tests updated.
