### PR TITLE
Fixed missing lockfile in Ghost-CLI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -999,6 +999,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install npm v8 # downgrade from v10 to v8 due to https://github.com/npm/cli/issues/6738
+        run: npm install -g npm@8
+
       - name: Install Ghost-CLI
         run: npm install -g ghost-cli@latest
 


### PR DESCRIPTION
refs https://github.com/npm/cli/issues/6738
refs https://github.com/TryGhost/Ghost-Moya/pull/92 refs https://ghost.slack.com/archives/C08AXV0N90T/p1738231830454619 refs https://ghost.slack.com/archives/C02G9E68C/p1741950594229099

- npm v10 doesn't include the yarn.lock when publishing packages, which we do want to include, but it doesn't give us an option to bypass that
- we rely on the yarn.lock file to ensure we're using specific versions of dependencies
- for now, we can just downgrade to npm v8 to get the old functionality back
