### PR TITLE
ActivityPub UI/UX refinements

### DIFF
--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
@@ -14,7 +14,7 @@ const FeedbackBox: React.FC = () => {
         NiceModal.show(ArticleModal, {
             activityId: targetPostId,
             object: {
-                content: 'Mollit laborum Lorem enim est occaecat. Sunt laboris velit proident laborum ad nostrud consequat esse irure fugiat. Anim enim tempor anim do elit mollit in voluptate amet amet qui. Cupidatat velit culpa dolor mollit mollit. Id cillum labore consequat nostrud ullamco eiusmod enim aliquip labore tempor voluptate. Veniam ipsum consectetur velit consectetur dolore aliquip ad commodo id. Consequat incididunt dolor enim.',
+                content: `<p>Thank you for trying the beta version of Social web in Ghost! We'd love to hear what you think — your feedback will help us fine-tune the experience.</p><p>If you've run into any issues or have suggestions, just leave a reply to this note and let us know.</p>`,
                 id: targetPostId,
                 published: '2025-03-10T15:00:58Z',
                 type: 'Note',

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -13,7 +13,11 @@ export default class HomeRoute extends Route {
             return this.router.transitionTo('setup.done');
         }
 
-        this.router.transitionTo('dashboard');
+        if (this.feature.ActivityPub) {
+            this.router.transitionTo('activitypub-x');
+        } else {
+            this.router.transitionTo('dashboard');
+        }
     }
 
     resetController(controller) {


### PR DESCRIPTION
ref AP-888

- Updated copy for Feedback post
- Set app default route (transition) to ActivityPub if the flag is on, otherwise load Dashboard