### PR TITLE
Moved ActivityPub Labs flag to Beta

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -36,10 +36,6 @@ const features = [{
     description: 'Wires up the Ghost NestJS App to the Admin API (also needs GHOST_ENABLE_NEST_FRAMEWORK=1 env var)',
     flag: 'NestPlayground'
 },{
-    title: 'ActivityPub',
-    description: '(Highly) Experimental support for ActivityPub.',
-    flag: 'ActivityPub'
-},{
     title: 'Content Visibility (Beta)',
     description: 'Enables content visibility in Emails - Changes already released to beta testers',
     flag: 'contentVisibility'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -15,10 +15,14 @@ const BetaFeatures: React.FC = () => {
 
     return (
         <List titleSeparator={false}>
-            <LabItem 
+            <LabItem
+                action={<FeatureToggle flag="ActivityPub" />}
+                detail={<>Federate your site with ActivityPub to join the world&apos;s largest open network. <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
+                title='Social web (beta)' />
+            <LabItem
                 action={<FeatureToggle flag="superEditors" />}
                 detail={<>Allows newly-assigned editors to manage members and comments in addition to regular roles.</>}
-                title='Enhanced Editor role (beta)' /> 
+                title='Enhanced Editor role (beta)' />
             <LabItem
                 action={<FeatureToggle flag="editorExcerpt" />}
                 detail={<>Adds the excerpt input below the post title in the editor</>}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-853/move-alpha-flag-to-beta

- With the public beta release of ActivityPub the labs flag should be moved to the Beta section