### PR TITLE
fix: use staleWhileRevalidate in caching middleware

### DIFF
--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -62,10 +62,16 @@ const getMiddleware = async (getFreeTier = async () => {
             // The member is either on the free tier or has a single active subscription
             // Cache the content based on the member's tier
             res.set({'X-Member-Cache-Tier': memberTier.id});
-            return shared.middleware.cacheControl('public', {maxAge: config.get('caching:frontend:maxAge')})(req, res, next);
+            return shared.middleware.cacheControl('public', {
+                maxAge: config.get('caching:frontend:maxAge'),
+                staleWhileRevalidate: config.get('caching:frontend:staleWhileRevalidate')
+            })(req, res, next);
         }
         // CASE: Site is not private and the request is not made by a member — cache the content
-        return shared.middleware.cacheControl('public', {maxAge: config.get('caching:frontend:maxAge')})(req, res, next);
+        return shared.middleware.cacheControl('public', {
+            maxAge: config.get('caching:frontend:maxAge'),
+            staleWhileRevalidate: config.get('caching:frontend:staleWhileRevalidate')
+        })(req, res, next);
     }
 
     return setFrontendCacheHeadersMiddleware;


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/22131

## Description

Passes `staleWhileRevalidate` to the `cacheControl` as it was missing previously, causing the above issue.

### Checklist

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

