### PR TITLE
fix: remove partial HTML entity in excerpt

### DIFF
--- a/ghost/core/core/frontend/helpers/excerpt.js
+++ b/ghost/core/core/frontend/helpers/excerpt.js
@@ -40,7 +40,12 @@ module.exports = function excerpt(options) {
         }
     }
 
-    return new SafeString(
-        getMetaDataExcerpt(excerptText, truncateOptions)
-    );
+    let excerptResult = getMetaDataExcerpt(excerptText, truncateOptions);
+
+    const lastAmp = excerptResult.lastIndexOf('&');
+    if (lastAmp !== -1 && excerptResult.indexOf(';', lastAmp) === -1) {
+        excerptResult = excerptResult.substring(0, lastAmp);
+    }
+
+    return new SafeString(excerptResult);
 };


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/21955

## Description

We cannot remove the escape since it has been added for preventing XSS attacks here: https://github.com/TryGhost/Ghost/pull/17190

So I just added a check to see if the text ends with ampersand and only consider till there.

## Screenshots

<img width="848" alt="Screenshot 2025-03-16 at 11 59 39 PM" src="https://github.com/user-attachments/assets/487f4aaf-af2f-4d59-8335-8ce03d338c29" />

<img width="937" alt="Screenshot 2025-03-16 at 11 59 11 PM" src="https://github.com/user-attachments/assets/75dc949d-8d63-4cd8-bd77-e1d4e45815c8" />


### Checklist

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
