### PR TITLE
Added stale time settings to ActivityPub feeds

### DIFF
--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -380,6 +380,7 @@ export function useActivitiesForUser({
 
     const getActivitiesQuery = useInfiniteQuery({
         queryKey,
+        staleTime: 5 * 60 * 1000, // 5m
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);
@@ -1013,6 +1014,7 @@ export function useFeedForUser(options: {enabled: boolean}) {
     const feedQuery = useInfiniteQuery({
         queryKey,
         enabled: options.enabled,
+        staleTime: 1 * 60 * 1000, // 1m
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI('index', siteUrl);
@@ -1048,6 +1050,7 @@ export function useInboxForUser(options: {enabled: boolean}) {
     const inboxQuery = useInfiniteQuery({
         queryKey,
         enabled: options.enabled,
+        staleTime: 20 * 1000, // 20s
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI('index', siteUrl);


### PR DESCRIPTION
ref AP-851

- currently it requires hard refresh to get the latest data for the feeds after the initial load
- it adds stale time setting to Inbox, Feed, and Notifications
- depending on the use case, each feed has different stale time set