### PR TITLE
Made links in articles open in a new tab in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -76,6 +76,23 @@ const ArticleBody: React.FC<{
 
     const cssContent = articleBodyStyles(siteData?.url.replace(/\/$/, ''));
 
+    const openLinksInNewTab = (content: string) => {
+        // Create a temporary div to parse the HTML
+        const div = document.createElement('div');
+        div.innerHTML = content;
+
+        // Find all anchor tags
+        const links = div.getElementsByTagName('a');
+
+        // Add target="_blank" and rel attributes to each link
+        for (let i = 0; i < links.length; i++) {
+            links[i].setAttribute('target', '_blank');
+            links[i].setAttribute('rel', 'noopener noreferrer');
+        }
+
+        return div.innerHTML;
+    };
+
     const htmlContent = `
         <html class="has-${!darkMode ? 'dark' : 'light'}-text">
         <head>
@@ -164,7 +181,7 @@ const ArticleBody: React.FC<{
                 ` : ''}
             </header>
             <div class='gh-content gh-canvas is-body'>
-                ${html}
+                ${openLinksInNewTab(html)}
             </div>
         </body>
         </html>


### PR DESCRIPTION
ref AP-906

- currently all links in articles are opened in the drawer which makes things look broken
- this adds `target="_blank"` attribute to all links in the post content so that they are opened in a new tab