### PR TITLE
Fixed ActivityPub feed link issues

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -21,6 +21,7 @@ import DeletedFeedItem from './DeletedFeedItem';
 import TableOfContents, {TOCItem} from './TableOfContents';
 import getReadingTime from '../../utils/get-reading-time';
 import {isPendingActivity} from '../../utils/pending-activity';
+import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
 
 interface ArticleModalProps {
@@ -75,23 +76,6 @@ const ArticleBody: React.FC<{
     const darkMode = document.documentElement.classList.contains('dark');
 
     const cssContent = articleBodyStyles(siteData?.url.replace(/\/$/, ''));
-
-    const openLinksInNewTab = (content: string) => {
-        // Create a temporary div to parse the HTML
-        const div = document.createElement('div');
-        div.innerHTML = content;
-
-        // Find all anchor tags
-        const links = div.getElementsByTagName('a');
-
-        // Add target="_blank" and rel attributes to each link
-        for (let i = 0; i < links.length; i++) {
-            links[i].setAttribute('target', '_blank');
-            links[i].setAttribute('rel', 'noopener noreferrer');
-        }
-
-        return div.innerHTML;
-    };
 
     const htmlContent = `
         <html class="has-${!darkMode ? 'dark' : 'light'}-text">

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -323,7 +323,17 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                     {!isLoading ?
                                                         <div dangerouslySetInnerHTML={{
                                                             __html: openLinksInNewTab(object.content || '') ?? ''
-                                                        }} ref={contentRef} />
+                                                        }} ref={contentRef}
+                                                        onClick={(e) => {
+                                                            const target = e.target as HTMLElement;
+                                                            if (
+                                                                target.tagName === 'A' ||
+                                                                target.closest('a')
+                                                            ) {
+                                                                e.stopPropagation();
+                                                            }
+                                                        }}
+                                                        />
                                                         :
                                                         <Skeleton count={2} />
                                                     }

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -10,8 +10,8 @@ import FeedItemStats from './FeedItemStats';
 import clsx from 'clsx';
 import getReadingTime from '../../utils/get-reading-time';
 import getUsername from '../../utils/get-username';
-import stripHtml from '../../utils/strip-html';
 import {handleProfileClick} from '../../utils/handle-profile-click';
+import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {renderTimestamp} from '../../utils/render-timestamp';
 import {useDeleteMutationForUser} from '../../hooks/use-activity-pub-queries';
 
@@ -322,7 +322,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                 <div className='ap-note-content line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'>
                                                     {!isLoading ?
                                                         <div dangerouslySetInnerHTML={{
-                                                            __html: object.content ?? ''
+                                                            __html: openLinksInNewTab(object.content || '') ?? ''
                                                         }} ref={contentRef} />
                                                         :
                                                         <Skeleton count={2} />

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -393,7 +393,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {object.name && <Heading className='mb-1 leading-tight' level={4} data-test-activity-heading>{object.name}</Heading>}
-                                        <div dangerouslySetInnerHTML={({__html: object.content ?? ''})} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>
+                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>
                                         {renderFeedAttachment(object)}
                                         <div className='space-between ml-[-7px] mt-3 flex'>
                                             {showStats && <FeedItemStats
@@ -450,7 +450,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='flex flex-col'>
                                         {(object.type === 'Article') && renderFeedAttachment(object)}
                                         {object.name && <Heading className='my-1 text-pretty leading-tight' level={5} data-test-activity-heading>{object.name}</Heading>}
-                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: object.content ?? ''})} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>}
+                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>}
                                         {(object.type === 'Note') && renderFeedAttachment(object)}
                                         {(object.type === 'Article') && <ButtonX
                                             className={`mt-3 self-start text-gray-900 transition-all hover:opacity-60`}

--- a/apps/admin-x-activitypub/src/utils/content-formatters.ts
+++ b/apps/admin-x-activitypub/src/utils/content-formatters.ts
@@ -1,0 +1,20 @@
+export function stripHtml(html: string): string {
+    return html.replace(/<[^>]*>/g, '');
+}
+
+export const openLinksInNewTab = (content: string) => {
+    // Create a temporary div to parse the HTML
+    const div = document.createElement('div');
+    div.innerHTML = content;
+
+    // Find all anchor tags
+    const links = div.getElementsByTagName('a');
+
+    // Add target="_blank" and rel attributes to each link
+    for (let i = 0; i < links.length; i++) {
+        links[i].setAttribute('target', '_blank');
+        links[i].setAttribute('rel', 'noopener noreferrer');
+    }
+
+    return div.innerHTML;
+};

--- a/apps/admin-x-activitypub/src/utils/strip-html.ts
+++ b/apps/admin-x-activitypub/src/utils/strip-html.ts
@@ -1,3 +1,0 @@
-export default function stripHtml(html: string): string {
-    return html.replace(/<[^>]*>/g, '');
-}

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -12,7 +12,6 @@ import Separator from '@components/global/Separator';
 
 import Layout from '@components/layout';
 import getUsername from '@utils/get-username';
-import stripHtml from '@utils/strip-html';
 import truncate from '@utils/truncate';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {
@@ -22,6 +21,7 @@ import {
 } from '@hooks/use-activity-pub-queries';
 import {type NotificationType} from '@components/activities/NotificationIcon';
 import {handleProfileClick} from '@utils/handle-profile-click';
+import {stripHtml} from '@src/utils/content-formatters';
 
 interface NotificationsProps {}
 


### PR DESCRIPTION
ref AP-908

- Links in feed items should always open in a new tab. ATM hashtags and mentions open in same window
- Clicking on a link shouldn't open the drawer
- Links from the drawer should open in a new tab