### PR TITLE
fix: do not trigger site.changed when draft posts are deleted

### DIFF
--- a/ghost/core/core/server/api/endpoints/pages.js
+++ b/ghost/core/core/server/api/endpoints/pages.js
@@ -221,6 +221,19 @@ const controller = {
             method: 'destroy'
         },
         async query(frame) {
+            const pagesToDelete = await models.Post.findAll({
+                filter: frame.options.filter,
+                status: 'all',
+                columns: ['status']
+            });
+
+            const allDraft = pagesToDelete.length > 0 && pagesToDelete.every((page) => {
+                return page.get('status') === 'draft';
+            });
+            if (allDraft) {
+                frame.setHeader('X-Cache-Invalidate', '');
+            }
+
             return await postsService.bulkDestroy(frame.options);
         }
     },
@@ -248,7 +261,17 @@ const controller = {
             docName: 'posts',
             unsafeAttrs: UNSAFE_ATTRS
         },
-        query(frame) {
+        async query(frame) {
+            const page = await models.Post.findOne({
+                id: frame.options.id,
+                type: 'page',
+                status: 'all'
+            }, {require: false, columns: ['status']});
+
+            if (page && page.get('status') === 'draft') {
+                frame.setHeader('X-Cache-Invalidate', '');
+            }
+
             return models.Post.destroy({...frame.options, require: true});
         }
     },

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -269,7 +269,7 @@ const controller = {
     bulkDestroy: {
         statusCode: 200,
         headers: {
-            cacheInvalidate: true
+            cacheInvalidate: false
         },
         options: [
             'filter'
@@ -278,6 +278,18 @@ const controller = {
             method: 'destroy'
         },
         async query(frame) {
+            const postsToDelete = await models.Post.findAll({
+                filter: frame.options.filter,
+                status: 'all'
+            });
+
+            const allDraft = postsToDelete.every((post) => {
+                return post.get('status') === 'draft';
+            });
+            if (!allDraft) {
+                frame.setHeader('X-Cache-Invalidate', '/*');
+            }
+
             return await postsService.bulkDestroy(frame.options);
         }
     },
@@ -285,7 +297,7 @@ const controller = {
     destroy: {
         statusCode: 204,
         headers: {
-            cacheInvalidate: true
+            cacheInvalidate: false
         },
         options: [
             'include',
@@ -304,7 +316,16 @@ const controller = {
         permissions: {
             unsafeAttrs: unsafeAttrs
         },
-        query(frame) {
+        async query(frame) {
+            const post = await models.Post.findOne({
+                id: frame.options.id,
+                status: 'all'
+            }, {require: false});
+
+            if (post && post.get('status') !== 'draft') {
+                frame.setHeader('X-Cache-Invalidate', '/*');
+            }
+
             return models.Post.destroy({...frame.options, require: true});
         }
     },

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -269,7 +269,7 @@ const controller = {
     bulkDestroy: {
         statusCode: 200,
         headers: {
-            cacheInvalidate: false
+            cacheInvalidate: true
         },
         options: [
             'filter'
@@ -280,14 +280,15 @@ const controller = {
         async query(frame) {
             const postsToDelete = await models.Post.findAll({
                 filter: frame.options.filter,
-                status: 'all'
+                status: 'all',
+                columns: ['status']
             });
 
-            const allDraft = postsToDelete.every((post) => {
+            const allDraft = postsToDelete.length > 0 && postsToDelete.every((post) => {
                 return post.get('status') === 'draft';
             });
-            if (!allDraft) {
-                frame.setHeader('X-Cache-Invalidate', '/*');
+            if (allDraft) {
+                frame.setHeader('X-Cache-Invalidate', '');
             }
 
             return await postsService.bulkDestroy(frame.options);
@@ -297,7 +298,7 @@ const controller = {
     destroy: {
         statusCode: 204,
         headers: {
-            cacheInvalidate: false
+            cacheInvalidate: true
         },
         options: [
             'include',
@@ -320,10 +321,10 @@ const controller = {
             const post = await models.Post.findOne({
                 id: frame.options.id,
                 status: 'all'
-            }, {require: false});
+            }, {require: false, columns: ['status']});
 
-            if (post && post.get('status') !== 'draft') {
-                frame.setHeader('X-Cache-Invalidate', '/*');
+            if (post && post.get('status') === 'draft') {
+                frame.setHeader('X-Cache-Invalidate', '');
             }
 
             return models.Post.destroy({...frame.options, require: true});

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -78,12 +78,12 @@ describe('site.* events', function () {
             setTimeout(resolve, 2000, false);
         });
 
-        const requestWasRecieved = await Promise.race([
+        const requestWasReceived = await Promise.race([
             receivedRequest,
             wait
         ]);
 
-        if (requestWasRecieved) {
+        if (requestWasReceived) {
             throw new Error('The webhook should not have been sent.');
         }
     });

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -163,4 +163,164 @@ describe('site.* events', function () {
             throw new Error('The webhook should not have been sent.');
         }
     });
+
+    it('site.changed event is NOT triggered when only draft posts are bulk deleted', async function () {
+        const webhookURL = 'https://test-webhook-receiver.com/site-changed';
+        await webhookMockReceiver.mock(webhookURL);
+        await fixtureManager.insertWebhook({
+            event: 'site.changed',
+            url: webhookURL
+        });
+
+        await adminAPIAgent
+            .post('posts/')
+            .body({
+                posts: [{
+                    title: 'bulk draft webhookz',
+                    status: 'draft',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const filter = 'title:\'bulk draft webhookz\'';
+
+        await adminAPIAgent
+            .delete('posts/?filter=' + encodeURIComponent(filter))
+            .expectStatus(200);
+
+        const receivedRequest = webhookMockReceiver.receivedRequest().then(() => true);
+        const wait = new Promise((resolve) => {
+            setTimeout(resolve, 2000, false);
+        });
+
+        const requestWasReceived = await Promise.race([
+            receivedRequest,
+            wait
+        ]);
+
+        if (requestWasReceived) {
+            throw new Error('The webhook should not have been sent.');
+        }
+    });
+
+    it('invalidates the cache when a published post is deleted', async function () {
+        const res = await adminAPIAgent
+            .post('posts/')
+            .body({
+                posts: [{
+                    title: 'published webhookz',
+                    status: 'published',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const id = res.body.posts[0].id;
+
+        await adminAPIAgent
+            .delete('posts/' + id)
+            .expectStatus(204)
+            .expectHeader('X-Cache-Invalidate', '/*');
+    });
+
+    it('site.changed event is NOT triggered when a draft page is deleted', async function () {
+        const webhookURL = 'https://test-webhook-receiver.com/site-changed';
+        await webhookMockReceiver.mock(webhookURL);
+        await fixtureManager.insertWebhook({
+            event: 'site.changed',
+            url: webhookURL
+        });
+
+        const res = await adminAPIAgent
+            .post('pages/')
+            .body({
+                pages: [{
+                    title: 'draft page webhookz',
+                    status: 'draft',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const id = res.body.pages[0].id;
+
+        await adminAPIAgent
+            .delete('pages/' + id)
+            .expectStatus(204);
+
+        const receivedRequest = webhookMockReceiver.receivedRequest().then(() => true);
+        const wait = new Promise((resolve) => {
+            setTimeout(resolve, 2000, false);
+        });
+
+        const requestWasReceived = await Promise.race([
+            receivedRequest,
+            wait
+        ]);
+
+        if (requestWasReceived) {
+            throw new Error('The webhook should not have been sent.');
+        }
+    });
+
+    it('site.changed event is NOT triggered when only draft pages are bulk deleted', async function () {
+        const webhookURL = 'https://test-webhook-receiver.com/site-changed';
+        await webhookMockReceiver.mock(webhookURL);
+        await fixtureManager.insertWebhook({
+            event: 'site.changed',
+            url: webhookURL
+        });
+
+        await adminAPIAgent
+            .post('pages/')
+            .body({
+                pages: [{
+                    title: 'bulk draft page webhookz',
+                    status: 'draft',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const filter = 'title:\'bulk draft page webhookz\'';
+
+        await adminAPIAgent
+            .delete('pages/?filter=' + encodeURIComponent(filter))
+            .expectStatus(200);
+
+        const receivedRequest = webhookMockReceiver.receivedRequest().then(() => true);
+        const wait = new Promise((resolve) => {
+            setTimeout(resolve, 2000, false);
+        });
+
+        const requestWasReceived = await Promise.race([
+            receivedRequest,
+            wait
+        ]);
+
+        if (requestWasReceived) {
+            throw new Error('The webhook should not have been sent.');
+        }
+    });
+
+    it('invalidates the cache when a published page is deleted', async function () {
+        const res = await adminAPIAgent
+            .post('pages/')
+            .body({
+                pages: [{
+                    title: 'published page webhookz',
+                    status: 'published',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const id = res.body.pages[0].id;
+
+        await adminAPIAgent
+            .delete('pages/' + id)
+            .expectStatus(204)
+            .expectHeader('X-Cache-Invalidate', '/*');
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/21699

## Description

This adds a check to see if all of the posts being deleted are drafted, and only sets `cacheInvalidate` if not (since `site.changed` is triggered because of `X-Cache-Invalidate` header)

## Checklist

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
