### PR TITLE
Added suggestion to bump the ActivityPub client app when changes are made

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -19,6 +19,10 @@ no_color='\033[0m'
 grey='\033[0;90m'
 red='\033[0;31m'
 
+##
+## 1) Check and remove submodules before committing
+##
+
 ROOT_DIR=$(git rev-parse --show-cdup)
 SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //')
 MOD_SUBMODULES=$(git diff --cached --name-only --ignore-submodules=none | grep -F "$SUBMODULES")
@@ -41,8 +45,71 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
         echo -e "nothing to commit, working tree clean"
         exit 1
     fi
-    exit 0
 else
     echo "No submodules in commit, continuing..."
-    exit 0
 fi
+
+##
+## 2) Suggest shipping a new version of @tryghost/admin-x-activitypub when changes are detected
+##    The intent is to ship smaller changes more frequently to production
+##
+
+increment_version() {
+    local package_json_path=$1
+    local version_type=$2
+
+    local current_version
+    current_version=$(grep '"version":' "$package_json_path" | awk -F '"' '{print $4}')
+
+    IFS='.' read -r major minor patch <<< "$current_version"
+
+    case "$version_type" in
+        major) ((major++)); minor=0; patch=0 ;;
+        minor) ((minor++)); patch=0 ;;
+        patch) ((patch++)) ;;
+        *) echo "Invalid version type"; exit 1 ;;
+    esac
+
+    new_version="$major.$minor.$patch"
+
+    # Update package.json with new version
+    sed -i '' -E "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$new_version\"/" "$package_json_path"
+
+    echo "Updated version to $new_version in $package_json_path"
+}
+
+AP_BUMP_NEEDED=false
+MODIFIED_FILES=$(git diff --cached --name-only)
+
+for FILE in $MODIFIED_FILES; do
+    if [[ "$FILE" == apps/admin-x-activitypub/* ]]; then
+        AP_BUMP_NEEDED=true
+        break
+    fi
+done
+
+if [[ "$AP_BUMP_NEEDED" == true ]]; then
+    echo -e "\nYou have made changes to @tryghost/admin-x-activitypub."
+    echo -e "Would you like to ship a new version? (yes)"
+    read -r new_version </dev/tty
+
+    if [[ -z "$new_version" || "$new_version" == "yes" || "$new_version" == "y" ]]; then
+        echo -e "Is that a patch, minor or major? (patch)"
+        read -r version_type </dev/tty
+
+        # Default to patch
+        if [[ -z "$version_type" ]]; then
+            version_type="patch"
+        fi
+
+        if [[ "$version_type" != "patch" && "$version_type" != "minor" && "$version_type" != "major" ]]; then
+            echo -e "${red}Invalid input. Skipping version bump.${no_color}"
+        else
+            echo "Bumping version ($version_type)..."
+            increment_version "apps/admin-x-activitypub/package.json" "$version_type"
+            git add apps/admin-x-activitypub/package.json
+        fi
+    fi
+fi
+
+exit 0

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -73,7 +73,13 @@ increment_version() {
     new_version="$major.$minor.$patch"
 
     # Update package.json with new version
-    sed -i '' -E "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$new_version\"/" "$package_json_path"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        sed -i '' -E "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$new_version\"/" "$package_json_path"
+    else
+        # Linux and others
+        sed -i -E "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$new_version\"/" "$package_json_path"
+    fi
 
     echo "Updated version to $new_version in $package_json_path"
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-861

- when changes are made to @tryghost/admin-x-activitypub, suggest shipping a new version
- the intent is to ship smaller changes to production and have more opportunities throughout the week to test our work in production

