### PR TITLE
Fixed AP onboarding view being showed to non-owners

### DIFF
--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -5,7 +5,7 @@ import Users from './components/settings/general/Users';
 import useFeatureFlag from './hooks/useFeatureFlag';
 import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {ReactNode, useEffect} from 'react';
-import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/users';
+import {canAccessSettings, isEditorUser, isOwnerUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -35,7 +35,7 @@ const MainContent: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 confirmIfDirty(isDirty, () => {
-                    if (hasActivityPub) {
+                    if (hasActivityPub && isOwnerUser(currentUser)) {
                         navigateAway('/activitypub');
                     } else {
                         navigateAway('/dashboard');

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import useFeatureFlag from '../hooks/useFeatureFlag';
 import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
+import {isOwnerUser} from '@tryghost/admin-x-framework/api/users';
+import {useGlobalData} from './providers/GlobalDataProvider';
 
 const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
+    const {currentUser} = useGlobalData();
     const hasActivityPub = useFeatureFlag('ActivityPub');
 
     const navigateAway = () => {
-        window.location.hash = hasActivityPub ? '/activitypub' : '/dashboard';
+        window.location.hash = (hasActivityPub && isOwnerUser(currentUser)) ? '/activitypub' : '/dashboard';
     };
 
     return (

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -5,6 +5,7 @@ export default class HomeRoute extends Route {
     @service feature;
     @service modals;
     @service router;
+    @service session;
 
     beforeModel(transition) {
         super.beforeModel(...arguments);
@@ -13,7 +14,7 @@ export default class HomeRoute extends Route {
             return this.router.transitionTo('setup.done');
         }
 
-        if (this.feature.ActivityPub) {
+        if (this.feature.ActivityPub && this.session.user.isOwnerOnly) {
             this.router.transitionTo('activitypub-x');
         } else {
             this.router.transitionTo('dashboard');


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C06TE92R3JR/p1742229540308619

- currently, only the owner staff user has access to ActivityPub
- therefore, we should also not render the onboarding screen for non-owners