### PR TITLE
Improved text for email MFA requests

### DIFF
--- a/ghost/admin/app/components/editor/modals/re-verify.hbs
+++ b/ghost/admin/app/components/editor/modals/re-verify.hbs
@@ -3,7 +3,6 @@
         <header>
             <h1>Verify it's really you</h1>
             <p>
-                We don't recognize this device.
                 To keep your account safe, we've sent a 6-digit verification code to your email to make sure it's you.
             </p>
         </header>

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -116,6 +116,11 @@ export default Model.extend(ValidationEngine, {
     defaultEmailAddress: attr('string'),
     supportEmailAddress: attr('string'),
 
+    /**
+     * Security settings
+     */
+    requireEmailMfa: attr('boolean'),
+
     // HACK - not a real model attribute but a workaround for Ember Data not
     //        exposing meta from save responses
     _meta: attr()

--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -8,7 +8,6 @@
                 </header>
 
                 <p>
-                    We don't recognize this device.
                     To keep your account safe, we've sent a 6-digit verification code to your email to make sure it's you.
                 </p>
                 <GhFormGroup @errors={{this.verifyData.errors}} @hasValidated={{this.verifyData.hasValidated}} @property="token">
@@ -56,7 +55,7 @@
                     @type="submit"
                     @useAccentColor={{true}}
                     data-test-button="verify" />
-                
+
                 <p class="main-notification">Not receiving the emails? <a href="https://ghost.org/docs/config/#mail" target="_blank" rel="noopener noreferrer">Learn more</a></p>
             </form>
 

--- a/ghost/session-service/lib/emails/signin.js
+++ b/ghost/session-service/lib/emails/signin.js
@@ -1,4 +1,4 @@
-module.exports = ({t, siteTitle, email, siteDomain, siteUrl, siteLogo, token, deviceDetails}) => `
+module.exports = ({t, siteTitle, email, siteDomain, siteUrl, siteLogo, token, deviceDetails, is2FARequired}) => `
 <!doctype html>
 <html>
   <head>
@@ -120,7 +120,7 @@ module.exports = ({t, siteTitle, email, siteDomain, siteUrl, siteLogo, token, de
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: 600; line-height: 24px; margin: 0; margin-bottom: 15px; margin-top: 50px;">${t('Sign in verification')}</p>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 24px; margin-bottom: 32px;">${t('You just tried to access your account from a new device. For security verification, enter the code below to sign in to {{siteTitle}}:', {siteTitle, interpolation: {escapeValue: false}})}</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 24px; margin-bottom: 32px;">${is2FARequired && t('You just tried to access your account from a new device.')} ${t('For security verification, enter the code below to sign in to {{siteTitle}}:', {siteTitle, interpolation: {escapeValue: false}})}</p>
                       </td>
                     </tr>
                     <tr>

--- a/ghost/session-service/lib/session-service.js
+++ b/ghost/session-service/lib/session-service.js
@@ -260,7 +260,8 @@ module.exports = function createSessionService({
             siteUrl: siteUrl,
             siteLogo: siteLogo,
             token: token,
-            deviceDetails: await getDeviceDetails(session.user_agent, session.ip)
+            deviceDetails: await getDeviceDetails(session.user_agent, session.ip),
+            is2FARequired: getSettingsCache('require_email_mfa')
         });
 
         try {


### PR DESCRIPTION
ref ENG-2074

The email text can be changed based on whether the verification code is available, but the messages in Ghost Admin can't as they rely on the settings API (which is authenticated). Instead they're simplified to remove the content about an unrecognised device, which could be incorrect if 2FA is required for every login.
