### PR TITLE
Fixed image width for small images in CTA card

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/cta.css
+++ b/ghost/core/core/frontend/src/cards/css/cta.css
@@ -160,6 +160,8 @@
 }
 
 .kg-cta-image-container img {
+    width: 100%;
+    height: auto;
     margin: 0;
     object-fit: cover;
     border-radius: 6px;


### PR DESCRIPTION
No ref
- When images are smaller than the container, they were being displayed at their original size. Instead, this change ensures that they are displayed full width when in full-width layout.