### PR TITLE
Fixed bounce rate % in the KPIs chart tooltip

### DIFF
--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -123,7 +123,7 @@ export default class KpisComponent extends Component {
                                 break;
                             case 'bounce_rate':
                                 tooltipTitle = 'Bounce rate';
-                                displayValue = fparams[0].value[1] !== null && fparams[0].value[1].toFixed(2) + '%';
+                                displayValue = fparams[0].value[1] !== null && (fparams[0].value[1] * 100).toFixed(0) + '%';
                                 break;
                             default:
                                 tooltipTitle = 'Unique visits';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-120

The data provided is in the form 0.0-1.0 and we need to properly convert in order to display a %age.
