### PR TITLE
Fixed audience toggle in stats

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -142,7 +142,7 @@ export function getStatsParams(config, props, additionalParams = {}) {
     };
 
     if (audience.length > 0) {
-        params.member_status = audience.join(',');
+        params.member_status = audience;
     }
 
     if (device) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-144

Tinybird pipes are expecting an array, not a comma-delimited string, causing there to be a type error.