### PR TITLE
Improved performance of post previews

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.114/2025-03-19-03-13-04-add-index-to-posts-uuid.js
+++ b/ghost/core/core/server/data/migrations/versions/5.114/2025-03-19-03-13-04-add-index-to-posts-uuid.js
@@ -1,0 +1,5 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const {createAddIndexMigration} = require('../../utils');
+
+module.exports = createAddIndexMigration('posts', ['uuid']);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -50,7 +50,7 @@ module.exports = {
     },
     posts: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
+        uuid: {type: 'string', maxlength: 36, nullable: false, index: true, validations: {isUUID: true}},
         title: {type: 'string', maxlength: 2000, nullable: false, validations: {isLength: {max: 255}}},
         slug: {type: 'string', maxlength: 191, nullable: false},
         mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'b26690fb57ffd0edbddb4cd9e02b17d6';
+    const currentSchemaHash = '238ad2a9efd5f43b7d8233c38f5a8a2e';
     const currentFixturesHash = '35d3cc0ce18f85dc66f0f385865f666d';
     const currentSettingsHash = '5eb97fee379c1d0420de58957d29fe26';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2081

- Added an index to the `posts` table on the `uuid` column to prevent a whole table scan when doing a posts preview which use a posts UUID to match against
- On sites with a large number of posts this can currently cause lookups to take several seconds just to look up a single post

Cost before index:
```
| -> Limit: 1 row(s)  (cost=68964 rows=1) (actual time=333..333 rows=1 loops=1)
    -> Filter: (posts.uuid = '5e75e7da-bdcc-4a5c-ac7f-876041f4aa1d')  (cost=68964 rows=8127) (actual time=333..333 rows=1 loops=1)
        -> Table scan on posts  (cost=68964 rows=81271) (actual time=0.0641..325 rows=78701 loops=1)
```

Cost after index:
```
| -> Limit: 1 row(s)  (cost=0.63 rows=1) (actual time=0.0717..0.0718 rows=1 loops=1)
    -> Index lookup on posts using posts_uuid_test_index (uuid='5e75e7da-bdcc-4a5c-ac7f-876041f4aa1d')  (cost=0.63 rows=1) (actual time=0.0707..0.0707 rows=1 loops=1)
```

Adding the index on a site with 140k+ posts took ~1.4 seconds:

```
> ALTER TABLE `posts` ADD INDEX `posts_uuid_test_index`(`uuid`);
Query OK, 0 rows affected (1.44 sec)
Records: 0  Duplicates: 0  Warnings: 0
```