### PR TITLE
Added naive stats button to Post analytics

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -35,6 +35,11 @@
                     {{/let}}
                 </div>
                 <div style="display: flex; gap: 8px;">
+                    {{#if (and (gh-user-can-admin this.session.user) this.config.stats)}}
+                    <LinkTo class="gh-btn gh-btn-icon" @route="stats" @query={{hash pathname=(concat "/" this.post.slug "/")}}>
+                        <span>{{svg-jar "stats" title="Post traffic stats"}} Traffic stats</span>
+                    </LinkTo>
+                    {{/if}}
                     <GhTaskButton
                         @buttonText="Refresh"
                         @task={{this.fetchPostTask}}

--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -4,6 +4,7 @@ import PostSuccessModal from '../modal-post-success';
 import anime from 'animejs/lib/anime.es.js';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
+import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -30,6 +31,9 @@ export default class Analytics extends Component {
     @service router;
     @service modals;
     @service notifications;
+    @service session;
+
+    @inject config;
 
     @tracked sources = null;
     @tracked links = null;


### PR DESCRIPTION
ref ANAL-141

- Traffic analytics can be filtered for pages but only from within stats. This PR adds a button in the Post analytics which allows direct filtering of the post in traffic analytics. This is a naive implementation as it simply redirects to Stats and prefilters for the slug, it doesn't check if any data exists for the post in analytics. Also since it's based on slug and not post.id it only works until the URL/slug is not changed.