### PR TITLE
Fixed flag for Unknown location in analytics

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -117,7 +117,7 @@ export const statsStaticColors = [
 ];
 
 export const getCountryFlag = (countryCode) => {
-    if (!countryCode) {
+    if (!countryCode || countryCode === null || countryCode.toUpperCase() === 'ᴺᵁᴸᴸ') {
         return '🏳️';
     }
     return countryCode.toUpperCase().replace(/./g, char => String.fromCodePoint(char.charCodeAt(0) + 127397)


### PR DESCRIPTION
ref ANAL-149

- For "Unknown" location the flag label returned was 'ᴺᵁᴸᴸ' which was not handled in the country flag utility