### PR TITLE
Update getLastJobRunTimestamp to return null if job properties empty

### DIFF
--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -93,7 +93,11 @@ module.exports = {
      */
     async getLastJobRunTimestamp(jobName) {
         const jobData = await this.getJobData(jobName);
-        return jobData ? jobData.finished_at || jobData.started_at : null;
+        if (!jobData) {
+            return null;
+        }
+
+        return jobData.finished_at || jobData.started_at || null;
     },
 
     /**


### PR DESCRIPTION
In production, I am seeing this error:

```
  begin.toISOString is not a function

  at #fetchEvents (/ghost/node_modules/@tryghost/email-analytics-service/lib/EmailAnalyticsService.js:292:64)
  at EmailAnalyticsService.fetchMissing (/ghost/node_modules/@tryghost/email-analytics-service/lib/EmailAnalyticsService.js:184:39)
  at async EmailAnalyticsServiceWrapper.fetchMissing (/ghost/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js:90:29)
```

It seems to stem from this function returning neither a Date nor a null. If it were null, we would likely see this: `TypeError: can't access property "toISOString" of null`. And, it can't be returning a `Date` because `toISOString()` is defined on `Date`. I can replicate this error message with the following code: `const begin = ""; begin.toISOString()`.

I think the problem is likely that `jobData.finished_at` and `jobData.started_at` are returning something else, likely an empty string or another falsey value. I think the original programmer intended to handle this because it's using the boolean OR (`||`) rather than the null coalescing operator (which would treat "" as truthy). In this case I think neither of them are set, so this function is returning something else.

This then causes a problem for `getLastMissingEventTimestamp`, which uses null coalescing rather than boolean OR; therefore it is returning something incorrect, for the `#fetchEvents` function to trip up over.

I don't think I'm the first person to see this issue, I found [this post](https://forum.ghost.org/t/issue-with-routes-yaml/54607/3) and I suspect given that this happens in the logs but is otherwise not visible, the error might be more widespread.

Fixes https://github.com/TryGhost/Ghost/issues/22561