### PR TITLE
Updated handling for stats page audience filters

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 
-export const TB_VERSION = 0;
+export const TB_VERSION = 1;
 
 export const RANGE_OPTIONS = [
     {name: 'Last 24 hours', value: 1},
@@ -184,7 +184,7 @@ export function getStatsParams(config, props, additionalParams = {}) {
     };
 
     if (audience.length > 0) {
-        params.member_status = audience;
+        params.member_status = audience.join(',');
     }
 
     if (device) {

--- a/ghost/web-analytics/datasources/_mv_pages.datasource
+++ b/ghost/web-analytics/datasources/_mv_pages.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -13,7 +13,7 @@ SCHEMA >
     `location` String,
     `source` String,
     `pathname` String,
-    `member_status` AggregateFunction(maxIf, String, UInt8),
+    `member_status` SimpleAggregateFunction(max, String),
     `visits` AggregateFunction(uniq, String),
     `pageviews` AggregateFunction(count)
 

--- a/ghost/web-analytics/datasources/_mv_sessions.datasource
+++ b/ghost/web-analytics/datasources/_mv_sessions.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -6,7 +6,7 @@ SCHEMA >
     `site_uuid` String,
     `date` Date,
     `session_id` String,
-    `member_status` AggregateFunction(maxIf, String, UInt8),
+    `member_status` SimpleAggregateFunction(max, String),
     `post_uuid` SimpleAggregateFunction(any, String),
     `post_type` SimpleAggregateFunction(any, String),
     `device` SimpleAggregateFunction(any, String),

--- a/ghost/web-analytics/datasources/_mv_sources.datasource
+++ b/ghost/web-analytics/datasources/_mv_sources.datasource
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -12,7 +12,7 @@ SCHEMA >
     `location` String,
     `source` String,
     `pathname` String,
-    `member_status` AggregateFunction(maxIf, String, UInt8),
+    `member_status` SimpleAggregateFunction(max, String),
     `visits` AggregateFunction(uniq, String),
     `pageviews` AggregateFunction(count),
     `post_type` SimpleAggregateFunction(any, String),

--- a/ghost/web-analytics/pipes/_hits.incl
+++ b/ghost/web-analytics/pipes/_hits.incl
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/_parsed_hits.incl
+++ b/ghost/web-analytics/pipes/_parsed_hits.incl
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_browsers.pipe
+++ b/ghost/web-analytics/pipes/api_top_browsers.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_devices.pipe
+++ b/ghost/web-analytics/pipes/api_top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_locations.pipe
+++ b/ghost/web-analytics/pipes/api_top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_os.pipe
+++ b/ghost/web-analytics/pipes/api_top_os.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_pages.pipe
+++ b/ghost/web-analytics/pipes/api_top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/api_top_sources.pipe
+++ b/ghost/web-analytics/pipes/api_top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 

--- a/ghost/web-analytics/pipes/mv_pages.pipe
+++ b/ghost/web-analytics/pipes/mv_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -18,7 +18,7 @@ SQL >
         location,
         source,
         pathname,
-        maxIfState(member_status, member_status IN ('paid', 'free', 'undefined')) AS member_status,
+        maxSimpleState(member_status) AS member_status,
         uniqState(session_id) AS visits,
         countState() AS pageviews
     FROM hits

--- a/ghost/web-analytics/pipes/mv_sessions.pipe
+++ b/ghost/web-analytics/pipes/mv_sessions.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -11,7 +11,7 @@ SQL >
         site_uuid,
         toDate(timestamp) AS date,
         session_id,
-        maxIfState(member_status, member_status IN ('paid', 'free', 'undefined')) AS member_status,
+        maxSimpleState(member_status) AS member_status,
         anySimpleState(post_uuid) AS post_uuid,
         anySimpleState(post_type) AS post_type,
         anySimpleState(device) AS device,

--- a/ghost/web-analytics/pipes/mv_sources.pipe
+++ b/ghost/web-analytics/pipes/mv_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 0
+VERSION 1
 
 TAGS "v0"
 
@@ -18,7 +18,7 @@ SQL >
             SELECT
                 session_id,
                 argMin(source, timestamp) AS source,
-                maxIfState(member_status, member_status IN ('paid', 'free', 'undefined')) AS member_status
+                maxSimpleState(member_status) AS member_status
             FROM hits
             GROUP BY session_id
         )


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-144/
- reverted previous change
- updated data files to use simpler aggregate fn

Type errors from the query params have been worked around by using a simpler aggregate function that should also be more performant. Still more to learn here - so far my understanding is this change is both appropriate and better, and at least works for the moment.