### PR TITLE
🐛 Fixed slug validation error for newly created posts without a title

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -952,17 +952,6 @@ export default class LexicalEditorController extends Controller {
             return;
         }
 
-        // Prevent slug regeneration when only whitespace changes are made to the title.
-        // This check compares the trimmed versions of the current and new titles to ensure
-        // that differences in leading or trailing spaces do not trigger unnecessary slug updates.
-        // Without this, adding or removing spaces would incorrectly generate a new slug,
-        // even though the meaningful content of the title hasn't changed.
-        const trimmedCurrentTitle = currentTitle?.trim();
-        const trimmedNewTitle = newTitle?.trim();
-        if (trimmedCurrentTitle === trimmedNewTitle) {
-            return;
-        }
-
         // Update the slug unless the slug looks to be a custom slug or the title is a default/has been cleared out
         if (
             (currentSlug && slugify(currentTitle) !== currentSlug)

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -1,6 +1,5 @@
 import EmberObject from '@ember/object';
 import RSVP from 'rsvp';
-import sinon from 'sinon';
 import {authenticateSession} from 'ember-simple-auth/test-support';
 import {defineProperty} from '@ember/object';
 import {describe, it} from 'mocha';
@@ -135,34 +134,6 @@ describe('Unit: Controller: lexical-editor', function () {
             await controller.generateSlugTask.perform();
 
             expect(controller.get('post.slug')).to.equal('newtitle-slug');
-        });
-
-        it('should not call generateSlug if only whitespace is added to the title', async function () {
-            let controller = this.owner.lookup('controller:lexical-editor');
-
-            const slugify = str => str.trim().toLowerCase().replace(/\s+/g, '-');
-
-            // Create a stub for generateSlug to track calls and return a predictable slug
-            const generateSlugStub = sinon.stub().callsFake((slugType, str) => {
-                return RSVP.resolve(slugify(str)); // Mimic real slug generation
-            });
-
-            // Set the slugGenerator with the stub
-            controller.set('slugGenerator', EmberObject.create({
-                generateSlug: generateSlugStub
-            }));
-
-            controller.set('post', createPost({
-                title: 'title',
-                slug: 'title'
-            }));
-
-            // Add whitespace to the titleScratch
-            controller.set('post.titleScratch', 'title ');
-            await controller.generateSlugTask.perform();
-
-            expect(generateSlugStub.called).to.be.false; // Should not be called with the fix
-            expect(controller.get('post.slug')).to.equal('title'); // Slug remains unchanged
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-833/support-escalation-re-issue-with-saving-articles-urgent

- This commit reverts https://github.com/TryGhost/Ghost/commit/1a0020d638856f2147688547eb303f2c05fedaa0, which introduced this regression
- A newly created post without a title will not generate a slug, which causes a validation error when saving the post, which causes the post to not save
