### PR TITLE
Added browser tests covering the editor's basic saving behavior

### DIFF
--- a/ghost/admin/tests/acceptance/editor/lexical-test.js
+++ b/ghost/admin/tests/acceptance/editor/lexical-test.js
@@ -3,6 +3,7 @@ import {blur, click, currentURL, fillIn, find, waitFor, waitUntil} from '@ember/
 import {enableLabsFlag} from '../../helpers/labs-flag';
 import {expect} from 'chai';
 import {invalidateSession} from 'ember-simple-auth/test-support';
+import {pasteInEditor} from '../../helpers/editor';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';
@@ -74,8 +75,20 @@ describe('Acceptance: Lexical editor', function () {
             expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
         });
 
-        // TODO: requires editor to be loading
-        it('saves on content change');
+        it('saves on content change', async function () {
+            await visit('/editor/post/');
+
+            await waitFor('[data-secondary-instance="false"] [data-lexical-editor]');
+
+            await click('[data-secondary-instance="false"] [data-lexical-editor]');
+            await pasteInEditor('Test content');
+
+            await waitUntil(function () {
+                return find('[data-test-editor-post-status]').textContent.includes('Saved');
+            }, {timeoutMessage: 'Timed out waiting for "Saved" status'});
+
+            expect(currentURL(), 'currentURL').to.equal(`/editor/post/1`);
+        });
     });
 
     describe('with existing post', function () {

--- a/ghost/core/test/e2e-browser/admin/editor.spec.js
+++ b/ghost/core/test/e2e-browser/admin/editor.spec.js
@@ -2,10 +2,19 @@ const test = require('../fixtures/ghost-test');
 const EditorPage = require('../utils/pages/EditorPage');
 
 test.describe('Editor', () => {
-    test('should save post when title is blank and only the content is changed', async ({page}) => {
-        const editorPage = new EditorPage(page);
-        await editorPage.goto();
-        await editorPage.typeInBody('Hello world');
-        await editorPage.checkPostStatus('Draft');
+    test.describe('Saving behavior', () => {
+        test('should save a draft when only the title is changed for the first time', async ({page}) => {
+            const editorPage = new EditorPage(page);
+            await editorPage.goto();
+            await editorPage.typeInTitle('Hello world');
+            await editorPage.checkPostStatus('Draft');
+        });
+        
+        test('should save a draft when only the content is changed for the first time', async ({page}) => {
+            const editorPage = new EditorPage(page);
+            await editorPage.goto();
+            await editorPage.typeInEditor('Hello world');
+            await editorPage.checkPostStatus('Draft');
+        });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/editor.spec.js
+++ b/ghost/core/test/e2e-browser/admin/editor.spec.js
@@ -3,17 +3,19 @@ const EditorPage = require('../utils/pages/EditorPage');
 
 test.describe('Editor', () => {
     test.describe('Saving behavior', () => {
-        test('should save a draft when only the title is changed for the first time', async ({page}) => {
+        test('should save a draft when only the title is changed and the input is blurred', async ({page}) => {
             const editorPage = new EditorPage(page);
             await editorPage.goto();
-            await editorPage.typeInTitle('Hello world');
+            await editorPage.setTitle('Hello world', {blur: true});
+            await editorPage.waitForCreatePostResponse();
             await editorPage.checkPostStatus('Draft');
         });
         
         test('should save a draft when only the content is changed for the first time', async ({page}) => {
             const editorPage = new EditorPage(page);
             await editorPage.goto();
-            await editorPage.typeInEditor('Hello world');
+            await editorPage.setBody('Hello world', {triggerAutosave: true});
+            await editorPage.waitForCreatePostResponse();
             await editorPage.checkPostStatus('Draft');
         });
     });

--- a/ghost/core/test/e2e-browser/admin/editor.spec.js
+++ b/ghost/core/test/e2e-browser/admin/editor.spec.js
@@ -1,0 +1,11 @@
+const test = require('../fixtures/ghost-test');
+const EditorPage = require('../utils/pages/EditorPage');
+
+test.describe('Editor', () => {
+    test('should save post when title is blank and only the content is changed', async ({page}) => {
+        const editorPage = new EditorPage(page);
+        await editorPage.goto();
+        await editorPage.typeInBody('Hello world');
+        await editorPage.checkPostStatus('Draft');
+    });
+});

--- a/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
+++ b/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
@@ -14,8 +14,13 @@ class EditorPage {
         this.postStatus = this.page.locator('[data-test-editor-post-status]').first();
         this.psmButton = this.page.locator('[data-test-editor-psm-trigger]');
         this.breadcrumb = this.page.locator('[data-test-breadcrumb]');
+        this.createPostPromise = this.getCreatePostPromise();
     }
 
+    /**
+     * Navigates to a blank new post or page
+     * @param {'post' | 'page'} type 
+     */
     async goto(type = 'post') {
         await this.page.goto('/ghost');
         if (type === 'post') {
@@ -25,42 +30,97 @@ class EditorPage {
         } else {
             throw new Error(`Invalid type: ${type}`);
         }
-
-        // wait for editor to be ready
         await expect(this.editor).toBeVisible();
     }
 
-    async focusTitle() {
-        await this.titleInput.click();
-    }
-
+    /**
+     * Blurs the title input
+     */
     async blurTitle() {
         await this.titleInput.blur();
     }
 
-    async typeInTitle(text) {
-        await this.focusTitle();
-        await this.page.keyboard.type(text);
-        await this.blurTitle();
+    /**
+     * Fill the title input with the provided text
+     * @param {string} text
+     */
+    async fillTitle(text) {
+        await this.titleInput.fill(text);
     }
 
-    async focusEditor() {
-        await this.editor.click();
+    /**
+     * Sets the title to the provided text, overwriting any existing text, and optionally blurs the input
+     * @param {string} text 
+     * @param {Object} options
+     * @param {boolean} [options.blur] Whether to blur the input after setting the title
+     */
+    async setTitle(text, options = {}) {
+        await this.titleInput.clear();
+        await this.titleInput.fill(text);
+        if (options.blur) {
+            await this.blurTitle();
+        }
     }
 
-    async typeInEditor(text) {
-        await this.focusEditor();
-        await this.page.keyboard.type(text);
+    /**
+     * Fills the editor with the provided text
+     * @param {string} text
+     */
+    async fillBody(text) {
+        await this.editor.fill(text);
     }
 
-    async checkPostStatus(status, hoverStatus) {
+    /**
+     * Sets the editor to the provided text, overwriting any existing text
+     * @param {string} text 
+     * @param {Object} options
+     * @param {boolean} [options.triggerAutosave] Whether to trigger an autosave
+     */
+    async setBody(text, options = {}) {
+        await this.editor.clear();
+        await this.fillBody(text);
+        if (options.triggerAutosave) {
+            await this.triggerAutosave();
+        }
+    }
+
+    /**
+     * Triggers an autosave by fast forwarding the clock by 5 seconds
+     * This saves us 3 seconds of waiting for the autosave to trigger
+     */
+    async triggerAutosave() {
+        await this.page.clock.install();
+        await this.page.clock.fastForward('00:05');
+    }
+
+    /**
+     * Waits for a successful response from the POST /posts endpoint
+     * @returns {Promise<import('@playwright/test').Response>} Playwright response object
+     */
+    async waitForCreatePostResponse() {
+        const response = await this.createPostPromise;
+        return response;
+    }
+
+    /**
+     * Checks that the post status is the provided status
+     * @param {string} status
+     */
+    async checkPostStatus(status) {
         await this.page.waitForLoadState('networkidle');
         await expect(this.postStatus).toContainText(status, {timeout: 10000});
+    }
 
-        if (hoverStatus) {
-            await this.postStatus.hover();
-            await expect(this.postStatus).toContainText(hoverStatus, {timeout: 5000});
-        }
+    /**
+     * Returns a promise that resolves when a successful response from the POST /posts endpoint is received
+     * @returns {Promise<import('@playwright/test').Response>} Playwright response object
+     */
+    getCreatePostPromise() {
+        return this.page.waitForResponse((response) => {
+            return response.request().method() === 'POST' &&
+                response.url().includes('/ghost/api/admin/posts/') &&
+                response.status() === 201;
+        });
     }
 }
 

--- a/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
+++ b/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
@@ -55,7 +55,7 @@ class EditorPage {
 
     async checkPostStatus(status, hoverStatus) {
         await this.page.waitForLoadState('networkidle');
-        await expect(this.postStatus).toContainText(status, {timeout: 5000});
+        await expect(this.postStatus).toContainText(status, {timeout: 10000});
 
         if (hoverStatus) {
             await this.postStatus.hover();

--- a/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
+++ b/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
@@ -9,6 +9,11 @@ const {expect} = require('@playwright/test');
 class EditorPage {
     constructor(page) {
         this.page = page;
+        this.titleInput = this.page.locator('[data-test-editor-title-input]');
+        this.editor = this.page.locator('[data-secondary-instance="false"] [data-lexical-editor]');
+        this.postStatus = this.page.locator('[data-test-editor-post-status]').first();
+        this.psmButton = this.page.locator('[data-test-editor-psm-trigger]');
+        this.breadcrumb = this.page.locator('[data-test-breadcrumb]');
     }
 
     async goto(type = 'post') {
@@ -22,25 +27,39 @@ class EditorPage {
         }
 
         // wait for editor to be ready
-        await expect(this.page.locator('[data-lexical-editor="true"]').first()).toBeVisible();
+        await expect(this.editor).toBeVisible();
     }
 
-    async focusBody() {
-        await this.page.locator('[data-secondary-instance="false"] [data-lexical-editor]').click();
+    async focusTitle() {
+        await this.titleInput.click();
     }
 
-    async typeInBody(text) {
-        await this.focusBody();
+    async blurTitle() {
+        await this.titleInput.blur();
+    }
+
+    async typeInTitle(text) {
+        await this.focusTitle();
+        await this.page.keyboard.type(text);
+        await this.blurTitle();
+    }
+
+    async focusEditor() {
+        await this.editor.click();
+    }
+
+    async typeInEditor(text) {
+        await this.focusEditor();
         await this.page.keyboard.type(text);
     }
 
     async checkPostStatus(status, hoverStatus) {
         await this.page.waitForLoadState('networkidle');
-        await expect(this.page.locator('[data-test-editor-post-status]').first()).toContainText(status, {timeout: 5000});
+        await expect(this.postStatus).toContainText(status, {timeout: 5000});
 
         if (hoverStatus) {
-            await this.page.locator('[data-test-editor-post-status]').first().hover();
-            await expect(this.page.locator('[data-test-editor-post-status]').first()).toContainText(hoverStatus, {timeout: 5000});
+            await this.postStatus.hover();
+            await expect(this.postStatus).toContainText(hoverStatus, {timeout: 5000});
         }
     }
 }

--- a/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
+++ b/ghost/core/test/e2e-browser/utils/pages/EditorPage.js
@@ -1,0 +1,48 @@
+const {expect} = require('@playwright/test');
+
+/**
+ * Page object model for the editor page
+ * https://playwright.dev/docs/pom
+ * @typedef {Object} EditorPageOptions
+ * @property {string} [type] The type of editor to open. Can be 'post' or 'page'.
+ */
+class EditorPage {
+    constructor(page) {
+        this.page = page;
+    }
+
+    async goto(type = 'post') {
+        await this.page.goto('/ghost');
+        if (type === 'post') {
+            await this.page.goto('/ghost/#/editor/post/');
+        } else if (type === 'page') {
+            await this.page.goto('/ghost/#/editor/page/');
+        } else {
+            throw new Error(`Invalid type: ${type}`);
+        }
+
+        // wait for editor to be ready
+        await expect(this.page.locator('[data-lexical-editor="true"]').first()).toBeVisible();
+    }
+
+    async focusBody() {
+        await this.page.locator('[data-secondary-instance="false"] [data-lexical-editor]').click();
+    }
+
+    async typeInBody(text) {
+        await this.focusBody();
+        await this.page.keyboard.type(text);
+    }
+
+    async checkPostStatus(status, hoverStatus) {
+        await this.page.waitForLoadState('networkidle');
+        await expect(this.page.locator('[data-test-editor-post-status]').first()).toContainText(status, {timeout: 5000});
+
+        if (hoverStatus) {
+            await this.page.locator('[data-test-editor-post-status]').first().hover();
+            await expect(this.page.locator('[data-test-editor-post-status]').first()).toContainText(hoverStatus, {timeout: 5000});
+        }
+    }
+}
+
+module.exports = EditorPage;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-833/support-escalation-re-issue-with-saving-articles-urgent

- We recently had a bug that caused the editor to fail to save if only the body was filled, and the title was left blank. With a blank title, the slug wasn't generating, which caused the initial `POST` request to fail with a validation error.
- We've had similar issues in the past and added some admin acceptance tests, but they didn't and wouldn't catch a case like this, where the bug is caused by an interaction between the editor, admin, and the Admin API.
- This commit adds a new browser test file for the editor and two basic test cases as a starting point. It uses Playwright's "Page Object Model" concept to make the tests easier to read and write, and to keep the test's as DRY as we can.
- It also adds a missing test in the Admin Acceptance tests, although this test wouldn't have caught this bug