### PR TITLE
Improved browser test utils to reduce flakiness

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -197,10 +197,10 @@ test.describe('Publishing', () => {
             await createMember(sharedPage, {email: 'test+recipient1@example.com', name: 'Publishing member'});
 
             await sharedPage.goto('/ghost');
-            const postSlug = await createPostDraft(sharedPage, postData);
+            await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'publish+send'});
             await closePublishFlow(sharedPage);
-            await checkPostPublished(sharedPage, {...postData, slug: postSlug});
+            await checkPostPublished(sharedPage, postData);
         });
 
         // Post should only be available on web
@@ -211,12 +211,12 @@ test.describe('Publishing', () => {
             };
 
             await sharedPage.goto('/ghost');
-            const postSlug = await createPostDraft(sharedPage, postData);
+            await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage);
             await closePublishFlow(sharedPage);
 
             await checkPostStatus(sharedPage, 'Published');
-            await checkPostPublished(sharedPage, {...postData, slug: postSlug});
+            await checkPostPublished(sharedPage, postData);
         });
 
         // Post should be available on web and sent as a newsletter
@@ -229,10 +229,10 @@ test.describe('Publishing', () => {
             await createMember(sharedPage, {email: 'test+recipient2@example.com', name: 'Publishing member'});
 
             await sharedPage.goto('/ghost');
-            const postSlug = await createPostDraft(sharedPage, postData);
+            await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'send'});
             await closePublishFlow(sharedPage);
-            await checkPostNotPublished(sharedPage, {...postData, slug: postSlug});
+            await checkPostNotPublished(sharedPage, postData);
         });
     });
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -197,10 +197,10 @@ test.describe('Publishing', () => {
             await createMember(sharedPage, {email: 'test+recipient1@example.com', name: 'Publishing member'});
 
             await sharedPage.goto('/ghost');
-            await createPostDraft(sharedPage, postData);
+            const postSlug = await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'publish+send'});
             await closePublishFlow(sharedPage);
-            await checkPostPublished(sharedPage, postData);
+            await checkPostPublished(sharedPage, {...postData, slug: postSlug});
         });
 
         // Post should only be available on web
@@ -211,12 +211,12 @@ test.describe('Publishing', () => {
             };
 
             await sharedPage.goto('/ghost');
-            await createPostDraft(sharedPage, postData);
+            const postSlug = await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage);
             await closePublishFlow(sharedPage);
 
             await checkPostStatus(sharedPage, 'Published');
-            await checkPostPublished(sharedPage, postData);
+            await checkPostPublished(sharedPage, {...postData, slug: postSlug});
         });
 
         // Post should be available on web and sent as a newsletter
@@ -229,10 +229,10 @@ test.describe('Publishing', () => {
             await createMember(sharedPage, {email: 'test+recipient2@example.com', name: 'Publishing member'});
 
             await sharedPage.goto('/ghost');
-            await createPostDraft(sharedPage, postData);
+            const postSlug = await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'send'});
             await closePublishFlow(sharedPage);
-            await checkPostNotPublished(sharedPage, postData);
+            await checkPostNotPublished(sharedPage, {...postData, slug: postSlug});
         });
     });
 


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1742295473212499

This commit includes two improvements to our browser test suite for the sake of reliability and reducing flakiness:

## Deleting all members via the API instead of the UI
- In certain browser tests, we need to delete all the existing members in between tests to start with a clean slate.
- Until now, this has been done by navigating to the members page in the UI and deleting each member one-by-one, which is error prone (leading to flaky test failures) and also time consuming.
- This commit modifies the `deleteAllMembers` utility function to use the Admin API directly to query all members and delete them one-by-one. This should be more reliable as it avoids the complexity of navigating the UI, and it should also be faster.

## Returning the slug of a post created with `createPostDraft`
- In our publishing tests, there is a commonly used utility function to create a post draft, which navigates through the UI to create a new post with the provided title and body.
- In almost every test case where this function is used, we then try to navigate to the created post on the frontend by its slug to confirm that it is/isn't published.
- These checks sometimes will return a 404, because the check is navigating to the wrong URL, ultimately because we try to deduce the slug of the created post from the post's title. However, the slug creation depends on the state in the DB, and if there are any other posts that conflict, that newly created post will have an unexpected slug, causing the check to incorrectly fail.
- This commit modifies the `createPostDraft` utility to explicitly return the `slug` of the post that it creates, so that tests can store a reference to the slug and visit it directly to confirm the post's status.