### PR TITLE
ActivityPub media cards UX improvement

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -20,8 +20,8 @@ import APReplyBox from '../global/APReplyBox';
 import DeletedFeedItem from './DeletedFeedItem';
 import TableOfContents, {TOCItem} from './TableOfContents';
 import getReadingTime from '../../utils/get-reading-time';
+import {formatArticle} from '@src/utils/content-formatters';
 import {isPendingActivity} from '../../utils/pending-activity';
-import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
 
 interface ArticleModalProps {
@@ -46,6 +46,7 @@ interface IframeWindow extends Window {
 const FONT_SANS = 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 const ArticleBody: React.FC<{
+    postUrl: string;
     heading: string;
     image: string|undefined;
     excerpt: string|undefined;
@@ -57,6 +58,7 @@ const ArticleBody: React.FC<{
     onIframeLoad?: (iframe: HTMLIFrameElement) => void;
     onLoadingChange?: (isLoading: boolean) => void;
 }> = ({
+    postUrl,
     heading,
     image,
     excerpt,
@@ -179,7 +181,7 @@ const ArticleBody: React.FC<{
                 ` : ''}
             </header>
             <div class='gh-content gh-canvas is-body'>
-                ${openLinksInNewTab(html)}
+                ${formatArticle(html, postUrl)}
             </div>
             <script>
                 (function () {
@@ -930,6 +932,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                                         html={object.content ?? ''}
                                         image={typeof object.image === 'string' ? object.image : object.image?.url}
                                         lineHeight={LINE_HEIGHTS[currentLineHeightIndex]}
+                                        postUrl={object?.url || ''}
                                         onHeadingsExtracted={handleHeadingsExtracted}
                                         onIframeLoad={handleIframeLoad}
                                         onLoadingChange={setIsLoading}

--- a/apps/admin-x-activitypub/src/utils/content-formatters.ts
+++ b/apps/admin-x-activitypub/src/utils/content-formatters.ts
@@ -2,6 +2,45 @@ export function stripHtml(html: string): string {
     return html.replace(/<[^>]*>/g, '');
 }
 
+export const formatArticle = (content: string, postUrl: string) => {
+    // Create a temporary div to parse the HTML
+    const div = document.createElement('div');
+    div.innerHTML = content;
+
+    if (postUrl) {
+        // Find all audio and video card divs
+        const mediaCards = div.querySelectorAll('.kg-audio-card, .kg-video-card');
+
+        // Wrap each media card in an anchor tag
+        for (let i = 0; i < mediaCards.length; i++) {
+            const mediaCard = mediaCards[i] as HTMLElement;
+            const wrapper = document.createElement('a');
+            wrapper.href = postUrl;
+            wrapper.target = '_blank';
+            wrapper.rel = 'noopener noreferrer';
+            wrapper.style.cursor = 'pointer';
+            wrapper.style.display = 'block';
+            wrapper.style.textDecoration = 'none';
+            wrapper.style.color = 'inherit';
+
+            // Move the media card into the wrapper
+            mediaCard.parentNode?.insertBefore(wrapper, mediaCard);
+            wrapper.appendChild(mediaCard);
+        }
+    }
+
+    // Find all anchor tags
+    const links = div.getElementsByTagName('a');
+
+    // Add target="_blank" and rel attributes to each link
+    for (let i = 0; i < links.length; i++) {
+        links[i].setAttribute('target', '_blank');
+        links[i].setAttribute('rel', 'noopener noreferrer');
+    }
+
+    return div.innerHTML;
+};
+
 export const openLinksInNewTab = (content: string) => {
     // Create a temporary div to parse the HTML
     const div = document.createElement('div');


### PR DESCRIPTION
ref AP-916, AP-915

- Audio and video cards cannot be played in the ActivityPub reader. This PR contains a temporary UX improvement that it renders audio and video cards in a wrapper that opens the original article in a new tab, so the cards don't look completely broken