### PR TITLE
Updated empty state for stats dashboard

### DIFF
--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -99,12 +99,31 @@ export default class KpisOverview extends Component {
         const formattedVisitDurations = formatVisitDuration(_ponderatedKPIsTotal('avg_session_sec'));
         const formattedBouceRate = (_ponderatedKPIsTotal('bounce_rate') * 100).toFixed(0);
 
-        return {
+        const totals = {
             avg_session_sec: isNaN(_ponderatedKPIsTotal('avg_session_sec')) ? '0m' : formattedVisitDurations,
             pageviews: formatNumber(_KPITotal('pageviews')) || '0',
             visits: formatNumber(totalVisits) || '0',
             bounce_rate: isNaN(formattedBouceRate) ? '0' : formattedBouceRate
         };
+
+        console.log('KPI Overview - Processed totals:', totals);
+        console.log('KPI Overview - Raw visits:', totalVisits);
+        console.log('KPI Overview - Raw pageviews:', _KPITotal('pageviews'));
+
+        this.totals = totals;
+        this.args.onTotalsChange?.(totals);
+
+        return totals;
+    }
+
+    get hasNoViews() {
+        const hasNoViews = this.totals?.visits === '0' || this.totals?.pageviews === '0';
+        console.log('KPI Overview - hasNoViews check:', {
+            visits: this.totals?.visits,
+            pageviews: this.totals?.pageviews,
+            hasNoViews
+        });
+        return hasNoViews;
     }
 
     willDestroy() {

--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -106,10 +106,6 @@ export default class KpisOverview extends Component {
             bounce_rate: isNaN(formattedBouceRate) ? '0' : formattedBouceRate
         };
 
-        console.log('KPI Overview - Processed totals:', totals);
-        console.log('KPI Overview - Raw visits:', totalVisits);
-        console.log('KPI Overview - Raw pageviews:', _KPITotal('pageviews'));
-
         this.totals = totals;
         this.args.onTotalsChange?.(totals);
 

--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -114,11 +114,6 @@ export default class KpisOverview extends Component {
 
     get hasNoViews() {
         const hasNoViews = this.totals?.visits === '0' || this.totals?.pageviews === '0';
-        console.log('KPI Overview - hasNoViews check:', {
-            visits: this.totals?.visits,
-            pageviews: this.totals?.pageviews,
-            hasNoViews
-        });
         return hasNoViews;
     }
 

--- a/ghost/admin/app/controllers/stats.js
+++ b/ghost/admin/app/controllers/stats.js
@@ -38,6 +38,20 @@ export default class StatsController extends Controller {
     @tracked audience = [];
     @tracked excludedAudiences = '';
     @tracked showStats = true;
+    @tracked totals = null;
+
+    @action
+    onTotalsChange(totals) {
+        console.log('Stats Controller - onTotalsChange:', totals);
+        this.totals = totals;
+        const hasNoViews = totals?.visits === '0' && totals?.pageviews === '0';
+        console.log('Stats Controller - hasNoViews check:', {
+            visits: totals?.visits,
+            pageviews: totals?.pageviews,
+            hasNoViews
+        });
+        this.showStats = !hasNoViews;
+    }
 
     @action
     onRangeChange(selected) {
@@ -65,6 +79,7 @@ export default class StatsController extends Controller {
         this.excludedAudiences = '';
         this.audience = this.audienceOptions.map(a => a.value);
         this.showStats = true;
+        this.clearFilters();
     }
 
     @action

--- a/ghost/admin/app/controllers/stats.js
+++ b/ghost/admin/app/controllers/stats.js
@@ -42,14 +42,8 @@ export default class StatsController extends Controller {
 
     @action
     onTotalsChange(totals) {
-        console.log('Stats Controller - onTotalsChange:', totals);
         this.totals = totals;
         const hasNoViews = totals?.visits === '0' && totals?.pageviews === '0';
-        console.log('Stats Controller - hasNoViews check:', {
-            visits: totals?.visits,
-            pageviews: totals?.pageviews,
-            hasNoViews
-        });
         this.showStats = !hasNoViews;
     }
 

--- a/ghost/admin/app/templates/stats.hbs
+++ b/ghost/admin/app/templates/stats.hbs
@@ -95,6 +95,7 @@
                 @pathname={{this.pathname}}
                 @os={{this.os}}
                 @mockData={{this.mockData}}
+                @onTotalsChange={{this.onTotalsChange}}
             />
         </section>
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-154
- expanded empty state display to whenever we have no views returned in the kpi overview
- updated see all stats button to also clear selected filters