### PR TITLE
Added alpha flag for experimental explore feature

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -51,6 +51,10 @@ const features = [{
     title: 'Sign-up CAPTCHA',
     description: 'Enable CAPTCHA for member sign-up and sign-in',
     flag: 'captcha'
+}, {
+    title: 'Explore',
+    description: 'Enables keeping in touch with the new Explore API',
+    flag: 'explore'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -52,7 +52,8 @@ const ALPHA_FEATURES = [
     'adminXDemo',
     'postsX',
     'captcha',
-    'contentVisibilityAlpha'
+    'contentVisibilityAlpha',
+    'explore'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -22,6 +22,7 @@ Object {
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,
+      "explore": true,
       "i18n": true,
       "importMemberTier": true,
       "lexicalIndicators": true,


### PR DESCRIPTION
- Getting ready to work on a new feature, adding the necessary labs flags first
- These flags are a no-op, and should therefore not cause any problems!

