### PR TITLE
Added the read:identity permission to Administrators

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.115/2025-03-24-07-19-27-add-identity-read-permission-to-administrators.js
+++ b/ghost/core/core/server/data/migrations/versions/5.115/2025-03-24-07-19-27-add-identity-read-permission-to-administrators.js
@@ -1,0 +1,6 @@
+const {addPermissionToRole} = require('../../utils');
+
+module.exports = addPermissionToRole({
+    permission: 'Read identities',
+    role: 'Administrator',
+});

--- a/ghost/core/core/server/data/migrations/versions/5.115/2025-03-24-07-19-27-add-identity-read-permission-to-administrators.js
+++ b/ghost/core/core/server/data/migrations/versions/5.115/2025-03-24-07-19-27-add-identity-read-permission-to-administrators.js
@@ -2,5 +2,5 @@ const {addPermissionToRole} = require('../../utils');
 
 module.exports = addPermissionToRole({
     permission: 'Read identities',
-    role: 'Administrator',
+    role: 'Administrator'
 });

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -875,7 +875,8 @@
                     "link": "all",
                     "mention": "browse",
                     "collection": "all",
-                    "recommendation": "all"
+                    "recommendation": "all",
+                    "identity": "read"
                 },
                 "DB Backup Integration": {
                     "db": "all"

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -191,7 +191,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 133;
+                const FIXTURE_COUNT = 134;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '238ad2a9efd5f43b7d8233c38f5a8a2e';
-    const currentFixturesHash = '35d3cc0ce18f85dc66f0f385865f666d';
+    const currentFixturesHash = '0e26f9262320630078b2dcc231db350c';
     const currentSettingsHash = '5eb97fee379c1d0420de58957d29fe26';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1044,7 +1044,8 @@
                     "link": "all",
                     "mention": "browse",
                     "collection": "all",
-                    "recommendation": "all"
+                    "recommendation": "all",
+                    "identity": "read"
                 },
                 "DB Backup Integration": {
                     "db": "all"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-974

Right now it is only possible for Owners to access the identity token endpoint. But we want to open up ActivityPub to Administrators.
