### PR TITLE
Fixed query for finding the Owner user

### DIFF
--- a/ghost/core/core/server/services/activitypub/ActivityPubService.ts
+++ b/ghost/core/core/server/services/activitypub/ActivityPubService.ts
@@ -66,7 +66,12 @@ export class ActivityPubService {
 
     async getWebhookSecret(): Promise<string | null> {
         try {
-            const ownerUser = await this.knex.select('*').from('users').where('id', '=', '1').first();
+            const ownerUser = await this.knex('users')
+                .select('users.*')
+                .join('roles_users', 'users.id', 'roles_users.user_id')
+                .join('roles', 'roles.id', 'roles_users.role_id')
+                .where('roles.name', 'Owner')
+                .first();
             const token = await this.identityTokenService.getTokenForUser(ownerUser.email, 'Owner');
 
             const res = await fetch(new URL('.ghost/activitypub/site', this.siteUrl), {

--- a/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
+++ b/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
@@ -18,6 +18,17 @@ async function getKnexInstance() {
         table.string('email');
     });
 
+    await knexInstance.schema.createTable('roles', (table) => {
+        table.string('id').primary();
+        table.string('name');
+    });
+
+    await knexInstance.schema.createTable('roles_users', (table) => {
+        table.string('id').primary();
+        table.string('user_id').references('users.id');
+        table.string('role_id').references('roles.id');
+    });
+
     await knexInstance.schema.createTable('integrations', (table) => {
         table.string('id').primary();
         table.string('slug');
@@ -36,14 +47,25 @@ async function getKnexInstance() {
         table.string('created_by');
     });
 
+    await knexInstance.insert({
+        id: 'owner-role-id',
+        name: 'Owner'
+    }).into('roles');
+
     return knexInstance;
 }
 
 async function addOwnerUser(knexInstance: Knex) {
     await knexInstance.insert({
-        id: '1',
+        id: 'non-standard-id',
         email: 'owner@user.com'
     }).into('users');
+
+    await knexInstance.insert({
+        id: 'roles-users-id',
+        user_id: 'non-standard-id',
+        role_id: 'owner-role-id'
+    }).into('roles_users');
 }
 async function addActivityPubIntegration(knexInstance: Knex) {
     await knexInstance.insert({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-975

Not all Owner users have an `id` of `'1'` - which caused the handshake between Ghost and ActivityPub to fail. This query now maps between the Owner role and the users table to correctly find the Owner user
