### PR TITLE
Added a type signature to settingscache.getPublic

### DIFF
--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -11,6 +11,59 @@ const _ = require('lodash');
  * - See the notes in core/server/lib/common/events
  * - There's also a plan to introduce a proper caching layer, and rewrite this on top of that
  */
+
+/**
+ * @typedef {Object} PublicSettingsCache
+ * @property {string|null} title - The blog's title
+ * @property {string|null} description - The blog's description
+ * @property {string|null} logo - URL to the blog's logo
+ * @property {string|null} icon - URL to the blog's icon
+ * @property {string|null} accent_color - The blog's accent color
+ * @property {string|null} cover_image - URL to the blog's cover image
+ * @property {string|null} facebook - Facebook page name
+ * @property {string|null} twitter - Twitter username
+ * @property {string|null} lang - The blog's language code
+ * @property {string|null} locale - The blog's locale
+ * @property {string|null} timezone - The blog's timezone
+ * @property {string|null} codeinjection_head - Code injected into head
+ * @property {string|null} codeinjection_foot - Code injected into footer
+ * @property {string|null} navigation - JSON string of navigation items
+ * @property {string|null} secondary_navigation - JSON string of secondary navigation items
+ * @property {string|null} meta_title - Custom meta title
+ * @property {string|null} meta_description - Custom meta description
+ * @property {string|null} og_image - Open Graph image URL
+ * @property {string|null} og_title - Open Graph title
+ * @property {string|null} og_description - Open Graph description
+ * @property {string|null} twitter_image - Twitter card image URL
+ * @property {string|null} twitter_title - Twitter card title
+ * @property {string|null} twitter_description - Twitter card description
+ * @property {string|null} members_support_address - Support email for members
+ * @property {boolean|null} members_enabled - Whether members feature is enabled
+ * @property {boolean|null} allow_self_signup - Whether self signup is allowed
+ * @property {boolean|null} members_invite_only - Whether membership is invite only
+ * @property {string|null} members_signup_access - Member signup access level
+ * @property {boolean|null} paid_members_enabled - Whether paid memberships are enabled
+ * @property {string|null} firstpromoter_account - FirstPromoter account ID
+ * @property {string|null} portal_button_style - Portal button style
+ * @property {string|null} portal_button_signup_text - Portal signup button text
+ * @property {string|null} portal_button_icon - Portal button icon
+ * @property {string|null} portal_signup_terms_html - Portal signup terms HTML
+ * @property {boolean|null} portal_signup_checkbox_required - Whether signup checkbox is required
+ * @property {string|null} portal_plans - JSON string of available portal plans
+ * @property {string|null} portal_default_plan - Default portal plan
+ * @property {boolean|null} portal_name - Whether to show portal names
+ * @property {boolean|null} portal_button - Whether to show the portal button
+ * @property {boolean|null} comments_enabled - Whether comments are enabled
+ * @property {boolean|null} recommendations_enabled - Whether recommendations are enabled
+ * @property {boolean|null} outbound_link_tagging - Whether outbound link tagging is enabled
+ * @property {string|null} default_email_address - Default email address
+ * @property {string|null} support_email_address - Support email address
+ * @property {string|null} editor_default_email_recipients - Default email recipients for editor
+ * @property {boolean|null} captcha_enabled - Whether captcha is enabled
+ * @property {string|null} labs - JSON string of enabled labs features
+ * @property {never} [x] - Prevent accessing undefined properties
+ */
+
 class CacheManager {
     /**
      * @prop {Object} options
@@ -164,14 +217,19 @@ class CacheManager {
     /**
      * Get all the publicly accessible cache entries with their correct names
      * Uses clone to prevent modifications from being reflected
-     * @return {object} cache
+    * @return {PublicSettingsCache} cache
      */
     getPublic() {
-        let settings = {};
+        // This block correctly builds the type signature for the return value
+        /** @type {PublicSettingsCache} */
+        let settings = Object.fromEntries(
+            Object.keys(this.publicSettings).map(key => [this.publicSettings[key], null])
+        );
 
-        _.each(this.publicSettings, (key, newKey) => {
-            settings[newKey] = this._doGet(key) ?? null;
-        });
+        // This block correctly populates the values from the cache
+        for (const newKey in this.publicSettings) {
+            settings[newKey] = this._doGet(this.publicSettings[newKey]) ?? null;
+        }
 
         return settings;
     }


### PR DESCRIPTION
- this piece of code returns settings based on their type, with schema changes, the returned type can change in potentially unexpected ways
- adding a type block here means that code using this method can determine if it's requested an unexpected property

