### PR TITLE
Updated new explore service to use settings cache

### DIFF
--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -1,6 +1,15 @@
 module.exports = class ExplorePingService {
-    constructor({PublicConfigService, config, labs, logging, ghostVersion, request}) {
-        this.PublicConfigService = PublicConfigService;
+    /**
+     * @param {object} deps
+     * @param {{getPublic: () => import('../../../shared/settings-cache/CacheManager').PublicSettingsCache}} deps.settingsCache
+     * @param {object} deps.config
+     * @param {object} deps.labs
+     * @param {object} deps.logging
+     * @param {object} deps.ghostVersion
+     * @param {object} deps.request
+     */
+    constructor({settingsCache, config, labs, logging, ghostVersion, request}) {
+        this.settingsCache = settingsCache;
         this.config = config;
         this.labs = labs;
         this.logging = logging;
@@ -9,17 +18,20 @@ module.exports = class ExplorePingService {
     }
 
     constructPayload() {
-        const {url, title, description, icon, locale, twitter, facebook} = this.PublicConfigService.site;
+        /* eslint-disable camelcase */
+        const {title, description, icon, locale, accent_color, twitter, facebook} = this.settingsCache.getPublic();
         return {
             ghost: this.ghostVersion.full,
-            url,
+            url: this.config.get('url'),
             title,
             description,
             icon,
             locale,
+            accent_color,
             twitter,
             facebook
         };
+        /* eslint-enable camelcase */
     }
 
     async makeRequest(exploreUrl, payload) {

--- a/ghost/core/core/server/services/explore-ping/index.js
+++ b/ghost/core/core/server/services/explore-ping/index.js
@@ -1,15 +1,15 @@
 const ExplorePingService = require('./ExplorePingService');
-const PublicConfigService = require('../public-config');
 const config = require('../../../shared/config');
 const labs = require('../../../shared/labs');
 const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
 const request = require('@tryghost/request');
+const settingsCache = require('../../../shared/settings-cache');
 
 // Export the creation function for testing
 module.exports.createService = function createService() {
     return new ExplorePingService({
-        PublicConfigService,
+        settingsCache,
         config,
         labs,
         logging,

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -4,7 +4,7 @@ const ExplorePingService = require('../../../../../core/server/services/explore-
 
 describe('ExplorePingService', function () {
     let explorePingService;
-    let publicConfigStub;
+    let settingsCacheStub;
     let configStub;
     let labsStub;
     let loggingStub;
@@ -13,21 +13,42 @@ describe('ExplorePingService', function () {
 
     beforeEach(function () {
         // Setup stubs
-        publicConfigStub = {
-            site: {
-                url: 'https://example.com',
+        settingsCacheStub = {
+            getPublic: sinon.stub().returns({
                 title: 'Test Blog',
                 description: 'Test Description',
                 icon: 'icon.png',
+                accent_color: '#000000',
+                lang: 'en',
+                timezone: 'Etc/UTC',
+                navigation: JSON.stringify([]),
+                secondary_navigation: JSON.stringify([]),
+                meta_title: null,
+                meta_description: null,
+                og_image: null,
+                og_title: null,
+                og_description: null,
+                twitter_image: null,
+                twitter_title: null,
+                twitter_description: null,
+                active_theme: 'casper',
+                cover_image: null,
+                logo: null,
+                portal_button: true,
+                portal_name: true,
                 locale: 'en',
                 twitter: '@test',
-                facebook: 'testfb'
-            }
+                facebook: 'testfb',
+                labs: JSON.stringify({})
+            })
         };
 
         configStub = {
-            get: sinon.stub().returns('https://explore-api.ghost.org')
+            get: sinon.stub()
         };
+
+        configStub.get.withArgs('url').returns('https://example.com');
+        configStub.get.withArgs('explore:url').returns('https://explore-api.ghost.org');
 
         labsStub = {
             isSet: sinon.stub().returns(true)
@@ -45,7 +66,7 @@ describe('ExplorePingService', function () {
         requestStub = sinon.stub();
 
         explorePingService = new ExplorePingService({
-            PublicConfigService: publicConfigStub,
+            settingsCache: settingsCacheStub,
             config: configStub,
             labs: labsStub,
             logging: loggingStub,
@@ -68,6 +89,7 @@ describe('ExplorePingService', function () {
                 title: 'Test Blog',
                 description: 'Test Description',
                 icon: 'icon.png',
+                accent_color: '#000000',
                 locale: 'en',
                 twitter: '@test',
                 facebook: 'testfb'
@@ -114,7 +136,7 @@ describe('ExplorePingService', function () {
         });
 
         it('does not ping if explore URL is not set', async function () {
-            configStub.get.returns(null);
+            configStub.get.withArgs('explore:url').returns(null);
 
             await explorePingService.ping();
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/c7cc68aa33def7349e064c763681f7a4858507fa

- We want to get properties that are not currently exposed via the public config service
- Therefore, I've changed to directly getting information from the settings cache
- This also means getting the URL direct from config, which we already have access to
- I also already added better types to the SettingsCache getPublic method, meaning we'll see an error if we try to add any properties that are not available (like url)


