### PR TITLE
Updated header links in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -757,11 +757,11 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                             </div>
                             <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={e => handleProfileClick(actor, e)}>
                                 <div className='flex w-full'>
-                                    <span className='min-w-0 truncate whitespace-nowrap font-semibold'>{actor.name}</span>
+                                    <span className='min-w-0 truncate whitespace-nowrap font-semibold hover:underline'>{actor.name}</span>
                                 </div>
                                 <div className='flex w-full'>
                                     <span className='text-gray-700 after:mx-1 after:font-normal after:text-gray-700 after:content-["·"]'>{getUsername(actor)}</span>
-                                    <span className='text-gray-700'>{renderTimestamp(object)}</span>
+                                    <span className='text-gray-700'>{renderTimestamp(object, !object.authored)}</span>
                                 </div>
                             </div>
                         </div>)}

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -20,6 +20,7 @@ import APReplyBox from '../global/APReplyBox';
 import DeletedFeedItem from './DeletedFeedItem';
 import TableOfContents, {TOCItem} from './TableOfContents';
 import getReadingTime from '../../utils/get-reading-time';
+import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
@@ -754,7 +755,7 @@ const ArticleModal: React.FC<ArticleModalProps> = ({
                             <div className='relative z-10 pt-[3px]'>
                                 <APAvatar author={actor}/>
                             </div>
-                            <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible text-[1.5rem]'>
+                            <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={e => handleProfileClick(actor, e)}>
                                 <div className='flex w-full'>
                                     <span className='min-w-0 truncate whitespace-nowrap font-semibold'>{actor.name}</span>
                                 </div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -281,17 +281,14 @@ const FeedItem: React.FC<FeedItemProps> = ({
                         <div className={`border-1 flex flex-col gap-2.5`} data-test-activity>
                             <div className='flex min-w-0 items-center gap-3'>
                                 <APAvatar author={author} disabled={isPending} />
-                                <div className='flex min-w-0 grow flex-col gap-0.5'>
+                                <div className='flex min-w-0 grow flex-col gap-0.5' onClick={e => !isPending && handleProfileClick(author, e)}>
                                     <span className={`min-w-0 truncate break-all font-semibold leading-[normal] ${!isPending ? 'hover-underline' : ''} dark:text-white`}
                                         data-test-activity-heading
-                                        onClick={e => !isPending && handleProfileClick(author, e)}
                                     >
                                         {!isLoading ? author.name : <Skeleton className='w-24' />}
                                     </span>
                                     <div className='flex w-full text-sm text-gray-700 dark:text-gray-600'>
-                                        <span className={`truncate leading-tight ${!isPending ? 'hover-underline' : ''}`}
-                                            onClick={e => !isPending && handleProfileClick(author, e)}
-                                        >
+                                        <span className={`truncate leading-tight ${!isPending ? 'hover-underline' : ''}`}>
                                             {!isLoading ? getUsername(author) : <Skeleton className='w-56' />}
                                         </span>
                                         <div className={`ml-1 leading-tight before:mr-1 ${!isLoading && 'before:content-["·"]'}`} title={`${timestamp}`}>
@@ -378,18 +375,20 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div><Icon colorClass='text-gray-700 shrink-0 dark:text-gray-600' name='reload' size={'sm'}></Icon></div>
                                     <span className='flex min-w-0 items-center gap-1'><span className='truncate break-all hover:underline' title={getUsername(actor)} onClick={e => handleProfileClick(actor, e)}>{actor.name}</span> reposted</span>
                                 </div>}
-                                {(showHeader) && <><div className='relative z-10 pt-[3px]'>
-                                    <APAvatar author={author}/>
-                                </div>
-                                <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible text-[1.5rem]'>
-                                    <div className='flex w-full'>
-                                        <span className='min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
-                                        <div>{renderTimestamp(object)}</div>
+                                {(showHeader) && <>
+                                    <div className='relative z-10 pt-[3px]'>
+                                        <APAvatar author={author}/>
                                     </div>
-                                    <div className='flex w-full'>
-                                        <span className='min-w-0 truncate text-gray-700 dark:text-gray-600'>{getUsername(author)}</span>
+                                    <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={e => !isPending && handleProfileClick(author, e)}>
+                                        <div className='flex w-full'>
+                                            <span className='min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
+                                            <div>{renderTimestamp(object)}</div>
+                                        </div>
+                                        <div className='flex w-full'>
+                                            <span className='min-w-0 truncate text-gray-700 dark:text-gray-600'>{getUsername(author)}</span>
+                                        </div>
                                     </div>
-                                </div></>}
+                                </>}
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {object.name && <Heading className='mb-1 leading-tight' level={4} data-test-activity-heading>{object.name}</Heading>}
@@ -428,7 +427,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             </div>
                             <div className='flex w-full min-w-0 flex-col gap-2'>
                                 <div className='flex w-full items-center justify-between'>
-                                    <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible'>
+                                    <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible' onClick={e => !isPending && handleProfileClick(author, e)}>
                                         <div className='flex'>
                                             <span className='min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"]' data-test-activity-heading>{author.name}</span>
                                             <div>{renderTimestamp(object, isPending === false)}</div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -292,7 +292,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                             {!isLoading ? getUsername(author) : <Skeleton className='w-56' />}
                                         </span>
                                         <div className={`ml-1 leading-tight before:mr-1 ${!isLoading && 'before:content-["·"]'}`} title={`${timestamp}`}>
-                                            {!isLoading ? renderTimestamp(object, isPending === false) : <Skeleton className='w-4' />}
+                                            {!isLoading ? renderTimestamp(object, (isPending === false && !object.authored)) : <Skeleton className='w-4' />}
                                         </div>
                                     </div>
                                 </div>
@@ -382,7 +382,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={e => !isPending && handleProfileClick(author, e)}>
                                         <div className='flex w-full'>
                                             <span className='min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
-                                            <div>{renderTimestamp(object)}</div>
+                                            <div>{renderTimestamp(object, !object.authored)}</div>
                                         </div>
                                         <div className='flex w-full'>
                                             <span className='min-w-0 truncate text-gray-700 dark:text-gray-600'>{getUsername(author)}</span>
@@ -430,7 +430,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible' onClick={e => !isPending && handleProfileClick(author, e)}>
                                         <div className='flex'>
                                             <span className='min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"]' data-test-activity-heading>{author.name}</span>
-                                            <div>{renderTimestamp(object, isPending === false)}</div>
+                                            <div>{renderTimestamp(object, (isPending === false && !object.authored))}</div>
                                         </div>
                                         <div className='flex'>
                                             <span className='truncate text-gray-700'>{getUsername(author)}</span>
@@ -498,7 +498,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         >{author.name}
                                         </span>
                                         {(type === 'Announce') && <span className='z-10 flex items-center gap-1 text-gray-700 dark:text-gray-600'><Icon colorClass='text-gray-700 shrink-0 dark:text-gray-600' name='reload' size={'sm'}></Icon><span className='hover:underline' title={getUsername(actor)} onClick={e => handleProfileClick(actor, e)}>{actor.name}</span> reposted</span>}
-                                        <span className='shrink-0 whitespace-nowrap text-gray-600 before:mr-1 before:content-["·"]' title={`${timestamp}`}>{renderTimestamp(object)}</span>
+                                        <span className='shrink-0 whitespace-nowrap text-gray-600 before:mr-1 before:content-["·"]' title={`${timestamp}`}>{renderTimestamp(object, !object.authored)}</span>
                                     </> :
                                     <Skeleton className='w-24' />
                                 }

--- a/apps/admin-x-activitypub/src/utils/render-timestamp.tsx
+++ b/apps/admin-x-activitypub/src/utils/render-timestamp.tsx
@@ -22,7 +22,10 @@ export function renderTimestamp(object: ObjectProperties, asLink = true) {
             <a
                 className='whitespace-nowrap text-gray-700 hover:underline'
                 href={object.url}
+                rel='noreferrer'
+                target='_blank'
                 title={timestamp}
+                onClick={e => e.stopPropagation()}
             >
                 {formattedTimestamp}
             </a>


### PR DESCRIPTION
ref AP-980

- ATM we only show profiles when clicking on the avatar, not the whole heading which makes access of profiles much harder, which eventually lowers the chance of people following each other