### PR TITLE
Enabled ActivityPub menu for Admin users

### DIFF
--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -5,7 +5,7 @@ import Users from './components/settings/general/Users';
 import useFeatureFlag from './hooks/useFeatureFlag';
 import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {ReactNode, useEffect} from 'react';
-import {canAccessSettings, isEditorUser, isOwnerUser} from '@tryghost/admin-x-framework/api/users';
+import {canAccessSettings, hasAdminAccess, isEditorUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -35,7 +35,7 @@ const MainContent: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 confirmIfDirty(isDirty, () => {
-                    if (hasActivityPub && isOwnerUser(currentUser)) {
+                    if (hasActivityPub && hasAdminAccess(currentUser)) {
                         navigateAway('/activitypub');
                     } else {
                         navigateAway('/dashboard');
@@ -49,7 +49,7 @@ const MainContent: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isDirty, hasActivityPub]);
+    }, [isDirty, hasActivityPub, currentUser]);
 
     useEffect(() => {
         // resets any toasts that may have been left open on initial load

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useFeatureFlag from '../hooks/useFeatureFlag';
 import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
-import {isOwnerUser} from '@tryghost/admin-x-framework/api/users';
+import {hasAdminAccess} from '@tryghost/admin-x-framework/api/users';
 import {useGlobalData} from './providers/GlobalDataProvider';
 
 const ExitSettingsButton: React.FC = () => {
@@ -10,7 +10,7 @@ const ExitSettingsButton: React.FC = () => {
     const hasActivityPub = useFeatureFlag('ActivityPub');
 
     const navigateAway = () => {
-        window.location.hash = (hasActivityPub && isOwnerUser(currentUser)) ? '/activitypub' : '/dashboard';
+        window.location.hash = (hasActivityPub && hasAdminAccess(currentUser)) ? '/activitypub' : '/dashboard';
     };
 
     return (

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -26,7 +26,7 @@
         {{#unless this.session.user.isContributor}}
         <div class="gh-nav-top">
             <ul class="gh-nav-list gh-nav-main">
-                {{#if (and (feature "ActivityPub") this.session.user.isOwnerOnly)}}
+                {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
                     <li>
                         <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "house"}}Home</LinkTo>
                     </li>
@@ -34,7 +34,7 @@
                 {{#if (gh-user-can-admin this.session.user)}}
                     <li class="relative gh-nav-list-home">
                         <LinkTo @route="dashboard" @alt="Dashboard" data-test-nav="dashboard">
-                            {{#if (and (feature "ActivityPub") this.session.user.isOwnerOnly)}}
+                            {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
                                 {{svg-jar "gauge"}}
                             {{else}}
                                 {{svg-jar "house"}}
@@ -61,7 +61,7 @@
                     </li>
                 {{/if}}
                 {{#if (gh-user-can-admin this.session.user)}}
-                    {{#if (not (and (feature "ActivityPub") this.session.user.isOwnerOnly))}}
+                    {{#if (not (and (feature "ActivityPub") this.session.user.isAdmin))}}
                         <li class="relative">
                             <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active" }} {{on "click" (fn
                                 this.toggleExploreWindow "" )}} data-test-nav="explore">

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -14,7 +14,7 @@ export default class HomeRoute extends Route {
             return this.router.transitionTo('setup.done');
         }
 
-        if (this.feature.ActivityPub && this.session.user.isOwnerOnly) {
+        if (this.feature.ActivityPub && this.session.user.isAdmin) {
             this.router.transitionTo('activitypub-x');
         } else {
             this.router.transitionTo('dashboard');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-985/display-ap-views-for-both-owners-and-admins

- ActivityPub is now available to Owner and Admin staff users
