### PR TITLE
Fixed duplicate KPI entries on stats page

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 
-export const TB_VERSION = 4;
+export const TB_VERSION = 5;
 
 export const RANGE_OPTIONS = [
     {name: 'Last 24 hours', value: 1},

--- a/ghost/web-analytics/datasources/_mv_hits.datasource
+++ b/ghost/web-analytics/datasources/_mv_hits.datasource
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 SCHEMA >
     `site_uuid` LowCardinality(String),

--- a/ghost/web-analytics/datasources/_mv_session_data.datasource
+++ b/ghost/web-analytics/datasources/_mv_session_data.datasource
@@ -1,0 +1,14 @@
+VERSION 5
+
+SCHEMA >
+    `site_uuid` String,
+    `session_id` String,
+    `pageviews` UInt64,
+    `first_pageview` DateTime,
+    `last_pageview` DateTime,
+    `duration` Int64,
+    `is_bounce` Boolean
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(first_pageview)"
+ENGINE_SORTING_KEY "site_uuid, first_pageview, session_id"

--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -1,108 +1,118 @@
-VERSION 4
+VERSION 5
 
 NODE timeseries
 SQL >
+
     %
-    {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
-    with
-        {% if defined(date_from) %}
-            toStartOfDay(
-                toDate(
-                    {{
-                        Date(
-                            date_from,
-                            description="Starting day for filtering a date range",
-                            required=False,
-                        )
-                    }}
-                )
-            ) as start,
-        {% else %} toStartOfDay(timestampAdd(today(), interval -7 day)) as start,
-        {% end %}
-        {% if defined(date_to) %}
-            toStartOfDay(
-                toDate(
-                    {{
-                        Date(
-                            date_to,
-                            description="Finishing day for filtering a date range",
-                            required=False,
-                        )
-                    }}
-                )
-            ) as end
-        {% else %} toStartOfDay(today()) as end
-        {% end %}
-    {% if _single_day %}
-        select
-            arrayJoin(
-                arrayMap(
-                    x -> toDateTime(x),
-                    range(
-                        toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+        {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
+        with
+            {% if defined(date_from) %}
+                toStartOfDay(
+                    toDate(
+                        {{
+                            Date(
+                                date_from,
+                                description="Starting day for filtering a date range",
+                                required=False,
+                            )
+                        }}
                     )
-                )
-            ) as date
-    {% else %}
-        select
-            arrayJoin(
-                arrayMap(
-                    x -> toDate(x),
-                    range(toUInt32(start), toUInt32(timestampAdd(end, interval 1 day)), 24 * 3600)
-                )
-            ) as date
-    {% end %}
+                ) as start,
+            {% else %} toStartOfDay(timestampAdd(today(), interval -7 day)) as start,
+            {% end %}
+            {% if defined(date_to) %}
+                toStartOfDay(
+                    toDate(
+                        {{
+                            Date(
+                                date_to,
+                                description="Finishing day for filtering a date range",
+                                required=False,
+                            )
+                        }}
+                    )
+                ) as end
+            {% else %} toStartOfDay(today()) as end
+            {% end %}
+        {% if _single_day %}
+            select
+                arrayJoin(
+                    arrayMap(
+                        x -> toDateTime(x),
+                        range(
+                            toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                        )
+                    )
+                ) as date
+        {% else %}
+            select
+                arrayJoin(
+                    arrayMap(
+                        x -> toDate(x),
+                        range(toUInt32(start), toUInt32(timestampAdd(end, interval 1 day)), 24 * 3600)
+                    )
+                ) as date
+        {% end %}
+
+
 
 NODE filtered_sessions
 DESCRIPTION >
     Get sessions that match the filter criteria
+    
 SQL >
     %
-    select distinct session_id
-    from mv_hits
-    where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %} and toDate(timestamp) >= {{ Date(date_from) }} {% else %} and toDate(timestamp) >= timestampAdd(today(), interval -7 day) {% end %}
-        {% if defined(date_to) %} and toDate(timestamp) <= {{ Date(date_to) }} {% else %} and toDate(timestamp) <= today() {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        select distinct session_id
+        from mv_hits
+        where
+             site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+            {% if defined(date_from) %} and toDate(timestamp) >= {{ Date(date_from) }} {% else %} and toDate(timestamp) >= timestampAdd(today(), interval -7 day) {% end %}
+            {% if defined(date_to) %} and toDate(timestamp) <= {{ Date(date_to) }} {% else %} and toDate(timestamp) <= today() {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
 
 NODE session_metrics
 DESCRIPTION >
     Calculate session-level metrics (visits, pageviews, bounce rate, avg session duration)
+
 SQL >
+
     %
-    select
-        site_uuid,
-        {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            toStartOfHour(timestamp) as date,
-        {% else %}
-            toDate(timestamp) as date,
-        {% end %}
-        session_id,
-        count() as pageviews,
-        case when min(timestamp) = max(timestamp) then 1 else 0 end as is_bounce,
-        (max(timestamp) - min(timestamp)) as session_sec
-    from mv_hits
-    where
-        session_id in (select session_id from filtered_sessions)
-        {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            and toDate(timestamp) = {{ Date(date_from) }}
-        {% else %}
-            {% if defined(date_from) %} and toDate(timestamp) >= {{ Date(date_from) }} {% else %} and toDate(timestamp) >= timestampAdd(today(), interval -7 day) {% end %}
-            {% if defined(date_to) %} and toDate(timestamp) <= {{ Date(date_to) }} {% else %} and toDate(timestamp) <= today() {% end %}
-        {% end %}
-    group by site_uuid, {% if defined(date_from) and day_diff(date_from, date_to) == 0 %} toStartOfHour(timestamp) {% else %} toDate(timestamp) {% end %}, session_id
+        select
+            site_uuid,
+            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                toStartOfHour(first_pageview) as date,
+            {% else %}
+                toDate(first_pageview) as date,
+            {% end %}
+            session_id,
+            pageviews,
+            is_bounce,
+            duration as session_sec
+        from mv_session_data
+        where
+            site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+            and session_id in (select session_id from filtered_sessions)
+            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                and toDate(first_pageview) = {{ Date(date_from) }}
+            {% else %}
+                {% if defined(date_from) %} and toDate(first_pageview) >= {{ Date(date_from) }} {% else %} and toDate(first_pageview) >= timestampAdd(today(), interval -7 day) {% end %}
+                {% if defined(date_to) %} and toDate(first_pageview) <= {{ Date(date_to) }} {% else %} and toDate(first_pageview) <= today() {% end %}
+            {% end %}
+
+
 
 NODE data
 DESCRIPTION >
     Calculate KPIs per time period
+
 SQL >
+
     select
         a.date,
         uniq(distinct s.session_id) as visits,
@@ -114,10 +124,14 @@ SQL >
     group by a.date
     order by a.date
 
+
+
 NODE finished_data
 DESCRIPTION >
     Calculate finished KPIs per time period
+
 SQL >
+
     select
         a.date,
         coalesce(b.visits, 0) as visits,
@@ -126,3 +140,5 @@ SQL >
         coalesce(b.avg_session_sec, 0) as avg_session_sec
     from timeseries a
     left join data b on a.date = b.date
+
+

--- a/ghost/web-analytics/pipes/api_top_browsers.pipe
+++ b/ghost/web-analytics/pipes/api_top_browsers.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_browsers_0
 SQL >

--- a/ghost/web-analytics/pipes/api_top_devices.pipe
+++ b/ghost/web-analytics/pipes/api_top_devices.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_devices_0
 SQL >

--- a/ghost/web-analytics/pipes/api_top_locations.pipe
+++ b/ghost/web-analytics/pipes/api_top_locations.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_locations_0
 SQL >

--- a/ghost/web-analytics/pipes/api_top_os.pipe
+++ b/ghost/web-analytics/pipes/api_top_os.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_os_0
 SQL >

--- a/ghost/web-analytics/pipes/api_top_pages.pipe
+++ b/ghost/web-analytics/pipes/api_top_pages.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_pages_0
 SQL >

--- a/ghost/web-analytics/pipes/api_top_sources.pipe
+++ b/ghost/web-analytics/pipes/api_top_sources.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE _top_sources_0
 SQL >

--- a/ghost/web-analytics/pipes/mv_hits.pipe
+++ b/ghost/web-analytics/pipes/mv_hits.pipe
@@ -1,4 +1,4 @@
-VERSION 4
+VERSION 5
 
 NODE mv_hits_0
 SQL >
@@ -20,8 +20,6 @@ SQL >
         lower(toString(getSubcolumn(payload,'user-agent'))) as user_agent
     FROM analytics_events
     where action = 'page_hit'
-
-
 
 NODE mv_hits_1
 SQL >
@@ -79,5 +77,3 @@ SQL >
 
 TYPE materialized
 DATASOURCE _mv_hits
-
-

--- a/ghost/web-analytics/pipes/mv_session_data.pipe
+++ b/ghost/web-analytics/pipes/mv_session_data.pipe
@@ -1,0 +1,27 @@
+VERSION 5
+
+NODE mv_hits_0
+SQL >
+    SELECT 
+        site_uuid,
+        session_id,
+        finalizeAggregation(countState()) as pageviews,
+        finalizeAggregation(minState(timestamp)) as first_pageview,
+        finalizeAggregation(maxState(timestamp)) as last_pageview
+    FROM _mv_hits__v4
+    GROUP BY site_uuid, session_id
+
+NODE data
+SQL >
+    SELECT 
+        site_uuid,
+        session_id,
+        pageviews,
+        first_pageview,
+        last_pageview,
+        last_pageview - first_pageview as duration,
+        pageviews = 1 as is_bounce
+    FROM mv_hits_0
+
+TYPE materialized
+DATASOURCE _mv_session_data


### PR DESCRIPTION
 ref https://linear.app/ghost/issue/ANAL-174/
 - updated pipes to filter out sessions based on site uuid AND session id

 Session ID should be unique per site, though we found it was not. This likely a limitation of the existing tracking script (ghost-stats, copied off flock.js) that will need a separate update.