### PR TITLE
Fixed reading progress indicator in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -411,6 +411,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
     history = [],
     remotePostId = null
 }) => {
+    const modalRef = useRef<HTMLElement>(null);
     const MODAL_SIZE_SM = 640;
     const MODAL_SIZE_LG = 1420;
     const [isFocused, setIsFocused] = useFocusedState(focusReply);
@@ -593,7 +594,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
     const PROGRESS_INCREMENT = 5; // Progress is shown in 5% increments (0%, 5%, 10%, etc.)
 
     useEffect(() => {
-        const container = document.querySelector('.overflow-y-auto');
+        const container = modalRef.current;
         const article = document.getElementById('object-content');
 
         const handleScroll = () => {
@@ -605,23 +606,18 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
                 return;
             }
 
-            const articleRect = article.getBoundingClientRect();
-            const containerRect = container.getBoundingClientRect();
+            // Get scroll position
+            const scrollTop = container.scrollTop;
+            // Get the total scrollable height (content height - viewport height)
+            const scrollHeight = container.scrollHeight - container.clientHeight;
 
-            const isContentShorterThanViewport = articleRect.height <= containerRect.height;
-
-            if (isContentShorterThanViewport) {
-                debouncedSetReadingProgress(100);
-                return;
-            }
-
-            const scrolledPast = Math.max(0, containerRect.top - articleRect.top);
-            const totalHeight = (article as HTMLElement).offsetHeight - (container as HTMLElement).offsetHeight;
-
-            const rawProgress = Math.min(Math.max((scrolledPast / totalHeight) * 100, 0), 100);
+            // Calculate percentage
+            const rawProgress = (scrollTop / scrollHeight) * 100;
             const progress = Math.round(rawProgress / PROGRESS_INCREMENT) * PROGRESS_INCREMENT;
 
-            debouncedSetReadingProgress(progress);
+            // Ensure progress stays between 0 and 100
+            const boundedProgress = Math.min(Math.max(progress, 0), 100);
+            debouncedSetReadingProgress(boundedProgress);
         };
 
         if (isLoading) {
@@ -740,6 +736,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
 
     return (
         <Modal
+            ref={modalRef}
             align='right'
             allowBackgroundInteraction={false}
             animate={true}
@@ -1035,7 +1032,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
                                 <div className='pointer-events-auto text-gray-600'>
                                     {getReadingTime(object.content ?? '')}
                                 </div>
-                                <div className='pointer-events-auto text-gray-600 transition-all duration-200 ease-out'>
+                                <div key={readingProgress} className='pointer-events-auto min-w-10 text-right text-gray-600 transition-all duration-200 ease-out'>
                                     {readingProgress}%
                                 </div>
                             </div>

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -591,7 +591,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
     // Add debounced version of setReadingProgress
     const [debouncedSetReadingProgress] = useDebounce(setReadingProgress, 100);
 
-    const PROGRESS_INCREMENT = 5; // Progress is shown in 5% increments (0%, 5%, 10%, etc.)
+    const PROGRESS_INCREMENT = 1; // Progress is shown in 5% increments (0%, 5%, 10%, etc.)
 
     useEffect(() => {
         const container = modalRef.current;

--- a/apps/admin-x-design-system/src/global/modal/Modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/Modal.tsx
@@ -1,6 +1,6 @@
 import {useModal} from '@ebay/nice-modal-react';
 import clsx from 'clsx';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, forwardRef} from 'react';
 import useGlobalDirtyState from '../../hooks/useGlobalDirtyState';
 import {confirmIfDirty} from '../../utils/modals';
 import Button, {ButtonColor, ButtonProps} from '../Button';
@@ -52,7 +52,7 @@ export interface ModalProps {
 
 export const topLevelBackdropClasses = 'bg-[rgba(98,109,121,0.2)] backdrop-blur-[3px]';
 
-const Modal: React.FC<ModalProps> = ({
+const Modal = forwardRef<HTMLElement, ModalProps>(({
     size = 'md',
     align = 'center',
     width,
@@ -85,7 +85,7 @@ const Modal: React.FC<ModalProps> = ({
     formSheet = false,
     enableCMDS = true,
     allowBackgroundInteraction = false
-}) => {
+}, ref) => {
     const modal = useModal();
     const {setGlobalDirtyState} = useGlobalDirtyState();
     const [animationFinished, setAnimationFinished] = useState(false);
@@ -430,7 +430,7 @@ const Modal: React.FC<ModalProps> = ({
                 (backDrop && !formSheet) && topLevelBackdropClasses,
                 formSheet && 'bg-[rgba(98,109,121,0.08)]'
             )}></div>
-            <section className={clsx(
+            <section ref={ref} className={clsx(
                 modalClasses,
                 allowBackgroundInteraction && 'pointer-events-auto'
             )} data-testid={testId} style={modalStyles}>
@@ -453,6 +453,8 @@ const Modal: React.FC<ModalProps> = ({
             </section>
         </div>
     );
-};
+});
+
+Modal.displayName = 'Modal';
 
 export default Modal;


### PR DESCRIPTION
ref AP-970

- the selector for the container element was too generic that was using a tailwind class
- for this reason, it didn't select the correct container, and the scroll event wasn't firing at all
- this makes the Modal component forward its ref, and uses that ref as the container element to make it more specific
- also it forces re-rendering for the reading progress element by adding a key to it
