### PR TITLE
Removed debug log from Traffic Analytics

### DIFF
--- a/ghost/admin/app/templates/stats.hbs
+++ b/ghost/admin/app/templates/stats.hbs
@@ -166,7 +166,6 @@
                 </button>
             </div>
         </div>
-        No audience selected
         {{/if}}
 
     </section>


### PR DESCRIPTION
- There's been an unnecessary static text on the empty stats page in Traffic Analytics