### PR TITLE
Added post stats to the new explore service

### DIFF
--- a/ghost/core/core/server/services/explore-ping/index.js
+++ b/ghost/core/core/server/services/explore-ping/index.js
@@ -5,6 +5,7 @@ const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
 const request = require('@tryghost/request');
 const settingsCache = require('../../../shared/settings-cache');
+const posts = require('../posts/posts-service');
 
 // Export the creation function for testing
 module.exports.createService = function createService() {
@@ -14,7 +15,8 @@ module.exports.createService = function createService() {
         labs,
         logging,
         ghostVersion,
-        request
+        request,
+        posts: posts()
     });
 };
 

--- a/ghost/core/core/server/services/posts/stats/PostStats.js
+++ b/ghost/core/core/server/services/posts/stats/PostStats.js
@@ -21,6 +21,19 @@ class PostStats {
     }
 
     /**
+     * Returns the first published post date
+     */
+    async getFirstPublishedPostDate() {
+        const result = await this.#db.knex.select('published_at')
+            .from('posts')
+            .whereIn('status', ['sent', 'published'])
+            .orderBy('published_at', 'asc')
+            .limit(1);
+
+        return result?.[0]?.published_at ? new Date(result?.[0]?.published_at) : null;
+    }
+
+    /**
      * Fetches count of all published posts
      */
     async getTotalPostsPublished() {


### PR DESCRIPTION
- The purpose of explore is to create a centralised listing of interesting sites for discovery purposes
- In order to find interesting sites, we need some data about the site
- This is a first set of "stats" around posts/publishing a simple count and first/last post date
- This gives us information about the scale and age of a site, very useful for discovery
- I've implemented this using the exiting poststats service, that was created for the OG explore implementation this already has tailor-built queries, bypassing bookshelf, because we're only looking for raw numbers
- We accept that underlying changes to the business logic of the models could require these queries to be updated

