### PR TITLE
Added tooling for running sql directly in tb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ tsconfig.tsbuildinfo
 .tinyb
 .venv
 .diff_tmp
+temp*.sql
 
 # Docker Yarn Cache
 .yarncache

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -17,6 +17,22 @@ prompt_tb() {
     echo $TB_BRANCH
 }
 
+# Function to run SQL queries from files
+tbsql() {
+    if [ -z "$1" ]; then
+        echo "Usage: tbsql <filename without .sql>"
+        return 1
+    fi
+
+    local sql_file="/ghost/ghost/web-analytics/sql/$1.sql"
+    if [ ! -f "$sql_file" ]; then
+        echo "Error: SQL file not found: $sql_file"
+        return 1
+    fi
+
+    tb sql "$(cat $sql_file)"
+}
+
 # Export the prompt with Tinybird branch information
 export PS1="\w\$(prompt_tb)\$ "
 

--- a/ghost/web-analytics/sql/README.md
+++ b/ghost/web-analytics/sql/README.md
@@ -1,0 +1,10 @@
+Run files in this folder by opening the tb cli:
+
+`yarn tb`
+
+And then running tbsql with the filename, minus .sql
+
+`tbsql example`
+
+You can have temporary files in this folder named `temp*.sql`
+This pattern is added to .gitignore, so they won't get committed

--- a/ghost/web-analytics/sql/example.sql
+++ b/ghost/web-analytics/sql/example.sql
@@ -1,0 +1,3 @@
+select timestamp, site_uuid, session_id from analytics_events
+WHERE timestamp > now() - INTERVAL 1 day
+ORDER BY timestamp DESC


### PR DESCRIPTION
- This is a tool to aid with debugging various steps of the process in tb
- It can be a challenge to see what raw queries are doing, and clicking around the UI is error prone and not repeatable
- The tb cli tool has `tb sql [query]` which is great, but typing out and fixing queries is a PITA
- Using the changes here, we can collect useful SQL snippets in the sql folder, and easily run them by first opening the tb cli using `yarn tb` and then typing `tbsql [name-of-file]` to run the sql query
- The file pattern `temp*.sql` is added to `.gitignore`, so you can always have a scratch pad going in your IDE without accidentally committing it


