### PR TITLE
Fixed compose.yml node_modules volumes

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -197,7 +197,7 @@ volumes:
   node_modules_ghost_domain-events: {}
   node_modules_ghost_donations: {}
   node_modules_ghost_email-addresses: {}
-  node_modules_ghost_email-analytics-provider-mailgun: {}
+  node_modules_ghost_email-analytics-service: {}
   node_modules_ghost_email-content-generator: {}
   node_modules_ghost_email-events: {}
   node_modules_ghost_email-service: {}


### PR DESCRIPTION
no issue

- The email-analytics-service volume in compose.yml was accidentally removed when deleting the email-analytics-provider-mailgun package, causing `docker compose up` to fail — this fixes that.
