### PR TITLE
Switched traffic analytics charts to use the browser's timezone

### DIFF
--- a/ghost/admin/app/components/stats/charts/kpis.js
+++ b/ghost/admin/app/components/stats/charts/kpis.js
@@ -20,8 +20,7 @@ export default class KpisComponent extends Component {
 
         const params = getStatsParams(
             this.config,
-            props,
-            {timezone: this.settings.timezone}
+            props
         );
 
         const {data, meta, error, loading} = useQuery({

--- a/ghost/admin/app/components/stats/charts/technical.js
+++ b/ghost/admin/app/components/stats/charts/technical.js
@@ -38,7 +38,7 @@ export default class TechnicalComponent extends Component {
         const params = getStatsParams(
             this.config,
             props,
-            {limit: 5, timezone: this.settings.timezone}
+            {limit: 5}
         );
 
         let endpoint;

--- a/ghost/admin/app/components/stats/charts/top-locations.js
+++ b/ghost/admin/app/components/stats/charts/top-locations.js
@@ -59,7 +59,7 @@ export default class TopLocations extends Component {
         const params = getStatsParams(
             this.config,
             props,
-            {limit: 7, timezone: this.settings.timezone}
+            {limit: 7}
         );
 
         const {data, meta, error, loading} = useQuery({

--- a/ghost/admin/app/components/stats/charts/top-pages.js
+++ b/ghost/admin/app/components/stats/charts/top-pages.js
@@ -57,7 +57,7 @@ export default class TopPages extends Component {
         const params = getStatsParams(
             this.config,
             props,
-            {limit: LIMIT + 1, timezone: this.settings.timezone}
+            {limit: LIMIT + 1}
         );
 
         const {data, meta, error, loading} = useQuery({

--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -62,7 +62,7 @@ export default class TopSources extends Component {
             params: getStatsParams(
                 this.config,
                 props,
-                {limit: 7, timezone: this.settings.timezone}
+                {limit: 7}
             )
         });
 

--- a/ghost/admin/app/components/stats/kpis-overview.js
+++ b/ghost/admin/app/components/stats/kpis-overview.js
@@ -59,8 +59,7 @@ export default class KpisOverview extends Component {
         try {
             const params = new URLSearchParams(getStatsParams(
                 this.config,
-                args,
-                {timezone: this.settings.timezone}
+                args
             ));
 
             const endpoint = `${this.config.stats.endpoint}/v0/pipes/api_kpis__v${TB_VERSION}.json?${params}`;

--- a/ghost/admin/app/components/stats/modal-stats-all.js
+++ b/ghost/admin/app/components/stats/modal-stats-all.js
@@ -17,7 +17,6 @@ export default class AllStatsModal extends Component {
     @inject config;
     @service router;
     @service modals;
-    @service settings;
 
     get type() {
         return this.args.data.type;

--- a/ghost/admin/app/components/stats/modal-stats-all.js
+++ b/ghost/admin/app/components/stats/modal-stats-all.js
@@ -17,6 +17,7 @@ export default class AllStatsModal extends Component {
     @inject config;
     @service router;
     @service modals;
+    @service settings;
 
     get type() {
         return this.args.data.type;

--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -144,9 +144,10 @@ export const getCountryFlag = (countryCode) => {
 };
 
 export function getDateRange(chartRange) {
-    const endDate = moment().endOf('day');
-    const startDate = moment().subtract(chartRange - 1, 'days').startOf('day');
-    return {startDate, endDate};
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const endDate = moment().tz(timezone).endOf('day');
+    const startDate = moment().tz(timezone).subtract(chartRange - 1, 'days').startOf('day');
+    return {startDate, endDate, timezone};
 }
 
 export function formatVisitDuration(duration) {
@@ -173,8 +174,8 @@ export function formatVisitDuration(duration) {
 }
 
 export function getStatsParams(config, props, additionalParams = {}) {
-    const {chartRange, audience, device, browser, location, source, pathname, os, timezone} = props;
-    const {startDate, endDate} = getDateRange(chartRange);
+    const {chartRange, audience, device, browser, location, source, pathname, os} = props;
+    const {startDate, endDate, timezone} = getDateRange(chartRange);
 
     const params = {
         site_uuid: props.mockData ? 'mock_site_uuid' : config.stats.id,


### PR DESCRIPTION
no issue

Originally I thought it would be smart to use the site's timezone for all users, regardless of where they are located, so that the data will always match if two people in different timezones are looking at the same filters. However, this created some issues with the charts, since they are all rendered in the browser's timezone, which led to some inconsistencies.

Ultimately I still think it might make sense to use the site timezone, but for now using the browser timezone feels reasonable and importantly it actually works with the charts in the UI as you'd expect it to.