### PR TITLE
Added tinybird-cli to devcontainer

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && \
 ## This stage adds development specific packages like the Stripe CLI, zsh, playwright, etc.
 ## It does not include the source code or node_modules
 FROM base AS development-base
-ARG WORKDIR=/home/ghost
 RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
     apt update && \
     apt install -y \
     git \
     stripe \
+    python3-pip \
     procps && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
@@ -127,6 +127,13 @@ COPY . .
 
 ## Build typescript packages
 RUN yarn nx run-many -t build:ts
+
+# Install the tinybird CLI
+WORKDIR /home/ghost/ghost/web-analytics
+RUN pip install -r requirements.txt
+
+WORKDIR $WORKDIR
+
 
 # Expose the ports
 EXPOSE 2368

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,6 +4,7 @@ ARG WORKDIR=/home/ghost
 # Base Image used for all targets
 ## This stage includes the OS, Node and a few apt packages
 FROM node:$NODE_VERSION-bullseye-slim AS base
+ARG WORKDIR=/home/ghost
 RUN apt-get update && \
     apt-get install -y \
     build-essential \
@@ -133,7 +134,6 @@ WORKDIR /home/ghost/ghost/web-analytics
 RUN pip install -r requirements.txt
 
 WORKDIR $WORKDIR
-
 
 # Expose the ports
 EXPOSE 2368

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,7 +4,6 @@ ARG WORKDIR=/home/ghost
 # Base Image used for all targets
 ## This stage includes the OS, Node and a few apt packages
 FROM node:$NODE_VERSION-bullseye-slim AS base
-ARG WORKDIR=/home/ghost
 RUN apt-get update && \
     apt-get install -y \
     build-essential \
@@ -20,6 +19,7 @@ RUN apt-get update && \
 ## This stage adds development specific packages like the Stripe CLI, zsh, playwright, etc.
 ## It does not include the source code or node_modules
 FROM base AS development-base
+ARG WORKDIR=/home/ghost
 RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
     apt update && \

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docker:build": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose build",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
     "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
-    "docker:sleep:stop": "docker stop ghost-devcontainer && docker rm ghost-devcontainer",
+    "docker:sleep:stop": "docker stop ghost-devcontainer",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm --no-deps ghost yarn test:unit",
     "docker:test:browser": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn test:browser",
     "docker:test:all": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn nx run ghost:test:all",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
     "docker:build": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose build",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
+    "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
+    "docker:sleep:stop": "docker stop ghost-devcontainer && docker rm ghost-devcontainer",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm --no-deps ghost yarn test:unit",
     "docker:test:browser": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn test:browser",
     "docker:test:all": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn nx run ghost:test:all",


### PR DESCRIPTION
no issue

Currently we're using the bespoke tinybird-cli docker container to run CLI commands. We have a command `yarn tb` to open a shell where the CLI is accessible, but we can't run `tb` commands locally or leverage the tinybird VSCode extension without installing the tinybird CLI.

This commit installs the Tinybird CLI in the development docker image, so we can run `tb` commands in a shell in the main Ghost docker image. It also introduces a `package.json` script to run an instance of the Ghost container that just sleeps infinitely, so you can attach your IDE to the container and run `tb` commands directly from your IDE's terminal.

Not only is this more convenient than keeping an extra terminal tab open to be able to run `tb` commands, it also lets us use the other tools in the devcontainer (e.g. `jq`, `node`, etc) in Tinybird scripts, which we couldn't do before because the tinybird-cli image is pretty barebones.