### PR TITLE
🐛 Fixed newsletter preferences for paid signups

### DIFF
--- a/apps/portal/src/components/pages/NewsletterSelectionPage.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.js
@@ -105,7 +105,10 @@ export default function NewsletterSelectionPage({pageData, onBack}) {
                             disabled={disabled}
                             onClick={() => {
                                 let newsletters = subscribedNewsletters.map((d) => {
-                                    return {name: d.name};
+                                    return {
+                                        id: d.id,
+                                        name: d.name
+                                    };
                                 });
                                 const {name, email, plan, phonenumber, offerId} = pageData;
                                 onAction('signup', {name, email, plan, phonenumber, newsletters, offerId});

--- a/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
@@ -27,7 +27,7 @@ const mockNewsletters = [
 
 const setup = () => {
     const {mockOnActionFn, ...utils} = render(
-        <NewsletterSelectionPage 
+        <NewsletterSelectionPage
             pageData={{
                 name: 'Test User',
                 email: 'test@example.com',
@@ -75,7 +75,7 @@ describe('NewsletterSelectionPage', () => {
         const {getByText, getByTitle} = setup();
         const paidNewsletter = getByText('Paid Newsletter');
         const lockIcon = getByTitle('Unlock access to all newsletters by becoming a paid subscriber.');
-        
+
         expect(paidNewsletter).toBeInTheDocument();
         expect(lockIcon).toBeInTheDocument();
     });
@@ -90,40 +90,40 @@ describe('NewsletterSelectionPage', () => {
             email: 'test@example.com',
             plan: 'free',
             phonenumber: undefined,
-            newsletters: [{name: 'Free Newsletter'}],
+            newsletters: [{name: 'Free Newsletter', id: '1'}],
             offerId: undefined
         });
     });
 
     test('allows selecting multiple free newsletters', async () => {
         const {getAllByTestId, continueBtn, mockOnActionFn} = setup();
-        
+
         // Find and click the switch for the additional free newsletter
         const switches = getAllByTestId('switch-input');
         const additionalNewsletterSwitch = switches[1]; // Second switch (first is default)
-        
+
         fireEvent.click(additionalNewsletterSwitch);
         fireEvent.click(continueBtn);
-    
+
         // Verify both newsletters are included
         expect(mockOnActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
             newsletters: expect.arrayContaining([
-                {name: 'Free Newsletter'},
-                {name: 'Another Free Newsletter'}
+                {name: 'Free Newsletter', id: '1'},
+                {name: 'Another Free Newsletter', id: '3'}
             ])
         }));
     });
 
     test('allows deselecting default newsletter', async () => {
         const {getAllByTestId, continueBtn, mockOnActionFn} = setup();
-        
+
         // Find and click the switch for the default newsletter
         const switches = getAllByTestId('switch-input');
         const defaultNewsletterSwitch = switches[0]; // First switch is default
-        
+
         fireEvent.click(defaultNewsletterSwitch);
         fireEvent.click(continueBtn);
-        
+
         // Verify no newsletters are included
         expect(mockOnActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
             newsletters: []


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-803
ref https://github.com/TryGhost/Ghost/commit/b3a30d63ee

When members signup through the paid flow, we take the `newsletters` payload and attach it to the Stripe checkout session as metadata. Later this is passed to the `add` method of the Member bookshelf model, and picked up by bookshelf-relations to set the newsletters.

When we stopped sending the `id` up in the linked commit, we broke this funtionality because bookshelf-relations doesn't work on the `name` property for Member Newsletters.

