### PR TITLE
Added member total to new explore service

### DIFF
--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -31,12 +31,24 @@ module.exports = class ExplorePingService {
         /* eslint-disable camelcase */
         const {title, description, icon, locale, accent_color, twitter, facebook} = this.settingsCache.getPublic();
 
-        const [totalPosts, lastPublishedAt, firstPublishedAt, totalMembers] = await Promise.all([
+        // Get post statistics
+        const [totalPosts, lastPublishedAt, firstPublishedAt] = await Promise.all([
             this.posts.stats.getTotalPostsPublished(),
             this.posts.stats.getMostRecentlyPublishedPostDate(),
-            this.posts.stats.getFirstPublishedPostDate(),
-            this.members.stats.getTotalMembers()
+            this.posts.stats.getFirstPublishedPostDate()
         ]);
+
+        // Get member statistics with error handling
+        let totalMembers = null;
+        try {
+            totalMembers = await this.members.stats.getTotalMembers();
+        } catch (err) {
+            this.logging.warn('Failed to fetch member statistics', {
+                error: err.message,
+                context: 'explore-ping-service'
+            });
+            // Continue without member statistics
+        }
 
         return {
             ghost: this.ghostVersion.full,

--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -12,8 +12,11 @@ module.exports = class ExplorePingService {
      *   getFirstPublishedPostDate: () => Promise<Date>,
      *   getTotalPostsPublished: () => Promise<number>
      * }}} deps.posts
+     * @param {{stats: {
+     *   getTotalMembers: () => Promise<number>
+     * }}} deps.members
      */
-    constructor({settingsCache, config, labs, logging, ghostVersion, request, posts}) {
+    constructor({settingsCache, config, labs, logging, ghostVersion, request, posts, members}) {
         this.settingsCache = settingsCache;
         this.config = config;
         this.labs = labs;
@@ -21,16 +24,18 @@ module.exports = class ExplorePingService {
         this.ghostVersion = ghostVersion;
         this.request = request;
         this.posts = posts;
+        this.members = members;
     }
 
     async constructPayload() {
         /* eslint-disable camelcase */
         const {title, description, icon, locale, accent_color, twitter, facebook} = this.settingsCache.getPublic();
 
-        const [totalPosts, lastPublishedAt, firstPublishedAt] = await Promise.all([
+        const [totalPosts, lastPublishedAt, firstPublishedAt, totalMembers] = await Promise.all([
             this.posts.stats.getTotalPostsPublished(),
             this.posts.stats.getMostRecentlyPublishedPostDate(),
-            this.posts.stats.getFirstPublishedPostDate()
+            this.posts.stats.getFirstPublishedPostDate(),
+            this.members.stats.getTotalMembers()
         ]);
 
         return {
@@ -45,7 +50,8 @@ module.exports = class ExplorePingService {
             facebook,
             posts_first: firstPublishedAt ? firstPublishedAt.toISOString() : null,
             posts_last: lastPublishedAt ? lastPublishedAt.toISOString() : null,
-            posts_total: totalPosts
+            posts_total: totalPosts,
+            members_total: totalMembers
         };
         /* eslint-enable camelcase */
     }

--- a/ghost/core/core/server/services/explore-ping/index.js
+++ b/ghost/core/core/server/services/explore-ping/index.js
@@ -6,6 +6,7 @@ const ghostVersion = require('@tryghost/version');
 const request = require('@tryghost/request');
 const settingsCache = require('../../../shared/settings-cache');
 const posts = require('../posts/posts-service');
+const members = require('../members');
 
 // Export the creation function for testing
 module.exports.createService = function createService() {
@@ -16,7 +17,8 @@ module.exports.createService = function createService() {
         logging,
         ghostVersion,
         request,
-        posts: posts()
+        posts: posts(),
+        members
     });
 };
 

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -127,6 +127,13 @@ describe('ExplorePingService', function () {
             assert.equal(payload.posts_last, null);
         });
 
+        it('returns null for members_total if no members data available', async function () {
+            membersStub.stats.getTotalMembers.resolves(null);
+
+            const payload = await explorePingService.constructPayload();
+            assert.equal(payload.members_total, null);
+        });
+
         // test that the payload is correct if the timezone is not UTC
         it('returns correct payload if the timezone is not UTC', async function () {
             settingsCacheStub.getPublic.returns({

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -11,6 +11,7 @@ describe('ExplorePingService', function () {
     let ghostVersionStub;
     let requestStub;
     let postsStub;
+    let membersStub;
 
     beforeEach(function () {
         // Setup stubs
@@ -74,6 +75,12 @@ describe('ExplorePingService', function () {
             }
         };
 
+        membersStub = {
+            stats: {
+                getTotalMembers: sinon.stub().resolves(50)
+            }
+        };
+
         explorePingService = new ExplorePingService({
             settingsCache: settingsCacheStub,
             config: configStub,
@@ -81,7 +88,8 @@ describe('ExplorePingService', function () {
             logging: loggingStub,
             ghostVersion: ghostVersionStub,
             request: requestStub,
-            posts: postsStub
+            posts: postsStub,
+            members: membersStub
         });
     });
 
@@ -105,7 +113,8 @@ describe('ExplorePingService', function () {
                 facebook: 'testfb',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
-                posts_first: '2020-01-01T00:00:00.000Z'
+                posts_first: '2020-01-01T00:00:00.000Z',
+                members_total: 50
             });
         });
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/edf7bf42597c213b38b2f90adacf409aeea7878e

- Continuing the work to create a centralised listing of interesting sites
- This is a first stat around members, aimed to help with discovery
- This gives us an indicator of the scale of the readership
- This is wired up using the membmer stats service, same as the old explore endpoint
- Underneath, this uses a raw query for performance
- We accept that underlying changes to the business logic of the models could require this query to be updated

