### PR TITLE
Fixed paths to Stripe libraries

### DIFF
--- a/ghost/core/test/e2e-browser/fixtures/ghost-test.js
+++ b/ghost/core/test/e2e-browser/fixtures/ghost-test.js
@@ -115,7 +115,7 @@ module.exports = base.test.extend({
         const stripeAccountId = await getStripeAccountId();
         const stripeIntegrationToken = await generateStripeIntegrationToken(stripeAccountId);
 
-        const WebhookManager = require('../../../../stripe/lib/WebhookManager');
+        const WebhookManager = require('../../../core/server/services/stripe/WebhookManager');
         const originalParseWebhook = WebhookManager.prototype.parseWebhook;
         const sandbox = sinon.createSandbox();
         sandbox.stub(WebhookManager.prototype, 'parseWebhook').callsFake(function (body, signature) {
@@ -129,7 +129,7 @@ module.exports = base.test.extend({
             }
         });
 
-        const StripeAPI = require('../../../../stripe/lib/StripeAPI');
+        const StripeAPI = require('../../../core/server/services/stripe/StripeAPI');
         const originalStripeConfigure = StripeAPI.prototype.configure;
         sandbox.stub(StripeAPI.prototype, 'configure').callsFake(function (stripeConfig) {
             originalStripeConfigure.call(this, stripeConfig);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2106/stripe

- I moved the files but neglected to update the requires for the browser tests, which are naughty and reach across package boundaries anyway
