### PR TITLE
Fixed kpis chart not displaying graph

### DIFF
--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -183,7 +183,7 @@ NODE finished_data
 SQL >
     %
     select
-        a.date,
+        a.date as date,
         coalesce(b.visits, 0) as visits,
         {% if defined(pathname) %}coalesce(c.pageviews, 0){% else %}coalesce(b.pageviews, 0){% end %} as pageviews,
         coalesce(b.bounce_rate, 0) as bounce_rate,

--- a/ghost/web-analytics/tests/date_range_one_day_filter_pathname_about_kpis.test.result
+++ b/ghost/web-analytics/tests/date_range_one_day_filter_pathname_about_kpis.test.result
@@ -1,4 +1,4 @@
-"a.date","visits","pageviews","bounce_rate","avg_session_sec"
+"date","visits","pageviews","bounce_rate","avg_session_sec"
 "2100-01-03 00:00:00",0,0,0,0
 "2100-01-03 01:00:00",1,1,0,1115
 "2100-01-03 02:00:00",0,1,0,0

--- a/ghost/web-analytics/tests/filter_pathname_about_kpis.test.result
+++ b/ghost/web-analytics/tests/filter_pathname_about_kpis.test.result
@@ -1,4 +1,4 @@
-"a.date","visits","pageviews","bounce_rate","avg_session_sec"
+"date","visits","pageviews","bounce_rate","avg_session_sec"
 "2100-01-01",1,1,0,630
 "2100-01-02",1,1,0,1027
 "2100-01-03",1,2,0,1115


### PR DESCRIPTION
no ref

The return value was a.date instead of date, which the chart didn't pick up.