### PR TITLE
Changed Last 24 hours filter to Today on stats page

### DIFF
--- a/ghost/admin/app/utils/stats.js
+++ b/ghost/admin/app/utils/stats.js
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 export const TB_VERSION = 7;
 
 export const RANGE_OPTIONS = [
-    {name: 'Last 24 hours', value: 1},
+    {name: 'Today', value: 1},
     {name: 'Last 7 days', value: 7},
     {name: 'Last 30 days', value: 30 + 1},
     {name: 'Last 3 months', value: 90 + 1},


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-180/last-24-hours-view-shows-today-not-the-last-24-hours

- The Last 24 hours filter on the stats page is currently showing "Today", not the last 24 hours.
- This changes the filter to say "Today" for now
