### PR TITLE
Fixed following not persisting to followers list in profile view

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.27",
+  "version": "0.6.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -579,7 +579,7 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
                         type: 'Person',
                         preferredUsername: 'index',
                         name: currentAccount.name,
-                        url: currentAccount.url || `https://${window.location.host}/ap/users/${currentAccount.username}`,
+                        url: currentAccount.url,
                         icon: {
                             type: 'Image',
                             url: currentAccount.avatarUrl

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -491,6 +491,13 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
 
             const profileFollowersQueryKey = QUERY_KEYS.profileFollowers(fullHandle);
 
+            // Invalidate the follows query cache for the account performing the follow
+            // because we cannot directly add to it due to potentially incompatible data
+            // shapes
+            const accountFollowsQueryKey = QUERY_KEYS.accountFollows('index', 'following');
+
+            queryClient.invalidateQueries({queryKey: accountFollowsQueryKey});
+
             // Add new follower to the followers list cache
             queryClient.setQueryData(profileFollowersQueryKey, (oldData?: any) => {
                 if (!oldData?.pages?.[0]) return oldData;

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -395,19 +395,66 @@ export function useUnfollowMutationForUser(handle: string, onSuccess: () => void
             // Update the profile followers query cache for the profile being unfollowed
             const profileFollowersQueryKey = QUERY_KEYS.profileFollowers(fullHandle);
 
-            queryClient.setQueryData(profileFollowersQueryKey, (oldData?: any) => {
-                if (!oldData?.pages?.[0]) return oldData;
+            queryClient.setQueryData(profileFollowersQueryKey, (oldData?: {
+                pages: Array<{
+                    followers: Array<{
+                        actor: {
+                            id: string;
+                            type: string;
+                            preferredUsername: string;
+                            name: string;
+                            url: string;
+                            icon: {
+                                type: string;
+                                url: string;
+                            };
+                        };
+                        isFollowing: boolean;
+                    }>;
+                }>;
+            }) => {
+                if (!oldData?.pages?.[0]) {
+                    return oldData;
+                }
 
                 const currentAccount = queryClient.getQueryData<Account>(QUERY_KEYS.account('index'));
-                if (!currentAccount) return oldData;
+                if (!currentAccount) {
+                    return oldData;
+                }
 
                 return {
                     ...oldData,
-                    pages: oldData.pages.map((page: any) => ({
+                    pages: oldData.pages.map((page: {
+                        followers: Array<{
+                            actor: {
+                                id: string;
+                                type: string;
+                                preferredUsername: string;
+                                name: string;
+                                url: string;
+                                icon: {
+                                    type: string;
+                                    url: string;
+                                };
+                            };
+                            isFollowing: boolean;
+                        }>;
+                    }) => ({
                         ...page,
-                        followers: page.followers.filter((follower: any) => 
-                            follower.actor.id !== currentAccount.id
-                        )
+                        followers: page.followers.filter((follower: {
+                            actor: {
+                                id: string;
+                                type: string;
+                                preferredUsername: string;
+                                name: string;
+                                url: string;
+                                icon: {
+                                    type: string;
+                                    url: string;
+                                };
+                            };
+                            isFollowing: boolean;
+                        }) => follower.actor.id !== currentAccount.id)
                     }))
                 };
             });
@@ -499,12 +546,32 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
             queryClient.invalidateQueries({queryKey: accountFollowsQueryKey});
 
             // Add new follower to the followers list cache
-            queryClient.setQueryData(profileFollowersQueryKey, (oldData?: any) => {
-                if (!oldData?.pages?.[0]) return oldData;
+            queryClient.setQueryData(profileFollowersQueryKey, (oldData?: {
+                pages: Array<{
+                    followers: Array<{
+                        actor: {
+                            id: string;
+                            type: string;
+                            preferredUsername: string;
+                            name: string;
+                            url: string;
+                            icon: {
+                                type: string;
+                                url: string;
+                            };
+                        };
+                        isFollowing: boolean;
+                    }>;
+                }>;
+            }) => {
+                if (!oldData?.pages?.[0]) {
+                    return oldData;
+                }
 
                 const currentAccount = queryClient.getQueryData<Account>(QUERY_KEYS.account('index'));
-                console.log('currentAccount: ', currentAccount);
-                if (!currentAccount) return oldData;
+                if (!currentAccount) {
+                    return oldData;
+                }
                 
                 const newFollower = {
                     actor: {
@@ -520,9 +587,6 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
                     },
                     isFollowing: false
                 };
-
-                console.log('data on page 0: ', oldData.pages[0]);
-                console.log('currentAccount: ', currentAccount);
 
                 return {
                     ...oldData,


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/AP-959

- While following/unfollowing user from profile view, there was no caching on the UI rather it will call the API and update the followers list that's why it was super slow. 
- Added caching on following/unfollowing which makes the update of followers list smoother