### PR TITLE
Fixed duplicate session entries in mv_session_data

### DIFF
--- a/ghost/web-analytics/datasources/_mv_pages.datasource
+++ b/ghost/web-analytics/datasources/_mv_pages.datasource
@@ -1,5 +1,4 @@
 VERSION 3
-TAGS "v0"
 
 SCHEMA >
     `site_uuid` String,

--- a/ghost/web-analytics/datasources/_mv_session_data.datasource
+++ b/ghost/web-analytics/datasources/_mv_session_data.datasource
@@ -1,15 +1,16 @@
 VERSION 7
+# Data Source created from Pipe 'mv_session_data__v7'
 
 SCHEMA >
-    `site_uuid` String,
+    `site_uuid` LowCardinality(String),
     `session_id` String,
     `pageviews` UInt64,
     `first_pageview` DateTime,
     `last_pageview` DateTime,
-    `duration` Int64,
-    `is_bounce` Bool,
+    `duration` Int32,
+    `is_bounce` UInt8,
     `source` String
 
-ENGINE "MergeTree"
+ENGINE "ReplacingMergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(first_pageview)"
-ENGINE_SORTING_KEY "site_uuid, first_pageview, session_id"
+ENGINE_SORTING_KEY "site_uuid, session_id"

--- a/ghost/web-analytics/datasources/_mv_sessions.datasource
+++ b/ghost/web-analytics/datasources/_mv_sessions.datasource
@@ -1,5 +1,4 @@
 VERSION 3
-TAGS "v0"
 
 SCHEMA >
     `site_uuid` String,

--- a/ghost/web-analytics/datasources/_mv_sources.datasource
+++ b/ghost/web-analytics/datasources/_mv_sources.datasource
@@ -1,5 +1,4 @@
 VERSION 3
-TAGS "v0"
 
 SCHEMA >
     `site_uuid` String,

--- a/ghost/web-analytics/datasources/analytics_events.datasource
+++ b/ghost/web-analytics/datasources/analytics_events.datasource
@@ -1,7 +1,6 @@
 TOKEN "tracker" APPEND
 
 
-
 SCHEMA >
     `timestamp` DateTime `json:$.timestamp`,
     `session_id` String `json:$.session_id`,

--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -1,59 +1,59 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE timeseries
 SQL >
+
     %
-            {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            with
-                {% if defined(date_from) %}
-                    toStartOfDay(
-                        toDate(
-                            {{
-                                Date(
-                                    date_from,
-                                    description="Starting day for filtering a date range",
-                                    required=False,
-                                )
-                            }}
-                        )
-                    ) as start,
-                {% else %} toStartOfDay(timestampAdd(today(), interval -7 day)) as start,
-                {% end %}
-                {% if defined(date_to) %}
-                    toStartOfDay(
-                        toDate(
-                            {{
-                                Date(
-                                    date_to,
-                                    description="Finishing day for filtering a date range",
-                                    required=False,
-                                )
-                            }}
-                        )
-                    ) as end
-                {% else %} toStartOfDay(today()) as end
-                {% end %}
-            {% if _single_day %}
-                select
-                    arrayJoin(
-                        arrayMap(
-                            x -> toDateTime(toString(toDateTime(x)), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}),
-                            range(
-                                toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                with
+                    {% if defined(date_from) %}
+                        toStartOfDay(
+                            toDate(
+                                {{
+                                    Date(
+                                        date_from,
+                                        description="Starting day for filtering a date range",
+                                        required=False,
+                                    )
+                                }}
                             )
-                        )
-                    ) as date
-            {% else %}
-                select
-                    arrayJoin(
-                        arrayMap(
-                            x -> toDate(x),
-                            range(toUInt32(start), toUInt32(timestampAdd(end, interval 1 day)), 24 * 3600)
-                        )
-                    ) as date
-            {% end %}
+                        ) as start,
+                    {% else %} toStartOfDay(timestampAdd(today(), interval -7 day)) as start,
+                    {% end %}
+                    {% if defined(date_to) %}
+                        toStartOfDay(
+                            toDate(
+                                {{
+                                    Date(
+                                        date_to,
+                                        description="Finishing day for filtering a date range",
+                                        required=False,
+                                    )
+                                }}
+                            )
+                        ) as end
+                    {% else %} toStartOfDay(today()) as end
+                    {% end %}
+                {% if _single_day %}
+                    select
+                        arrayJoin(
+                            arrayMap(
+                                x -> toDateTime(toString(toDateTime(x)), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}),
+                                range(
+                                    toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                                )
+                            )
+                        ) as date
+                {% else %}
+                    select
+                        arrayJoin(
+                            arrayMap(
+                                x -> toDate(x),
+                                range(toUInt32(start), toUInt32(timestampAdd(end, interval 1 day)), 24 * 3600)
+                            )
+                        ) as date
+                {% end %}
 
 
 
@@ -62,20 +62,23 @@ DESCRIPTION >
     Get sessions that match the filter criteria
 
 SQL >
+
     %
-            select distinct session_id
-            from mv_hits
-            where
-                 site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-                {% if defined(date_from) %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) >= {{ Date(date_from) }} {% else %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) >= timestampAdd(today(), interval -7 day) {% end %}
-                {% if defined(date_to) %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) <= {{ Date(date_to) }} {% else %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) <= today() {% end %}
-                {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-                {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-                {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-                {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-                {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-                {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-                {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+                select distinct session_id
+                from mv_hits
+                where
+                     site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+                    {% if defined(date_from) %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) >= {{ Date(date_from) }} {% else %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) >= timestampAdd(today(), interval -7 day) {% end %}
+                    {% if defined(date_to) %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) <= {{ Date(date_to) }} {% else %} and toDate(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) <= today() {% end %}
+                    {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+                    {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+                    {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+                    {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+                    {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+                    {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+                    {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+
+
 
 NODE session_metrics
 DESCRIPTION >
@@ -84,39 +87,39 @@ DESCRIPTION >
 SQL >
 
     %
-            select
-                site_uuid,
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                    toStartOfHour(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
-                {% else %}
-                    toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
-                {% end %}
-                session_id,
-                {% if defined(pathname) %}
-                    -- Count only hits matching the pathname
-                    (
-                        select count()
-                        from mv_hits h 
-                        inner join filtered_sessions
-                            on h.session_id = filtered_sessions.session_id
-                        where h.pathname = {{ String(pathname) }}
-                          and h.session_id = session_id
-                    ) as pageviews,
-                {% else %}
-                    pageviews,
-                {% end %}
-                is_bounce,
-                duration as session_sec
-            from mv_session_data
-            where
-                site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-                and session_id in (select session_id from filtered_sessions)
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                    and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
-                {% else %}
-                    {% if defined(date_from) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
-                    {% if defined(date_to) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
-                {% end %}
+                select
+                    site_uuid,
+                    {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                        toStartOfHour(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                    {% else %}
+                        toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                    {% end %}
+                    session_id,
+                    {% if defined(pathname) %}
+                        -- Count only hits matching the pathname
+                        (
+                            select count()
+                            from mv_hits h 
+                            inner join filtered_sessions
+                                on h.session_id = filtered_sessions.session_id
+                            where h.pathname = {{ String(pathname) }}
+                              and h.session_id = session_id
+                        ) as pageviews,
+                    {% else %}
+                        pageviews,
+                    {% end %}
+                    is_bounce,
+                    duration as session_sec
+                from mv_session_data
+                where
+                    site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+                    and session_id in (select session_id from filtered_sessions)
+                    {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                        and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
+                    {% else %}
+                        {% if defined(date_from) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
+                        {% if defined(date_to) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
+                    {% end %}
 
 
 
@@ -144,50 +147,54 @@ DESCRIPTION >
     Calculate pageviews for specific pathname with time granularity handling
 
 SQL >
+
     %
-    select
-        {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
-        {% else %}
-            toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
-        {% end %}
-        count() pageviews
-    from timeseries a
-    inner join mv_hits h on 
-        {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-        {% else %}
-            a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-        {% end %}
-    where 
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
-        {% else %}
-            {% if defined(date_from) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
-            {% if defined(date_to) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by date
-    order by date
+        select
+            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+            {% else %}
+                toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+            {% end %}
+            count() pageviews
+        from timeseries a
+        inner join mv_hits h on 
+            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            {% else %}
+                a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            {% end %}
+        where 
+            site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
+            {% else %}
+                {% if defined(date_from) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
+                {% if defined(date_to) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by date
+        order by date
 
 
 
 NODE finished_data
 SQL >
+
     %
-    select
-        a.date as date,
-        coalesce(b.visits, 0) as visits,
-        {% if defined(pathname) %}coalesce(c.pageviews, 0){% else %}coalesce(b.pageviews, 0){% end %} as pageviews,
-        coalesce(b.bounce_rate, 0) as bounce_rate,
-        coalesce(b.avg_session_sec, 0) as avg_session_sec
-    from timeseries a
-    left join data b on a.date = b.date
-    {% if defined(pathname) %}left join pathname_pageviews c on a.date = c.date{% end %}
+        select
+            a.date as date,
+            coalesce(b.visits, 0) as visits,
+            {% if defined(pathname) %}coalesce(c.pageviews, 0){% else %}coalesce(b.pageviews, 0){% end %} as pageviews,
+            coalesce(b.bounce_rate, 0) as bounce_rate,
+            coalesce(b.avg_session_sec, 0) as avg_session_sec
+        from timeseries a
+        left join data b on a.date = b.date
+        {% if defined(pathname) %}left join pathname_pageviews c on a.date = c.date{% end %}
+
+

--- a/ghost/web-analytics/pipes/api_top_browsers.pipe
+++ b/ghost/web-analytics/pipes/api_top_browsers.pipe
@@ -1,43 +1,44 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE _top_browsers_0
 SQL >
 
     %
-    select
-        browser,
-        uniqExact(session_id) as visits,
-        count() as pageviews
-    from _mv_hits
-    where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(date_from) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            timestampAdd(today(), interval -7 day)
-        {% end %}
-        {% if defined(date_to) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            today()
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by browser
-    order by visits desc
-    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+        select
+            browser,
+            uniqExact(session_id) as visits,
+            count() as pageviews
+        from _mv_hits
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                timestampAdd(today(), interval -7 day)
+            {% end %}
+            {% if defined(date_to) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                today()
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by browser
+        order by visits desc
+        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+
+

--- a/ghost/web-analytics/pipes/api_top_devices.pipe
+++ b/ghost/web-analytics/pipes/api_top_devices.pipe
@@ -1,43 +1,44 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE _top_devices_0
 SQL >
 
     %
-    select
-        device,
-        uniqExact(session_id) as visits,
-        count() as pageviews
-    from mv_hits
-    where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(date_from) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            timestampAdd(today(), interval -7 day)
-        {% end %}
-        {% if defined(date_to) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            today()
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by device
-    order by visits desc
-    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+        select
+            device,
+            uniqExact(session_id) as visits,
+            count() as pageviews
+        from mv_hits
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                timestampAdd(today(), interval -7 day)
+            {% end %}
+            {% if defined(date_to) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                today()
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by device
+        order by visits desc
+        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+
+

--- a/ghost/web-analytics/pipes/api_top_locations.pipe
+++ b/ghost/web-analytics/pipes/api_top_locations.pipe
@@ -1,43 +1,44 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE _top_locations_0
 SQL >
 
     %
-    select
-        location,
-        uniqExact(session_id) as visits,
-        count() as pageviews
-    from _mv_hits
-    where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(date_from) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            timestampAdd(today(), interval -7 day)
-        {% end %}
-        {% if defined(date_to) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            today()
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by location
-    order by visits desc
-    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+        select
+            location,
+            uniqExact(session_id) as visits,
+            count() as pageviews
+        from _mv_hits
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                timestampAdd(today(), interval -7 day)
+            {% end %}
+            {% if defined(date_to) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                today()
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by location
+        order by visits desc
+        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+
+

--- a/ghost/web-analytics/pipes/api_top_os.pipe
+++ b/ghost/web-analytics/pipes/api_top_os.pipe
@@ -1,43 +1,44 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE _top_os_0
 SQL >
 
     %
-    select
-        os,
-        uniqExact(session_id) as visits,
-        count() as pageviews
-    from _mv_hits
-    where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(date_from) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            timestampAdd(today(), interval -1 year)
-        {% end %}
-        {% if defined(date_to) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            today()
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by os
-    order by visits desc
-    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+        select
+            os,
+            uniqExact(session_id) as visits,
+            count() as pageviews
+        from _mv_hits
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                timestampAdd(today(), interval -1 year)
+            {% end %}
+            {% if defined(date_to) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                today()
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by os
+        order by visits desc
+        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+
+

--- a/ghost/web-analytics/pipes/api_top_pages.pipe
+++ b/ghost/web-analytics/pipes/api_top_pages.pipe
@@ -1,43 +1,44 @@
 VERSION 7
-
-TOKEN stats_page READ
+TOKEN "stats_page" READ
 
 NODE _top_pages_0
 SQL >
 
     %
-    select
-        pathname,
-        uniqExact(session_id) as visits,
-        count() as pageviews
-    from _mv_hits
-    where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(date_from) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            >=
-            timestampAdd(today(), interval -7 day)
-        {% end %}
-        {% if defined(date_to) %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-        {% else %}
-            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-            <=
-            today()
-        {% end %}
-        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-    group by pathname
-    order by visits desc
-    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+        select
+            pathname,
+            uniqExact(session_id) as visits,
+            count() as pageviews
+        from _mv_hits
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                >=
+                timestampAdd(today(), interval -7 day)
+            {% end %}
+            {% if defined(date_to) %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+            {% else %}
+                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                <=
+                today()
+            {% end %}
+            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        group by pathname
+        order by visits desc
+        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+
+

--- a/ghost/web-analytics/pipes/api_top_sources__v7_0751_dup.pipe
+++ b/ghost/web-analytics/pipes/api_top_sources__v7_0751_dup.pipe
@@ -1,8 +1,3 @@
-VERSION 7
-TOKEN "stats_page" READ
-
-TOKEN "api_top_sources__v7_endpoint_read_2345" READ
-
 NODE filtered_sessions
 DESCRIPTION >
     Get sessions that match the filter criteria
@@ -40,7 +35,7 @@ SQL >
 
 
 
-NODE top_sources
+NODE api_top_sources_2
 SQL >
 
     %

--- a/ghost/web-analytics/pipes/mv_hits.pipe
+++ b/ghost/web-analytics/pipes/mv_hits.pipe
@@ -1,5 +1,4 @@
 VERSION 7
-
 NODE mv_hits_0
 SQL >
 
@@ -20,6 +19,8 @@ SQL >
         lower(toString(getSubcolumn(payload,'user-agent'))) as user_agent
     FROM analytics_events
     where action = 'page_hit'
+
+
 
 NODE mv_hits_1
 SQL >
@@ -77,3 +78,5 @@ SQL >
 
 TYPE materialized
 DATASOURCE _mv_hits
+
+

--- a/ghost/web-analytics/pipes/mv_pages.pipe
+++ b/ghost/web-analytics/pipes/mv_pages.pipe
@@ -1,5 +1,5 @@
 VERSION 3
-TAGS "v0"
+TOKEN "stats_page" READ
 
 NODE parsed_hits
 SQL >

--- a/ghost/web-analytics/pipes/mv_session_data.pipe
+++ b/ghost/web-analytics/pipes/mv_session_data.pipe
@@ -1,7 +1,7 @@
 VERSION 7
-
 NODE mv_hits_0
 SQL >
+
     SELECT
         site_uuid,
         session_id,
@@ -12,18 +12,23 @@ SQL >
     FROM _mv_hits
     GROUP BY site_uuid, session_id
 
+
+
 NODE data
 SQL >
+
     SELECT
         site_uuid,
         session_id,
         pageviews,
         first_pageview,
         last_pageview,
-        last_pageview - first_pageview as duration,
-        pageviews = 1 as is_bounce,
+        last_pageview - first_pageview AS duration,
+        pageviews = 1 AS is_bounce,
         source
     FROM mv_hits_0
 
 TYPE materialized
 DATASOURCE _mv_session_data
+
+

--- a/ghost/web-analytics/pipes/mv_sessions.pipe
+++ b/ghost/web-analytics/pipes/mv_sessions.pipe
@@ -1,5 +1,5 @@
 VERSION 3
-TAGS "v0"
+TOKEN "stats_page" READ
 
 NODE parsed_hits
 SQL >

--- a/ghost/web-analytics/pipes/mv_sources.pipe
+++ b/ghost/web-analytics/pipes/mv_sources.pipe
@@ -1,5 +1,5 @@
 VERSION 3
-TAGS "v0"
+TOKEN "stats_page" READ
 
 NODE parsed_hits
 SQL >


### PR DESCRIPTION
no ref

We had incorrect handling of sources, which are attributed to the first hit for a session. This needs to be applied more generally - this only fixes the source component.
