### PR TITLE
Removed sources filter link from stats page

### DIFF
--- a/ghost/admin/app/components/stats/charts/top-sources.js
+++ b/ghost/admin/app/components/stats/charts/top-sources.js
@@ -81,11 +81,12 @@ export default class TopSources extends Component {
                         <span className="gh-stats-data-label">
                             <a
                                 href="#"
+                                style={{cursor: 'default'}}
                                 onClick={(e) => {
                                     e.preventDefault();
-                                    this.navigateToFilter(label || 'direct');
+                                //     this.navigateToFilter(label || 'direct');
                                 }}
-                                className="gh-stats-bar-text"
+                                className="gh-stats-bar-text-nolink"
                             >
                                 <img
                                     src={`https://www.faviconextractor.com/favicon/${label || 'direct'}?larger=true`}

--- a/ghost/admin/app/styles/layouts/stats.css
+++ b/ghost/admin/app/styles/layouts/stats.css
@@ -302,6 +302,14 @@ a.gh-stats-data-label:hover {
     line-height: 1.3em;
 }
 
+.gh-stats-bar-text-nolink {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--black);
+    line-height: 1.3em;
+}
+
 .gh-stats-bar-text:hover span {
     text-decoration: underline;
 }


### PR DESCRIPTION
no ref

Sources filtering is inconsistent so we've disabled the filtering functionality until we can fix it.