### PR TITLE
Added login to dockerhub to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,13 @@ jobs:
         run: sudo service mysql stop
         if: matrix.env.DB == 'mysql8'
 
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: tryghost/mysql-action@main
         if: matrix.env.DB == 'mysql8'
         timeout-minutes: 3


### PR DESCRIPTION
I've proven this iteration does not break forks here: https://github.com/TryGhost/Ghost/pull/22707

This change should mean only fork PRs use our unauthenticated rate limit on dockerhub

----


- We ran into an error: Unable to find image ‘mysql:8.0’ locall
docker: Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit. See ‘docker run --help’.
- It seems we hit our unauthenticated rate limit for dockerhub
- This adds a login, so that we get the authenticated rate limit which is much much higher
- It only attempts the login, if we're not on a fork PR, as that will cause the PR to error out completely because GitHub does not allow forks to access secrets

