### PR TITLE
Unified members/paid-members enabled checks in Admin

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -9,7 +9,7 @@
             <div class="gh-contentfilter gh-btn-group">
                 <button type="button" class="gh-btn {{if (eq this.tab "browser") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changeTab "browser")}}><span>{{svg-jar "desktop"}}</span></button>
                 <button type="button" class="gh-btn {{if (eq this.tab "mobile") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changeTab "mobile")}}><span>{{svg-jar "mobile-phone"}}</span></button>
-                {{#if (and (not-eq this.settings.membersSignupAccess "none") (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
+                {{#if (and this.settings.membersEnabled (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
                     {{#if (and @data.publishOptions.post.isPost (not @data.publishOptions.user.isContributor))}}
                         <button type="button" class="gh-btn {{if (eq this.tab "email") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changeTab "email")}} data-test-button="email-preview"><span>{{svg-jar "email-unread"}}</span></button>
                     {{/if}}

--- a/ghost/admin/app/components/gh-member-details.hbs
+++ b/ghost/admin/app/components/gh-member-details.hbs
@@ -72,7 +72,7 @@
                 {{/if}}
             </div>
 
-            {{#if (and (not-eq this.settings.membersSignupAccess "none") (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
+            {{#if (and this.settings.membersEnabled (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
                 <div class="gh-member-details-stats-container">
                     <h4 class="gh-main-section-header small bn">Engagement</h4>
                     {{#if (eq @member.emailCount 0)}}

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -79,7 +79,7 @@
                 />
             {{/if}}
 
-            {{#if this.membersUtils.paidMembersEnabled}}
+            {{#if this.settings.paidMembersEnabled}}
                 <h4 class="gh-main-section-header small bn">Subscriptions</h4>
 
                 {{#unless this.tiers}}

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -6,7 +6,6 @@ import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
 export default class extends Component {
-    @service membersUtils;
     @service ghostPaths;
     @service ajax;
     @service store;
@@ -24,7 +23,7 @@ export default class extends Component {
     @tracked newslettersList;
 
     get isAddComplimentaryAllowed() {
-        if (!this.membersUtils.paidMembersEnabled) {
+        if (!this.settings.paidMembersEnabled) {
             return false;
         }
 

--- a/ghost/admin/app/components/gh-members-no-members.hbs
+++ b/ghost/admin/app/components/gh-members-no-members.hbs
@@ -1,7 +1,7 @@
 <div class="gh-members-empty">
     {{svg-jar "members-placeholder" class="gh-members-placeholder"}}
     <h4>Start building your audience</h4>
-    {{#if (not-eq this.settings.membersSignupAccess "none")}}
+    {{#if this.settings.membersEnabled}}
         <p>Use memberships to allow your readers to sign up and subscribe to your content.</p>
         <button class="gh-btn gh-btn-green" type="button" {{on "click" this.addYourself}} data-test-button="add-yourself">
             <span>Add yourself as a member to test</span>

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -9,7 +9,7 @@ import {tracked} from '@glimmer/tracking';
 const BASE_FILTERS = ['status:free', 'status:-free'];
 
 export default class GhMembersRecipientSelect extends Component {
-    @service membersUtils;
+    @service settings;
     @service store;
 
     @tracked forceSpecificChecked = false;
@@ -40,7 +40,7 @@ export default class GhMembersRecipientSelect extends Component {
     }
 
     get isPaidAvailable() {
-        return this.membersUtils.isStripeEnabled;
+        return this.settings.paidMembersEnabled;
     }
 
     get specificFilters() {

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -161,7 +161,6 @@ export default class KoenigLexicalEditor extends Component {
     @service feature;
     @service ghostPaths;
     @service koenig;
-    @service membersUtils;
     @service search;
     @service session;
     @service settings;
@@ -283,7 +282,7 @@ export default class KoenigLexicalEditor extends Component {
 
             const memberLinks = () => {
                 let links = [];
-                if (this.membersUtils.paidMembersEnabled) {
+                if (this.settings.paidMembersEnabled) {
                     links = [
                         {
                             label: 'Paid signup',
@@ -447,7 +446,7 @@ export default class KoenigLexicalEditor extends Component {
             deprecated: { // todo fix typo
                 headerV1: true // if false, shows header v1 in the menu
             },
-            membersEnabled: this.settings.membersSignupAccess === 'all',
+            membersEnabled: this.settings.membersEnabled,
             searchLinks,
             siteTitle: this.settings.title,
             siteDescription: this.settings.description,

--- a/ghost/admin/app/components/member-attribution/modals/all-sources.hbs
+++ b/ghost/admin/app/components/member-attribution/modals/all-sources.hbs
@@ -9,7 +9,7 @@
             <div class="gh-dashboard-list-header">
                 <div class="gh-dashboard-list-title">Sources</div>
                 <div class="gh-dashboard-list-title">Free signups</div>
-                    {{#if this.membersUtils.paidMembersEnabled}}
+                    {{#if this.settings.paidMembersEnabled}}
                         <div class="gh-dashboard-list-title"><span class="hide-when-small">Paid </span>Conversions</div>
                     {{/if}}
             </div>
@@ -29,7 +29,7 @@
                                     {{/if}}
                                 </span>
                             </div>
-                                {{#if this.membersUtils.paidMembersEnabled}}
+                                {{#if this.settings.paidMembersEnabled}}
                                     <div class="gh-dashboard-list-item-sub">
                                         <span class="gh-dashboard-metric-minivalue">
                                             {{#if sourceData.paidConversions}}

--- a/ghost/admin/app/components/member-attribution/modals/all-sources.js
+++ b/ghost/admin/app/components/member-attribution/modals/all-sources.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {inject as service} from '@ember/service';
 
 export default class FullAttributionTable extends Component {
-    @service membersUtils;
+    @service settings;
 
     static modalOptions = {
         className: 'epm-modal fullscreen-modal-action fullscreen-modal-wide'

--- a/ghost/admin/app/components/member-attribution/source-attribution-table.hbs
+++ b/ghost/admin/app/components/member-attribution/source-attribution-table.hbs
@@ -6,9 +6,9 @@
             class="gh-dashboard-list-title {{if (eq @sortColumn "signups") "sorted-by"}}"
             {{on "click" (fn @setSortColumn "signups")}}
         >
-            <span class="hide-when-small">Free </span>signups{{#if this.membersUtils.paidMembersEnabled}}{{svg-jar "arrow-down-fill"}}{{/if}}
+            <span class="hide-when-small">Free </span>signups{{#if this.settings.paidMembersEnabled}}{{svg-jar "arrow-down-fill"}}{{/if}}
         </div>
-        {{#if this.membersUtils.paidMembersEnabled}}
+        {{#if this.settings.paidMembersEnabled}}
             <div
                 role="button" aria-label="Sort by paid conversions"
                 class="gh-dashboard-list-title {{if (eq @sortColumn "paid") "sorted-by"}}"
@@ -37,7 +37,7 @@
                             </span>
                         {{/if}}
                     </div>
-                        {{#if this.membersUtils.paidMembersEnabled}}
+                        {{#if this.settings.paidMembersEnabled}}
                             <div class="gh-dashboard-list-item-sub gh-dashboard-list-item-sub-paid {{if (eq @sortColumn "paid") "sorted-by"}}">
                                 {{#if sourceData.paidConversions}}
                                     <span class="gh-dashboard-metric-minivalue">
@@ -69,7 +69,7 @@
                                 </span>
                             {{/if}}
                         </div>
-                        {{#if this.membersUtils.paidMembersEnabled}}
+                        {{#if this.settings.paidMembersEnabled}}
                             <div class="gh-dashboard-list-item-sub gh-dashboard-list-item-sub-other {{if (eq @sortColumn "paid") "sorted-by"}}">
                                 {{#if this.others.paidConversions}}
                                     <span class="gh-dashboard-metric-minivalue">

--- a/ghost/admin/app/components/member-attribution/source-attribution-table.js
+++ b/ghost/admin/app/components/member-attribution/source-attribution-table.js
@@ -4,8 +4,8 @@ import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default class SourceAttributionTable extends Component {
-    @service membersUtils;
     @service modals;
+    @service settings;
 
     @action
     openAllSources() {

--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -51,7 +51,7 @@
         </button>
     </li>
 
-    {{#if this.membersUtils.isMembersEnabled}}
+    {{#if this.settings.membersEnabled}}
         <li>
             <button class="mr2" type="button" {{on "click" this.editPostsAccess}} data-test-button="change-access">
                 <span>{{svg-jar "lock"}}Change access</span>

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -65,7 +65,7 @@ export default class PostsContextMenu extends Component {
     @service infinity;
     @service store;
     @service notifications;
-    @service membersUtils;
+    @service settings;
 
     get menu() {
         return this.args.menu;

--- a/ghost/admin/app/controllers/dashboard.js
+++ b/ghost/admin/app/controllers/dashboard.js
@@ -19,9 +19,9 @@ const DAYS_OPTIONS = [{
 export default class DashboardController extends Controller {
     @service dashboardStats;
     @service feature;
-    @service membersUtils;
     @service mentionUtils;
     @service onboarding;
+    @service settings;
     @service store;
 
     @tracked mentions = [];

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -7,7 +7,7 @@ import {inject as service} from '@ember/service';
 export default class ParseMemberEventHelper extends Helper {
     @service feature;
     @service utils;
-    @service membersUtils;
+    @service settings;
 
     compute([event, hasMultipleNewsletters]) {
         const subject = event.data.member ? (event.data.member.name || event.data.member.email) : (event.data.name || event.data.email || '');
@@ -293,7 +293,7 @@ export default class ParseMemberEventHelper extends Helper {
             return `MRR ${sign}${symbol}${Math.abs(mrrDelta)}`;
         }
 
-        if (event.type === 'signup_event' && this.membersUtils.paidMembersEnabled) {
+        if (event.type === 'signup_event' && this.settings.paidMembersEnabled) {
             return 'Free';
         }
 

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -73,7 +73,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     clock: service(),
     search: service(),
     settings: service(),
-    membersUtils: service(),
 
     config: inject(),
 
@@ -195,7 +194,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     showEmailOpenAnalytics: computed('hasBeenEmailed', 'isSent', 'isPublished', function () {
         return this.hasBeenEmailed
             && !this.session.user.isContributor
-            && this.settings.membersSignupAccess !== 'none'
+            && this.settings.membersEnabled
             && this.email.trackOpens
             && this.settings.emailTrackOpens;
     }),
@@ -203,21 +202,21 @@ export default Model.extend(Comparable, ValidationEngine, {
     showEmailClickAnalytics: computed('hasBeenEmailed', 'isSent', 'isPublished', 'email', function () {
         return this.hasBeenEmailed
             && !this.session.user.isContributor
-            && this.settings.membersSignupAccess !== 'none'
+            && this.settings.membersEnabled
             && (this.isSent || this.isPublished)
             && this.email.trackClicks
             && this.settings.emailTrackClicks;
     }),
 
-    showAttributionAnalytics: computed('isPage', 'emailOnly', 'isPublished', 'membersUtils.isMembersInviteOnly', 'settings.membersTrackSources', function () {
+    showAttributionAnalytics: computed('isPage', 'emailOnly', 'isPublished', 'settings.{membersInviteOnly,membersTrackSources}', function () {
         return (this.isPage || !this.emailOnly)
                 && this.isPublished
                 && this.settings.membersTrackSources
-                && !this.membersUtils.isMembersInviteOnly
+                && !this.settings.membersInviteOnly
                 && !this.session.user.isContributor;
     }),
 
-    showPaidAttributionAnalytics: computed.and('showAttributionAnalytics', 'membersUtils.paidMembersEnabled'),
+    showPaidAttributionAnalytics: computed.and('showAttributionAnalytics', 'settings.paidMembersEnabled'),
 
     hasAnalyticsPage: computed('isPost', 'showEmailOpenAnalytics', 'showEmailClickAnalytics', 'showAttributionAnalytics', function () {
         return this.isPost

--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -86,7 +86,6 @@ export default class DashboardStatsService extends Service {
     @service ghostPaths;
     @service membersCountCache;
     @service settings;
-    @service membersUtils;
     @service membersStats;
 
     /**
@@ -362,17 +361,17 @@ export default class DashboardStatsService extends Service {
             return;
         }
 
-        if (this.membersUtils.paidMembersEnabled) {
+        if (this.settings.paidMembersEnabled) {
             yield this.loadPaidTiers();
         }
 
-        const hasPaidTiers = this.membersUtils.paidMembersEnabled && this.activePaidTiers && this.activePaidTiers.length > 0;
+        const hasPaidTiers = this.settings.paidMembersEnabled && this.activePaidTiers && this.activePaidTiers.length > 0;
 
         this.siteStatus = {
             hasPaidTiers,
             hasMultipleTiers: hasPaidTiers && this.activePaidTiers.length > 1,
             newslettersEnabled: this.settings.editorDefaultEmailRecipients !== 'disabled',
-            membersEnabled: this.membersUtils.isMembersEnabled
+            membersEnabled: this.settings.membersEnabled
         };
     }
 

--- a/ghost/admin/app/services/member-import-validator.js
+++ b/ghost/admin/app/services/member-import-validator.js
@@ -7,7 +7,6 @@ import {isEmpty} from '@ember/utils';
 export default class MemberImportValidatorService extends Service {
     @service ajax;
     @service feature;
-    @service membersUtils;
 
     @service ghostPaths;
 

--- a/ghost/admin/app/services/members-utils.js
+++ b/ghost/admin/app/services/members-utils.js
@@ -11,24 +11,16 @@ export default class MembersUtilsService extends Service {
 
     paidTiers = null;
 
-    get isMembersEnabled() {
-        return this.settings.membersEnabled;
-    }
-
-    get paidMembersEnabled() {
-        return this.settings.paidMembersEnabled;
-    }
-
     get isMembersInviteOnly() {
         return this.settings.membersInviteOnly;
     }
 
     get hasMultipleTiers() {
-        return this.paidMembersEnabled && this.paidTiers && this.paidTiers.length > 1;
+        return this.settings.paidMembersEnabled && this.paidTiers && this.paidTiers.length > 1;
     }
 
     get hasActiveTiers() {
-        return this.paidMembersEnabled && this.paidTiers && this.paidTiers.length > 0;
+        return this.settings.paidMembersEnabled && this.paidTiers && this.paidTiers.length > 0;
     }
 
     async fetch() {
@@ -54,7 +46,7 @@ export default class MembersUtilsService extends Service {
     }
 
     /**
-     * Note: always use paidMembersEnabled! Only use this getter for the Stripe Connection UI.
+     * Note: always use settings.paidMembersEnabled! Only use this getter for the Stripe Connection UI.
      */
     get isStripeEnabled() {
         const stripeDirect = this.config.stripeDirect;

--- a/ghost/admin/app/templates/dashboard.hbs
+++ b/ghost/admin/app/templates/dashboard.hbs
@@ -102,7 +102,7 @@
                                 </article>
                             </section>
                         {{/if}}
-                        {{#unless this.membersUtils.isMembersInviteOnly}}
+                        {{#unless this.settings.membersInviteOnly}}
                             <Dashboard::Charts::Attribution />
                         {{/unless}}
                         {{#if this.areNewslettersEnabled}}

--- a/ghost/admin/app/templates/members.hbs
+++ b/ghost/admin/app/templates/members.hbs
@@ -63,7 +63,7 @@
                             @tagName="ul"
                             @classNames="gh-member-actions-menu dropdown-menu dropdown-triangle-top-right"
                         >
-                            {{#if (not-eq this.settings.membersSignupAccess "none")}}
+                            {{#if this.settings.membersEnabled}}
                                 <li>
                                     <LinkTo @route="members.import" class="mr2" data-test-link="import-csv">
                                         <span>Import members</span>
@@ -97,7 +97,7 @@
                                         <span>Remove label from selected members ({{this.members.length}})</span>
                                     </button>
                                 </li>
-                                {{#if (not-eq this.settings.membersSignupAccess "none")}}
+                                {{#if this.settings.membersEnabled}}
                                     <li>
                                         <button class="mr2" data-test-button="unsubscribe-selected" type="button" {{on "click" this.bulkUnsubscribe}}>
                                             <span>Unsubscribe selected members ({{this.members.length}})</span>
@@ -115,7 +115,7 @@
                             {{/if}}
                         </GhDropdown>
                     </span>
-                    {{#if (not-eq this.settings.membersSignupAccess "none")}}
+                    {{#if this.settings.membersEnabled}}
                         <LinkTo @route="member.new" class="gh-btn gh-btn-primary" data-test-new-member-button="true"><span>New member</span><span class="gh-btn-text-hide-for-mobile">New</span></LinkTo>
                     {{/if}}
                 </div>

--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -123,7 +123,7 @@ export default class PublishOptions {
 
     get emailDisabledInSettings() {
         return this.settings.editorDefaultEmailRecipients === 'disabled'
-            || this.settings.membersSignupAccess === 'none';
+            || !this.settings.membersEnabled;
     }
 
     // publish type dropdown is not shown at all

--- a/ghost/admin/mirage/config/stats.js
+++ b/ghost/admin/mirage/config/stats.js
@@ -70,4 +70,44 @@ export default function mockStats(server) {
             meta: {}
         };
     });
+
+    server.get('/stats/mrr/', function () {
+        return {
+            stats: [
+                {
+                    date: '2025-01-08',
+                    mrr: 18333,
+                    currency: 'usd'
+                },
+                {
+                    date: '2025-01-09',
+                    mrr: 18749,
+                    currency: 'usd'
+                },
+                {
+                    date: '2025-02-19',
+                    mrr: 8749,
+                    currency: 'usd'
+                },
+                {
+                    date: '2025-03-05',
+                    mrr: 416,
+                    currency: 'usd'
+                },
+                {
+                    date: '2025-03-27',
+                    mrr: 832,
+                    currency: 'usd'
+                }
+            ],
+            meta: {
+                totals: [
+                    {
+                        currency: 'usd',
+                        mrr: 832
+                    }
+                ]
+            }
+        };
+    });
 }

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -57,6 +57,8 @@ export default [
     setting('private', 'public_hash', ''),
 
     // MEMBERS
+    setting('members', 'members_enabled', true),
+    setting('members', 'paid_members_enabled', true),
     setting('members', 'default_content_visibility', 'public'),
     setting('members', 'default_content_visibility_tiers', JSON.stringify([])),
     setting('members', 'members_signup_access', 'all'),

--- a/ghost/admin/mirage/routes-test.js
+++ b/ghost/admin/mirage/routes-test.js
@@ -32,7 +32,7 @@ import mockWebhooks from './config/webhooks';
 export default function () {
     this.namespace = ghostPaths().apiRoot;
     // this.timing = 400;      // delay for each request, automatically set to 0 during testing
-    this.logging = false;
+    this.logging = true;
 
     mockApiKeys(this);
     mockAuthentication(this);

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -145,6 +145,8 @@ describe('Acceptance: Posts / Pages', function () {
             let editor, editorPost;
 
             beforeEach(async function () {
+                this.server.loadFixtures('settings');
+
                 let editorRole = this.server.create('role', {name: 'Editor'});
                 editor = this.server.create('user', {roles: [editorRole]});
                 editorPost = this.server.create('post', {authors: [editor], status: 'published', title: 'Editor Post'});
@@ -167,12 +169,13 @@ describe('Acceptance: Posts / Pages', function () {
 
                     // Test that the context menu has the correct buttons
                     const buttons = contextMenu.querySelectorAll('button');
-                    expect(buttons.length, 'context menu buttons').to.equal(5);
+                    expect(buttons.length, 'context menu buttons').to.equal(6);
                     expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
                     expect(buttons[1].innerText.trim(), 'context menu button 2').to.contain('Unpublish');
                     expect(buttons[2].innerText.trim(), 'context menu button 3').to.contain('Feature');
                     expect(buttons[3].innerText.trim(), 'context menu button 4').to.contain('Add a tag');
-                    expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Duplicate');
+                    expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Change access');
+                    expect(buttons[5].innerText.trim(), 'context menu button 6').to.contain('Duplicate');
                 });
 
                 // Note: we cover the functionality of the context menu buttons in the 'as admin' section
@@ -333,16 +336,17 @@ describe('Acceptance: Posts / Pages', function () {
                         let buttons = contextMenu.querySelectorAll('button');
 
                         expect(contextMenu, 'context menu').to.exist;
-                        expect(buttons.length, 'context menu buttons').to.equal(6);
+                        expect(buttons.length, 'context menu buttons').to.equal(7);
                         expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
-                        expect(buttons[1].innerText.trim(), 'context menu button 1').to.contain('Unpublish');
-                        expect(buttons[2].innerText.trim(), 'context menu button 2').to.contain('Feature'); // or Unfeature
-                        expect(buttons[3].innerText.trim(), 'context menu button 3').to.contain('Add a tag');
-                        expect(buttons[4].innerText.trim(), 'context menu button 4').to.contain('Duplicate');
-                        expect(buttons[5].innerText.trim(), 'context menu button 5').to.contain('Delete');
+                        expect(buttons[1].innerText.trim(), 'context menu button 2').to.contain('Unpublish');
+                        expect(buttons[2].innerText.trim(), 'context menu button 3').to.contain('Feature'); // or Unfeature
+                        expect(buttons[3].innerText.trim(), 'context menu button 4').to.contain('Add a tag');
+                        expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Change access');
+                        expect(buttons[5].innerText.trim(), 'context menu button 6').to.contain('Duplicate');
+                        expect(buttons[6].innerText.trim(), 'context menu button 7').to.contain('Delete');
 
                         // duplicate the post
-                        await click(buttons[4]);
+                        await click(buttons[5]);
 
                         const posts = findAll('[data-test-post-id]');
                         expect(posts.length, 'all posts count').to.equal(5);
@@ -366,15 +370,9 @@ describe('Acceptance: Posts / Pages', function () {
                         let buttons = contextMenu.querySelectorAll('button');
 
                         expect(contextMenu, 'context menu').to.exist;
-                        expect(buttons.length, 'context menu buttons').to.equal(6);
-                        expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
-                        expect(buttons[1].innerText.trim(), 'context menu button 1').to.contain('Unpublish');
-                        expect(buttons[2].innerText.trim(), 'context menu button 2').to.contain('Feature'); // or Unfeature
-                        expect(buttons[3].innerText.trim(), 'context menu button 3').to.contain('Add a tag');
-                        expect(buttons[4].innerText.trim(), 'context menu button 4').to.contain('Duplicate');
-                        expect(buttons[5].innerText.trim(), 'context menu button 5').to.contain('Delete');
 
                         // Copy the post link
+                        expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
                         await click(buttons[0]);
 
                         // Check that the notification is displayed
@@ -400,15 +398,9 @@ describe('Acceptance: Posts / Pages', function () {
 
                         let buttons = contextMenu.querySelectorAll('button');
 
-                        expect(contextMenu, 'context menu').to.exist;
-                        expect(buttons.length, 'context menu buttons').to.equal(5);
-                        expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy preview link');
-                        expect(buttons[1].innerText.trim(), 'context menu button 2').to.contain('Feature'); // or Unfeature
-                        expect(buttons[2].innerText.trim(), 'context menu button 3').to.contain('Add a tag');
-                        expect(buttons[3].innerText.trim(), 'context menu button 4').to.contain('Duplicate');
-                        expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Delete');
-
                         // Copy the preview link
+                        expect(contextMenu, 'context menu').to.exist;
+                        expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy preview link');
                         await click(buttons[0]);
 
                         // Check that the notification is displayed

--- a/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
@@ -1,6 +1,7 @@
 import loginAsRole from '../../helpers/login-as-role';
 import {click, find, findAll} from '@ember/test-helpers';
 import {clickTrigger, selectChoose} from 'ember-power-select/test-support/helpers';
+import {disablePaidMembers} from '../../helpers/members';
 import {enableMailgun} from '../../helpers/mailgun';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
@@ -16,24 +17,25 @@ describe('Acceptance: Post email preview', function () {
     });
 
     it('should hide newsletters list and paid/free select by default', async function () {
+        disablePaidMembers(this.server);
+
         await loginAsRole('Administrator', this.server);
 
         const post = this.server.create('post', {status: 'draft'});
         await visit(`/editor/post/${post.id}`);
 
         // go to email preview modal
-        expect(find('[data-test-button="publish-preview"]'), 'Preview').to.exist;
         await click('[data-test-button="publish-preview"]');
-
-        expect(find('[data-test-button="email-preview"]')).to.exist;
         await click('[data-test-button="email-preview"]');
 
-        expect(find('[data-test-email-preview-newsletter-select]')).not.to.exist;
-        expect(find('[data-test-email-preview-segment-select]')).not.to.exist;
+        expect(find('[data-test-email-preview-newsletter-select]'), 'newsletter select').not.to.exist;
+        expect(find('[data-test-email-preview-segment-select]'), 'segment select').not.to.exist;
     });
 
     it('can select newsletter and paid/free member for preview', async function () {
         enableMailgun(this.server);
+        disablePaidMembers(this.server);
+
         await loginAsRole('Administrator', this.server);
         const post = this.server.create('post', {status: 'draft'});
         this.server.create('newsletter', {
@@ -50,8 +52,8 @@ describe('Acceptance: Post email preview', function () {
         expect(find('[data-test-button="email-preview"]')).to.exist;
         await click('[data-test-button="email-preview"]');
 
-        expect(find('[data-test-email-preview-newsletter-select]')).to.exist;
-        expect(find('[data-test-email-preview-segment-select]')).not.to.exist;
+        expect(find('[data-test-email-preview-newsletter-select]'), 'newsletter select').to.exist;
+        expect(find('[data-test-email-preview-segment-select]'), 'segment select').not.to.exist;
 
         // check newsletters options
         await clickTrigger('[data-test-email-preview-newsletter-select-section]');
@@ -77,11 +79,6 @@ describe('Acceptance: Post email preview', function () {
         enableMailgun(this.server);
         await loginAsRole('Administrator', this.server);
         const post = this.server.create('post', {status: 'draft'});
-        this.server.create('setting', {
-            group: 'site',
-            key: 'paid_members_enabled',
-            value: true
-        });
 
         await visit(`/editor/post/${post.id}`);
 

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -4,7 +4,6 @@ import {authenticateSession} from 'ember-simple-auth/test-support';
 import {blur, click, currentURL, fillIn, find, findAll, focus} from '@ember/test-helpers';
 import {datepickerSelect} from 'ember-power-datepicker/test-support';
 import {enableNewsletters} from '../../helpers/newsletters';
-import {enablePaidMembers} from '../../helpers/members';
 import {enableStripe} from '../../helpers/stripe';
 import {expect} from 'chai';
 import {selectChoose} from 'ember-power-select/test-support/helpers';
@@ -22,9 +21,9 @@ describe('Acceptance: Members filtering', function () {
         this.server.loadFixtures('configs');
         this.server.loadFixtures('settings');
         this.server.loadFixtures('newsletters');
+        this.server.loadFixtures('themes');
         enableStripe(this.server);
         enableNewsletters(this.server, true);
-        enablePaidMembers(this.server);
 
         let role = this.server.create('role', {name: 'Owner'});
         this.server.create('user', {roles: [role]});

--- a/ghost/admin/tests/helpers/members.js
+++ b/ghost/admin/tests/helpers/members.js
@@ -1,21 +1,25 @@
-export function enableMembers(server) {
+export function enableMembers(server, membersEnabled = true) {
+    const membersSignupAccess = membersEnabled ? 'all' : 'none';
+
     server.db.settings.find({key: 'members_signup_access'})
-        ? server.db.settings.update({key: 'members_signup_access'}, {value: 'all'})
-        : server.create('setting', {key: 'members_signup_access', value: 'all', group: 'members'});
+        ? server.db.settings.update({key: 'members_signup_access'}, {value: membersSignupAccess})
+        : server.create('setting', {key: 'members_signup_access', value: membersSignupAccess, group: 'members'});
 
     server.db.settings.find({key: 'members_enabled'})
-        ? server.db.settings.update({key: 'members_enabled'}, {value: true})
-        : server.create('setting', {key: 'members_enabled', value: true, group: 'members'});
+        ? server.db.settings.update({key: 'members_enabled'}, {value: membersEnabled})
+        : server.create('setting', {key: 'members_enabled', value: membersEnabled, group: 'members'});
 }
 
 export function disableMembers(server) {
-    server.db.settings.find({key: 'members_signup_access'})
-        ? server.db.settings.update({key: 'members_signup_access'}, {value: 'none'})
-        : server.create('setting', {key: 'members_signup_access', value: 'none', group: 'members'});
+    enableMembers(server, false);
 }
 
-export function enablePaidMembers(server) {
+export function enablePaidMembers(server, enabled = true) {
     server.db.settings.find({key: 'paid_members_enabled'})
-        ? server.db.settings.update({key: 'paid_members_enabled'}, {value: true})
-        : server.create('setting', {key: 'paid_members_enabled', value: true, group: 'members'});
+        ? server.db.settings.update({key: 'paid_members_enabled'}, {value: enabled})
+        : server.create('setting', {key: 'paid_members_enabled', value: enabled, group: 'members'});
+}
+
+export function disablePaidMembers(server) {
+    enablePaidMembers(server, false);
 }

--- a/ghost/admin/tests/integration/services/member-import-validator-test.js
+++ b/ghost/admin/tests/integration/services/member-import-validator-test.js
@@ -1,12 +1,7 @@
 import Pretender from 'pretender';
-import Service from '@ember/service';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
-
-let MembersUtilsStub = Service.extend({
-    isStripeEnabled: true
-});
 
 describe('Integration: Service: member-import-validator', function () {
     setupTest();
@@ -15,7 +10,6 @@ describe('Integration: Service: member-import-validator', function () {
 
     beforeEach(function () {
         server = new Pretender();
-        this.owner.register('service:membersUtils', MembersUtilsStub);
     });
 
     afterEach(function () {
@@ -35,10 +29,6 @@ describe('Integration: Service: member-import-validator', function () {
 
     describe('data sampling method', function () {
         it('returns whole data set when sampled size is less then default 30', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
 
             const result = await service._sampleData([{
@@ -51,10 +41,6 @@ describe('Integration: Service: member-import-validator', function () {
         });
 
         it('returns dataset with sample size for non empty values only', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
             let data = [{
                 email: null
@@ -77,10 +63,6 @@ describe('Integration: Service: member-import-validator', function () {
         });
 
         it('returns dataset with sample size for non empty values for objects with multiple properties', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
             let data = [{
                 email: null,
@@ -112,10 +94,6 @@ describe('Integration: Service: member-import-validator', function () {
 
     describe('data detection method', function () {
         it('correctly detects only email mapping', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
 
             const result = service._detectDataTypes([{
@@ -129,10 +107,6 @@ describe('Integration: Service: member-import-validator', function () {
         });
 
         it('correctly detects email mapping', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
 
             const result = service._detectDataTypes([{
@@ -147,10 +121,6 @@ describe('Integration: Service: member-import-validator', function () {
         });
 
         it('correctly detects variation of "name" mapping', async function () {
-            this.owner.register('service:membersUtils', Service.extend({
-                isStripeEnabled: false
-            }));
-
             let service = this.owner.lookup('service:member-import-validator');
 
             const result = service._detectDataTypes([{


### PR DESCRIPTION
no issue

- we had a confusing mix of manual underlying access setting checks, direct `settings.membersEnabled/paidMembersEnabled` checks, and `membersUtils.membersEnabled/paidMembersEnabled` checks
  - the `membersUtils.xEnabled` checks were originally in place to remove the repeated direct checks of `settings.membersSignupAccess !== 'none'` type checks that were spread around the codebase but the refactor to switch to those utils was never fully completed
  - we've later added API-level `membersEnabled` and `paidMembersEnabled` settings which `membersUtils.xEnabled` checks were switched to but we also started using the underlying settings directly in different parts of the codebase meaning we ended up with three different approaches
  - the confusion around and slightly different behaviour between these different methods meant our tests were also difficult to determine as setup helpers were doing different things that meant code paths using each different approach were not necessarily doing what was intended
- unified to always use `settings.membersEnabled` and `settings.paidMembersEnabled`
  - removed the duplicate properties from `membersUtils`
  - switched all uses of `membersUtils` and manual checks over to `settings` checks
  - updated test utils to update all impacted settings when enabling/disabling members
- fixed tests that were incorrectly testing against members disabled
- added missing `/api/admin/stats/mrr/` mocked endpoint that was causing dashboard tests to fail now that we are correctly testing against the members enabled state
