### PR TITLE
Added tinybird tests for the browser filter for all endpoints

### DIFF
--- a/ghost/web-analytics/sql/hits_browser_chrome.sql
+++ b/ghost/web-analytics/sql/hits_browser_chrome.sql
@@ -1,0 +1,3 @@
+select timestamp, session_id, browser, os, device, location, pathname from _mv_hits__v${TB_VERSION:-0}
+where browser = 'chrome'
+order by session_id, timestamp

--- a/ghost/web-analytics/sql/sanity_browser_chrome.sql
+++ b/ghost/web-analytics/sql/sanity_browser_chrome.sql
@@ -1,0 +1,2 @@
+select count(distinct session_id) as sessions, count(*) as pageviews from _mv_hits__v${TB_VERSION:-0}
+where browser = 'chrome'

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_devices.test
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_devices.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_devices__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_devices.test.result
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_devices.test.result
@@ -1,0 +1,2 @@
+"device","visits","pageviews"
+"desktop",7,16

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_locations.test
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_locations.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_locations__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_locations.test.result
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_locations.test.result
@@ -1,0 +1,4 @@
+"location","visits","pageviews"
+"GB",5,11
+"DE",1,3
+"ES",1,2

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_os.test
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_os.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_os__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --browser chrome

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_os.test.result
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_os.test.result
@@ -1,0 +1,2 @@
+"os","visits","pageviews"
+"windows",7,16


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-194/automated-tests-for-all-queries-including-every-filter-plus-one-other

- This commit adds Tinybird fixture tests for filtering by browser for all endpoints that didn't previously have these tests
- The two `.sql` files are also useful to validate the test results in the snapshot file
- This is part of an effort to generally improve our test coverage on our Tinybird endpoints so that we can more confidently make changes to them without breaking other endpoints or filter combinations