### PR TITLE
Updated Tinybird `tbsql` function

### DIFF
--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -27,7 +27,7 @@ tbsql() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             --format)
-                if [[ ! " $valid_formats " =~ " $2 " ]]; then
+                if [[ ! " $valid_formats " =~ $2 ]]; then
                     echo "Error: Invalid format '$2'. Valid formats are: $valid_formats"
                     return 1
                 fi

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -19,18 +19,47 @@ prompt_tb() {
 
 # Function to run SQL queries from files
 tbsql() {
-    if [ -z "$1" ]; then
-        echo "Usage: tbsql <filename without .sql>"
+    local format="csv"
+    local query_file=""
+    local valid_formats="json csv human"
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --format)
+                if [[ ! " $valid_formats " =~ " $2 " ]]; then
+                    echo "Error: Invalid format '$2'. Valid formats are: $valid_formats"
+                    return 1
+                fi
+                format="$2"
+                shift 2
+                ;;
+            *)
+                query_file="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$query_file" ]; then
+        echo "Usage: tbsql [--format <json|csv|human>] <filename without .sql>"
         return 1
     fi
 
-    local sql_file="/ghost/ghost/web-analytics/sql/$1.sql"
+    # Get the directory where this script is located
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    local sql_file="$SCRIPT_DIR/sql/$query_file.sql"
+
     if [ ! -f "$sql_file" ]; then
         echo "Error: SQL file not found: $sql_file"
         return 1
     fi
 
-    tb sql "$(cat $sql_file)"
+    # Read SQL file and process environment variables with bash parameter expansion
+    local query
+    # Use eval to process the SQL content with bash parameter expansion
+    eval "query=\"$(cat "$sql_file")\""
+    tb sql --format="$format" "$query"
 }
 
 # Export the prompt with Tinybird branch information

--- a/ghost/web-analytics/sql/events.sql
+++ b/ghost/web-analytics/sql/events.sql
@@ -1,0 +1,1 @@
+select * from analytics_events

--- a/ghost/web-analytics/sql/hits.sql
+++ b/ghost/web-analytics/sql/hits.sql
@@ -1,0 +1,1 @@
+select * from _mv_hits__v${TB_VERSION:-0}

--- a/ghost/web-analytics/sql/hits_tz_la.sql
+++ b/ghost/web-analytics/sql/hits_tz_la.sql
@@ -1,0 +1,4 @@
+select
+    toTimeZone(timestamp, 'America/Los_Angeles') as timestamp_la,
+    *
+from _mv_hits__v${TB_VERSION:-0}


### PR DESCRIPTION
no issue

This commit enhances the `tbsql` utility function that we use to run SQL queries against our Tinybird workspace during debugging.

- Enables `tbsql` in the Ghost container by using `$BASH_SOURCE` to determine the path to the `.sql` files
- Adds a `--format` parameter, which can be set to `csv`, `json`, or `human`. It defaults to `csv` for consistency
- Adds environment variable substitution, so we can use e.g. `${TB_VERSION:-0}` in our SQL queries to target the current version without having to find/replace

It also adds a few basic `.sql` queries to the repo which are useful when working with our fixture tests.