### PR TITLE
Bumped Tinybird `.tinyenv` version to 0.0.2

### DIFF
--- a/ghost/web-analytics/.tinyenv
+++ b/ghost/web-analytics/.tinyenv
@@ -3,7 +3,7 @@
 # bump post to deploy to the current live Release, rollback to previous post version is not available
 # bump patch or minor to deploy a new Release and auto-promote it to live. Add TB_AUTO_PROMOTE=0 to create the Release in preview status
 # bump major to deploy a new Release in preview status
-VERSION=0.0.1
+VERSION=0.0.2
 
 
 


### PR DESCRIPTION
no issue

- The Tinybird CI jobs aren't functioning right now, since there is a custom deploy script for `0.0.1` and that is the version currently specified in the `.tinyenv` file. Each "deploy" is just re-running the same custom deploy script, and not actually deploying the changes in the datafiles.
- The result is that the CI jobs are running tests against the current implementation, without including the changes in the PR (because they aren't deployed), which could lead to false passing results
- This bumps the version in the `.tinyenv` file, which doesn't do anything other than fix the CI jobs, since there aren't any actual changes to the datafiles in this commit