### PR TITLE
Reverted change to Tinybird `exec_test` script

### DIFF
--- a/ghost/web-analytics/scripts/exec_test.sh
+++ b/ghost/web-analytics/scripts/exec_test.sh
@@ -15,9 +15,8 @@ check_sum() {
     local file=$1
     local expected_count=$2
 
-    # Skip check if file starts with "all_" AND contains "timezone" in the name
-    # TODO: we should handle this for all tests and in a better way
-    if [[ ! $(basename "$file") =~ ^all_ ]] || [[ $(basename "$file") =~ timezone ]]; then
+    # Only perform the check if the file starts with "all_"
+    if [[ ! $(basename "$file") =~ ^all_ ]]; then
         return 0
     fi
 


### PR DESCRIPTION
no issue

- This commit reverts a change to our Tinybird `exec_test` script, which added an exclusion to the sanity check warnings if the test included `timezone` in its file name
- The warnings were fixed by renaming the timezone tests so they don't start with `all`, and therefore this change to the `exec_test` script isn't necessary
