### PR TITLE
🌵 Spike: run Tinybird tests in mocha

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -34,6 +34,7 @@
     "test:integration": "yarn test:base './test/integration' --timeout=10000",
     "test:e2e": "yarn test:base ./test/e2e-* --timeout=15000",
     "test:regression": "yarn test:base './test/regression' --timeout=60000",
+    "test:tinybird": "yarn test:base './test/tinybird' --timeout=60000",
     "test:browser": "NODE_ENV=testing-browser playwright test",
     "test:browser:admin": "NODE_ENV=testing-browser  playwright test test/e2e-browser --project=admin",
     "test:browser:portal": "NODE_ENV=testing-browser playwright test test/e2e-browser --project=portal",

--- a/ghost/core/test/tinybird/api_kpi.test.js
+++ b/ghost/core/test/tinybird/api_kpi.test.js
@@ -1,25 +1,33 @@
-const { runTbCommand, checkAuth, createBranch, deleteBranch, deploy, appendFixtures } = require('../utils/tinybird-utils');
+const TinybirdCLI = require('../utils/tinybird-utils');
 const assert = require('node:assert').strict;
 
 describe('api_kpi tests', () => {
-    let branchName;
+    let tb, branchName;
     before(async () => {
         // Authenticate with Tinybird
-        await checkAuth();
-        // Create a new branch
+        tb = new TinybirdCLI();
+        await tb.auth();
+        // // Create a new branch
         branchName = `test_${Date.now()}`;
-        console.log('Creating branch:', branchName);
-        await createBranch(branchName);
+        await tb.branchCreate(branchName);
+        // console.log('Creating branch:', branchName);
+        await tb.branchUse(branchName);
         // Deploy local changes
-        await deploy();
+        // await deploy();
         // Append fixtures
-        await appendFixtures();
+        await tb.appendFixtures();
     });
+
     after(async () => {
-        await deleteBranch(branchName);
-    })
+        // await tb.branchDelete(branchName);
+    });
+
     it('runs a simple query', async () => {
-        const result = await runTbCommand('tb pipe ls');
-        assert.ok(result);
+        // const result = await pipeData('api_kpis__v7', {
+        //     date_from: '2100-01-01',
+        //     date_to: '2100-01-07',
+        //     site_uuid: 'mock_site_uuid'
+        // });
+        // assert.ok(result);
     });
 });

--- a/ghost/core/test/tinybird/api_kpi.test.js
+++ b/ghost/core/test/tinybird/api_kpi.test.js
@@ -1,0 +1,25 @@
+const { runTbCommand, checkAuth, createBranch, deleteBranch, deploy, appendFixtures } = require('../utils/tinybird-utils');
+const assert = require('node:assert').strict;
+
+describe('api_kpi tests', () => {
+    let branchName;
+    before(async () => {
+        // Authenticate with Tinybird
+        await checkAuth();
+        // Create a new branch
+        branchName = `test_${Date.now()}`;
+        console.log('Creating branch:', branchName);
+        await createBranch(branchName);
+        // Deploy local changes
+        await deploy();
+        // Append fixtures
+        await appendFixtures();
+    });
+    after(async () => {
+        await deleteBranch(branchName);
+    })
+    it('runs a simple query', async () => {
+        const result = await runTbCommand('tb pipe ls');
+        assert.ok(result);
+    });
+});

--- a/ghost/core/test/utils/tinybird-utils.js
+++ b/ghost/core/test/utils/tinybird-utils.js
@@ -1,0 +1,93 @@
+const util = require('node:util');
+const exec = util.promisify(require('node:child_process').exec);
+const path = require('node:path');
+const fs = require('node:fs');
+
+// Bit of a fragile path — will improve when we move these files into core
+const datafileDirectory = path.join(__dirname, '..', '..', '..', 'web-analytics');
+const fixtureDirectory = path.join(datafileDirectory, 'tests', 'fixtures');
+
+async function runTbCommand(command) {
+    console.log('Running Tinybird command:', command);
+    const {stdout, stderr } = await exec(command);
+    if (stderr) {
+        return Promise.reject(new Error(stderr));
+    }
+    return Promise.resolve(stdout);
+}
+
+async function checkAuth() {
+    const token = process.env.TB_TOKEN;
+    if (!token) {
+        throw new Error('TB_TOKEN is not set');
+    }
+    const result = await runTbCommand('tb auth');
+    if (!result.includes('Auth successful')) {
+        return Promise.reject(new Error('Failed to authenticate with Tinybird'));
+    }
+    console.log('Successfully authenticated with Tinybird');
+    return Promise.resolve();
+
+}
+
+async function createBranch(branchName) {
+    const command = `tb branch create ${branchName}`;
+    const result = await runTbCommand(command);
+    if (!result.includes(`Now using ${branchName}`)) {
+        return Promise.reject(new Error('Failed to create Tinybird branch'));
+    }
+    console.log('Successfully created Tinybird branch:', branchName);
+    return Promise.resolve(branchName);
+}
+
+async function deleteBranch(branchName) {
+    if (branchName.toLowerCase() === 'main') {
+        return Promise.reject(new Error('Cannot delete main branch'));
+    }
+    const command = `tb branch rm --yes ${branchName}`;
+    const result = await runTbCommand(command);
+    if (!result.includes(`Branch '${branchName}' deleted`)) {
+        return Promise.reject(new Error('Failed to delete Tinybird branch'));
+    }
+    console.log('Successfully deleted Tinybird branch:', branchName);
+    return Promise.resolve(branchName);
+}
+
+async function deploy() {
+    const command = `tb deploy`;
+    const result = await runTbCommand(command);
+    if (!result.includes('Deployed')) {
+        return Promise.reject(new Error('Failed to deploy Tinybird'));
+    }
+    console.log('Successfully deployed Tinybird');
+    return Promise.resolve();
+}
+
+async function appendFixtures() {
+    console.log('Appending fixtures');
+    console.log('Fixture directory:', fixtureDirectory);
+    const extensions = ['ndjson'];
+    for (const extension of extensions) {
+        const files = fs.readdirSync(fixtureDirectory, { withFileTypes: true })
+            .filter(file => file.isFile() && file.name.endsWith(`.${extension}`))
+            .map(file => path.join(fixtureDirectory, file.name));
+        console.log('Files:', files);
+        for (const file of files) {
+            const file_name_without_extension = path.basename(file, `.${extension}`);
+            const command = `tb datasource append ${file_name_without_extension} ${file}`;
+            console.log('Command:', command);
+            const result = await runTbCommand(command);
+            console.log('Result:', result);
+        }
+    }
+}
+
+
+module.exports = {
+    runTbCommand,
+    checkAuth,
+    createBranch,
+    deleteBranch,
+    deploy,
+    appendFixtures
+}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-192/write-tests-in-jsmocha

- Our current Tinybird tests are written in bash — this spike attempts to adapt our existing Tinybird tests to a more convention JS/mocha setup