### PR TITLE
Fixed Admin test helpers not correctly updating mocked db settings

### DIFF
--- a/ghost/admin/tests/helpers/mailgun.js
+++ b/ghost/admin/tests/helpers/mailgun.js
@@ -1,13 +1,13 @@
 export function enableMailgun(server, enabled = true) {
-    server.db.settings.find({key: 'mailgun_api_key'})
+    server.db.settings.findBy({key: 'mailgun_api_key'})
         ? server.db.settings.update({key: 'mailgun_api_key'}, {value: (enabled ? 'MAILGUN_API_KEY' : null)})
         : server.create('setting', {key: 'mailgun_api_key', value: (enabled ? 'MAILGUN_API_KEY' : null), group: 'email'});
 
-    server.db.settings.find({key: 'mailgun_domain'})
+    server.db.settings.findBy({key: 'mailgun_domain'})
         ? server.db.settings.update({key: 'mailgun_domain'}, {value: (enabled ? 'MAILGUN_DOMAIN' : null)})
         : server.create('setting', {key: 'mailgun_domain', value: (enabled ? 'MAILGUN_DOMAIN' : null), group: 'email'});
 
-    server.db.settings.find({key: 'mailgun_base_url'})
+    server.db.settings.findBy({key: 'mailgun_base_url'})
         ? server.db.settings.update({key: 'mailgun_base_url'}, {value: (enabled ? 'MAILGUN_BASE_URL' : null)})
         : server.create('setting', {key: 'mailgun_base_url', value: (enabled ? 'MAILGUN_BASE_URL' : null), group: 'email'});
 }

--- a/ghost/admin/tests/helpers/members.js
+++ b/ghost/admin/tests/helpers/members.js
@@ -1,21 +1,33 @@
-export function enableMembers(server) {
-    server.db.settings.find({key: 'members_signup_access'})
-        ? server.db.settings.update({key: 'members_signup_access'}, {value: 'all'})
-        : server.create('setting', {key: 'members_signup_access', value: 'all', group: 'members'});
+function toggleMembers(server, enabled) {
+    const membersSignupAccess = enabled ? 'all' : 'none';
 
-    server.db.settings.find({key: 'members_enabled'})
-        ? server.db.settings.update({key: 'members_enabled'}, {value: true})
-        : server.create('setting', {key: 'members_enabled', value: true, group: 'members'});
+    server.db.settings.findBy({key: 'members_signup_access'})
+        ? server.db.settings.update({key: 'members_signup_access'}, {value: membersSignupAccess})
+        : server.create('setting', {key: 'members_signup_access', value: membersSignupAccess, group: 'members'});
+
+    server.db.settings.findBy({key: 'members_enabled'})
+        ? server.db.settings.update({key: 'members_enabled'}, {value: enabled})
+        : server.create('setting', {key: 'members_enabled', value: enabled, group: 'members'});
+}
+
+export function enableMembers(server) {
+    toggleMembers(server, true);
 }
 
 export function disableMembers(server) {
-    server.db.settings.find({key: 'members_signup_access'})
-        ? server.db.settings.update({key: 'members_signup_access'}, {value: 'none'})
-        : server.create('setting', {key: 'members_signup_access', value: 'none', group: 'members'});
+    toggleMembers(server, false);
+}
+
+function togglePaidMembers(server, enabled) {
+    server.db.settings.findBy({key: 'paid_members_enabled'})
+        ? server.db.settings.update({key: 'paid_members_enabled'}, {value: enabled})
+        : server.create('setting', {key: 'paid_members_enabled', value: enabled, group: 'members'});
 }
 
 export function enablePaidMembers(server) {
-    server.db.settings.find({key: 'paid_members_enabled'})
-        ? server.db.settings.update({key: 'paid_members_enabled'}, {value: true})
-        : server.create('setting', {key: 'paid_members_enabled', value: true, group: 'members'});
+    togglePaidMembers(server, true);
+}
+
+export function disablePaidMembers(server) {
+    togglePaidMembers(server, false);
 }

--- a/ghost/admin/tests/helpers/newsletters.js
+++ b/ghost/admin/tests/helpers/newsletters.js
@@ -1,5 +1,5 @@
 export function enableNewsletters(server, enabled = true) {
-    server.db.settings.find({key: 'editor_default_email_recipients'})
+    server.db.settings.findBy({key: 'editor_default_email_recipients'})
         ? server.db.settings.update({key: 'editor_default_email_recipients'}, {value: (enabled ? 'visibility' : 'disabled')})
         : server.create('setting', {key: 'editor_default_email_recipients', value: (enabled ? 'visibility' : 'disabled'), group: 'editor'});
 }

--- a/ghost/admin/tests/helpers/stripe.js
+++ b/ghost/admin/tests/helpers/stripe.js
@@ -1,16 +1,16 @@
 export function enableStripe(server, enabled = true) {
-    server.db.settings.find({key: 'stripe_connect_account_id'})
+    server.db.settings.findBy({key: 'stripe_connect_account_id'})
         ? server.db.settings.update({key: 'stripe_connect_account_id'}, {value: (enabled ? 'stripe_account_id' : null)})
         : server.create('setting', {key: 'stripe_connect_account_id', value: (enabled ? 'stripe_account_id' : null), group: 'members'});
     // needed for membersUtils.isStripeEnabled
-    server.db.settings.find({key: 'stripe_connect_secret_key'})
+    server.db.settings.findBy({key: 'stripe_connect_secret_key'})
         ? server.db.settings.update({key: 'stripe_connect_secret_key'}, {value: (enabled ? 'stripe_secret_key' : null)})
         : server.create('setting', {key: 'stripe_connect_secret_key', value: (enabled ? 'stripe_secret_key' : null), group: 'members'});
-    server.db.settings.find({key: 'stripe_connect_publishable_key'})
+    server.db.settings.findBy({key: 'stripe_connect_publishable_key'})
         ? server.db.settings.update({key: 'stripe_connect_publishable_key'}, {value: (enabled ? 'stripe_secret_key' : null)})
         : server.create('setting', {key: 'stripe_connect_publishable_key', value: (enabled ? 'stripe_secret_key' : null), group: 'members'});
 
-    server.db.settings.find({key: 'paid_members_enabled'})
+    server.db.settings.findBy({key: 'paid_members_enabled'})
         ? server.db.settings.update({key: 'paid_members_enabled'}, {value: enabled})
         : server.create('setting', {key: 'paid_members_enabled', value: enabled, group: 'members'});
 }


### PR DESCRIPTION
no issue

- if helpers were called after some db settings had already been set then they were creating new settings rather than updating existing ones meaning the helper call didn't have the expected effect when the test is run
- switching to the correct `.findBy()` API fixes the conditional so an existing setting is updated
