### PR TITLE
Fixed Docker build failing due to deleted `package.json` file

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -70,7 +70,6 @@ COPY ghost/admin/lib/asset-delivery/package.json ghost/admin/lib/asset-delivery/
 COPY ghost/admin/lib/ember-power-calendar-moment/package.json ghost/admin/lib/ember-power-calendar-moment/package.json
 COPY ghost/admin/lib/ember-power-calendar-utils/package.json ghost/admin/lib/ember-power-calendar-utils/package.json
 COPY ghost/admin/package.json ghost/admin/package.json
-COPY ghost/announcement-bar-settings/package.json ghost/announcement-bar-settings/package.json
 COPY ghost/api-framework/package.json ghost/api-framework/package.json
 COPY ghost/constants/package.json ghost/constants/package.json
 COPY ghost/core/package.json ghost/core/package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,28 +205,6 @@ jobs:
       has_browser_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browser-tests') }}
       dependency_cache_key: ${{ env.cachekey }}
 
-  job_docker_build:
-    runs-on: ubuntu-latest
-    needs: [job_setup]
-    if: needs.job_setup.outputs.changed_any_code == 'true'
-    name: Docker build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          context: .
-          file: ./.docker/Dockerfile
-          target: development
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   job_lint:
     runs-on: ubuntu-latest
     needs: [job_setup]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
     if: needs.job_setup.outputs.changed_any_code == 'true'
     name: Docker build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,24 @@ jobs:
       has_browser_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browser-tests') }}
       dependency_cache_key: ${{ env.cachekey }}
 
+  job_docker_build:
+    runs-on: ubuntu-latest
+    needs: [job_setup]
+    if: needs.job_setup.outputs.changed_any_code == 'true'
+    name: Docker build
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v16
+        with:
+          push: false
+          context: .
+          file: .docker/Dockerfile
+          target: development
+
   job_lint:
     runs-on: ubuntu-latest
     needs: [job_setup]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
           context: .
           file: ./.docker/Dockerfile
           target: development
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   job_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image
-        uses: docker/build-push-action@v16
+        uses: docker/build-push-action@v6
         with:
           push: false
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
         with:
           push: false
           context: .
-          file: .docker/Dockerfile
+          file: ./.docker/Dockerfile
           target: development
 
   job_lint:


### PR DESCRIPTION
no issue

- The Docker build was failing because it referenced a `package.json` file which no longer exists — this commit removes the `COPY` line for the deleted `package.json` file so it will build successfully again.