### PR TITLE
Fixed `yarn docker:test:browser` command

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -53,6 +53,7 @@ ENV NX_REJECT_UNKNOWN_LOCAL_CACHE=false
 COPY package.json yarn.lock ./
 
 # Copy all package.json files
+COPY apps/stats/package.json apps/stats/package.json
 COPY apps/admin-x-activitypub/package.json apps/admin-x-activitypub/package.json
 COPY apps/admin-x-demo/package.json apps/admin-x-demo/package.json
 COPY apps/admin-x-design-system/package.json apps/admin-x-design-system/package.json

--- a/compose.yml
+++ b/compose.yml
@@ -84,6 +84,7 @@ services:
       - node_modules_apps_shade:/home/ghost/apps/shade/node_modules:delegated
       - node_modules_apps_signup-form:/home/ghost/apps/signup-form/node_modules:delegated
       - node_modules_apps_sodo-search:/home/ghost/apps/sodo-search/node_modules:delegated
+      - node_modules_apps_stats:/home/ghost/apps/stats/node_modules:delegated
     tty: true
     depends_on:
       mysql:
@@ -102,7 +103,9 @@ services:
   mysql:
     image: mysql:8.0.35
     container_name: ghost-mysql
-    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
+    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M
+      --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0
+      --innodb-flush-method=O_DIRECT
     ports:
       - 3306:3306
     environment:
@@ -218,3 +221,4 @@ volumes:
   node_modules_apps_shade: {}
   node_modules_apps_signup-form: {}
   node_modules_apps_sodo-search: {}
+  node_modules_apps_stats: {}


### PR DESCRIPTION
no issue

- Last week we added the `apps/stats` package, which wasn't accounted for in the `Dockerfile` or the `compose.yml` file. This caused the admin build to fail in the container due to a dependency mismatch, and the `yarn docker:test:browser` command would also fail for the same reason.
- This commit updates the Docker setup to properly install the stats app's dependencies, which fixes the admin build and the `yarn docker:test:browser` command.