### PR TITLE
Updated tracking script to use ref

### DIFF
--- a/ghost/core/core/frontend/public/ghost-stats.js
+++ b/ghost/core/core/frontend/public/ghost-stats.js
@@ -240,11 +240,47 @@
         'user-agent': window.navigator.userAgent,
         locale,
         location: country,
-        referrer: document.referrer,
+        referrer: getReferrer(),
         pathname: window.location.pathname,
         href: window.location.href,
       })
     }, 300)
+  }
+
+  function getReferrer() {
+    // Fetch referrer data from query params - priority is the following order: ref, source, utm_source, utm_medium, referrer
+    let refParam;
+    let sourceParam;
+    let utmSourceParam;
+    let utmMediumParam;
+    let referrerSource;
+
+    // Fetch source/medium from query param
+    const url = new URL(window.location.href);
+    refParam = url.searchParams.get('ref');
+    sourceParam = url.searchParams.get('source');
+    utmSourceParam = url.searchParams.get('utm_source');
+    utmMediumParam = url.searchParams.get('utm_medium');
+
+    referrerSource = refParam || sourceParam || utmSourceParam || null;
+
+    // if referrerSource is not set, check to see if the url contains a hash like ghost.org/#/portal/signup?ref=ghost and pull the ref from the hash
+    if (!referrerSource && url.hash && url.hash.includes('#/portal')) {
+        const hashUrl = new URL(window.location.href.replace('/#/portal', ''));
+        refParam = hashUrl.searchParams.get('ref');
+        sourceParam = hashUrl.searchParams.get('source');
+        utmSourceParam = hashUrl.searchParams.get('utm_source');
+        utmMediumParam = hashUrl.searchParams.get('utm_medium');
+
+        referrerSource = refParam || sourceParam || utmSourceParam || null;
+    }
+
+    // Get referrer medium and url
+    const referrerMedium = utmMediumParam || null;
+    const referrerUrl = window.document.referrer || null;
+
+    // Return based on priority
+    return referrerSource || referrerMedium || referrerUrl || null;
   }
 
   // Client


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-178

Updated tracking script to use the same logic as our member-attribution script for parsing the url - the hierarchy is ?ref > source > utm_source > utm_medium > document.referrer.