### PR TITLE
Updated tinybird test suite to run in parallel

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,6 +26,7 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
     apt install -y \
     git \
     stripe \
+    parallel \
     python3-pip \
     procps && \
     rm -rf /var/lib/apt/lists/* && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,7 +973,7 @@ jobs:
       - name: Run fixture tests
         run: |
           if [ -f ./scripts/exec_test.sh ]; then
-          ./scripts/exec_test.sh
+          ./scripts/exec_test.sh -j 10
           fi
 
       - name: Try to delete previous Branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,7 +973,7 @@ jobs:
       - name: Run fixture tests
         run: |
           if [ -f ./scripts/exec_test.sh ]; then
-          ./scripts/exec_test.sh -j 10
+          ./scripts/exec_test.sh
           fi
 
       - name: Try to delete previous Branch

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -3,13 +3,12 @@
 # Function to prompt Tinybird branch information
 prompt_tb() {
     if [ -e ".tinyb" ]; then
-        TB_CHAR=$'\U1F423'
         branch_name=$(grep '"name":' .tinyb | cut -d : -f 2 | cut -d '"' -f 2)
         region=$(grep '"host":' .tinyb | cut -d / -f 3 | cut -d . -f 2 | cut -d : -f 1)
         if [ "$region" = "tinybird" ]; then
             region=$(grep '"host":' .tinyb | cut -d / -f 3 | cut -d . -f 1)
         fi
-        TB_BRANCH="${TB_CHAR}tb:${region}=>${branch_name}"
+        TB_BRANCH=":tb=>${branch_name}"
     else
         TB_BRANCH=''
     fi

--- a/ghost/web-analytics/scripts/exec_test.sh
+++ b/ghost/web-analytics/scripts/exec_test.sh
@@ -50,9 +50,9 @@ export expected_count=$(grep -c '^' "$ndjson_file" || echo "0")
 # Get number of CPU cores if not overridden
 if [[ -z "$jobs" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        jobs=$(sysctl -n hw.ncpu)
+        jobs=$(( $(sysctl -n hw.ncpu) * 2 ))
     else
-        jobs=$(nproc)
+        jobs=$(( $(nproc) * 2 ))
     fi
 fi
 
@@ -157,7 +157,7 @@ if [[ -n "${test_name:-}" ]]; then
     fi
 else
     # If no test name provided, run all tests in parallel
-    echo "Running tests in parallel using $jobs cores"
+    echo "Running tests in parallel using $jobs workers"
     # Use parallel to run the tests, maintaining output order
     find ./tests -name "*.test" -print0 | \
         parallel -0 --jobs "$jobs" --keep-order --line-buffer \

--- a/ghost/web-analytics/scripts/exec_test.sh
+++ b/ghost/web-analytics/scripts/exec_test.sh
@@ -1,6 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Record start time
+start_time=$(date +%s)
+
+# Set locale environment variables to avoid Perl warnings
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+# Check if GNU Parallel is available
+if ! command -v parallel >/dev/null 2>&1; then
+    echo "GNU Parallel is required but not installed. Please install it first."
+    echo "On Ubuntu/Debian: sudo apt-get install parallel"
+    echo "On macOS: brew install parallel"
+    exit 1
+fi
+
+# Parse command line options
+jobs=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -j|--jobs)
+            if [[ -n "${2:-}" ]]; then
+                jobs="$2"
+                shift 2
+            else
+                echo "Error: -j|--jobs requires a number argument"
+                exit 1
+            fi
+            ;;
+        *)
+            # Store the test name if provided
+            test_name="$1"
+            shift
+            ;;
+    esac
+done
+
 export TB_VERSION_WARNING=0
 
 # Default version if not provided
@@ -10,6 +46,17 @@ echo "TB_VERSION: $TB_VERSION"
 # Get the expected count once, outside of any function
 ndjson_file="./tests/fixtures/analytics_events.ndjson"
 export expected_count=$(grep -c '^' "$ndjson_file" || echo "0")
+
+# Get number of CPU cores if not overridden
+if [[ -z "$jobs" ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+        jobs=$(sysctl -n hw.ncpu)
+    else
+        jobs=$(nproc)
+    fi
+fi
+
+echo "Using $jobs parallel jobs for test execution"
 
 check_sum() {
     local file=$1
@@ -99,8 +146,7 @@ export -f check_sum
 fail=0
 
 # Check if a test name was provided as an argument
-if [ $# -eq 1 ]; then
-    test_name=$1
+if [[ -n "${test_name:-}" ]]; then
     # Find the test file that matches the provided name
     test_file=$(find ./tests -name "${test_name}*.test")
     if [ -n "$test_file" ]; then
@@ -110,11 +156,24 @@ if [ $# -eq 1 ]; then
         fail=1
     fi
 else
-    # If no test name provided, run all tests
-    find ./tests -name "*.test" -print0 | xargs -0 -I {} bash -c 'run_test "$@"' _ {} || fail=1
+    # If no test name provided, run all tests in parallel
+    echo "Running tests in parallel using $jobs cores"
+    # Use parallel to run the tests, maintaining output order
+    find ./tests -name "*.test" -print0 | \
+        parallel -0 --jobs "$jobs" --keep-order --line-buffer \
+        'run_test {} || echo "PARALLEL_TEST_FAILED"' | \
+        tee >(if grep -q "PARALLEL_TEST_FAILED"; then exit 1; fi)
+    fail=${PIPESTATUS[1]}
 fi
 
 if [ $fail == 1 ]; then
     echo "🚨 ERROR: Some tests failed"
     exit 1
 fi
+
+# Calculate and display duration
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+minutes=$((duration / 60))
+seconds=$((duration % 60))
+echo "✨ Test suite completed in ${minutes}m ${seconds}s"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it -w /home/ghost/ghost/web-analytics ghost /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "docker start tinybird-local 2>/dev/null || docker run --platform linux/amd64 -p 7181:7181 --name tinybird-local -d tinybirdco/tinybird-local:latest && echo 'Waiting for Tinybird to be ready...' && until curl -s http://localhost:7181/tokens > /dev/null; do sleep 1; done && docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/sh -c '(command -v curl >/dev/null && command -v jq >/dev/null) || (apt-get update && apt-get install -y curl jq) && TOKEN=$(curl -s http://host.docker.internal:7181/tokens | jq -r .workspace_admin_token) && tb auth --host http://host.docker.internal:7181 --token \"$TOKEN\" && /bin/sh'",
     "tb:local:stop": "docker stop tinybird-local && docker rm tinybird-local"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it -w /home/ghost/ghost/web-analytics ghost /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm --no-deps -it -w /home/ghost/ghost/web-analytics ghost /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb:old": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "docker start tinybird-local 2>/dev/null || docker run --platform linux/amd64 -p 7181:7181 --name tinybird-local -d tinybirdco/tinybird-local:latest && echo 'Waiting for Tinybird to be ready...' && until curl -s http://localhost:7181/tokens > /dev/null; do sleep 1; done && docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/sh -c '(command -v curl >/dev/null && command -v jq >/dev/null) || (apt-get update && apt-get install -y curl jq) && TOKEN=$(curl -s http://host.docker.internal:7181/tokens | jq -r .workspace_admin_token) && tb auth --host http://host.docker.internal:7181 --token \"$TOKEN\" && /bin/sh'",
     "tb:local:stop": "docker stop tinybird-local && docker rm tinybird-local"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-189/run-tests-in-parallel

- As we've added more tests to gain confidence in making changes to Tinybird, our test suite has begun to become a bottleneck.
- Since all of our current tests are operating on the same static fixture dataset, and we're just checking the result of API calls, there's no reason these tests need to run in series, one after the other.
- This change adds some logic to the `exec_test.sh` script to determine the number of available CPU cores, and run the tests with {cpu_cores} jobs.
- The `exec_test.sh` script also accepts a `-j` option, to override the number of jobs — this allows us to run without parallelism by using `./scripts/exec_test.sh -j 1`
- Before this commit, the CI test job was taking ~1 minute, 45 seconds total, with the `Run fixture tests` step taking a full 1 minute. After, the CI test job is taking < 1 minute, and the `Run fixture tests` step is taking ~15 seconds.
- The difference when running locally is even more dramatic, at least in west coast US — before, the `exec_test` script was taking ~1 minute 45 seconds, and now it's only taking ~6 seconds
