### PR TITLE
Removed unneeded volumes from the `compose.yml` 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -56,13 +56,10 @@ services:
       - node_modules_ghost_member-events:/home/ghost/ghost/member-events/node_modules:delegated
       - node_modules_ghost_members-api:/home/ghost/ghost/members-api/node_modules:delegated
       - node_modules_ghost_members-csv:/home/ghost/ghost/members-csv/node_modules:delegated
-      - node_modules_ghost_metrics-server:/home/ghost/ghost/metrics-server/node_modules:delegated
       - node_modules_ghost_milestones:/home/ghost/ghost/milestones/node_modules:delegated
       - node_modules_ghost_minifier:/home/ghost/ghost/minifier/node_modules:delegated
-      - node_modules_ghost_model-to-domain-event-interceptor:/home/ghost/ghost/model-to-domain-event-interceptor/node_modules:delegated
       - node_modules_ghost_mw-error-handler:/home/ghost/ghost/mw-error-handler/node_modules:delegated
       - node_modules_ghost_mw-vhost:/home/ghost/ghost/mw-vhost/node_modules:delegated
-      - node_modules_ghost_nql-filter-expansions:/home/ghost/ghost/nql-filter-expansions/node_modules:delegated
       - node_modules_ghost_offers:/home/ghost/ghost/offers/node_modules:delegated
       - node_modules_ghost_post-events:/home/ghost/ghost/post-events/node_modules:delegated
       - node_modules_ghost_post-revisions:/home/ghost/ghost/post-revisions/node_modules:delegated
@@ -193,13 +190,10 @@ volumes:
   node_modules_ghost_member-events: {}
   node_modules_ghost_members-api: {}
   node_modules_ghost_members-csv: {}
-  node_modules_ghost_metrics-server: {}
   node_modules_ghost_milestones: {}
   node_modules_ghost_minifier: {}
-  node_modules_ghost_model-to-domain-event-interceptor: {}
   node_modules_ghost_mw-error-handler: {}
   node_modules_ghost_mw-vhost: {}
-  node_modules_ghost_nql-filter-expansions: {}
   node_modules_ghost_offers: {}
   node_modules_ghost_post-events: {}
   node_modules_ghost_post-revisions: {}


### PR DESCRIPTION
no issue

- This commit removes some `node_modules` volumes from the `compose.yml` file that have remained, even though the associated packages have been deleted. Now that the packages are gone, we don't need the volumes, and they could potentially lead to weird dependency resolution issues if left around.
