### PR TITLE
[WIP] Added Captcha settings for self-hosters

### DIFF
--- a/ghost/core/core/server/api/endpoints/settings-public.js
+++ b/ghost/core/core/server/api/endpoints/settings-public.js
@@ -6,9 +6,15 @@ const labs = require('../../../shared/labs');
 
 const getCaptchaSettings = () => {
     if (labs.isSet('captcha')) {
-        return {
-            captcha_sitekey: config.get('captcha:siteKey')
-        };
+        const siteKey = config.get('hostSettings:captcha:siteKey');
+        if (siteKey) {
+            return {
+                captcha_sitekey: siteKey
+            };
+        } else {
+            // Sitekey pulled from settings for self-hosters, no need to override
+            return {};
+        }
     } else {
         return {
             captcha_enabled: false

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -77,6 +77,8 @@ const EDITABLE_SETTINGS = [
     'heading_font',
     'blocked_email_domains',
     'captcha_enabled',
+    'captcha_sitekey',
+    'captcha_secret',
     'require_email_mfa'
 ];
 

--- a/ghost/core/core/server/data/migrations/versions/5.116/2025-03-28-17-58-29-add-captcha-selfhoster-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.116/2025-03-28-17-58-29-add-captcha-selfhoster-settings.js
@@ -1,0 +1,16 @@
+const {addSetting, combineTransactionalMigrations} = require('../../utils');
+
+module.exports = combineTransactionalMigrations([
+    addSetting({
+        key: 'captcha_sitekey',
+        value: null,
+        type: 'string',
+        group: 'members'
+    }),
+    addSetting({
+        key: 'captcha_secret',
+        value: null,
+        type: 'string',
+        group: 'members'
+    })
+]);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -327,6 +327,14 @@
                 "isIn": [["true", "false"]]
             },
             "type": "boolean"
+        },
+        "captcha_sitekey": {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "captcha_secret": {
+            "defaultValue": null,
+            "type": "string"
         }
     },
     "portal": {

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -244,7 +244,7 @@ function createApiInstance(config) {
         captchaService: new CaptchaService({
             enabled: labsService.isSet('captcha') && sharedConfig.get('captcha:enabled'),
             scoreThreshold: sharedConfig.get('captcha:scoreThreshold'),
-            secretKey: sharedConfig.get('captcha:secretKey')
+            secretKey: sharedConfig.get('hostSettings:captcha:secretKey') || settingsCache.get('captcha_secret')
         })
     });
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -60,6 +60,8 @@ const _ = require('lodash');
  * @property {string|null} support_email_address - Support email address
  * @property {string|null} editor_default_email_recipients - Default email recipients for editor
  * @property {boolean|null} captcha_enabled - Whether captcha is enabled
+ * @property {string|null} captcha_sitekey - Unique sitekey for hCaptcha
+ * @property {string|null} captcha_secret - Private key to validate hCaptcha responses
  * @property {string|null} labs - JSON string of enabled labs features
  * @property {never} [x] - Prevent accessing undefined properties
  */


### PR DESCRIPTION
ref BAE-403

Issues with this PR currently:

* No design review, copy needs addressing for the new fields in Ghost Admin
* The change to using `hostSettings:captcha` for siteKey & secretKey needs to be actioned for Ghost (Pro)