### PR TITLE
Moved renovate config out of package.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,56 @@
+{
+    "extends": [
+        "github>tryghost/renovate-config:quiet"
+    ],
+    "rebaseWhen": "never",
+    "ignoreDeps": [
+        "got",
+        "intl-messageformat",
+        "moment",
+        "moment-timezone",
+        "simple-dom",
+        "ember-drag-drop",
+        "normalize.css",
+        "validator",
+        "codemirror",
+        "faker",
+        "ember-cli-code-coverage",
+        "ember-cli-terser"
+    ],
+    "ignorePaths": [
+        "test",
+        "ghost/admin/lib/koenig-editor/package.json"
+    ],
+    "packageRules": [
+        {
+        "groupName": "ember-basic-dropdown addons",
+        "packagePatterns": [
+            "^ember-basic",
+            "^ember-power"
+        ]
+        },
+        {
+        "groupName": "ember core",
+        "packageNames": [
+            "ember-source",
+            "ember-cli",
+            "ember-data"
+        ]
+        },
+        {
+        "groupName": "disable css",
+        "matchFiles": [
+            "ghost/admin/package.json"
+        ],
+        "packagePatterns": [
+            "^postcss",
+            "^css"
+        ],
+        "packageNames": [
+            "autoprefixer",
+            "ember-cli-postcss"
+        ],
+        "enabled": false
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -67,62 +67,6 @@
     "moment": "2.24.0",
     "moment-timezone": "0.5.45"
   },
-  "renovate": {
-    "extends": [
-      "github>tryghost/renovate-config:quiet"
-    ],
-    "rebaseWhen": "never",
-    "ignoreDeps": [
-      "got",
-      "intl-messageformat",
-      "moment",
-      "moment-timezone",
-      "simple-dom",
-      "ember-drag-drop",
-      "normalize.css",
-      "validator",
-      "codemirror",
-      "faker",
-      "ember-cli-code-coverage",
-      "ember-cli-terser"
-    ],
-    "ignorePaths": [
-      "test",
-      "ghost/admin/lib/koenig-editor/package.json"
-    ],
-    "packageRules": [
-      {
-        "groupName": "ember-basic-dropdown addons",
-        "packagePatterns": [
-          "^ember-basic",
-          "^ember-power"
-        ]
-      },
-      {
-        "groupName": "ember core",
-        "packageNames": [
-          "ember-source",
-          "ember-cli",
-          "ember-data"
-        ]
-      },
-      {
-        "groupName": "disable css",
-        "matchFiles": [
-          "ghost/admin/package.json"
-        ],
-        "packagePatterns": [
-          "^postcss",
-          "^css"
-        ],
-        "packageNames": [
-          "autoprefixer",
-          "ember-cli-postcss"
-        ],
-        "enabled": false
-      }
-    ]
-  },
   "lint-staged": {
     "*.js": "eslint"
   },


### PR DESCRIPTION
ref https://docs.renovatebot.com/configuration-options/

- Renovate have deprecated using package.json for configuration
- We are defaulting to using `.github/renovate.json` as we prefer not having lots of top-level config filess
