### PR TITLE
Fixed dropdowns not closing on web preview

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/browser.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/browser.hbs
@@ -2,14 +2,14 @@
     <div class="modal-body modal-preview-email-content gh-pe-mobile-container gh-post-preview-container h-auto overflow-auto {{unless @skipAnimation "fade-in"}}">
         <div class="gh-pe-mobile-bezel">
             <div class="gh-pe-mobile-screen">
-                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview"></iframe>
+                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{did-insert this.setupIframe}}></iframe>
             </div>
         </div>
     </div>
 {{else}}
     <div class="gh-post-preview-container gh-post-preview-browser-container {{unless @skipAnimation "fade-in"}}">
         <div class="gh-browserpreview-iframecontainer">
-            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview"></iframe>
+            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{did-insert this.setupIframe}}></iframe>
         </div>
     </div>
 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+
+export default class ModalPostPreviewBrowserComponent extends Component {
+    @service dropdown;
+
+    @action
+    setupIframe(iframe) {
+        if (!iframe) {
+            return;
+        }
+
+        iframe.addEventListener('load', () => {
+            const iframeDoc = iframe.contentWindow?.document;
+            if (iframeDoc) {
+                iframeDoc.removeEventListener('click', this.dropdown.closeDropdowns);
+                iframeDoc.addEventListener('click', this.dropdown.closeDropdowns);
+            }
+        });
+    }
+} 


### PR DESCRIPTION
No ref
- The share dropdown and the preview-segment dropdown were not closing when clicking inside the iframe of the post preview. This was fixed by adding an event listener to the iframe's document to close the dropdowns when clicking inside the iframe.