### PR TITLE
Fixed selects not closing when clicking preview iframes

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/browser.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/browser.hbs
@@ -2,14 +2,14 @@
     <div class="modal-body modal-preview-email-content gh-pe-mobile-container gh-post-preview-container h-auto overflow-auto {{unless @skipAnimation "fade-in"}}">
         <div class="gh-pe-mobile-bezel">
             <div class="gh-pe-mobile-screen">
-                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview"></iframe>
+                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{close-dropdowns-on-click}}></iframe>
             </div>
         </div>
     </div>
 {{else}}
     <div class="gh-post-preview-container gh-post-preview-browser-container {{unless @skipAnimation "fade-in"}}">
         <div class="gh-browserpreview-iframecontainer">
-            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview"></iframe>
+            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{close-dropdowns-on-click}}></iframe>
         </div>
     </div>
 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -94,6 +94,7 @@
                 sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                 {{did-insert this.renderEmailPreview}}
                 {{did-update this.renderEmailPreview @memberSegment}}
+                {{close-dropdowns-on-click}}
             ></iframe>
         </div>
     </div>

--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -34,7 +34,6 @@ const SEGMENT_OPTIONS = [{
 // TODO: remove duplication with <ModalPostEmailPreview>
 export default class ModalPostPreviewEmailComponent extends Component {
     @service ajax;
-    @service dropdown;
     @service feature;
     @service ghostPaths;
     @service session;
@@ -78,9 +77,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
             iframe.contentWindow.document.open();
             iframe.contentWindow.document.write(this.html);
             iframe.contentWindow.document.close();
-
-            iframe.contentWindow.document.removeEventListener('click', this.dropdown.closeDropdowns);
-            iframe.contentWindow.document.addEventListener('click', this.dropdown.closeDropdowns);
         }
     }
 

--- a/ghost/admin/app/modifiers/close-dropdowns-on-click.js
+++ b/ghost/admin/app/modifiers/close-dropdowns-on-click.js
@@ -1,0 +1,33 @@
+import Modifier from 'ember-modifier';
+import {registerDestructor} from '@ember/destroyable';
+import {inject as service} from '@ember/service';
+
+export default class CloseDropdownsOnClickModifier extends Modifier {
+    @service dropdown;
+
+    constructor(owner, args) {
+        super(owner, args);
+        registerDestructor(this, this.cleanup);
+
+        function onClick() {
+            this.dropdown.closeDropdowns();
+        }
+        this.onClick = onClick.bind(this);
+    }
+
+    modify(element) {
+        if (element.tagName === 'IFRAME') {
+            element.addEventListener('load', () => {
+                this.element = element.contentDocument;
+                this.element.addEventListener('click', this.onClick);
+            });
+        } else {
+            this.element = element;
+            this.element.addEventListener('click', this.onClick);
+        }
+    }
+
+    cleanup = () => {
+        this.element?.removeEventListener('click', this.onClick);
+    };
+}


### PR DESCRIPTION
no issue

- added `{{close-dropdowns-on-click}}` modifier
  - handles usage on normal elements and iframes by attaching event handler to iframe content document when used on an iframe
- updated all preview modal iframes to use the modifier
