### PR TITLE
Fixed share dropdown not closing when audience dropdown opened

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -27,6 +27,7 @@
                     @triggerClass="gh-preview-segment-trigger"
                     @dropdownClass="gh-preview-segment-dropdown"
                     @matchTriggerWidth={{false}}
+                    @onOpen={{this.dropdown.closeDropdowns}}
                     as |option|
                 >
                     {{option.label}}

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -6,6 +6,7 @@ import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 export default class EditorPostPreviewModal extends Component {
+    @service dropdown;
     @service settings;
     @service session;
 


### PR DESCRIPTION
no issue

- select dropdowns do not automatically close other dropdowns because sometimes we have selects inside dropdowns
- added explicit dropdown close to the preview-as select's `@onOpen` argument
