### PR TITLE
Fixed pages component for filtering by source

### DIFF
--- a/ghost/web-analytics/pipes/api_top_pages.pipe
+++ b/ghost/web-analytics/pipes/api_top_pages.pipe
@@ -5,42 +5,43 @@ NODE _top_pages_0
 SQL >
 
     %
-        select
-            pathname,
-            uniqExact(session_id) as visits,
-            count() as pageviews
-        from _mv_hits h
-        inner join filtered_sessions fs
-            on fs.session_id = h.session_id
-        where
-            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-            {% if defined(date_from) %}
-                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-                >=
-                {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
-            {% else %}
-                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-                >=
-                timestampAdd(today(), interval -7 day)
-            {% end %}
-            {% if defined(date_to) %}
-                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-                <=
-                {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
-            {% else %}
-                and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
-                <=
-                today()
-            {% end %}
-            {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-            {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
-            {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
-            {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
-            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-        group by pathname
-        order by visits desc
-        limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
+    select
+        pathname,
+        uniqExact(session_id) as visits,
+        count() as pageviews
+    from _mv_hits h
+    inner join filtered_sessions fs
+        on fs.session_id = h.session_id
+    where
+        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+        {% if defined(date_from) %}
+            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            >=
+            {{ Date(date_from, description="Starting day for filtering a date range", required=False) }}
+        {% else %}
+            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            >=
+            timestampAdd(today(), interval -7 day)
+        {% end %}
+        {% if defined(date_to) %}
+            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            <=
+            {{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}
+        {% else %}
+            and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+            <=
+            today()
+        {% end %}
+        {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
+        {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}
+        {% if defined(browser) %} and browser = {{ String(browser, description="Browser to filter on", required=False) }} {% end %}
+        {% if defined(os) %} and os = {{ String(os, description="Operating system to filter on", required=False) }} {% end %}
+        -- we do filtering on source in the filtered_sessions pipe
+        --{% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
+        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+    group by pathname
+    order by visits desc
+    limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
 
 

--- a/ghost/web-analytics/tests/filter_source_bing_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_pages.test.result
@@ -1,2 +1,4 @@
 "pathname","visits","pageviews"
-"/about/",2,2
+"/about/",2,3
+"/",1,1
+"/blog/hello-world/",1,1

--- a/ghost/web-analytics/tests/filter_source_direct_top_pages.test
+++ b/ghost/web-analytics/tests/filter_source_direct_top_pages.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_pages__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source ""

--- a/ghost/web-analytics/tests/filter_source_direct_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_source_direct_top_pages.test.result
@@ -1,4 +1,4 @@
 "pathname","visits","pageviews"
-"/blog/hello-world/",3,3
-"/about/",2,3
+"/about/",4,5
+"/blog/hello-world/",4,4
 "/",2,3


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-195

When filtering by source, we were accidentally double-filtering. The component is intended to display all pageviews for any session with the filtered-by-source. It was instead showing only the views with that source as well.