### PR TITLE
Adjusted ghost-stats session TTL to 4 hours

### DIFF
--- a/ghost/core/core/frontend/public/ghost-stats.js
+++ b/ghost/core/core/frontend/public/ghost-stats.js
@@ -116,7 +116,7 @@
       const now = new Date()
       const item = {
         value: sessionId,
-        expiry: now.getTime() + 1800 * 1000,
+        expiry: now.getTime() + 14400 * 1000, // 4 hours
       }
       const value = JSON.stringify(item)
       const storage =


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ANAL-197/

TTL was previously only 30 minutes, leading to sessions that would go stale awfully quickly, resulting in what looked like a lot of internal traffic.