### PR TITLE
Fixed test failure exit code handling in Tinybird `exec_test` script

### DIFF
--- a/ghost/web-analytics/tests/filter_source_bing_top_sources.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_sources.test.result
@@ -1,2 +1,1 @@
 "source","visits","pageviews"
-"bing.com",2,5

--- a/ghost/web-analytics/tests/filter_source_bing_top_sources.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_sources.test.result
@@ -1,1 +1,2 @@
 "source","visits","pageviews"
+"bing.com",2,5


### PR DESCRIPTION
no issue

The `exec_test` script was exiting with code 141 when a test failed, which CI wasn't interpreting as a failure, and was therefore showing passing results. This commit aims to fix that by modifying the script to exit with code 1 if any tests fail.

The previous implementation used process substitution with tee and PIPESTATUS
to detect test failures, but this was unreliable because:
1. Process substitution runs in a subshell, so its exit code wasn't properly
   propagated to the parent shell
2. The SIGPIPE (141) errors occurred when the grep process in the subshell
   terminated before the tee process finished writing

Changed to use a temporary file instead, which:
1. Ensures all test output is captured before checking for failures
2. Avoids subshell exit code propagation issues
3. Eliminates the SIGPIPE errors by removing the process substitution
4. Makes the failure detection more reliable by checking the output file
   after all tests have completed