### PR TITLE
Added site title validation in Ghost settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
@@ -6,6 +6,7 @@ import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 
 const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
+        errors,
         localSettings,
         isEditing,
         saveState,
@@ -14,7 +15,35 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleCancel,
         updateSetting,
         handleEditingChange
-    } = useSettingGroup();
+    } = useSettingGroup({
+        onValidate: () => {
+            if (!title) {
+                return {
+                    title: 'Please enter a site title.'
+                };
+            }
+
+            if (title.length < 4) {
+                return {
+                    title: 'Please use a site title longer than 3 characters.'
+                };
+            }
+
+            if (title.length > 63) {
+                return {
+                    title: 'Please use a site title shorter than 63 characters.'
+                };
+            }
+
+            if (!title.match(/^[\p{L}\p{N}\u0900-\u097F\u0E00-\u0E7F\s;.,:()!?.'"'’”]+$/u)) {
+                return {
+                    title: 'Please use a site title without special characters.'
+                };
+            }
+
+            return {};
+        }
+    });
 
     const [title, description] = getSettingValues(localSettings, ['title', 'description']) as string[];
 
@@ -47,9 +76,10 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const inputFields = (
         <SettingGroupContent>
             <TextField
-                hint="The name of your site"
+                error={Boolean(errors.title)}
+                hint={errors.title || 'The name of your site'}
                 inputRef={focusRef}
-                maxLength={150}
+                maxLength={63}
                 placeholder="Site title"
                 title="Site title"
                 value={title}

--- a/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
@@ -11,6 +11,7 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
         isEditing,
         saveState,
         focusRef,
+        clearError,
         handleSave,
         handleCancel,
         updateSetting,
@@ -84,6 +85,7 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 title="Site title"
                 value={title}
                 onChange={handleTitleChange}
+                onKeyDown={() => clearError('title')}
             />
             <TextField
                 hint="A short description, used in your theme, meta data and search results"

--- a/apps/admin-x-settings/test/acceptance/general/titleAndDescription.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/titleAndDescription.test.ts
@@ -38,4 +38,37 @@ test.describe('Title and description settings', async () => {
             ]
         });
     });
+
+    test('Shows an error if the title is invalid and does not save', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: /^\/settings\/$/, response: updatedSettingsResponse([
+                {key: 'title', value: 'New Site Title'}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('title-and-description');
+        await expect(section.getByText('Test Site')).toHaveCount(1);
+
+        await section.getByRole('button', {name: 'Edit'}).click();
+
+        // Empty title
+        await section.getByLabel('Site title').fill('');
+        await section.getByRole('button', {name: 'Save'}).click();
+        await expect(section.getByText('Please enter a site title.')).toHaveCount(1);
+
+        // Title is too short
+        await section.getByLabel('Site title').fill('ab');
+        await section.getByRole('button', {name: 'Save'}).click();
+        await expect(section.getByText('Please use a site title longer than 3 characters.')).toHaveCount(1);
+
+        // Title has invalid characters
+        await section.getByLabel('Site title').fill('Title with emoji: 🕵️‍♂️');
+        await section.getByRole('button', {name: 'Save'}).click();
+        await expect(section.getByText('Please use a site title without special characters.')).toHaveCount(1);
+
+        expect(lastApiRequests.editSettings).toBeUndefined();
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1021

- on signup, we validate the title sitle: it must be present, be between 3 and 63 characters and should not contain special characters such as emojis
- we have now added the same validation in Ghost settings, to avoid empty or invalid site titles
