### PR TITLE
Added cache invalidation to preview queries

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -30,10 +30,16 @@ function getCacheHeaderFromEventString(event, dto) {
         return true;
     }
     if (event === 'scheduled_updated' || event === 'draft_updated') {
+        const baseUrl = urlUtils.urlFor({
+            relativeUrl: urlUtils.urlJoin('/p', dto.uuid, '/')
+        });
         return {
-            value: urlUtils.urlFor({
-                relativeUrl: urlUtils.urlJoin('/p', dto.uuid, '/')
-            })
+            value: [
+                baseUrl,
+                `${baseUrl}?member_status=anonymous`,
+                `${baseUrl}?member_status=free`,
+                `${baseUrl}?member_status=paid`
+            ].join(',')
         };
     }
 }

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -39,7 +39,7 @@ function getCacheHeaderFromEventString(event, dto) {
                 `${baseUrl}?member_status=anonymous`,
                 `${baseUrl}?member_status=free`,
                 `${baseUrl}?member_status=paid`
-            ].join(',')
+            ].join(', ')
         };
     }
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -1506,6 +1506,34 @@ Object {
 }
 `;
 
+exports[`Posts API Create invalidates cache when updating a draft post 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "3920",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Posts API Create invalidates preview cache when updating a draft post 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "3920",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Posts API Delete Can delete posts belonging to a collection and returns empty response when filtering by that collection 1: [body] 1`] = `
 Object {
   "meta": Object {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -1529,7 +1529,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free,\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -407,7 +407,9 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        res2.headers['x-cache-invalidate'].should.eql('/p/' + res2.body.posts[0].uuid + '/');
+        const uuid = res2.body.posts[0].uuid;
+        const expectedPattern = `/p/${uuid}/,/p/${uuid}/?member_status=anonymous,/p/${uuid}/?member_status=free,/p/${uuid}/?member_status=paid`;
+        res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
         // Newsletter should be returned as null
         should(res2.body.posts[0].newsletter).be.null();
@@ -444,7 +446,9 @@ describe('Posts API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private);
 
-        res2.headers['x-cache-invalidate'].should.eql('/p/' + res2.body.posts[0].uuid + '/');
+        const uuid = res2.body.posts[0].uuid;
+        const expectedPattern = `/p/${uuid}/,/p/${uuid}/?member_status=anonymous,/p/${uuid}/?member_status=free,/p/${uuid}/?member_status=paid`;
+        res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
         unsplashMock.isDone().should.be.true();
 

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -408,7 +408,7 @@ describe('Posts API', function () {
             .expect(200);
 
         const uuid = res2.body.posts[0].uuid;
-        const expectedPattern = `/p/${uuid}/,/p/${uuid}/?member_status=anonymous,/p/${uuid}/?member_status=free,/p/${uuid}/?member_status=paid`;
+        const expectedPattern = `/p/${uuid}/, /p/${uuid}/?member_status=anonymous, /p/${uuid}/?member_status=free, /p/${uuid}/?member_status=paid`;
         res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
         // Newsletter should be returned as null
@@ -447,7 +447,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private);
 
         const uuid = res2.body.posts[0].uuid;
-        const expectedPattern = `/p/${uuid}/,/p/${uuid}/?member_status=anonymous,/p/${uuid}/?member_status=free,/p/${uuid}/?member_status=paid`;
+        const expectedPattern = `/p/${uuid}/, /p/${uuid}/?member_status=anonymous, /p/${uuid}/?member_status=free, /p/${uuid}/?member_status=paid`;
         res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
         unsplashMock.isDone().should.be.true();

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -403,6 +403,33 @@ describe('Posts API', function () {
             should.exist(emptyPageCount);
             emptyPageCount.should.equal(0, 'post-creation empty page count');
         });
+
+        it('invalidates preview cache when updating a draft post', async function () {
+            const post = {
+                title: 'Cache invalidation test',
+                status: 'draft'
+            };
+
+            const {body: postBody} = await agent
+                .post('/posts/?formats=mobiledoc,lexical,html')
+                .body({posts: [post]})
+                .expectStatus(201);
+
+            const [postResponse] = postBody.posts;
+
+            // check that header contains the correct cache invalidation pattern which is the post url and the post url with member_status=anonymous, free, paid
+            await agent
+                .put(`/posts/${postResponse.id}/?formats=mobiledoc,lexical,html`)
+                .body({posts: [Object.assign({}, postResponse, {status: 'draft'})]})
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/,\/p\/[a-z0-9-]+\/\?member_status=anonymous,\/p\/[a-z0-9-]+\/\?member_status=free,\/p\/[a-z0-9-]+\/\?member_status=paid$/)
+                });
+        });
+
+        // update when updating a scheduled post
     });
 
     describe('Update', function () {

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -425,7 +425,7 @@ describe('Posts API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag,
-                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/,\/p\/[a-z0-9-]+\/\?member_status=anonymous,\/p\/[a-z0-9-]+\/\?member_status=free,\/p\/[a-z0-9-]+\/\?member_status=paid$/)
+                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                 });
         });
 

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -480,7 +480,7 @@ class PostsService {
                     `${baseUrl}?member_status=anonymous`,
                     `${baseUrl}?member_status=free`,
                     `${baseUrl}?member_status=paid`
-                ].join(',')
+                ].join(', ')
             };
         } else {
             cacheInvalidate = false;

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -471,10 +471,16 @@ class PostsService {
             model.get('status') === 'draft' && model.previous('status') !== 'published' ||
             model.get('status') === 'scheduled' && model.wasChanged()
         ) {
+            const baseUrl = this.urlUtils.urlFor({
+                relativeUrl: this.urlUtils.urlJoin('/p', model.get('uuid'), '/')
+            }, true);
             cacheInvalidate = {
-                value: this.urlUtils.urlFor({
-                    relativeUrl: this.urlUtils.urlJoin('/p', model.get('uuid'), '/')
-                })
+                value: [
+                    baseUrl,
+                    `${baseUrl}?member_status=anonymous`,
+                    `${baseUrl}?member_status=free`,
+                    `${baseUrl}?member_status=paid`
+                ].join(',')
             };
         } else {
             cacheInvalidate = false;

--- a/ghost/posts-service/test/PostsService.test.js
+++ b/ghost/posts-service/test/PostsService.test.js
@@ -247,4 +247,54 @@ describe('Posts Service', function () {
             assert.equal(postsService.generateCopiedPostLocationFromUrl(url), expectedUrl);
         });
     });
+
+    describe('handleCacheInvalidation', function () {
+        let postsService;
+        let urlUtils;
+
+        beforeEach(function () {
+            urlUtils = {
+                urlFor: sinon.stub().returns('http://example.com/p/123/'),
+                urlJoin: sinon.stub().returns('/p/123/')
+            };
+            postsService = new PostsService({urlUtils});
+        });
+
+        it('returns comma-separated URLs for draft posts that were changed', function () {
+            const model = {
+                get: sinon.stub().returns('draft'),
+                previous: sinon.stub().returns('draft'),
+                wasChanged: sinon.stub().returns(true),
+                uuid: '123'
+            };
+
+            const result = postsService.handleCacheInvalidation(model);
+            assert.deepEqual(result, {
+                value: [
+                    'http://example.com/p/123/',
+                    'http://example.com/p/123/?member_status=anonymous',
+                    'http://example.com/p/123/?member_status=free',
+                    'http://example.com/p/123/?member_status=paid'
+                ].join(',')
+            });
+        });
+
+        it('returns comma-separated URLs for scheduled posts that were changed', function () {
+            const model = {
+                get: sinon.stub().returns('scheduled'),
+                wasChanged: sinon.stub().returns(true),
+                uuid: '123'
+            };
+
+            const result = postsService.handleCacheInvalidation(model);
+            assert.deepEqual(result, {
+                value: [
+                    'http://example.com/p/123/',
+                    'http://example.com/p/123/?member_status=anonymous',
+                    'http://example.com/p/123/?member_status=free',
+                    'http://example.com/p/123/?member_status=paid'
+                ].join(',')
+            });
+        });
+    });
 });

--- a/ghost/posts-service/test/PostsService.test.js
+++ b/ghost/posts-service/test/PostsService.test.js
@@ -275,7 +275,7 @@ describe('Posts Service', function () {
                     'http://example.com/p/123/?member_status=anonymous',
                     'http://example.com/p/123/?member_status=free',
                     'http://example.com/p/123/?member_status=paid'
-                ].join(',')
+                ].join(', ')
             });
         });
 
@@ -293,7 +293,7 @@ describe('Posts Service', function () {
                     'http://example.com/p/123/?member_status=anonymous',
                     'http://example.com/p/123/?member_status=free',
                     'http://example.com/p/123/?member_status=paid'
-                ].join(',')
+                ].join(', ')
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-384/paid-only-content-not-showing-in-web-preview-for-paid-member

Previously, `handleCacheInvalidation` only purged the base preview path (`/p/<UUID>/`) for draft and scheduled posts, leaving variants with query params (e.g., `?member_status=free`) cached in Fastly/Varnish. This caused stale content to persist in routes with the query parameters.

This change updates:
- `handleCacheInvalidation` to return a comma-separated list of URLs—including the base path and variants with `member_status=anonymous`, `free`, and `paid`—when a draft post changes (and wasn’t previously published) or a scheduled post is modified.
- `getCacheHeaderFromEventString` in the controller to apply the same logic for `scheduled_updated` and `draft_updated` events.

This change updates `handleCacheInvalidation` to return a comma-separated list of preview paths and variants with `member_status=anonymous`, `free`, and `paid` when a draft post changes or a scheduled post is modified.

