### PR TITLE
Improved performance of processing gated content blocks

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/post-gating.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/post-gating.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert/strict');
 const sinon = require('sinon');
+const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const gating = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/post-gating');
 const membersContentGating = require('../../../../../../../../core/server/services/members/content-gating');
 const labs = require('../../../../../../../../core/shared/labs');
@@ -157,6 +158,19 @@ describe('Unit: endpoints/utils/serializers/output/utils/post-gating', function 
 
                 sinon.assert.notCalled(regexSpy);
                 sinon.assert.notCalled(stripGatedBlocksStub);
+            });
+
+            it('does not call htmlToPlaintext.excerpt more than once', function () {
+                const excerptStub = sinon.stub(htmlToPlaintext, 'excerpt').returns('excerpt');
+
+                const attrs = {
+                    visibility: 'public',
+                    html: '<!--kg-gated-block:begin nonMember:true--><p>gated block</p><!--kg-gated-block:end-->',
+                    excerpt: 'gated block'
+                };
+
+                gating.forPost(attrs, frame);
+                sinon.assert.calledOnce(excerptStub);
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-371

- profiling the `forPost` method showed we spend most of the time re-generating plaintext content after the `html` value is updated, it also showed that we were doing this twice - once for `plaintext` and once for `excerpt` - even though `excerpt` is just a substring of the same content we generated for `plaintext`
- replaced the extra `htmlToPlaintext.excerpt()` call with a `plaintext.substring()` where possible
- simplified the gated blocks regex by tightening up the allowed whitespace in the HTML comments which improved it's performance
  - currently our own code is the only source of gated block comments and we have only ever used the minimal-whitespace variant so we're in a good position to make that change at this point without breaking existing content
