### PR TITLE
✨ Added new CTA card with web and email visibility controls

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,7 +25,8 @@ const GA_FEATURES = [
     'i18n',
     'themeErrorsNotification',
     'announcementBar',
-    'customFonts'
+    'customFonts',
+    'contentVisibility'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -38,7 +39,6 @@ const BETA_FEATURES = [
     'ActivityPub',
     'importMemberTier',
     'staff2fa',
-    'contentVisibility',
     'superEditors'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1163,7 +1163,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4436",
+  "content-length": "4463",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-371

Keep an eye on https://ghost.org/changelog/ for the full announcement of new features.

- a new "Call to action" card replaces the older "Email CTA" card
  - improves design possibilities to better cover in-page ad/sponsorship use cases
  - adds visibility settings to control who sees the content across both web and email
- adds visibility settings to HTML card to improve it's usefulness when embedding ad content
