### PR TITLE
Fixed loss of full error in flaky data generator test

### DIFF
--- a/ghost/core/test/unit/server/data/seeders/data-generator.test.js
+++ b/ghost/core/test/unit/server/data/seeders/data-generator.test.js
@@ -93,11 +93,7 @@ describe('Data Generator', function () {
             }],
             withDefault: true
         });
-        try {
-            return await dataGenerator.importData();
-        } catch (err) {
-            (false).should.eql(true, err.message);
-        }
+        await dataGenerator.importData();
     });
 });
 
@@ -239,11 +235,7 @@ describe('Events Generator', function () {
         const shapes = ['linear', 'flat', 'ease-in', 'ease-out'];
 
         for (const shape of shapes) {
-            try {
-                generateEvents(Object.assign({}, options, {shape}));
-            } catch (err) {
-                (false).should.eql(true, err.message);
-            }
+            generateEvents(Object.assign({}, options, {shape}));
         }
     });
 });


### PR DESCRIPTION
- because of how the test is written, it's just asserting true === false if the function throws an error, which of course fails, and then it passes the error message to the body
- because of this, we lose the stacktrace for the original err, and the message might not be very descriptive
- with this change, we're just running the importData function
- if there's an error, it'll just fail the test with that, so we should keep the stacktrace