### PR TITLE
Fixed link width in ActivityPub reader

### DIFF
--- a/apps/admin-x-activitypub/src/components/articleBodyStyles.ts
+++ b/apps/admin-x-activitypub/src/components/articleBodyStyles.ts
@@ -166,6 +166,7 @@ a:hover {
     font-size: 1.5rem;
     line-height: 1.2;
     color: var(--color-secondary-text);
+    width: fit-content;
 }
 
 .gh-article-source:hover {

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -176,9 +176,9 @@ const ArticleBody: React.FC<{
             <header class='gh-article-header gh-canvas'>
                 <h1 class='gh-article-title is-title' data-test-article-heading>${heading}</h1>
                 ${excerpt ? `<p class='gh-article-excerpt'>${excerpt}</p>` : ''}
-                <a href="${postUrl}" target="_blank" rel="noopener noreferrer" class="gh-article-source">
+                <div><a href="${postUrl}" target="_blank" rel="noopener noreferrer" class="gh-article-source">
                     ${postUrl ? new URL(postUrl).hostname : ''} <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon lucide-external-link"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
-                </a>
+                </a></div>
                 ${image ? `
                 <figure class='gh-article-image'>
                     <img src='${image}' alt='${heading}' />


### PR DESCRIPTION
no ref

- Small fix to set the width of the link to original article in the header of the ActivityPub reader