### PR TITLE
Allowed non-url refs in ghost stats referrer field

### DIFF
--- a/ghost/core/core/frontend/public/ghost-stats.js
+++ b/ghost/core/core/frontend/public/ghost-stats.js
@@ -282,16 +282,18 @@
     // Get the final referrer value based on priority
     const finalReferrer = referrerSource || referrerMedium || referrerUrl || null;
 
-    // If the final referrer matches the current site's domain, return null
     if (finalReferrer) {
         try {
             const referrerHost = new URL(finalReferrer).hostname;
             const currentHost = window.location.hostname;
+            // If the final referrer matches the current site's domain, return null
             if (referrerHost === currentHost) {
                 return null;
             }
         } catch (e) {
-            // If URL parsing fails, return the original value
+            // If URL parsing fails (e.g. for non-URL refs like "ghost-newsletter"),
+            // just return the original referrer value
+            return finalReferrer;
         }
     }
 


### PR DESCRIPTION
no ref

We want to include refs like ghost-newsletter, not just URLs. This previously worked but regressed due to adding new checks.