### PR TITLE
Updated mv_hits pipe to allow for non-url referrers

### DIFF
--- a/ghost/web-analytics/pipes/mv_hits.pipe
+++ b/ghost/web-analytics/pipes/mv_hits.pipe
@@ -36,7 +36,7 @@ SQL >
         post_uuid,
         post_type,
         location,
-        domainWithoutWWW(referrer) as source,
+        coalesce(domainWithoutWWW(referrer), referrer, '') as source,
         pathname,
         href,
         case


### PR DESCRIPTION
no ref

Moved to coalesce to first try to keep the URL, and instead fall back to the plain referrer field. This may include extra garbage entries, so we'll open it up and we'll see what comes in. The intent is to include `ghost-newsletter` which is traffic from our user newsletters.