### PR TITLE
Added basic linting for Tinybird datafiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,9 +859,6 @@ jobs:
         working-directory: ghost/web-analytics
     if: needs.job_setup.outputs.changed_tinybird == 'true'
     steps:
-      - name: Lint datasources and pipes
-        run: |
-          ./scripts/lint.sh
       - name: Get User Permission
         id: get-user-permission
         uses: actions-cool/check-user-permission@v2
@@ -883,6 +880,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 300
+      - name: Lint datasources and pipes
+        run: |
+          ./scripts/lint.sh
       - name: Check secrets
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,6 +859,9 @@ jobs:
         working-directory: ghost/web-analytics
     if: needs.job_setup.outputs.changed_tinybird == 'true'
     steps:
+      - name: Lint datasources and pipes
+        run: |
+          ./scripts/lint.sh
       - name: Get User Permission
         id: get-user-permission
         uses: actions-cool/check-user-permission@v2

--- a/ghost/web-analytics/README.md
+++ b/ghost/web-analytics/README.md
@@ -1,6 +1,6 @@
 # Tinybird
 
-This folder contains configuration for Tinybird, so that the stats feature can be used.
+This folder contains configuration for Tinybird, so that the Traffic Analytics feature can be used.
 
 We sync this configuration with Tinybird via the Tinybird CLI.
 
@@ -21,5 +21,9 @@ How to work with version control: https://docs.tinybird.co/v/0.22.0/guides/versi
 
 This project uses the `dedicated_staging_stats` workspace. To set up your local environment:
 
-1. Run `yarn tb` to spin up a Tinybird CLI container.
+1. Run `yarn tb` to spin up a Ghost container with the Tinybird CLI installed
 2. Run `tb auth` and provide your token for the `dedicated_staging_stats` workspace. This generates a `.tinyb` file specific to your user - this should not be committed.
+
+## Linting
+
+We have some basic linting checks that run on our Tinybird datafiles. You can run these checks with `./scripts/lint.sh`. These checks are also run in CI before running the fixture test suite, to catch common errors as quickly as possible for a faster feedback loop.

--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -1,5 +1,5 @@
 VERSION 8
-TOKEN "stats_page" READ
+
 
 NODE timeseries
 SQL >

--- a/ghost/web-analytics/pipes/api_kpis.pipe
+++ b/ghost/web-analytics/pipes/api_kpis.pipe
@@ -1,5 +1,5 @@
 VERSION 8
-
+TOKEN "stats_page" READ
 
 NODE timeseries
 SQL >

--- a/ghost/web-analytics/pipes/api_top_locations.pipe
+++ b/ghost/web-analytics/pipes/api_top_locations.pipe
@@ -49,5 +49,3 @@ SQL >
         group by location
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
-
-

--- a/ghost/web-analytics/scripts/lint.sh
+++ b/ghost/web-analytics/scripts/lint.sh
@@ -28,6 +28,7 @@ run_checks() {
     checks=(
         "check_filename"
         "check_token"
+        "check_version_parameter"
         # Add more check functions here as we create them
     )
 
@@ -65,6 +66,29 @@ check_token() {
     if [[ "$basename" == api*.pipe ]]; then
         if ! grep -q 'TOKEN "stats_page" READ' "$file"; then
             error_messages+=("→ $relative_file is missing required 'TOKEN \"stats_page\" READ' declaration")
+            ((errors++))
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Check that all datasource and pipe files (except analytics_events.datasource) have a VERSION parameter
+check_version_parameter() {
+    local file="$1"
+    local relative_file="$2"
+    local basename=$(basename "$file")
+
+    # Skip analytics_events.datasource
+    if [[ "$basename" == "analytics_events.datasource" ]]; then
+        return 0
+    fi
+
+    # Only check .datasource and .pipe files
+    if [[ "$file" == *.datasource || "$file" == *.pipe ]]; then
+        if ! grep -q '^VERSION [0-9]\+' "$file"; then
+            error_messages+=("→ $relative_file is missing required 'VERSION' parameter")
             ((errors++))
             return 1
         fi

--- a/ghost/web-analytics/scripts/lint.sh
+++ b/ghost/web-analytics/scripts/lint.sh
@@ -29,11 +29,9 @@ run_checks() {
 
     # List of check functions - we'll add more here
     checks=(
-        "check_filename"
         "check_token"
         "check_version_parameter"
         "check_consistent_version"
-        # Add more check functions here as we create them
     )
 
     # Run each check
@@ -46,17 +44,6 @@ run_checks() {
     if [ $file_errors -gt 0 ]; then
         return 1
     fi
-    return 0
-}
-
-# Example check function - validates filename format
-check_filename() {
-    local file="$1"
-    local relative_file="$2"
-    local basename=$(basename "$file")
-
-    # For now just return true
-    # We'll add actual checks later
     return 0
 }
 

--- a/ghost/web-analytics/scripts/lint.sh
+++ b/ghost/web-analytics/scripts/lint.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Get the web-analytics root directory (parent of scripts)
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Initialize error counter and array for error messages
+errors=0
+declare -a error_messages
+
+# Function to run all checks on a file
+run_checks() {
+    local file="$1"
+    local relative_file="${file#$ROOT_DIR/}"
+    local file_errors=0
+    echo "Checking $relative_file..."
+
+    # List of check functions - we'll add more here
+    checks=(
+        "check_filename"
+        "check_token"
+        # Add more check functions here as we create them
+    )
+
+    # Run each check
+    for check in "${checks[@]}"; do
+        if ! $check "$file" "$relative_file"; then
+            ((file_errors++))
+        fi
+    done
+
+    if [ $file_errors -gt 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+# Example check function - validates filename format
+check_filename() {
+    local file="$1"
+    local relative_file="$2"
+    local basename=$(basename "$file")
+
+    # For now just return true
+    # We'll add actual checks later
+    return 0
+}
+
+# Check that api*.pipe files have the required token declaration
+check_token() {
+    local file="$1"
+    local relative_file="$2"
+    local basename=$(basename "$file")
+
+    # Only check .pipe files that start with api
+    if [[ "$basename" == api*.pipe ]]; then
+        if ! grep -q 'TOKEN "stats_page" READ' "$file"; then
+            error_messages+=("→ $relative_file is missing required 'TOKEN \"stats_page\" READ' declaration")
+            ((errors++))
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Main execution
+echo "Running linting checks..."
+
+# Process all files using find
+while IFS= read -r file; do
+    if [ -f "$file" ]; then
+        # Run checks but don't let failures stop the loop
+        run_checks "$file" || true
+    fi
+done < <(find "$ROOT_DIR/datasources" "$ROOT_DIR/pipes" -type f \( -name "*.datasource" -o -name "*.pipe" \))
+
+# Final output
+echo
+if [ $errors -eq 0 ]; then
+    echo -e "${GREEN}All checks passed!${NC}"
+else
+    echo -e "${RED}Found $errors error(s):${NC}"
+    echo "----------------------------------------"
+    for msg in "${error_messages[@]}"; do
+        echo -e "${RED}$msg${NC}"
+    done
+    echo "----------------------------------------"
+fi
+echo
+
+# Exit with error if any checks failed
+exit $((errors > 0))


### PR DESCRIPTION
no issue

- We've had issues where the TOKEN parameter is accidentally removed from a pipe, which then requires manual intervention after a deployment to fix the ugly red errors in the charts due to the "stats_page" token not having permissions for the pipe.
- This commit adds a basic lint.sh script, which loops over all the datafiles and runs some checks on them. Right now, there are only 3 simple checks, but we can add to this as we discover issues.

The checks included in this commit are:
- `check_token` — for any pipe starting with `api`, it checks that the "stats_page" token is added to it
- `check_version` — for any datafile other than `analytics_events.datasource`, it checks that there is a VERSION parameter specified
- `check_consistent_version` — checks that all the versioned datafiles are on the same version, to prevent accidentally shipping a partial version.