### PR TITLE
Removed unused node_modules volumes from compose.yml

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -81,7 +81,6 @@ COPY ghost/donations/package.json ghost/donations/package.json
 COPY ghost/email-addresses/package.json ghost/email-addresses/package.json
 COPY ghost/email-service/package.json ghost/email-service/package.json
 COPY ghost/email-suppression-list/package.json ghost/email-suppression-list/package.json
-COPY ghost/ghost/package.json ghost/ghost/package.json
 COPY ghost/html-to-plaintext/package.json ghost/html-to-plaintext/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 COPY ghost/job-manager/package.json ghost/job-manager/package.json

--- a/compose.yml
+++ b/compose.yml
@@ -43,7 +43,6 @@ services:
       - node_modules_ghost_email-addresses:/home/ghost/ghost/email-addresses/node_modules:delegated
       - node_modules_ghost_email-service:/home/ghost/ghost/email-service/node_modules:delegated
       - node_modules_ghost_email-suppression-list:/home/ghost/ghost/email-suppression-list/node_modules:delegated
-      - node_modules_ghost_ghost:/home/ghost/ghost/ghost/node_modules:delegated
       - node_modules_ghost_html-to-plaintext:/home/ghost/ghost/html-to-plaintext/node_modules:delegated
       - node_modules_ghost_i18n:/home/ghost/ghost/i18n/node_modules:delegated
       - node_modules_ghost_job-manager:/home/ghost/ghost/job-manager/node_modules:delegated
@@ -170,7 +169,6 @@ volumes:
   node_modules_ghost_email-addresses: {}
   node_modules_ghost_email-service: {}
   node_modules_ghost_email-suppression-list: {}
-  node_modules_ghost_ghost: {}
   node_modules_ghost_html-to-plaintext: {}
   node_modules_ghost_i18n: {}
   node_modules_ghost_job-manager: {}


### PR DESCRIPTION
no issue

- The `ghost/ghost` package was removed from the repo, and therefore we don't need these node_modules volumes anymore.
- This also fixes the Docker build, which was failing because it was trying to copy the `ghost/ghost/package.json` file, which no longer exists.