### PR TITLE
Removed main from ActivityPub Explore

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/lib/explore-sites.ts
+++ b/apps/admin-x-activitypub/src/lib/explore-sites.ts
@@ -34,7 +34,6 @@ export const exploreSites = {
             '@index@www.nevillehobson.io',
             '@index@www.leadsticks.com',
             '@index@minus1.ghost.io',
-            '@index@main.ghost.org',
             '@index@blogpocket-week.ghost.io',
             '@index@erreur2000.info',
             '@index@www.nightwater.email',
@@ -101,7 +100,8 @@ export const exploreSites = {
             '@index@blog.warrenweb.net',
             '@index@bibelotages.com',
             '@index@www.ryanhamilton.work',
-            '@index@www.dalekeiger.net'
+            '@index@www.dalekeiger.net',
+            '@index@onemilliongoal.com'
         ]
     }
     // featured: {


### PR DESCRIPTION
no ref.

`main` accidentally was added to ActivityPub Explore.