### PR TITLE
Improved Tinybird scripts and tooling

### DIFF
--- a/ghost/web-analytics/.tinyenv
+++ b/ghost/web-analytics/.tinyenv
@@ -5,6 +5,9 @@
 # bump major to deploy a new Release in preview status
 VERSION=0.0.2
 
+# Use TB_VERSION to specify the current VERSION for the pipes and datasources
+TB_VERSION=8
+
 
 
 ##########

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Set the TB_VERSION variable from .tinyenv file
+source "$SCRIPT_DIR/.tinyenv"
+export TB_VERSION
+echo "Using TB_VERSION: $TB_VERSION"
+
 # Function to prompt Tinybird branch information
 prompt_tb() {
     if [ -e ".tinyb" ]; then

--- a/ghost/web-analytics/scripts/append_fixtures.sh
+++ b/ghost/web-analytics/scripts/append_fixtures.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 set -euxo pipefail
 

--- a/ghost/web-analytics/scripts/branch_and_test.sh
+++ b/ghost/web-analytics/scripts/branch_and_test.sh
@@ -17,8 +17,9 @@ for arg in "$@"; do
     fi
 done
 
-# Allow version to be passed in or default to 0
-export TB_VERSION=${TB_VERSION:-0}
+# Set the TB_VERSION variable from .tinyenv file
+source "$SCRIPT_DIR/../.tinyenv"
+export TB_VERSION
 echo "Using TB_VERSION: $TB_VERSION"
 
 # Attempt to create the branch and check for errors

--- a/ghost/web-analytics/scripts/branch_deploy_append.sh
+++ b/ghost/web-analytics/scripts/branch_deploy_append.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Create a variable with a timestamp to use as a random name for the branch
+BRANCH_NAME="TEST_$(date +%s)"
+
+# Attempt to create the branch and check for errors
+if ! tb branch create "$BRANCH_NAME"; then
+    echo "🚨 ERROR: Failed to create branch $BRANCH_NAME. Exiting."
+    exit 1
+fi
+
+# Deploy the current changes to the branch
+if ! tb deploy; then
+    echo "🚨 ERROR: Failed to deploy changes to branch. Exiting."
+    exit 1
+fi
+
+# Append fixture data
+"$SCRIPT_DIR/append_fixtures.sh"

--- a/ghost/web-analytics/scripts/exec_test.sh
+++ b/ghost/web-analytics/scripts/exec_test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # Record start time
 start_time=$(date +%s)
 
@@ -36,13 +39,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+# Set and export the TB_VERSION variable from .tinyenv file
+source "$SCRIPT_DIR/../.tinyenv"
+export TB_VERSION
+echo "Using TB_VERSION: $TB_VERSION"
 
-export TB_VERSION_WARNING=0
-
-# Default version if not provided
-export TB_VERSION=${TB_VERSION:-8}
-
-echo "TB_VERSION: $TB_VERSION"
 # Get the expected count once, outside of any function
 ndjson_file="./tests/fixtures/analytics_events.ndjson"
 export expected_count=$(grep -c '^' "$ndjson_file" || echo "0")

--- a/ghost/web-analytics/scripts/gen_test_results.sh
+++ b/ghost/web-analytics/scripts/gen_test_results.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 # Directory containing the test files
 TEST_DIR="./tests"
 
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Set the TB_VERSION variable from .tinyenv file
+source "$SCRIPT_DIR/../.tinyenv"
+export TB_VERSION
+echo "Using TB_VERSION: $TB_VERSION"
+
 # Parse command line options
 jobs=""
 while [[ $# -gt 0 ]]; do

--- a/ghost/web-analytics/scripts/install-tinybird-cli.sh
+++ b/ghost/web-analytics/scripts/install-tinybird-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if command -v python3 &>/dev/null; then
     echo "✅ Python3 is installed"

--- a/ghost/web-analytics/scripts/unsafe_redeploy.sh
+++ b/ghost/web-analytics/scripts/unsafe_redeploy.sh
@@ -7,14 +7,15 @@ if [[ "$@" == *"--force"* ]]; then
     force=true
 fi
 
-# Get version from TB_VERSION environment variable or prompt
-version=${TB_VERSION:-0}
-if [ "$version" = "0" ]; then
-    read -p "Enter version number to cleanup (default: 0): " input_version
-    if [ ! -z "$input_version" ]; then
-        version=$input_version
-    fi
-fi
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+# Set the TB_VERSION variable from .tinyenv file
+source "$SCRIPT_DIR/../.tinyenv"
+export TB_VERSION
+echo "Using TB_VERSION: $TB_VERSION"
+version=$TB_VERSION
 
 # Get current branch info
 branch_info=$(tb branch current)
@@ -61,7 +62,7 @@ safe_remove() {
     local type=$1
     local name=$2
     local version=$3
-    
+
     if [ "$type" == "pipe" ]; then
         if echo "$pipes" | grep -q "${name}"; then
             echo "Removing pipe: ${name}__v${version}"
@@ -83,7 +84,7 @@ safe_remove() {
 update_file_versions() {
     local new_version=$1
     echo "Updating version to ${new_version} in all files..."
-    
+
     # Update pipe files
     for pipe in "${endpoint_pipes[@]}" "${data_pipes[@]}"; do
         pipe_file="pipes/${pipe}.pipe"
@@ -92,7 +93,7 @@ update_file_versions() {
             sed -i "1s/^VERSION .*$/VERSION ${new_version}/" "$pipe_file"
         fi
     done
-    
+
     # Update datasource files
     for mv in "${materialized_views[@]}"; do
         ds_file="datasources/${mv}.datasource"


### PR DESCRIPTION
no issue

This commit includes various improvements to our Tinybird scripts, which I made while working on improvements to the datafiles in a separate PR. Pulling the tooling changes into this PR to separate the tooling changes from the actual datafile changes.

- Adds a new `branch_deploy_append.sh` script which creates a new branch, deploys local changes, and appends fixtures. This was a common workflow for me that I was doing manually, so this script should save some time.
- Added TB_VERSION to `.tinyenv` file, and exports the TB_VERSION from this value in all scripts. Now we should only have to update this value in this file to get all the scripts (i.e. `exec_test`, `gen_test_results`, etc) to run against the current version of Tinybird.