### PR TITLE
Updated 2FA to clarify different modes

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -200,13 +200,13 @@ export class TwoFactorTokenRequiredError extends AjaxError {
 }
 
 export function isTwoFactorTokenRequiredError(errorOrStatus, payload) {
-    const tokenRequiredCode = '2FA_TOKEN_REQUIRED';
+    const twoFactorAuthCodes = ['2FA_TOKEN_REQUIRED', '2FA_NEW_DEVICE_DETECTED'];
 
     if (isAjaxError(errorOrStatus)) {
-        return errorOrStatus instanceof TwoFactorTokenRequiredError || getErrorCode(errorOrStatus) === tokenRequiredCode;
+        return errorOrStatus instanceof TwoFactorTokenRequiredError || twoFactorAuthCodes.includes(getErrorCode(errorOrStatus));
     } else {
         payload = getJSONPayload(payload);
-        return get(payload || {}, 'errors.firstObject.code') === tokenRequiredCode;
+        return twoFactorAuthCodes.includes(get(payload || {}, 'errors.firstObject.code'));
     }
 }
 

--- a/ghost/admin/tests/integration/services/ajax-test.js
+++ b/ghost/admin/tests/integration/services/ajax-test.js
@@ -205,6 +205,24 @@ describe('Integration: Service: ajax', function () {
         });
     });
 
+    it('handles error checking for TwoFactorTokenRequiredError on 2FA New Device Detected 403 errors', function (done) {
+        stubAjaxEndpoint(server, {
+            errors: [{
+                code: '2FA_NEW_DEVICE_DETECTED'
+            }]
+        }, 403);
+
+        let ajax = this.owner.lookup('service:ajax');
+
+        ajax.request('/test/').then(() => {
+            expect(false).to.be.true;
+        }).catch((error) => {
+            expect(isTwoFactorTokenRequiredError(error)).to.be.true;
+            expect(getErrorCode(error)).to.equal('2FA_NEW_DEVICE_DETECTED');
+            done();
+        });
+    });
+
     it('handles error checking for TwoFactorTokenRequiredError on a 403 error with no code', function (done) {
         stubAjaxEndpoint(server, {
             errors: [{

--- a/ghost/core/core/server/services/auth/session/middleware.js
+++ b/ghost/core/core/server/services/auth/session/middleware.js
@@ -15,7 +15,8 @@ function SessionMiddleware({sessionService}) {
             } else {
                 await sessionService.sendAuthCodeToUser(req, res);
                 throw new errors.NoPermissionError({
-                    code: '2FA_TOKEN_REQUIRED',
+                    code: sessionService.isVerificationRequired() ? '2FA_TOKEN_REQUIRED' : '2FA_NEW_DEVICE_DETECTED',
+                    context: 'A 6-digit sign-in verification code has been sent to your email to keep your account safe.',
                     errorType: 'Needs2FAError',
                     message: 'User must verify session to login.'
                 });

--- a/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
@@ -4,8 +4,8 @@ exports[`Sessions API Staff 2FA can verify a session with 2FA code 1: [body] 1`]
 Object {
   "errors": Array [
     Object {
-      "code": "2FA_TOKEN_REQUIRED",
-      "context": null,
+      "code": "2FA_NEW_DEVICE_DETECTED",
+      "context": "A 6-digit sign-in verification code has been sent to your email to keep your account safe.",
       "details": null,
       "ghostErrorCode": null,
       "help": null,
@@ -22,7 +22,7 @@ exports[`Sessions API Staff 2FA can verify a session with 2FA code 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "236",
+  "content-length": "329",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -38,8 +38,8 @@ exports[`Sessions API Staff 2FA sends verification email if labs flag enabled 1:
 Object {
   "errors": Array [
     Object {
-      "code": "2FA_TOKEN_REQUIRED",
-      "context": null,
+      "code": "2FA_NEW_DEVICE_DETECTED",
+      "context": "A 6-digit sign-in verification code has been sent to your email to keep your account safe.",
       "details": null,
       "ghostErrorCode": null,
       "help": null,
@@ -56,7 +56,7 @@ exports[`Sessions API Staff 2FA sends verification email if labs flag enabled 2:
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "236",
+  "content-length": "329",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/session.test.js
+++ b/ghost/core/test/e2e-api/admin/session.test.js
@@ -104,7 +104,7 @@ describe('Sessions API', function () {
                 .expectStatus(403)
                 .matchBodySnapshot({
                     errors: [{
-                        code: '2FA_TOKEN_REQUIRED',
+                        code: '2FA_NEW_DEVICE_DETECTED',
                         id: anyUuid,
                         message: 'User must verify session to login.',
                         type: 'Needs2FAError'
@@ -133,7 +133,7 @@ describe('Sessions API', function () {
                 .expectStatus(403)
                 .matchBodySnapshot({
                     errors: [{
-                        code: '2FA_TOKEN_REQUIRED',
+                        code: '2FA_NEW_DEVICE_DETECTED',
                         id: anyUuid,
                         message: 'User must verify session to login.',
                         type: 'Needs2FAError'


### PR DESCRIPTION

ref https://linear.app/ghost/issue/ENG-2074/adjust-verification-copy-if-2fa-is-enabled-for-all-logins
- 2FA is actually two features: New device detection, and forced/required 2FA
- These two features do the same thing, they both add security to logins by requiring a code is provided from email
- However, depending on what mode you are in, the feature can be expected, or a bit of a surprise
- We want to handle them slightly differently, so we can make it clearer to users what is happening and why