### PR TITLE
Fixed admin render issue caused by @embroider/macros

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
         "moment-timezone",
         "simple-dom",
         "ember-drag-drop",
+        "@embroider/macros",
         "normalize.css",
         "validator",
         "codemirror",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -37,7 +37,7 @@
     "@ember/render-modifiers": "2.1.0",
     "@ember/test-helpers": "2.9.6",
     "@ember/test-waiters": "3.1.0",
-    "@embroider/macros": "1.17.0",
+    "@embroider/macros": "1.16.13",
     "@faker-js/faker": "7.6.0",
     "@glimmer/component": "1.1.2",
     "@html-next/vertical-collection": "3.0.0",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -37,7 +37,7 @@
     "@ember/render-modifiers": "2.1.0",
     "@ember/test-helpers": "2.9.6",
     "@ember/test-waiters": "3.1.0",
-    "@embroider/macros": "1.17.1",
+    "@embroider/macros": "1.17.0",
     "@faker-js/faker": "7.6.0",
     "@glimmer/component": "1.1.2",
     "@html-next/vertical-collection": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,14 +2598,14 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/macros@1.17.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.12.2", "@embroider/macros@^1.2.0", "@embroider/macros@^1.8.0", "@embroider/macros@^1.8.3", "@embroider/macros@^1.9.0":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.17.0.tgz#928bb6dafe2ea9df8e44bd75c29ef8a0998f174d"
-  integrity sha512-VtlntSWnS6hGXoVYXcvjeImu1ZHp1VWQmfowZAgirYLzpzipHcR+ELy3fRmUDVtP+0seR4vEc9Ib3stCJiFQEQ==
+"@embroider/macros@1.16.13", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.12.2", "@embroider/macros@^1.2.0", "@embroider/macros@^1.8.0", "@embroider/macros@^1.8.3", "@embroider/macros@^1.9.0":
+  version "1.16.13"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.16.13.tgz#3647839de7154400115e0b874bbf5aed9312a7a8"
+  integrity sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==
   dependencies:
-    "@embroider/shared-internals" "3.0.0"
+    "@embroider/shared-internals" "2.9.0"
     assert-never "^1.2.1"
-    babel-import-util "^3.0.1"
+    babel-import-util "^2.0.0"
     ember-cli-babel "^7.26.6"
     find-up "^5.0.0"
     lodash "^4.17.21"
@@ -2638,12 +2638,12 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/shared-internals@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-3.0.0.tgz#98251e6b99d36d64120361a449569ef5384b3812"
-  integrity sha512-5J5ipUMCAinQS38WW7wedruq5Z4VnHvNo+ZgOduw0PtI9w0CQWx7/HE+98PBDW8jclikeF+aHwF317vc1hwuzg==
+"@embroider/shared-internals@2.9.0", "@embroider/shared-internals@^2.0.0", "@embroider/shared-internals@^2.8.1":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.9.0.tgz#5d945b92e08db163de60d82f7c388e2b7260f0cc"
+  integrity sha512-8untWEvGy6av/oYibqZWMz/yB+LHsKxEOoUZiLvcpFwWj2Sipc0DcXeTJQZQZ++otNkLCWyDrDhOLrOkgjOPSg==
   dependencies:
-    babel-import-util "^3.0.1"
+    babel-import-util "^2.0.0"
     debug "^4.3.2"
     ember-rfc176-data "^0.3.17"
     fs-extra "^9.1.0"
@@ -2653,7 +2653,6 @@
     minimatch "^3.0.4"
     pkg-entry-points "^1.1.0"
     resolve-package-path "^4.0.1"
-    resolve.exports "^2.0.2"
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
@@ -2680,24 +2679,6 @@
     fs-extra "^9.1.0"
     js-string-escape "^1.0.1"
     lodash "^4.17.21"
-    resolve-package-path "^4.0.1"
-    semver "^7.3.5"
-    typescript-memoize "^1.0.1"
-
-"@embroider/shared-internals@^2.0.0", "@embroider/shared-internals@^2.8.1":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.9.0.tgz#5d945b92e08db163de60d82f7c388e2b7260f0cc"
-  integrity sha512-8untWEvGy6av/oYibqZWMz/yB+LHsKxEOoUZiLvcpFwWj2Sipc0DcXeTJQZQZ++otNkLCWyDrDhOLrOkgjOPSg==
-  dependencies:
-    babel-import-util "^2.0.0"
-    debug "^4.3.2"
-    ember-rfc176-data "^0.3.17"
-    fs-extra "^9.1.0"
-    is-subdir "^1.2.0"
-    js-string-escape "^1.0.1"
-    lodash "^4.17.21"
-    minimatch "^3.0.4"
-    pkg-entry-points "^1.1.0"
     resolve-package-path "^4.0.1"
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
@@ -10638,7 +10619,7 @@ babel-import-util@^2.0.0:
   resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-2.0.0.tgz#99a2e7424bcde01898bc61bb19700ff4c74379a3"
   integrity sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==
 
-babel-import-util@^3.0.0, babel-import-util@^3.0.1:
+babel-import-util@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-3.0.1.tgz#62dd0476e855bf57522e1d0027916dc0c0b0fdb2"
   integrity sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==
@@ -28420,10 +28401,10 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
-resolve.exports@^2.0.0, resolve.exports@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
-  integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
+resolve.exports@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
+  integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
 resolve@1.22.8, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.22.2, resolve@^1.22.3, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.22.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/macros@1.17.1", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.12.2", "@embroider/macros@^1.2.0", "@embroider/macros@^1.8.0", "@embroider/macros@^1.8.3", "@embroider/macros@^1.9.0":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.17.1.tgz#2cc9f55706af17e7569900517a68f49e814a3d65"
-  integrity sha512-pi039RDy2CvgM+RwJ9NMFU4wYMKlSp9p+WyHFfQpZ2e/HL78O1KM1+MEaKnIve6MrXvo7QD7/Kn6MpMTzV1MSQ==
+"@embroider/macros@1.17.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.12.2", "@embroider/macros@^1.2.0", "@embroider/macros@^1.8.0", "@embroider/macros@^1.8.3", "@embroider/macros@^1.9.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.17.0.tgz#928bb6dafe2ea9df8e44bd75c29ef8a0998f174d"
+  integrity sha512-VtlntSWnS6hGXoVYXcvjeImu1ZHp1VWQmfowZAgirYLzpzipHcR+ELy3fRmUDVtP+0seR4vEc9Ib3stCJiFQEQ==
   dependencies:
     "@embroider/shared-internals" "3.0.0"
     assert-never "^1.2.1"


### PR DESCRIPTION
Render is being blocked by this error:

```
runtime.js:4905 

Error occurred:

- While rendering:
  -top-level
    application
      gh-app
        gh-nav-menu
          gh-nav-menu/main
            gh-nav-menu/footer

loader.js:247 Uncaught (in promise) Error: Could not find module `@ember/test-helpers` imported from `ember-basic-dropdown/components/basic-dropdown`
    at missingModule (loader.js:247:1)
    at findModule (loader.js:258:1)
    at Module.findDeps (loader.js:168:1)
    at findModule (loader.js:262:1)
    at Module.findDeps (loader.js:168:1)
    at findModule (loader.js:262:1)
    at requireModule (loader.js:24:1)
    at ModuleRegistry.get (index.js:22:1)
    at Class._extractDefaultExport (index.js:378:1)
    at Class.resolveOther (index.js:107:1)
```

This is very strange because @ember/test-helpers is a test helper, and to the best of my knowledge should not, and is not, part of the render or being used in ember-basic-dropdown/components/basic-dropdown

ember-basic-dropdown is marked in resolutions, hasn’t been touched in ages

Reverting the change to @ember/test-helpers doesn’t fix the issue either (Even with doing an extensive clear out beyond yarn fix

Going back through commits, `@embroider/macros` appears to  be the issue.

The update of @embroider/macros from v1.16.13 to v1.17.0 included:

- A major change in @embroider/shared-internals from v2.9.0 to v3.0.0
- Updating babel-import-util from v2.0.0 to v3.0.1
- A new dependency resolve.exports which handles module resolution

Given that reverting `@ember/test-helpers` didn't fix the issue, it tracks that the problem is with the underlying system handling the import, and not the module itself.