### PR TITLE
Update CONTRIBUTING.md with Documentation guidance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,9 @@ We aim to merge any straightforward, well-understood bug fixes or improvements i
 
 Please provide plenty of context and reasoning around your changes, to help us merge quickly. Closing an already open issue is our preferred workflow. If your PR gets out of date, we may ask you to rebase as you are more familiar with your changes than we will be.
 
+### Sharing feedback on Documentation
 
+While the Docs are no longer Open Source, we welcome revisions and ideas on the forum! Please create a Post with your questions or suggestions in the [Contributing to Ghost Category](https://forum.ghost.org/c/contributing/27). Thank you for helping us keep the Docs relevant and up-to-date.
 
 ---
 


### PR DESCRIPTION
When looking for how to propose updates to the [Install From Source Documentation](https://ghost.org/docs/install/source/), I found that the Docs were no longer open to public contributions. After some exploration, I found forum Posts from the Ghost Staff directing people to share feedback on Documentation via the forums.

It would have saved me some time searching to read this in the Contributing guide, and spell it out explicitly. The header mentions sharing "ideas" and asking questions in the forum, but I think updating the Docs is its own category, and people may be expecting them to be open source or live with the project code by default. 

This change is intended to make it easier for Contributors to know how to update the docs, and hopefully reduce frustration of needing to search for the right place to do it.  Thanks!

- [X] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [X] I've explained my change
- N/A I've written an automated test to prove my change works

We appreciate your contribution! 🙏
