### PR TITLE
Added Tinybird linting check to pre-commit hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -118,4 +118,29 @@ if [[ "$AP_BUMP_NEEDED" == true ]]; then
     fi
 fi
 
+##
+## 3) Lint Tinybird datafiles if they have been modified
+##
+
+echo -e "Checking Tinybird datafiles ${grey}(pre-commit hook)${no_color}"
+
+MODIFIED_FILES=$(git diff --cached --name-only)
+TINYBIRD_FILES_MODIFIED=false
+
+for FILE in $MODIFIED_FILES; do
+    if [[ "$FILE" == ghost/web-analytics/*.pipe || "$FILE" == ghost/web-analytics/*.datasource ]]; then
+        TINYBIRD_FILES_MODIFIED=true
+        break
+    fi
+done
+
+if [[ "$TINYBIRD_FILES_MODIFIED" == true ]]; then
+    echo -e "Tinybird datafiles have been modified. Running linter..."
+    if ! ghost/web-analytics/scripts/lint.sh; then
+        echo -e "${red}❌ Tinybird datafile linting failed${no_color}"
+        exit 1
+    fi
+    echo -e "${green}✓ Tinybird datafile linting passed${no_color}"
+fi
+
 exit 0


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-171/formatting-linting-the-pipe-and-datasource-files

- We now have a linting job that will catch any issues with the `VERSION` or `TOKEN` parameter in our Tinybird datafiles, which will run in CI and prevent merging if either of these parameters is missing or incorrect. 
- This commit adds the same check as a pre-commit hook to shorten the feedback loop, so we don't have to wait until CI runs or run the linter manually to notice the error.
- The linting job should only run in the pre-commit hook if a `*.datasource` or `*.pipe` file in `ghost/web-analytics` is modified.