### PR TITLE
Removed flag for routes support in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -19,11 +19,10 @@ import APReplyBox from '../global/APReplyBox';
 import DeletedFeedItem from './DeletedFeedItem';
 import TableOfContents, {TOCItem} from './TableOfContents';
 import getReadingTime from '../../utils/get-reading-time';
-import {handleProfileClick, handleProfileClickRR} from '@src/utils/handle-profile-click';
+import {handleProfileClickRR} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 interface ArticleModalProps {
@@ -726,7 +725,6 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
         return () => clearTimeout(timeoutId);
     }, [iframeElement, tocItems, activeHeadingId]);
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
@@ -766,11 +764,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
                                             <APAvatar author={actor}/>
                                         </div>
                                         <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={(e) => {
-                                            if (isEnabled('ap-routes')) {
-                                                handleProfileClickRR(actor, navigate, e);
-                                            } else {
-                                                handleProfileClick(actor, e);
-                                            }
+                                            handleProfileClickRR(actor, navigate, e);
                                         }}>
                                             <div className='flex w-full'>
                                                 <span className='min-w-0 truncate whitespace-nowrap font-semibold tracking-tight hover:underline'>{actor.name}</span>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -10,11 +10,10 @@ import FeedItemStats from './FeedItemStats';
 import clsx from 'clsx';
 import getReadingTime from '../../utils/get-reading-time';
 import getUsername from '../../utils/get-username';
-import {handleProfileClick, handleProfileClickRR} from '../../utils/handle-profile-click';
+import {handleProfileClickRR} from '../../utils/handle-profile-click';
 import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {renderTimestamp} from '../../utils/render-timestamp';
 import {useDeleteMutationForUser} from '../../hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 function getAttachment(object: ObjectProperties) {
@@ -268,7 +267,6 @@ const FeedItem: React.FC<FeedItemProps> = ({
         </Button>
     );
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     if (layout === 'feed') {
@@ -280,11 +278,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             <Icon colorClass='text-gray-700 shrink-0 dark:text-gray-600' name='reload' size={'sm'} />
                             <div className='flex min-w-0 items-center gap-1 text-sm'>
                                 <span className='truncate break-all hover:underline' title={getUsername(actor)} onClick={(e) => {
-                                    if (isEnabled('ap-routes')) {
-                                        handleProfileClickRR(actor, navigate, e);
-                                    } else {
-                                        handleProfileClick(actor, e);
-                                    }
+                                    handleProfileClickRR(actor, navigate, e);
                                 }}>{actor.name}</span>
                                 reposted
                             </div>
@@ -294,11 +288,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <APAvatar author={author} disabled={isPending} />
                                 <div className='flex min-w-0 grow flex-col gap-0.5' onClick={(e) => {
                                     if (!isPending) {
-                                        if (isEnabled('ap-routes')) {
-                                            handleProfileClickRR(author, navigate, e);
-                                        } else {
-                                            handleProfileClick(author, e);
-                                        }
+                                        handleProfileClickRR(author, navigate, e);
                                     }
                                 }}>
                                     <span className={`min-w-0 truncate break-all font-semibold leading-[normal] ${!isPending ? 'hover-underline' : ''} dark:text-white`}
@@ -393,11 +383,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 {(type === 'Announce') && <div className='z-10 col-span-2 mb-2 flex items-center gap-2 text-gray-700 dark:text-gray-600'>
                                     <div><Icon colorClass='text-gray-700 shrink-0 dark:text-gray-600' name='reload' size={'sm'}></Icon></div>
                                     <span className='flex min-w-0 items-center gap-1'><span className='truncate break-all hover:underline' title={getUsername(actor)} onClick={(e) => {
-                                        if (isEnabled('ap-routes')) {
-                                            handleProfileClickRR(actor, navigate, e);
-                                        } else {
-                                            handleProfileClick(actor, e);
-                                        }
+                                        handleProfileClickRR(actor, navigate, e);
                                     }}>{actor.name}</span> reposted</span>
                                 </div>}
                                 {(showHeader) && <>
@@ -406,11 +392,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     </div>
                                     <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={(e) => {
                                         if (!isPending) {
-                                            if (isEnabled('ap-routes')) {
-                                                handleProfileClickRR(author, navigate, e);
-                                            } else {
-                                                handleProfileClick(author, e);
-                                            }
+                                            handleProfileClickRR(author, navigate, e);
                                         }
                                     }}>
                                         <div className='flex w-full'>
@@ -462,11 +444,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className='flex w-full items-center justify-between'>
                                     <div className='relative z-10 flex w-full min-w-0 flex-col overflow-visible' onClick={(e) => {
                                         if (!isPending) {
-                                            if (isEnabled('ap-routes')) {
-                                                handleProfileClickRR(author, navigate, e);
-                                            } else {
-                                                handleProfileClick(author, e);
-                                            }
+                                            handleProfileClickRR(author, navigate, e);
                                         }
                                     }}>
                                         <div className='flex'>
@@ -536,20 +514,12 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                             title={getUsername(author)}
                                             data-test-activity-heading
                                             onClick={(e) => {
-                                                if (isEnabled('ap-routes')) {
-                                                    handleProfileClickRR(author, navigate, e);
-                                                } else {
-                                                    handleProfileClick(author, e);
-                                                }
+                                                handleProfileClickRR(author, navigate, e);
                                             }}
                                         >{author.name}
                                         </span>
                                         {(type === 'Announce') && <span className='z-10 flex items-center gap-1 text-gray-700 dark:text-gray-600'><Icon colorClass='text-gray-700 shrink-0 dark:text-gray-600' name='reload' size={'sm'}></Icon><span className='hover:underline' title={getUsername(actor)} onClick={(e) => {
-                                            if (isEnabled('ap-routes')) {
-                                                handleProfileClickRR(actor, navigate, e);
-                                            } else {
-                                                handleProfileClick(actor, e);
-                                            }
+                                            handleProfileClickRR(actor, navigate, e);
                                         }}>{actor.name}</span> reposted</span>}
                                         <span className='shrink-0 whitespace-nowrap text-gray-600 before:mr-1 before:content-["·"]' title={`${timestamp}`}>{renderTimestamp(object, !object.authored)}</span>
                                     </> :

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -1,12 +1,9 @@
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
-import ViewProfileModal from '../modals/ViewProfileModal';
 import clsx from 'clsx';
 import getUsername from '../../utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Icon} from '@tryghost/admin-x-design-system';
 import {Skeleton} from '@tryghost/shade';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 type AvatarSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'notification';
@@ -25,12 +22,11 @@ interface APAvatarProps {
     disabled?: boolean;
 }
 
-const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, onClick, disabled = false}) => {
+const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, disabled = false}) => {
     let iconSize = 18;
     let containerClass = `shrink-0 items-center justify-center rounded-full overflow-hidden relative z-10 flex bg-gray-100 dark:bg-gray-900 ${size === 'lg' || disabled ? '' : 'hover:opacity-80 cursor-pointer'}`;
     let imageClass = 'z-10 object-cover';
     const [iconUrl, setIconUrl] = useState(author?.icon?.url);
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -83,12 +79,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, onC
 
     const handleClick = (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (isEnabled('ap-routes')) {
-            navigate(`/profile/${handle}`);
-        } else {
-            NiceModal.show(ViewProfileModal, {handle});
-            onClick?.();
-        }
+        navigate(`/profile/${handle}`);
     };
 
     const title = `${author?.name} ${handle}`;

--- a/apps/admin-x-activitypub/src/components/global/SuggestedProfiles.tsx
+++ b/apps/admin-x-activitypub/src/components/global/SuggestedProfiles.tsx
@@ -1,12 +1,9 @@
 import APAvatar from './APAvatar';
 import ActivityItem from '../activities/ActivityItem';
 import FollowButton from './FollowButton';
-import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
-import ViewProfileModal from '../modals/ViewProfileModal';
 import {type Account} from '../../api/activitypub';
 import {Skeleton} from '@tryghost/shade';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
 
@@ -33,19 +30,13 @@ export const SuggestedProfile: React.FC<SuggestedProfileProps & {
         });
     };
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
         <ActivityItem
             key={profile.id}
             onClick={() => {
-                if (isEnabled('ap-routes')) {
-                    navigate(`/profile/${profile.handle}`);
-                } else {
-                    onOpenChange?.(false);
-                    NiceModal.show(ViewProfileModal, {handle: profile.handle, onFollow, onUnfollow});
-                }
+                navigate(`/profile/${profile.handle}`);
             }}
         >
             <APAvatar author={

--- a/apps/admin-x-activitypub/src/components/layout/Header/Header.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Header/Header.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import useActiveRoute from '@src/hooks/use-active-route';
 import {H1} from '@tryghost/shade';
 import {useBaseRoute, useNavigationStack, useRouteHasParams} from '@tryghost/admin-x-framework';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 
 interface HeaderTitleProps {
     title: string;
@@ -23,11 +22,10 @@ const Header: React.FC = () => {
     const {canGoBack} = useNavigationStack();
     const baseRoute = useBaseRoute();
     const routeHasParams = useRouteHasParams();
-    const {isEnabled} = useFeatureFlags();
 
     // Logic for special pages
     let onlyBackButton = false;
-    if (baseRoute === 'profile' && isEnabled('ap-routes')) {
+    if (baseRoute === 'profile') {
         onlyBackButton = true;
     }
 

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import APAvatar from '@components/global/APAvatar';
 import ActivityItem from '@components/activities/ActivityItem';
 import {Button, H4, LucideIcon, Skeleton} from '@tryghost/shade';
-import {handleProfileClick, handleProfileClickRR} from '@utils/handle-profile-click';
-import {useFeatureFlags} from '@src/lib/feature-flags';
+import {handleProfileClickRR} from '@utils/handle-profile-click';
 import {useNavigate, useNavigationStack} from '@tryghost/admin-x-framework';
 import {useSuggestedProfilesForUser} from '@hooks/use-activity-pub-queries';
 
@@ -12,7 +11,6 @@ const Recommendations: React.FC = () => {
     const {data: suggestedData, isLoading: isLoadingSuggested} = suggestedProfilesQuery;
     const suggested = isLoadingSuggested ? Array(3).fill(null) : (suggestedData || []);
     const navigate = useNavigate();
-    const {isEnabled} = useFeatureFlags();
     const {resetStack} = useNavigationStack();
 
     const hideClassName = '[@media(max-height:740px)]:hidden';
@@ -53,11 +51,7 @@ const Recommendations: React.FC = () => {
                             <li key={actorId} className={className}>
                                 <ActivityItem onClick={() => {
                                     if (!isLoadingSuggested && profile) {
-                                        if (isEnabled('ap-routes')) {
-                                            handleProfileClickRR(profile, navigate);
-                                        } else {
-                                            handleProfileClick(actorHandle);
-                                        }
+                                        handleProfileClickRR(profile, navigate);
                                     }
                                 }}>
                                     {!isLoadingSuggested ? <APAvatar author={

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -1,14 +1,11 @@
 import APAvatar from '@components/global/APAvatar';
 import ActivityItem from '@components/activities/ActivityItem';
 import FollowButton from '@components/global/FollowButton';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
-import ViewProfileModal from '@components/modals/ViewProfileModal';
 import {H4, LucideIcon} from '@tryghost/shade';
 import {LoadingIndicator, NoValueLabel, TextField} from '@tryghost/admin-x-design-system';
 import {SuggestedProfiles} from '../global/SuggestedProfiles';
 import {useDebounce} from 'use-debounce';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useSearchForUser} from '@hooks/use-activity-pub-queries';
 
@@ -28,7 +25,7 @@ interface AccountSearchResultItemProps {
 
 const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
     onOpenChange?: (open: boolean) => void;
-}> = ({account, update, onOpenChange}) => {
+}> = ({account, update}) => {
     const onFollow = () => {
         update(account.id, {
             followedByMe: true,
@@ -43,19 +40,13 @@ const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
         });
     };
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
         <ActivityItem
             key={account.id}
             onClick={() => {
-                if (isEnabled('ap-routes')) {
-                    navigate(`/profile/${account.handle}`);
-                } else {
-                    onOpenChange?.(false);
-                    NiceModal.show(ViewProfileModal, {handle: account.handle, onFollow, onUnfollow});
-                }
+                navigate(`/profile/${account.handle}`);
             }}
         >
             <APAvatar author={{

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -1,11 +1,8 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
-// Define all available feature flags here
-export const FEATURE_FLAGS = [
-    'feed-routes',
-    'ap-routes'
-] as const;
+// Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
+export const FEATURE_FLAGS = [] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Explore/Explore.tsx
+++ b/apps/admin-x-activitypub/src/views/Explore/Explore.tsx
@@ -1,15 +1,12 @@
 import APAvatar from '@src/components/global/APAvatar';
 import FollowButton from '@src/components/global/FollowButton';
 import Layout from '@components/layout';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect} from 'react';
-import ViewProfileModal from '@src/components/modals/ViewProfileModal';
 import {type Account} from '@src/api/activitypub';
 import {Button, H4, LucideIcon, Skeleton} from '@tryghost/shade';
 import {LoadingIndicator} from '@tryghost/admin-x-design-system';
 import {formatFollowNumber} from '@src/utils/content-formatters';
 import {useExploreProfilesForUser} from '@hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useOnboardingStatus} from '@src/components/layout/Onboarding';
 
@@ -36,19 +33,13 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
         });
     };
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
         <div
             className='flex w-full cursor-pointer items-start gap-3 pt-4 [&:last-of-type>:nth-child(2)]:border-none'
             onClick={() => {
-                if (isEnabled('ap-routes')) {
-                    navigate(`/profile/${profile.handle}`);
-                } else {
-                    onOpenChange?.(false);
-                    NiceModal.show(ViewProfileModal, {handle: profile.handle, onFollow, onUnfollow});
-                }
+                navigate(`/profile/${profile.handle}`);
             }}
         >
             <APAvatar author={

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -8,10 +8,8 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {LoadingIndicator} from '@tryghost/admin-x-design-system';
-import {handleViewContent} from '@src/utils/content-handlers';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export type FeedListProps = {
@@ -32,7 +30,6 @@ const FeedList:React.FC<FeedListProps> = ({
     isFetchingNextPage
 }) => {
     const navigate = useNavigate();
-    const {isEnabled} = useFeatureFlags();
 
     const observerRef = useRef<IntersectionObserver | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -94,18 +91,10 @@ const FeedList:React.FC<FeedListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            if (isEnabled('ap-routes')) {
-                                                                navigate(`/feed/${encodeURIComponent(activity.id)}`);
-                                                            } else {
-                                                                handleViewContent(activity, false);
-                                                            }
+                                                            navigate(`/feed/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                         onCommentClick={() => {
-                                                            if (isEnabled('ap-routes')) {
-                                                                navigate(`/feed/${encodeURIComponent(activity.id)}?focusReply=true`);
-                                                            } else {
-                                                                handleViewContent(activity, true);
-                                                            }
+                                                            navigate(`/feed/${encodeURIComponent(activity.id)}?focusReply=true`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (

--- a/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
@@ -5,10 +5,8 @@ import {Activity} from '@src/api/activitypub';
 import {Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {LoadingIndicator} from '@tryghost/admin-x-design-system';
-import {handleViewContent} from '@src/utils/content-handlers';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef, useState} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 
 export type InboxListProps = {
@@ -30,7 +28,6 @@ const InboxList:React.FC<InboxListProps> = ({
     const {canGoBack, goBack} = useNavigationStack();
     const [isReaderOpen, setIsReaderOpen] = useState(false);
     const params = useParams();
-    const {isEnabled} = useFeatureFlags();
 
     useEffect(() => {
         setIsReaderOpen(!!params.postId);
@@ -96,18 +93,10 @@ const InboxList:React.FC<InboxListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            if (isEnabled('ap-routes')) {
-                                                                navigate(`/inbox/${encodeURIComponent(activity.id)}`);
-                                                            } else {
-                                                                handleViewContent(activity, false);
-                                                            }
+                                                            navigate(`/inbox/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                         onCommentClick={() => {
-                                                            if (isEnabled('ap-routes')) {
-                                                                navigate(`/inbox/${encodeURIComponent(activity.id)}?focusReply=true`);
-                                                            } else {
-                                                                handleViewContent(activity, true);
-                                                            }
+                                                            navigate(`/inbox/${encodeURIComponent(activity.id)}?focusReply=true`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -1,4 +1,3 @@
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
 import {LucideIcon, Skeleton} from '@tryghost/shade';
 
@@ -9,14 +8,12 @@ import APAvatar from '@components/global/APAvatar';
 import NotificationItem from '@components/activities/NotificationItem';
 import Separator from '@components/global/Separator';
 
-import ArticleModal from '@src/components/feed/ArticleModal';
 import Layout from '@components/layout';
 import truncate from '@utils/truncate';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {Notification} from '@src/api/activitypub';
-import {handleProfileClick, handleProfileClickRR} from '@utils/handle-profile-click';
+import {handleProfileClickRR} from '@utils/handle-profile-click';
 import {stripHtml} from '@src/utils/content-formatters';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useNotificationsForUser} from '@hooks/use-activity-pub-queries';
 
@@ -88,7 +85,6 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
 
     const actorClass = 'cursor-pointer font-semibold hover:underline';
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     const actorText = (
@@ -97,11 +93,7 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
                 className={actorClass}
                 onClick={(e) => {
                     e?.stopPropagation();
-                    if (isEnabled('ap-routes')) {
-                        handleProfileClickRR(firstActor.handle, navigate);
-                    } else {
-                        handleProfileClick(firstActor.handle, e);
-                    }
+                    handleProfileClickRR(firstActor.handle, navigate);
                 }}
             >
                 {firstActor.name}
@@ -113,11 +105,7 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
                         className={actorClass}
                         onClick={(e) => {
                             e?.stopPropagation();
-                            if (isEnabled('ap-routes')) {
-                                handleProfileClickRR(secondActor.handle, navigate);
-                            } else {
-                                handleProfileClick(secondActor.handle, e);
-                            }
+                            handleProfileClickRR(secondActor.handle, navigate);
                         }}
                     >
                         {secondActor.name}
@@ -153,7 +141,6 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
 
 const Notifications: React.FC = () => {
     const [openStates, setOpenStates] = React.useState<{[key: string]: boolean}>({});
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     const toggleOpen = (groupId: string) => {
@@ -202,44 +189,25 @@ const Notifications: React.FC = () => {
     const handleNotificationClick = (group: NotificationGroup, index: number) => {
         switch (group.type) {
         case 'like':
-            if (isEnabled('ap-routes') && group.post) {
+            if (group.post) {
                 navigate(`/${group.post.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
-            } else {
-                NiceModal.show(ArticleModal, {
-                    remotePostId: group.post?.id || '',
-                    width: group.post?.type === 'article' ? 'wide' : 'narrow'
-                });
             }
             break;
         case 'reply':
-            if (isEnabled('ap-routes') && group.post && group.inReplyTo) {
+            if (group.post && group.inReplyTo) {
                 navigate(`/${group.inReplyTo.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
-            } else {
-                NiceModal.show(ArticleModal, {
-                    remotePostId: group.post?.id || '',
-                    width: group.inReplyTo?.type === 'article' ? 'wide' : 'narrow'
-                });
             }
             break;
         case 'repost':
-            if (isEnabled('ap-routes') && group.post) {
+            if (group.post) {
                 navigate(`/${group.post.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
-            } else {
-                NiceModal.show(ArticleModal, {
-                    remotePostId: group.post?.id || '',
-                    width: group.post?.type === 'article' ? 'wide' : 'narrow'
-                });
             }
             break;
         case 'follow':
             if (group.actors.length > 1) {
                 toggleOpen(group.id || `${group.type}_${index}`);
             } else {
-                if (isEnabled('ap-routes')) {
-                    handleProfileClickRR(group.actors[0].handle, navigate);
-                } else {
-                    handleProfileClick(group.actors[0].handle);
-                }
+                handleProfileClickRR(group.actors[0].handle, navigate);
             }
             break;
         }
@@ -317,11 +285,7 @@ const Notifications: React.FC = () => {
                                                                         className='flex items-center hover:opacity-80'
                                                                         onClick={(e) => {
                                                                             e?.stopPropagation();
-                                                                            if (isEnabled('ap-routes')) {
-                                                                                handleProfileClickRR(actor.handle, navigate);
-                                                                            } else {
-                                                                                handleProfileClick(actor.handle, e);
-                                                                            }
+                                                                            handleProfileClickRR(actor.handle, navigate);
                                                                         }}
                                                                     >
                                                                         <APAvatar author={{

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -6,8 +6,7 @@ import getName from '@src/utils/get-name';
 import getUsername from '@src/utils/get-username';
 import {Actor} from '@src/api/activitypub';
 import {List, LoadingIndicator, NoValueLabel} from '@tryghost/admin-x-design-system';
-import {handleProfileClick, handleProfileClickRR} from '@src/utils/handle-profile-click';
-import {useFeatureFlags} from '@src/lib/feature-flags';
+import {handleProfileClickRR} from '@src/utils/handle-profile-click';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 type ActorListProps = {
@@ -52,7 +51,6 @@ const ActorList: React.FC<ActorListProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
@@ -69,11 +67,7 @@ const ActorList: React.FC<ActorListProps> = ({
                                 <React.Fragment key={actor.id}>
                                     <ActivityItem key={actor.id}
                                         onClick={() => {
-                                            if (isEnabled('ap-routes')) {
-                                                handleProfileClickRR(actor, navigate);
-                                            } else {
-                                                handleProfileClick(actor.handle || actor);
-                                            }
+                                            handleProfileClickRR(actor, navigate);
                                         }}
                                     >
                                         <APAvatar author={actor} />

--- a/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
@@ -2,9 +2,7 @@ import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
 import {LoadingIndicator, NoValueLabel} from '@tryghost/admin-x-design-system';
 import {Separator} from '@tryghost/shade';
-import {handleViewContent} from '@src/utils/content-handlers';
 import {useEffect, useRef} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export type LikesProps = {
@@ -54,7 +52,6 @@ const Likes: React.FC<LikesProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
@@ -80,25 +77,17 @@ const Likes: React.FC<LikesProps> = ({
                             repostCount={activity.object.repostCount}
                             type={activity.type}
                             onClick={() => {
-                                if (isEnabled('ap-routes')) {
-                                    if (activity.object.type === 'Note') {
-                                        navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                    } else if (activity.object.type === 'Article') {
-                                        navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                    }
-                                } else {
-                                    handleViewContent(activity, false);
+                                if (activity.object.type === 'Note') {
+                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                } else if (activity.object.type === 'Article') {
+                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                             onCommentClick={() => {
-                                if (isEnabled('ap-routes')) {
-                                    if (activity.object.type === 'Note') {
-                                        navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                    } else if (activity.object.type === 'Article') {
-                                        navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                    }
-                                } else {
-                                    handleViewContent(activity, true);
+                                if (activity.object.type === 'Note') {
+                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                } else if (activity.object.type === 'Article') {
+                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />

--- a/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
@@ -2,9 +2,7 @@ import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
 import {LoadingIndicator, NoValueLabel} from '@tryghost/admin-x-design-system';
 import {Separator} from '@tryghost/shade';
-import {handleViewContent} from '@src/utils/content-handlers';
 import {useEffect, useRef} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export type PostsProps = {
@@ -56,7 +54,6 @@ const Posts: React.FC<PostsProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     return (
@@ -82,25 +79,17 @@ const Posts: React.FC<PostsProps> = ({
                             repostCount={activity.object.repostCount}
                             type={activity.type}
                             onClick={() => {
-                                if (isEnabled('ap-routes')) {
-                                    if (activity.object.type === 'Note') {
-                                        navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                    } else if (activity.object.type === 'Article') {
-                                        navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                    }
-                                } else {
-                                    handleViewContent(activity, false);
+                                if (activity.object.type === 'Note') {
+                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                } else if (activity.object.type === 'Article') {
+                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                             onCommentClick={() => {
-                                if (isEnabled('ap-routes')) {
-                                    if (activity.object.type === 'Note') {
-                                        navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                    } else if (activity.object.type === 'Article') {
-                                        navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                    }
-                                } else {
-                                    handleViewContent(activity, true);
+                                if (activity.object.type === 'Note') {
+                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                } else if (activity.object.type === 'Article') {
+                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />


### PR DESCRIPTION
ref AP-1006

- In ActivityPub routing was enabled only on the topmost view level inbox, feed etc. which is not a viable solution on the long term — without proper routes it's not possible to refer to any particular object (note, article, profile etc.). This PR removes the feature flag that enables a full routing support for inbox and feed items, profiles and more.