### PR TITLE
Added `wa` wrapper for the Tinybird CLI

### DIFF
--- a/ghost/web-analytics/.tinyenv
+++ b/ghost/web-analytics/.tinyenv
@@ -23,7 +23,7 @@ TB_VERSION=8
 # TB_FORCE_REMOVE_OLDEST_ROLLBACK=0
 
 # Don't print CLI version warning message if there's a new available version
-# TB_VERSION_WARNING=0
+TB_VERSION_WARNING=0
 
 # Skip regression tests
 # TB_SKIP_REGRESSION=0

--- a/ghost/web-analytics/.tinyenv
+++ b/ghost/web-analytics/.tinyenv
@@ -23,7 +23,7 @@ TB_VERSION=8
 # TB_FORCE_REMOVE_OLDEST_ROLLBACK=0
 
 # Don't print CLI version warning message if there's a new available version
-TB_VERSION_WARNING=0
+# TB_VERSION_WARNING=0
 
 # Skip regression tests
 # TB_SKIP_REGRESSION=0

--- a/ghost/web-analytics/README.md
+++ b/ghost/web-analytics/README.md
@@ -1,16 +1,17 @@
 # Tinybird
 
-This folder contains configuration for Tinybird, so that the Traffic Analytics feature can be used.
+This folder contains configuration for Tinybird, so that the Traffic Analytics feature can be used in Ghost.
 
 We sync this configuration with Tinybird via the Tinybird CLI.
 
 ## Tinybird CLI
 
-The Tinybird CLI is used via Docker.
+The Tinybird CLI is installed in Ghost's Docker development image. You can easily open a shell to use the Tinybird CLI by running:
 
-```bash
-yarn tb
-```
+### Usage
+
+1. Run `yarn tb` from the monorepo root. This opens an interactive shell in Ghost's development container, which has the Tinybird CLI pre-installed.
+2. Run any Tinybird CLI commands using `tb`, such as `tb auth -i`
 
 Documentation for the Tinybird CLI: https://docs.tinybird.co/v/0.22.0/cli/overview
 Note: you can use python if you prefer, but we use Docker for consistency.
@@ -24,6 +25,43 @@ This project uses the `dedicated_staging_stats` workspace. To set up your local 
 1. Run `yarn tb` to spin up a Ghost container with the Tinybird CLI installed
 2. Run `tb auth` and provide your token for the `dedicated_staging_stats` workspace. This generates a `.tinyb` file specific to your user - this should not be committed.
 
-## Linting
+## Development CLI (`wa`)
 
-We have some basic linting checks that run on our Tinybird datafiles. You can run these checks with `./scripts/lint.sh`. These checks are also run in CI before running the fixture test suite, to catch common errors as quickly as possible for a faster feedback loop.
+To simplify common development tasks a wrapper CLI called `wa` is available within the `yarn tb` shell.
+
+### Usage
+
+1.  Run `yarn tb` from the monorepo root.
+2.  The `wa` command is automatically available in the shell.
+
+### Commands
+
+*   `wa test [-n <test_name>] [-u|--update]`
+    *   Runs the test suite against the current branch.
+    *   `-n <test_name>`: Run only a specific test file (name without `.test.sql`).
+    *   `-u` or `--update`: Regenerate test result snapshots instead of running tests. Cannot be used with `-n`.
+*   `wa branch [-a|--append] [-d|--deploy]`
+    *   Creates a new development branch in Tinybird.
+    *   `-a` or `--append`: Appends fixture data after creating the branch.
+    *   `-d` or `--deploy`: Deploys local changes to the branch after creation. Note: your git workspace must be clean with no uncommitted changes for this to work.
+*   `wa branch rm`
+    *   Deletes the *current* Tinybird branch. Prompts for confirmation.
+*   `wa lint`
+    *   Runs the linting script (`./scripts/lint.sh`) on Tinybird `.datasource` and `.pipe` files.
+*   `wa help`
+    *   Displays the help message with all commands and options.
+
+
+## CI/CD
+
+All changes to the `main` branch of the staging and production workspaces should be made exclusively via the CI/CD jobs.
+
+### Testing
+
+When you raise a PR that contains changes to the files in `ghost/web-analytics`, the Tinybird fixture tests will run and gate merging your PR until they pass.
+
+### Deployment
+
+Upon merging your PR to `main`, your changes will be deployed to both the `dedicated_staging_stats` workspace and the `dedicated_production_stats` workspace simultaneously.
+
+Note: this is likely to change soon — in the future changes will be automatically deployed to the staging workspace, but the deployment to the production workspace will likely be handled differently.

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -3,9 +3,10 @@
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Set the TB_VERSION variable from .tinyenv file
+# Evaluate and export the environment variables from the .tinyenv file
 source "$SCRIPT_DIR/.tinyenv"
 export TB_VERSION
+export TB_VERSION_WARNING
 echo "Using TB_VERSION: $TB_VERSION"
 
 # Function to prompt Tinybird branch information
@@ -71,5 +72,11 @@ tbsql() {
 
 # Export the prompt with Tinybird branch information
 export PS1="\w\$(prompt_tb)\$ "
+
+# Define the wa function wrapper
+wa() {
+    # Execute the main wa script located in the same directory
+    "$SCRIPT_DIR/wa" "$@"
+}
 
 exec "$@"

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Evaluate and export the environment variables from the .tinyenv file
 source "$SCRIPT_DIR/.tinyenv"
 export TB_VERSION
-export TB_VERSION_WARNING
 echo "Using TB_VERSION: $TB_VERSION"
 
 # Function to prompt Tinybird branch information

--- a/ghost/web-analytics/scripts/check_branch_safety.sh
+++ b/ghost/web-analytics/scripts/check_branch_safety.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Ensures pipeline errors are propagated
+set -o pipefail
+
+# Get the directory where this script is located
+# (Assuming .tinyb is in the parent directory relative to this script)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Color definitions
+COLOR_RED='\033[0;31m'
+COLOR_NC='\033[0m' # No Color
+
+# Function for colored error messages
+echo_error() {
+    echo -e "${COLOR_RED}🚨 SAFETY ERROR: $@${COLOR_NC}" >&2
+}
+
+# --- Main Check Logic ---
+
+current_branch_name=""
+tinyb_file="$PARENT_DIR/.tinyb"
+
+if [ ! -f "$tinyb_file" ]; then
+    echo_error ".tinyb file not found at $tinyb_file."
+    echo_error "Cannot determine current branch."
+    exit 1
+fi
+
+# Extract the name value from the JSON-like structure in .tinyb
+current_branch_name=$(grep '"name":' "$tinyb_file" | cut -d : -f 2 | cut -d '"' -f 2)
+
+if [ -z "$current_branch_name" ]; then
+    echo_error "Could not extract branch name from $tinyb_file."
+    exit 1
+fi
+
+# The actual safety check
+if [[ "$current_branch_name" == "dedicated_staging_stats" || "$current_branch_name" == "dedicated_production_stats" ]]; then
+    echo_error "Current branch '$current_branch_name' is a protected branch."
+    echo_error "Operation aborted for safety."
+    exit 1 # Exit with non-zero status indicating failure/unsafe
+fi
+
+# If we reach here, the branch is considered safe
+exit 0

--- a/ghost/web-analytics/scripts/create_branch.sh
+++ b/ghost/web-analytics/scripts/create_branch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Set the TB_VERSION variable from .tinyenv file
+# This ensures the script can run independently if needed,
+# although entrypoint.sh usually handles this.
+if [ -f "$SCRIPT_DIR/../.tinyenv" ]; then
+    source "$SCRIPT_DIR/../.tinyenv"
+    export TB_VERSION
+else
+    echo "Warning: .tinyenv file not found."
+fi
+
+# Generate a unique branch name using a timestamp
+BRANCH_NAME="dev_$(date +%s)"
+
+echo "Attempting to create branch: $BRANCH_NAME..."
+
+# Attempt to create the branch and check for errors
+if ! tb branch create "$BRANCH_NAME"; then
+    # Using ANSI escape codes for red color
+    echo -e "\033[0;31m🚨 ERROR: Failed to create branch $BRANCH_NAME. Exiting.\033[0m" >&2
+    exit 1
+fi
+
+# Commented out the verbose success message
+# echo "Successfully created branch: $BRANCH_NAME"
+
+# Output ONLY the branch name to stdout on success
+echo "$BRANCH_NAME"

--- a/ghost/web-analytics/scripts/delete_branch.sh
+++ b/ghost/web-analytics/scripts/delete_branch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Ensures pipeline errors are propagated
+set -o pipefail
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+SCRIPTS_SUBDIR="$SCRIPT_DIR"
+
+# Color definitions
+COLOR_RED='\033[0;31m'
+COLOR_GREEN='\033[0;32m'
+COLOR_BLUE='\033[0;34m'
+COLOR_NC='\033[0m' # No Color
+
+# Function for colored error messages
+echo_error() {
+    echo -e "${COLOR_RED}🚨 ERROR: $@${COLOR_NC}" >&2
+}
+
+# Function for informational messages
+echo_info() {
+    echo -e "${COLOR_BLUE}ℹ️  INFO: $@${COLOR_NC}"
+}
+
+# Function for success messages
+echo_success() {
+    echo -e "${COLOR_GREEN}✅ SUCCESS: $@${COLOR_NC}"
+}
+
+# --- Main Logic ---
+
+# 1. Perform safety check first
+echo_info "Performing branch safety check..."
+if ! "$SCRIPTS_SUBDIR/check_branch_safety.sh"; then
+    # Error message is printed by check_branch_safety.sh
+    echo_error "Branch safety check failed. Cannot delete protected branch."
+    exit 1
+fi
+# No success message needed here, check_branch_safety is silent on success within other scripts
+
+# 2. Get the current branch name from .tinyb
+current_branch_name=""
+tinyb_file="$PARENT_DIR/.tinyb"
+
+if [ ! -f "$tinyb_file" ]; then
+    echo_error ".tinyb file not found at $tinyb_file."
+    echo_error "Cannot determine current branch to delete."
+    exit 1
+fi
+
+current_branch_name=$(grep '"name":' "$tinyb_file" | cut -d : -f 2 | cut -d '"' -f 2)
+
+if [ -z "$current_branch_name" ]; then
+    echo_error "Could not extract branch name from $tinyb_file."
+    exit 1
+fi
+
+echo_info "Attempting to delete current branch: '$current_branch_name'..."
+
+# 3. Run the delete command (requires user confirmation)
+tb branch rm "$current_branch_name"
+delete_exit_code=$?
+
+if [ $delete_exit_code -ne 0 ]; then
+    echo_error "Failed to delete branch '$current_branch_name' (or operation cancelled). Exit code: $delete_exit_code"
+    exit 1
+fi
+
+# Note: We don't have a definitive success message here, as the user might cancel.
+# The tb command output itself serves as confirmation.
+echo_info "If confirmed, branch '$current_branch_name' should now be deleted."
+
+exit 0

--- a/ghost/web-analytics/scripts/exec_test.sh
+++ b/ghost/web-analytics/scripts/exec_test.sh
@@ -21,21 +21,31 @@ fi
 
 # Parse command line options
 jobs=""
+test_name=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         -j|--jobs)
-            if [[ -n "${2:-}" ]]; then
-                jobs="$2"
-                shift 2
-            else
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
                 echo "Error: -j|--jobs requires a number argument"
                 exit 1
             fi
+            jobs="$2"
+            shift 2
+            ;;
+        -n|--name)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: -n|--name requires a <test_name> argument"
+                exit 1
+            fi
+            test_name="$2"
+            shift 2
             ;;
         *)
             # Store the test name if provided
-            test_name="$1"
-            shift
+            # test_name="$1"
+            # shift
+            echo "Error: Unknown option: $1"
+            exit 1
             ;;
     esac
 done

--- a/ghost/web-analytics/wa
+++ b/ghost/web-analytics/wa
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status.
+# set -e
+# Treat unset variables as an error when substituting.
+# set -u
+# Ensures pipeline errors are propagated
+set -o pipefail
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPTS_SUBDIR="$SCRIPT_DIR/scripts"
+
+# Color definitions
+COLOR_RED='\033[0;31m'
+COLOR_GREEN='\033[0;32m'
+COLOR_YELLOW='\033[0;33m'
+COLOR_BLUE='\033[0;34m'
+COLOR_NC='\033[0m' # No Color
+
+# --- Helper Functions ---
+
+# Function to display help message
+show_help() {
+cat << EOF
+Usage: wa <command> [options]
+
+A CLI wrapper for common Tinybird development tasks.
+
+Commands:
+  test [-n|--name <test_name>] [-u|--update] Run the test suite or update test snapshots against the current branch.
+                          Use -n or --name to specify a single test file (without .test.sql).
+                          Use -u or --update to regenerate test result snapshots.
+                          (-n/--name and -u/--update are mutually exclusive).
+  branch [-a|--append] [-d|--deploy] Create a new Tinybird branch. Optionally append fixtures and/or deploy.
+  branch rm                 Delete the current Tinybird branch (prompts for confirmation).
+  lint                    Lint the Tinybird `.datasource` and `.pipe` files.
+  help, -h                Show this help message.
+
+Examples:
+  wa test
+  wa test -n my_specific_test
+  wa test --name my_specific_test
+  wa test -u
+  wa branch
+  wa branch -d
+  wa branch -a -d
+  wa branch rm
+  wa lint
+EOF
+}
+
+# Function for colored error messages
+echo_error() {
+    echo -e "${COLOR_RED}🚨 ERROR: $@${COLOR_NC}" >&2
+}
+
+# Function for colored success messages
+echo_success() {
+    echo -e "${COLOR_GREEN}✅ SUCCESS: $@${COLOR_NC}"
+}
+
+# Function for informational messages
+echo_info() {
+    echo -e "${COLOR_BLUE}ℹ️  INFO: $@${COLOR_NC}"
+}
+
+# --- Argument Parsing & Command Dispatch ---
+
+# Check if any command was provided
+if [ -z "$1" ]; then
+    show_help
+    exit 1
+fi
+
+# Main command dispatcher
+COMMAND=$1
+shift # Remove the command name from the arguments list
+
+case $COMMAND in
+    test)
+        test_name=""
+        update_snapshots=false
+        # Parse flags for the test command
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                -n|--name)
+                    if [[ -z "$2" || "$2" == --* ]]; then
+                        echo_error "Option -n/--name requires a <test_name> argument."
+                        exit 1
+                    fi
+                    test_name="$2"
+                    shift # past argument
+                    shift # past value
+                    ;;
+                -u|--update)
+                    update_snapshots=true
+                    shift # past argument
+                    ;;
+                *)
+                    echo_error "Unknown option for test command: $1"
+                    show_help
+                    exit 1
+                    ;;
+            esac
+        done
+
+        # Check for conflicting flags
+        if [ "$update_snapshots" = true ] && [ -n "$test_name" ]; then
+            echo_error "The -n/--name (specific test) and -u/--update (update snapshots) flags cannot be used together."
+            exit 1
+        fi
+
+        # Execute the appropriate script based on flags
+        if [ "$update_snapshots" = true ]; then
+            echo_info "Updating test snapshots..."
+            if ! "$SCRIPTS_SUBDIR/gen_test_results.sh"; then
+                 echo_error "Failed to update test snapshots."
+                 exit 1
+            fi
+            echo_success "Test snapshots updated."
+        elif [ -n "$test_name" ]; then
+            echo_info "Running test: $test_name..."
+            if ! "$SCRIPTS_SUBDIR/exec_test.sh" "$test_name"; then
+                echo_error "Test '$test_name' failed."
+                exit 1
+            fi
+            echo_success "Test '$test_name' completed."
+        else
+            echo_info "Running all tests..."
+            if ! "$SCRIPTS_SUBDIR/exec_test.sh"; then
+                 echo_error "Test suite failed."
+                 exit 1
+            fi
+            echo_success "Test suite completed."
+        fi
+        ;;
+    branch)
+        # Check if the first argument is a subcommand like 'rm'
+        if [ "$1" == "rm" ]; then
+            shift # Consume 'rm'
+            # Ensure no other arguments were passed with 'rm'
+            if [ $# -gt 0 ]; then
+                echo_error "Unknown arguments for 'branch rm' command: $@"
+                show_help
+                exit 1
+            fi
+
+            # Execute deletion script
+            echo_info "Running delete_branch.sh script..."
+            if ! "$SCRIPTS_SUBDIR/delete_branch.sh"; then
+                echo_error "Branch deletion process failed or was cancelled."
+                exit 1
+            fi
+            exit 0 # Exit successfully after handling delete
+        fi
+
+        # --- Branch Creation Logic (if no subcommand like 'rm' was found) ---
+
+        # Flags for branch creation
+        append_fixtures=false
+        deploy_branch=false
+
+        # Parse flags for branch creation
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                -a|--append)
+                    append_fixtures=true
+                    shift # past argument
+                    ;;
+                -d|--deploy)
+                    deploy_branch=true
+                    shift # past argument
+                    ;;
+                # -d|--delete) # This is now handled by the 'rm' subcommand
+                #     delete_branch_flag=true
+                #     shift # past argument
+                #     ;;
+                *)
+                    echo_error "Unknown option for branch creation: $1"
+                    show_help
+                    exit 1
+                    ;;
+            esac
+        done
+
+        # Handle delete action first if the flag is set # MOVED to subcommand logic
+        # if [ "$delete_branch_flag" = true ]; then ...
+
+        # --- Actual Branch Creation Steps ---
+
+        # 1. Create the new branch
+        echo_info "Running create_branch.sh script..."
+
+        # Run the script directly, letting its output (stdout/stderr) go to the terminal.
+        "$SCRIPTS_SUBDIR/create_branch.sh"
+        script_exit_code=$? # Capture exit code *immediately*
+
+        if [ $script_exit_code -ne 0 ]; then
+            # Error message should have been printed by create_branch.sh itself
+            echo_error "create_branch.sh script failed (Exit code: $script_exit_code)."
+            exit 1
+        fi
+
+        # Assume create_branch succeeded and updated the .tinyb file.
+        # Get the name of the newly created branch from .tinyb
+        echo_info "Fetching branch name from .tinyb file..."
+        created_branch_name=""
+        tinyb_file="$SCRIPT_DIR/.tinyb"
+
+        if [ ! -f "$tinyb_file" ]; then
+            echo_error ".tinyb file not found at $tinyb_file after branch creation."
+            echo_error "Did create_branch.sh run correctly and update the workspace?"
+            exit 1
+        fi
+
+        # Extract the name value from the JSON-like structure in .tinyb
+        created_branch_name=$(grep '"name":' "$tinyb_file" | cut -d : -f 2 | cut -d '"' -f 2)
+
+        if [ -z "$created_branch_name" ]; then
+            echo_error "Could not extract branch name from $tinyb_file."
+            echo_error "Is the file format correct?"
+            exit 1
+        fi
+
+        echo_success "Branch '$created_branch_name' is active."
+
+        # SAFETY CHECK: Ensure we are not operating on a main/production branch by calling the dedicated script
+        echo_info "Performing branch safety check..."
+        if ! "$SCRIPTS_SUBDIR/check_branch_safety.sh"; then
+            # Error message is printed by check_branch_safety.sh
+            echo_error "Branch safety check failed. Halting operation."
+            exit 1
+        fi
+        echo_success "Branch safety check passed."
+
+        # 2. Deploy the branch if requested
+        if [ "$deploy_branch" = true ]; then
+            echo_info "Deploying branch '$created_branch_name'..."
+            if ! tb deploy --branch "$created_branch_name"; then
+                echo_error "Deployment of branch '$created_branch_name' failed."
+                exit 1
+            fi
+            echo_success "Branch '$created_branch_name' deployed."
+        fi
+
+        # 3. Append fixtures if requested
+        if [ "$append_fixtures" = true ]; then
+
+            echo_info "Running append_fixtures.sh script..."
+            "$SCRIPTS_SUBDIR/append_fixtures.sh"
+            append_exit_code=$?
+
+            if [ $append_exit_code -ne 0 ]; then
+                echo_error "Appending fixtures failed for branch '$created_branch_name' (Exit code: $append_exit_code)."
+                exit 1
+            fi
+            echo_success "Fixtures appended to branch '$created_branch_name'."
+        fi
+        ;;
+    lint)
+        # Execute the lint script
+        echo_info "Running lint script..."
+        if ! "$SCRIPTS_SUBDIR/lint.sh"; then
+            echo_error "Linting failed."
+            exit 1
+        fi
+        echo_success "Linting completed."
+        ;;
+    help|-h|--help)
+        show_help
+        ;;
+    *)
+        echo_error "Unknown command: $COMMAND"
+        echo ""
+        show_help
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-208/wrap-our-tinybird-scripts-in-a-basic-cli

- We currently have a handful of bash scripts which we use many times daily when working on Tinybird, and we're invoking the scripts using `./scripts/{script_name}.sh`. Major "first world problem" here, but it would be nice to avoid typing so many characters multiple times every day.
- This commit introduces a tiny bash wrapper called `wa` which then delegates to the existing script files. The CLI is available using the `yarn tb` script to launch a shell, then you can run e.g. `wa branch` to create a new Tinybird branch with a randomly generated name.
- More details on the usage are in the README.md, and you can also run `wa help` to output all the available commands and options
- This is just an experimental starting point that we can keep building on if it feels right, or we can delete it later if we find it's not useful.