### PR TITLE
Ignored Tinybird CLI version warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,6 +851,8 @@ jobs:
   job_tinybird:
     name: Tinybird Tests (Web Analytics)
     runs-on: ubuntu-latest
+    env:
+      TB_VERSION_WARNING: 0
     needs: [
       job_setup
     ]
@@ -1299,6 +1301,8 @@ jobs:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
   deploy_tinybird:
     runs-on: ubuntu-latest
+    env:
+      TB_VERSION_WARNING: 0
     needs: [
       job_setup,
       job_tinybird

--- a/ghost/web-analytics/.tinyenv
+++ b/ghost/web-analytics/.tinyenv
@@ -23,7 +23,7 @@ TB_VERSION=8
 # TB_FORCE_REMOVE_OLDEST_ROLLBACK=0
 
 # Don't print CLI version warning message if there's a new available version
-# TB_VERSION_WARNING=0
+TB_VERSION_WARNING=0
 
 # Skip regression tests
 # TB_SKIP_REGRESSION=0

--- a/ghost/web-analytics/entrypoint.sh
+++ b/ghost/web-analytics/entrypoint.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Evaluate and export the environment variables from the .tinyenv file
 source "$SCRIPT_DIR/.tinyenv"
 export TB_VERSION
+export TB_VERSION_WARNING
 echo "Using TB_VERSION: $TB_VERSION"
 
 # Function to prompt Tinybird branch information


### PR DESCRIPTION
no issue

- The Tinybird CLI outputs a warning message when the version of the CLI is not the latest version.
- This can be a problem because the warning message is included in the test results files, which causes tests to fail.
- This is particularly annoying because we are on the latest version of the CLI, but we are getting the warning for development builds of the CLI, not just the latest stable release.
- This commit adds the `TB_VERSION_WARNING` environment variable to the shell opened with `yarn tb` and to the Github Actions workflows to suppress the warning message.
