### PR TITLE
Added Tinybird tests for remaining single filter test cases

### DIFF
--- a/ghost/web-analytics/tests/filter_pathname_about_top_sources.test
+++ b/ghost/web-analytics/tests/filter_pathname_about_top_sources.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_sources__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --pathname /about/

--- a/ghost/web-analytics/tests/filter_pathname_about_top_sources.test.result
+++ b/ghost/web-analytics/tests/filter_pathname_about_top_sources.test.result
@@ -1,0 +1,5 @@
+"source","visits"
+"",4
+"bing.com",2
+"google.com",1
+"wilted-tick.com",1

--- a/ghost/web-analytics/tests/filter_source_bing_top_devices.test
+++ b/ghost/web-analytics/tests/filter_source_bing_top_devices.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_devices__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/web-analytics/tests/filter_source_bing_top_devices.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_devices.test.result
@@ -1,0 +1,2 @@
+"device","visits"
+"desktop",2

--- a/ghost/web-analytics/tests/filter_source_bing_top_locations.test
+++ b/ghost/web-analytics/tests/filter_source_bing_top_locations.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_locations__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/web-analytics/tests/filter_source_bing_top_locations.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_locations.test.result
@@ -1,0 +1,3 @@
+"location","visits"
+"DE",1
+"GB",1

--- a/ghost/web-analytics/tests/filter_source_bing_top_os.test
+++ b/ghost/web-analytics/tests/filter_source_bing_top_os.test
@@ -1,0 +1,1 @@
+tb pipe data api_top_os__v${TB_VERSION:-0} --date_from 2100-01-01 --date_to 2100-01-07 --site_uuid mock_site_uuid --format CSV --source bing.com

--- a/ghost/web-analytics/tests/filter_source_bing_top_os.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_os.test.result
@@ -1,0 +1,2 @@
+"os","visits"
+"windows",2


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-169/automated-tests-for-all-queries-including-every-filter-plus-one-other

- This commit is part of a general effort to improve out test coverage for our Tinybird endpoints, so we can be more confident making changes quickly in the future.
- This PR in particular adds the final remaining single-filter test cases for all endpoints, so we now have 1 test per filter per endpoint