### PR TITLE
Improved verify modal and screen

### DIFF
--- a/ghost/admin/app/components/editor/modals/re-verify.hbs
+++ b/ghost/admin/app/components/editor/modals/re-verify.hbs
@@ -17,7 +17,7 @@
                         type="text"
                         inputmode="numeric"
                         pattern="[0-9]*"
-                        placeholder="123456"
+                        placeholder="******"
                         autocomplete="one-time-code"
                         class="gh-input"
                         value={{this.token}}
@@ -54,7 +54,6 @@
             @useAccentColor={{true}}
             data-test-button="verify"
         />
-        <p class="main-notification">Not receiving the emails? <a href="https://ghost.org/docs/config/#mail" target="_blank" rel="noopener noreferrer">Learn more</a></p>
 
         {{#if (or this.flowErrors this.verifyData.validationMessage)}}
             <p class="response" data-test-error="verify">{{or this.flowErrors this.verifyData.validationMessage}}</p>

--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -48,7 +48,7 @@
                 </GhFormGroup>
 
                 <GhTaskButton
-                    @buttonText="Verify sign in &rarr;"
+                    @buttonText="Verify &rarr;"
                     @task={{this.verifyTokenTask}}
                     @showSuccess={{false}}
                     @class="login gh-btn gh-btn-login gh-btn-block gh-btn-icon"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2133/visual-tweaks ref 33be7237a4

- There's a modal form of verify that happens in the editor if you try to save whilst logged out
- This mostly updates the modal to be the same as the screen
- I also simplified the screen button text to be just "Verify" like the modal
- Everything is now matching and simple


