### PR TITLE
Added CI job for Tinybird Forward tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,7 +856,6 @@ jobs:
     name: Tinybird Tests (Forward)
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
     env:
       TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
       TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -858,8 +858,8 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
     env:
-      TINYBIRD_HOST:
-      TINYBIRD_TOKEN:
+      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
+      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
     defaults:
         run:
           working-directory: ghost/core/core/server/data/tinybird
@@ -877,7 +877,7 @@ jobs:
       - name: Test project
         run: tb test run
       - name: Deployment check
-        run: tb --cloud --host ${{ env.TINYBIRD_FORWARD_HOST }} --token ${{ env.TINYBIRD_FORWARD_TOKEN }} deploy --check
+        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
 
   # Tinyird Tests (Classic) — This test suite is deprecated and will be removed very soon.
   job_tinybird:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,6 +856,7 @@ jobs:
     name: Tinybird Tests (Forward)
     runs-on: ubuntu-latest
     needs: [job_setup]
+    if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
     env:
       TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
       TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
             tinybird:
               - 'ghost/web-analytics/**'
               - '!ghost/web-analytics/**/*.md'
+            tinybird-forward:
+              - 'ghost/core/core/server/data/tinybird'
+              - '!'ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
 
@@ -197,6 +200,7 @@ jobs:
       changed_signup_form: ${{ steps.changed.outputs.signup-form }}
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
+      changed_tinybird_forward: ${{ steps.changed.outputs.tinybird-forward }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
@@ -848,6 +852,34 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  job_tinybird_forward:
+    name: Tinybird Tests (Forward)
+    runs-on: ubuntu-latest
+    needs: [job_setup]
+    if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
+    env:
+      TINYBIRD_HOST:
+      TINYBIRD_TOKEN:
+    defaults:
+        run:
+          working-directory: ghost/core/core/server/data/tinybird
+    services:
+      tinybird:
+        image: tinybirdco/tinybird-local:latest
+        ports:
+          - 7181:7181
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tinybird CLI
+        run: curl https://tinybird.co | sh
+      - name: Build project
+        run: tb build
+      - name: Test project
+        run: tb test run
+      - name: Deployment check
+        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
+
+  # Tinyird Tests (Classic) — This test suite is deprecated and will be removed very soon.
   job_tinybird:
     name: Tinybird Tests (Web Analytics)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,7 +871,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Tinybird CLI
-        run: curl https://tinybird.co | sh
+        run: curl -fsSL https://tinybird.co/install.sh | sh
       - name: Build project
         run: tb build
       - name: Test project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1178,6 +1178,7 @@ jobs:
         job_admin_x_settings,
         job_comments_ui,
         job_signup_form,
+        job_tinybird_forward,
         job_tinybird
       ]
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
               - '!ghost/web-analytics/**/*.md'
             tinybird-forward:
               - 'ghost/core/core/server/data/tinybird'
-              - '!'ghost/core/core/server/data/tinybird/**/*.md'
+              - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,7 +877,7 @@ jobs:
       - name: Test project
         run: tb test run
       - name: Deployment check
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
+        run: tb --cloud --host ${{ env.TINYBIRD_FORWARD_HOST }} --token ${{ env.TINYBIRD_FORWARD_TOKEN }} deploy --check
 
   # Tinyird Tests (Classic) — This test suite is deprecated and will be removed very soon.
   job_tinybird:

--- a/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
@@ -54,7 +54,6 @@
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&member_status=undefined
   expected_result: |
     {"device":"desktop","visits":5}
-    {"device":"bot","visits":1}
 
 - name: Filtered by timezone - America/Los_Angeles
   description: Filtered by timezone - America/Los_Angeles

--- a/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
@@ -54,6 +54,7 @@
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&member_status=undefined
   expected_result: |
     {"device":"desktop","visits":5}
+    {"device":"bot","visits":1}
 
 - name: Filtered by timezone - America/Los_Angeles
   description: Filtered by timezone - America/Los_Angeles


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-217/figure-out-deployment-and-cicd-strategy-with-tinybird-forward

- Now that we've migrated our datafiles to Tinybird Forward (the 2.0 of the Tinybird development experience), we need to start testing our setup in CI, before merging which will soon trigger a deployment.
- This commit adds the CI / test job for the new Tinybird workspace. The existing `job_tinybird` job remains (for now) until we are fully migrated to Tinybird Forward, at which point this job will be removed.
