### PR TITLE
Add dynamic translation support to content-cta.hbs

### DIFF
--- a/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
@@ -2,19 +2,19 @@
 <aside class="gh-post-upgrade-cta">
     <div class="gh-post-upgrade-cta-content" style="background-color: {{@site.accent_color}}">
         {{#has visibility="paid"}}
-            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for paying subscribers only</h2>
+            <h2>{{t "This"}} {{#is "page"}}{{t "page"}}{{else}}{{t "post"}}{{/is}} {{t "is for paying subscribers only"}}</h2>
         {{/has}}
         {{#has visibility="members"}}
-            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers only</h2>
+            <h2>{{t "This"}} {{#is "page"}}{{t "page"}}{{else}}{{t "post"}}{{/is}} {{t "is for subscribers only"}}</h2>
         {{/has}}
         {{#has visibility="tiers"}}
-            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers on the {{tiers}} only </h2>
+            <h2>{{t "This"}} {{#is "page"}}{{t "page"}}{{else}}{{t "post"}}{{/is}} {{t "is for subscribers on the"}} {{tiers}} {{t "only"}}</h2>
         {{/has}}
         {{#if @member}}
-            <a class="gh-btn" data-portal="account/plans" href="#/portal/account/plans" style="color:{{@site.accent_color}}">Upgrade your account</a>
+            <a class="gh-btn" data-portal="account/plans" href="#/portal/account/plans" style="color:{{@site.accent_color}}">{{t "Upgrade your account"}}</a>
         {{else}}
-            <a class="gh-btn" data-portal="signup" href="#/portal/signup" style="color:{{@site.accent_color}}">Subscribe now</a>
-            <p><small>Already have an account? <a data-portal="signin" href="#/portal/signin">Sign in</a></small></p>
+            <a class="gh-btn" data-portal="signup" href="#/portal/signup" style="color:{{@site.accent_color}}">{{t "Subscribe now"}}</a>
+            <p><small>{{t "Already have an account?"}} <a data-portal="signin" href="#/portal/signin">{{t "Sign in"}}</a></small></p>
         {{/if}}
     </div>
 </aside>


### PR DESCRIPTION
This update replaces static text strings in with dynamic translation helpers using the helper provided by Ghost. It improves internationalization (i18n) support, allowing the upgrade CTA component to automatically adapt to the active site language, with fallback to English. No layout or logic changes were made, ensuring full backward compatibility.content-cta.hbs{{t}}

✨ Got some code for us? Awesome 🎊!
Please take a minute to explain the change you're making:

Why are you making it?
To improve multilingual support in Ghost themes, especially for users running publications in non-English languages like Portuguese, Spanish, French, etc.

What does it do?
It enables dynamic translations for all CTA messages in by replacing hardcoded strings with the built-in translation helper.content-cta.hbs{{t}}

Why is this something Ghost users or developers need?
Many Ghost sites operate in languages other than English. Adding translation support to theme components like this one ensures a better user experience for members, improves accessibility, and aligns with Ghost’s growing international user base.

✅ Please check your PR against these items:
 I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)

 I've explained my change

 I've written an automated test to prove my change works (Not applicable in this case — no logic modified)