### PR TITLE
Fixed layout break with long content in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.44",
+  "version": "0.6.45",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/activities/NotificationItem.tsx
+++ b/apps/admin-x-activitypub/src/components/activities/NotificationItem.tsx
@@ -20,7 +20,7 @@ interface NotificationItemProps {
 const NotificationItem = ({children, onClick, url, className}: NotificationItemProps) => {
     return (
         <NotificationContext.Provider value={{onClick, url}}>
-            <div className={`relative -mx-4 -my-px grid cursor-pointer grid-cols-[auto_1fr] gap-x-3 gap-y-2 rounded-lg p-4 text-left hover:bg-gray-75 ${className}`}
+            <div className={`relative -mx-4 -my-px grid cursor-pointer grid-cols-[auto_1fr] gap-x-3 gap-y-2 break-all rounded-lg p-4 text-left hover:bg-gray-75 ${className}`}
                 role='button'
                 onClick={onClick}
             >


### PR DESCRIPTION
ref AP-1068

- AP notification layout broke when it contains long-form content 
- this adds proper word break styling to the notification item