### PR TITLE
Prevent 1password on verification code input

### DIFF
--- a/ghost/admin/app/components/editor/modals/re-verify.hbs
+++ b/ghost/admin/app/components/editor/modals/re-verify.hbs
@@ -22,6 +22,7 @@
                         class="gh-input"
                         value={{this.token}}
                         data-test-input="token"
+                        data-1p-ignore
                         {{on "input" this.handleTokenInput}}
                     />
 

--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -25,6 +25,7 @@
                             class="gh-input email"
                             value={{this.token}}
                             data-test-input="token"
+                            data-1p-ignore
                             {{on "input" this.handleTokenInput}}
                         />
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2133/visual-tweaks
- The verification code comes from email, so cannot be known by 1pass
- 1pass firing is annoying and not useful, therefore we tell it not to

