### PR TITLE
🐛 Fixed bug where staff2fa lab was not listed in the beta labs UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -33,6 +33,10 @@ const BetaFeatures: React.FC = () => {
                 detail={<>Adds the excerpt input below the post title in the editor</>}
                 title='Show post excerpt inline' />
             <LabItem
+                action={<FeatureToggle flag="staff2fa" />}
+                detail={<>Enables support for staff multi-factor authentication</>}
+                title='Staff multi-factor authentication' />
+            <LabItem
                 action={<FeatureToggle flag="additionalPaymentMethods" />}
                 detail={<>Enable support for CashApp, iDEAL, Bancontact, and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/22882
- staff2fa is listed a beta lab and can be enabled using the API
- previously this was an alpha lab, but was moved to being a beta lab
- when being switched from an alpha to beta lab, it was removed from the alpha labs UI but never added to the beta labs UI

This PR basically just adds the staff2fa lab to the beta labs UI given it was not added after being switched from alpha (likely unintentionally?).

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
~~I've written an automated test to prove my change works~~ Not applicable.