### PR TITLE
Updated 2fa verify screens based on use case

### DIFF
--- a/ghost/admin/app/components/editor/modals/re-authenticate.js
+++ b/ghost/admin/app/components/editor/modals/re-authenticate.js
@@ -70,6 +70,9 @@ export default class ReAuthenticateModal extends Component {
             }
 
             if (isTwoFactorTokenRequiredError(error)) {
+                let errorCode = error.payload?.errors[0]?.code;
+                // login was successful, but 2FA verification is required
+                this.session.set('errorCode', errorCode);
                 yield this.modals.open('editor/modals/re-verify');
                 this.args.close();
                 return true;

--- a/ghost/admin/app/components/editor/modals/re-verify.hbs
+++ b/ghost/admin/app/components/editor/modals/re-verify.hbs
@@ -1,10 +1,12 @@
 <div class="modal-content" data-test-modal="re-verify">
     <form id="verify" class="gh-signin" method="post" novalidate="novalidate" {{on "submit" (perform this.verifyTokenTask)}}>
         <header>
-            <h1>Verify it's really you</h1>
-            <p>
-                To keep your account safe, we've sent a 6-digit verification code to your email to make sure it's you.
-            </p>
+            <h1>{{#if this.twoFactorRequired}}2FA confirmation{{else}}Verify it's really you{{/if}}</h1>
+            {{#if this.twoFactorRequired}}
+                <p>Enter the sign-in verification code sent to your email.</p>
+            {{else}}
+                <p>It looks like you're signing in from a new device. A 6-digit sign-in verification code has been sent to your email to keep your account safe.</p>
+            {{/if}}
         </header>
 
         <div class="form-group">

--- a/ghost/admin/app/components/editor/modals/re-verify.js
+++ b/ghost/admin/app/components/editor/modals/re-verify.js
@@ -68,10 +68,18 @@ export default class ReVerifyModal extends Component {
     @tracked flowErrors = '';
     @tracked verifyData = new VerifyData();
     @tracked resendTokenCountdown = DEFAULT_RESEND_TOKEN_COUNTDOWN;
+    @tracked twoFactorRequired = false;
 
     constructor() {
         super(...arguments);
         this.resetData();
+
+        const errorCode = this.session.get('errorCode');
+
+        if (errorCode === '2FA_TOKEN_REQUIRED') {
+            this.twoFactorRequired = true;
+        }
+        this.session.set('errorCode', null); // Clear it after reading
     }
 
     @action
@@ -102,7 +110,7 @@ export default class ReVerifyModal extends Component {
         } catch (error) {
             if (error?.payload?.errors) {
                 const [firstError] = error.payload.errors;
-                
+
                 if (firstError.type === 'UnauthorizedError') {
                     this.verifyData.setTokenError('Your verification code is incorrect.');
                 } else {
@@ -136,12 +144,12 @@ export default class ReVerifyModal extends Component {
                 contentType: 'application/json;charset=utf-8',
                 dataType: 'text'
             });
-            
+
             this.notifications.showNotification(
                 'A new verification code has been sent to your email.',
                 {type: 'success'}
             );
-            
+
             this.delayResendAvailabilityTask.perform();
             return TASK_SUCCESS;
         } catch (error) {

--- a/ghost/admin/app/controllers/signin-verify.js
+++ b/ghost/admin/app/controllers/signin-verify.js
@@ -64,6 +64,18 @@ export default class SigninVerifyController extends Controller {
     @tracked flowErrors = '';
     @tracked verifyData = new VerifyData();
     @tracked resendTokenCountdown = DEFAULT_RESEND_TOKEN_COUNTDOWN;
+    @tracked twoFactorRequired = false;
+
+    constructor() {
+        super(...arguments);
+        // Get the error from session and clear it immediately
+        const errorCode = this.session.get('errorCode');
+
+        if (errorCode === '2FA_TOKEN_REQUIRED') {
+            this.twoFactorRequired = true;
+        }
+        this.session.set('errorCode', null); // Clear it after reading
+    }
 
     resetResendTokenCountdown() {
         clearInterval(this.resendTokenCountdownInterval);

--- a/ghost/admin/app/controllers/signin.js
+++ b/ghost/admin/app/controllers/signin.js
@@ -4,8 +4,7 @@ import {action} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {inject} from 'ghost-admin/decorators/inject';
 import {isArray as isEmberArray} from '@ember/array';
-import {isTwoFactorTokenRequiredError} from '../services/ajax';
-import {isVersionMismatchError} from 'ghost-admin/services/ajax';
+import {isTwoFactorTokenRequiredError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -58,7 +57,9 @@ export default class SigninController extends Controller.extend(ValidationEngine
             return SUCCESS;
         } catch (error) {
             if (isTwoFactorTokenRequiredError(error)) {
+                let errorCode = error.payload?.errors[0]?.code;
                 // login was successful, but 2FA verification is required
+                this.session.set('errorCode', errorCode);
                 this.router.transitionTo('signin-verify');
                 return SUCCESS;
             }

--- a/ghost/admin/app/templates/signin-verify.hbs
+++ b/ghost/admin/app/templates/signin-verify.hbs
@@ -4,12 +4,16 @@
             <form id="login" method="post" action="javascript:void(0)" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.verifyTokenTask)}}>
                 <header>
                     <div class="gh-site-icon" style={{site-icon-style}}></div>
-                    <h1>Verify it's really you</h1>
+                    <h1>{{#if this.twoFactorRequired}}2FA confirmation{{else}}Verify it's really you{{/if}}</h1>
                 </header>
 
-                <p>
-                    To keep your account safe, we've sent a 6-digit verification code to your email to make sure it's you.
-                </p>
+
+                {{#if this.twoFactorRequired}}
+                    <p>Enter the sign-in verification code sent to your email.</p>
+                {{else}}
+                    <p>It looks like you're signing in from a new device. A 6-digit sign-in verification code has been sent to your email to keep your account safe.</p>
+                {{/if}}
+
                 <GhFormGroup @errors={{this.verifyData.errors}} @hasValidated={{this.verifyData.hasValidated}} @property="token">
                     <label for="token">Verification code</label>
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2074/adjust-verification-copy-if-2fa-is-enabled-for-all-logins

- Updated the verify screen and modal to detect the error code for the 2fa error
- We then display different messaging based on whether we are in "force 2fa" mode or this is a new device detected situation

