### PR TITLE
Stripped dubdubdub prefix from handles

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.46",
+  "version": "0.6.47",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/utils/get-username.ts
+++ b/apps/admin-x-activitypub/src/utils/get-username.ts
@@ -3,7 +3,7 @@ function getUsername(actor: {preferredUsername: string; id: string|null;}) {
         return '@unknown@unknown';
     }
     try {
-        return `@${actor.preferredUsername}@${(new URL(actor.id)).hostname}`;
+        return `@${actor.preferredUsername}@${(new URL(actor.id)).hostname.replace(/^www\./, '')}`;
     } catch (err) {
         return '@unknown@unknown';
     }

--- a/apps/admin-x-activitypub/test/unit/utils/get-username.test.tsx
+++ b/apps/admin-x-activitypub/test/unit/utils/get-username.test.tsx
@@ -9,7 +9,7 @@ describe('getUsername', function () {
 
         const result = getUsername(user);
 
-        expect(result).toBe('@index@www.platformer.news');
+        expect(result).toBe('@index@platformer.news');
     });
 
     it('returns a default username if the user object is missing data', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-963

All of the handles generated by Ghost now no longer have a www. in the host. By updating this util we ensure that handles throughout the application have this www. prefix stripped.

This includes handles external to the Ghost service, which means we may show incorrect handles in the UI for external sites, however we've deemed this to be an edge case for now, and in the case of a bug, it's purely a cosmetic one, those account can still be searched and interacted with using their handle.
