### PR TITLE
🐛 Fixed if all comments are hidden, no comments are visible

### DIFF
--- a/apps/comments-ui/src/App.tsx
+++ b/apps/comments-ui/src/App.tsx
@@ -224,7 +224,7 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
             <CommentsFrame ref={iframeRef}>
                 <ContentBox done={done} />
             </CommentsFrame>
-            {state.comments.length > 0 ? <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/> : null}
+            {state.initStatus === 'success' && <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/>}
             <PopupBox />
         </AppContext.Provider>
     );

--- a/apps/comments-ui/src/App.tsx
+++ b/apps/comments-ui/src/App.tsx
@@ -224,7 +224,7 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
             <CommentsFrame ref={iframeRef}>
                 <ContentBox done={done} />
             </CommentsFrame>
-            {state.initStatus === 'success' && <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/>}
+            {done && <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/>}
             <PopupBox />
         </AppContext.Provider>
     );

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -44,15 +44,7 @@ test.describe('Admin moderation', async () => {
         });
     }
 
-    test('skips rendering the auth frame with no comments', async ({page}) => {
-        await initializeTest(page);
-
-        const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(0);
-    });
-
-    test('renders the auth frame when there are comments', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
+    test('renders the auth frame', async ({page}) => {
         await initializeTest(page);
 
         const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
@@ -226,6 +218,15 @@ test.describe('Admin moderation', async () => {
         await expect(comments.nth(1)).toContainText('Hidden for members');
 
         expect(adminBrowseSpy.called).toBe(true);
+    });
+
+    test('comment panel is shown when all comments are hidden', async ({page}) => {
+        mockedApi.addComment({html: '<p>This is comment 1</p>', status: 'hidden'});
+        mockedApi.addComment({html: '<p>This is comment 2</p>', status: 'hidden'});
+
+        const {frame} = await initializeTest(page);
+        const comments = await frame.getByTestId('comment-component');
+        await expect(comments).toHaveCount(2);
     });
 
     test('can hide and show comments', async ({page}) => {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/22331

load the auth frame even if there are no visible comments because we can't check for hidden comments without having the auth frame loaded

The fix is based on the suggestion in https://github.com/TryGhost/Ghost/issues/22331#issuecomment-2710516576

Change covered with automated tests and confirmed manually in dev environment.
