### PR TITLE
🐛 Show hidden comments to admin when there are just hidden comments

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -377,7 +377,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
             <CommentsFrame ref={iframeRef}>
                 <ContentBox done={done} />
             </CommentsFrame>
-            {state.comments.length > 0 ? <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/> : null}
+            {done && <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/>}
             <PopupBox />
         </AppContext.Provider>
     );

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -38,11 +38,11 @@ test.describe('Admin moderation', async () => {
         });
     }
 
-    test('skips rendering the auth frame with no comments', async ({page}) => {
+    test('renders the auth frame when there are no comments', async ({page}) => {
         await initializeTest(page);
 
         const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(0);
+        await expect(iframeElement).toHaveCount(1);
     });
 
     test('renders the auth frame when there are comments', async ({page}) => {
@@ -262,6 +262,17 @@ test.describe('Admin moderation', async () => {
         await replyToHide.getByTestId('show-button').click();
 
         await expect(replyToHide).not.toContainText('Hidden for members');
+    });
+
+    test('admin can see comments hidden from members even when all comments are hidden', async ({page}) => {
+        mockedApi.addComment({html: '<p>This is comment 1</p>', status: 'hidden'});
+
+        const {frame} = await initializeTest(page);
+
+        const comments = frame.getByTestId('comment-component');
+        await expect(comments).toHaveCount(1);
+        await expect(comments.nth(0)).toContainText('This is comment 1');
+        await expect(comments.nth(0)).toContainText('Hidden for members');
     });
 
     test('updates in-reply-to snippets when hiding', async ({page}) => {


### PR DESCRIPTION
## Context
When the admin hides all comments, it becomes impossible to see the hidden comments, so you can't unhide or even delete them.

fixes https://github.com/TryGhost/Ghost/issues/22331

## The Solution
As described [here](https://github.com/TryGhost/Ghost/issues/22331#issuecomment-2710516576) by @cathysarisky, the major problem was the AuthFrame not being loaded.

But things get a bit complex when you notice that even after loading it, hidden comments still don't show. We got stuck in the loading state. The reason is that because of the way we update the states inside `initSetup`, we can never change our `done` to success, leaving us in an eternal loading state.

So, besides loading the AuthFrame, the major work was handling the state update on `initSetup` to avoid unnecessary re-renders.

## Screenshots
| Admin Perspective | Member Perspective |
| --- | --- |
![CleanShot 2025-04-16 at 07 18 26@2x](https://github.com/user-attachments/assets/2322b58f-738f-417b-a0a9-c6be795874e4) | ![CleanShot 2025-04-16 at 07 19 23@2x](https://github.com/user-attachments/assets/78c6ae6f-b920-4f87-966d-abd83dc3d473) |


