### PR TITLE
Improved 2fa setting visibility implementation

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -1,3 +1,4 @@
+import BehindFeatureFlag from '../../BehindFeatureFlag';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import clsx from 'clsx';
@@ -278,7 +279,6 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
 
     const {settings} = useGlobalData();
     const require2fa = getSettingValue<boolean>(settings, 'require_email_mfa') || false;
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
     const {mutateAsync: editSettings} = useEditSettings();
     const handleError = useHandleError();
 
@@ -299,33 +299,36 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
                 link
                 onClick={() => fetchNextPage()}
             />}
-            {labs.staff2fa && !isEditorUser(currentUser) && (
-                <div className={`flex flex-col gap-6 ${users.length > 1 || invites.length > 0 ? '-mt-6' : ''}`}>
-                    <Separator />
-                    <div className='flex items-baseline justify-between'>
-                        <div className='flex flex-col'>
-                            <span className='text-[1.5rem] font-semibold tracking-tight'>Security settings</span>
-                            <span>Require email 2FA codes to be used on all staff logins</span>
+
+            <BehindFeatureFlag flag='staff2fa'>
+                {hasAdminAccess(currentUser) && (
+                    <div className={`flex flex-col gap-6 ${users.length > 1 || invites.length > 0 ? '-mt-6' : ''}`}>
+                        <Separator />
+                        <div className='flex items-baseline justify-between'>
+                            <div className='flex flex-col'>
+                                <span className='text-[1.5rem] font-semibold tracking-tight'>Security settings</span>
+                                <span>Require email 2FA codes to be used on all staff logins</span>
+                            </div>
+                            <Toggle
+                                checked={require2fa}
+                                direction='rtl'
+                                gap='gap-0'
+                                onChange={async () => {
+                                    const newValue = !require2fa;
+                                    try {
+                                        await editSettings([{
+                                            key: 'require_email_mfa',
+                                            value: newValue
+                                        }]);
+                                    } catch (error) {
+                                        handleError(error);
+                                    }
+                                }}
+                            />
                         </div>
-                        <Toggle
-                            checked={require2fa}
-                            direction='rtl'
-                            gap='gap-0'
-                            onChange={async () => {
-                                const newValue = !require2fa;
-                                try {
-                                    await editSettings([{
-                                        key: 'require_email_mfa',
-                                        value: newValue
-                                    }]);
-                                } catch (error) {
-                                    handleError(error);
-                                }
-                            }}
-                        />
                     </div>
-                </div>
-            )}
+                )}
+            </BehindFeatureFlag>
         </TopLevelGroup>
     );
 };

--- a/apps/admin-x-settings/test/acceptance/general/users/security.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/security.test.ts
@@ -1,0 +1,78 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests} from '../../../utils/acceptance';
+import {meWithRole, mockApi, responseFixtures, toggleLabsFlag} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('User security settings', async () => {
+    test('Owners can see 2FA settings', async ({page}) => {
+        // Enable staff2fa
+        toggleLabsFlag('staff2fa', true);
+
+        // Mock the API with an editor user
+        await mockApi({
+            page, requests: {
+                ...globalDataRequests,
+                browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
+            }
+        });
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        await section.scrollIntoViewIfNeeded();
+
+        // Verify the 2FA settings section is visible
+        await expect(section.getByText('Security settings')).toBeVisible();
+        await expect(section.getByText('Require email 2FA codes to be used on all staff logins')).toBeVisible();
+
+        // Verify that the toggle is off
+        await expect(section.getByRole('switch')).not.toBeChecked();
+    });
+
+    test('Admins can see 2FA settings', async ({page}) => {
+        // Enable staff2fa
+        toggleLabsFlag('staff2fa', true);
+
+        // Mock the API with an editor user
+        await mockApi({
+            page, requests: {
+                ...globalDataRequests,
+                browseMe: {...globalDataRequests.browseMe, response: meWithRole('Administrator')},
+                browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
+            }
+        });
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        await section.scrollIntoViewIfNeeded();
+
+        // Verify the 2FA settings section is visible
+        await expect(section.getByText('Security settings')).toBeVisible();
+        await expect(section.getByText('Require email 2FA codes to be used on all staff logins')).toBeVisible();
+
+        // Verify that the toggle is off
+        await expect(section.getByRole('switch')).not.toBeChecked();
+    });
+
+    test('Editor users cannot see 2FA settings', async ({page}) => {
+        // Enable staff2fa
+        toggleLabsFlag('staff2fa', true);
+
+        // Mock the API with an editor user and staff2fa enabled
+        await mockApi({
+            page, requests: {
+                ...globalDataRequests,
+                browseMe: {...globalDataRequests.browseMe, response: meWithRole('Editor')},
+                browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
+            }
+        });
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+
+        // Verify the 2FA settings section is not visible
+        await expect(section.getByText('Security settings')).not.toBeVisible();
+        await expect(section.getByText('Require email 2FA codes to be used on all staff logins')).not.toBeVisible();
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2076/editors-should-not-be-able-to-turn-onoff-2fa-for-everyone
- Added tests to ensure that owners and admins see the setting, but that editors do not, which is the intended behaviour
- This also changes how the labs flag was used, so it can be toggled correctly in the tests
- Lastly switched from using !isEditorUser to hasAdminAccess as I believe this is the correct and more idiomatic pattern

