### PR TITLE
Added config flag for Device Verification

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -21,7 +21,8 @@ module.exports = {
             'tenor',
             'pintura',
             'signupForm',
-            'stats'
+            'stats',
+            'security'
         ];
 
         frame.response = {

--- a/ghost/core/core/server/services/auth/session/index.js
+++ b/ghost/core/core/server/services/auth/session/index.js
@@ -5,12 +5,12 @@ const createSessionMiddleware = require('./middleware');
 const settingsCache = require('../../../../shared/settings-cache');
 const {GhostMailer} = require('../../mail');
 const {t} = require('../../i18n');
-const labs = require('../../../../shared/labs');
 
 const expressSession = require('./express-session');
 
 const models = require('../../../models');
 const urlUtils = require('../../../../shared/url-utils');
+const config = require('../../../../shared/config');
 const {blogIcon} = require('../../../lib/image');
 const url = require('url');
 
@@ -47,13 +47,16 @@ const sessionService = createSessionService({
     getSettingsCache(key) {
         return settingsCache.get(key);
     },
+    isStaffDeviceVerificationDisabled() {
+        // This config flag is set to true by default, so we need to check for false
+        return config.get('security.staffDeviceVerification') !== true;
+    },
     getBlogLogo() {
         return blogIcon.getIconUrl({absolute: true, fallbackToDefault: false})
             || 'https://static.ghost.org/v4.0.0/images/ghost-orb-1.png';
     },
     mailer,
     urlUtils,
-    labs,
     t
 });
 

--- a/ghost/core/core/server/services/auth/session/session-service.js
+++ b/ghost/core/core/server/services/auth/session/session-service.js
@@ -47,6 +47,7 @@ totp.options = {
  * @prop {(req: Req, res: Res) => Promise<boolean>} verifyAuthCodeForUser
  * @prop {(req: Req, res: Res) => Promise<boolean>} isVerifiedSession
  * @prop {() => boolean} isVerificationRequired
+ * @prop {() => boolean} isStaffDeviceVerificationDisabled
  */
 
 /**
@@ -57,9 +58,9 @@ totp.options = {
  * @param {(key: 'require_email_mfa' | 'admin_session_secret' | 'title') => boolean | string} deps.getSettingsCache
  * @param {() => string} deps.getBlogLogo
  * @param {import('../../core/core/server/services/mail').GhostMailer} deps.mailer
- * @param {import('../../core/core/shared/labs')} deps.labs
  * @param {import('../../core/core/server/services/i18n').t} deps.t
  * @param {import('../../core/core/shared/url-utils')} deps.urlUtils
+ * @param {() => boolean} deps.isStaffDeviceVerificationDisabled
  * @returns {SessionService}
  */
 
@@ -71,7 +72,7 @@ module.exports = function createSessionService({
     getBlogLogo,
     mailer,
     urlUtils,
-    labs,
+    isStaffDeviceVerificationDisabled,
     t
 }) {
     /**
@@ -128,7 +129,7 @@ module.exports = function createSessionService({
         session.user_agent = req.get('user-agent');
         session.ip = req.ip;
 
-        if (!labs.isSet('staff2fa')) {
+        if (isStaffDeviceVerificationDisabled()) {
             session.verified = true;
         }
     }
@@ -260,7 +261,7 @@ module.exports = function createSessionService({
         const siteTitle = getSettingsCache('title');
         const siteLogo = getBlogLogo();
         const siteUrl = urlUtils.urlFor('home', true);
-        const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+        const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)','i'));
         const siteDomain = (domain && domain[1]);
         const email = emailTemplate({
             t,
@@ -370,5 +371,6 @@ module.exports = function createSessionService({
         verifyAuthCodeForUser,
         generateAuthCodeForUser,
         isVerificationRequired
+
     };
 };

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -20,7 +20,8 @@ module.exports = function getConfigProperties() {
         hostSettings: config.get('hostSettings'),
         tenor: config.get('tenor'),
         pintura: config.get('pintura'),
-        signupForm: config.get('signupForm')
+        signupForm: config.get('signupForm'),
+        security: config.get('security')
     };
 
     // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -13,6 +13,9 @@
         "forceUpdate": false
     },
     "privacy": false,
+    "security": {
+        "staffDeviceVerification": true
+    },
     "useMinFiles": true,
     "paths": {
         "contentPath": "content/",

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -8,6 +8,9 @@
         "useNullAsDefault": true,
         "debug": false
     },
+    "security": {
+        "staffDeviceVerification": false
+    },
     "server": {
         "port": 2369
     },

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -18,6 +18,9 @@
     "logging": {
         "level": "error"
     },
+    "security": {
+        "staffDeviceVerification": false
+    },
     "spam": {
         "user_login": {
             "minWait": 600000,

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -14,6 +14,9 @@
     "logging": {
         "level": "error"
     },
+    "security": {
+        "staffDeviceVerification": false
+    },
     "spam": {
         "user_login": {
             "minWait": 600000,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -40,7 +40,7 @@ Object {
     "mail": "",
     "mailgunIsConfigured": false,
     "security": Object {
-      "staffDeviceVerification": true,
+      "staffDeviceVerification": false,
     },
     "signupForm": Object {
       "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -39,6 +39,9 @@ Object {
     },
     "mail": "",
     "mailgunIsConfigured": false,
+    "security": Object {
+      "staffDeviceVerification": true,
+    },
     "signupForm": Object {
       "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
       "version": "0.2",

--- a/ghost/core/test/e2e-api/admin/session.test.js
+++ b/ghost/core/test/e2e-api/admin/session.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {mockLabsEnabled, mockLabsDisabled, mockMail, assert, restore} = require('../../utils/e2e-framework-mock-manager');
 const {anyContentVersion, anyEtag, anyErrorId, stringMatching, anyISODateTime, anyUuid} = matchers;
 
@@ -79,7 +79,7 @@ describe('Sessions API', function () {
         let mail;
 
         beforeEach(async function () {
-            mockLabsEnabled('staff2fa');
+            configUtils.set('security.staffDeviceVerification', true);
             mail = mockMail();
 
             // Setup the agent & fixtures again, to ensure no cookies are set
@@ -88,7 +88,7 @@ describe('Sessions API', function () {
         });
 
         afterEach(async function () {
-            mockLabsDisabled('staff2fa');
+            configUtils.set('security.staffDeviceVerification', false);
             restore();
         });
 

--- a/ghost/core/test/e2e-api/admin/sso.test.js
+++ b/ghost/core/test/e2e-api/admin/sso.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {mockLabsEnabled, mockLabsDisabled, restore} = require('../../utils/e2e-framework-mock-manager');
 const {stringMatching} = matchers;
 const sinon = require('sinon');
@@ -51,11 +51,12 @@ describe('SSO API', function () {
 
     describe('SSO with 2FA enabled', function () {
         beforeEach(async function () {
-            mockLabsEnabled('staff2fa');
+            configUtils.set('security.staffDeviceVerification', true);
         });
 
         afterEach(async function () {
-            mockLabsDisabled('staff2fa');
+            configUtils.set('security.staffDeviceVerification', false);
+            restore();
         });
 
         it('can sign in with SSO when 2FA is enabled', async function () {

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -26,16 +26,15 @@ describe('SessionService', function () {
 
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => false
-        };
+
+        const isStaffDeviceVerificationDisabled = sinon.stub().returns(false);
 
         const sessionService = SessionService({
             getSession,
             findUserById,
             getOriginOfRequest,
             getSettingsCache,
-            labs
+            isStaffDeviceVerificationDisabled
         });
 
         const req = Object.create(express.request, {
@@ -83,15 +82,11 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('other-origin');
-        const labs = {
-            isSet: () => false
-        };
 
         const sessionService = SessionService({
             getSession,
             findUserById,
-            getOriginOfRequest,
-            labs
+            getOriginOfRequest
         });
 
         const req = Object.create(express.request, {
@@ -126,15 +121,11 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('other-origin');
-        const labs = {
-            isSet: () => false
-        };
 
         const sessionService = SessionService({
             getSession,
             findUserById,
-            getOriginOfRequest,
-            labs
+            getOriginOfRequest
         });
 
         const req = Object.create(express.request, {
@@ -171,16 +162,15 @@ describe('SessionService', function () {
 
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => true
-        };
+
+        const isStaffDeviceVerificationDisabled = sinon.stub().returns(false);
 
         const sessionService = SessionService({
             getSession,
             findUserById,
             getOriginOfRequest,
             getSettingsCache,
-            labs
+            isStaffDeviceVerificationDisabled
         });
 
         const req = Object.create(express.request, {
@@ -228,16 +218,12 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => true
-        };
 
         const sessionService = SessionService({
             getSession,
             findUserById,
             getOriginOfRequest,
-            getSettingsCache,
-            labs
+            getSettingsCache
         });
 
         const req = Object.create(express.request, {
@@ -281,16 +267,12 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: true
-        };
 
         const sessionService = SessionService({
             getSession,
             findUserById,
             getOriginOfRequest,
-            getSettingsCache,
-            labs
+            getSettingsCache
         });
 
         const req = Object.create(express.request, {
@@ -334,9 +316,6 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => true
-        };
 
         const req = Object.create(express.request, {
             ip: {
@@ -359,8 +338,7 @@ describe('SessionService', function () {
             getSession,
             findUserById,
             getOriginOfRequest,
-            getSettingsCache: getSecretFirst,
-            labs
+            getSettingsCache: getSecretFirst
         });
 
         const authCodeFirst = await sessionServiceFirst.generateAuthCodeForUser(req, res);
@@ -414,10 +392,7 @@ describe('SessionService', function () {
             getBlogLogo,
             urlUtils,
             mailer,
-            t,
-            labs: {
-                isSet: () => false
-            }
+            t
         });
 
         const req = Object.create(express.request);
@@ -467,10 +442,7 @@ describe('SessionService', function () {
             getBlogLogo,
             urlUtils,
             mailer,
-            t,
-            labs: {
-                isSet: () => false
-            }
+            t
         });
 
         const req = Object.create(express.request);
@@ -494,15 +466,14 @@ describe('SessionService', function () {
         };
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => false
-        };
+
+        const isStaffDeviceVerificationDisabled = sinon.stub().returns(false);
 
         const sessionService = SessionService({
             getSession,
             findUserById,
             getOriginOfRequest,
-            labs
+            isStaffDeviceVerificationDisabled
         });
 
         const req = Object.create(express.request, {
@@ -560,10 +531,7 @@ describe('SessionService', function () {
             getBlogLogo,
             urlUtils,
             mailer,
-            t,
-            labs: {
-                isSet: () => false
-            }
+            t
         });
 
         const req = Object.create(express.request);
@@ -588,10 +556,8 @@ describe('SessionService', function () {
 
         const findUserById = sinon.spy(async ({id}) => ({id}));
         const getOriginOfRequest = sinon.stub().returns('origin');
-        const labs = {
-            isSet: () => true
-        };
 
+        const isStaffDeviceVerificationDisabled = sinon.stub().returns(false);
         getSettingsCache.withArgs('require_email_mfa').returns(true);
 
         const sessionService = SessionService({
@@ -599,7 +565,7 @@ describe('SessionService', function () {
             findUserById,
             getOriginOfRequest,
             getSettingsCache,
-            labs
+            isStaffDeviceVerificationDisabled
         });
 
         const req = Object.create(express.request, {

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -21,7 +21,8 @@ const allowedKeys = [
     'hostSettings',
     'tenor',
     'pintura',
-    'signupForm'
+    'signupForm',
+    'security'
 ];
 
 describe('Public-config Service', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2127/swap-2fa-labs-flag-to-a-proper-config-flag ref https://github.com/TryGhost/Ghost.org/pull/574

- Added a new "security" block to config, with a new flag staffDeviceVerification to enable / disable the Device Verification feature
- The flag is enabled by default, as the feature is meant to be on by default now
- This just adds the flag everywhere ready to be used, it is not yet used anywhere

