### PR TITLE
Increase toke expiration time for self-service migrations

### DIFF
--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -53,7 +53,7 @@ export default class MigrateService extends Service {
                     kid: id
                 })
                 .setIssuedAt()
-                .setExpirationTime('5m')
+                .setExpirationTime('15m')
                 .setAudience('/admin/')
                 .sign(encodedSecret);
 


### PR DESCRIPTION
no ref

Larger migrations can take longer than 5 minutes to complete, by which time the token may have expired. Increasing the lifetime of it allows larger migrations to happen with a greater level of success.