### PR TITLE
Increased max usage count of magic links from 3 -> 7

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -25,7 +25,7 @@ const sharedConfig = require('../../../shared/config');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
-const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 3;
+const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 7;
 
 const ghostMailer = new mail.GhostMailer();
 

--- a/ghost/core/core/server/services/newsletters/index.js
+++ b/ghost/core/core/server/services/newsletters/index.js
@@ -9,7 +9,7 @@ const emailAddressService = require('../email-address');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
-const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 3;
+const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 7;
 
 module.exports = new NewslettersService({
     NewsletterModel: models.Newsletter,

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -20,7 +20,7 @@ const emailAddressService = require('../email-address');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
-const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 3;
+const MAGIC_LINK_TOKEN_MAX_USAGE_COUNT = 7;
 
 /**
  * @returns {SettingsBREADService} instance of the PostsService


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-227

Inbox security clients will make requests to URLs found in emails in an attempt to detect security threats. This causes a problem when magic links or tokens are single use, because they are invalidated by the time the user is presented with them. We originally had a usage count set to 3 to alleviate this problem, but we are still seeing issues with clients like Barracuda. As a short term experiment we are raising the max usage from 3 -> 7 and monitoring the impact.

