### PR TITLE
Store Mastodon link as URL path instead of handle

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/SocialLinksTab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/SocialLinksTab.tsx
@@ -11,7 +11,7 @@ import {
     linkedinHandleToUrl,
     linkedinUrlToHandle,
     mastodonHandleToUrl,
-    mastodonUrlToHandle,
+    sanitiseMastodonUrl,
     threadsHandleToUrl,
     threadsUrlToHandle,
     tiktokHandleToUrl,
@@ -168,7 +168,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                         if (validateField('mastodon', e.target.value)) {
                             const url = validateMastodonUrl(e.target.value);
                             setMastodonUrl(url);
-                            setUserData({...user, mastodon: mastodonUrlToHandle(url)});
+                            setUserData({...user, mastodon: sanitiseMastodonUrl(url)});
                         }
                     }}
                     onChange={(e) => {

--- a/apps/admin-x-settings/src/utils/socialUrls/mastodon.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/mastodon.ts
@@ -108,3 +108,7 @@ export const mastodonUrlToHandle = (url: string) => {
 
     return null;
 };
+
+export const sanitiseMastodonUrl = (url: string) => {
+    return url.replace(/^https?:\/\//, '');
+};

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -817,7 +817,7 @@ test.describe('User profile', async () => {
 
             await testUrlValidation(mastodonInput, 'https://mastodon.social/johnsmith', 'https://mastodon.social/johnsmith', 'The URL must be in a format like @username@instance.tld or https://instance.tld/@username or https://website.com/@username@instance.tld');
 
-            await testUrlValidation(mastodonInput, 'https://mastodon.xyz/@Flipboard@flipboard.social', 'https://mastodon.xyz/@Flipboard@flipboard.social');
+            await testUrlValidation(mastodonInput, '@johnsmith@mastodon.social', 'https://mastodon.social/@johnsmith');
 
             await modal.getByRole('button', {name: 'Save'}).click();
 
@@ -825,7 +825,7 @@ test.describe('User profile', async () => {
 
             expect(lastApiRequests.editUser?.body).toMatchObject({
                 users: [{
-                    mastodon: 'mastodon.xyz/@Flipboard@flipboard.social'
+                    mastodon: 'mastodon.social/@johnsmith'
                 }]
             });
         });

--- a/apps/admin-x-settings/test/unit/utils/mastodonUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/mastodonUrls.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert/strict';
-import {mastodonHandleToUrl, mastodonUrlToHandle, validateMastodonUrl, sanitiseMastodonUrl} from '../../../src/utils/socialUrls/index';
+import {mastodonHandleToUrl, mastodonUrlToHandle, sanitiseMastodonUrl, validateMastodonUrl} from '../../../src/utils/socialUrls/index';
 
 describe('Mastodon URL validation', () => {
     it('should return empty string when input is empty', () => {

--- a/apps/admin-x-settings/test/unit/utils/mastodonUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/mastodonUrls.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert/strict';
-import {mastodonHandleToUrl, mastodonUrlToHandle, validateMastodonUrl} from '../../../src/utils/socialUrls/index';
+import {mastodonHandleToUrl, mastodonUrlToHandle, validateMastodonUrl, sanitiseMastodonUrl} from '../../../src/utils/socialUrls/index';
 
 describe('Mastodon URL validation', () => {
     it('should return empty string when input is empty', () => {
@@ -72,5 +72,10 @@ describe('URL to Mastodon handle extraction', () => {
         assert.equal(mastodonUrlToHandle('mastodon.social/johnsmith'), null);
         assert.equal(mastodonUrlToHandle('invalid/@johnsmith'), null);
         assert.equal(mastodonUrlToHandle('@johnsmith'), null);
+    });
+
+    it('should sanitise Mastodon URLs', () => {
+        assert.equal(sanitiseMastodonUrl('https://mastodon.xyz/@Flipboard@flipboard.social'), 'mastodon.xyz/@Flipboard@flipboard.social');
+        assert.equal(sanitiseMastodonUrl('https://mastodon.social/@user@other.instance'), 'mastodon.social/@user@other.instance');
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-414/mastodon-validation-bug

- Modified `SocialLinksTab.tsx` to store `sanitiseMastodonUrl(url)` instead of `mastodonUrlToHandle(url)`, saving the URL path.
- Added `sanitiseMastodonUrl` in `mastodon.ts` to strip the protocol from URLs (e.g., `https://mastodon.social/@johnsmith` → `mastodon.social/@johnsmith`).
- Updated tests in `profile.test.ts` and `mastodonUrls.test.ts` to reflect the new storage format and verify `sanitiseMastodonUrl` behavior.
- Ensures support for special cases like `mastodon.xyz/@Flipboard@flipboard.social`.
