### PR TITLE
Removed validation of special characters in site title

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
@@ -36,12 +36,6 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 };
             }
 
-            if (!title.match(/^[\p{L}\p{N}\u0900-\u097F\u0E00-\u0E7F\s;.,:()!?.'"'’”]+$/u)) {
-                return {
-                    title: 'Please use a site title without special characters.'
-                };
-            }
-
             return {};
         }
     });

--- a/apps/admin-x-settings/test/acceptance/general/titleAndDescription.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/titleAndDescription.test.ts
@@ -64,11 +64,6 @@ test.describe('Title and description settings', async () => {
         await section.getByRole('button', {name: 'Save'}).click();
         await expect(section.getByText('Please use a site title longer than 3 characters.')).toHaveCount(1);
 
-        // Title has invalid characters
-        await section.getByLabel('Site title').fill('Title with emoji: 🕵️‍♂️');
-        await section.getByRole('button', {name: 'Save'}).click();
-        await expect(section.getByText('Please use a site title without special characters.')).toHaveCount(1);
-
         expect(lastApiRequests.editSettings).toBeUndefined();
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ONC-883

- the special character validation exists on Ghost (Pro) signups due to a limitation in Daisy; it is not needed inside Ghost

