### PR TITLE
Fixed Admin error due to cross-origin iframes

### DIFF
--- a/ghost/admin/app/modifiers/close-dropdowns-on-click.js
+++ b/ghost/admin/app/modifiers/close-dropdowns-on-click.js
@@ -18,8 +18,11 @@ export default class CloseDropdownsOnClickModifier extends Modifier {
     modify(element) {
         if (element.tagName === 'IFRAME') {
             element.addEventListener('load', () => {
-                this.element = element.contentDocument;
-                this.element.addEventListener('click', this.onClick);
+                // Extra check for cross-origin iframes
+                if (element.contentDocument) {
+                    this.element = element.contentDocument;
+                    this.element.addEventListener('click', this.onClick);
+                }
             });
         } else {
             this.element = element;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ONC-887

- when Ghost and Admin are on a different domain, the close-dropdown-modifier would throw a TypeError when attempting to attach a click listener
- however, this does not seem to create a bug in the product - thus silencing it for now

