### PR TITLE
Added config flag for Device Verification

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -21,7 +21,8 @@ module.exports = {
             'tenor',
             'pintura',
             'signupForm',
-            'stats'
+            'stats',
+            'security'
         ];
 
         frame.response = {

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -20,7 +20,8 @@ module.exports = function getConfigProperties() {
         hostSettings: config.get('hostSettings'),
         tenor: config.get('tenor'),
         pintura: config.get('pintura'),
-        signupForm: config.get('signupForm')
+        signupForm: config.get('signupForm'),
+        security: config.get('security')
     };
 
     // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -13,6 +13,9 @@
         "forceUpdate": false
     },
     "privacy": false,
+    "security": {
+        "staffDeviceVerification": true
+    },
     "useMinFiles": true,
     "paths": {
         "contentPath": "content/",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -39,6 +39,9 @@ Object {
     },
     "mail": "",
     "mailgunIsConfigured": false,
+    "security": Object {
+      "staffDeviceVerification": true,
+    },
     "signupForm": Object {
       "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
       "version": "0.2",

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -21,7 +21,8 @@ const allowedKeys = [
     'hostSettings',
     'tenor',
     'pintura',
-    'signupForm'
+    'signupForm',
+    'security'
 ];
 
 describe('Public-config Service', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2127/swap-2fa-labs-flag-to-a-proper-config-flag
ref https://github.com/TryGhost/Ghost.org/pull/574

- Added a new "security" block to config, with a new flag staffDeviceVerification to
  enable / disable the Device Verification feature
- The flag is enabled by default, as the feature is meant to be on by default now
- This just adds the flag everywhere ready to be used, it is not yet used anywhere