### PR TITLE
Released social web handle in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.51",
+  "version": "0.6.52",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -48,7 +48,7 @@ const Sidebar: React.FC = () => {
                             <LucideIcon.User size={18} strokeWidth={1.5} />
                             Profile
                         </SidebarMenuLink>
-                        {isEnabled('settings') &&
+                        {isEnabled('settings-full') &&
                             <SidebarMenuLink to='/preferences'>
                                 <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
                                 Preferences

--- a/apps/admin-x-activitypub/src/views/Preferences/components/BlueskySharing.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/BlueskySharing.tsx
@@ -60,7 +60,7 @@ const BlueskySharing: React.FC = () => {
                     </div> :
                     <>
                         <p className='mt-3 text-base'>Your content is now live on Bluesky! We&apos;ve created a dedicated Bluesky account shown below. This account automatically displays everything you publish on Ghost.</p>
-                        <div className='mt-6 flex flex-col items-center gap-4 rounded-lg bg-gray-150 p-8'>
+                        <div className='mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 p-8 dark:border-gray-950'>
                             <div className='relative'>
                                 <APAvatar
                                     author={
@@ -80,9 +80,9 @@ const BlueskySharing: React.FC = () => {
                             </div>
                             <div className='flex grow flex-col items-center'>
                                 <H3>{account.name}</H3>
-                                <div className='flex items-center gap-1'>
+                                <div className='flex items-center gap-1 text-gray-800'>
                                     <span className='text-lg font-medium'>@{convertedHandle}.ap.brid.gy</span>
-                                    <Button className='size-6 p-0 hover:opacity-80' variant='link' onClick={handleCopy}>
+                                    <Button className='size-6 p-0 hover:opacity-80' title='Copy handle' variant='link' onClick={handleCopy}>
                                         {!copied ?
                                             <LucideIcon.Copy size={16} /> :
                                             <LucideIcon.Check size={16} />
@@ -90,10 +90,10 @@ const BlueskySharing: React.FC = () => {
                                     </Button>
                                 </div>
                             </div>
-                            <Button className='mt-2 h-10 px-6 text-base' asChild>
+                            <Button className='mt-2 w-full' size='lg' variant='secondary' asChild>
                                 <a href={`https://bsky.app/profile/${convertedHandle}.ap.brid.gy`} rel='noreferrer' target='_blank'>
-                                    Go to profile
-                                    <LucideIcon.ExternalLink size={14} />
+                                    Open profile
+                                    <LucideIcon.ExternalLink size={14} strokeWidth={1.25} />
                                 </a>
                             </Button>
                         </div>

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -250,7 +250,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                                 <div className='relative flex items-center'>
                                     <Input className='pl-8' placeholder="index" {...field} />
                                     <LucideIcon.AtSign className='absolute left-3 text-gray-700' size={16} />
-                                    <span className='pointer-events-none absolute right-3 text-gray-700'>{handleDomain}</span>
+                                    <span className='pointer-events-none absolute right-3 text-gray-700'>@{handleDomain}</span>
                                 </div>
                             </FormControl>
                             {!hasHandleError && (

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -14,9 +14,16 @@ const FormSchema = z.object({
     name: z.string().nonempty({
         message: 'Name is required.'
     }),
-    handle: z.string().min(2, {
-        message: 'Handle must be at least 2 characters.'
-    }),
+    handle: z.string()
+        .min(2, {
+            message: 'Handle must be at least 2 characters.'
+        })
+        .max(100, {
+            message: 'Handle must be less than 100 characters.'
+        })
+        .regex(/^[a-zA-Z0-9_]+$/, {
+            message: 'Handle must contain only letters, numbers, and underscores.'
+        }),
     bio: z.string().optional()
 });
 
@@ -147,7 +154,16 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
 
     return (
         <Form {...form}>
-            <form className="flex flex-col gap-5" onSubmit={form.handleSubmit(onSubmit)}>
+            <form
+                className="flex flex-col gap-5"
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        form.handleSubmit(onSubmit)();
+                    }
+                }}
+                onSubmit={form.handleSubmit(onSubmit)}
+            >
                 {isEnabled('settings-full') && (
                     <div className='relative mb-2'>
                         <div className='group relative h-[180px] cursor-pointer bg-gray-100' onClick={triggerCoverImageInput}>
@@ -247,10 +263,10 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                                 <FormLabel>Handle</FormLabel>
                             )}
                             <FormControl>
-                                <div className='relative flex items-center'>
-                                    <Input className='pl-8' placeholder="index" {...field} />
-                                    <LucideIcon.AtSign className='absolute left-3 text-gray-700' size={16} />
-                                    <span className='pointer-events-none absolute right-3 text-gray-700'>@{handleDomain}</span>
+                                <div className='relative flex items-center justify-stretch gap-1 rounded-md bg-gray-150 px-3 dark:bg-gray-900'>
+                                    <LucideIcon.AtSign className='w-4 min-w-4 text-gray-700' size={16} />
+                                    <Input className='w-auto grow !border-none bg-transparent px-0 !shadow-none !outline-none' placeholder="index" {...field} />
+                                    <span className='max-w-[320px] truncate whitespace-nowrap text-right text-gray-700' title={`@${handleDomain}`}>@{handleDomain}</span>
                                 </div>
                             </FormControl>
                             {!hasHandleError && (

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
@@ -23,7 +23,7 @@ const Profile: React.FC<ProfileProps> = ({account, isLoading}) => {
                 }
                 size='lg'
             />
-            <Heading className='mb-1 mt-4' level={3}>{!isLoading ? account?.name : <Skeleton className='w-32' />}</Heading>
+            <Heading className='mb-0.5 mt-4' level={3}>{!isLoading ? account?.name : <Skeleton className='w-32' />}</Heading>
             <span className='text-[1.5rem] text-gray-700'>{!isLoading ? account?.handle : <Skeleton className='w-full max-w-56' />}</span>
         </div>
     );

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
@@ -48,35 +48,32 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                     </DialogContent>
                 </Dialog>
             </SettingItem>
-            {isEnabled('settings-full') && (
-                <>
-                    <SettingItem withHover onClick={() => navigate('/preferences/threads-sharing', {state: {account, threadsAccount: threadsData?.accounts[0], isEnabled: threadsEnabled}})}>
-                        <SettingHeader>
-                            <SettingTitle>Threads sharing</SettingTitle>
-                            <SettingDescription>Share content directly on Threads</SettingDescription>
-                        </SettingHeader>
-                        <SettingAction className='flex items-center gap-2'>
-                            {threadsIsFetching ? <LoadingIndicator size='sm' /> : threadsEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
-                            <LucideIcon.ChevronRight size={20} />
-                        </SettingAction>
-                    </SettingItem>
-                    <SettingItem withHover onClick={() => navigate('/preferences/bluesky-sharing', {state: {account, blueskyAccount: blueskyData?.accounts[0], isEnabled: blueskyEnabled}})}>
-                        <SettingHeader>
-                            <SettingTitle>Bluesky sharing</SettingTitle>
-                            <SettingDescription>Share content directly on Bluesky</SettingDescription>
-                        </SettingHeader>
-                        <SettingAction className='flex items-center gap-2'>
-                            {blueskyIsFetching ? <LoadingIndicator size='sm' /> : blueskyEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
-                            <LucideIcon.ChevronRight size={20} />
-                        </SettingAction>
-                    </SettingItem>
-                </>
-            )}
+
+            <SettingItem withHover onClick={() => navigate('/preferences/threads-sharing', {state: {account, threadsAccount: threadsData?.accounts[0], isEnabled: threadsEnabled}})}>
+                <SettingHeader>
+                    <SettingTitle>Threads sharing</SettingTitle>
+                    <SettingDescription>Share content directly on Threads</SettingDescription>
+                </SettingHeader>
+                <SettingAction className='flex items-center gap-2'>
+                    {threadsIsFetching ? <LoadingIndicator size='sm' /> : threadsEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
+                    <LucideIcon.ChevronRight size={20} />
+                </SettingAction>
+            </SettingItem>
+            <SettingItem withHover onClick={() => navigate('/preferences/bluesky-sharing', {state: {account, blueskyAccount: blueskyData?.accounts[0], isEnabled: blueskyEnabled}})}>
+                <SettingHeader>
+                    <SettingTitle>Bluesky sharing</SettingTitle>
+                    <SettingDescription>Share content directly on Bluesky</SettingDescription>
+                </SettingHeader>
+                <SettingAction className='flex items-center gap-2'>
+                    {blueskyIsFetching ? <LoadingIndicator size='sm' /> : blueskyEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
+                    <LucideIcon.ChevronRight size={20} />
+                </SettingAction>
+            </SettingItem>
             <SettingSeparator />
             <SettingItem href='https://ghost.org/help/social-web/' withHover>
                 <SettingHeader>
                     <SettingTitle>Help</SettingTitle>
-                    <SettingDescription>Access guides and support resources</SettingDescription>
+                    <SettingDescription>Social web guides and support resources</SettingDescription>
                 </SettingHeader>
                 <SettingAction><LucideIcon.ExternalLink size={18} /></SettingAction>
             </SettingItem>
@@ -106,7 +103,7 @@ interface SettingHeaderProps {
 
 const SettingHeader: React.FC<SettingHeaderProps> = ({children, className = ''}) => {
     return (
-        <div className={`relative flex flex-col gap-1 ${className}`}>
+        <div className={`relative flex flex-col gap-0.5 ${className}`}>
             {children}
         </div>
     );
@@ -117,7 +114,7 @@ interface SettingActionProps {
     className?: string;
 }
 
-const SettingAction: React.FC<SettingActionProps> = ({children, className = ''}) => {
+export const SettingAction: React.FC<SettingActionProps> = ({children, className = ''}) => {
     return (
         <div className={`relative text-gray-500 ${className}`}>
             {children}

--- a/apps/admin-x-activitypub/src/views/Preferences/components/ThreadsSharing.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/ThreadsSharing.tsx
@@ -60,7 +60,7 @@ const ThreadsSharing: React.FC = () => {
                     </div> :
                     <>
                         <p className='mt-3 text-base'>Your content is now being shared to Threads. To view your Threads profile, you&apos;ll need to enable the <a className='text-purple' href="https://www.threads.net/settings/fediverse" rel="noreferrer" target="_blank">Fediverse beta</a> feature in your Threads account. Please note that Thread&apos;s Fediverse features are not available for users in the EU.</p>
-                        <div className='mt-6 flex flex-col items-center gap-4 rounded-lg bg-gray-150 p-8'>
+                        <div className='mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 p-8 dark:border-gray-950'>
                             <div className='relative'>
                                 <APAvatar
                                     author={
@@ -90,10 +90,10 @@ const ThreadsSharing: React.FC = () => {
                                     </Button>
                                 </div>
                             </div>
-                            <Button className='mt-2 h-10 px-6 text-base' asChild>
+                            <Button className='mt-2 w-full px-6' size='lg' variant='secondary' asChild>
                                 <a href={`https://www.threads.net/fediverse_profile/${convertedHandle}`} rel='noreferrer' target='_blank'>
                                     Go to profile
-                                    <LucideIcon.ExternalLink size={14} />
+                                    <LucideIcon.ExternalLink size={14} strokeWidth={1.25} />
                                 </a>
                             </Button>
                         </div>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -1,12 +1,15 @@
 import APAvatar from '@src/components/global/APAvatar';
+import EditProfile from '@src/views/Preferences/components/EditProfile';
 import FollowButton from '@src/components/global/FollowButton';
 import Layout from '@src/components/layout';
 import {Account} from '@src/api/activitypub';
-import {Button, Heading, Icon, NoValueLabel, Tab, TabView} from '@tryghost/admin-x-design-system';
+import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, Skeleton} from '@tryghost/shade';
+import {Heading, Icon, NoValueLabel, Button as OldButton, Tab, TabView} from '@tryghost/admin-x-design-system';
 import {ProfileTab} from '../Profile';
-import {Skeleton} from '@tryghost/shade';
+import {SettingAction} from '@src/views/Preferences/components/Settings';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useRef, useState} from 'react';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 
 const noop = () => {};
@@ -72,6 +75,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     ].filter(Boolean) as Tab<ProfileTab>[];
 
     const [isExpanded, setisExpanded] = useState(false);
+    const [isEditingProfile, setIsEditingProfile] = useState(false);
 
     const toggleExpand = () => {
         setisExpanded(!isExpanded);
@@ -79,6 +83,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
 
     const contentRef = useRef<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);
+    const {isEnabled} = useFeatureFlags();
 
     useEffect(() => {
         if (contentRef.current) {
@@ -136,9 +141,22 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                         onUnfollow={noop}
                                     />
                                 }
+                                {isCurrentUser && isEnabled('settings') && !isLoadingAccount &&
+                                    <Dialog open={isEditingProfile} onOpenChange={setIsEditingProfile}>
+                                        <DialogTrigger>
+                                            <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>
+                                        </DialogTrigger>
+                                        <DialogContent onOpenAutoFocus={e => e.preventDefault()}>
+                                            <DialogHeader>
+                                                <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Handle'}</DialogTitle>
+                                            </DialogHeader>
+                                            {account && <EditProfile account={account} setIsEditingProfile={setIsEditingProfile} />}
+                                        </DialogContent>
+                                    </Dialog>
+                                }
                             </div>
                             <Heading className='mt-4' level={3}>{!isLoadingAccount ? account?.name : <Skeleton className='w-32' />}</Heading>
-                            <a className='group/handle mt-1 flex items-center gap-1 text-[1.5rem] text-gray-800 hover:text-gray-900' href={account?.url} rel='noopener noreferrer' target='_blank'>
+                            <a className='group/handle mb-4 inline-flex items-center gap-1 text-[1.5rem] text-gray-800 hover:text-gray-900' href={account?.url} rel='noopener noreferrer' target='_blank'>
                                 <span>{!isLoadingAccount ? account?.handle : <Skeleton className='w-full max-w-56' />}</span>
                                 <Icon className='opacity-0 transition-opacity group-hover/handle:opacity-100' name='arrow-top-right' size='xs'/>
                             </a>
@@ -159,7 +177,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                 {!isExpanded && isOverflowing && (
                                     <div className='absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white via-white/90 via-60% to-transparent' />
                                 )}
-                                {isOverflowing && <Button
+                                {isOverflowing && <OldButton
                                     className='absolute bottom-0'
                                     label={isExpanded ? 'Show less' : 'Show all'}
                                     link={true}

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -146,7 +146,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                         <DialogTrigger>
                                             <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>
                                         </DialogTrigger>
-                                        <DialogContent onOpenAutoFocus={e => e.preventDefault()}>
+                                        <DialogContent className='w-full max-w-xl' onOpenAutoFocus={e => e.preventDefault()}>
                                             <DialogHeader>
                                                 <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Handle'}</DialogTitle>
                                             </DialogHeader>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -148,7 +148,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                         </DialogTrigger>
                                         <DialogContent className='w-full max-w-xl' onOpenAutoFocus={e => e.preventDefault()}>
                                             <DialogHeader>
-                                                <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Handle'}</DialogTitle>
+                                                <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Edit handle'}</DialogTitle>
                                             </DialogHeader>
                                             {account && <EditProfile account={account} setIsEditingProfile={setIsEditingProfile} />}
                                         </DialogContent>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -141,7 +141,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                         onUnfollow={noop}
                                     />
                                 }
-                                {isCurrentUser && isEnabled('settings') && !isLoadingAccount &&
+                                {isCurrentUser && !isLoadingAccount &&
                                     <Dialog open={isEditingProfile} onOpenChange={setIsEditingProfile}>
                                         <DialogTrigger>
                                             <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>

--- a/apps/shade/src/components/ui/button.tsx
+++ b/apps/shade/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
                 default: 'bg-primary font-medium text-primary-foreground hover:bg-primary/90',
                 destructive: 'bg-destructive font-medium text-destructive-foreground hover:bg-destructive/90',
                 outline: 'border border-input bg-transparent font-medium hover:bg-accent hover:text-accent-foreground',
-                secondary: 'bg-secondary font-medium text-secondary-foreground hover:bg-secondary/80',
+                secondary: 'bg-secondary font-medium text-secondary-foreground hover:bg-secondary/80 dark:bg-gray-925/70 dark:hover:bg-gray-900',
                 ghost: 'font-medium hover:bg-accent hover:text-accent-foreground',
                 link: 'font-medium text-primary underline-offset-4 hover:underline',
                 dropdown: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground'

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -84,7 +84,7 @@
         --card-foreground: 213 31% 91%;
         --primary: 200 12% 96%;
         --primary-foreground: 216 11% 9%;
-        --secondary: 216 11% 9%;
+        --secondary: 210 11% 25%;
         --secondary-foreground: 200 12% 96%;
         --destructive: 354 81% 31%;
         --destructive-foreground: 240 11% 98%;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-902/custom-social-web-handle

- The social web handle in ActivityPub was hardcoded to `@index@mysite.com` and could not be customised. This PR enabled users to change their handles

