### PR TITLE
Removed traffic stats button on posts analytics page

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -35,11 +35,6 @@
                     {{/let}}
                 </div>
                 <div style="display: flex; gap: 8px;">
-                    {{#if (and (gh-user-can-admin this.session.user) this.config.stats)}}
-                    <LinkTo class="gh-btn gh-btn-icon" @route="stats" @query={{hash pathname=(concat "/" this.post.slug "/")}}>
-                        <span>{{svg-jar "stats" title="Post traffic stats"}} Traffic stats</span>
-                    </LinkTo>
-                    {{/if}}
                     <GhTaskButton
                         @buttonText="Refresh"
                         @task={{this.fetchPostTask}}


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1744943280182419
- the lack of 'stats' route (in favor of 'stats-x') caused this to prevent rendering of the analytics route

We'll add this back in when we have filtering routes supported. Going straight to the stats page w/o filters lacks purpose and feels a bit broken.