### PR TITLE
Updated change handle dialog size in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.52",
+  "version": "0.6.53",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -266,7 +266,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                                 <div className='relative flex items-center justify-stretch gap-1 rounded-md bg-gray-150 px-3 dark:bg-gray-900'>
                                     <LucideIcon.AtSign className='w-4 min-w-4 text-gray-700' size={16} />
                                     <Input className='w-auto grow !border-none bg-transparent px-0 !shadow-none !outline-none' placeholder="index" {...field} />
-                                    <span className='max-w-[320px] truncate whitespace-nowrap text-right text-gray-700' title={`@${handleDomain}`}>@{handleDomain}</span>
+                                    <span className='max-w-[260px] truncate whitespace-nowrap text-right text-gray-700' title={`@${handleDomain}`}>@{handleDomain}</span>
                                 </div>
                             </FormControl>
                             {!hasHandleError && (

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -146,7 +146,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                         <DialogTrigger>
                                             <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>
                                         </DialogTrigger>
-                                        <DialogContent className='w-full max-w-xl' onOpenAutoFocus={e => e.preventDefault()}>
+                                        <DialogContent className='w-full max-w-[520px]' onOpenAutoFocus={e => e.preventDefault()}>
                                             <DialogHeader>
                                                 <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Edit handle'}</DialogTitle>
                                             </DialogHeader>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-902/custom-social-web-handle

- The change handle dialog was too wide for having just a single input field in it