### PR TITLE
Updated stats-x to use config for endpoints

### DIFF
--- a/apps/stats/src/config/stats-config.ts
+++ b/apps/stats/src/config/stats-config.ts
@@ -1,8 +1,13 @@
+import {StatsConfig} from '@src/providers/GlobalDataProvider';
+
 export const TB_VERSION = 8;
 
-export const getStatEndpointUrl = (baseUrl?: string, endpoint?: string) => {
-    if (!baseUrl) {
+export const getStatEndpointUrl = (config?: StatsConfig | null, endpoint?: string, params = '') => {
+    if (!config) {
         return '';
     }
-    return `${baseUrl}/v0/pipes/${endpoint}__v${TB_VERSION}.json`;
+
+    return config.local?.enabled ? 
+        `${config.local?.endpoint || ''}/v0/pipes/${endpoint}.json?${params}` : 
+        `${config.endpoint || ''}/v0/pipes/${endpoint}__v${TB_VERSION}.json?${params}`;
 };

--- a/apps/stats/src/config/stats-config.ts
+++ b/apps/stats/src/config/stats-config.ts
@@ -11,3 +11,7 @@ export const getStatEndpointUrl = (config?: StatsConfig | null, endpoint?: strin
         `${config.local?.endpoint || ''}/v0/pipes/${endpoint}.json?${params}` : 
         `${config.endpoint || ''}/v0/pipes/${endpoint}__v${TB_VERSION}.json?${params}`;
 };
+
+export const getToken = (config?: StatsConfig) => {
+    return config?.local?.enabled ? config?.local?.token : config?.token;
+};

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -10,6 +10,7 @@ export interface StatsConfig {
     local?: {
         enabled?: boolean;
         endpoint?: string;
+        token?: string;
     };
 }
 

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -2,18 +2,20 @@ import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_DEFAULT_RANGE_KEY, STATS_RANGE_OPTIONS} from '@src/utils/constants';
 
-type GlobalData = Config & {
-    config: {
-        stats?: {
-            endpoint: string;
-            id: string;
-            token: string;
-        };
+// Stats-specific configuration
+export interface StatsConfig {
+    endpoint?: string;
+    id?: string;
+    token?: string;
+    local?: {
+        enabled?: boolean;
+        endpoint?: string;
     };
 }
 
 type GlobalDataContextType = {
-    data: GlobalData | undefined;
+    data: Config | undefined;
+    statsConfig: StatsConfig | undefined;
     isLoading: boolean;
     range: number;
     audience: number;
@@ -32,7 +34,7 @@ export const useGlobalData = () => {
 };
 
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
-    const config = useBrowseConfig() as unknown as { data: GlobalData | null, isLoading: boolean, error: Error | null };
+    const config = useBrowseConfig() as unknown as { data: Config & { config: { stats?: StatsConfig } } | null, isLoading: boolean, error: Error | null };
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
@@ -47,6 +49,7 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
 
     return <GlobalDataContext.Provider value={{
         data: config.data ?? undefined,
+        statsConfig: config.data?.config?.stats,
         isLoading,
         range,
         setRange,

--- a/apps/stats/src/views/Stats/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations.tsx
@@ -30,13 +30,13 @@ interface TooltipData {
 }
 
 const Locations:React.FC = () => {
-    const {data: configData, isLoading: isConfigLoading} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
 
     const params = {
-        site_uuid: configData?.config.stats?.id || '',
+        site_uuid: statsConfig?.id || '',
         date_from: formatQueryDate(startDate),
         date_to: formatQueryDate(endDate),
         timezone: timezone,
@@ -44,8 +44,8 @@ const Locations:React.FC = () => {
     };
 
     const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(configData?.config.stats?.endpoint, 'api_top_locations'),
-        token: configData?.config.stats?.token || '',
+        endpoint: getStatEndpointUrl(statsConfig, 'api_top_locations'),
+        token: statsConfig?.token || '',
         params
     });
 

--- a/apps/stats/src/views/Stats/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations.tsx
@@ -12,7 +12,7 @@ import {STATS_LABEL_MAPPINGS} from '@src/utils/constants';
 import {SVGMap} from 'react-svg-map';
 import {formatNumber, formatQueryDate} from '@src/utils/data-formatters';
 import {getCountryFlag, getPeriodText, getRangeDates} from '@src/utils/chart-helpers';
-import {getStatEndpointUrl} from '@src/config/stats-config';
+import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -45,7 +45,7 @@ const Locations:React.FC = () => {
 
     const {data, loading} = useQuery({
         endpoint: getStatEndpointUrl(statsConfig, 'api_top_locations'),
-        token: statsConfig?.token || '',
+        token: getToken(statsConfig),
         params
     });
 

--- a/apps/stats/src/views/Stats/Sources.tsx
+++ b/apps/stats/src/views/Stats/Sources.tsx
@@ -32,12 +32,12 @@ const SourceRow: React.FC<SourceRowProps> = ({className, source}) => {
 };
 
 const Sources:React.FC = () => {
-    const {data: configData, isLoading: isConfigLoading} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
     const params = {
-        site_uuid: configData?.config.stats?.id || '',
+        site_uuid: statsConfig?.id || '',
         date_from: formatQueryDate(startDate),
         date_to: formatQueryDate(endDate),
         timezone: timezone,
@@ -45,8 +45,8 @@ const Sources:React.FC = () => {
     };
 
     const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(configData?.config.stats?.endpoint, 'api_top_sources'),
-        token: configData?.config.stats?.token || '',
+        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
+        token: statsConfig?.token || '',
         params
     });
 

--- a/apps/stats/src/views/Stats/Sources.tsx
+++ b/apps/stats/src/views/Stats/Sources.tsx
@@ -8,7 +8,7 @@ import {Header, HeaderActions} from '@src/components/layout/Header';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
 import {formatNumber, formatQueryDate} from '@src/utils/data-formatters';
 import {getPeriodText, getRangeDates} from '@src/utils/chart-helpers';
-import {getStatEndpointUrl} from '@src/config/stats-config';
+import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -46,7 +46,7 @@ const Sources:React.FC = () => {
 
     const {data, loading} = useQuery({
         endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
-        token: statsConfig?.token || '',
+        token: getToken(statsConfig),
         params
     });
 

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -13,12 +13,12 @@ import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
 const Web:React.FC = () => {
-    const {data: configData, isLoading: isConfigLoading} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
     const params = {
-        site_uuid: configData?.config.stats?.id || '',
+        site_uuid: statsConfig?.id || '',
         date_from: formatQueryDate(startDate),
         date_to: formatQueryDate(endDate),
         timezone: timezone,
@@ -26,8 +26,8 @@ const Web:React.FC = () => {
     };
 
     const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(configData?.config.stats?.endpoint, 'api_top_pages'),
-        token: configData?.config.stats?.token || '',
+        endpoint: getStatEndpointUrl(statsConfig, 'api_top_pages'),
+        token: statsConfig?.token || '',
         params
     });
 

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -8,7 +8,7 @@ import {Card, CardContent, CardDescription, CardHeader, CardTitle, Table, TableB
 import {Header, HeaderActions} from '@src/components/layout/Header';
 import {formatNumber, formatQueryDate} from '@src/utils/data-formatters';
 import {getPeriodText, getRangeDates} from '@src/utils/chart-helpers';
-import {getStatEndpointUrl} from '@src/config/stats-config';
+import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -27,7 +27,7 @@ const Web:React.FC = () => {
 
     const {data, loading} = useQuery({
         endpoint: getStatEndpointUrl(statsConfig, 'api_top_pages'),
-        token: statsConfig?.token || '',
+        token: getToken(statsConfig),
         params
     });
 

--- a/apps/stats/src/views/Stats/components/WebKpis.tsx
+++ b/apps/stats/src/views/Stats/components/WebKpis.tsx
@@ -39,13 +39,13 @@ const KPI_METRICS: Record<string, KpiMetric> = {
 };
 
 const WebKpis:React.FC = ({}) => {
-    const {data: configData, isLoading: isConfigLoading} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const [currentTab, setCurrentTab] = useState('visits');
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
     const params = {
-        site_uuid: configData?.config.stats?.id || '',
+        site_uuid: statsConfig?.id || '',
         date_from: formatQueryDate(startDate),
         date_to: formatQueryDate(endDate),
         timezone: timezone,
@@ -53,8 +53,8 @@ const WebKpis:React.FC = ({}) => {
     };
 
     const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(configData?.config.stats?.endpoint, 'api_kpis'),
-        token: configData?.config.stats?.token || '',
+        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
+        token: statsConfig?.token || '',
         params
     });
 

--- a/apps/stats/src/views/Stats/components/WebKpis.tsx
+++ b/apps/stats/src/views/Stats/components/WebKpis.tsx
@@ -5,7 +5,7 @@ import {KpiTabTrigger, KpiTabValue} from './KpiTab';
 import {calculateYAxisWidth, getRangeDates, getYTicks} from '@src/utils/chart-helpers';
 import {formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@src/utils/data-formatters';
 import {getAudienceQueryParam} from './AudienceSelect';
-import {getStatEndpointUrl} from '@src/config/stats-config';
+import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -54,7 +54,7 @@ const WebKpis:React.FC = ({}) => {
 
     const {data, loading} = useQuery({
         endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: statsConfig?.token || '',
+        token: getToken(statsConfig),
         params
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-222
- updated global data use of stats config
- updated endpoint helper to use config to construct (support tb local; still needs changes for tb forward)