### PR TITLE
Added `trafficAnalytics` beta flag

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -38,7 +38,8 @@ const BETA_FEATURES = [
     'editorExcerpt',
     'ActivityPub',
     'importMemberTier',
-    'superEditors'
+    'superEditors',
+    'trafficAnalytics'
 ];
 
 const ALPHA_FEATURES = [

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -37,9 +37,9 @@ const BETA_FEATURES = [
     'webmentions',
     'editorExcerpt',
     'ActivityPub',
+    'trafficAnalytics',
     'importMemberTier',
     'superEditors',
-    'trafficAnalytics'
 ];
 
 const ALPHA_FEATURES = [

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -39,7 +39,7 @@ const BETA_FEATURES = [
     'ActivityPub',
     'trafficAnalytics',
     'importMemberTier',
-    'superEditors',
+    'superEditors'
 ];
 
 const ALPHA_FEATURES = [

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -39,7 +39,7 @@ const BETA_FEATURES = [
     'ActivityPub',
     'importMemberTier',
     'superEditors',
-    'trafficAnalytics'
+    'trafficAnalytics',
 ];
 
 const ALPHA_FEATURES = [

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -39,7 +39,7 @@ const BETA_FEATURES = [
     'ActivityPub',
     'importMemberTier',
     'superEditors',
-    'trafficAnalytics',
+    'trafficAnalytics'
 ];
 
 const ALPHA_FEATURES = [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -33,6 +33,7 @@ Object {
       "stripeAutomaticTax": true,
       "superEditors": true,
       "themeErrorsNotification": true,
+      "trafficAnalytics": true,
       "urlCache": true,
       "webmentions": true,
     },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-635/enable-trafficanalytics-with-a-private-beta-flag-instead-of-via-config

The Traffic Analytics private beta is currently enabled via config. This is a pain, because it requires a code change in Zuul to enable the beta for new sites.

Putting the Traffic Analytics features behind a private beta flag makes it easier to enable the feature without having to make a code/config change. This commit just adds the beta flag on the backend, but doesn't do anything with it yet.
