### PR TITLE
Improved coverage gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
-coverage-e2e
-coverage-integration
-coverage-regression
-coverage_*
+coverage*
 
 # nyc test coverage
 .nyc_output


### PR DESCRIPTION
- Ignore all directories and files called coverage
- This allows for using temporary folders and files whilst debugging
- Also simplifies the list and makes it more extensible
- If we ever have a file or folder called coverage, which is unlikely, we can add an exclude or make the pattern more nuanced again

