### PR TITLE
Cleaned up Nest Playground labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -32,10 +32,6 @@ const features = [{
     description: 'Adds a navigation link to the AdminX demo app',
     flag: 'adminXDemo'
 },{
-    title: 'NestJS Playground',
-    description: 'Wires up the Ghost NestJS App to the Admin API (also needs GHOST_ENABLE_NEST_FRAMEWORK=1 env var)',
-    flag: 'NestPlayground'
-},{
     title: 'Content Visibility (Beta)',
     description: 'Enables content visibility in Emails - Changes already released to beta testers',
     flag: 'contentVisibility'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -43,7 +43,6 @@ const BETA_FEATURES = [
 ];
 
 const ALPHA_FEATURES = [
-    'NestPlayground',
     'urlCache',
     'emailCustomization',
     'mailEvents',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -10,7 +10,6 @@ Object {
     "environment": StringMatching /\\^testing/,
     "labs": Object {
       "ActivityPub": true,
-      "NestPlayground": true,
       "additionalPaymentMethods": true,
       "adminXDemo": true,
       "announcementBar": true,


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/327a82f9a203639baa2e996c979500ba23547e1f
- The code has been removed, but the flag was still present in the UI
- I'm working to reduce the number of labs flags in play,
  in order to make some improvements to the flag system more easily