### PR TITLE
Removed deprecated meta tags

### DIFF
--- a/ghost/admin/app/index.html
+++ b/ghost/admin/app/index.html
@@ -1,32 +1,23 @@
-<!doctype html>
-<!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
-<!--[if (gte IE 9)| IEMobile |!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
+<!DOCTYPE html>
+<html class="no-js" lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta charset="UTF-8" />
 
-    <title>Ghost Admin</title>
+    <title>Ghost</title>
 
     {{content-for "head"}}
 
-    <meta name="HandheldFriendly" content="True" />
-    <meta name="MobileOptimized" content="320" />
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover" />
     <meta name="pinterest" content="nopin" />
 
-    <meta http-equiv="cleartype" content="on" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="application-name" content="Ghost" />
+    <meta name="apple-mobile-web-app-title" content="Ghost" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <meta name="apple-mobile-web-app-title" content="Ghost" />
 
     <link rel="shortcut icon" href="assets/img/favicon.ico" />
     <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png" />
-
-    <meta name="application-name" content="Ghost" />
-    <meta name="msapplication-TileColor" content="#15171A" />
-    <meta name="msapplication-square70x70logo" content="assets/img/small.png" />
-    <meta name="msapplication-square150x150logo" content="assets/img/medium.png" />
-    <meta name="msapplication-square310x310logo" content="assets/img/large.png" />
 
     <!-- variables that we don't want postcss-custom-properties to remove -->
     <style>

--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -1,9 +1,7 @@
-<!doctype html>
-<!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
-<!--[if (gte IE 9)| IEMobile |!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
+<!DOCTYPE html>
+<html class="no-js" lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+        <meta charset="UTF-8" />
 
         <title>{{@site.title}}</title>
         <meta property="og:type" content="website">
@@ -30,16 +28,10 @@
             <meta name="twitter:image" content="{{img_url @site.cover_image absolute="true"}}">
         {{/if}}
 
-        <meta name="twitter:card" content="summary_large_image">
-        <meta name="twitter:site" content="@ghost">
-        <meta property="article:publisher" content="https://www.facebook.com/ghost">
         <meta name="referrer" content="no-referrer-when-downgrade">
-        <meta name="HandheldFriendly" content="True">
-        <meta name="MobileOptimized" content="320">
         <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-
-        <meta http-equiv="cleartype" content="on">
 
         <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}"/>
     </head>

--- a/ghost/core/core/server/views/error.hbs
+++ b/ghost/core/core/server/views/error.hbs
@@ -1,18 +1,13 @@
-<!doctype html>
-<!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
-<!--[if (gte IE 9)| IEMobile |!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
+<!DOCTYPE html>
+<html class="no-js" lang="en">
   <head>
-    <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta charset="UTF-8" />
 
     <title>{{statusCode}} — {{message}}</title>
 
-    <meta name="HandheldFriendly" content="True">
-    <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <meta http-equiv="cleartype" content="on">
 
     <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}"/>
 


### PR DESCRIPTION
Most of this stuff is for Internet Explorer 8 compatibility, and the tags have long been deprecated. Some were throwing warnings in console

![CleanShot 2025-04-22 at 15 06 37@2x](https://github.com/user-attachments/assets/f0d0bb0f-920c-4edf-961e-886077f59776)

https://web.dev/learn/html/metadata#other_useful_meta_information