### PR TITLE
Added mailhog to docker dev environment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -152,6 +152,14 @@ services:
     container_name: ghost-pushgateway
     ports:
       - 9091:9091
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: ghost-mailhog
+    profiles: [ ghost ]
+    ports:
+      - "1025:1025" # SMTP server
+      - "8025:8025" # Web interface
+    restart: always
 volumes:
   mysql-data: {}
   redis-data: {}

--- a/ghost/core/core/shared/config/env/config.development.docker.json
+++ b/ghost/core/core/shared/config/env/config.development.docker.json
@@ -8,6 +8,14 @@
             "database": "ghost"
         }
     },
+    "mail": {
+        "from": "test@example.com",
+        "transport": "SMTP",
+        "options": {
+            "host": "mailhog",
+            "port": 1025
+        }
+    },
     "adapters": {
         "Redis": {
             "host": "redis",


### PR DESCRIPTION
- Now that device verification is on by default, having a working mail config when developing locally is even more important
- Mailhog is an AWESOME tool for working with mail locally:
   - It acts as a mailserver, so we don't get email failure errors
   - AND It gives you an admin panel at localhost:8025 which looks like an inbox
   - Meaning it's easy to get verification codes, and see what emails look like
