### PR TITLE
Removed postsX flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -36,10 +36,6 @@ const features = [{
     description: 'Enables content visibility in Emails - Additional changes for internal testing. NOTE: requires `contentVisibility` to also be enabled',
     flag: 'contentVisibilityAlpha'
 },{
-    title: 'Post analytics redesign',
-    description: 'Enables redesigned Post analytics page',
-    flag: 'postsX'
-},{
     title: 'Stats redesign',
     description: 'Enables redesigned Stats page',
     flag: 'statsX'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -48,7 +48,6 @@ const ALPHA_FEATURES = [
     'mailEvents',
     'collectionsCard',
     'lexicalIndicators',
-    'postsX',
     'statsX',
     'captcha',
     'contentVisibilityAlpha',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -26,7 +26,6 @@ Object {
       "lexicalIndicators": true,
       "mailEvents": true,
       "members": true,
-      "postsX": true,
       "statsX": true,
       "stripeAutomaticTax": true,
       "superEditors": true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-635/

This flag is not used and will not be used. Instead we'll use trafficAnalytics and trafficAnalyticsAlpha.