### PR TITLE
Suppressed console logs during JS asset minification

### DIFF
--- a/ghost/core/bin/minify-assets.js
+++ b/ghost/core/bin/minify-assets.js
@@ -3,10 +3,10 @@
 /**
  * Script to minify multiple JavaScript files using esbuild
  * Supports per-file configuration for bundling and other options
- * 
+ *
  * The tryghost/minifier package is not used because it is intended to be used at runtime,
  * allowing for replacements to be made on the fly (e.g. for card-assets and theme activation).
- * 
+ *
  * This script is intended to be run at build time, allowing for us to use the minified files
  * in the production build and be able to utilize bundler benefits.
  */
@@ -15,27 +15,28 @@
 const esbuild = require('esbuild');
 const path = require('path');
 const fs = require('fs');
+const logging = require('@tryghost/logging');
 
 // Determine the root directory by checking for common project files
 function findProjectRoot() {
     let currentDir = process.cwd();
-    
+
     // Check if we're already in ghost/core
     if (currentDir.endsWith('ghost/core') || currentDir.endsWith('ghost\\core')) {
         return currentDir;
     }
-    
+
     // Look for ghost/core directory
     const ghostCorePath = path.join(currentDir, 'ghost', 'core');
     if (fs.existsSync(ghostCorePath)) {
         return ghostCorePath;
     }
-    
+
     return currentDir;
 }
 
 const projectRoot = findProjectRoot();
-console.log(`Resolving paths from: ${projectRoot}`);
+logging.debug(`Resolving paths from: ${projectRoot}`);
 
 // Helper to resolve paths relative to project root
 function resolvePath(filePath) {
@@ -78,19 +79,19 @@ const filesToMinify = [
 
 // Process all files
 (async () => {
-    console.log('Starting JS minification...');
-    
+    logging.debug('Starting JS minification...');
+
     for (const file of filesToMinify) {
         try {
             const srcPath = resolvePath(file.src);
             const destPath = resolvePath(file.dest);
-            
+
             // Ensure the destination directory exists
             const destDir = path.dirname(destPath);
             if (!fs.existsSync(destDir)) {
                 fs.mkdirSync(destDir, {recursive: true});
             }
-            
+
             // Create build configuration by merging default options with file-specific options
             const buildConfig = {
                 entryPoints: [srcPath],
@@ -102,15 +103,15 @@ const filesToMinify = [
             };
 
             await esbuild.build(buildConfig);
-            
+
             // Show bundling status in output
             const bundleStatus = buildConfig.bundle ? 'bundled + minified' : 'minified';
-            console.log(`✓ ${file.src} → ${file.dest} (${bundleStatus})`);
+            logging.debug(`✓ ${file.src} → ${file.dest} (${bundleStatus})`);
         } catch (error) {
             console.error(`✗ Error processing ${file.src}:`, error);
             process.exit(1);
         }
     }
-    
-    console.log('JS processing complete');
+
+    logging.debug('JS processing complete');
 })();

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -308,7 +308,8 @@
       },
       "test:all": {
         "dependsOn": [
-          "^build:ts"
+          "^build:ts",
+          "build:assets"
         ]
       },
       "test:unit": {
@@ -330,18 +331,21 @@
       "test:browser": {
         "dependsOn": [
           "^build:ts",
+          "build:assets",
           "ghost-admin:build"
         ]
       },
       "test:browser:admin": {
         "dependsOn": [
           "^build:ts",
+          "build:assets",
           "ghost-admin:build"
         ]
       },
       "test:browser:portal": {
         "dependsOn": [
           "^build:ts",
+          "build:assets",
           "ghost-admin:build"
         ]
       },


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/2b9ff7f095384c36a7d8bfc59ab9871c1ef9a231

The `minify-assets.js` had some console logs that were running on boot. These logs are useful for debugging, but most of the time it should be fine to do the asset minification silently. This commit downgrades the `console.log()`s to `logging.debug()`s, so we can still enable it if we're debugging the asset minification, but it doesn't add noise to the console.

It also adds an NX `depends_on` configuration for `yarn test:all` (which includes unit tests and was failing unless you had manually run `build:assets` or run `yarn dev` previously) and the `yarn test:browser*` commands to ensure the assets are built when running browser tests.