### PR TITLE
Fixed global stub in lastSeenAtUpdater test

### DIFF
--- a/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
+++ b/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
@@ -9,14 +9,17 @@ const {EmailOpenedEvent} = require('@tryghost/email-service');
 const EventEmitter = require('events');
 const logging = require('@tryghost/logging');
 
-sinon.stub(logging, 'error');
-
 describe('LastSeenAtUpdater', function () {
     let events;
 
     beforeEach(function () {
+        sinon.stub(logging, 'error');
         events = new EventEmitter();
         DomainEvents.ee.removeAllListeners();
+    });
+
+    afterEach(function () {
+        sinon.restore();
     });
 
     describe('constructor', function () {


### PR DESCRIPTION
no issue

This stub must have been added by some kind of idiot (me), because it's set globally and never cleaned up. This caused subsequent attempts to stub `logging.error` in other unit test files to fail, because the method was already wrapped here.  