### PR TITLE
Added design improvements to note and replies in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.56",
+  "version": "0.6.57",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -84,7 +84,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
             setProfileImagePreview(null);
             form.setValue('profileImage', '');
             showToast({
-                message: 'Failed to upload image. Please try again.',
+                message: 'Failed to upload image. Try again.',
                 type: 'error'
             });
         } finally {
@@ -119,7 +119,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
             setCoverImagePreview(null);
             form.setValue('coverImage', '');
             showToast({
-                message: 'Failed to upload image. Please try again.',
+                message: 'Failed to upload image. Try again.',
                 type: 'error'
             });
         } finally {


### PR DESCRIPTION
ref AP-1083

- disables post button when images are uploading
- added pulse animation to the image preview while uploading
- shows an error message when image fails to upload