### PR TITLE
Added toast error messages to image uploads in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.57",
+  "version": "0.6.58",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.58",
+  "version": "0.6.59",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -413,7 +413,7 @@ export class ActivityPubAPI {
             bannerImageUrl
         });
     }
-    
+
     async upload(file: File): Promise<string> {
         const url = new URL('.ghost/activitypub/upload/image', this.apiUrl);
         const formData = new FormData();
@@ -429,7 +429,10 @@ export class ActivityPubAPI {
         });
 
         if (!response.ok) {
-            throw new Error('Upload failed');
+            throw {
+                message: 'Upload failed',
+                statusCode: response.status
+            };
         }
 
         const json = await response.json();

--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -129,8 +129,23 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
             setUploadedImageUrl(imageUrl);
         } catch (err) {
             setImagePreview(null);
+
+            let errorMessage = 'Failed to upload image. Try again.';
+
+            if (err && typeof err === 'object' && 'statusCode' in err) {
+                switch (err.statusCode) {
+                case 413:
+                    errorMessage = 'Image size exceeds limit.';
+                    break;
+                case 415:
+                    errorMessage = 'The file type is not supported.';
+                    break;
+                default:
+                    errorMessage = errorMessage;
+                }
+            }
             showToast({
-                message: 'Failed to upload image. Try again.',
+                message: errorMessage,
                 type: 'error'
             });
         } finally {

--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -141,7 +141,7 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
                     errorMessage = 'The file type is not supported.';
                     break;
                 default:
-                    errorMessage = errorMessage;
+                    // Use the default error message
                 }
             }
             showToast({

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -65,8 +65,23 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, ...props}) => {
             setUploadedImageUrl(imageUrl);
         } catch (error) {
             setImagePreview(null);
+
+            let errorMessage = 'Failed to upload image. Try again.';
+
+            if (error && typeof error === 'object' && 'statusCode' in error) {
+                switch (error.statusCode) {
+                case 413:
+                    errorMessage = 'Image size exceeds limit.';
+                    break;
+                case 415:
+                    errorMessage = 'The file type is not supported.';
+                    break;
+                default:
+                    errorMessage = errorMessage;
+                }
+            }
             showToast({
-                message: 'Failed to upload image. Try again.',
+                message: errorMessage,
                 type: 'error'
             });
         } finally {

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -77,7 +77,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, ...props}) => {
                     errorMessage = 'The file type is not supported.';
                     break;
                 default:
-                    errorMessage = errorMessage;
+                    // Use the default error message
                 }
             }
             showToast({

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -83,8 +83,23 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
         } catch (error) {
             setProfileImagePreview(null);
             form.setValue('profileImage', '');
+
+            let errorMessage = 'Failed to upload image. Try again.';
+
+            if (error && typeof error === 'object' && 'statusCode' in error) {
+                switch (error.statusCode) {
+                case 413:
+                    errorMessage = 'Image size exceeds limit.';
+                    break;
+                case 415:
+                    errorMessage = 'The file type is not supported.';
+                    break;
+                default:
+                    errorMessage = errorMessage;
+                }
+            }
             showToast({
-                message: 'Failed to upload image. Try again.',
+                message: errorMessage,
                 type: 'error'
             });
         } finally {
@@ -118,8 +133,23 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
         } catch (error) {
             setCoverImagePreview(null);
             form.setValue('coverImage', '');
+
+            let errorMessage = 'Failed to upload image. Try again.';
+
+            if (error && typeof error === 'object' && 'statusCode' in error) {
+                switch (error.statusCode) {
+                case 413:
+                    errorMessage = 'Image size exceeds limit.';
+                    break;
+                case 415:
+                    errorMessage = 'The file type is not supported.';
+                    break;
+                default:
+                    errorMessage = errorMessage;
+                }
+            }
             showToast({
-                message: 'Failed to upload image. Try again.',
+                message: errorMessage,
                 type: 'error'
             });
         } finally {

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -95,7 +95,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                     errorMessage = 'The file type is not supported.';
                     break;
                 default:
-                    errorMessage = errorMessage;
+                    // Use the default error message
                 }
             }
             showToast({
@@ -145,7 +145,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                     errorMessage = 'The file type is not supported.';
                     break;
                 default:
-                    errorMessage = errorMessage;
+                    // Use the default error message
                 }
             }
             showToast({


### PR DESCRIPTION
ref AP-1083

- adds file size, type, and generic error message to image uploads
- updates the upload api to throw an error with the status code