### PR TITLE
Added file size and dimension check to image uploads in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.59",
+  "version": "0.6.60",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -4,10 +4,16 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, LucideIcon, Skeleton} from '@tryghost/shade';
 import {ChangeEvent, useEffect, useRef, useState} from 'react';
 import {ComponentPropsWithoutRef, ReactNode} from 'react';
+import {checkImageDimensions, getDimensionErrorMessage} from '@utils/image';
 import {showToast} from '@tryghost/admin-x-design-system';
 import {uploadFile, useAccountForUser, useNoteMutationForUser, useUserDataForUser} from '@hooks/use-activity-pub-queries';
 import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB limit
+const FILE_SIZE_ERROR_MESSAGE = 'Image must be less than 1MB in size.';
+
+const IMAGE_MAX_DIMENSIONS = {width: 3000, height: 2000};
 
 interface NewNoteModalProps extends ComponentPropsWithoutRef<typeof Dialog> {
     children?: ReactNode;
@@ -94,6 +100,31 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, ...props}) => {
 
         if (files && files.length > 0) {
             const file = files[0];
+
+            if (file.size > MAX_FILE_SIZE) {
+                showToast({
+                    message: FILE_SIZE_ERROR_MESSAGE,
+                    type: 'error'
+                });
+                e.target.value = '';
+                return;
+            }
+
+            const withinMaxDimensions = await checkImageDimensions(
+                file,
+                IMAGE_MAX_DIMENSIONS.width,
+                IMAGE_MAX_DIMENSIONS.height
+            );
+            if (!withinMaxDimensions) {
+                showToast({
+                    message: getDimensionErrorMessage(
+                        IMAGE_MAX_DIMENSIONS.width,
+                        IMAGE_MAX_DIMENSIONS.height
+                    ),
+                    type: 'error'
+                });
+                return;
+            }
 
             const previewUrl = URL.createObjectURL(file);
             setImagePreview(previewUrl);

--- a/apps/admin-x-activitypub/src/utils/image.ts
+++ b/apps/admin-x-activitypub/src/utils/image.ts
@@ -1,0 +1,25 @@
+/**
+ * Checks if an image file's dimensions are within specified maximum limits
+ */
+export const checkImageDimensions = (
+    file: File,
+    maxWidth: number,
+    maxHeight: number
+): Promise<boolean> => {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+            URL.revokeObjectURL(img.src);
+            const withinMaxDimensions = img.width <= maxWidth && img.height <= maxHeight;
+            resolve(withinMaxDimensions);
+        };
+        img.src = URL.createObjectURL(file);
+    });
+};
+
+/**
+ * Creates an error message for image dimension validation failures
+ */
+export const getDimensionErrorMessage = (maxWidth: number, maxHeight: number) => {
+    return `Image dimensions must not exceed ${maxWidth}x${maxHeight} pixels.`;
+};


### PR DESCRIPTION
ref AP-1091

- profile image - 1MB in file size and 400x400 in dimension
- banner image and note/reply attachment - 1MB in file size and 3000x2000 in dimension