### PR TITLE
Fixed profile images not being removeable in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.61",
+  "version": "0.6.62",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -243,8 +243,8 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
             name: data.name || account.name,
             username: data.handle || account.handle,
             bio: data.bio || account.bio,
-            avatarUrl: data.profileImage || account.avatarUrl,
-            bannerImageUrl: data.coverImage || account.bannerImageUrl || ''
+            avatarUrl: data.profileImage || '',
+            bannerImageUrl: data.coverImage || ''
         }, {
             onSettled() {
                 setIsSubmitting(false);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/AP-1097

Fixed profile images not being removeable in `admin-x-activitypub` due to using the original image URL as a fallback when an empty value is provided
