### PR TITLE
Removed Captcha from the alpha feature UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -40,10 +40,6 @@ const features = [{
     description: 'Enables redesigned Stats page',
     flag: 'statsX'
 }, {
-    title: 'Sign-up CAPTCHA',
-    description: 'Enable CAPTCHA for member sign-up and sign-in',
-    flag: 'captcha'
-}, {
     title: 'Explore',
     description: 'Enables keeping in touch with the new Explore API',
     flag: 'explore'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-904/support-escalation-fwd-issue-with-sign-in ref https://linear.app/ghost/issue/ONC-855/support-escalation-re-urgent-website-not-allowing-sign-ins-or-sign-ups

- The current implementation doesn't work properly and breaks sign-in for sites when it is enabled
- This makes extra-especially sure we can't enable this feature until it's fixed

