### PR TITLE
Fixed misc issues in edit profile modal in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -14,9 +14,13 @@ import {zodResolver} from '@hookform/resolvers/zod';
 const FormSchema = z.object({
     profileImage: z.string().optional(),
     coverImage: z.string().optional(),
-    name: z.string().nonempty({
-        message: 'Name is required.'
-    }),
+    name: z.string()
+        .nonempty({
+            message: 'Display name is required.'
+        })
+        .max(64, {
+            message: 'Display name must be less than 64 characters.'
+        }),
     handle: z.string()
         .min(2, {
             message: 'Handle must be at least 2 characters.'

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -27,7 +27,11 @@ const FormSchema = z.object({
         .regex(/^[a-zA-Z0-9_]+$/, {
             message: 'Handle must contain only letters, numbers, and underscores.'
         }),
-    bio: z.string().optional()
+    bio: z.string()
+        .max(250, {
+            message: 'Bio must be less than 250 characters.'
+        })
+        .optional()
 });
 
 type EditProfileProps = {

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -242,7 +242,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
         updateAccount({
             name: data.name || account.name,
             username: data.handle || account.handle,
-            bio: data.bio || account.bio,
+            bio: data.bio || '',
             avatarUrl: data.profileImage || '',
             bannerImageUrl: data.coverImage || ''
         }, {


### PR DESCRIPTION
Fixed misc issues in edit profile modal in `admin-x-activitypub`

- Allow `bio` to be empty
- Ensured bio cannot be longer than `250` characters
- Ensured display name cannot be longer than `64` characters
