### PR TITLE
Removed `settings-full`, `settings` and `note-image` feature flags for activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.67",
+  "version": "0.6.68",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -9,7 +9,6 @@ import {Button, LucideIcon} from '@tryghost/shade';
 import {FILE_SIZE_ERROR_MESSAGE, COVER_MAX_DIMENSIONS as IMAGE_MAX_DIMENSIONS, MAX_FILE_SIZE, checkImageDimensions, getDimensionErrorMessage} from '@utils/image';
 import {showToast} from '@tryghost/admin-x-design-system';
 import {uploadFile, useReplyMutationForUser, useUserDataForUser} from '@hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 
 export interface APTextAreaProps extends HTMLProps<HTMLTextAreaElement> {
     title?: string;
@@ -60,7 +59,6 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
     onReplyError,
     ...props
 }) => {
-    const {isEnabled} = useFeatureFlags();
     const id = useId();
     const [textValue, setTextValue] = useState(value); // Manage the textarea value with state
     const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
@@ -275,9 +273,7 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
                     </div>
                 }
                 <div className={`${imagePreview ? 'mt-4' : 'absolute'} bottom-[3px] right-0 flex justify-end space-x-3 transition-[opacity] duration-150`}>
-                    {isEnabled('note-image') &&
-                        <Button ref={imageButtonRef} className='w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
-                    }
+                    <Button ref={imageButtonRef} className='w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
                     <Button className='min-w-20' color='black' disabled={buttonDisabled || isImageUploading} id='post' onClick={handleClick}>Post</Button>
                 </div>
             </div>

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import {Button, Dialog, DialogContent, DialogTrigger, LucideIcon} from '@tryghos
 import {useFeatureFlags} from '@src/lib/feature-flags';
 
 const Sidebar: React.FC = () => {
-    const {allFlags, flags, isEnabled} = useFeatureFlags();
+    const {allFlags, flags} = useFeatureFlags();
     const [isSearchOpen, setIsSearchOpen] = React.useState(false);
     const [searchQuery, setSearchQuery] = React.useState('');
 
@@ -48,12 +48,10 @@ const Sidebar: React.FC = () => {
                             <LucideIcon.User size={18} strokeWidth={1.5} />
                             Profile
                         </SidebarMenuLink>
-                        {isEnabled('settings-full') &&
-                            <SidebarMenuLink to='/preferences'>
-                                <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
-                                Preferences
-                            </SidebarMenuLink>
-                        }
+                        <SidebarMenuLink to='/preferences'>
+                            <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
+                            Preferences
+                        </SidebarMenuLink>
                     </div>
                     <NewNoteModal>
                         <Button className='h-9 rounded-full bg-purple-500 px-3 text-md text-white dark:hover:bg-purple-500'>

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -7,7 +7,6 @@ import {ComponentPropsWithoutRef, ReactNode} from 'react';
 import {FILE_SIZE_ERROR_MESSAGE, COVER_MAX_DIMENSIONS as IMAGE_MAX_DIMENSIONS, MAX_FILE_SIZE, checkImageDimensions, getDimensionErrorMessage} from '@utils/image';
 import {showToast} from '@tryghost/admin-x-design-system';
 import {uploadFile, useAccountForUser, useNoteMutationForUser, useUserDataForUser} from '@hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 interface NewNoteModalProps extends ComponentPropsWithoutRef<typeof Dialog> {
@@ -15,7 +14,6 @@ interface NewNoteModalProps extends ComponentPropsWithoutRef<typeof Dialog> {
 }
 
 const NewNoteModal: React.FC<NewNoteModalProps> = ({children, ...props}) => {
-    const {isEnabled} = useFeatureFlags();
     const {data: user} = useUserDataForUser('index');
     const noteMutation = useNoteMutationForUser('index', user);
     const {data: account, isLoading: isLoadingAccount} = useAccountForUser('index', 'me');
@@ -215,9 +213,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, ...props}) => {
                     </div>
                 }
                 <DialogFooter>
-                    {isEnabled('note-image') &&
-                        <Button className='mr-auto w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
-                    }
+                    <Button className='mr-auto w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
                     <DialogClose>
                         <Button className='min-w-16' variant='outline'>Cancel</Button>
                     </DialogClose>

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['settings', 'settings-full', 'note-image'] as const;
+export const FEATURE_FLAGS = [] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -4,7 +4,6 @@ import {Button, DialogClose, DialogFooter, Form, FormControl, FormDescription, F
 import {COVER_MAX_DIMENSIONS, FILE_SIZE_ERROR_MESSAGE, MAX_FILE_SIZE, PROFILE_MAX_DIMENSIONS, checkImageDimensions, getDimensionErrorMessage} from '@utils/image';
 import {showToast} from '@tryghost/admin-x-design-system';
 import {uploadFile} from '@hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useForm} from 'react-hook-form';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useUpdateAccountMutationForUser} from '@hooks/use-activity-pub-queries';
@@ -53,7 +52,6 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
     const [handleDomain, setHandleDomain] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const {mutate: updateAccount} = useUpdateAccountMutationForUser(account?.handle || '');
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigate();
 
     const form = useForm<z.infer<typeof FormSchema>>({
@@ -274,104 +272,94 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                 }}
                 onSubmit={form.handleSubmit(onSubmit)}
             >
-                {isEnabled('settings-full') && (
-                    <div className='relative mb-2'>
-                        <div className='group relative h-[180px] cursor-pointer bg-gray-100' onClick={triggerCoverImageInput}>
-                            {coverImagePreview ?
-                                <>
-                                    <img className={`size-full object-cover ${isCoverImageUploading && 'animate-pulse'}`} src={coverImagePreview} />
-                                    <Button className='absolute right-3 top-3 size-8 bg-black/60 opacity-0 hover:bg-black/80 group-hover:opacity-100' onClick={(e) => {
-                                        e.stopPropagation();
-                                        setCoverImagePreview(null);
-                                        form.setValue('coverImage', '');
-                                    }}><LucideIcon.Trash2 /></Button>
-                                </> :
-                                <Button className='pointer-events-none absolute bottom-3 right-3 bg-gray-250 group-hover:bg-gray-300' variant='secondary'>Upload cover image</Button>
-                            }
-                        </div>
-                        <div className='group absolute -bottom-10 left-4 flex size-20 cursor-pointer items-center justify-center rounded-full border-2 border-white bg-gray-100' onClick={triggerProfileImageInput}>
-                            {profileImagePreview ?
-                                <>
-                                    <img className={`size-full rounded-full object-cover ${isProfileImageUploading && 'animate-pulse'}`} src={profileImagePreview} />
-                                    <Button className='absolute -right-2 -top-2 h-8 w-10 rounded-full bg-black/80 opacity-0 hover:bg-black/90 group-hover:opacity-100' onClick={(e) => {
-                                        e.stopPropagation();
-                                        setProfileImagePreview(null);
-                                        form.setValue('profileImage', '');
-                                    }}><LucideIcon.Trash2 /></Button>
-                                </> :
-                                <LucideIcon.UserRoundPlus size={32} strokeWidth={1.5} />
-                            }
-                        </div>
+
+                <div className='relative mb-2'>
+                    <div className='group relative h-[180px] cursor-pointer bg-gray-100' onClick={triggerCoverImageInput}>
+                        {coverImagePreview ?
+                            <>
+                                <img className={`size-full object-cover ${isCoverImageUploading && 'animate-pulse'}`} src={coverImagePreview} />
+                                <Button className='absolute right-3 top-3 size-8 bg-black/60 opacity-0 hover:bg-black/80 group-hover:opacity-100' onClick={(e) => {
+                                    e.stopPropagation();
+                                    setCoverImagePreview(null);
+                                    form.setValue('coverImage', '');
+                                }}><LucideIcon.Trash2 /></Button>
+                            </> :
+                            <Button className='pointer-events-none absolute bottom-3 right-3 bg-gray-250 group-hover:bg-gray-300' variant='secondary'>Upload cover image</Button>
+                        }
                     </div>
-                )}
-                {isEnabled('settings-full') && (
-                    <FormField
-                        control={form.control}
-                        name="profileImage"
-                        render={() => (
-                            <FormItem>
-                                <FormControl>
-                                    <Input
-                                        ref={profileImageInputRef}
-                                        accept="image/*"
-                                        className='hidden'
-                                        type="file"
-                                        onChange={handleProfileImageChange}
-                                    />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                )}
-                {isEnabled('settings-full') && (
-                    <FormField
-                        control={form.control}
-                        name="coverImage"
-                        render={() => (
-                            <FormItem>
-                                <FormControl>
-                                    <Input
-                                        ref={coverImageInputRef}
-                                        accept="image/*"
-                                        className='hidden'
-                                        type="file"
-                                        onChange={handleCoverImageChange}
-                                    />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                )}
-                {isEnabled('settings-full') && (
-                    <FormField
-                        control={form.control}
-                        name="name"
-                        render={({field}) => (
-                            <FormItem>
-                                <FormLabel>Display name</FormLabel>
-                                <FormControl>
-                                    <Input placeholder="Jamie Larson" {...field} />
-                                </FormControl>
-                                {!hasNameError && (
-                                    <FormDescription>
-                                        The name shown to your followers in the Inbox and Feed
-                                    </FormDescription>
-                                )}
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                )}
+                    <div className='group absolute -bottom-10 left-4 flex size-20 cursor-pointer items-center justify-center rounded-full border-2 border-white bg-gray-100' onClick={triggerProfileImageInput}>
+                        {profileImagePreview ?
+                            <>
+                                <img className={`size-full rounded-full object-cover ${isProfileImageUploading && 'animate-pulse'}`} src={profileImagePreview} />
+                                <Button className='absolute -right-2 -top-2 h-8 w-10 rounded-full bg-black/80 opacity-0 hover:bg-black/90 group-hover:opacity-100' onClick={(e) => {
+                                    e.stopPropagation();
+                                    setProfileImagePreview(null);
+                                    form.setValue('profileImage', '');
+                                }}><LucideIcon.Trash2 /></Button>
+                            </> :
+                            <LucideIcon.UserRoundPlus size={32} strokeWidth={1.5} />
+                        }
+                    </div>
+                </div>
+                <FormField
+                    control={form.control}
+                    name="profileImage"
+                    render={() => (
+                        <FormItem>
+                            <FormControl>
+                                <Input
+                                    ref={profileImageInputRef}
+                                    accept="image/*"
+                                    className='hidden'
+                                    type="file"
+                                    onChange={handleProfileImageChange}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={form.control}
+                    name="coverImage"
+                    render={() => (
+                        <FormItem>
+                            <FormControl>
+                                <Input
+                                    ref={coverImageInputRef}
+                                    accept="image/*"
+                                    className='hidden'
+                                    type="file"
+                                    onChange={handleCoverImageChange}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={form.control}
+                    name="name"
+                    render={({field}) => (
+                        <FormItem>
+                            <FormLabel>Display name</FormLabel>
+                            <FormControl>
+                                <Input placeholder="Jamie Larson" {...field} />
+                            </FormControl>
+                            {!hasNameError && (
+                                <FormDescription>
+                                    The name shown to your followers in the Inbox and Feed
+                                </FormDescription>
+                            )}
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
                 <FormField
                     control={form.control}
                     name="handle"
                     render={({field}) => (
                         <FormItem>
-                            {isEnabled('settings-full') && (
-                                <FormLabel>Handle</FormLabel>
-                            )}
                             <FormControl>
                                 <div className='relative flex items-center justify-stretch gap-1 rounded-md bg-gray-150 px-3 dark:bg-gray-900'>
                                     <LucideIcon.AtSign className='w-4 min-w-4 text-gray-700' size={16} />
@@ -388,21 +376,19 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                         </FormItem>
                     )}
                 />
-                {isEnabled('settings-full') && (
-                    <FormField
-                        control={form.control}
-                        name="bio"
-                        render={({field}) => (
-                            <FormItem>
-                                <FormLabel>Bio</FormLabel>
-                                <FormControl>
-                                    <Textarea {...field} />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                )}
+                <FormField
+                    control={form.control}
+                    name="bio"
+                    render={({field}) => (
+                        <FormItem>
+                            <FormLabel>Bio</FormLabel>
+                            <FormControl>
+                                <Textarea {...field} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
                 <DialogFooter>
                     <DialogClose>
                         <Button variant='outline'>Cancel</Button>

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
@@ -4,7 +4,6 @@ import {Account} from '@src/api/activitypub';
 import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LucideIcon, cn} from '@tryghost/shade';
 import {Link, useNavigate} from '@tryghost/admin-x-framework';
 import {LoadingIndicator} from '@tryghost/admin-x-design-system';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useSearchForUser} from '@hooks/use-activity-pub-queries';
 
 interface SettingsProps {
@@ -24,7 +23,6 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
 
     const threadsEnabled = threadsData?.accounts[0]?.followedByMe;
     const blueskyEnabled = blueskyData?.accounts[0]?.followedByMe;
-    const {isEnabled} = useFeatureFlags();
 
     return (
         <div className={`flex flex-col ${className}`}>
@@ -33,16 +31,16 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                 <SettingHeader>
                     <SettingTitle>Account</SettingTitle>
                     <SettingDescription>
-                        {isEnabled('settings-full') ? 'Edit your profile information and account details' : 'Edit your social web handle'}
+                        Edit your profile information and account details
                     </SettingDescription>
                 </SettingHeader>
                 <Dialog open={isEditingProfile} onOpenChange={setIsEditingProfile}>
                     <DialogTrigger>
-                        <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>
+                        <SettingAction><Button variant='secondary'>Edit profile</Button></SettingAction>
                     </DialogTrigger>
                     <DialogContent onOpenAutoFocus={e => e.preventDefault()}>
                         <DialogHeader>
-                            <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Handle'}</DialogTitle>
+                            <DialogTitle>Profile settings</DialogTitle>
                         </DialogHeader>
                         {account && <EditProfile account={account} setIsEditingProfile={setIsEditingProfile} />}
                     </DialogContent>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -9,7 +9,6 @@ import {ProfileTab} from '../Profile';
 import {SettingAction} from '@src/views/Preferences/components/Settings';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useRef, useState} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 
 const noop = () => {};
@@ -83,7 +82,6 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
 
     const contentRef = useRef<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);
-    const {isEnabled} = useFeatureFlags();
 
     useEffect(() => {
         if (contentRef.current) {
@@ -144,11 +142,11 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                 {isCurrentUser && !isLoadingAccount &&
                                     <Dialog open={isEditingProfile} onOpenChange={setIsEditingProfile}>
                                         <DialogTrigger>
-                                            <SettingAction><Button variant='secondary'>{isEnabled('settings-full') ? 'Edit profile' : 'Edit handle'}</Button></SettingAction>
+                                            <SettingAction><Button variant='secondary'>Edit profile</Button></SettingAction>
                                         </DialogTrigger>
                                         <DialogContent className='w-full max-w-[520px]' onOpenAutoFocus={e => e.preventDefault()}>
                                             <DialogHeader>
-                                                <DialogTitle>{isEnabled('settings-full') ? 'Profile settings' : 'Edit handle'}</DialogTitle>
+                                                <DialogTitle>Profile settings</DialogTitle>
                                             </DialogHeader>
                                             {account && <EditProfile account={account} setIsEditingProfile={setIsEditingProfile} />}
                                         </DialogContent>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-670, https://linear.app/ghost/issue/PROD-671, https://linear.app/ghost/issue/PROD-1042

Removed the feature flags: `settings-full`, `settings` and `note-image` which releases the edit profile modal and note image attachment features in `admin-x-activitypub`