### PR TITLE
Added Traffic Analytics to Alpha flag UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -35,6 +35,11 @@ const features = [{
     title: 'Content Visibility (Alpha)',
     description: 'Enables content visibility in Emails - Additional changes for internal testing. NOTE: requires `contentVisibility` to also be enabled',
     flag: 'contentVisibilityAlpha'
+},
+{
+    title: 'Traffic Analytics',
+    description: 'Enables traffic analytics',
+    flag: 'trafficAnalytics'
 },{
     title: 'Stats redesign',
     description: 'Enables redesigned Stats page',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-635/enable-trafficanalytics-with-a-private-beta-flag

- This tiny change just makes the flag visible for developers to toggle in Ghost admin

