### PR TITLE
Removed deprecated labs flags from admin

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -65,7 +65,6 @@ export default class FeatureService extends Service {
     @feature('emailCustomization') emailCustomization;
     @feature('i18n') i18n;
     @feature('announcementBar') announcementBar;
-    @feature('signupCard') signupCard;
     @feature('mailEvents') mailEvents;
     @feature('collectionsCard') collectionsCard;
     @feature('importMemberTier') importMemberTier;
@@ -74,7 +73,6 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
-    @feature('postsX') postsX;
     @feature('trafficAnalyticsAlpha') trafficAnalyticsAlpha;
     @feature('trafficAnalytics') trafficAnalytics;
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/2765ff4233e195d63faa6d2b74ce164022721dcf ref https://github.com/TryGhost/Ghost/commit/8a08cf3628a0a79933545e4e2bb0fa370fee6616

- These flags were already removed from the labs system
- This file in admin was missed, so cleaning up

