### PR TITLE
Changed alpha flags to work without developer flag

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -60,12 +60,6 @@ module.exports.WRITABLE_KEYS_ALLOWLIST = [...BETA_FEATURES, ...ALPHA_FEATURES];
 module.exports.getAll = () => {
     const labs = _.cloneDeep(settingsCache.get('labs')) || {};
 
-    ALPHA_FEATURES.forEach((alphaKey) => {
-        if (labs[alphaKey] && !(config.get('enableDeveloperExperiments') || process.env.NODE_ENV.startsWith('test'))) {
-            delete labs[alphaKey];
-        }
-    });
-
     GA_FEATURES.forEach((gaKey) => {
         labs[gaKey] = true;
     });

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -47,24 +47,6 @@ describe('Labs Service', function () {
         assert.equal(labs.isSet('urlCache'), true);
     });
 
-    it('returns a falsy alpha flag when dev experiments in NOT toggled', function () {
-        configUtils.set('enableDeveloperExperiments', false);
-        sinon.stub(process.env, 'NODE_ENV').value('production');
-        sinon.stub(settingsCache, 'get');
-        settingsCache.get.withArgs('labs').returns({
-            urlCache: true
-        });
-
-        // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
-        //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        assert.deepEqual(labs.getAll(), expectedLabsObject({
-            members: true
-        }));
-
-        assert.equal(labs.isSet('members'), true);
-        assert.equal(labs.isSet('urlCache'), false);
-    });
-
     it('respects the value in config over settings', function () {
         configUtils.set('labs', {
             collections: false


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1558/remove-enabledeveloperexperiments-requirement-from-alpha-flags
- We want alpha flags to work without the enableDeveloperExperiments flag set
- They won't be output in the UI unless this is set
- But they should work if they are toggled on regardless of any other condition

