### PR TITLE
Reduced github output in CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,12 @@ jobs:
           fetch-depth: 2
 
       - name: Output GitHub context
-        run: echo "$GITHUB_CONTEXT"
+        run: |
+          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
+          echo "GITHUB_CONTEXT: $GITHUB_CONTEXT"
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_CONTEXT: ${{ toJson(github.event) }}
 
       - name: Get metadata (push)
         if: github.event_name == 'push'


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/14673112768/job/41205060470 ref https://github.com/TryGhost/Ghost/actions/runs/14678931627/job/41204762772

- Although in the PR this output worked OK, for some reason on main it's suddenly seemingly too much output
- This is a fairly speculative attempt to fix this issue - although the output is purely for debug purposes

