### PR TITLE
Removed enableLabs utility from e2e-browser tests

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -4,10 +4,6 @@ import React from 'react';
 import {List} from '@tryghost/admin-x-design-system';
 
 const features = [{
-    title: 'Webmentions',
-    description: 'Allows viewing received mentions on the dashboard.',
-    flag: 'webmentions'
-},{
     title: 'Stripe Automatic Tax (private beta)',
     description: 'Use Stripe Automatic Tax at Stripe Checkout. Needs to be enabled in Stripe',
     flag: 'stripeAutomaticTax'

--- a/ghost/core/test/e2e-browser/fixtures/ghost-test.js
+++ b/ghost/core/test/e2e-browser/fixtures/ghost-test.js
@@ -2,7 +2,7 @@
 const base = require('@playwright/test');
 const {promisify} = require('util');
 const {spawn, exec} = require('child_process');
-const {setupGhost, setupMailgun, enableLabs, setupStripe, getStripeAccountId, generateStripeIntegrationToken} = require('../utils/e2e-browser-utils');
+const {setupGhost, setupMailgun, setupStripe, getStripeAccountId, generateStripeIntegrationToken} = require('../utils/e2e-browser-utils');
 const {allowStripe, mockMail, mockGeojs, assert} = require('../../utils/e2e-framework-mock-manager');
 const sinon = require('sinon');
 const ObjectID = require('bson-objectid').default;
@@ -178,7 +178,6 @@ module.exports = base.test.extend({
         await setupGhost(page);
         await setupStripe(page, stripeIntegrationToken);
         await setupMailgun(page);
-        await enableLabs(page);
         const state = await page.context().storageState();
 
         await page.close();

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -128,22 +128,6 @@ const setupMailgun = async (page) => {
 };
 
 /**
- * Enable experimental labs features
- * @param {import('@playwright/test').Page} page
- */
-const enableLabs = async (page) => {
-    await page.locator('.gh-nav a[href="#/settings/"]').click();
-
-    const section = page.getByTestId('labs');
-    await section.getByRole('button', {name: 'Open'}).click();
-
-    await section.getByRole('tab', {name: 'Private features'}).click();
-    await section.getByLabel('Webmentions').click();
-
-    await page.getByTestId('exit-settings').click();
-};
-
-/**
  * Delete all members, 1 by 1, using the UI
  * @param {import('@playwright/test').Page} page
  */
@@ -539,7 +523,6 @@ module.exports = {
     setupGhost,
     setupStripe,
     disconnectStripe,
-    enableLabs,
     getStripeAccountId,
     generateStripeIntegrationToken,
     setupMailgun,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1561/clean-up-deprecated-unused-flags

- Cleaning up this utility as it speicfically enabled only webmentions
- Ideally, we'd have a generic utiltiy for enabling a flag if needed
- For now, remove the util and see if that causes any unexpected issues


