### PR TITLE
Added block UI to the profile page in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.68",
+  "version": "0.6.69",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = [] as const;
+export const FEATURE_FLAGS = ['block'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -1,3 +1,4 @@
+import {Account} from '@src/api/activitypub';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -17,6 +18,7 @@ import {
 } from '@tryghost/shade';
 
 interface ProfileMenuProps {
+    account: Account,
     trigger: React.ReactNode;
     onCopyHandle: () => void;
     onBlockAccount: () => void;
@@ -25,6 +27,7 @@ interface ProfileMenuProps {
 }
 
 const ProfileMenu: React.FC<ProfileMenuProps> = ({
+    account,
     trigger,
     onCopyHandle,
     onBlockAccount,
@@ -70,7 +73,10 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
             </Popover>
             <AlertDialogContent onClick={e => e.stopPropagation()}>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>{isBlocked ? 'Unblock this user?' : 'Block this user?'}</AlertDialogTitle>
+                    <AlertDialogTitle className='flex flex-col gap-0.5'>
+                        {isBlocked ? 'Unblock this user?' : 'Block this user?'}
+                        <span className='text-base font-normal tracking-normal'>{account.handle}</span>
+                    </AlertDialogTitle>
                     <AlertDialogDescription>
                         {isBlocked
                             ? 'They will be able to follow you and engage with your public posts.'

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -1,0 +1,96 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+    Button,
+    Popover,
+    PopoverClose,
+    PopoverContent,
+    PopoverTrigger,
+    buttonVariants
+} from '@tryghost/shade';
+
+interface ProfileMenuProps {
+    trigger: React.ReactNode;
+    onCopyHandle: () => void;
+    onBlockAccount: () => void;
+    disabled?: boolean;
+    isBlocked?: boolean;
+}
+
+const ProfileMenu: React.FC<ProfileMenuProps> = ({
+    trigger,
+    onCopyHandle,
+    onBlockAccount,
+    disabled = false,
+    isBlocked = false
+}) => {
+    const handleCopyHandleClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+        onCopyHandle();
+    };
+
+    const handleBlockAccountClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+        onBlockAccount();
+    };
+
+    return (
+        <AlertDialog>
+            <Popover>
+                <PopoverTrigger disabled={disabled} asChild onClick={e => e.stopPropagation()}>
+                    {trigger}
+                </PopoverTrigger>
+                <PopoverContent align="end" className='p-2'>
+                    <div className='flex w-48 flex-col'>
+                        <PopoverClose asChild>
+                            <Button className='justify-start' variant='ghost' onClick={handleCopyHandleClick}>
+                                Copy handle
+                            </Button>
+                        </PopoverClose>
+                        <AlertDialogTrigger asChild>
+                            <PopoverClose asChild>
+                                <Button
+                                    className='justify-start text-red hover:bg-red/5 hover:text-red'
+                                    variant='ghost'
+                                    onClick={e => e.stopPropagation()}
+                                >
+                                    {isBlocked ? 'Unblock user' : 'Block user'}
+                                </Button>
+                            </PopoverClose>
+                        </AlertDialogTrigger>
+                    </div>
+                </PopoverContent>
+            </Popover>
+            <AlertDialogContent onClick={e => e.stopPropagation()}>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{isBlocked ? 'Unblock this user?' : 'Block this user?'}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        {isBlocked
+                            ? 'They will be able to follow you and engage with your public posts.'
+                            : 'They will be able to see your public posts, but will no longer be able follow you or interact with your content on the social web.'}
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={e => e.stopPropagation()}>
+                        Cancel
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        className={isBlocked ? undefined : buttonVariants({variant: 'destructive'})}
+                        onClick={handleBlockAccountClick}
+                    >
+                        {isBlocked ? 'Unblock' : 'Block'}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default ProfileMenu;

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -73,7 +73,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
             </Popover>
             <AlertDialogContent onClick={e => e.stopPropagation()}>
                 <AlertDialogHeader>
-                    <AlertDialogTitle className='flex flex-col gap-0.5'>
+                    <AlertDialogTitle className='mb-1 flex flex-col gap-1'>
                         {isBlocked ? 'Unblock this user?' : 'Block this user?'}
                         <span className='text-base font-normal tracking-normal'>{account.handle}</span>
                     </AlertDialogTitle>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -94,8 +94,10 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
         }
     }, [isExpanded]);
 
+    // TODO: Wire up the block state
     const [isBlocked, setIsBlocked] = useState(false);
 
+    // TODO: Wire up the block functionality
     const handleBlock = () => {
         setIsBlocked(!isBlocked);
     };

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -72,7 +72,9 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
         {
             id: 'posts',
             title: 'Posts',
-            contents: !isBlocked ? postsTab : <div className="text-center">Blocked</div>
+            contents: !isBlocked ? postsTab : <NoValueLabel icon='block'>
+                {account.name} is blocked
+            </NoValueLabel>
         },
         !params.handle && {
             id: 'likes',

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -52,11 +52,27 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     const {data: currentUser} = params.handle ? currentAccountQuery : {data: undefined};
     const isCurrentUser = params.handle === currentUser?.handle || !params.handle;
 
+    // TODO: Wire up the block state
+    const [isBlocked, setIsBlocked] = useState(false);
+
+    // TODO: Wire up the block functionality
+    const handleBlock = () => {
+        setIsBlocked(!isBlocked);
+    };
+
+    const handleCopy = async () => {
+        await navigator.clipboard.writeText(account.handle);
+        showToast({
+            title: 'Handle copied',
+            type: 'success'
+        });
+    };
+
     const tabs = [
         {
             id: 'posts',
             title: 'Posts',
-            contents: postsTab
+            contents: !isBlocked ? postsTab : <div className="text-center">Blocked</div>
         },
         !params.handle && {
             id: 'likes',
@@ -93,22 +109,6 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
             setIsOverflowing(contentRef.current.scrollHeight > 160); // Compare content height to max height
         }
     }, [isExpanded]);
-
-    // TODO: Wire up the block state
-    const [isBlocked, setIsBlocked] = useState(false);
-
-    // TODO: Wire up the block functionality
-    const handleBlock = () => {
-        setIsBlocked(!isBlocked);
-    };
-
-    const handleCopy = async () => {
-        await navigator.clipboard.writeText(account.handle);
-        showToast({
-            title: 'Handle copied',
-            type: 'success'
-        });
-    };
 
     return (
         <Layout>
@@ -161,10 +161,11 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                                 onFollow={noop}
                                                 onUnfollow={noop}
                                             /> :
-                                            <UnblockButton onUnblock={handleBlock} />
+                                            <UnblockButton account={account} onUnblock={handleBlock} />
                                         }
                                         {isEnabled('block') &&
                                             <ProfileMenu
+                                                account={account}
                                                 isBlocked={isBlocked}
                                                 trigger={<Button aria-label='Open profile menu' variant='outline'><LucideIcon.Ellipsis /></Button>}
                                                 onBlockAccount={handleBlock}

--- a/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
@@ -44,7 +44,7 @@ const UnblockButton: React.FC<UnblockButtonProps> = ({
             </AlertDialogTrigger>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle className='flex flex-col gap-0.5'>
+                    <AlertDialogTitle className='mb-1 flex flex-col gap-1'>
                         Unblock this user?
                         <span className='text-base font-normal tracking-normal'>{account.handle}</span>
                     </AlertDialogTitle>

--- a/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
@@ -41,9 +41,9 @@ const UnblockButton: React.FC<UnblockButtonProps> = ({
             </AlertDialogTrigger>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Unblock this account?</AlertDialogTitle>
+                    <AlertDialogTitle>Unblock this user?</AlertDialogTitle>
                     <AlertDialogDescription>
-                        Unblocking will allow this account to interact with your posts and you will see their content again.
+                        They will be able to follow you and engage with your public posts.
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {Account} from '@src/api/activitypub';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -13,11 +14,13 @@ import {
 } from '@tryghost/shade';
 
 interface UnblockButtonProps {
+    account: Account,
     onUnblock: () => void;
     className?: string;
 }
 
 const UnblockButton: React.FC<UnblockButtonProps> = ({
+    account,
     onUnblock,
     className = ''
 }) => {
@@ -41,7 +44,10 @@ const UnblockButton: React.FC<UnblockButtonProps> = ({
             </AlertDialogTrigger>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Unblock this user?</AlertDialogTitle>
+                    <AlertDialogTitle className='flex flex-col gap-0.5'>
+                        Unblock this user?
+                        <span className='text-base font-normal tracking-normal'>{account.handle}</span>
+                    </AlertDialogTitle>
                     <AlertDialogDescription>
                         They will be able to follow you and engage with your public posts.
                     </AlertDialogDescription>

--- a/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/UnblockButton.tsx
@@ -1,0 +1,58 @@
+import React, {useState} from 'react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+    Button
+} from '@tryghost/shade';
+
+interface UnblockButtonProps {
+    onUnblock: () => void;
+    className?: string;
+}
+
+const UnblockButton: React.FC<UnblockButtonProps> = ({
+    onUnblock,
+    className = ''
+}) => {
+    const [isHovered, setIsHovered] = useState(false);
+
+    const handleUnblock = () => {
+        onUnblock();
+    };
+
+    return (
+        <AlertDialog>
+            <AlertDialogTrigger>
+                <Button
+                    className={`min-w-[90px] ${className}`}
+                    variant='destructive'
+                    onMouseEnter={() => setIsHovered(true)}
+                    onMouseLeave={() => setIsHovered(false)}
+                >
+                    {isHovered ? 'Unblock' : 'Blocked'}
+                </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Unblock this account?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        Unblocking will allow this account to interact with your posts and you will see their content again.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleUnblock}>Unblock</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default UnblockButton;

--- a/apps/shade/src/components/ui/alert-dialog.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.tsx
@@ -65,7 +65,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 [&>button]:min-w-20',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/alert-dialog.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.tsx
@@ -79,7 +79,7 @@ const AlertDialogTitle = React.forwardRef<
 >(({className, ...props}, ref) => (
     <AlertDialogPrimitive.Title
         ref={ref}
-        className={cn('text-lg font-semibold', className)}
+        className={cn('text-[1.6rem] font-semibold', className)}
         {...props}
     />
 ));
@@ -91,7 +91,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({className, ...props}, ref) => (
     <AlertDialogPrimitive.Description
         ref={ref}
-        className={cn('text-sm text-muted-foreground', className)}
+        className={cn('text-base text-muted-foreground', className)}
         {...props}
     />
 ));


### PR DESCRIPTION
ref PROD-1570

- adds a menu to the profile page
- the menu contains two items — copy handle and block user
- adds unblock button to the profile
- puts them behind a feature flag `block`