### PR TITLE
Fixed icon related bugs in Traffic Analytics

### DIFF
--- a/apps/posts/src/utils/chart-helpers.ts
+++ b/apps/posts/src/utils/chart-helpers.ts
@@ -50,7 +50,7 @@ export const getRangeDates = (range: number) => {
  * Converts a country code to corresponding flag emoji
  */
 export function getCountryFlag(countryCode:string) {
-    if (!countryCode || countryCode === null || countryCode.toUpperCase() === 'NULL') {
+    if (!countryCode || countryCode === null || countryCode.toUpperCase() === 'NULL' || countryCode === 'ᴺᵁᴸᴸ') {
         return '🏳️';
     }
     return countryCode.toUpperCase().replace(/./g, char => String.fromCodePoint(char.charCodeAt(0) + 127397)

--- a/apps/posts/src/views/PostAnalytics/components/Web/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Web/Sources.tsx
@@ -14,7 +14,7 @@ const SourceRow: React.FC<SourceRowProps> = ({className, source}) => {
     return (
         <>
             <img
-                className="gh-stats-favicon"
+                className="size-4"
                 src={`https://www.faviconextractor.com/favicon/${source || 'direct'}?larger=true`}
                 onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
                     e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;

--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -50,7 +50,7 @@ export const getRangeDates = (range: number) => {
  * Converts a country code to corresponding flag emoji
  */
 export function getCountryFlag(countryCode:string) {
-    if (!countryCode || countryCode === null || countryCode.toUpperCase() === 'ᴺᵁᴸᴸ') {
+    if (!countryCode || countryCode === null || countryCode.toUpperCase() === 'NULL' || countryCode === 'ᴺᵁᴸᴸ') {
         return '🏳️';
     }
     return countryCode.toUpperCase().replace(/./g, char => String.fromCodePoint(char.charCodeAt(0) + 127397)

--- a/apps/stats/src/views/Stats/Sources.tsx
+++ b/apps/stats/src/views/Stats/Sources.tsx
@@ -19,7 +19,7 @@ const SourceRow: React.FC<SourceRowProps> = ({className, source}) => {
     return (
         <>
             <img
-                className="gh-stats-favicon"
+                className="size-4"
                 src={`https://www.faviconextractor.com/favicon/${source || 'direct'}?larger=true`}
                 onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
                     e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-666/unknown-location-has-broken-icons closes https://linear.app/ghost/issue/PROD-1568/icon-bug-in-sources

- The icon sizes class for Sources was missing after removing the Ember version of Traffic Analytics
- The flag for Unknown locations were not rendering correctly. Instead of the flag you'd see four squares