### PR TITLE
Added `post_uuid` filter to all Tinybird FORWARD pipes

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -140,6 +140,7 @@ SQL >
                 {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
                 {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
                 {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+                {% if defined(post_uuid) %} and post_uuid = {{String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
             group by date
             order by date
 
@@ -151,11 +152,10 @@ SQL >
             select
                 a.date as date,
                 coalesce(b.visits, 0) as visits,
-                {% if defined(pathname) %}coalesce(c.pageviews, 0){% else %}coalesce(b.pageviews, 0){% end %} as pageviews,
+                {% if defined(pathname) or defined(post_uuid) %}coalesce(c.pageviews, 0){% else %}coalesce(b.pageviews, 0){% end %} as pageviews,
                 coalesce(b.bounce_rate, 0) as bounce_rate,
                 coalesce(b.avg_session_sec, 0) as avg_session_sec
             from timeseries a
             left join data b on a.date = b.date
-            {% if defined(pathname) %}left join pathname_pageviews c on a.date = c.date{% end %}
-
+            {% if defined(pathname) or defined(post_uuid) %}left join pathname_pageviews c on a.date = c.date{% end %}
 TYPE ENDPOINT

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_browsers.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_browsers.pipe
@@ -45,6 +45,7 @@ SQL >
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+            {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
         group by browser
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
@@ -44,6 +44,7 @@ SQL >
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+            {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
         group by device
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
@@ -44,6 +44,7 @@ SQL >
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+            {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
         group by location
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_os.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_os.pipe
@@ -44,6 +44,7 @@ SQL >
             {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
             {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
             {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+            {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
         group by os
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -45,6 +45,7 @@ SQL >
         # --{% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
+        {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
     group by pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -24,10 +24,10 @@ SQL >
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-
+        {% if defined (post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
 
 NODE sessions_filtered_by_source
-DESCRIPTION > 
+DESCRIPTION >
     Further filter by source when using the source filter. This is necessary because the source is specific to the first hit in a session,
     whereas other filters are on hits.
 

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
@@ -71,6 +71,18 @@
     {"date":"2100-01-06","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
     {"date":"2100-01-07","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":1,"bounce_rate":0,"avg_session_sec":630}
+    {"date":"2100-01-02","visits":1,"pageviews":1,"bounce_rate":0,"avg_session_sec":1027}
+    {"date":"2100-01-03","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1115}
+    {"date":"2100-01-04","visits":2,"pageviews":3,"bounce_rate":0,"avg_session_sec":858}
+    {"date":"2100-01-05","visits":1,"pageviews":1,"bounce_rate":0,"avg_session_sec":123}
+    {"date":"2100-01-06","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&source=bing.com
@@ -147,7 +159,7 @@
     {"date":"2100-01-01 21:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 22:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 23:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
-    
+
 - name: Single day - Filtered by pathname - /about/
   description: Filtered by pathname - /about/
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-03&date_to=2100-01-03&pathname=%2Fabout%2F

--- a/ghost/core/core/server/data/tinybird/tests/api_top_browsers.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_browsers.yaml
@@ -50,6 +50,15 @@
     {"browser":"ie","visits":2}
     {"browser":"safari","visits":1}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"browser":"chrome","visits":3}
+    {"browser":"firefox","visits":2}
+    {"browser":"ie","visits":2}
+    {"browser":"safari","visits":1}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com

--- a/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_devices.yaml
@@ -37,6 +37,12 @@
   expected_result: |
     {"device":"desktop","visits":8}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"device":"desktop","visits":8}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com

--- a/ghost/core/core/server/data/tinybird/tests/api_top_locations.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_locations.yaml
@@ -53,6 +53,16 @@
     {"location":"DE","visits":1}
     {"location":"ES","visits":1}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"location":"GB","visits":4}
+    {"location":"FR","visits":1}
+    {"location":"US","visits":1}
+    {"location":"DE","visits":1}
+    {"location":"ES","visits":1}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com

--- a/ghost/core/core/server/data/tinybird/tests/api_top_os.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_os.yaml
@@ -40,6 +40,13 @@
     {"os":"windows","visits":7}
     {"os":"macos","visits":1}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"os":"windows","visits":7}
+    {"os":"macos","visits":1}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com

--- a/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
@@ -45,6 +45,12 @@
   expected_result: |
     {"pathname":"\/about\/","visits":8}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"pathname":"\/about\/","visits":8}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com

--- a/ghost/core/core/server/data/tinybird/tests/api_top_sources.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_sources.yaml
@@ -68,6 +68,15 @@
     {"source":"google.com","visits":1}
     {"source":"wilted-tick.com","visits":1}
 
+- name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"source":"","visits":4}
+    {"source":"bing.com","visits":2}
+    {"source":"google.com","visits":1}
+    {"source":"wilted-tick.com","visits":1}
+
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1541/add-a-filter-by-post-uuid-to-all-our-pipes

This commit makes the same changes as https://github.com/TryGhost/Ghost/commit/224b38dc16dc39f3453dbef5f3ae0a3b77e9fca8 to our Tinybird FORWARD pipes, to keep both implementations in sync while we transition to the Tinybird FORWARD implementation.

The events that we're sending from the tracker script pass along the
full `pathname` of the pageview. However, in the Admin views where we
pull the data, we're filtering on the `pathname` using
`pathname=/{slug}/`. This isn't always the actual path to the post on
the site's frontend, depending on their routing setup, so in some cases
this returns the incorrect data.

We do store the `post_uuid` for any pageviews, so we should filter by
that parameter instead of the `pathname`. This commit adds those filters to the Tinybird FORWARD pipes.