### PR TITLE
Prevented database tests running in CI when only Tinybird files have changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,7 +885,7 @@ jobs:
 
   # Tinyird Tests (Classic) — This test suite is deprecated and will be removed very soon.
   job_tinybird:
-    name: Tinybird Tests (Web Analytics)
+    name: Tinybird Tests (Classic)
     runs-on: ubuntu-latest
     env:
       TB_VERSION_WARNING: 0
@@ -1338,7 +1338,7 @@ jobs:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
 
   deploy_tinybird_forward:
-    name: Deploy Tinybird Forward
+    name: Deploy Tinybird (Forward)
     runs-on: ubuntu-latest
     needs: [
       job_setup,
@@ -1374,7 +1374,7 @@ jobs:
     strategy:
       matrix:
         environment: [ 'staging', 'production']
-    name: Deploy Tinybird
+    name: Deploy Tinybird (Classic)
     defaults:
       run:
         working-directory: ghost/web-analytics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
               - 'ghost/**'
               - '!ghost/admin/**'
               - '!ghost/web-analytics/**'
+              - '!ghost/core/core/server/data/tinybird/**'
             admin:
               - *shared
               - 'ghost/admin/**'


### PR DESCRIPTION
no refs

To make CI run faster on PRs that only change Tinybird datafiles, we shouldn't need to run the database tests. This had been working with the Tinybird files in `ghost/web-analytics`, but now that the Tinybird FORWARD files live in `ghost/core`, it was triggering the database tests. This commit adds an exclusion, so it will ignore changes to `ghost/core/core/server/data/tinybird` when deciding whether or not to run the database tests. 