### PR TITLE
Fixed filtering by post in post analytics web stats

### DIFF
--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -5,6 +5,7 @@ export type Post = {
     url: string;
     slug: string;
     title: string;
+    uuid: string;
 };
 
 export interface PostsResponseType {

--- a/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
+++ b/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
@@ -42,8 +42,7 @@ const PostAnalytics: React.FC<postAnalyticsProps> = () => {
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
             timezone: timezone,
-            member_status: getAudienceQueryParam(audience),
-            pathname: ''
+            member_status: getAudienceQueryParam(audience)
         };
 
         if (!isPostLoading && post?.slug) {

--- a/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
+++ b/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
@@ -42,7 +42,8 @@ const PostAnalytics: React.FC<postAnalyticsProps> = () => {
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
             timezone: timezone,
-            member_status: getAudienceQueryParam(audience)
+            member_status: getAudienceQueryParam(audience),
+            post_uuid: ''
         };
 
         if (!isPostLoading && post?.uuid) {

--- a/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
+++ b/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
@@ -29,7 +29,7 @@ const PostAnalytics: React.FC<postAnalyticsProps> = () => {
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at'
+            fields: 'title,slug,published_at,uuid'
         }
     });
 
@@ -49,7 +49,7 @@ const PostAnalytics: React.FC<postAnalyticsProps> = () => {
         if (!isPostLoading && post?.slug) {
             return {
                 ...baseParams,
-                pathname: `/${post.slug}/`
+                post_uuid: post.uuid
             };
         }
 

--- a/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
+++ b/apps/posts/src/views/PostAnalytics/PostAnalytics.tsx
@@ -45,7 +45,7 @@ const PostAnalytics: React.FC<postAnalyticsProps> = () => {
             member_status: getAudienceQueryParam(audience)
         };
 
-        if (!isPostLoading && post?.slug) {
+        if (!isPostLoading && post?.uuid) {
             return {
                 ...baseParams,
                 post_uuid: post.uuid


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1541/add-a-filter-by-post-uuid-to-all-our-pipes

The Post Analytics web stats view was filtering to the post using the `pathname` parameter, based on the slug of the post. This doesn't work for posts that are impacted by custom routing, since the events have the full pathname, while the filter we were using here only includes the slug.

This commit updates this view to filter on the `post_uuid` instead of the pathname, so we can accurately return all the pageviews for the post, regardless of custom routing or if the slug ever changes.