### PR TITLE
Fixed CI skipping `admin-x-settings` tests if only `admin-x-framework` changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
               - *shared
               - 'apps/admin-x-settings/**'
               - 'apps/admin-x-design-system/**'
+              - 'apps/admin-x-framework/**'
             announcement-bar:
               - *shared
               - 'apps/announcement-bar/**'


### PR DESCRIPTION
no refs

The `admin-x-settings` packages all depend on `admin-x-framework` in some capacity, so we should always run their tests if `admin-x-framework` changes. This wasn't happening previously — this commit fixes that.

Without this, it's possible to make changes to `admin-x-framework` which inadvertently break `admin-x-settings` without realizing it. With this fix, we'll always run the tests if we update the framework, which should catch such instances.