### PR TITLE
Fixed `ESC` key behaviour in Post Preview

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/browser.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/browser.hbs
@@ -2,14 +2,14 @@
     <div class="modal-body modal-preview-email-content gh-pe-mobile-container gh-post-preview-container h-auto overflow-auto {{unless @skipAnimation "fade-in"}}">
         <div class="gh-pe-mobile-bezel">
             <div class="gh-pe-mobile-screen">
-                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{close-dropdowns-on-click}}></iframe>
+                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupIframe}}></iframe>
             </div>
         </div>
     </div>
 {{else}}
     <div class="gh-post-preview-container gh-post-preview-browser-container {{unless @skipAnimation "fade-in"}}">
         <div class="gh-browserpreview-iframecontainer">
-            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{close-dropdowns-on-click}}></iframe>
+            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupIframe}}></iframe>
         </div>
     </div>
 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+
+export default class ModalPostPreviewBrowserComponent extends Component {
+    @action
+    setupIframe(event) {
+        const iframe = event.target;
+
+        // Add keydown event listener to the iframe's contentWindow
+        iframe.contentWindow.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                // Prevent the default behavior in the iframe
+                e.preventDefault();
+                e.stopPropagation();
+
+                // Create and dispatch a new ESC key event to the parent window
+                const escEvent = new KeyboardEvent('keydown', {
+                    key: 'Escape',
+                    code: 'Escape',
+                    keyCode: 27,
+                    which: 27,
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true
+                });
+
+                // Dispatch the event on the document instead of window
+                document.dispatchEvent(escEvent);
+            }
+        });
+    }
+}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/DES-1181/esc-is-not-escaping-post-preview

- The `ESC` key wasn't closing the Post Preview modal once the focus was on the preview (by clicking on the preview iFrame)