### PR TITLE
🐛 Fixed shared preview links not respecting selected member segment

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -5,10 +5,10 @@
         </div>
         <div class="gh-post-preview-btn-group">
             <div class="gh-contentfilter gh-btn-group">
-                <button type="button" class="gh-btn gh-post-preview-mode {{if (eq this.previewFormat "browser") "gh-btn-group-selected"}}" {{on "click" (fn this.changePreviewFormat "browser")}}><span>Web</span></button>
+                <button type="button" class="gh-btn gh-post-preview-mode {{if (eq this.previewFormat "browser") "gh-btn-group-selected"}}" {{on "click" (fn this.changePreviewFormat "browser")}} data-test-button="browser-preview" data-test-selected={{eq this.previewFormat "browser"}}><span>Web</span></button>
                 {{#if (and this.settings.membersEnabled (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
                     {{#if (and @data.publishOptions.post.isPost (not @data.publishOptions.user.isContributor))}}
-                        <button type="button" class="gh-btn {{if (eq this.previewFormat "email") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewFormat "email")}} data-test-button="email-preview"><span>Email</span></button>
+                        <button type="button" class="gh-btn {{if (eq this.previewFormat "email") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewFormat "email")}} data-test-button="email-preview" data-test-selected={{eq this.previewFormat "email"}}><span>Email</span></button>
                     {{/if}}
                 {{/if}}
             </div>
@@ -39,7 +39,7 @@
                 <GhDropdownButton
                     @dropdownName="post-preview-share"
                     @classNames="gh-btn gh-btn-preview gh-post-preview-url"
-                    data-test-button="post-preview-test-email"
+                    data-test-button="share-preview"
                 >
                     <span>{{svg-jar "share"}}</span>
                 </GhDropdownButton>
@@ -59,7 +59,7 @@
                             @class="gh-btn gh-btn-icon gh-btn-preview gh-post-copy-url"
                             data-test-button="copy-draft-link"
                         />
-                        <a href={{@data.publishOptions.post.previewUrl}} target="_blank" rel="noopener noreferrer" class="gh-btn gh-btn-preview gh-publish-preview-newtab" data-test-link="open-draft">
+                        <a href={{this.browserPreviewUrl}} target="_blank" rel="noopener noreferrer" class="gh-btn gh-btn-preview gh-publish-preview-newtab" data-test-link="open-draft">
                             <span>{{svg-jar "external"}}Open in new tab</span>
                         </a>
                     </div>

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -126,7 +126,7 @@ export default class EditorPostPreviewModal extends Component {
 
     @task
     *copyPreviewUrlTask() {
-        copyTextToClipboard(this.args.data.publishOptions.post.previewUrl);
+        copyTextToClipboard(this.browserPreviewUrl);
         return yield true;
     }
 }

--- a/ghost/admin/tests/acceptance/editor/post-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-preview-test.js
@@ -1,0 +1,48 @@
+import loginAsRole from '../../helpers/login-as-role';
+import {click, find} from '@ember/test-helpers';
+import {enableMailgun} from '../../helpers/mailgun';
+import {enableMembers, enablePaidMembers} from '../../helpers/members';
+import {expect} from 'chai';
+import {selectChoose} from 'ember-power-select/test-support/helpers';
+import {setupApplicationTest} from 'ember-mocha';
+import {setupMirage} from 'ember-cli-mirage/test-support';
+import {visit} from '../../helpers/visit';
+
+describe('Acceptance: Post preview', function () {
+    let hooks = setupApplicationTest();
+    setupMirage(hooks);
+
+    beforeEach(async function () {
+        this.server.loadFixtures();
+        enableMailgun(this.server);
+        enableMembers(this.server);
+        enablePaidMembers(this.server);
+        await loginAsRole('Administrator', this.server);
+    });
+
+    const openPreviewModal = async function () {
+        const post = this.server.create('post', {status: 'draft'});
+        await visit(`/editor/post/${post.id}`);
+        await click('[data-test-button="publish-preview"]');
+    };
+
+    it('uses correct member status for new tab preview link', async function () {
+        await openPreviewModal.call(this);
+
+        // ensure we're on the browser tab and "free" segment is selected
+        expect(find('[data-test-button="browser-preview"]')).to.have.attribute('data-test-selected');
+        expect(find('[data-test-select="preview-segment"]')).to.contain.text('Free member');
+
+        // open the share dropdown
+        await click('[data-test-button="share-preview"]');
+
+        // check the preview link has the expected query param added
+        let url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('free');
+
+        // changing segment should update the link
+        await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
+        url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('paid');
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-594

- switched "Open in new tab" and "Copy preview link" over to the `member_status` query-param containing URL so they match what's shown in the preview modal
