### PR TITLE
Added parsed referrer to ghost-stats script

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import timezoneData from '@tryghost/timezone-data';
-import { getReferrer } from '../utils/url-attribution';
+import { getReferrer, parseReferrer } from '../utils/url-attribution';
 import { getSessionId, setSessionId, getStorageObject } from '../utils/session-storage';
 import { processPayload } from '../utils/privacy';
 
@@ -168,7 +168,8 @@ import { processPayload } from '../utils/privacy';
                 'user-agent': window.navigator.userAgent,
                 locale,
                 location: country,
-                referrer: getReferrer(),
+                referrer: getReferrer(window.location.href),
+                parsedReferrer: parseReferrer(window.location.href),
                 pathname: window.location.pathname,
                 href: window.location.href,
             });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-4/

In order for the analytics proxy server to process the referrer, we need to pass the whole object. For now, we'll do this as a separate value in the payload while we validate the results.