### PR TITLE
Added `post_uuid` to top pages pipe

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -5,6 +5,7 @@ SQL >
 
     %
     select
+        case when post_uuid = 'undefined' then '' else post_uuid end as post_uuid,
         pathname,
         uniqExact(session_id) as visits
     from _mv_hits h
@@ -46,7 +47,7 @@ SQL >
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
         {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
-    group by pathname
+    group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}
 

--- a/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
@@ -3,90 +3,96 @@
   description: All fixture data
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":10}
-    {"pathname":"\/about\/","visits":8}
-    {"pathname":"\/","visits":7}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":9}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
+    {"post_uuid":"","pathname":"\/","visits":7}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Filtered by browser - Chrome
   description: Filtered by browser - Chrome
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&browser=chrome
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":6}
-    {"pathname":"\/about\/","visits":3}
-    {"pathname":"\/","visits":3}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":6}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":3}
+    {"post_uuid":"","pathname":"\/","visits":3}
 
 - name: Filtered by device - desktop
   description: Filtered by device - desktop
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&device=desktop
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":9}
-    {"pathname":"\/about\/","visits":8}
-    {"pathname":"\/","visits":7}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":8}
+    {"post_uuid":"","pathname":"\/","visits":7}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Filtered by location - UK
   description: Filtered by location - UK
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&location=GB
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":6}
-    {"pathname":"\/about\/","visits":4}
-    {"pathname":"\/","visits":4}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":6}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":4}
+    {"post_uuid":"","pathname":"\/","visits":4}
 
 - name: Filtered by OS - Windows
   description: Filtered by OS - Windows
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&os=windows
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":9}
-    {"pathname":"\/about\/","visits":7}
-    {"pathname":"\/","visits":7}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":8}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":7}
+    {"post_uuid":"","pathname":"\/","visits":7}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Filtered by pathname - /about/
   description: Filtered by pathname - /about/
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&pathname=%2Fabout%2F
   expected_result: |
-    {"pathname":"\/about\/","visits":8}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
 
 - name: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
   description: Filtered by post_uuid - 06b1b0c9-fb53-4a15-a060-3db3fde7b1fc (/about/)
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_uuid=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
   expected_result: |
-    {"pathname":"\/about\/","visits":8}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
 
 - name: Filtered by source - bing.com
   description: Filtered by source - bing.com
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&source=bing.com
   expected_result: |
-    {"pathname":"\/about\/","visits":2}
-    {"pathname":"\/","visits":1}
-    {"pathname":"\/blog\/hello-world\/","visits":1}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":2}
+    {"post_uuid":"","pathname":"\/","visits":1}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Filtered by member status - paid
   description: Filtered by member status - paid
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&member_status=paid
   expected_result: |
-    {"pathname":"\/about\/","visits":3}
-    {"pathname":"\/blog\/hello-world\/","visits":3}
-    {"pathname":"\/","visits":2}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":3}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":3}
+    {"post_uuid":"","pathname":"\/","visits":2}
 
 - name: Filtered by member status - undefined
   description: Filtered by member status - undefined
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&member_status=undefined
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":5}
-    {"pathname":"\/about\/","visits":2}
-    {"pathname":"\/","visits":1}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":4}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":2}
+    {"post_uuid":"","pathname":"\/","visits":1}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Filtered by timezone - America/Los_Angeles
   description: Filtered by timezone - America/Los_Angeles
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=America/Los_Angeles
   expected_result: |
-    {"pathname":"\/blog\/hello-world\/","visits":9}
-    {"pathname":"\/about\/","visits":7}
-    {"pathname":"\/","visits":5}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":8}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":7}
+    {"post_uuid":"","pathname":"\/","visits":5}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
 
 - name: Test with multiple filters combined
   description: Test with multiple filters combined
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&device=desktop&browser=firefox
   expected_result: |
-    {"pathname":"\/","visits":3}
-    {"pathname":"\/about\/","visits":2}
-    {"pathname":"\/blog\/hello-world\/","visits":2}
+    {"post_uuid":"","pathname":"\/","visits":3}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":2}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":1}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}

--- a/ghost/web-analytics/pipes/api_top_pages.pipe
+++ b/ghost/web-analytics/pipes/api_top_pages.pipe
@@ -6,6 +6,7 @@ SQL >
 
     %
     select
+        case when post_uuid = 'undefined' then '' else post_uuid end as post_uuid,
         pathname,
         uniqExact(session_id) as visits
     from _mv_hits h
@@ -47,6 +48,6 @@ SQL >
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
         {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
-    group by pathname
+    group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/web-analytics/tests/all_top_pages.test.result
+++ b/ghost/web-analytics/tests/all_top_pages.test.result
@@ -1,4 +1,5 @@
-"pathname","visits"
-"/blog/hello-world/",10
-"/about/",8
-"/",7
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",9
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",8
+"","/",7
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","/blog/hello-world/",1

--- a/ghost/web-analytics/tests/filter_browser_chrome_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_browser_chrome_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/blog/hello-world/",6
-"/about/",3
-"/",3
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",6
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",3
+"","/",3

--- a/ghost/web-analytics/tests/filter_device_desktop_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_device_desktop_top_pages.test.result
@@ -1,4 +1,5 @@
-"pathname","visits"
-"/blog/hello-world/",9
-"/about/",8
-"/",7
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",8
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",8
+"","/",7
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","/blog/hello-world/",1

--- a/ghost/web-analytics/tests/filter_location_gb_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_location_gb_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/blog/hello-world/",6
-"/about/",4
-"/",4
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",6
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",4
+"","/",4

--- a/ghost/web-analytics/tests/filter_member_status_paid_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_member_status_paid_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/about/",3
-"/blog/hello-world/",3
-"/",2
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",3
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",3
+"","/",2

--- a/ghost/web-analytics/tests/filter_member_status_undefined_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_member_status_undefined_top_pages.test.result
@@ -1,4 +1,5 @@
-"pathname","visits"
-"/blog/hello-world/",5
-"/about/",2
-"/",1
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",4
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",2
+"","/",1
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","/blog/hello-world/",1

--- a/ghost/web-analytics/tests/filter_os_windows_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_os_windows_top_pages.test.result
@@ -1,4 +1,5 @@
-"pathname","visits"
-"/blog/hello-world/",9
-"/about/",7
-"/",7
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",8
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",7
+"","/",7
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","/blog/hello-world/",1

--- a/ghost/web-analytics/tests/filter_pathname_about_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_pathname_about_top_pages.test.result
@@ -1,2 +1,2 @@
-"pathname","visits"
-"/about/",8
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",8

--- a/ghost/web-analytics/tests/filter_post_uuid_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_post_uuid_top_pages.test.result
@@ -1,2 +1,2 @@
-"pathname","visits"
-"/about/",8
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",8

--- a/ghost/web-analytics/tests/filter_source_bing_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_source_bing_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/about/",2
-"/",1
-"/blog/hello-world/",1
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",2
+"","/",1
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",1

--- a/ghost/web-analytics/tests/filter_source_direct_browser_chrome_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_source_direct_browser_chrome_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/blog/hello-world/",3
-"/about/",2
-"/",2
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",3
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",2
+"","/",2

--- a/ghost/web-analytics/tests/filter_source_direct_top_pages.test.result
+++ b/ghost/web-analytics/tests/filter_source_direct_top_pages.test.result
@@ -1,4 +1,4 @@
-"pathname","visits"
-"/about/",4
-"/blog/hello-world/",4
-"/",2
+"post_uuid","pathname","visits"
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",4
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",4
+"","/",2

--- a/ghost/web-analytics/tests/timezone_top_pages.test.result
+++ b/ghost/web-analytics/tests/timezone_top_pages.test.result
@@ -1,4 +1,5 @@
-"pathname","visits"
-"/blog/hello-world/",9
-"/about/",7
-"/",5
+"post_uuid","pathname","visits"
+"6b8635fb-292f-4422-9fe4-d76cfab2ba31","/blog/hello-world/",8
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","/about/",7
+"","/",5
+"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","/blog/hello-world/",1


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-12/

The top pages pipe/endpoint currently only outputs the pathname and count. We want to be able to display the name of the content (post name, page name, etc), so we need to expose the post_uuid.

Because we need to mesh this data with Ghost data, we'll have to follow this up with Ghost's backend doing the fetching from Tinybird and meshing that with data from Ghost's db.