### PR TITLE
Added `jsonc` parsing for local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ test/functional/*.png
 
 # ignore all custom json files for config
 /ghost/core/config.*.json
+/ghost/core/config.*.jsonc
 
 # Built asset files
 /ghost/core/core/built

--- a/ghost/core/core/shared/config/loader.js
+++ b/ghost/core/core/shared/config/loader.js
@@ -5,7 +5,6 @@ const debug = _debug('ghost:config');
 const localUtils = require('./utils');
 const helpers = require('./helpers');
 const urlHelpers = require('@tryghost/config-url-helpers');
-const env = process.env.NODE_ENV || 'development';
 
 /**
  * @param {object} options
@@ -13,6 +12,7 @@ const env = process.env.NODE_ENV || 'development';
  */
 function loadNconf(options) {
     debug('config start');
+    const env = localUtils.getNodeEnv();
     options = options || {};
 
     const baseConfigPath = options.baseConfigPath || __dirname;
@@ -35,6 +35,10 @@ function loadNconf(options) {
             nconf.file('docker-env', path.join(baseConfigPath, 'env', 'config.development.docker.json'));
         }
         nconf.file('local-env', path.join(customConfigPath, 'config.local.json'));
+        nconf.file('local-env-jsonc', {
+            file: path.join(customConfigPath, 'config.local.jsonc'),
+            format: localUtils.jsoncFormat
+        });
     }
     nconf.file('default-env', path.join(baseConfigPath, 'env', 'config.' + env + '.json'));
 
@@ -73,7 +77,8 @@ function loadNconf(options) {
     }
 
     debug('config end');
-    return nconf;
+    // Assert the type to include the dynamically bound helpers
+    return /** @type {Nconf.Provider & urlHelpers.BoundHelpers & helpers.ConfigHelpers} */ (nconf);
 }
 
 module.exports.loadNconf = loadNconf;

--- a/ghost/core/core/shared/config/utils.js
+++ b/ghost/core/core/shared/config/utils.js
@@ -86,8 +86,7 @@ const jsoncFormat = {
     stringify: function (obj, replacer, spacing) {
         return JSON.stringify(obj, replacer, spacing);
     }
-}
-
+};
 
 module.exports = {
     makePathsAbsolute,

--- a/ghost/core/core/shared/config/utils.js
+++ b/ghost/core/core/shared/config/utils.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const jsonc = require('jsonc-parser');
 
 /**
  * transform all relative paths to absolute paths
@@ -74,9 +75,25 @@ const sanitizeDatabaseProperties = function sanitizeDatabaseProperties(nconf) {
     }
 };
 
+const getNodeEnv = () => {
+    return process.env.NODE_ENV || 'development';
+};
+
+const jsoncFormat = {
+    parse: function (text) {
+        return jsonc.parse(text);
+    },
+    stringify: function (obj, replacer, spacing) {
+        return JSON.stringify(obj, replacer, spacing);
+    }
+}
+
+
 module.exports = {
     makePathsAbsolute,
     doesContentPathExist,
     checkUrlProtocol,
-    sanitizeDatabaseProperties
+    sanitizeDatabaseProperties,
+    getNodeEnv,
+    jsoncFormat
 };

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -177,7 +177,7 @@
     "intl-messageformat": "5.4.3",
     "js-yaml": "4.1.0",
     "json-stable-stringify": "1.3.0",
-    "jsonc-parser": "^3.3.1",
+    "jsonc-parser": "3.3.1",
     "jsonpath": "1.1.1",
     "jsonwebtoken": "8.5.1",
     "juice": "9.1.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -177,6 +177,7 @@
     "intl-messageformat": "5.4.3",
     "js-yaml": "4.1.0",
     "json-stable-stringify": "1.3.0",
+    "jsonc-parser": "^3.3.1",
     "jsonpath": "1.1.1",
     "jsonwebtoken": "8.5.1",
     "juice": "9.1.0",

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -3,7 +3,8 @@ const path = require('path');
 const rewire = require('rewire');
 const _ = require('lodash');
 const configUtils = require('../../../utils/configUtils');
-
+const sinon = require('sinon');
+const localUtils = require('../../../../core/shared/config/utils');
 describe('Config Loader', function () {
     before(async function () {
         await configUtils.restore();
@@ -18,12 +19,13 @@ describe('Config Loader', function () {
         let originalArgv;
         let customConfig;
         let loader;
+        let nodeEnvStub;
 
         beforeEach(function () {
             originalEnv = _.clone(process.env);
             originalArgv = _.clone(process.argv);
             loader = rewire('../../../../core/shared/config/loader');
-
+            nodeEnvStub = sinon.stub(localUtils, 'getNodeEnv').returns('testing');
             // we manually call `loadConf` in the tests and we need to ensure that the minimum
             // required config properties are available
             process.env.paths__contentPath = 'content/';
@@ -32,6 +34,7 @@ describe('Config Loader', function () {
         afterEach(function () {
             process.env = originalEnv;
             process.argv = originalArgv;
+            sinon.restore();
         });
 
         it('env parameter is stronger than file', function () {
@@ -82,6 +85,17 @@ describe('Config Loader', function () {
             customConfig.get('url').should.eql('http://localhost:2368');
             customConfig.get('logging:level').should.eql('error');
             customConfig.get('logging:transports').should.eql(['stdout']);
+        });
+
+        it('should load JSONC files', function () {
+            nodeEnvStub.returns('development');
+            customConfig = loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            });
+
+            customConfig.get('site_uuid').should.eql('a58fe20c-0af0-4fc6-9b1a-20873d5b7d03');
+            should.not.exist(customConfig.get('commented'));
         });
     });
 

--- a/ghost/core/test/utils/fixtures/config/config.local.jsonc
+++ b/ghost/core/test/utils/fixtures/config/config.local.jsonc
@@ -1,0 +1,16 @@
+{
+    // "commented": "This is a commented out config",
+    "site_uuid": "a58fe20c-0af0-4fc6-9b1a-20873d5b7d03",
+    "paths": {
+        "corePath": "try-to-override"
+    },
+    "database": {
+        "connection": {
+            "filename": "/hehe.db"
+        },
+        "debug": true
+    },
+    "logging": {
+        "level": "error"
+    }
+}

--- a/ghost/core/test/utils/fixtures/config/env/config.development.json
+++ b/ghost/core/test/utils/fixtures/config/env/config.development.json
@@ -1,0 +1,7 @@
+{
+    "url": "http://localhost:2368",
+    "logging": {
+        "level": "info",
+        "transports": ["stdout"]
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21178,6 +21178,11 @@ jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
+jsonc-parser@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"


### PR DESCRIPTION
no refs

It would be nice to be able to comment out parts of our local configuration when in development, so we can easily enable/disable certain blocks of configuration depending on what we're working on without having to completely delete it. Currently we can't do this because our config loader only accepts `.json` files, and the standard JSON spec does not allow comments.

However, nconf can be extended to use custom file formats, and that's exactly what this PR does. With this current implementation, Ghost will look for a `ghost/core/config.local.jsonc` file in your local repo, in addition to the default `config.local.json` file. If you rename your current `config.local.json` to `config.local.jsonc`, it will be loaded instead, and you can enable/disable blocks of config using JavaScript style comments.

The actual `jsonc` parsing is handled by `[jsonc-parser](https://www.npmjs.com/package/jsonc-parser)`, which is a small node project maintained by Microsoft. 

There may also be applications for doing this in other configuration files for the purpose of documentation, but for now this only adds `jsonc` parsing for the `config.local.jsonc` file.