### PR TITLE
Fixed reply notification issues in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.6.73",
+  "version": "0.6.74",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -132,7 +132,7 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
                 content = stripHtml(group.inReplyTo.title);
             }
 
-            return <>{actorText} replied to your {group.post?.type === 'article' ? 'post' : 'note'} <span className='font-semibold'>{truncate(content, 80)}</span></>;
+            return <>{actorText} replied to your {group.inReplyTo?.type === 'article' ? 'post' : 'note'} <span className='font-semibold'>{truncate(content, 80)}</span></>;
         }
     }
 
@@ -195,7 +195,7 @@ const Notifications: React.FC = () => {
             break;
         case 'reply':
             if (group.post && group.inReplyTo) {
-                navigate(`/${group.inReplyTo.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
+                navigate(`/feed/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'repost':


### PR DESCRIPTION
ref PROD-1555

- instead of opening the reader when post replies are clicked in the notifications, they're now displayed in the feed layout
- article and notes weren't distinguished in reply notifications, now they are correctly identified