### PR TITLE
Added nx reset to docker entrypoint

### DIFF
--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+yarn nx reset
+
 # Execute the CMD
 exec "$@"


### PR DESCRIPTION
no refs

The NX Daemon gets into a bad state fairly often when running in docker compose, causing annoying errors. The immediate solution to this is to run `yarn nx reset` to restart the daemon and clear the nx cache.

Luckily this command is pretty quick to run, so until we're able to fully fix the NX Daemon issues, this should hopefully reduce the error rate in the meantime.