### PR TITLE
Added delay before purging jsDelivr cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1332,7 +1332,13 @@ jobs:
         if: steps.version_check.outputs.version_changed == 'true'
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
-      - name: Purge jsdelivr cache
+      - name: Wait before purging jsDelivr cache
+        if: steps.version_check.outputs.version_changed == 'true'
+        run: |
+          echo "Purging jsDelivr cache immediately after publishing a new version on NPM is unreliable. Waiting 1 minute before purging cache..."
+          sleep 60
+
+      - name: Purge jsDelivr cache
         if: steps.version_check.outputs.version_changed == 'true'
         uses: gacts/purge-jsdelivr-cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1333,7 +1333,7 @@ jobs:
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
       - name: Wait before purging jsDelivr cache
-        if: steps.version_check.outputs.version_changed == 'true'
+        if: steps.version_check.outputs.version_changed == 'true' && matrix.package_name == '@tryghost/admin-x-activitypub'
         run: |
           echo "Purging jsDelivr cache immediately after publishing a new version on NPM is unreliable. Waiting 1 minute before purging cache..."
           sleep 60


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1573

- last week, purging jsDelivr cache after publishing a new NPM version of admin-x-activitypub was unreliable:
   - we released a new version (0.6.68) of our JS package, admin-x-activitypub, last Thursday 24/04 around ~17:45 UTC. The cache was purged immediately after and Mike could see the latest version on his production site 
   - but, on the next day, Mike opened his production site again and was served a previous version. Same browser / same location (no VPN)

- release process:
    1. We bump the version of a package in a commit
    2. Once the commit is merged to our main branch, CI checks whether a new version has been created, and if yes, publishes a new version to npm
    3. Once a new version has been published, CI immediately clears jsDelivr cache

- maintainer of jsDelivr suggested adding one minute delay to avoid this edge case: npm registry takes at least a few seconds to start reporting the new version after it's published and jsDelivr caches the version list for 30 seconds

