### PR TITLE
Removed Node v18 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
     if: needs.job_setup.outputs.changed_any_code == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1', '20.11.1', '22.13.1' ]
+        node: [ '20.11.1', '22.13.1' ]
     name: Unit tests (Node ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4
@@ -504,7 +504,7 @@ jobs:
     if: needs.job_setup.outputs.changed_core == 'true'
     strategy:
       matrix:
-        node: [ '18.12.1', '20.11.1', '22.13.1' ]
+        node: [ '20.11.1', '22.13.1' ]
         env:
           - DB: mysql8
             NODE_ENV: testing-mysql


### PR DESCRIPTION
ref https://github.com/nodejs/release#release-schedule

- Node v18 is EOL as of today. We no longer need to support it.
- Today we will drop the build from CI, so we won't be aware of bugs introduced
- We will drop Node v18 from the supported versions in the engines flags sometime later, likely in our next major bump, as this is quite disruptive and abrupt for people self hosting

