### PR TITLE
Added explicit types for event handlers to fix flakey tests

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -22,7 +22,7 @@
     "lint": "yarn run lint:code && yarn run lint:test",
     "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
     "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx --cache test",
-    "test:unit": "echo \"Fix me!!\"",
+    "test:unit": "tsc --noEmit && vitest run",
     "test:acceptance": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
     "test:acceptance:slowmo": "TIMEOUT=100000 PLAYWRIGHT_SLOWMO=100 yarn test:acceptance --headed",
     "test:acceptance:full": "ALL_BROWSERS=1 yarn test:acceptance",

--- a/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/ArticleModal.tsx
@@ -780,7 +780,7 @@ export const ArticleModal: React.FC<ArticleModalProps> = ({
                                                         title='Typeface'
                                                         value={fontFamily}
                                                         onFocus={() => {}}
-                                                        onSelect={option => setFontFamily(option || {
+                                                        onSelect={(option: SelectOption | null) => setFontFamily(option || {
                                                             value: FONT_SANS,
                                                             label: 'Clean sans-serif',
                                                             className: 'font-sans'

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -139,7 +139,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                     clearBg
                     hideTitle
                     unstyled
-                    onChange={e => setQuery(e.target.value)}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
                 />
             </div>
             <div className='min-h-[320px]'>

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -261,7 +261,7 @@ const Notifications: React.FC = () => {
                                                         )}
 
                                                         {group.actors.length > 1 && (
-                                                            <Button className={`group flex items-center gap-0.5 text-gray-700 hover:bg-transparent hover:text-black dark:text-gray-600 dark:hover:text-white ${openStates[group.id || `${group.type}_${index}`] ? 'ml-[-20px]' : 'ml-0 w-[28px]'}`} variant='ghost' onClick={(event) => {
+                                                            <Button className={`group flex items-center gap-0.5 text-gray-700 hover:bg-transparent hover:text-black dark:text-gray-600 dark:hover:text-white ${openStates[group.id || `${group.type}_${index}`] ? 'ml-[-20px]' : 'ml-0 w-[28px]'}`} variant='ghost'onClick={(event?: React.MouseEvent<HTMLElement>) => {
                                                                 event?.stopPropagation();
                                                                 toggleOpen(group.id || `${group.type}_${index}`);
                                                             }}>

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -261,7 +261,7 @@ const Notifications: React.FC = () => {
                                                         )}
 
                                                         {group.actors.length > 1 && (
-                                                            <Button className={`group flex items-center gap-0.5 text-gray-700 hover:bg-transparent hover:text-black dark:text-gray-600 dark:hover:text-white ${openStates[group.id || `${group.type}_${index}`] ? 'ml-[-20px]' : 'ml-0 w-[28px]'}`} variant='ghost'onClick={(event?: React.MouseEvent<HTMLElement>) => {
+                                                            <Button className={`group flex items-center gap-0.5 text-gray-700 hover:bg-transparent hover:text-black dark:text-gray-600 dark:hover:text-white ${openStates[group.id || `${group.type}_${index}`] ? 'ml-[-20px]' : 'ml-0 w-[28px]'}`} variant='ghost' onClick={(event?: React.MouseEvent<HTMLElement>) => {
                                                                 event?.stopPropagation();
                                                                 toggleOpen(group.id || `${group.type}_${index}`);
                                                             }}>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1574
    
- Typescript should normally be able to infer type for e.g. 'event' in an onClick handler, but we're seeing flakey tests on CI with the TS error: `error TS7006: Parameter 'event' implicitly has an 'any' type`
- Writing these types explicitly should help reduce flakey tests, by not relying on Typescript's inference system