### PR TITLE
Fixed notification header text overflow issue in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -306,7 +306,7 @@ const Notifications: React.FC = () => {
                                                             <Skeleton className='w-full max-w-60' />
                                                         </> :
                                                         <div className='flex items-center gap-1'>
-                                                            <span><NotificationGroupDescription group={group} /></span>
+                                                            <span className='truncate'><NotificationGroupDescription group={group} /></span>
                                                             <span className='mt-px text-[8px]'>&bull;</span>
                                                             <span className='mt-0.5 text-sm'>{renderTimestamp(group, false)}</span>
                                                         </div>

--- a/apps/admin-x-activitypub/src/views/Notifications/components/NotificationItem.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/components/NotificationItem.tsx
@@ -50,7 +50,7 @@ const Avatars = ({children}: {children: React.ReactNode}) => {
 
 const Content = ({children}: {children: React.ReactNode}) => {
     return (
-        <div className='col-start-2 row-start-2 -mt-0.5'>
+        <div className='col-start-2 row-start-2 -mt-0.5 overflow-hidden'>
             {children}
         </div>
     );


### PR DESCRIPTION
no issues

- when notification author name contains long text, it broke the layout of the notification header
- now it applies correct truncation fix, so the long text doesn't overflow and break the layout