### PR TITLE
Fixed yarn docker:dev console coloring

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -195,6 +195,7 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
+    tty: true
 
   storybook:
     <<: *service-template


### PR DESCRIPTION
no refs

I accidentally removed the `tty` from the `ghost` service earlier, and it made the output sad in black and white. Adding it back now.