### PR TITLE
Added WebP image attachment support to the feed in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -86,6 +86,7 @@ export function renderFeedAttachment(
     case 'image/jpeg':
     case 'image/png':
     case 'image/gif':
+    case 'image/webp':
         return <img alt={attachment.name || 'Image'} className={`cursor-pointer ${object.type === 'Article' ? 'w-full rounded-t-md' : 'mt-3 max-h-[420px] rounded-md outline outline-1 -outline-offset-1 outline-black/10'}`} src={attachment.url} onClick={onImageClick ? handleImageClick(attachment.url) : undefined} />;
     case 'video/mp4':
     case 'video/webm':


### PR DESCRIPTION
ref PROD-1567

- extended note attachment renderer to display WebP format images in addition to existing JPG, PNG, and GIF formats
- users can now view WebP images in notes, providing better visual quality with smaller file sizes