### PR TITLE
Handled 403 errors from account interactions

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -190,6 +190,13 @@ export class ActivityPubAPI {
         }
 
         const json = await response.json();
+
+        if (!response.ok) {
+            const error = new Error(json?.message || json?.error || 'Unexpected Error');
+            error.statusCode = response.status;
+            throw error;
+        }
+
         return json;
     }
 

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -192,8 +192,10 @@ export class ActivityPubAPI {
         const json = await response.json();
 
         if (!response.ok) {
-            const error = new Error(json?.message || json?.error || 'Unexpected Error');
-            error.statusCode = response.status;
+            const error = {
+                message: json?.message || json?.error || 'Unexpected Error',
+                statusCode: response.status
+            };
             throw error;
         }
 

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -59,7 +59,11 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const handleLikeClick = async (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         if (!isLiked) {
-            likeMutation.mutate(object.id);
+            likeMutation.mutate(object.id, {
+                onError() {
+                    setIsLiked(false);
+                }
+            });
         } else {
             unlikeMutation.mutate(object.id);
         }
@@ -119,7 +123,12 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
                 e?.stopPropagation();
 
                 if (!isReposted) {
-                    repostMutation.mutate(object.id);
+                    repostMutation.mutate(object.id, {
+                        onError() {
+                            setIsReposted(false);
+                            decrementReposts();
+                        }
+                    });
                     incrementReposts();
                 } else {
                     derepostMutation.mutate(object.id);

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -1131,7 +1131,7 @@ export function useReplyMutationForUser(handle: string, actorProps?: ActorProper
 
             updateActivityInCollection(queryClient, QUERY_KEYS.thread(variables.inReplyTo), 'posts', context?.id ?? '', () => preparedActivity);
         },
-          onError(error: {message: string, statusCode: number}, variables, context) {
+        onError(error: {message: string, statusCode: number}, variables, context) {
             // eslint-disable-next-line no-console
             console.error(error);
 

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -261,7 +261,8 @@ export function useLikeMutationForUser(handle: string) {
 
             if (error.statusCode === 403) {
                 showToast({
-                    message: 'You cannot interact with this account.',
+                    title: 'Action failed',
+                    message: 'This user has restricted who can interact with their account.',
                     type: 'error'
                 });
             }
@@ -405,7 +406,8 @@ export function useRepostMutationForUser(handle: string) {
             updateRepostCache(queryClient, QUERY_KEYS.inbox, id, false);
             if (error.statusCode === 403) {
                 showToast({
-                    message: 'You cannot interact with this account.',
+                    title: 'Action failed',
+                    message: 'This user has restricted who can interact with their account.',
                     type: 'error'
                 });
             }
@@ -671,7 +673,8 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
 
             if (error.statusCode === 403) {
                 showToast({
-                    message: 'You cannot interact with this account.',
+                    title: 'Action failed',
+                    message: 'This user has restricted who can interact with their account.',
                     type: 'error'
                 });
             }
@@ -1143,7 +1146,8 @@ export function useReplyMutationForUser(handle: string, actorProps?: ActorProper
 
             if (error.statusCode === 403) {
                 return showToast({
-                    message: 'You cannot interact with this account.',
+                    title: 'Action failed',
+                    message: 'This user has restricted who can interact with their account.',
                     type: 'error'
                 });
             }

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -242,7 +242,7 @@ export function useLikeMutationForUser(handle: string) {
                 };
             });
         },
-        onError(error, id) {
+        onError(error: {message: string, statusCode: number}, id) {
             updateLikedCache(queryClient, QUERY_KEYS.feed, id, false);
             updateLikedCache(queryClient, QUERY_KEYS.inbox, id, false);
             updateLikedCache(queryClient, QUERY_KEYS.profilePosts('index'), id, false);
@@ -401,7 +401,7 @@ export function useRepostMutationForUser(handle: string) {
             updateRepostCache(queryClient, QUERY_KEYS.feed, id, true);
             updateRepostCache(queryClient, QUERY_KEYS.inbox, id, true);
         },
-        onError(error, id) {
+        onError(error: {message: string, statusCode: number}, id) {
             updateRepostCache(queryClient, QUERY_KEYS.feed, id, false);
             updateRepostCache(queryClient, QUERY_KEYS.inbox, id, false);
             if (error.statusCode === 403) {
@@ -668,8 +668,8 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
 
             onSuccess();
         },
-        onError(error) {
-            onError(error);
+        onError(error: {message: string, statusCode: number}) {
+            onError();
 
             if (error.statusCode === 403) {
                 showToast({
@@ -1131,7 +1131,7 @@ export function useReplyMutationForUser(handle: string, actorProps?: ActorProper
 
             updateActivityInCollection(queryClient, QUERY_KEYS.thread(variables.inReplyTo), 'posts', context?.id ?? '', () => preparedActivity);
         },
-        onError: (error, variables, context) => {
+          onError(error: {message: string, statusCode: number}, variables, context) {
             // eslint-disable-next-line no-console
             console.error(error);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-669

We have to actually throw errors when we get non-successful responses back from the API, we've done that in the `fetchJSON` method so we get the functionality everywhere. We also attach the status code so that hooks can use it to determine the type of error. For now we're just using the 403 to determine blocked status, but eventually we'll probably want to move to using @tryghost/errors and have specific error codes

