### PR TITLE
Fixed the ability to overwrite protected settings key with data import

### DIFF
--- a/ghost/core/core/server/data/importer/importers/data/SettingsImporter.js
+++ b/ghost/core/core/server/data/importer/importers/data/SettingsImporter.js
@@ -10,7 +10,7 @@ const {WRITABLE_KEYS_ALLOWLIST} = require('../../../../../shared/labs');
 const {sequence} = require('@tryghost/promise');
 
 const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
-const ignoredSettings = ['slack_url', 'members_from_address', 'members_support_address', 'portal_products'];
+const ignoredSettings = ['slack_url', 'members_from_address', 'members_support_address', 'portal_products', 'email_verification_required'];
 
 // Importer maintains as much backwards compatibility as possible
 const renamedSettingsMap = {

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -70,6 +70,22 @@ describe('SettingsImporter', function () {
             should.not.exist(membersSupportAddress);
         });
 
+        it('Does not overwrite email_verification_required setting', function () {
+            const fakeSettings = [{
+                key: 'email_verification_required',
+                value: true,
+                flags: 'RO'
+            }];
+
+            const importer = new SettingsImporter({settings: fakeSettings}, {dataKeyToImport: 'settings'});
+
+            importer.beforeImport();
+
+            const emailVerificationRequired = find(importer.dataToImport, {key: 'email_verification_required'});
+
+            should.not.exist(emailVerificationRequired);
+        });
+
         it('Adds a problem if the existing data is_private is false, and new data is_private is true', function () {
             const fakeSettings = [{
                 key: 'password',


### PR DESCRIPTION
closes ONC-900

When importing a data file that included updating the `email_verification_required` flag, the key would successfully be updated because the setting is not part of the `ignoredSettings` list. This can prevent our email verification logic from working and open the door for malicious spammers.

Adding this key to the list of ignored settings gives basic protection from intentionally or accidentally overwriting this value with an import.