### PR TITLE
Reverted card assets generation mw changes

### DIFF
--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -76,26 +76,8 @@ module.exports = function setupSiteApp(routerConfig) {
     siteApp.use(mw.servePublicFile('static', 'public/ghost-stats.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
 
     // Card assets
-    const cardAssetsCSSPath = 'public/cards.min.css';
-    const cardAssetsJSPath = 'public/cards.min.js';
-    siteApp.use(
-        function serveCardAssetsCssMiddleware(req, res, next) {
-            if (req.path === `/${cardAssetsCSSPath}`) {
-                return cardAssets.serveMiddleware()(req, res, next);
-            }
-            next();
-        },
-        mw.servePublicFile('built', cardAssetsCSSPath, 'text/css', config.get('caching:publicAssets:maxAge'))
-    );
-    siteApp.use(
-        function serveCardAssetsJsMiddleware(req, res, next) {
-            if (req.path === `/${cardAssetsJSPath}`) {
-                return cardAssets.serveMiddleware()(req, res, next);
-            }
-            next();
-        },
-        mw.servePublicFile('built', cardAssetsJSPath, 'application/javascript', config.get('caching:publicAssets:maxAge'))
-    );
+    siteApp.use(cardAssets.serveMiddleware(), mw.servePublicFile('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge')));
+    siteApp.use(cardAssets.serveMiddleware(), mw.servePublicFile('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
 
     // Comment counts
     siteApp.use(mw.servePublicFile('static', 'public/comment-counts.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C025584CA/p1746099965766049
ref https://github.com/TryGhost/Ghost/pull/23006/

We had a handful of reports of missing/empty cards.min.css files. We made recent changes to the middleware to only attempt to generate on request for the assets rather than every request, and this may have exposed gaps in the minification process' fidelity. We never had reports of this previously, so it seems worth reverting this portion.