### PR TITLE
Wired up member counts to stats growth page

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -25,7 +25,7 @@ export type MemberStatusItem = {
 }
 
 export type MemberCountHistoryResponseType = {
-    data: MemberStatusItem[];
+    stats: MemberStatusItem[];
     meta: {
         totals: {
             paid: number;

--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -15,11 +15,37 @@ export type TopContentResponseType = {
     meta: Meta;
 }
 
+export type MemberStatusItem = {
+    date: string;
+    paid: number;
+    free: number;
+    comped: number;
+    paid_subscribed: number;
+    paid_canceled: number;
+}
+
+export type MemberCountHistoryResponseType = {
+    data: MemberStatusItem[];
+    meta: {
+        totals: {
+            paid: number;
+            free: number;
+            comped: number;
+        }
+    };
+}
+
 // Requests
 
 const dataType = 'TopContentResponseType';
+const memberCountHistoryDataType = 'MemberCountHistoryResponseType';
 
 export const useTopContent = createQuery<TopContentResponseType>({
     dataType,
     path: '/stats/top-content/'
+});
+
+export const useMemberCountHistory = createQuery<MemberCountHistoryResponseType>({
+    dataType: memberCountHistoryDataType,
+    path: '/stats/member_count/'
 });

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -8,7 +8,8 @@ export type DiffDirection = 'up' | 'down' | 'same';
 
 // Helper function to convert range to date parameters
 export const getRangeDates = (rangeInDays: number) => {
-    const endDate = moment().format('YYYY-MM-DD');
+    // Always use UTC to stay aligned with the backend’s date arithmetic
+    const endDate = moment.utc().format('YYYY-MM-DD');
     let dateFrom;
     
     if (rangeInDays === 1) {
@@ -19,7 +20,9 @@ export const getRangeDates = (rangeInDays: number) => {
         dateFrom = '2010-01-01';
     } else {
         // Specific range
-        dateFrom = moment().subtract(rangeInDays - 1, 'days').format('YYYY-MM-DD');
+        // Guard against invalid ranges
+        const safeRange = Math.max(1, rangeInDays);
+        dateFrom = moment.utc().subtract(safeRange - 1, 'days').format('YYYY-MM-DD');
     }
     
     return {dateFrom, endDate};

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -102,6 +102,9 @@ const formatChartData = (memberData: MemberStatusItem[]) => {
     return memberData.map(item => ({
         date: item.date,
         value: item.free + item.paid + item.comped,
+        free: item.free,
+        paid: item.paid,
+        comped: item.comped,
         formattedValue: formatNumber(item.free + item.paid + item.comped),
         label: 'Total members'
     }));

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -120,7 +120,16 @@ export const useGrowthStats = (range: number) => {
     });
     
     // Process member data with stable reference
-    const memberData = useMemo(() => memberCountResponse?.data || [], [memberCountResponse?.data]);
+    const memberData = useMemo(() => {
+        // Check the structure of the response and extract data
+        if (memberCountResponse?.stats) {
+            return memberCountResponse.stats;
+        } else if (Array.isArray(memberCountResponse)) {
+            // If response is directly an array
+            return memberCountResponse;
+        }
+        return [];
+    }, [memberCountResponse]);
     
     // Calculate totals
     const totalsData = useMemo(() => calculateTotals(memberData), [memberData]);

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -1,0 +1,139 @@
+import moment from 'moment';
+import {MemberStatusItem, useMemberCountHistory} from '@tryghost/admin-x-framework/api/stats';
+import {formatNumber} from '@tryghost/shade';
+import {useMemo} from 'react';
+
+// Type for direction values
+export type DiffDirection = 'up' | 'down' | 'same';
+
+// Helper function to convert range to date parameters
+export const getRangeDates = (rangeInDays: number) => {
+    const endDate = moment().format('YYYY-MM-DD');
+    let startDate;
+    
+    if (rangeInDays === 1) {
+        // Today
+        startDate = endDate;
+    } else if (rangeInDays === 1000) {
+        // All time - use a far past date
+        startDate = '2010-01-01';
+    } else {
+        // Specific range
+        startDate = moment().subtract(rangeInDays - 1, 'days').format('YYYY-MM-DD');
+    }
+    
+    return {startDate, endDate};
+};
+
+// Calculate totals from member data
+const calculateTotals = (memberData: MemberStatusItem[]) => {
+    if (!memberData.length) {
+        return {
+            totalMembers: 0,
+            freeMembers: 0,
+            paidMembers: 0,
+            percentChanges: {
+                total: '0%',
+                free: '0%',
+                paid: '0%'
+            },
+            directions: {
+                total: 'same' as DiffDirection,
+                free: 'same' as DiffDirection,
+                paid: 'same' as DiffDirection
+            }
+        };
+    }
+    
+    // Get latest values
+    const latest = memberData[memberData.length - 1];
+    
+    // Calculate total members
+    const totalMembers = latest.free + latest.paid + latest.comped;
+    
+    // Calculate percentage changes if we have enough data
+    const percentChanges = {
+        total: '0%',
+        free: '0%',
+        paid: '0%'
+    };
+    
+    const directions = {
+        total: 'same' as DiffDirection,
+        free: 'same' as DiffDirection,
+        paid: 'same' as DiffDirection
+    };
+    
+    if (memberData.length > 1) {
+        // Get first day in range
+        const first = memberData[0];
+        const firstTotal = first.free + first.paid + first.comped;
+        
+        if (firstTotal > 0) {
+            const totalChange = ((totalMembers - firstTotal) / firstTotal) * 100;
+            percentChanges.total = `${Math.abs(totalChange).toFixed(1)}%`;
+            directions.total = totalChange > 0 ? 'up' : totalChange < 0 ? 'down' : 'same';
+        }
+        
+        if (first.free > 0) {
+            const freeChange = ((latest.free - first.free) / first.free) * 100;
+            percentChanges.free = `${Math.abs(freeChange).toFixed(1)}%`;
+            directions.free = freeChange > 0 ? 'up' : freeChange < 0 ? 'down' : 'same';
+        }
+        
+        if (first.paid > 0) {
+            const paidChange = ((latest.paid - first.paid) / first.paid) * 100;
+            percentChanges.paid = `${Math.abs(paidChange).toFixed(1)}%`;
+            directions.paid = paidChange > 0 ? 'up' : paidChange < 0 ? 'down' : 'same';
+        }
+    }
+    
+    return {
+        totalMembers,
+        freeMembers: latest.free,
+        paidMembers: latest.paid,
+        percentChanges,
+        directions
+    };
+};
+
+// Format chart data 
+const formatChartData = (memberData: MemberStatusItem[]) => {
+    return memberData.map(item => ({
+        date: item.date,
+        value: item.free + item.paid + item.comped,
+        formattedValue: formatNumber(item.free + item.paid + item.comped),
+        label: 'Total members'
+    }));
+};
+
+export const useGrowthStats = (range: number) => {
+    // Calculate date range
+    const {startDate, endDate} = useMemo(() => getRangeDates(range), [range]);
+    
+    // Fetch member count history from API
+    const {data: memberCountResponse, isLoading} = useMemberCountHistory({
+        searchParams: {
+            date_from: startDate,
+            date_to: endDate
+        }
+    });
+    
+    // Process member data with stable reference
+    const memberData = useMemo(() => memberCountResponse?.data || [], [memberCountResponse?.data]);
+    
+    // Calculate totals
+    const totalsData = useMemo(() => calculateTotals(memberData), [memberData]);
+    
+    // Format chart data
+    const chartData = useMemo(() => formatChartData(memberData), [memberData]);
+    
+    return {
+        isLoading,
+        memberData,
+        startDate,
+        endDate,
+        totals: totalsData,
+        chartData
+    };
+}; 

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -9,20 +9,20 @@ export type DiffDirection = 'up' | 'down' | 'same';
 // Helper function to convert range to date parameters
 export const getRangeDates = (rangeInDays: number) => {
     const endDate = moment().format('YYYY-MM-DD');
-    let startDate;
+    let dateFrom;
     
     if (rangeInDays === 1) {
         // Today
-        startDate = endDate;
+        dateFrom = endDate;
     } else if (rangeInDays === 1000) {
         // All time - use a far past date
-        startDate = '2010-01-01';
+        dateFrom = '2010-01-01';
     } else {
         // Specific range
-        startDate = moment().subtract(rangeInDays - 1, 'days').format('YYYY-MM-DD');
+        dateFrom = moment().subtract(rangeInDays - 1, 'days').format('YYYY-MM-DD');
     }
     
-    return {startDate, endDate};
+    return {dateFrom, endDate};
 };
 
 // Calculate totals from member data
@@ -112,13 +112,12 @@ const formatChartData = (memberData: MemberStatusItem[]) => {
 
 export const useGrowthStats = (range: number) => {
     // Calculate date range
-    const {startDate, endDate} = useMemo(() => getRangeDates(range), [range]);
+    const {dateFrom, endDate} = useMemo(() => getRangeDates(range), [range]);
     
     // Fetch member count history from API
     const {data: memberCountResponse, isLoading} = useMemberCountHistory({
         searchParams: {
-            date_from: startDate,
-            date_to: endDate
+            date_from: dateFrom
         }
     });
     
@@ -143,7 +142,7 @@ export const useGrowthStats = (range: number) => {
     return {
         isLoading,
         memberData,
-        startDate,
+        dateFrom,
         endDate,
         totals: totalsData,
         chartData

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -1,154 +1,24 @@
 import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import DateRangeSelect from './components/DateRangeSelect';
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import moment from 'moment';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
-import {MemberStatusItem, useMemberCountHistory} from '@tryghost/admin-x-framework/api/stats';
 import {Navigate} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth, getYTicks} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useGrowthStats} from '@src/hooks/useGrowthStats';
 
-// Type for direction values
-type DiffDirection = 'up' | 'down' | 'same';
-
-// Helper function to convert range to date parameters
-const getRangeDates = (rangeInDays: number) => {
-    const endDate = moment().format('YYYY-MM-DD');
-    let startDate;
-    
-    if (rangeInDays === 1) {
-        // Today
-        startDate = endDate;
-    } else if (rangeInDays === 1000) {
-        // All time - use a far past date
-        startDate = '2010-01-01';
-    } else {
-        // Specific range
-        startDate = moment().subtract(rangeInDays - 1, 'days').format('YYYY-MM-DD');
-    }
-    
-    return {startDate, endDate};
-};
-
-// Extract the calculation to a separate function to avoid conditional hook calls
-const calculateTotals = (memberData: MemberStatusItem[]) => {
-    if (!memberData.length) {
-        return {
-            totalMembers: 0,
-            freeMembers: 0,
-            paidMembers: 0,
-            percentChanges: {
-                total: '0%',
-                free: '0%',
-                paid: '0%'
-            },
-            directions: {
-                total: 'same' as DiffDirection,
-                free: 'same' as DiffDirection,
-                paid: 'same' as DiffDirection
-            }
-        };
-    }
-    
-    // Get latest values
-    const latest = memberData[memberData.length - 1];
-    
-    // Calculate total members
-    const totalMembers = latest.free + latest.paid + latest.comped;
-    
-    // Calculate percentage changes if we have enough data
-    const percentChanges = {
-        total: '0%',
-        free: '0%',
-        paid: '0%'
-    };
-    
-    const directions = {
-        total: 'same' as DiffDirection,
-        free: 'same' as DiffDirection,
-        paid: 'same' as DiffDirection
-    };
-    
-    if (memberData.length > 1) {
-        // Get first day in range
-        const first = memberData[0];
-        const firstTotal = first.free + first.paid + first.comped;
-        
-        if (firstTotal > 0) {
-            const totalChange = ((totalMembers - firstTotal) / firstTotal) * 100;
-            percentChanges.total = `${Math.abs(totalChange).toFixed(1)}%`;
-            directions.total = totalChange > 0 ? 'up' : totalChange < 0 ? 'down' : 'same';
-        }
-        
-        if (first.free > 0) {
-            const freeChange = ((latest.free - first.free) / first.free) * 100;
-            percentChanges.free = `${Math.abs(freeChange).toFixed(1)}%`;
-            directions.free = freeChange > 0 ? 'up' : freeChange < 0 ? 'down' : 'same';
-        }
-        
-        if (first.paid > 0) {
-            const paidChange = ((latest.paid - first.paid) / first.paid) * 100;
-            percentChanges.paid = `${Math.abs(paidChange).toFixed(1)}%`;
-            directions.paid = paidChange > 0 ? 'up' : paidChange < 0 ? 'down' : 'same';
-        }
-    }
-    
-    return {
-        totalMembers,
-        freeMembers: latest.free,
-        paidMembers: latest.paid,
-        percentChanges,
-        directions
-    };
-};
-
-// Format chart data outside component
-const formatChartData = (memberData: MemberStatusItem[]) => {
-    return memberData.map(item => ({
-        date: item.date,
-        value: item.free + item.paid + item.comped,
-        formattedValue: formatNumber(item.free + item.paid + item.comped),
-        label: 'Total members'
-    }));
-};
-
-const GrowthKPIs:React.FC = () => {
+const GrowthKPIs: React.FC = () => {
     const [currentTab, setCurrentTab] = useState('free-members');
     const {settings, range} = useGlobalData();
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
-    // Get date range using useMemo to prevent unnecessary recalculations
-    const {startDate, endDate} = useMemo(() => getRangeDates(range), [range]);
-
-    // Fetch member count history from API
-    const {data: memberCountResponse} = useMemberCountHistory({
-        searchParams: {
-            date_from: startDate,
-            date_to: endDate
-        }
-    });
-    
-    // Wrap memberData in useMemo to maintain stable reference
-    const memberData = useMemo(() => memberCountResponse?.data || [], [memberCountResponse?.data]);
-    
-    // Use useMemo to calculate totals
-    const totalsData = useMemo(() => calculateTotals(memberData), [memberData]);
-    
-    // Destructure the totals
-    const {
-        totalMembers,
-        freeMembers,
-        paidMembers,
-        percentChanges,
-        directions
-    } = totalsData;
-
-    // Chart data
-    const chartData = useMemo(() => formatChartData(memberData), [memberData]);
+    // Get growth stats from custom hook
+    const {chartData, totals} = useGrowthStats(range);
+    const {totalMembers, freeMembers, paidMembers, percentChanges, directions} = totals;
 
     if (!labs.trafficAnalyticsAlpha) {
         return <Navigate to='/' />;
@@ -258,10 +128,11 @@ const GrowthKPIs:React.FC = () => {
     );
 };
 
-const Growth:React.FC = () => {
+const Growth: React.FC = () => {
     const {range} = useGlobalData();
-    // Use useMemo to prevent unnecessary recalculations
-    const {startDate, endDate} = useMemo(() => getRangeDates(range), [range]);
+    
+    // Get stats from custom hook
+    const {isLoading} = useGrowthStats(range);
     
     // TODO: Replace this with real top posts data from API
     const mockTopPosts = [
@@ -281,14 +152,6 @@ const Growth:React.FC = () => {
         {id: 'post-014', title: 'Creating a Productive Workspace on a Budget', freeMembers: 1, paidMembers: 0, mrr: 0},
         {id: 'post-015', title: 'Simple Ways to Reduce Your Carbon Footprint', freeMembers: 1, paidMembers: 0, mrr: 0}
     ];
-
-    // Get member count data to determine if we're loading
-    const {isLoading} = useMemberCountHistory({
-        searchParams: {
-            date_from: startDate,
-            date_to: endDate
-        }
-    });
 
     return (
         <StatsLayout>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -129,6 +129,7 @@ const GrowthKPIs: React.FC = () => {
                         />
                         <Recharts.YAxis
                             axisLine={false}
+                            domain={['dataMin', 'auto']}
                             tickFormatter={(value) => {
                                 switch (currentTab) {
                                 case 'total-members':

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -4,20 +4,47 @@ import React, {useMemo, useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {Navigate} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth, getYTicks} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useGrowthStats} from '@src/hooks/useGrowthStats';
 
-const GrowthKPIs: React.FC = () => {
+type ChartDataItem = {
+    date: string;
+    value: number;
+    free: number;
+    paid: number;
+    comped: number;
+    formattedValue: string;
+    label?: string;
+};
+
+type Totals = {
+    totalMembers: number;
+    freeMembers: number;
+    paidMembers: number;
+    percentChanges: {
+        total: string;
+        free: string;
+        paid: string;
+    };
+    directions: {
+        total: DiffDirection;
+        free: DiffDirection;
+        paid: DiffDirection;
+    };
+};
+
+const GrowthKPIs: React.FC<{
+    chartData: ChartDataItem[];
+    totals: Totals;
+}> = ({chartData: allChartData, totals}) => {
     const [currentTab, setCurrentTab] = useState('total-members');
-    const {settings, range} = useGlobalData();
+    const {settings} = useGlobalData();
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
-    // Get growth stats from custom hook
-    const {chartData: allChartData, totals} = useGrowthStats(range);
     const {totalMembers, freeMembers, paidMembers, percentChanges, directions} = totals;
 
     // Create chart data based on selected tab
@@ -168,8 +195,8 @@ const GrowthKPIs: React.FC = () => {
 const Growth: React.FC = () => {
     const {range} = useGlobalData();
     
-    // Get stats from custom hook
-    const {isLoading} = useGrowthStats(range);
+    // Get stats from custom hook once
+    const {isLoading, chartData, totals} = useGrowthStats(range);
     
     // TODO: Replace this with real top posts data from API
     const mockTopPosts = [
@@ -201,7 +228,7 @@ const Growth: React.FC = () => {
             <StatsView data={['a']} isLoading={isLoading}>
                 <Card variant='plain'>
                     <CardContent>
-                        <GrowthKPIs />
+                        <GrowthKPIs chartData={chartData} totals={totals} />
                     </CardContent>
                 </Card>
                 <Card variant='plain'>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -156,7 +156,7 @@ const GrowthKPIs: React.FC = () => {
                             isAnimationActive={false}
                             stroke="hsl(var(--chart-1))"
                             strokeWidth={2}
-                            type='bump'
+                            type='monotone'
                         />
                     </Recharts.LineChart>
                 </ChartContainer>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -78,7 +78,6 @@ const GrowthKPIs: React.FC<{
                 label: 'MRR'
             }));
         }
-        case 'total-members':
         default:
             return allChartData;
         }

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -226,7 +226,7 @@ const Growth: React.FC = () => {
                     <DateRangeSelect />
                 </ViewHeaderActions>
             </ViewHeader>
-            <StatsView data={['a']} isLoading={isLoading}>
+            <StatsView data={chartData} isLoading={isLoading}>
                 <Card variant='plain'>
                     <CardContent>
                         <GrowthKPIs chartData={chartData} totals={totals} />

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -68,15 +68,16 @@ const GrowthKPIs: React.FC<{
                 formattedValue: formatNumber(item.paid),
                 label: 'Paid members'
             }));
-        case 'mrr':
-            // For MRR we'd need actual MRR data, but we can simulate it based on paid members
-            const avgMrrPerMember = 958 / paidMembers; // Estimate based on total MRR / total paid members
+        case 'mrr': {
+            // TODO: replace the hard-coded 958 once real MRR is available
+            const avgMrrPerMember = paidMembers > 0 ? 958 / paidMembers : 0;
             return allChartData.map(item => ({
                 ...item,
                 value: item.paid * avgMrrPerMember,
                 formattedValue: `$${(item.paid * avgMrrPerMember).toFixed(0)}`,
                 label: 'MRR'
             }));
+        }
         case 'total-members':
         default:
             return allChartData;

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -12,8 +12,7 @@ const controller = {
             method: 'browse'
         },
         options: [
-            'date_from',
-            'date_to'
+            'date_from'
         ],
         cache: statsService.cache,
         generateCacheKeyData(frame) {
@@ -24,7 +23,7 @@ const controller = {
         },
         async query(frame) {
             return await statsService.api.getMemberCountHistory({
-                startDate: frame.options.start_date
+                dateFrom: frame.options.date_from
             });
         }
     },

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -23,7 +23,7 @@ const controller = {
         },
         async query(frame) {
             return await statsService.api.getMemberCountHistory({
-                dateFrom: frame.options.date_from
+                dateFrom: frame?.options?.date_from
             });
         }
     },

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -24,8 +24,7 @@ const controller = {
         },
         async query(frame) {
             return await statsService.api.getMemberCountHistory({
-                startDate: frame.options.date_from,
-                endDate: frame.options.date_to
+                startDate: frame.options.start_date
             });
         }
     },

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -11,14 +11,22 @@ const controller = {
             docName: 'members',
             method: 'browse'
         },
+        options: [
+            'date_from',
+            'date_to'
+        ],
         cache: statsService.cache,
-        generateCacheKeyData() {
+        generateCacheKeyData(frame) {
             return {
-                method: 'memberCountHistory'
+                method: 'memberCountHistory',
+                options: frame.options
             };
         },
-        async query() {
-            return await statsService.api.getMemberCountHistory();
+        async query(frame) {
+            return await statsService.api.getMemberCountHistory({
+                startDate: frame.options.date_from,
+                endDate: frame.options.date_to
+            });
         }
     },
     mrr: {

--- a/ghost/core/core/server/services/stats/MembersStatsService.js
+++ b/ghost/core/core/server/services/stats/MembersStatsService.js
@@ -32,21 +32,17 @@ class MembersStatsService {
 
     /**
      * Get the member deltas by status for all days, sorted ascending
-     * @param {Object} options 
-     * @param {string} [options.startDate] - Start date in YYYY-MM-DD format
-     * @param {string} [options.endDate] - End date in YYYY-MM-DD format
+     * @param {Object} options
+     * @param {string|Date} [options.startDate=91 days ago] - Start date for fetching deltas (ISO format or Date object)
      * @returns {Promise<MemberStatusDelta[]>} The deltas of paid, free and comped users per day, sorted ascending
      */
     async fetchAllStatusDeltas(options = {}) {
         const knex = this.knex;
         const startDate = options.startDate ? 
-            moment.utc(options.startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss') :
-            moment.utc().subtract(91, 'days').startOf('day').format('YYYY-MM-DD HH:mm:ss');
+            moment.utc(options.startDate).startOf('day') : 
+            moment.utc().subtract(91, 'days').startOf('day');
         
-        const endDate = options.endDate ?
-            moment.utc(options.endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss') :
-            moment.utc().endOf('day').format('YYYY-MM-DD HH:mm:ss');
-
+        const formattedStartDate = startDate.format('YYYY-MM-DD HH:mm:ss');
         const rows = await knex('members_status_events')
             .select(knex.raw('DATE(created_at) as date'))
             .select(knex.raw(`SUM(
@@ -67,18 +63,15 @@ class MembersStatsService {
                 WHEN from_status='free' THEN -1
                 ELSE 0 END
             ) as free_delta`))
-            .where('created_at', '>=', startDate)
-            .where('created_at', '<=', endDate)
+            .where('created_at', '>=', formattedStartDate)
             .groupByRaw('DATE(created_at)');
-
         return rows;
     }
 
     /**
      * Returns a list of the total members by status for each day, including the paid deltas paid_subscribed and paid_canceled
      * @param {Object} options
-     * @param {string} [options.startDate] - Start date in YYYY-MM-DD format
-     * @param {string} [options.endDate] - End date in YYYY-MM-DD format
+     * @param {string|Date} [options.startDate=91] - Start date for fetching history (ISO format or Date object)
      * @returns {Promise<CountHistory>}
      */
     async getCountHistory(options = {}) {
@@ -93,7 +86,7 @@ class MembersStatsService {
 
         const cumulativeResults = [];
 
-        rows.sort((a, b) => moment(a.date).valueOf() - moment(b.date).valueOf());
+        rows.sort((a, b) => new Date(a.date) - new Date(b.date));
         // Loop in reverse order (needed to have correct sorted result)
         for (let i = rows.length - 1; i >= 0; i -= 1) {
             const row = rows[i];
@@ -149,7 +142,7 @@ module.exports = MembersStatsService;
 /**
  * @typedef MemberStatusDelta
  * @type {Object}
- * @property {Date} date
+ * @property {string} date Date in SQL format
  * @property {number} paid_subscribed Paid members that subscribed on this day
  * @property {number} paid_canceled Paid members that canceled on this day
  * @property {number} comped_delta Total net comped members on this day

--- a/ghost/core/core/server/services/stats/MembersStatsService.js
+++ b/ghost/core/core/server/services/stats/MembersStatsService.js
@@ -33,7 +33,7 @@ class MembersStatsService {
     /**
      * Get the member deltas by status for all days, sorted ascending
      * @param {Object} options
-     * @param {string|Date} [options.startDate=91 days ago] - Start date for fetching deltas (ISO format or Date object)
+     * @param {string|Date} [options.startDate] - Start date for fetching deltas (ISO format or Date object, defaults to 91 days ago)
      * @returns {Promise<MemberStatusDelta[]>} The deltas of paid, free and comped users per day, sorted ascending
      */
     async fetchAllStatusDeltas(options = {}) {
@@ -71,7 +71,7 @@ class MembersStatsService {
     /**
      * Returns a list of the total members by status for each day, including the paid deltas paid_subscribed and paid_canceled
      * @param {Object} options
-     * @param {string|Date} [options.startDate=91] - Start date for fetching history (ISO format or Date object)
+     * @param {string|Date} [options.startDate] - Start date for fetching history (ISO format or Date object, defaults to 91 days ago). Note: result always includes one day before the startDate as a baseline.
      * @returns {Promise<CountHistory>}
      */
     async getCountHistory(options = {}) {

--- a/ghost/core/core/server/services/stats/MembersStatsService.js
+++ b/ghost/core/core/server/services/stats/MembersStatsService.js
@@ -142,7 +142,7 @@ module.exports = MembersStatsService;
 /**
  * @typedef MemberStatusDelta
  * @type {Object}
- * @property {string} date Date in SQL format
+ * @property {string|Date} date Date in SQL format or Date object
  * @property {number} paid_subscribed Paid members that subscribed on this day
  * @property {number} paid_canceled Paid members that canceled on this day
  * @property {number} comped_delta Total net comped members on this day

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -28,11 +28,18 @@ class StatsService {
 
     /**
      * @param {Object} [options]
-     * @param {string} [options.startDate] - Start date in YYYY-MM-DD format
+     * @param {string} [options.dateFrom] - Start date in YYYY-MM-DD format
      * @param {string} [options.endDate] - End date in YYYY-MM-DD format
      */
     async getMemberCountHistory(options = {}) {
-        return this.members.getCountHistory(options);
+        // Map dateFrom to startDate for backwards compatibility
+        const mappedOptions = {
+            ...options,
+            startDate: options.dateFrom
+        };
+        delete mappedOptions.dateFrom;
+        
+        return this.members.getCountHistory(mappedOptions);
     }
 
     async getSubscriptionCountHistory() {

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -26,8 +26,13 @@ class StatsService {
         return this.mrr.getHistory();
     }
 
-    async getMemberCountHistory() {
-        return this.members.getCountHistory();
+    /**
+     * @param {Object} [options]
+     * @param {string} [options.startDate] - Start date in YYYY-MM-DD format
+     * @param {string} [options.endDate] - End date in YYYY-MM-DD format
+     */
+    async getMemberCountHistory(options = {}) {
+        return this.members.getCountHistory(options);
     }
 
     async getSubscriptionCountHistory() {

--- a/ghost/core/test/unit/server/services/stats/members.test.js
+++ b/ghost/core/test/unit/server/services/stats/members.test.js
@@ -372,5 +372,73 @@ describe('MembersStatsService', function () {
             ]);
             assert.deepEqual(meta.totals, currentCounts);
         });
+
+        it('Accepts custom start date', async function () {
+            // Update faked status events
+            events = [
+                {
+                    date: dayBeforeYesterdayDate,
+                    paid_subscribed: 2,
+                    paid_canceled: 1,
+                    free_delta: 2,
+                    comped_delta: 1
+                },
+                {
+                    date: yesterdayDate,
+                    paid_subscribed: 1,
+                    paid_canceled: 0,
+                    free_delta: 1,
+                    comped_delta: 0
+                },
+                {
+                    date: todayDate,
+                    paid_subscribed: 4,
+                    paid_canceled: 3,
+                    free_delta: 2,
+                    comped_delta: 3
+                }
+            ];
+
+            // Update current faked counts
+            currentCounts.paid = 3;
+            currentCounts.free = 5;
+            currentCounts.comped = 4;
+
+            await setupDB();
+
+            // Test with yesterday as start date - should include day-before-yesterday as baseline, yesterday, and today
+            const {data: results, meta} = await membersStatsService.getCountHistory({
+                startDate: yesterdayDate
+            });
+            
+            assert.equal(results.length, 3);
+            assert.deepEqual(results, [
+                {
+                    date: dayBeforeYesterday,
+                    paid: 1,
+                    free: 2,
+                    comped: 1,
+                    paid_subscribed: 0,
+                    paid_canceled: 0
+                },
+                {
+                    date: yesterday,
+                    paid: 2,
+                    free: 3,
+                    comped: 1,
+                    paid_subscribed: 1,
+                    paid_canceled: 0
+                },
+                {
+                    date: today,
+                    paid: 3,
+                    free: 5,
+                    comped: 4,
+                    paid_subscribed: 4,
+                    paid_canceled: 3
+                }
+            ]);
+            assert.deepEqual(meta.totals, currentCounts);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/stats/members.test.js
+++ b/ghost/core/test/unit/server/services/stats/members.test.js
@@ -14,8 +14,7 @@ describe('MembersStatsService', function () {
          */
         const currentCounts = {paid: 0, free: 0, comped: 0};
         /**
-         * @typedef {{date: Date, paid_subscribed: number, paid_canceled: number, free_delta: number, comped_delta: number}} MemberEvent
-         * @type {MemberEvent[]}
+         * @type {MembersStatsService.MemberStatusDelta[]}
          */
         let events = [];
 
@@ -95,12 +94,13 @@ describe('MembersStatsService', function () {
             /**
              * @param {string} status
              * @param {number} number
-             * @param {Date} date
+             * @param {Date|string} date
              * @returns {StatusEvent[]}
              **/
             function generateEvents(status, number, date) {
+                const dateObj = date instanceof Date ? date : new Date(date);
                 return Array.from({length: Math.abs(number)}).map(() => ({
-                    created_at: date.toISOString(),
+                    created_at: dateObj.toISOString(),
                     from_status: number > 0 ? null : status,
                     to_status: number < 0 ? null : status
                 }));

--- a/ghost/core/test/unit/server/services/stats/members.test.js
+++ b/ghost/core/test/unit/server/services/stats/members.test.js
@@ -14,7 +14,8 @@ describe('MembersStatsService', function () {
          */
         const currentCounts = {paid: 0, free: 0, comped: 0};
         /**
-         * @type {MembersStatsService.MemberStatusDelta[]}
+         * @typedef {{date: Date, paid_subscribed: number, paid_canceled: number, free_delta: number, comped_delta: number}} MemberEvent
+         * @type {MemberEvent[]}
          */
         let events = [];
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-658/

The growth tab currently has fixture data for demo purposes. This wires up the member counts endpoint used by the Admin Dashboard. We had to make a small adjustment to allow for a start date, as it was previously always looking back 91 days. We will probably want to make some additional adjustments to this down the road.