### PR TITLE
Fixed docker build error for missing package.json fle

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -82,7 +82,6 @@ COPY ghost/html-to-plaintext/package.json ghost/html-to-plaintext/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 COPY ghost/job-manager/package.json ghost/job-manager/package.json
 COPY ghost/link-replacer/package.json ghost/link-replacer/package.json
-COPY ghost/magic-link/package.json ghost/magic-link/package.json
 COPY ghost/member-attribution/package.json ghost/member-attribution/package.json
 COPY ghost/members-csv/package.json ghost/members-csv/package.json
 COPY ghost/mw-error-handler/package.json ghost/mw-error-handler/package.json

--- a/compose.yml
+++ b/compose.yml
@@ -172,7 +172,6 @@ volumes:
   node_modules_ghost_i18n: {}
   node_modules_ghost_job-manager: {}
   node_modules_ghost_link-replacer: {}
-  node_modules_ghost_magic-link: {}
   node_modules_ghost_member-attribution: {}
   node_modules_ghost_members-csv: {}
   node_modules_ghost_mw-error-handler: {}

--- a/compose.yml
+++ b/compose.yml
@@ -45,7 +45,6 @@ services:
       - node_modules_ghost_i18n:/home/ghost/ghost/i18n/node_modules:delegated
       - node_modules_ghost_job-manager:/home/ghost/ghost/job-manager/node_modules:delegated
       - node_modules_ghost_link-replacer:/home/ghost/ghost/link-replacer/node_modules:delegated
-      - node_modules_ghost_magic-link:/home/ghost/ghost/magic-link/node_modules:delegated
       - node_modules_ghost_member-attribution:/home/ghost/ghost/member-attribution/node_modules:delegated
       - node_modules_ghost_members-csv:/home/ghost/ghost/members-csv/node_modules:delegated
       - node_modules_ghost_mw-error-handler:/home/ghost/ghost/mw-error-handler/node_modules:delegated


### PR DESCRIPTION
no refs

The docker build was failing because it's looking for the `magic-link` package's package.json, but there no longer is a `magic-link` package ✨