### PR TITLE
Improved site-wide analytics design

### DIFF
--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -43,7 +43,7 @@ const cardHeaderVariants = cva(
     {
         variants: {
             variant: {
-                outline: 'px-6 py-5',
+                outline: 'p-6',
                 plain: 'border-b py-5'
             }
         },

--- a/apps/shade/src/components/ui/table.tsx
+++ b/apps/shade/src/components/ui/table.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {cn} from '@/lib/utils';
+import {Button} from './button';
 
 const Table = React.forwardRef<
     HTMLTableElement,
@@ -81,6 +82,21 @@ const TableHead = React.forwardRef<
 ));
 TableHead.displayName = 'TableHead';
 
+type TableHeadButtonProps = React.ComponentProps<typeof Button>;
+
+const TableHeadButton: React.FC<TableHeadButtonProps> = ({className, children, ...props}) => {
+    const buttonClassName = cn(
+        'text-sm text-gray-700 hover:bg-transparent px-0 [&_svg]:size-4 gap-1',
+        className
+    );
+    return (
+        <Button className={buttonClassName} size='sm' variant='ghost' {...props}>
+            {children}
+        </Button>
+    );
+};
+TableHeadButton.displayName = 'TableHeadButton';
+
 const TableCell = React.forwardRef<
     HTMLTableCellElement,
     React.TdHTMLAttributes<HTMLTableCellElement>
@@ -114,6 +130,7 @@ export {
     TableBody,
     TableFooter,
     TableHead,
+    TableHeadButton,
     TableRow,
     TableCell,
     TableCaption

--- a/apps/shade/tailwind.config.cjs
+++ b/apps/shade/tailwind.config.cjs
@@ -322,7 +322,8 @@ module.exports = {
                 max: 'max-content',
                 fit: 'fit-content',
                 prose: '65ch',
-                page: '148rem'
+                page: '148rem',
+                pageminsidebar: '116rem'
             },
             borderRadius: {
                 sm: 'calc(var(--radius) - 4px)',

--- a/apps/shade/test/unit/components/ui/card.test.tsx
+++ b/apps/shade/test/unit/components/ui/card.test.tsx
@@ -2,11 +2,11 @@ import assert from 'assert/strict';
 import {describe, it} from 'vitest';
 import {screen} from '@testing-library/react';
 import {
-    Card, 
-    CardHeader, 
-    CardFooter, 
-    CardTitle, 
-    CardDescription, 
+    Card,
+    CardHeader,
+    CardFooter,
+    CardTitle,
+    CardDescription,
     CardContent
 } from '../../../../src/components/ui/card';
 import {render} from '../../utils/test-utils';
@@ -15,7 +15,7 @@ describe('Card Components', () => {
     it('renders Card with default outline variant', () => {
         render(<Card data-testid="card">Card Content</Card>);
         const card = screen.getByTestId('card');
-        
+
         assert.ok(card, 'Card should be rendered');
         assert.equal(card.textContent, 'Card Content', 'Card should render its content');
         assert.ok(card.className.includes('rounded-xl border'), 'Should have outline variant styling');
@@ -24,7 +24,7 @@ describe('Card Components', () => {
     it('renders Card with plain variant', () => {
         render(<Card variant="plain" data-testid="card">Card Content</Card>);
         const card = screen.getByTestId('card');
-        
+
         assert.ok(card, 'Card should be rendered');
         assert.ok(!card.className.includes('rounded-xl border'), 'Should not have outline variant styling');
     });
@@ -32,7 +32,7 @@ describe('Card Components', () => {
     it('applies custom className to Card correctly', () => {
         render(<Card className="custom-card-class" data-testid="card">Card Content</Card>);
         const card = screen.getByTestId('card');
-        
+
         assert.ok(card.className.includes('custom-card-class'), 'Should have custom class');
     });
 
@@ -42,11 +42,11 @@ describe('Card Components', () => {
                 <CardHeader data-testid="card-header">Header Content</CardHeader>
             </Card>
         );
-        
+
         const header = screen.getByTestId('card-header');
         assert.ok(header, 'CardHeader should be rendered');
         assert.equal(header.textContent, 'Header Content', 'CardHeader should render its content');
-        assert.ok(header.className.includes('px-6 py-5'), 'Should have outline variant styling');
+        assert.ok(header.className.includes('p-6'), 'Header should have appropriate padding');
     });
 
     it('renders CardHeader with plain variant styling', () => {
@@ -55,14 +55,14 @@ describe('Card Components', () => {
                 <CardHeader data-testid="card-header">Header Content</CardHeader>
             </Card>
         );
-        
+
         const header = screen.getByTestId('card-header');
         assert.ok(header.className.includes('border-b py-5'), 'Should have plain variant styling');
     });
 
     it('renders CardTitle with correct styling', () => {
         render(<CardTitle data-testid="card-title">Card Title</CardTitle>);
-        
+
         const title = screen.getByTestId('card-title');
         assert.ok(title, 'CardTitle should be rendered');
         assert.equal(title.textContent, 'Card Title', 'CardTitle should render its content');
@@ -71,7 +71,7 @@ describe('Card Components', () => {
 
     it('renders CardDescription with correct styling', () => {
         render(<CardDescription data-testid="card-description">Card Description</CardDescription>);
-        
+
         const description = screen.getByTestId('card-description');
         assert.ok(description, 'CardDescription should be rendered');
         assert.equal(description.textContent, 'Card Description', 'CardDescription should render its content');
@@ -84,7 +84,7 @@ describe('Card Components', () => {
                 <CardContent data-testid="card-content">Content</CardContent>
             </Card>
         );
-        
+
         const content = screen.getByTestId('card-content');
         assert.ok(content, 'CardContent should be rendered');
         assert.equal(content.textContent, 'Content', 'CardContent should render its content');
@@ -97,7 +97,7 @@ describe('Card Components', () => {
                 <CardContent data-testid="card-content">Content</CardContent>
             </Card>
         );
-        
+
         const content = screen.getByTestId('card-content');
         assert.ok(content.className.includes('border-b'), 'Should have plain variant styling');
     });
@@ -108,7 +108,7 @@ describe('Card Components', () => {
                 <CardFooter data-testid="card-footer">Footer Content</CardFooter>
             </Card>
         );
-        
+
         const footer = screen.getByTestId('card-footer');
         assert.ok(footer, 'CardFooter should be rendered');
         assert.equal(footer.textContent, 'Footer Content', 'CardFooter should render its content');
@@ -121,7 +121,7 @@ describe('Card Components', () => {
                 <CardFooter data-testid="card-footer">Footer Content</CardFooter>
             </Card>
         );
-        
+
         const footer = screen.getByTestId('card-footer');
         assert.ok(footer.className.includes('py-5'), 'Should have plain variant styling');
     });
@@ -137,7 +137,7 @@ describe('Card Components', () => {
                 <CardFooter data-testid="card-footer">Card Footer</CardFooter>
             </Card>
         );
-        
+
         assert.ok(screen.getByTestId('card'), 'Card should be rendered');
         assert.ok(screen.getByTestId('card-header'), 'CardHeader should be rendered');
         assert.ok(screen.getByTestId('card-title'), 'CardTitle should be rendered');
@@ -145,4 +145,4 @@ describe('Card Components', () => {
         assert.ok(screen.getByTestId('card-content'), 'CardContent should be rendered');
         assert.ok(screen.getByTestId('card-footer'), 'CardFooter should be rendered');
     });
-}); 
+});

--- a/apps/stats/src/components/chart/CustomTooltipContent.tsx
+++ b/apps/stats/src/components/chart/CustomTooltipContent.tsx
@@ -12,7 +12,7 @@ interface TooltipPayload {
 interface TooltipProps {
     active?: boolean;
     payload?: TooltipPayload[];
-    range: number;
+    range?: number;
 }
 
 const CustomTooltipContent = ({active, payload, range}: TooltipProps) => {
@@ -25,7 +25,7 @@ const CustomTooltipContent = ({active, payload, range}: TooltipProps) => {
 
     return (
         <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
-            {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range)}</div>}
+            {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range || 0)}</div>}
             <div className='flex items-center gap-1'>
                 <span className='inline-block size-[10px] rounded-[2px]' style={{backgroundColor: 'hsl(var(--chart-1))'}}></span>
                 <div className='flex grow items-center justify-between gap-3'>

--- a/apps/stats/src/components/chart/CustomTooltipContent.tsx
+++ b/apps/stats/src/components/chart/CustomTooltipContent.tsx
@@ -24,12 +24,12 @@ const CustomTooltipContent = ({active, payload, range}: TooltipProps) => {
     const displayValue = formattedValue || payload[0].value;
 
     return (
-        <div className="bg-background min-w-[120px] rounded-lg border px-3 py-2 shadow-lg">
-            {date && <div className="text-foreground text-sm">{formatDisplayDateWithRange(date, range)}</div>}
+        <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
+            {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range)}</div>}
             <div className='flex items-center gap-1'>
                 <span className='inline-block size-[10px] rounded-[2px]' style={{backgroundColor: 'hsl(var(--chart-1))'}}></span>
                 <div className='flex grow items-center justify-between gap-3'>
-                    {label && <div className="text-muted-foreground text-sm">{label}</div>}
+                    {label && <div className="text-sm text-muted-foreground">{label}</div>}
                     <div className="font-mono font-medium">{displayValue}</div>
                 </div>
             </div>

--- a/apps/stats/src/components/chart/CustomTooltipContent.tsx
+++ b/apps/stats/src/components/chart/CustomTooltipContent.tsx
@@ -1,4 +1,4 @@
-import {formatDisplayDate} from '@tryghost/shade';
+import {formatDisplayDateWithRange} from '@src/utils/chart-helpers';
 
 interface TooltipPayload {
     value: number;
@@ -12,9 +12,10 @@ interface TooltipPayload {
 interface TooltipProps {
     active?: boolean;
     payload?: TooltipPayload[];
+    range: number;
 }
 
-const CustomTooltipContent = ({active, payload}: TooltipProps) => {
+const CustomTooltipContent = ({active, payload, range}: TooltipProps) => {
     if (!active || !payload?.length) {
         return null;
     }
@@ -23,12 +24,12 @@ const CustomTooltipContent = ({active, payload}: TooltipProps) => {
     const displayValue = formattedValue || payload[0].value;
 
     return (
-        <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
-            {date && <div className="text-sm text-foreground">{formatDisplayDate(date)}</div>}
+        <div className="bg-background min-w-[120px] rounded-lg border px-3 py-2 shadow-lg">
+            {date && <div className="text-foreground text-sm">{formatDisplayDateWithRange(date, range)}</div>}
             <div className='flex items-center gap-1'>
                 <span className='inline-block size-[10px] rounded-[2px]' style={{backgroundColor: 'hsl(var(--chart-1))'}}></span>
                 <div className='flex grow items-center justify-between gap-3'>
-                    {label && <div className="text-sm text-muted-foreground">{label}</div>}
+                    {label && <div className="text-muted-foreground text-sm">{label}</div>}
                     <div className="font-mono font-medium">{displayValue}</div>
                 </div>
             </div>

--- a/apps/stats/src/components/layout/MainLayout.tsx
+++ b/apps/stats/src/components/layout/MainLayout.tsx
@@ -5,7 +5,7 @@ const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, .
     return (
         <div className='h-screen w-full overflow-y-scroll'>
             <div className='relative grid h-screen grid-cols-[auto_288px] xl:grid-cols-[auto_320px]' {...props}>
-                <div className='max-w-pageminsidebar mx-auto w-full'>
+                <div className='mx-auto w-full max-w-pageminsidebar'>
                     {children}
                 </div>
                 <Sidebar />

--- a/apps/stats/src/components/layout/MainLayout.tsx
+++ b/apps/stats/src/components/layout/MainLayout.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import Sidebar from '@src/views/Stats/layout/Sidebar';
 
 const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
         <div className='h-screen w-full overflow-y-scroll'>
-            <div className='relative mx-auto flex h-screen max-w-page flex-col' {...props}>
-                {children}
+            <div className='relative grid h-screen grid-cols-[auto_288px] xl:grid-cols-[auto_320px]' {...props}>
+                <div className='max-w-pageminsidebar mx-auto w-full'>
+                    {children}
+                </div>
+                <Sidebar />
             </div>
         </div>
     );

--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 import {STATS_RANGE_OPTIONS} from '@src/utils/constants';
+import {formatDisplayDate} from '@tryghost/shade';
 
 /**
  * Calculates the Y-axis range with appropriate padding
@@ -235,4 +236,19 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
 
     // Return original data for ranges < 91 days
     return data;
+};
+
+/**
+ * Formats a date based on the range
+ * - For ranges above 365 days: shows month and year (e.g. "Apr 2025")
+ * - For ranges above 91 days: shows "Week of [date]"
+ * - For other ranges: uses the default formatDisplayDate
+ */
+export const formatDisplayDateWithRange = (date: string, range: number): string => {
+    if (range > 365) {
+        return moment(date).format('MMM YYYY');
+    } else if (range >= 91) {
+        return `Week of ${formatDisplayDate(date)}`;
+    }
+    return formatDisplayDate(date);
 };

--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -2,20 +2,74 @@ import moment from 'moment-timezone';
 import {STATS_RANGE_OPTIONS} from '@src/utils/constants';
 
 /**
+ * Calculates the Y-axis range with appropriate padding
+ */
+export const getYRange = (data: { value: number }[]): {min: number; max: number} => {
+    if (!data.length) {
+        return {min: 0, max: 1};
+    }
+
+    const values = data.map(d => Number(d.value));
+    let min = Math.min(...values);
+    let max = Math.max(...values);
+
+    // If min and max are equal, create a range around the value
+    if (min === max) {
+        const value = min;
+        // For zero, use a range of 0 to 1
+        if (value === 0) {
+            min = 0;
+            max = 1;
+        } else {
+            // For non-zero values, create a 10% range around the value
+            const range = Math.abs(value) * 0.1;
+            min = Math.max(0, value - range);
+            max = value + range;
+        }
+    } else {
+        // Ensure minimum 10% range between min and max
+        const range = max - min;
+        const minRange = Math.max(Math.abs(max), Math.abs(min)) * 0.1;
+        if (range < minRange) {
+            const padding = (minRange - range) / 2;
+            min = Math.max(0, min - padding);
+            max += padding;
+        }
+    }
+
+    return {min, max};
+};
+
+/**
  * Calculates Y-axis ticks based on the data values
  */
 export const getYTicks = (data: { value: number }[]): number[] => {
-    if (!data?.length) {
+    if (!data.length) {
         return [];
     }
-    const values = data.map(d => Number(d.value));
-    const max = Math.max(...values);
-    const min = Math.min(...values);
-    const step = Math.pow(10, Math.floor(Math.log10(max - min)));
+
+    const {min, max} = getYRange(data);
+
+    // Calculate the range and initial step
+    const range = max - min;
+    const initialStep = Math.pow(10, Math.floor(Math.log10(range)));
+
+    // Try different step sizes until we get 6 or fewer ticks
+    let step = initialStep;
+    let numTicks = Math.ceil(range / step) + 1;
+
+    // If we have too many ticks, increase the step size
+    while (numTicks > 6) {
+        step *= 2;
+        numTicks = Math.ceil(range / step) + 1;
+    }
+
+    // Generate the ticks
     const ticks = [];
     for (let i = Math.floor(min / step) * step; i <= Math.ceil(max / step) * step; i += step) {
         ticks.push(i);
     }
+
     return ticks;
 };
 

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -325,7 +325,7 @@ const Growth: React.FC = () => {
                                         </TableCell>
                                         <TableCell className={`text-right font-mono text-sm ${post.mrr === 0 && 'text-gray-700'}`}>
                                             {/* TODO: Update to use actual currency */}
-                                            {(post.mrr > 0 && '+')}${post.mrr}
+                                            {(post.mrr > 0 && '+')}${(post.mrr / 100).toFixed(0)}
                                         </TableCell>
                                         <TableCell className='text-right text-gray-700 hover:text-black'>
                                             <PostMenu pathName='' postId={post.post_id} />

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -5,11 +5,11 @@ import React, {useMemo, useState} from 'react';
 import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatNumber} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {Navigate} from '@tryghost/admin-x-framework';
-import {calculateYAxisWidth, formatDisplayDateWithRange, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
@@ -214,7 +214,7 @@ const GrowthKPIs: React.FC<{
                             //         </g>
                             //     );
                             // }}
-                            tickFormatter={date => formatDisplayDateWithRange(date, range)}
+                            tickFormatter={formatDisplayDate}
                             tickLine={false}
                             tickMargin={8}
                             ticks={chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -9,7 +9,7 @@ import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, 
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {Navigate} from '@tryghost/admin-x-framework';
-import {calculateYAxisWidth, getYTicks} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, getYRange, getYTicks} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
@@ -161,7 +161,7 @@ const GrowthKPIs: React.FC<{
                         />
                         <Recharts.YAxis
                             axisLine={false}
-                            domain={['dataMin', 'auto']}
+                            domain={[getYRange(chartData).min, getYRange(chartData).max]}
                             tickFormatter={(value) => {
                                 switch (currentTab) {
                                 case 'total-members':

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -3,7 +3,7 @@ import DateRangeSelect from './components/DateRangeSelect';
 import React, {useMemo, useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {Navigate} from '@tryghost/admin-x-framework';
@@ -205,24 +205,25 @@ const Growth: React.FC = () => {
 
     return (
         <StatsLayout>
-            <ViewHeader>
+            <ViewHeader className='before:hidden'>
                 <H1>Growth</H1>
                 <ViewHeaderActions>
                     <DateRangeSelect />
                 </ViewHeaderActions>
             </ViewHeader>
             <StatsView data={chartData} isLoading={isLoading}>
-                <Card variant='plain'>
+                <Card>
                     <CardContent>
                         <GrowthKPIs chartData={chartData} totals={totals} />
                     </CardContent>
                 </Card>
-                <Card variant='plain'>
+                <Card>
                     <CardHeader>
                         <CardTitle>Top performing posts</CardTitle>
                         <CardDescription>Which posts drove the most growth</CardDescription>
                     </CardHeader>
                     <CardContent>
+                        <Separator/>
                         <Table>
                             <TableHeader>
                                 <TableRow>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -5,11 +5,11 @@ import React, {useMemo, useState} from 'react';
 import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {Navigate} from '@tryghost/admin-x-framework';
-import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, formatDisplayDateWithRange, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
@@ -192,7 +192,29 @@ const GrowthKPIs: React.FC<{
                             axisLine={false}
                             dataKey="date"
                             interval={0}
-                            tickFormatter={formatDisplayDate}
+                            // tick={({x, y, payload, index, ticks}) => {
+                            //     if (!ticks) {
+                            //         return <g />;
+                            //     }
+                            //     const isFirst = index === 0;
+                            //     const isLast = index === ticks.length - 1;
+                            //     return (
+                            //         <g transform={`translate(${x},${y})`}>
+                            //             <text
+                            //                 className="fill-gray-500"
+                            //                 dy={16}
+                            //                 fill="hsl(var(--foreground))"
+                            //                 fontSize={12}
+                            //                 textAnchor={isFirst ? 'start' : isLast ? 'end' : 'middle'}
+                            //                 x={0}
+                            //                 y={0}
+                            //             >
+                            //                 {formatDisplayDateWithRange(payload.value, range)}
+                            //             </text>
+                            //         </g>
+                            //     );
+                            // }}
+                            tickFormatter={date => formatDisplayDateWithRange(date, range)}
                             tickLine={false}
                             tickMargin={8}
                             ticks={chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}
@@ -217,7 +239,7 @@ const GrowthKPIs: React.FC<{
                             width={calculateYAxisWidth(getYTicks(chartData), formatNumber)}
                         />
                         <ChartTooltip
-                            content={<CustomTooltipContent />}
+                            content={<CustomTooltipContent range={range} />}
                             cursor={true}
                         />
                         <Recharts.Line

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -1,5 +1,6 @@
 import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import DateRangeSelect from './components/DateRangeSelect';
+import PostMenu from './components/PostMenu';
 import React, {useMemo, useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
@@ -227,19 +228,38 @@ const Growth: React.FC = () => {
                         <Table>
                             <TableHeader>
                                 <TableRow>
-                                    <TableHead>Title</TableHead>
-                                    <TableHead className='w-[110px] text-right'>Free members</TableHead>
-                                    <TableHead className='w-[110px] text-right'>Paid members</TableHead>
-                                    <TableHead className='text-right'>MRR</TableHead>
+                                    <TableHead>
+                                        Title
+                                    </TableHead>
+                                    <TableHead className='w-[110px] text-right'>
+                                        Free members
+                                    </TableHead>
+                                    <TableHead className='w-[110px] text-right'>
+                                        Paid members
+                                    </TableHead>
+                                    <TableHead className='w-[100px] text-right'>
+                                        MRR
+                                    </TableHead>
+                                    <TableHead className='w-[32px] text-right'></TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
                                 {topPosts.map(post => (
                                     <TableRow key={post.post_id}>
                                         <TableCell className="font-medium">{post.title}</TableCell>
-                                        <TableCell className='text-right font-mono text-sm'>+{formatNumber(post.free_members)}</TableCell>
-                                        <TableCell className='text-right font-mono text-sm'>+{formatNumber(post.paid_members)}</TableCell>
-                                        <TableCell className='text-right font-mono text-sm'>+${post.mrr}</TableCell>
+                                        <TableCell className={`text-right font-mono text-sm ${post.free_members === 0 && 'text-gray-700'}`}>
+                                            {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
+                                        </TableCell>
+                                        <TableCell className={`text-right font-mono text-sm ${post.paid_members === 0 && 'text-gray-700'}`}>
+                                            {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
+                                        </TableCell>
+                                        <TableCell className={`text-right font-mono text-sm ${post.mrr === 0 && 'text-gray-700'}`}>
+                                            {/* TODO: Update to use actual currency */}
+                                            {(post.mrr > 0 && '+')}${post.mrr}
+                                        </TableCell>
+                                        <TableCell className='text-right text-gray-700 hover:text-black'>
+                                            <PostMenu pathName='' postId={post.post_id} />
+                                        </TableCell>
                                     </TableRow>
                                 ))}
                             </TableBody>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -2,6 +2,7 @@ import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import DateRangeSelect from './components/DateRangeSelect';
 import PostMenu from './components/PostMenu';
 import React, {useMemo, useState} from 'react';
+import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
@@ -12,6 +13,8 @@ import {calculateYAxisWidth, getYTicks} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
+
+type TopPostsOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc';
 
 type ChartDataItem = {
     date: string;
@@ -196,11 +199,12 @@ const GrowthKPIs: React.FC<{
 
 const Growth: React.FC = () => {
     const {range} = useGlobalData();
+    const [sortBy, setSortBy] = useState<TopPostsOrder>('free_members desc');
 
     // Get stats from custom hook once
     const {isLoading, chartData, totals} = useGrowthStats(range);
 
-    const {data: topPostsData} = useTopPostsStatsWithRange(range, 'free_members desc');
+    const {data: topPostsData} = useTopPostsStatsWithRange(range, sortBy);
 
     const topPosts = topPostsData?.stats || [];
 
@@ -231,14 +235,20 @@ const Growth: React.FC = () => {
                                     <TableHead>
                                         Title
                                     </TableHead>
-                                    <TableHead className='w-[110px] text-right'>
-                                        Free members
+                                    <TableHead className='text-right'>
+                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='free_members desc'>
+                                            Free members
+                                        </SortButton>
                                     </TableHead>
-                                    <TableHead className='w-[110px] text-right'>
-                                        Paid members
+                                    <TableHead className='text-right'>
+                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='paid_members desc'>
+                                            Paid members
+                                        </SortButton>
                                     </TableHead>
-                                    <TableHead className='w-[100px] text-right'>
-                                        MRR
+                                    <TableHead className='text-right'>
+                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='mrr desc'>
+                                            MRR
+                                        </SortButton>
                                     </TableHead>
                                     <TableHead className='w-[32px] text-right'></TableHead>
                                 </TableRow>

--- a/apps/stats/src/views/Stats/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations.tsx
@@ -6,7 +6,7 @@ import StatsView from './layout/StatsView';
 import World from '@svg-maps/world';
 import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, H1, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, cn, formatNumber, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, H1, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, cn, formatNumber, formatQueryDate} from '@tryghost/shade';
 import {STATS_LABEL_MAPPINGS} from '@src/utils/constants';
 import {SVGMap} from 'react-svg-map';
 import {getCountryFlag, getPeriodText, getRangeDates} from '@src/utils/chart-helpers';
@@ -167,8 +167,8 @@ const Locations:React.FC = () => {
             </ViewHeader>
             <StatsView data={data} isLoading={isLoading}>
                 <Card variant='plain'>
-                    <CardContent className='-mb-5 border-none pt-8'>
-                        <div className='svg-map-container relative mx-auto max-w-[680px] [&_.svg-map]:stroke-background'>
+                    <CardContent className='border-none pt-8'>
+                        <div className='svg-map-container [&_.svg-map]:stroke-background relative mx-auto max-w-[680px]'>
                             <SVGMap
                                 locationClassName={getLocationClassName}
                                 map={World}
@@ -177,7 +177,7 @@ const Locations:React.FC = () => {
                             />
                             {tooltipData && (
                                 <div
-                                    className="pointer-events-none fixed z-50 min-w-[120px] rounded-lg border bg-background px-3 py-2 text-sm text-foreground shadow-lg transition-all duration-150 ease-in-out"
+                                    className="bg-background text-foreground pointer-events-none fixed z-50 min-w-[120px] rounded-lg border px-3 py-2 text-sm shadow-lg transition-all duration-150 ease-in-out"
                                     style={{
                                         left: tooltipData.x + 10,
                                         top: tooltipData.y + 10,
@@ -189,7 +189,7 @@ const Locations:React.FC = () => {
                                         <span className="font-medium">{tooltipData.countryName}</span>
                                     </div>
                                     <div className='flex grow items-center justify-between gap-3'>
-                                        <div className="text-sm text-muted-foreground">Visitors</div>
+                                        <div className="text-muted-foreground text-sm">Visitors</div>
                                         <div className="font-mono font-medium">{formatNumber(tooltipData.visits)}</div>
                                     </div>
                                 </div>
@@ -197,34 +197,37 @@ const Locations:React.FC = () => {
                         </div>
                     </CardContent>
                 </Card>
-                <Card variant='plain'>
+                <Card>
                     <CardHeader>
                         <CardTitle>Top Locations</CardTitle>
                         <CardDescription>A geographic breakdown of your readers {getPeriodText(range)}</CardDescription>
                     </CardHeader>
                     <CardContent>
                         {isLoading ? 'Loading' :
-                            <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead className='w-[80%]'>Country</TableHead>
-                                        <TableHead className='w-[20%] text-right'>Visitors</TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {data?.map((row) => {
-                                        const countryName = getCountryName(`${row.location}`) || 'Unknown';
-                                        return (
-                                            <TableRow key={row.location || 'unknown'}>
-                                                <TableCell className="font-medium">
-                                                    <span title={countryName || 'Unknown'}>{getCountryFlag(`${row.location}`)} {countryName}</span>
-                                                </TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
-                                            </TableRow>
-                                        );
-                                    })}
-                                </TableBody>
-                            </Table>
+                            <>
+                                <Separator />
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className='w-[80%]'>Country</TableHead>
+                                            <TableHead className='w-[20%] text-right'>Visitors</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {data?.map((row) => {
+                                            const countryName = getCountryName(`${row.location}`) || 'Unknown';
+                                            return (
+                                                <TableRow key={row.location || 'unknown'}>
+                                                    <TableCell className="font-medium">
+                                                        <span title={countryName || 'Unknown'}>{getCountryFlag(`${row.location}`)} {countryName}</span>
+                                                    </TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
+                                                </TableRow>
+                                            );
+                                        })}
+                                    </TableBody>
+                                </Table>
+                            </>
                         }
                     </CardContent>
                 </Card>

--- a/apps/stats/src/views/Stats/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations.tsx
@@ -168,7 +168,7 @@ const Locations:React.FC = () => {
             <StatsView data={data} isLoading={isLoading}>
                 <Card variant='plain'>
                     <CardContent className='border-none pt-8'>
-                        <div className='svg-map-container [&_.svg-map]:stroke-background relative mx-auto max-w-[680px]'>
+                        <div className='svg-map-container relative mx-auto max-w-[680px] [&_.svg-map]:stroke-background'>
                             <SVGMap
                                 locationClassName={getLocationClassName}
                                 map={World}
@@ -177,7 +177,7 @@ const Locations:React.FC = () => {
                             />
                             {tooltipData && (
                                 <div
-                                    className="bg-background text-foreground pointer-events-none fixed z-50 min-w-[120px] rounded-lg border px-3 py-2 text-sm shadow-lg transition-all duration-150 ease-in-out"
+                                    className="pointer-events-none fixed z-50 min-w-[120px] rounded-lg border bg-background px-3 py-2 text-sm text-foreground shadow-lg transition-all duration-150 ease-in-out"
                                     style={{
                                         left: tooltipData.x + 10,
                                         top: tooltipData.y + 10,
@@ -189,7 +189,7 @@ const Locations:React.FC = () => {
                                         <span className="font-medium">{tooltipData.countryName}</span>
                                     </div>
                                     <div className='flex grow items-center justify-between gap-3'>
-                                        <div className="text-muted-foreground text-sm">Visitors</div>
+                                        <div className="text-sm text-muted-foreground">Visitors</div>
                                         <div className="font-mono font-medium">{formatNumber(tooltipData.visits)}</div>
                                     </div>
                                 </div>

--- a/apps/stats/src/views/Stats/Sources.tsx
+++ b/apps/stats/src/views/Stats/Sources.tsx
@@ -3,7 +3,7 @@ import DateRangeSelect from './components/DateRangeSelect';
 import React from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, H1, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber, formatQueryDate} from '@tryghost/shade';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
 import {getPeriodText, getRangeDates} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
@@ -91,7 +91,7 @@ const Sources:React.FC = () => {
 
     return (
         <StatsLayout>
-            <ViewHeader>
+            <ViewHeader className='before:hidden'>
                 <H1>Sources</H1>
                 <ViewHeaderActions>
                     <AudienceSelect />
@@ -99,14 +99,14 @@ const Sources:React.FC = () => {
                 </ViewHeaderActions>
             </ViewHeader>
             <StatsView data={data} isLoading={isLoading}>
-                <Card className='-mb-5' variant='plain'>
+                <Card className='-mb-5'>
                     <CardHeader className='border-none'>
                         <CardTitle>Top Sources</CardTitle>
                         <CardDescription>How readers found your site {getPeriodText(range)}</CardDescription>
                     </CardHeader>
-                    <CardContent className='border-none text-gray-500 [&_.recharts-pie-label-line]:stroke-gray-300'>
+                    <CardContent className='border-none [&_.recharts-pie-label-line]:stroke-gray-300'>
                         <ChartContainer
-                            className="mx-auto h-[16vw] max-h-[320px] w-full"
+                            className="mx-auto h-[16vw] max-h-[320px] w-full text-gray-500"
                             config={chartConfig}
                         >
                             <Recharts.PieChart>
@@ -139,41 +139,40 @@ const Sources:React.FC = () => {
                                     strokeWidth={1} />
                             </Recharts.PieChart>
                         </ChartContainer>
-                    </CardContent>
-                </Card>
-                <Card variant='plain'>
-                    <CardContent>
                         {isLoading ? 'Loading' :
-                            <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead className='w-[80%]'>Source</TableHead>
-                                        <TableHead className='text-right'>Visitors</TableHead>
-                                        <TableHead className='w-5 text-right'></TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {data?.map((row, key) => {
-                                        return (
-                                            <TableRow key={row.source || 'direct'}>
-                                                <TableCell className="font-medium">
-                                                    {row.source ?
-                                                        <a className='group flex items-center gap-1' href={`https://${row.source}`} rel="noreferrer" target="_blank">
-                                                            <SourceRow className='group-hover:underline' source={row.source} />
-                                                        </a>
-                                                        :
-                                                        <span className='flex items-center gap-1'>
-                                                            <SourceRow source={row.source} />
-                                                        </span>
-                                                    }
-                                                </TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
-                                                <TableCell className='text-right'>{key < 5 && <span className='inline-block size-[10px] rounded-[2px]' style={{backgroundColor: colors[key]}}></span>}</TableCell>
-                                            </TableRow>
-                                        );
-                                    })}
-                                </TableBody>
-                            </Table>
+                            <>
+                                <Separator className='mt-10' />
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className='w-[80%]'>Source</TableHead>
+                                            <TableHead className='text-right'>Visitors</TableHead>
+                                            <TableHead className='w-5 text-right'></TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {data?.map((row, key) => {
+                                            return (
+                                                <TableRow key={row.source || 'direct'}>
+                                                    <TableCell className="font-medium">
+                                                        {row.source ?
+                                                            <a className='group flex items-center gap-1' href={`https://${row.source}`} rel="noreferrer" target="_blank">
+                                                                <SourceRow className='group-hover:underline' source={row.source} />
+                                                            </a>
+                                                            :
+                                                            <span className='flex items-center gap-1'>
+                                                                <SourceRow source={row.source} />
+                                                            </span>
+                                                        }
+                                                    </TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
+                                                    <TableCell className='text-right'>{key < 5 && <span className='inline-block size-[10px] rounded-[2px]' style={{backgroundColor: colors[key]}}></span>}</TableCell>
+                                                </TableRow>
+                                            );
+                                        })}
+                                    </TableBody>
+                                </Table>
+                            </>
                         }
                     </CardContent>
                 </Card>

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -4,13 +4,14 @@ import DateRangeSelect from './components/DateRangeSelect';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
 import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {useQuery} from '@tinybirdco/charts';
 import {useTopContent} from '@tryghost/admin-x-framework/api/stats';
 
@@ -196,6 +197,7 @@ const Web:React.FC = () => {
     const {isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
+    const navigate = useNavigate();
 
     // Include essential query parameters that change frequently
     // Server will use defaults for other values
@@ -255,10 +257,15 @@ const Web:React.FC = () => {
                                 {topContent?.map((row: TopContentData) => {
                                     return (
                                         <TableRow key={row.pathname}>
-                                            <TableCell className="font-medium"><a className='-mx-2 inline-block px-2 hover:underline' href={`${row.pathname}`} rel="noreferrer" target='_blank'>{row.title || row.pathname}</a></TableCell>
+                                            <TableCell className="font-medium">
+                                                <a className='group/link -mx-2 inline-flex min-h-6 items-center gap-1 px-2 hover:underline' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
+                                                    {row.title || row.pathname}
+                                                    <LucideIcon.SquareArrowOutUpRight className='opacity-0 group-hover/link:opacity-100' size={12} strokeWidth={2.5} />
+                                                </a>
+                                            </TableCell>
                                             <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
                                             <TableCell className='text-center'>
-                                                {row.post_id && (
+                                                {/* {row.post_id && (
                                                     <a
                                                         className="text-gray-500 hover:text-gray-900"
                                                         href={`/ghost/#/posts/analytics/${row.post_id}/web`}
@@ -266,7 +273,30 @@ const Web:React.FC = () => {
                                                     >
                                                         <LucideIcon.BarChart2 className="size-4" />
                                                     </a>
-                                                )}
+                                                )} */}
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger>
+                                                        <Button className='h-6 px-2 hover:bg-gray-200' variant='ghost'>
+                                                            <LucideIcon.Ellipsis />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent align='end'>
+                                                        {row.post_id && (
+                                                            <DropdownMenuItem onClick={() => {
+                                                                navigate(`/posts/analytics/${row.post_id}`, {crossApp: true});
+                                                            }}>
+                                                                <LucideIcon.BarChart2 />
+                                                            Post analytics
+                                                            </DropdownMenuItem>
+                                                        )}
+                                                        <DropdownMenuItem asChild>
+                                                            <a href={`${row.pathname}`} rel="noreferrer" target='_blank'>
+                                                                <LucideIcon.SquareArrowOutUpRight />
+                                                                Open in browser
+                                                            </a>
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
                                             </TableCell>
                                         </TableRow>
                                     );

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -5,11 +5,11 @@ import PostMenu from './components/PostMenu';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
-import {calculateYAxisWidth, formatDisplayDateWithRange, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
@@ -176,7 +176,7 @@ const WebKPIs:React.FC = ({}) => {
                                 //         </g>
                                 //     );
                                 // }}
-                                tickFormatter={date => formatDisplayDateWithRange(date, range)}
+                                tickFormatter={formatDisplayDate}
                                 tickLine={false}
                                 tickMargin={8}
                                 ticks={chartData && chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -1,17 +1,17 @@
 import AudienceSelect, {getAudienceQueryParam} from './components/AudienceSelect';
 import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import DateRangeSelect from './components/DateRangeSelect';
+import PostMenu from './components/PostMenu';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
 import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate} from '@tryghost/admin-x-framework';
 import {useQuery} from '@tinybirdco/charts';
 import {useTopContent} from '@tryghost/admin-x-framework/api/stats';
 
@@ -197,7 +197,6 @@ const Web:React.FC = () => {
     const {isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
-    const navigate = useNavigate();
 
     // Include essential query parameters that change frequently
     // Server will use defaults for other values
@@ -250,7 +249,7 @@ const Web:React.FC = () => {
                                 <TableRow>
                                     <TableHead className='w-[75%]'>Content</TableHead>
                                     <TableHead className='w-[20%] text-right'>Visitors</TableHead>
-                                    <TableHead className='w-[5%]'></TableHead>
+                                    <TableHead className='w-[32px]'></TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
@@ -264,39 +263,8 @@ const Web:React.FC = () => {
                                                 </a>
                                             </TableCell>
                                             <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
-                                            <TableCell className='text-center'>
-                                                {/* {row.post_id && (
-                                                    <a
-                                                        className="text-gray-500 hover:text-gray-900"
-                                                        href={`/ghost/#/posts/analytics/${row.post_id}/web`}
-                                                        title="View post analytics"
-                                                    >
-                                                        <LucideIcon.BarChart2 className="size-4" />
-                                                    </a>
-                                                )} */}
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger>
-                                                        <Button className='h-6 px-2 hover:bg-gray-200' variant='ghost'>
-                                                            <LucideIcon.Ellipsis />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align='end'>
-                                                        {row.post_id && (
-                                                            <DropdownMenuItem onClick={() => {
-                                                                navigate(`/posts/analytics/${row.post_id}`, {crossApp: true});
-                                                            }}>
-                                                                <LucideIcon.BarChart2 />
-                                                            Post analytics
-                                                            </DropdownMenuItem>
-                                                        )}
-                                                        <DropdownMenuItem asChild>
-                                                            <a href={`${row.pathname}`} rel="noreferrer" target='_blank'>
-                                                                <LucideIcon.SquareArrowOutUpRight />
-                                                                Open in browser
-                                                            </a>
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
+                                            <TableCell className='text-center text-gray-700 hover:text-black'>
+                                                <PostMenu pathName={row.pathname} postId={row.post_id} />
                                             </TableCell>
                                         </TableRow>
                                     );

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -9,7 +9,7 @@ import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, 
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
-import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
@@ -22,6 +22,11 @@ interface TopContentData {
     title?: string;
     post_uuid?: string;
     post_id?: string;
+}
+
+interface KpiDataItem {
+    date: string;
+    [key: string]: string | number;
 }
 
 const KPI_METRICS: Record<string, KpiMetric> = {
@@ -72,10 +77,10 @@ const WebKPIs:React.FC = ({}) => {
 
     const currentMetric = KPI_METRICS[currentTab];
 
-    const chartData = data?.map((item) => {
+    const chartData = sanitizeChartData<KpiDataItem>(data as KpiDataItem[] || [], range, currentMetric.dataKey as keyof KpiDataItem, 'sum')?.map((item) => {
         const value = Number(item[currentMetric.dataKey]);
         return {
-            date: item.date,
+            date: String(item.date),
             value,
             formattedValue: currentMetric.formatter(value),
             label: currentMetric.label

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -4,7 +4,7 @@ import DateRangeSelect from './components/DateRangeSelect';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
@@ -217,13 +217,13 @@ const Web:React.FC = () => {
     });
 
     const isLoading = isConfigLoading || isDataLoading;
-    
+
     // The data structure from the hook is {stats: TopContentData[]}
     const topContent = data?.stats || [];
 
     return (
         <StatsLayout>
-            <ViewHeader>
+            <ViewHeader className='before:hidden'>
                 <H1>Web</H1>
                 <ViewHeaderActions>
                     <AudienceSelect />
@@ -231,17 +231,18 @@ const Web:React.FC = () => {
                 </ViewHeaderActions>
             </ViewHeader>
             <StatsView data={topContent} isLoading={isLoading}>
-                <Card variant='plain'>
+                <Card>
                     <CardContent>
                         <WebKPIs />
                     </CardContent>
                 </Card>
-                <Card variant='plain'>
+                <Card>
                     <CardHeader>
                         <CardTitle>Top content</CardTitle>
                         <CardDescription>Your highest viewed posts or pages {getPeriodText(range)}</CardDescription>
                     </CardHeader>
                     <CardContent>
+                        <Separator />
                         <Table>
                             <TableHeader>
                                 <TableRow>
@@ -258,12 +259,12 @@ const Web:React.FC = () => {
                                             <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
                                             <TableCell className='text-center'>
                                                 {row.post_id && (
-                                                    <a 
+                                                    <a
                                                         className="text-gray-500 hover:text-gray-900"
                                                         href={`/ghost/#/posts/analytics/${row.post_id}/web`}
-                                                        title="View post analytics" 
+                                                        title="View post analytics"
                                                     >
-                                                        <LucideIcon.BarChart2 className="h-4 w-4" />
+                                                        <LucideIcon.BarChart2 className="size-4" />
                                                     </a>
                                                 )}
                                             </TableCell>

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -5,11 +5,11 @@ import PostMenu from './components/PostMenu';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
-import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, formatDisplayDateWithRange, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
@@ -154,7 +154,29 @@ const WebKPIs:React.FC = ({}) => {
                                 axisLine={false}
                                 dataKey="date"
                                 interval={0}
-                                tickFormatter={formatDisplayDate}
+                                // tick={({x, y, payload, index, ticks}) => {
+                                //     if (!ticks) {
+                                //         return <g />;
+                                //     }
+                                //     const isFirst = index === 0;
+                                //     const isLast = index === ticks.length - 1;
+                                //     return (
+                                //         <g transform={`translate(${x},${y})`}>
+                                //             <text
+                                //                 className="fill-gray-500"
+                                //                 dy={16}
+                                //                 fill="hsl(var(--foreground))"
+                                //                 fontSize={12}
+                                //                 textAnchor={isFirst ? 'start' : isLast ? 'end' : 'middle'}
+                                //                 x={0}
+                                //                 y={0}
+                                //             >
+                                //                 {formatDisplayDateWithRange(payload.value, range)}
+                                //             </text>
+                                //         </g>
+                                //     );
+                                // }}
+                                tickFormatter={date => formatDisplayDateWithRange(date, range)}
                                 tickLine={false}
                                 tickMargin={8}
                                 ticks={chartData && chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}
@@ -179,7 +201,7 @@ const WebKPIs:React.FC = ({}) => {
                                 width={calculateYAxisWidth(getYTicks(chartData || []), currentMetric.formatter)}
                             />
                             <ChartTooltip
-                                content={<CustomTooltipContent />}
+                                content={<CustomTooltipContent range={range} />}
                                 cursor={true}
                             />
                             <Recharts.Line

--- a/apps/stats/src/views/Stats/components/KpiTab.tsx
+++ b/apps/stats/src/views/Stats/components/KpiTab.tsx
@@ -40,9 +40,6 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({label, value, diffDirection, d
                             {diffDirection === 'down' &&
                                 <LucideIcon.TrendingDown className='!size-[14px]' size={14} strokeWidth={2} />
                             }
-                            {diffDirection === 'same' &&
-                                <LucideIcon.MoveRight className='!size-[14px]' size={14} strokeWidth={2} />
-                            }
                             <span className='font-medium'>{diffValue}</span>
                         </div>
                     </>

--- a/apps/stats/src/views/Stats/components/KpiTab.tsx
+++ b/apps/stats/src/views/Stats/components/KpiTab.tsx
@@ -21,7 +21,7 @@ interface KpiTabValueProps {
 
 const KpiTabValue: React.FC<KpiTabValueProps> = ({label, value, diffDirection, diffValue}) => {
     const diffContainerClassName = cn(
-        'flex items-center gap-1 rounded-full px-1.5 text-xs',
+        'hidden xl:!flex xl:!visible items-center gap-1 rounded-full px-1.5 text-xs -mb-0.5',
         diffDirection === 'up' && 'bg-green/15 text-green-600',
         diffDirection === 'down' && 'bg-red/10 text-red-600',
         diffDirection === 'same' && 'bg-gray-200 text-gray-700'
@@ -29,8 +29,8 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({label, value, diffDirection, d
     return (
         <div className='flex w-full flex-col items-start'>
             <span className='font-semibold tracking-tight'>{label}</span>
-            <div className='-mt-0.5 flex items-baseline gap-3'>
-                <span className='text-[2.3rem] tracking-[-0.04em]'>{value}</span>
+            <div className='-mt-0.5 flex items-center gap-3'>
+                <span className='text-[2.0rem] tracking-tight xl:text-[2.3rem] xl:tracking-[-0.04em]'>{value}</span>
                 {diffValue &&
                     <>
                         <div className={diffContainerClassName}>

--- a/apps/stats/src/views/Stats/components/PostMenu.tsx
+++ b/apps/stats/src/views/Stats/components/PostMenu.tsx
@@ -19,7 +19,7 @@ const PostMenu:React.FC<PostMenuProps> = ({
 
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger>
+            <DropdownMenuTrigger asChild>
                 <Button className='h-6 px-2 hover:bg-gray-200' variant='ghost'>
                     <LucideIcon.Ellipsis />
                 </Button>

--- a/apps/stats/src/views/Stats/components/PostMenu.tsx
+++ b/apps/stats/src/views/Stats/components/PostMenu.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, LucideIcon} from '@tryghost/shade';
+import {useNavigate} from '@tryghost/admin-x-framework';
+
+interface PostMenuProps {
+    postId?: string;
+    pathName?: string;
+}
+
+const PostMenu:React.FC<PostMenuProps> = ({
+    postId,
+    pathName
+}) => {
+    const navigate = useNavigate();
+
+    if (!postId && !pathName) {
+        return <></>;
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger>
+                <Button className='h-6 px-2 hover:bg-gray-200' variant='ghost'>
+                    <LucideIcon.Ellipsis />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+                {postId && (
+                    <DropdownMenuItem onClick={() => {
+                        navigate(`/posts/analytics/${postId}`, {crossApp: true});
+                    }}>
+                        <LucideIcon.BarChart2 />
+                        Post analytics
+                    </DropdownMenuItem>
+                )}
+                {pathName && (
+
+                    <DropdownMenuItem asChild>
+                        <a href={`${pathName}`} rel="noreferrer" target='_blank'>
+                            <LucideIcon.SquareArrowOutUpRight />
+                            Open in browser
+                        </a>
+                    </DropdownMenuItem>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default PostMenu;

--- a/apps/stats/src/views/Stats/components/SortButton.tsx
+++ b/apps/stats/src/views/Stats/components/SortButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {LucideIcon, TableHeadButton} from '@tryghost/shade';
+
+type TopPostsOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc';
+
+interface SortButtonProps {
+    sortBy: TopPostsOrder;
+    setSortBy: (sort: TopPostsOrder) => void;
+    activeSortBy: TopPostsOrder;
+    children: React.ReactNode;
+}
+
+const SortButton:React.FC<SortButtonProps> = ({
+    sortBy,
+    setSortBy,
+    activeSortBy,
+    children
+}) => {
+    return (
+        <TableHeadButton
+            className={`${sortBy === activeSortBy && 'text-black'}`}
+            onClick={() => {
+                setSortBy(sortBy);
+            }}
+        >
+            {children}
+            {sortBy === activeSortBy && <LucideIcon.ArrowUp />}
+        </TableHeadButton>
+    );
+};
+
+export default SortButton;

--- a/apps/stats/src/views/Stats/layout/Sidebar.tsx
+++ b/apps/stats/src/views/Stats/layout/Sidebar.tsx
@@ -11,8 +11,9 @@ const Sidebar:React.FC = () => {
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
     return (
-        <div className='grow border-l py-8 pl-6 pr-0'>
-            <RightSidebarMenu className='sticky top-[134px]'>
+        <div className='grow border-l px-6 py-8'>
+            <RightSidebarMenu className='sticky top-[33px]'>
+                {/* <RightSidebarMenu className='sticky top-[134px]'> */}
                 <RightSidebarMenuLink active={location.pathname === '/' || location.pathname === '/web/'} onClick={() => {
                     navigate('/');
                 }}>

--- a/apps/stats/src/views/Stats/layout/StatsContent.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsContent.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import Sidebar from './Sidebar';
+// import Sidebar from './Sidebar';
 import {cn} from '@tryghost/shade';
 
 const StatsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <section className={cn('gap-8 pb-8 grid w-full grow grid-cols-[auto_288px]', className)} {...props}>
+        <section className={cn('gap-8 pb-8 w-full grow', className)} {...props}>
+            {/* <section className={cn('gap-8 pb-8 grid w-full grow grid-cols-[auto_288px]', className)} {...props}> */}
             <div className='flex size-full flex-col gap-8'>
                 {children}
             </div>
-            <Sidebar />
+            {/* <Sidebar /> */}
         </section>
     );
 };

--- a/apps/stats/src/views/Stats/layout/StatsLayout.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsLayout.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const StatsLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children}) => {
     return (
         <MainLayout>
-            <div className='grid w-full grow'>
+            <div className='w-full grow'>
                 <div className='flex h-full flex-col px-8'>
                     {children}
                 </div>

--- a/apps/stats/src/views/Stats/layout/StatsLayout.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsLayout.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const StatsLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children}) => {
     return (
         <MainLayout>
-            <div className='w-full grow'>
+            <div className='size-full grow'>
                 <div className='flex h-full flex-col px-8'>
                     {children}
                 </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-657/add-growth-tab-to-sitewide-context

- Changed the sidebar layout in side-wide stats to match with longer term concept
- Refined card layout to improve visual grouping and consistency
- Updated how post analytics can be accessed from the Web tab. By being explicit the assumption is to be less confusing WRT orientation
- Sanitized charts so that relative changes are reflected more realistically, e.g. a 0.x% increase is not shown as a "huge" change
- Updated charts granularity so it only shows weekly breakdown for 90+ days, and monthly breakdown for 365+ days
- Added ordering to Growth data table