### PR TITLE
Added dedicated tinybird target to improve build time

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,8 +26,6 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
     apt install -y \
     git \
     stripe \
-    parallel \
-    python3-pip \
     procps && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
@@ -106,10 +104,6 @@ COPY . .
 ## Build typescript packages
 RUN yarn nx run-many -t build:ts
 
-# Install the tinybird CLI
-WORKDIR /home/ghost/ghost/web-analytics
-RUN pip install -r requirements.txt
-
 WORKDIR $WORKDIR
 
 # Expose the ports
@@ -126,3 +120,13 @@ EXPOSE 7174
 
 ## Start the dev server
 CMD ["yarn", "dev"]
+
+FROM development AS tinybird
+
+RUN apt update && apt install -y \
+    parallel \
+    python3-pip
+
+# Install the tinybird CLI
+WORKDIR /home/ghost/ghost/web-analytics
+RUN pip install -r requirements.txt

--- a/compose.yml
+++ b/compose.yml
@@ -84,6 +84,16 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
+
+  tinybird:
+    extends:
+      service: ghost
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+      target: tinybird
+    working_dir: /home/ghost/ghost/web-analytics
+    entrypoint: ["/home/ghost/ghost/web-analytics/entrypoint.sh"]
   mysql:
     image: mysql:8.4.5
     container_name: ghost-mysql

--- a/compose.yml
+++ b/compose.yml
@@ -93,7 +93,8 @@ services:
       dockerfile: ./.docker/Dockerfile
       target: tinybird
     working_dir: /home/ghost/ghost/web-analytics
-    entrypoint: ["/home/ghost/ghost/web-analytics/entrypoint.sh"]
+    profiles: [ tinybird]
+    tty: true
   mysql:
     image: mysql:8.4.5
     container_name: ghost-mysql

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm --no-deps -it -w /home/ghost/ghost/web-analytics ghost /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "COMPOSE_PROFILES=tinybird docker compose run --no-deps -it -w /home/ghost/ghost/web-analytics tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
     "tbcli": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "tb local start",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "COMPOSE_PROFILES=tinybird docker compose run --no-deps -it -w /home/ghost/ghost/web-analytics tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "COMPOSE_PROFILES=tinybird docker compose run --rm --no-deps -it -w /home/ghost/ghost/web-analytics tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
     "tbcli": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "tb local start",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "COMPOSE_PROFILES=tinybird docker compose run --rm --no-deps -it tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "docker compose run --rm --no-deps -it tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
     "tbcli": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "tb local start",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
-    "tb": "COMPOSE_PROFILES=tinybird docker compose run --rm --no-deps -it -w /home/ghost/ghost/web-analytics tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
+    "tb": "COMPOSE_PROFILES=tinybird docker compose run --rm --no-deps -it tinybird /bin/bash --init-file /home/ghost/ghost/web-analytics/entrypoint.sh",
     "tbcli": "docker run --rm -v $(pwd):/ghost -w /ghost/ghost/web-analytics -it tinybirdco/tinybird-cli-docker /bin/bash --init-file /ghost/ghost/web-analytics/entrypoint.sh",
     "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
     "tb:local": "tb local start",


### PR DESCRIPTION
no refs

The Tinybird CLI installation in the Docker build was running after all the code and node dependencies had been copied in and installed. This means if the build cache was busted by a dependency change, we'd also have to reinstall the tinybird CLI, even if nothing had changed.

We only need the Tinybird CLI installed in select circumstances, so this commit creates a new target in the Docker build that inherits from the base development image and just installs the Tinybird CLI. This should speed up builds and rebuilds from the main docker build and for subsequent rebuilds.