### PR TITLE
Added dedicated browser-tests target to improve docker build time

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -95,9 +95,6 @@ COPY ghost/webmentions/package.json ghost/webmentions/package.json
 ## Install dependencies
 RUN yarn install --frozen-lockfile --prefer-offline
 
-## Install playwright w/ dependencies
-RUN npx -y playwright install --with-deps
-
 ## Copy the rest of the code
 COPY . .
 
@@ -130,3 +127,11 @@ RUN apt update && apt install -y \
 # Install the tinybird CLI
 WORKDIR /home/ghost/ghost/web-analytics
 RUN pip install -r requirements.txt
+
+FROM development AS browser-tests
+
+## Install playwright w/ dependencies
+RUN npx -y playwright install --with-deps
+
+## Run the browser tests
+CMD ["yarn", "test:browser"]

--- a/compose.yml
+++ b/compose.yml
@@ -84,7 +84,6 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
-
   tinybird:
     extends:
       service: ghost
@@ -95,6 +94,17 @@ services:
     working_dir: /home/ghost/ghost/web-analytics
     profiles: [ tinybird]
     tty: true
+
+  browser-tests:
+    extends:
+      service: ghost
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+      target: browser-tests
+    command: [ "yarn", "test:browser" ]
+    profiles: [ browser-tests ]
+
   mysql:
     image: mysql:8.4.5
     container_name: ghost-mysql

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
     "docker:sleep:stop": "docker stop ghost-devcontainer",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm --no-deps ghost yarn test:unit",
-    "docker:test:browser": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn test:browser",
+    "docker:test:browser": "COMPOSE_PROFILES=browser-tests docker compose up browser-tests --no-log-prefix --force-recreate",
     "docker:test:all": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm ghost yarn nx run ghost:test:all",
     "docker:reset": "docker compose down -v && docker compose up -d --wait",
     "docker:restart": "docker compose down && docker compose up -d --wait",


### PR DESCRIPTION
no refs

Currently playwright is installed as part of the base development build. The playwright install step needs to be after the main `yarn install` step to ensure we install the correct version, and as a consequence, we have to reinstall playwright everytime any dependency or package.json changes. 

This commit gets around this problem by creating a dedicated build target for browser-tests that includes the playwright build. The `yarn docker:test:browser` command uses this build target, while the regular `yarn docker:dev` command uses the development target, so now we only have to wait for playwright to install if we're actually running the browser tests.