### PR TITLE
Fix async media storage method not awaited

### DIFF
--- a/ghost/core/core/server/api/endpoints/media.js
+++ b/ghost/core/core/server/api/endpoints/media.js
@@ -40,7 +40,7 @@ const controller = {
 
             // NOTE: need to cleanup otherwise the parent media name won't match thumb name
             //       due to "unique name" generation during save
-            if (mediaStorage.exists(frame.file.name, targetDir)) {
+            if (await mediaStorage.exists(frame.file.name, targetDir)) {
                 await mediaStorage.delete(frame.file.name, targetDir);
             }
 


### PR DESCRIPTION
In the media thumbnail upload handler, it first checks if the file already exists in media storage and then deletes it before re-saving.

The [`exists`](https://github.com/TryGhost/Ghost/blob/bec0b9724d52d75e25a7a5a309fea8df9f29b879/ghost/core/core/server/adapters/storage/LocalStorageBase.js#L136) method in the `LocalStorageBase` class returns a promise, which is not awaited here. So the if statement is always truthy due to receiving a promise as the response, which causes the media handler to attempt to delete a file that doesn't exist, which causes an error.