### PR TITLE
Updated yarn docker:build command to only build ghost service

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reset:data:xxl": "cd ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123",
     "docker": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost",
     "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
-    "docker:build": "yarn docker:clean && COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose build",
+    "docker:build": "yarn docker:clean && docker compose build ghost",
     "docker:clean": "echo \"Deleting node_modules volumes...\" && COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose down --remove-orphans && docker volume ls -q -f name=ghost_node_modules | xargs -I{} docker volume rm {}",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
     "docker:mysql": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up mysql -d --wait && docker compose exec mysql mysql -u root -proot ghost",


### PR DESCRIPTION
no refs

Running `docker compose build` is not profile aware, so it will be default build all images that are in the compose.yml file. This includes the browser-tests target and the tinybird build target. These were split into their own targets to avoid incurring the cost of installing them unless you're actually using them. However, the build script still built them, even if their profiles weren't enabled.

This simplifies the `yarn docker:build` script by removing the COMPOSE_PROFILES which isn't used anyways, and speeds up the build significantly by specifying to only build the ghost service, without playwright or tinybird.