### PR TITLE
🐛 Fixed shade unit test for formatting date to display

### DIFF
--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -123,7 +123,7 @@ describe('utils', function () {
             // Using a predefined date for testing, bypassing the current date check
             // Test different year formatting without mocking Date
             const differentYearFormatted = formatDisplayDate('2020-12-31');
-            assert.equal(differentYearFormatted, '30 Dec 2020');
+            assert.equal(differentYearFormatted, '31 Dec 2020');
         });
     });
 


### PR DESCRIPTION
In [recent PR that added config for Stats X app](https://github.com/TryGhost/Ghost/pull/22971) shade unit tests were updated.

Running unit tests with "yarn test:unit" will fail since one of the shade unit tests that tests formatDisplayDate function asserts function result incorrectly. This minor update fixes the unit test.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works


