### PR TITLE
✨ Theme i18n converted to use i18next (with feature flag)

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -72,6 +72,10 @@ const BetaFeatures: React.FC = () => {
                 detail={<>Enable support for CashApp, iDEAL, Bancontact, and others. <a className='text-green' href="https://ghost.org/help/payment-methods" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
                 title='Additional payment methods' />
             <LabItem
+                action={<FeatureToggle flag="themeTranslation" />}
+                detail={<>Enable theme translation using i18next instead of the old translation package.</>}
+                title='Updated theme Translation (beta)' />
+            <LabItem
                 action={<div className='flex flex-col items-end gap-1'>
                     <FileUpload
                         id='upload-redirects'

--- a/ghost/core/core/frontend/helpers/t.js
+++ b/ghost/core/core/frontend/helpers/t.js
@@ -32,6 +32,7 @@ module.exports = function t(text, options = {}) {
 
     if (labs.isSet('themeTranslation')) {
         // Use the new translation package when feature flag is enabled
+        
         // Initialize only if needed
         if (!themeI18next._i18n) {
             themeI18next.init({
@@ -43,6 +44,7 @@ module.exports = function t(text, options = {}) {
         return themeI18next.t(text, bindings);
     } else {
         // Use the existing translation package when feature flag is disabled
+        
         // Initialize only if needed
         if (!themeI18n._strings) {
             themeI18n.init({

--- a/ghost/core/core/frontend/helpers/t.js
+++ b/ghost/core/core/frontend/helpers/t.js
@@ -11,6 +11,8 @@
 // {{tags prefix=(t " on ")}}
 
 const {themeI18n} = require('../services/handlebars');
+const {themeI18next} = require('../services/handlebars');
+const labs = require('../../shared/labs');
 
 module.exports = function t(text, options = {}) {
     if (!text || text.length === 0) {
@@ -26,5 +28,13 @@ module.exports = function t(text, options = {}) {
         }
     }
 
-    return themeI18n.t(text, bindings);
+    if (labs.isSet('themeTranslation')) {
+        // Use the new translation package when feature flag is enabled
+        console.log('====================themeI18next=======================');
+        return themeI18next.t(text, bindings);
+    } else {
+        // Use the existing translation package when feature flag is disabled
+        console.log('====================themeI18n=======================');
+        return themeI18n.t(text, bindings);
+    }
 };

--- a/ghost/core/core/frontend/helpers/t.js
+++ b/ghost/core/core/frontend/helpers/t.js
@@ -13,6 +13,8 @@
 const {themeI18n} = require('../services/handlebars');
 const {themeI18next} = require('../services/handlebars');
 const labs = require('../../shared/labs');
+const config = require('../../shared/config');
+const settingsCache = require('../../shared/settings-cache');
 
 module.exports = function t(text, options = {}) {
     if (!text || text.length === 0) {
@@ -31,10 +33,28 @@ module.exports = function t(text, options = {}) {
     if (labs.isSet('themeTranslation')) {
         // Use the new translation package when feature flag is enabled
         console.log('====================themeI18next=======================');
+        
+        // Initialize only if needed
+        if (!themeI18next._i18n) {
+            themeI18next.init({
+                activeTheme: settingsCache.get('active_theme'),
+                locale: config.get('locale')
+            });
+        }
+        
         return themeI18next.t(text, bindings);
     } else {
         // Use the existing translation package when feature flag is disabled
         console.log('====================themeI18n=======================');
+        
+        // Initialize only if needed
+        if (!themeI18n._strings) {
+            themeI18n.init({
+                activeTheme: settingsCache.get('active_theme'),
+                locale: config.get('locale')
+            });
+        }
+        
         return themeI18n.t(text, bindings);
     }
 };

--- a/ghost/core/core/frontend/helpers/t.js
+++ b/ghost/core/core/frontend/helpers/t.js
@@ -32,8 +32,6 @@ module.exports = function t(text, options = {}) {
 
     if (labs.isSet('themeTranslation')) {
         // Use the new translation package when feature flag is enabled
-        console.log('====================themeI18next=======================');
-        
         // Initialize only if needed
         if (!themeI18next._i18n) {
             themeI18next.init({
@@ -45,8 +43,6 @@ module.exports = function t(text, options = {}) {
         return themeI18next.t(text, bindings);
     } else {
         // Use the existing translation package when feature flag is disabled
-        console.log('====================themeI18n=======================');
-        
         // Initialize only if needed
         if (!themeI18n._strings) {
             themeI18n.init({

--- a/ghost/core/core/frontend/services/handlebars.js
+++ b/ghost/core/core/frontend/services/handlebars.js
@@ -19,7 +19,7 @@ module.exports = {
     // Theme i18n
     // @TODO: this should live somewhere else...
     themeI18n: require('./theme-engine/i18n'),
-
+    themeI18next: require('./theme-engine/i18next'),
     // TODO: these need a more sensible home
     localUtils: require('./theme-engine/handlebars/utils')
 };

--- a/ghost/core/core/frontend/services/theme-engine/active.js
+++ b/ghost/core/core/frontend/services/theme-engine/active.js
@@ -18,6 +18,8 @@ const themeConfig = require('./config');
 const config = require('../../../shared/config');
 const engine = require('./engine');
 const themeI18n = require('./i18n');
+const themeI18next = require('./i18next');
+const labs = require('../../../shared/labs');
 
 // Current instance of ActiveTheme
 let currentActiveTheme;
@@ -101,7 +103,13 @@ class ActiveTheme {
         options.activeTheme = options.activeTheme || this._name;
         options.locale = options.locale || this._locale;
 
-        themeI18n.init(options);
+        if (labs.isSet('themeTranslation')) {
+            // Initialize the new translation service
+            themeI18next.init(options);
+        } else {
+            // Initialize the legacy translation service
+            themeI18n.init(options);
+        }
     }
 
     mount(siteApp) {

--- a/ghost/core/core/frontend/services/theme-engine/i18next/ThemeI18n.js
+++ b/ghost/core/core/frontend/services/theme-engine/i18next/ThemeI18n.js
@@ -74,7 +74,7 @@ class ThemeI18n {
             try {
                 const enPath = path.join(themeLocalesPath, 'en.json');
                 await fs.access(enPath);
-                this._i18n = i18nLib(this._locale, 'theme', {themePath: themeLocalesPath});
+                this._i18n = i18nLib('en', 'theme', {themePath: themeLocalesPath});
             } catch (enErr) {
                 // If both fail, use the key as the translation
                 this._i18n = {

--- a/ghost/core/core/frontend/services/theme-engine/i18next/ThemeI18n.js
+++ b/ghost/core/core/frontend/services/theme-engine/i18next/ThemeI18n.js
@@ -1,0 +1,103 @@
+const errors = require('@tryghost/errors');
+const i18nLib = require('@tryghost/i18n');
+const path = require('path');
+const fs = require('fs-extra');
+
+class ThemeI18n {
+    /**
+     * @param {object} options
+     * @param {string} options.basePath - the base path for the translation directory (e.g. where themes live)
+     * @param {string} [options.locale] - a locale string
+     */
+    constructor(options) {
+        if (!options || !options.basePath) {
+            throw new errors.IncorrectUsageError({message: 'basePath is required'});
+        }
+        this._basePath = options.basePath;
+        this._locale = options.locale || 'en';
+        this._activeTheme = null;
+        this._i18n = null;
+    }
+
+    /**
+     * BasePath getter & setter used for testing
+     */
+    set basePath(basePath) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
+    }
+
+    /**
+     * Setup i18n support for themes:
+     *  - Load correct language file into memory
+     *
+     * @param {object} options
+     * @param {string} options.activeTheme - name of the currently loaded theme
+     * @param {string} options.locale - name of the currently loaded locale
+     */
+    async init(options) {
+        if (!options || !options.activeTheme) {
+            throw new errors.IncorrectUsageError({message: 'activeTheme is required'});
+        }
+
+        this._locale = options.locale || this._locale;
+        this._activeTheme = options.activeTheme;
+
+        const themeLocalesPath = path.join(this._basePath, this._activeTheme, 'locales');
+
+        // Check if the theme path exists
+        const themePathExists = await fs.pathExists(themeLocalesPath);
+
+        if (!themePathExists) {
+            // If the theme path doesn't exist, use the key as the translation
+            this._i18n = {
+                t: key => key
+            };
+            return;
+        }
+
+        // Initialize i18n with the theme path
+        // Note: @tryghost/i18n uses synchronous file operations internally
+        // This is fine in production but in tests we need to ensure the files exist first
+        try {
+            // Verify the locale file exists
+            const localePath = path.join(themeLocalesPath, `${this._locale}.json`);
+            await fs.access(localePath);
+
+            // Initialize i18n
+            this._i18n = i18nLib(this._locale, 'theme', {themePath: themeLocalesPath});
+        } catch (err) {
+            // If the requested locale fails, try English as fallback
+            try {
+                const enPath = path.join(themeLocalesPath, 'en.json');
+                await fs.access(enPath);
+                this._i18n = i18nLib(this._locale, 'theme', {themePath: themeLocalesPath});
+            } catch (enErr) {
+                // If both fail, use the key as the translation
+                this._i18n = {
+                    t: key => key
+                };
+            }
+        }
+    }
+
+    /**
+     * Helper method to find and compile the given data context with a proper string resource.
+     *
+     * @param {string} key - The translation key
+     * @param {object} [bindings] - Optional bindings for the translation
+     * @returns {string}
+     */
+    t(key, bindings) {
+        if (!this._i18n) {
+            throw new errors.IncorrectUsageError({message: `Theme translation was used before it was initialised with key ${key}`});
+        }
+        const result = this._i18n.t(key, bindings);
+        return typeof result === 'string' ? result : String(result);
+    }
+}
+
+module.exports = ThemeI18n;

--- a/ghost/core/core/frontend/services/theme-engine/i18next/index.js
+++ b/ghost/core/core/frontend/services/theme-engine/i18next/index.js
@@ -1,0 +1,6 @@
+const config = require('../../../../shared/config');
+
+const ThemeI18n = require('./ThemeI18n');
+
+module.exports = new ThemeI18n({basePath: config.getContentPath('themes')});
+module.exports.ThemeI18n = ThemeI18n;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -34,7 +34,8 @@ const PUBLIC_BETA_FEATURES = [
     'ActivityPub',
     'superEditors',
     'editorExcerpt',
-    'additionalPaymentMethods'
+    'additionalPaymentMethods',
+    'themeTranslation'
 ];
 
 // These features are considered private they live in the private tab of the labs settings page

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -27,6 +27,7 @@ Object {
       "stripeAutomaticTax": true,
       "superEditors": true,
       "themeErrorsNotification": true,
+      "themeTranslation": true,
       "trafficAnalytics": true,
       "ui60": true,
       "urlCache": true,

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -1,0 +1,85 @@
+const should = require('should');
+const path = require('path');
+const t = require('../../../../core/frontend/helpers/t');
+const themeI18n = require('../../../../core/frontend/services/theme-engine/i18next');
+
+describe('NEW{{t}} helper', function () {
+    let ogBasePath = themeI18n.basePath;
+
+    before(function () {
+        themeI18n.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
+    });
+
+    after(function () {
+        themeI18n.basePath = ogBasePath;
+    });
+
+    beforeEach(async function () {
+        // Reset the i18n instance before each test
+        themeI18n._i18n = null;
+    });
+
+    it('theme translation is DE', async function () {
+        await themeI18n.init({activeTheme: 'locale-theme', locale: 'de'});
+
+        let rendered = t.call({}, 'Top left Button', {
+            hash: {}
+        });
+
+        rendered.should.eql('Oben Links.');
+    });
+
+    it('theme translation is EN', async function () {
+        await themeI18n.init({activeTheme: 'locale-theme', locale: 'en'});
+
+        let rendered = t.call({}, 'Top left Button', {
+            hash: {}
+        });
+
+        rendered.should.eql('Left Button on Top');
+    });
+
+    it('[fallback] no theme translation file found for FR', async function () {
+        await themeI18n.init({activeTheme: 'locale-theme', locale: 'fr'});
+
+        let rendered = t.call({}, 'Top left Button', {
+            hash: {}
+        });
+
+        rendered.should.eql('Left Button on Top');
+    });
+
+    it('[fallback] no theme files at all, use key as translation', async function () {
+        await themeI18n.init({activeTheme: 'locale-theme-1.4', locale: 'de'});
+
+        let rendered = t.call({}, 'Top left Button', {
+            hash: {}
+        });
+
+        rendered.should.eql('Top left Button');
+    });
+
+    it('returns an empty string if translation key is an empty string', function () {
+        let rendered = t.call({}, '', {
+            hash: {}
+        });
+
+        rendered.should.eql('');
+    });
+
+    it('returns an empty string if translation key is missing', function () {
+        let rendered = t.call({}, undefined, {
+            hash: {}
+        });
+
+        rendered.should.eql('');
+    });
+
+    it('returns a translated string even if no options are passed', async function () {
+        await themeI18n.init({activeTheme: 'locale-theme', locale: 'en'});
+
+        let rendered = t.call({}, 'Top left Button');
+
+        rendered.should.eql('Left Button on Top');
+    });
+});

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -1,26 +1,30 @@
 const should = require('should');
 const path = require('path');
+const sinon = require('sinon');
 const t = require('../../../../core/frontend/helpers/t');
-const themeI18n = require('../../../../core/frontend/services/theme-engine/i18next');
+const themeI18next = require('../../../../core/frontend/services/theme-engine/i18next');
+const labs = require('../../../../core/shared/labs');
 
 describe('NEW{{t}} helper', function () {
-    let ogBasePath = themeI18n.basePath;
+    let ogBasePath = themeI18next.basePath;
 
     before(function () {
-        themeI18n.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
+        sinon.stub(labs, 'isSet').withArgs('themeTranslation').returns(true);
+        themeI18next.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
     });
 
     after(function () {
-        themeI18n.basePath = ogBasePath;
+        sinon.restore();
+        themeI18next.basePath = ogBasePath;
     });
 
     beforeEach(async function () {
         // Reset the i18n instance before each test
-        themeI18n._i18n = null;
+        themeI18next._i18n = null;
     });
 
     it('theme translation is DE', async function () {
-        await themeI18n.init({activeTheme: 'locale-theme', locale: 'de'});
+        await themeI18next.init({activeTheme: 'locale-theme', locale: 'de'});
 
         let rendered = t.call({}, 'Top left Button', {
             hash: {}
@@ -30,7 +34,7 @@ describe('NEW{{t}} helper', function () {
     });
 
     it('theme translation is EN', async function () {
-        await themeI18n.init({activeTheme: 'locale-theme', locale: 'en'});
+        await themeI18next.init({activeTheme: 'locale-theme', locale: 'en'});
 
         let rendered = t.call({}, 'Top left Button', {
             hash: {}
@@ -40,7 +44,7 @@ describe('NEW{{t}} helper', function () {
     });
 
     it('[fallback] no theme translation file found for FR', async function () {
-        await themeI18n.init({activeTheme: 'locale-theme', locale: 'fr'});
+        await themeI18next.init({activeTheme: 'locale-theme', locale: 'fr'});
 
         let rendered = t.call({}, 'Top left Button', {
             hash: {}
@@ -50,7 +54,7 @@ describe('NEW{{t}} helper', function () {
     });
 
     it('[fallback] no theme files at all, use key as translation', async function () {
-        await themeI18n.init({activeTheme: 'locale-theme-1.4', locale: 'de'});
+        await themeI18next.init({activeTheme: 'locale-theme-1.4', locale: 'de'});
 
         let rendered = t.call({}, 'Top left Button', {
             hash: {}
@@ -76,7 +80,7 @@ describe('NEW{{t}} helper', function () {
     });
 
     it('returns a translated string even if no options are passed', async function () {
-        await themeI18n.init({activeTheme: 'locale-theme', locale: 'en'});
+        await themeI18next.init({activeTheme: 'locale-theme', locale: 'en'});
 
         let rendered = t.call({}, 'Top left Button');
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
@@ -1,0 +1,62 @@
+const should = require('should');
+const sinon = require('sinon');
+const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i18next/ThemeI18n');
+const path = require('path');
+
+describe('NEW i18nextThemeI18n Class behavior', function () {
+    let i18n;
+    const testBasePath = path.join(__dirname, '../../../../utils/fixtures/themes/');
+
+    beforeEach(async function () {
+        i18n = new ThemeI18n({basePath: testBasePath});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('defaults to en', function () {
+        i18n._locale.should.eql('en');
+    });
+
+    it('can have a different locale set', async function () {
+        await i18n.init({activeTheme: 'locale-theme', locale: 'fr'});
+        i18n._locale.should.eql('fr');
+    });
+    
+    it('initializes with theme path', async function () {
+        await i18n.init({activeTheme: 'locale-theme', locale: 'de'});
+        const result = i18n.t('Top left Button');
+        result.should.eql('Oben Links.');
+    });
+
+    it('falls back to en when translation not found', async function () {
+        await i18n.init({activeTheme: 'locale-theme', locale: 'fr'});
+        const result = i18n.t('Top left Button');
+        result.should.eql('Left Button on Top');
+    });
+
+    it('uses key as fallback when no translation files exist', async function () {
+        await i18n.init({activeTheme: 'locale-theme-1.4', locale: 'de'});
+        const result = i18n.t('Top left Button');
+        result.should.eql('Top left Button');
+    });
+
+    it('returns empty string for empty key', async function () {
+        await i18n.init({activeTheme: 'locale-theme', locale: 'en'});
+        const result = i18n.t('');
+        result.should.eql('');
+    });
+
+    it('throws error if used before initialization', function () {
+        should(function () {
+            i18n.t('some key');
+        }).throw('Theme translation was used before it was initialised with key some key');
+    });
+
+    it('uses key fallback correctly', async function () {
+        await i18n.init({activeTheme: 'locale-theme', locale: 'en'});
+        const result = i18n.t('unknown string');
+        result.should.eql('unknown string');
+    });
+});

--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -1,4 +1,6 @@
 const i18next = require('i18next');
+const fs = require('fs-extra');
+const path = require('path');
 
 const SUPPORTED_LOCALES = [
     'af', // Afrikaans
@@ -86,16 +88,61 @@ function generateResources(locales, ns) {
 
 /**
  * @param {string} [lng]
- * @param {'ghost'|'portal'|'test'|'signup-form'|'comments'|'search'} ns
+ * @param {'ghost'|'portal'|'test'|'signup-form'|'comments'|'search'|'newsletter'|'theme'} ns
+ * @param {object} [options]
+ * @param {string} [options.themePath] - Path to theme's locales directory for theme namespace
  */
-module.exports = (lng = 'en', ns = 'portal') => {
+module.exports = (lng = 'en', ns = 'portal', options = {}) => {
     const i18nextInstance = i18next.createInstance();
     const interpolation = {
         prefix: '{',
         suffix: '}'
     };
 
-    let resources = generateResources(SUPPORTED_LOCALES, ns);
+    // Only disable HTML escaping for theme namespace
+    if (ns === 'theme') {
+        interpolation.escapeValue = false;
+    }
+
+    let resources;
+    if (ns !== 'theme') {
+        resources = generateResources(SUPPORTED_LOCALES, ns);
+    } else {
+        // For theme namespace, we need to load translations from the theme's locales directory
+        resources = {};
+        const themeLocalesPath = options.themePath;
+
+        if (themeLocalesPath) {
+            // Try to load the requested locale first
+            try {
+                const localePath = path.join(themeLocalesPath, `${lng}.json`);
+                const content = fs.readFileSync(localePath, 'utf8');
+                resources[lng] = {
+                    theme: JSON.parse(content)
+                };
+            } catch (err) {
+                // If the requested locale fails, try English as fallback
+                try {
+                    const enPath = path.join(themeLocalesPath, 'en.json');
+                    const content = fs.readFileSync(enPath, 'utf8');
+                    resources[lng] = {
+                        theme: JSON.parse(content)
+                    };
+                } catch (enErr) {
+                    // If both fail, use an empty object
+                    resources[lng] = {
+                        theme: {}
+                    };
+                }
+            }
+        } else {
+            // If no theme path provided, use empty translations
+            resources[lng] = {
+                theme: {}
+            };
+        }
+    }
+
     i18nextInstance.init({
         lng,
 
@@ -104,9 +151,11 @@ module.exports = (lng = 'en', ns = 'portal') => {
         keySeparator: false,
 
         // if the value is an empty string, return the key
+        // this allows empty strings for the en files, and causes all other languages to fallback to en.
         returnEmptyString: false,
 
-        // do not load a fallback
+        // load en as the fallback for any missing language.
+        // load nb as the fallback for no for backwards compatibility
         fallbackLng: {
             no: ['nb', 'en'],
             default: ['en']

--- a/ghost/i18n/test/i18n.test.js
+++ b/ghost/i18n/test/i18n.test.js
@@ -16,7 +16,7 @@ describe('i18n', function () {
         }
     });
 
-    it('is uses default export if available', async function () {
+    it('uses default export if available', async function () {
         const translationFile = require(path.join(`../locales/`, 'nl', 'portal.json'));
         translationFile.Name = undefined;
         translationFile.default = {
@@ -253,16 +253,6 @@ describe('i18n', function () {
             assert.equal(resources.fr.theme['Read more'], 'Read more');
         });
 
-        it('handles interpolation correctly', async function () {
-            const enContent = {
-                'Welcome {name}': 'Welcome {name}'
-            };
-            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
-
-            const t = i18n('en', 'theme', {themePath: themeLocalesPath}).t;
-            assert.equal(t('Welcome {name}', {name: 'John'}), 'Welcome John');
-        });
-
         it('interpolates variables in theme translations', async function () {
             const enContent = {
                 'Welcome, {name}': 'Welcome, {name}',
@@ -300,6 +290,15 @@ describe('i18n', function () {
         it('uses single curly braces for newsletter namespace interpolation', async function () {
             const t = i18n('en', 'newsletter').t;
             assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
+        });
+
+        it('does not html encode interpolated values in the theme namespace', async function () {
+            const enContent = {
+                'Welcome, {name}': 'Welcome, {name}'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+            const t = i18n('en', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Welcome, {name}', {name: '<b>John O\'Nolan</b>'}), 'Welcome, <b>John O\'Nolan</b>');
         });
     });
 

--- a/ghost/i18n/test/i18n.test.js
+++ b/ghost/i18n/test/i18n.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert/strict');
 const fs = require('fs/promises');
 const path = require('path');
+const fsExtra = require('fs-extra');
 
 const i18n = require('../');
 
@@ -164,4 +165,209 @@ describe('i18n', function () {
             checkForEmptyValues(context);
         });
     }); */
+
+    // i18n theme translations when feature flag is enabled
+    describe('theme resources', function () {
+        let themeLocalesPath;
+        let cleanup;
+
+        beforeEach(async function () {
+            // Create a temporary theme locales directory
+            themeLocalesPath = path.join(__dirname, 'temp-theme-locales');
+            await fsExtra.ensureDir(themeLocalesPath);
+            cleanup = async () => {
+                await fsExtra.remove(themeLocalesPath);
+            };
+        });
+
+        afterEach(async function () {
+            await cleanup();
+        });
+
+        it('loads translations from theme locales directory', async function () {
+            // Create test translation files
+            const enContent = {
+                'Read more': 'Read more',
+                Subscribe: 'Subscribe'
+            };
+            const frContent = {
+                'Read more': 'Lire plus',
+                Subscribe: 'S\'abonner'
+            };
+
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'fr.json'), frContent);
+
+            const t = i18n('fr', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Read more'), 'Lire plus');
+            assert.equal(t('Subscribe'), 'S\'abonner');
+        });
+
+        it('falls back to en when translation is missing', async function () {
+            // Create only English translation file
+            const enContent = {
+                'Read more': 'Read more',
+                Subscribe: 'Subscribe'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+
+            const t = i18n('fr', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Read more'), 'Read more');
+            assert.equal(t('Subscribe'), 'Subscribe');
+        });
+
+        it('uses empty translations when no files exist', async function () {
+            const t = i18n('fr', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Read more'), 'Read more');
+            assert.equal(t('Subscribe'), 'Subscribe');
+        });
+
+        it('handles invalid JSON files gracefully', async function () {
+            // Create invalid JSON file
+            await fsExtra.writeFile(path.join(themeLocalesPath, 'fr.json'), 'invalid json');
+
+            const t = i18n('fr', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Read more'), 'Read more');
+            assert.equal(t('Subscribe'), 'Subscribe');
+        });
+
+        it('initializes i18next with correct configuration', async function () {
+            const enContent = {
+                'Read more': 'Read more'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+
+            const instance = i18n('fr', 'theme', {themePath: themeLocalesPath});
+
+            // Verify i18next configuration
+            assert.equal(instance.language, 'fr');
+            assert.deepEqual(instance.options.ns, ['theme']);
+            assert.equal(instance.options.defaultNS, 'theme');
+            assert.equal(instance.options.fallbackLng.default[0], 'en');
+            assert.equal(instance.options.returnEmptyString, false);
+
+            // Verify resources are loaded correctly
+            const resources = instance.store.data;
+            assert(resources.fr);
+            assert(resources.fr.theme);
+            assert.equal(resources.fr.theme['Read more'], 'Read more');
+        });
+
+        it('handles interpolation correctly', async function () {
+            const enContent = {
+                'Welcome {name}': 'Welcome {name}'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+
+            const t = i18n('en', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Welcome {name}', {name: 'John'}), 'Welcome John');
+        });
+
+        it('interpolates variables in theme translations', async function () {
+            const enContent = {
+                'Welcome, {name}': 'Welcome, {name}',
+                'Hello {firstName} {lastName}': 'Hello {firstName} {lastName}'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+
+            const t = i18n('en', 'theme', {themePath: themeLocalesPath}).t;
+
+            // Test simple interpolation
+            assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
+
+            // Test multiple variables
+            assert.equal(
+                t('Hello {firstName} {lastName}', {firstName: 'John', lastName: 'Doe'}),
+                'Hello John Doe'
+            );
+        });
+
+        it('uses single curly braces for theme namespace interpolation', async function () {
+            const enContent = {
+                'Welcome, {name}': 'Welcome, {name}'
+            };
+            await fsExtra.writeJson(path.join(themeLocalesPath, 'en.json'), enContent);
+
+            const t = i18n('en', 'theme', {themePath: themeLocalesPath}).t;
+            assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
+        });
+
+        it('uses double curly braces for portal namespace interpolation', async function () {
+            const t = i18n('en', 'portal').t;
+            assert.equal(t('Welcome, {{name}}', {name: 'John'}), 'Welcome, John');
+        });
+
+        it('uses single curly braces for newsletter namespace interpolation', async function () {
+            const t = i18n('en', 'newsletter').t;
+            assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
+        });
+    });
+
+    describe('i18next initialization', function () {
+        it('initializes with correct default configuration', function () {
+            const instance = i18n('en', 'portal');
+
+            // Verify basic configuration
+            assert.equal(instance.language, 'en');
+            assert.deepEqual(instance.options.ns, ['portal']);
+            assert.equal(instance.options.defaultNS, 'portal');
+            assert.equal(instance.options.fallbackLng.default[0], 'en');
+            assert.equal(instance.options.returnEmptyString, false);
+            assert.equal(instance.options.nsSeparator, false);
+            assert.equal(instance.options.keySeparator, false);
+
+            // Verify interpolation configuration for portal namespace
+            assert.equal(instance.options.interpolation.prefix, '{{');
+            assert.equal(instance.options.interpolation.suffix, '}}');
+        });
+
+        it('initializes with correct theme configuration', function () {
+            const instance = i18n('en', 'theme', {themePath: '/path/to/theme'});
+
+            // Verify basic configuration
+            assert.equal(instance.language, 'en');
+            assert.deepEqual(instance.options.ns, ['theme']);
+            assert.equal(instance.options.defaultNS, 'theme');
+            assert.equal(instance.options.fallbackLng.default[0], 'en');
+            assert.equal(instance.options.returnEmptyString, false);
+            assert.equal(instance.options.nsSeparator, false);
+            assert.equal(instance.options.keySeparator, false);
+
+            // Verify interpolation configuration for theme namespace
+            assert.equal(instance.options.interpolation.prefix, '{');
+            assert.equal(instance.options.interpolation.suffix, '}');
+        });
+
+        it('initializes with correct newsletter configuration', function () {
+            const instance = i18n('en', 'newsletter');
+
+            // Verify basic configuration
+            assert.equal(instance.language, 'en');
+            assert.deepEqual(instance.options.ns, ['newsletter']);
+            assert.equal(instance.options.defaultNS, 'newsletter');
+            assert.equal(instance.options.fallbackLng.default[0], 'en');
+            assert.equal(instance.options.returnEmptyString, false);
+            assert.equal(instance.options.nsSeparator, false);
+            assert.equal(instance.options.keySeparator, false);
+
+            // Verify interpolation configuration for newsletter namespace
+            assert.equal(instance.options.interpolation.prefix, '{');
+            assert.equal(instance.options.interpolation.suffix, '}');
+        });
+
+        it('initializes with correct fallback language configuration', function () {
+            const instance = i18n('no', 'portal');
+
+            // Verify Norwegian fallback chain
+            assert.deepEqual(instance.options.fallbackLng.no, ['nb', 'en']);
+            assert.deepEqual(instance.options.fallbackLng.default, ['en']);
+        });
+
+        it('initializes with empty theme resources when no theme path provided', function () {
+            const instance = i18n('en', 'theme');
+
+            // Verify empty theme resources
+            assert.deepEqual(instance.store.data.en.theme, {});
+        });
+    });
 });

--- a/ghost/i18n/test/i18n.test.js
+++ b/ghost/i18n/test/i18n.test.js
@@ -283,9 +283,9 @@ describe('i18n', function () {
             assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
         });
 
-        it('uses double curly braces for portal namespace interpolation', async function () {
+        it('uses single curly braces for portal namespace interpolation', async function () {
             const t = i18n('en', 'portal').t;
-            assert.equal(t('Welcome, {{name}}', {name: 'John'}), 'Welcome, John');
+            assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
         });
 
         it('uses single curly braces for ghost namespace interpolation', async function () {
@@ -317,8 +317,8 @@ describe('i18n', function () {
             assert.equal(instance.options.keySeparator, false);
 
             // Verify interpolation configuration for portal namespace
-            assert.equal(instance.options.interpolation.prefix, '{{');
-            assert.equal(instance.options.interpolation.suffix, '}}');
+            assert.equal(instance.options.interpolation.prefix, '{');
+            assert.equal(instance.options.interpolation.suffix, '}');
         });
 
         it('initializes with correct theme configuration', function () {

--- a/ghost/i18n/test/i18n.test.js
+++ b/ghost/i18n/test/i18n.test.js
@@ -126,12 +126,13 @@ describe('i18n', function () {
         });
     });
 
-    describe('newsletter i18n', function () {
+    describe('newsletter (now ghost) i18n', function () {
         it('should be able to translate and interpolate a date', async function () {
             const t = i18n('fr', 'ghost').t;
             assert.equal(t('Your subscription will renew on {date}.', {date: '8 Oct 2024'}), 'Votre abonnement sera renouvelé le 8 Oct 2024.');
         });
     });
+
     describe('it gracefully falls back to en if a file is missing', function () {
         it('should be able to translate a key that is missing in the locale', async function () {
             const resources = i18n.generateResources(['xx'], 'portal');
@@ -287,8 +288,8 @@ describe('i18n', function () {
             assert.equal(t('Welcome, {{name}}', {name: 'John'}), 'Welcome, John');
         });
 
-        it('uses single curly braces for newsletter namespace interpolation', async function () {
-            const t = i18n('en', 'newsletter').t;
+        it('uses single curly braces for ghost namespace interpolation', async function () {
+            const t = i18n('en', 'ghost').t;
             assert.equal(t('Welcome, {name}', {name: 'John'}), 'Welcome, John');
         });
 
@@ -337,19 +338,20 @@ describe('i18n', function () {
             assert.equal(instance.options.interpolation.suffix, '}');
         });
 
-        it('initializes with correct newsletter configuration', function () {
-            const instance = i18n('en', 'newsletter');
+        it('initializes with correct newsletter (now ghost) configuration', function () {
+            // note: we just merged newsletter into Ghost, so there might be some redundancy here
+            const instance = i18n('en', 'ghost');
 
             // Verify basic configuration
             assert.equal(instance.language, 'en');
-            assert.deepEqual(instance.options.ns, ['newsletter']);
-            assert.equal(instance.options.defaultNS, 'newsletter');
+            assert.deepEqual(instance.options.ns, ['ghost']);
+            assert.equal(instance.options.defaultNS, 'ghost');
             assert.equal(instance.options.fallbackLng.default[0], 'en');
             assert.equal(instance.options.returnEmptyString, false);
             assert.equal(instance.options.nsSeparator, false);
             assert.equal(instance.options.keySeparator, false);
 
-            // Verify interpolation configuration for newsletter namespace
+            // Verify interpolation configuration for ghost namespace
             assert.equal(instance.options.interpolation.prefix, '{');
             assert.equal(instance.options.interpolation.suffix, '}');
         });


### PR DESCRIPTION
**Goal:** Replace the old theme i18n implementation with use of i18next, matching what we do for the apps and ghost core.

**This PR**:
- adds a themeTranslation feature flag (perhaps badly named?) that switches to using i18next.
- adds changes necessary to ghost/i18n to accommodate theme translations
- adds theme-engine/i18next, that parallels the theme-engine/i18n folder structure but uses i18next.
- updates the 't' helper to check the themeTranslation flag and then use the correct t from either the i18n or i18next folder.
- adds tests for the new implemetation

I don't love having an i18n and i18next folder with partially duplicated functions during the transitional/beta period, but once we're sure we like the new i18next implementation, we can easily remove the logic in the t helper, the theme-engine/i18n folder, and that set of tests.  This approach allowed a clean split at the t helper, rather than a bunch of complicated logic and dealing with sync vs async differences in the two packages.   
