### PR TITLE
Implemented UI for the domain block feature in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['block'] as const;
+export const FEATURE_FLAGS = ['block', 'block-domain'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -1,3 +1,4 @@
+import React, {useState} from 'react';
 import {Account} from '@src/api/activitypub';
 import {
     AlertDialog,
@@ -16,6 +17,7 @@ import {
     PopoverTrigger,
     buttonVariants
 } from '@tryghost/shade';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 
 interface ProfileMenuProps {
     account: Account,
@@ -24,6 +26,7 @@ interface ProfileMenuProps {
     onBlockAccount: () => void;
     disabled?: boolean;
     isBlocked?: boolean;
+    isDomainBlocked?: boolean;
 }
 
 const ProfileMenu: React.FC<ProfileMenuProps> = ({
@@ -32,8 +35,12 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
     onCopyHandle,
     onBlockAccount,
     disabled = false,
-    isBlocked = false
+    isBlocked = false,
+    isDomainBlocked = false
 }) => {
+    const {isEnabled} = useFeatureFlags();
+    const [dialogType, setDialogType] = useState<'user' | 'domain' | null>(null);
+
     const handleCopyHandleClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         onCopyHandle();
@@ -42,6 +49,10 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
     const handleBlockAccountClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         onBlockAccount();
+    };
+
+    const handleBlockDomainClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
     };
 
     return (
@@ -62,25 +73,54 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                 <Button
                                     className='justify-start text-red hover:bg-red/5 hover:text-red'
                                     variant='ghost'
-                                    onClick={e => e.stopPropagation()}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setDialogType('user');
+                                    }}
                                 >
                                     {isBlocked ? 'Unblock user' : 'Block user'}
                                 </Button>
                             </PopoverClose>
                         </AlertDialogTrigger>
+                        {isEnabled('block-domain') &&
+                            <AlertDialogTrigger asChild>
+                                <PopoverClose asChild>
+                                    <Button
+                                        className='justify-start text-red hover:bg-red/5 hover:text-red'
+                                        variant='ghost'
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            setDialogType('domain');
+                                        }}
+                                    >
+                                        {isDomainBlocked ? 'Unblock domain' : 'Block domain'}
+                                    </Button>
+                                </PopoverClose>
+                            </AlertDialogTrigger>
+                        }
                     </div>
                 </PopoverContent>
             </Popover>
             <AlertDialogContent onClick={e => e.stopPropagation()}>
                 <AlertDialogHeader>
                     <AlertDialogTitle className='mb-1 flex flex-col gap-1'>
-                        {isBlocked ? 'Unblock this user?' : 'Block this user?'}
-                        <span className='text-base font-normal tracking-normal'>{account.handle}</span>
+                        {dialogType === 'user'
+                            ? (isBlocked ? 'Unblock this user?' : 'Block this user?')
+                            : (isDomainBlocked ? 'Unblock this domain?' : 'Block this domain?')}
+                        <span className='text-base font-normal tracking-normal'>
+                            {dialogType === 'user'
+                                ? account.handle
+                                : account.handle.split('@').filter(Boolean)[1]}
+                        </span>
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                        {isBlocked
-                            ? 'They will be able to follow you and engage with your public posts.'
-                            : 'They will be able to see your public posts, but will no longer be able follow you or interact with your content on the social web.'}
+                        {dialogType === 'user'
+                            ? (isBlocked
+                                ? 'They will be able to follow you and engage with your public posts.'
+                                : 'They will be able to see your public posts, but will no longer be able follow you or interact with your content on the social web.')
+                            : (isDomainBlocked
+                                ? 'Users from this domain will be able to follow you and engage with your public posts.'
+                                : 'All users from this domain will be able to see your public posts, but won\'t be able to follow you or interact with your content.')}
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -89,7 +129,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                     </AlertDialogCancel>
                     <AlertDialogAction
                         className={isBlocked ? undefined : buttonVariants({variant: 'destructive'})}
-                        onClick={handleBlockAccountClick}
+                        onClick={dialogType === 'user' ? handleBlockAccountClick : handleBlockDomainClick}
                     >
                         {isBlocked ? 'Unblock' : 'Block'}
                     </AlertDialogAction>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -26,7 +26,6 @@ interface ProfileMenuProps {
     onBlockAccount: () => void;
     disabled?: boolean;
     isBlocked?: boolean;
-    isDomainBlocked?: boolean;
 }
 
 const ProfileMenu: React.FC<ProfileMenuProps> = ({
@@ -35,8 +34,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
     onCopyHandle,
     onBlockAccount,
     disabled = false,
-    isBlocked = false,
-    isDomainBlocked = false
+    isBlocked = false
 }) => {
     const {isEnabled} = useFeatureFlags();
     const [dialogType, setDialogType] = useState<'user' | 'domain' | null>(null);
@@ -93,7 +91,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                             setDialogType('domain');
                                         }}
                                     >
-                                        {isDomainBlocked ? 'Unblock domain' : 'Block domain'}
+                                        {isBlocked ? 'Unblock domain' : 'Block domain'}
                                     </Button>
                                 </PopoverClose>
                             </AlertDialogTrigger>
@@ -106,7 +104,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                     <AlertDialogTitle className='mb-1 flex flex-col gap-1'>
                         {dialogType === 'user'
                             ? (isBlocked ? 'Unblock this user?' : 'Block this user?')
-                            : (isDomainBlocked ? 'Unblock this domain?' : 'Block this domain?')}
+                            : (isBlocked ? 'Unblock this domain?' : 'Block this domain?')}
                         <span className='text-base font-normal tracking-normal'>
                             {dialogType === 'user'
                                 ? account.handle
@@ -118,7 +116,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                             ? (isBlocked
                                 ? 'They will be able to follow you and engage with your public posts.'
                                 : 'They will be able to see your public posts, but will no longer be able follow you or interact with your content on the social web.')
-                            : (isDomainBlocked
+                            : (isBlocked
                                 ? 'Users from this domain will be able to follow you and engage with your public posts.'
                                 : 'All users from this domain will be able to see your public posts, but won\'t be able to follow you or interact with your content.')}
                     </AlertDialogDescription>


### PR DESCRIPTION
ref PROD-697

- extended the profile menu with a new "Block domain" option alongside existing user blocking feature
- put it behind a feature flag `block-domain`