### PR TITLE
Fixed docker compose profiles

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,8 @@ name: ghost
 x-common-volumes: &common-volumes
   volumes:
     - .:/home/ghost
+    - ${SSH_AUTH_SOCK}:/ssh-agent
+    - ${HOME}/.gitconfig:/root/.gitconfig:ro
     - node_modules_ghost_root:/home/ghost/node_modules:delegated
     - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
     - node_modules_ghost_api-framework:/home/ghost/ghost/api-framework/node_modules:delegated
@@ -62,9 +64,6 @@ services:
       - "7173:7173" # Comments
       - "7174:7174" # Comments HTTPS
     profiles: [ ghost ]
-    volumes:
-      - ${SSH_AUTH_SOCK}:/ssh-agent
-      - ${HOME}/.gitconfig:/root/.gitconfig:ro
     tty: true
     depends_on:
       mysql:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 name: ghost
 
-x-common-volumes: &common-volumes
+# Template to share volumes and environment variable between all services running the same base image
+x-service-template: &service-template
   volumes:
     - .:/home/ghost
     - ${SSH_AUTH_SOCK}:/ssh-agent
@@ -42,10 +43,20 @@ x-common-volumes: &common-volumes
     - node_modules_apps_signup-form:/home/ghost/apps/signup-form/node_modules:delegated
     - node_modules_apps_sodo-search:/home/ghost/apps/sodo-search/node_modules:delegated
     - node_modules_apps_stats:/home/ghost/apps/stats/node_modules:delegated
+  environment:
+    - DEBUG=${DEBUG:-}
+    - SSH_AUTH_SOCK=/ssh-agent
+    - NX_DAEMON=${NX_DAEMON:-true}
+    - GHOST_DEV_IS_DOCKER=true
+    - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
+    - GHOST_UPSTREAM=${GHOST_UPSTREAM:-}
+    - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+    - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
+    - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
 
 services:
   ghost:
-    <<: *common-volumes
+    <<: *service-template
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
@@ -70,19 +81,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    environment:
-      - DEBUG=${DEBUG:-}
-      - SSH_AUTH_SOCK=/ssh-agent
-      - NX_DAEMON=${NX_DAEMON:-true}
-      - GHOST_DEV_IS_DOCKER=true
-      - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
-      - GHOST_UPSTREAM=${GHOST_UPSTREAM:-}
-      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
-      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
-      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
 
   tinybird:
-    <<: *common-volumes
+    <<: *service-template
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
@@ -92,13 +93,14 @@ services:
     tty: true
 
   browser-tests:
-    <<: *common-volumes
+    <<: *service-template
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
       target: browser-tests
     command: [ "yarn", "test:browser" ]
     profiles: [ browser-tests ]
+    tty: true
 
   mysql:
     image: mysql:8.4.5

--- a/compose.yml
+++ b/compose.yml
@@ -81,26 +81,25 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
-  # tinybird:
-  #   extends:
-  #     service: ghost
-  #   build:
-  #     context: .
-  #     dockerfile: ./.docker/Dockerfile
-  #     target: tinybird
-  #   working_dir: /home/ghost/ghost/web-analytics
-  #   profiles: [ tinybird]
-  #   tty: true
 
-  # browser-tests:
-  #   extends:
-  #     service: ghost
-  #   build:
-  #     context: .
-  #     dockerfile: ./.docker/Dockerfile
-  #     target: browser-tests
-  #   command: [ "yarn", "test:browser" ]
-  #   profiles: [ browser-tests ]
+  tinybird:
+    <<: *common-volumes
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+      target: tinybird
+    working_dir: /home/ghost/ghost/web-analytics
+    profiles: [ tinybird ]
+    tty: true
+
+  browser-tests:
+    <<: *common-volumes
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+      target: browser-tests
+    command: [ "yarn", "test:browser" ]
+    profiles: [ browser-tests ]
 
   mysql:
     image: mysql:8.4.5

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,49 @@
 name: ghost
+
+x-common-volumes: &common-volumes
+  volumes:
+    - .:/home/ghost
+    - node_modules_ghost_root:/home/ghost/node_modules:delegated
+    - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
+    - node_modules_ghost_api-framework:/home/ghost/ghost/api-framework/node_modules:delegated
+    - node_modules_ghost_constants:/home/ghost/ghost/constants/node_modules:delegated
+    - node_modules_ghost_core:/home/ghost/ghost/core/node_modules:delegated
+    - node_modules_ghost_custom-fonts:/home/ghost/ghost/custom-fonts/node_modules:delegated
+    - node_modules_ghost_domain-events:/home/ghost/ghost/domain-events/node_modules:delegated
+    - node_modules_ghost_donations:/home/ghost/ghost/donations/node_modules:delegated
+    - node_modules_ghost_email-addresses:/home/ghost/ghost/email-addresses/node_modules:delegated
+    - node_modules_ghost_email-service:/home/ghost/ghost/email-service/node_modules:delegated
+    - node_modules_ghost_html-to-plaintext:/home/ghost/ghost/html-to-plaintext/node_modules:delegated
+    - node_modules_ghost_i18n:/home/ghost/ghost/i18n/node_modules:delegated
+    - node_modules_ghost_job-manager:/home/ghost/ghost/job-manager/node_modules:delegated
+    - node_modules_ghost_link-replacer:/home/ghost/ghost/link-replacer/node_modules:delegated
+    - node_modules_ghost_member-attribution:/home/ghost/ghost/member-attribution/node_modules:delegated
+    - node_modules_ghost_members-csv:/home/ghost/ghost/members-csv/node_modules:delegated
+    - node_modules_ghost_mw-error-handler:/home/ghost/ghost/mw-error-handler/node_modules:delegated
+    - node_modules_ghost_mw-vhost:/home/ghost/ghost/mw-vhost/node_modules:delegated
+    - node_modules_ghost_offers:/home/ghost/ghost/offers/node_modules:delegated
+    - node_modules_ghost_post-events:/home/ghost/ghost/post-events/node_modules:delegated
+    - node_modules_ghost_post-revisions:/home/ghost/ghost/post-revisions/node_modules:delegated
+    - node_modules_ghost_prometheus-metrics:/home/ghost/ghost/prometheus-metrics/node_modules:delegated
+    - node_modules_ghost_security:/home/ghost/ghost/security/node_modules:delegated
+    - node_modules_ghost_tiers:/home/ghost/ghost/tiers/node_modules:delegated
+    - node_modules_ghost_webmentions:/home/ghost/ghost/webmentions/node_modules:delegated
+    - node_modules_apps_admin-x-activitypub:/home/ghost/apps/admin-x-activitypub/node_modules:delegated
+    - node_modules_apps_admin-x-design-system:/home/ghost/apps/admin-x-design-system/node_modules:delegated
+    - node_modules_apps_admin-x-framework:/home/ghost/apps/admin-x-framework/node_modules:delegated
+    - node_modules_apps_admin-x-settings:/home/ghost/apps/admin-x-settings/node_modules:delegated
+    - node_modules_apps_announcement-bar:/home/ghost/apps/announcement-bar/node_modules:delegated
+    - node_modules_apps_comments-ui:/home/ghost/apps/comments-ui/node_modules:delegated
+    - node_modules_apps_portal:/home/ghost/apps/portal/node_modules:delegated
+    - node_modules_apps_posts:/home/ghost/apps/posts/node_modules:delegated
+    - node_modules_apps_shade:/home/ghost/apps/shade/node_modules:delegated
+    - node_modules_apps_signup-form:/home/ghost/apps/signup-form/node_modules:delegated
+    - node_modules_apps_sodo-search:/home/ghost/apps/sodo-search/node_modules:delegated
+    - node_modules_apps_stats:/home/ghost/apps/stats/node_modules:delegated
+
 services:
   ghost:
+    <<: *common-volumes
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
@@ -20,54 +63,8 @@ services:
       - "7174:7174" # Comments HTTPS
     profiles: [ ghost ]
     volumes:
-      # Mount the source code
-      - .:/home/ghost
-
-      ## SSH Agent forwarding
       - ${SSH_AUTH_SOCK}:/ssh-agent
-
-      ## Git config
       - ${HOME}/.gitconfig:/root/.gitconfig:ro
-
-      # Volume exclusions:
-      ## Prevent collisions between host and container node_modules
-      - node_modules_ghost_root:/home/ghost/node_modules:delegated
-      - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
-      - node_modules_ghost_api-framework:/home/ghost/ghost/api-framework/node_modules:delegated
-      - node_modules_ghost_constants:/home/ghost/ghost/constants/node_modules:delegated
-      - node_modules_ghost_core:/home/ghost/ghost/core/node_modules:delegated
-      - node_modules_ghost_custom-fonts:/home/ghost/ghost/custom-fonts/node_modules:delegated
-      - node_modules_ghost_domain-events:/home/ghost/ghost/domain-events/node_modules:delegated
-      - node_modules_ghost_donations:/home/ghost/ghost/donations/node_modules:delegated
-      - node_modules_ghost_email-addresses:/home/ghost/ghost/email-addresses/node_modules:delegated
-      - node_modules_ghost_email-service:/home/ghost/ghost/email-service/node_modules:delegated
-      - node_modules_ghost_html-to-plaintext:/home/ghost/ghost/html-to-plaintext/node_modules:delegated
-      - node_modules_ghost_i18n:/home/ghost/ghost/i18n/node_modules:delegated
-      - node_modules_ghost_job-manager:/home/ghost/ghost/job-manager/node_modules:delegated
-      - node_modules_ghost_link-replacer:/home/ghost/ghost/link-replacer/node_modules:delegated
-      - node_modules_ghost_member-attribution:/home/ghost/ghost/member-attribution/node_modules:delegated
-      - node_modules_ghost_members-csv:/home/ghost/ghost/members-csv/node_modules:delegated
-      - node_modules_ghost_mw-error-handler:/home/ghost/ghost/mw-error-handler/node_modules:delegated
-      - node_modules_ghost_mw-vhost:/home/ghost/ghost/mw-vhost/node_modules:delegated
-      - node_modules_ghost_offers:/home/ghost/ghost/offers/node_modules:delegated
-      - node_modules_ghost_post-events:/home/ghost/ghost/post-events/node_modules:delegated
-      - node_modules_ghost_post-revisions:/home/ghost/ghost/post-revisions/node_modules:delegated
-      - node_modules_ghost_prometheus-metrics:/home/ghost/ghost/prometheus-metrics/node_modules:delegated
-      - node_modules_ghost_security:/home/ghost/ghost/security/node_modules:delegated
-      - node_modules_ghost_tiers:/home/ghost/ghost/tiers/node_modules:delegated
-      - node_modules_ghost_webmentions:/home/ghost/ghost/webmentions/node_modules:delegated
-      - node_modules_apps_admin-x-activitypub:/home/ghost/apps/admin-x-activitypub/node_modules:delegated
-      - node_modules_apps_admin-x-design-system:/home/ghost/apps/admin-x-design-system/node_modules:delegated
-      - node_modules_apps_admin-x-framework:/home/ghost/apps/admin-x-framework/node_modules:delegated
-      - node_modules_apps_admin-x-settings:/home/ghost/apps/admin-x-settings/node_modules:delegated
-      - node_modules_apps_announcement-bar:/home/ghost/apps/announcement-bar/node_modules:delegated
-      - node_modules_apps_comments-ui:/home/ghost/apps/comments-ui/node_modules:delegated
-      - node_modules_apps_portal:/home/ghost/apps/portal/node_modules:delegated
-      - node_modules_apps_posts:/home/ghost/apps/posts/node_modules:delegated
-      - node_modules_apps_shade:/home/ghost/apps/shade/node_modules:delegated
-      - node_modules_apps_signup-form:/home/ghost/apps/signup-form/node_modules:delegated
-      - node_modules_apps_sodo-search:/home/ghost/apps/sodo-search/node_modules:delegated
-      - node_modules_apps_stats:/home/ghost/apps/stats/node_modules:delegated
     tty: true
     depends_on:
       mysql:
@@ -84,26 +81,26 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
-  tinybird:
-    extends:
-      service: ghost
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile
-      target: tinybird
-    working_dir: /home/ghost/ghost/web-analytics
-    profiles: [ tinybird]
-    tty: true
+  # tinybird:
+  #   extends:
+  #     service: ghost
+  #   build:
+  #     context: .
+  #     dockerfile: ./.docker/Dockerfile
+  #     target: tinybird
+  #   working_dir: /home/ghost/ghost/web-analytics
+  #   profiles: [ tinybird]
+  #   tty: true
 
-  browser-tests:
-    extends:
-      service: ghost
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile
-      target: browser-tests
-    command: [ "yarn", "test:browser" ]
-    profiles: [ browser-tests ]
+  # browser-tests:
+  #   extends:
+  #     service: ghost
+  #   build:
+  #     context: .
+  #     dockerfile: ./.docker/Dockerfile
+  #     target: browser-tests
+  #   command: [ "yarn", "test:browser" ]
+  #   profiles: [ browser-tests ]
 
   mysql:
     image: mysql:8.4.5


### PR DESCRIPTION
no refs

These two commits (https://github.com/TryGhost/Ghost/commit/bec0b9724d52d75e25a7a5a309fea8df9f29b879 & https://github.com/TryGhost/Ghost/commit/55f2e42ec8fe043c85d7d0cccd36b86a16c96903) used the `extends` feature of Docker Compose to share the list of volumes and environment variables, to avoid duplicating the long list of `node_modules` volumes.

However, this didn't work as expected, because the `tinybird` and `browser-tests` services also inherit the `profiles` key. This means that the `tinybird` and `browser-tests` services _also_ implicitly have the `ghost` service, so they were running when using `yarn docker:dev`, which we don't want. This change refactors to use a common base template service using YAML anchors and aliases, rather than using Docker Compose `extends`. This allows these services to share just the volumes and environment, without also sharing profiles and other settings from the base service.

One caveat that I haven't solved yet: this pattern doesn't allow you to add additional volumes and environment variables to particular services, so we can't i.e. use all the shared volumes, plus declare additional volumes on a service-by-service basis. This isn't ideal, but it'll do for now.