### PR TITLE
Updated member upgrade to use welcome page url if provided

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -238,7 +238,8 @@ function createApiInstance(config) {
         emailSuppressionList,
         settingsCache,
         sentry,
-        settingsHelpers
+        settingsHelpers,
+        urlUtils
     });
 
     return membersApiInstance;

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -413,7 +413,12 @@ module.exports = class RouterController {
         try {
             // Create URL objects
             const siteUrl = this._urlUtils.getSiteUrl();
-            const welcomeUrl = new URL(welcomePageURL.startsWith('http') ? welcomePageURL : welcomePageURL, siteUrl);
+            
+            // This will throw if welcomePageURL is invalid
+            const welcomeUrl = new URL(
+                welcomePageURL.startsWith('http') ? welcomePageURL : welcomePageURL, 
+                siteUrl
+            );
             
             // Add success parameters
             welcomeUrl.searchParams.set('success', 'true');
@@ -421,7 +426,7 @@ module.exports = class RouterController {
             
             return welcomeUrl.href;
         } catch (err) {
-            logging.warn('Invalid welcome page URL, using original success URL', err);
+            logging.warn(`Invalid welcome page URL "${welcomePageURL}", using original success URL`, err);
             return originalSuccessUrl;
         }
     }

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -72,7 +72,8 @@ module.exports = function MembersAPI({
     emailSuppressionList,
     settingsCache,
     sentry,
-    settingsHelpers
+    settingsHelpers,
+    urlUtils
 }) {
     const tokenService = new TokenService({
         privateKey,
@@ -196,7 +197,8 @@ module.exports = function MembersAPI({
         labsService,
         newslettersService,
         settingsCache,
-        sentry
+        sentry,
+        urlUtils
     });
 
     const wellKnownController = new WellKnownController({


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/23095

We have the concept of a welcome url for tiers, which we utilize for new signups via `createSessionFromToken`. We do not use this code path for already-authenticated users, the result being that the paid tier URL is not used whenever an existing member upgrades their tier (or downgrades). 

This certainly isn't the best supported feature out there. I've updated the router the handle this upgrade case, although there's likely better ways about it. 