### PR TITLE
Allowed cors for Portal dev mode

### DIFF
--- a/apps/portal/vite.config.js
+++ b/apps/portal/vite.config.js
@@ -22,7 +22,8 @@ export default defineConfig((config) => {
         },
         preview: {
             host: '0.0.0.0',
-            port: 4175
+            port: 4175,
+            cors: true
         },
         server: {
             port: 5368


### PR DESCRIPTION
no ref

I was seeing issues requesting the minified file at localhost:4175 while ghost is on :2368 when running dev locally (`yarn dev --portal`). This was the resolution to that.