### PR TITLE
Allowed cors for comments dev

### DIFF
--- a/apps/comments-ui/vite.config.ts
+++ b/apps/comments-ui/vite.config.ts
@@ -21,7 +21,8 @@ export default (function viteConfig() {
         },
         preview: {
             host: '0.0.0.0',
-            port: 7173
+            port: 7173,
+            cors: true
         },
         server: {
             port: 5368


### PR DESCRIPTION
no ref

This should avoid cors errors when doing dev locally using `yarn dev --comments` in Ghost.