### PR TITLE
🐛 Fixed CTA for public preview card not showing on post previews

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/email-post.js
+++ b/ghost/core/core/frontend/services/routing/controllers/email-post.js
@@ -51,7 +51,7 @@ module.exports = function emailPostController(req, res, next) {
                 return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
-            // post.access = !!post.html;
+            post.access = !!post.html;
 
             return renderer.renderEntry(req, res)(post);
         })

--- a/ghost/core/core/frontend/services/routing/controllers/email-post.js
+++ b/ghost/core/core/frontend/services/routing/controllers/email-post.js
@@ -51,7 +51,7 @@ module.exports = function emailPostController(req, res, next) {
                 return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
-            post.access = !!post.html;
+            // post.access = !!post.html;
 
             return renderer.renderEntry(req, res)(post);
         })

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -59,13 +59,6 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
             }
 
-            // Set access based on member status and post visibility
-            const member = req.query?.member_status && req.query.member_status !== 'anonymous' 
-                ? {status: req.query.member_status} 
-                : null;
-            // we literally don't even need this, because we get post.access from the API anyway.
-            //post.access = checkPostAccess(post, member);
-
             return renderer.renderEntry(req, res)(post);
         })
         .catch(renderer.handleError(next));

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -3,7 +3,6 @@ const config = require('../../../../shared/config');
 const {routerManager} = require('../');
 const urlUtils = require('../../../../shared/url-utils');
 const renderer = require('../../rendering');
-const {checkPostAccess} = require('../../../../server/services/members/content-gating');
 
 /**
  * @description Preview Controller.
@@ -28,7 +27,7 @@ module.exports = function previewController(req, res, next) {
         .read(params)
         .then(function then(result) {
             const post = result[res.routerOptions.query.resource][0];
-
+            console.log('post', post);
             if (!post) {
                 return next();
             }
@@ -65,7 +64,8 @@ module.exports = function previewController(req, res, next) {
             const member = req.query?.member_status && req.query.member_status !== 'anonymous' 
                 ? {status: req.query.member_status} 
                 : null;
-            post.access = checkPostAccess(post, member);
+            // we literally don't even need this, because we get post.access from the API anyway.
+            //post.access = checkPostAccess(post, member);
 
             return renderer.renderEntry(req, res)(post);
         })

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -3,6 +3,7 @@ const config = require('../../../../shared/config');
 const {routerManager} = require('../');
 const urlUtils = require('../../../../shared/url-utils');
 const renderer = require('../../rendering');
+const {checkPostAccess} = require('../../../../server/services/members/content-gating');
 
 /**
  * @description Preview Controller.
@@ -60,7 +61,11 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
             }
 
-            post.access = !!post.html;
+            // Set access based on member status and post visibility
+            const member = req.query?.member_status && req.query.member_status !== 'anonymous' 
+                ? {status: req.query.member_status} 
+                : null;
+            post.access = checkPostAccess(post, member);
 
             return renderer.renderEntry(req, res)(post);
         })

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -27,7 +27,6 @@ module.exports = function previewController(req, res, next) {
         .read(params)
         .then(function then(result) {
             const post = result[res.routerOptions.query.resource][0];
-            console.log('post', post);
             if (!post) {
                 return next();
             }

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -74,6 +74,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect((res) => {
                 res.text.should.match(/Before paywall/);
                 res.text.should.not.match(/After paywall/);
+                res.text.should.match(/This post is for/);
             });
     });
 
@@ -85,6 +86,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect((res) => {
                 res.text.should.match(/Before paywall/);
                 res.text.should.match(/After paywall/);
+                res.text.should.not.match(/This post is for/);
             });
     });
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/23181
closes https://linear.app/ghost/issue/ONC-921/oss-issue-content-cta-does-not-display-on-preview-when-it-should
refs https://linear.app/ghost/issue/ONC-930/support-escalation-re-freepaywalls-on-web-versions-of-email-only-posts

When a post is set to members only or paid only and there is a public preview card present, the "This post is for members only" CTA wasn't appearing in the post preview, even though the private content was correctly omitted. The CTA was correctly being displayed on the actual post on the frontend, however.

This pattern of setting `post.access` in the frontend controller route was previously used in all of the `entry`, `preview` and `email` routers. This [commit](https://github.com/TryGhost/Ghost/commit/fa91c6c9545a9107ba9b938f545c674ff70a462c#diff-42f164398878ef21b6e9ab8e68f273a167fe1f5e85f4b3fe0036d92ab8128e94) from 2020 switches this pattern to calculate the value of `post.access` in the content API rather than the frontend, and this same `post.access = !!post.html` line was removed from the `entry` controller at that time. However, the change wasn't carried over to the `email` or `preview` controllers.

This commit carries the pattern over to the `preview` controller, and adds a test to ensure the CTA is rendered in the preview route. I'll follow up with another PR to do the same for the `email` controller.