### PR TITLE
Added MRR data to the site wide Growth tab

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -119,5 +119,5 @@ export const usePostGrowthStats = createQueryWithId<PostGrowthStatsResponseType>
 });
 export const useMrrHistory = createQuery<MrrHistoryResponseType>({
     dataType: mrrHistoryDataType,
-    path: '/stats/mrr-history/'
+    path: '/stats/mrr/'
 });

--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -92,7 +92,6 @@ const postReferrersDataType = 'PostReferrersResponseType';
 const postGrowthStatsDataType = 'PostGrowthStatsResponseType';
 const mrrHistoryDataType = 'MrrHistoryResponseType';
 
-
 export const useTopContent = createQuery<TopContentResponseType>({
     dataType,
     path: '/stats/top-content/'

--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -72,13 +72,26 @@ export type PostGrowthStatsResponseType = {
     meta: Meta;
 };
 
+export type MrrHistoryItem = {
+    date: string;
+    mrr: number;
+    currency: string;
+};
+export type MrrHistoryResponseType = {
+    stats: MrrHistoryItem[];
+    meta: Meta;
+};
+
 // Requests
 
 const dataType = 'TopContentResponseType';
 const memberCountHistoryDataType = 'MemberCountHistoryResponseType';
 const topPostsStatsDataType = 'TopPostsStatsResponseType';
 const postReferrersDataType = 'PostReferrersResponseType';
+
 const postGrowthStatsDataType = 'PostGrowthStatsResponseType';
+const mrrHistoryDataType = 'MrrHistoryResponseType';
+
 
 export const useTopContent = createQuery<TopContentResponseType>({
     dataType,
@@ -103,4 +116,8 @@ export const usePostReferrers = createQueryWithId<PostReferrersResponseType>({
 export const usePostGrowthStats = createQueryWithId<PostGrowthStatsResponseType>({
     dataType: postGrowthStatsDataType,
     path: id => `/stats/posts/${id}/growth`
+});
+export const useMrrHistory = createQuery<MrrHistoryResponseType>({
+    dataType: mrrHistoryDataType,
+    path: '/stats/mrr-history/'
 });

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -52,9 +52,9 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
     }
 
     // Get latest values
-    const latest = memberData[memberData.length - 1];
+    const latest = memberData.length > 0 ? memberData[memberData.length - 1] : {free: 0, paid: 0, comped: 0};
 
-    const latestMrr = mrrData[mrrData.length - 1];
+    const latestMrr = mrrData.length > 0 ? mrrData[mrrData.length - 1] : {mrr: 0};
 
     // Calculate total members
     const totalMembers = latest.free + latest.paid + latest.comped;

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -127,7 +127,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
     const mrrDates = mrrData.map(item => item.date);
 
     const allDates = [...dates, ...mrrDates];
-    const uniqueDates = [...new Set(allDates)];
+    const uniqueDates = [...new Set(allDates)].sort();
 
     return uniqueDates.map((date) => {
         const memberItem = memberData.find(item => item.date === date);

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import {MemberStatusItem, useMemberCountHistory} from '@tryghost/admin-x-framework/api/stats';
+import {MemberStatusItem, useMemberCountHistory, useMrrHistory, MrrHistoryItem} from '@tryghost/admin-x-framework/api/stats';
 import {formatNumber} from '@tryghost/shade';
 import {useMemo} from 'react';
 
@@ -11,7 +11,7 @@ export const getRangeDates = (rangeInDays: number) => {
     // Always use UTC to stay aligned with the backend’s date arithmetic
     const endDate = moment.utc().format('YYYY-MM-DD');
     let dateFrom;
-    
+
     if (rangeInDays === 1) {
         // Today
         dateFrom = endDate;
@@ -24,106 +24,145 @@ export const getRangeDates = (rangeInDays: number) => {
         const safeRange = Math.max(1, rangeInDays);
         dateFrom = moment.utc().subtract(safeRange - 1, 'days').format('YYYY-MM-DD');
     }
-    
+
     return {dateFrom, endDate};
 };
 
 // Calculate totals from member data
-const calculateTotals = (memberData: MemberStatusItem[]) => {
+const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem[]) => {
     if (!memberData.length) {
         return {
             totalMembers: 0,
             freeMembers: 0,
             paidMembers: 0,
+            mrr: 0,
             percentChanges: {
                 total: '0%',
                 free: '0%',
-                paid: '0%'
+                paid: '0%',
+                mrr: '0%'
             },
             directions: {
                 total: 'same' as DiffDirection,
                 free: 'same' as DiffDirection,
-                paid: 'same' as DiffDirection
+                paid: 'same' as DiffDirection,
+                mrr: 'same' as DiffDirection
             }
         };
     }
-    
+
     // Get latest values
     const latest = memberData[memberData.length - 1];
-    
+
+    const latestMrr = mrrData[mrrData.length - 1];
+
     // Calculate total members
     const totalMembers = latest.free + latest.paid + latest.comped;
-    
+
+    const totalMrr = latestMrr.mrr;
+
     // Calculate percentage changes if we have enough data
     const percentChanges = {
         total: '0%',
         free: '0%',
-        paid: '0%'
+        paid: '0%',
+        mrr: '0%'
     };
-    
+
     const directions = {
         total: 'same' as DiffDirection,
         free: 'same' as DiffDirection,
-        paid: 'same' as DiffDirection
+        paid: 'same' as DiffDirection,
+        mrr: 'same' as DiffDirection
     };
-    
+
     if (memberData.length > 1) {
         // Get first day in range
         const first = memberData[0];
         const firstTotal = first.free + first.paid + first.comped;
-        
+
         if (firstTotal > 0) {
             const totalChange = ((totalMembers - firstTotal) / firstTotal) * 100;
             percentChanges.total = `${Math.abs(totalChange).toFixed(1)}%`;
             directions.total = totalChange > 0 ? 'up' : totalChange < 0 ? 'down' : 'same';
         }
-        
+
         if (first.free > 0) {
             const freeChange = ((latest.free - first.free) / first.free) * 100;
             percentChanges.free = `${Math.abs(freeChange).toFixed(1)}%`;
             directions.free = freeChange > 0 ? 'up' : freeChange < 0 ? 'down' : 'same';
         }
-        
+
         if (first.paid > 0) {
             const paidChange = ((latest.paid - first.paid) / first.paid) * 100;
             percentChanges.paid = `${Math.abs(paidChange).toFixed(1)}%`;
             directions.paid = paidChange > 0 ? 'up' : paidChange < 0 ? 'down' : 'same';
         }
     }
-    
+
+    if (mrrData.length > 1) {
+        const first = mrrData[0];
+        const firstMrr = first.mrr;
+
+        if (firstMrr > 0) {
+            const mrrChange = ((totalMrr - firstMrr) / firstMrr) * 100;
+            percentChanges.mrr = `${Math.abs(mrrChange).toFixed(1)}%`;
+            directions.mrr = mrrChange > 0 ? 'up' : mrrChange < 0 ? 'down' : 'same';
+        }
+    }
+
     return {
         totalMembers,
         freeMembers: latest.free,
         paidMembers: latest.paid,
+        mrr: totalMrr,
         percentChanges,
         directions
     };
 };
 
-// Format chart data 
-const formatChartData = (memberData: MemberStatusItem[]) => {
-    return memberData.map(item => ({
-        date: item.date,
-        value: item.free + item.paid + item.comped,
-        free: item.free,
-        paid: item.paid,
-        comped: item.comped,
-        formattedValue: formatNumber(item.free + item.paid + item.comped),
-        label: 'Total members'
-    }));
+// Format chart data
+const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem[]) => {
+    const dates = memberData.map(item => item.date);
+    const mrrDates = mrrData.map(item => item.date);
+
+    const allDates = [...dates, ...mrrDates];
+    const uniqueDates = [...new Set(allDates)];
+
+    return uniqueDates.map(date => {
+        const memberItem = memberData.find(item => item.date === date);
+        const mrrItem = mrrData.find(item => item.date === date);
+        const free = memberItem?.free || 0;
+        const paid = memberItem?.paid || 0;
+        const comped = memberItem?.comped || 0;
+        const value = free + paid + comped;
+
+        return {
+            date,
+            value,
+            free,
+            paid,
+            comped,
+            mrr: mrrItem?.mrr || 0,
+            formattedValue: formatNumber(value),
+            label: 'Total members'
+        }
+    })
 };
 
 export const useGrowthStats = (range: number) => {
     // Calculate date range
     const {dateFrom, endDate} = useMemo(() => getRangeDates(range), [range]);
-    
+
     // Fetch member count history from API
-    const {data: memberCountResponse, isLoading} = useMemberCountHistory({
+    const {data: memberCountResponse, isLoading: isMemberCountLoading} = useMemberCountHistory({
         searchParams: {
             date_from: dateFrom
         }
     });
-    
+
+    const {data: mrrHistoryResponse, isLoading: isMrrLoading} = useMrrHistory();
+
     // Process member data with stable reference
     const memberData = useMemo(() => {
         // Check the structure of the response and extract data
@@ -135,19 +174,33 @@ export const useGrowthStats = (range: number) => {
         }
         return [];
     }, [memberCountResponse]);
-    
+
+    const mrrData = useMemo(() => {
+        // HACK: We should do this filtering on the backend, but the API doesn't support it yet
+        const dateFromMoment = moment(dateFrom).subtract(1, 'day');
+        if (mrrHistoryResponse?.stats) {
+            return mrrHistoryResponse.stats.filter(item => {
+                return moment(item.date).isSameOrAfter(dateFromMoment);
+            });
+        }
+        return [];
+    }, [mrrHistoryResponse]);
+
     // Calculate totals
-    const totalsData = useMemo(() => calculateTotals(memberData), [memberData]);
-    
+    const totalsData = useMemo(() => calculateTotals(memberData, mrrData), [memberData, mrrData]);
+
     // Format chart data
-    const chartData = useMemo(() => formatChartData(memberData), [memberData]);
-    
+    const chartData = useMemo(() => formatChartData(memberData, mrrData), [memberData, mrrData]);
+
+    const isLoading = useMemo(() => isMemberCountLoading || isMrrLoading, [isMemberCountLoading, isMrrLoading]);
+
     return {
         isLoading,
         memberData,
+        mrrData,
         dateFrom,
         endDate,
         totals: totalsData,
         chartData
     };
-}; 
+};

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import {MemberStatusItem, useMemberCountHistory, useMrrHistory, MrrHistoryItem} from '@tryghost/admin-x-framework/api/stats';
+import {MemberStatusItem, MrrHistoryItem, useMemberCountHistory, useMrrHistory} from '@tryghost/admin-x-framework/api/stats';
 import {formatNumber} from '@tryghost/shade';
 import {useMemo} from 'react';
 
@@ -129,7 +129,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
     const allDates = [...dates, ...mrrDates];
     const uniqueDates = [...new Set(allDates)];
 
-    return uniqueDates.map(date => {
+    return uniqueDates.map((date) => {
         const memberItem = memberData.find(item => item.date === date);
         const mrrItem = mrrData.find(item => item.date === date);
         const free = memberItem?.free || 0;
@@ -146,8 +146,8 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             mrr: mrrItem?.mrr || 0,
             formattedValue: formatNumber(value),
             label: 'Total members'
-        }
-    })
+        };
+    });
 };
 
 export const useGrowthStats = (range: number) => {
@@ -179,7 +179,7 @@ export const useGrowthStats = (range: number) => {
         // HACK: We should do this filtering on the backend, but the API doesn't support it yet
         const dateFromMoment = moment(dateFrom).subtract(1, 'day');
         if (mrrHistoryResponse?.stats) {
-            return mrrHistoryResponse.stats.filter(item => {
+            return mrrHistoryResponse.stats.filter((item) => {
                 return moment(item.date).isSameOrAfter(dateFromMoment);
             });
         }

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -126,7 +126,7 @@ const GrowthKPIs: React.FC<{
         }
 
         return processedData;
-    }, [currentTab, allChartData, paidMembers, range]);
+    }, [currentTab, allChartData, mrr, range]);
 
     if (!labs.trafficAnalyticsAlpha) {
         return <Navigate to='/' />;

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -17,7 +17,7 @@ import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
 // TODO: Move to @tryghost/shade
 const centsToDollars = (value: number) => {
     return Math.round(value / 100);
-}
+};
 
 type TopPostsOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc';
 
@@ -91,7 +91,6 @@ const GrowthKPIs: React.FC<{
         // Then map the sanitized data to the final format
         let processedData: ChartDataItem[] = [];
 
-        console.log(currentTab);
         switch (currentTab) {
         case 'free-members':
             processedData = sanitizedData.map(item => ({
@@ -138,8 +137,6 @@ const GrowthKPIs: React.FC<{
             label: currentTab === 'mrr' ? 'MRR' : 'Members'
         }
     } satisfies ChartConfig;
-
-    console.log('chartData', chartData);
 
     return (
         <Tabs defaultValue="total-members" variant='underline'>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1577/stats-api-endpoint-for-top-performing-posts-list

On the site wide analytics Growth tab, we want to show an MRR chart, similar to how it is presented on the current Dashboard. This commit wires up the already existing chart in the frontend to the `stats/mrr` Admin API endpoint.