### PR TITLE
Added mutations for blocking & unblocking domains

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -202,6 +202,24 @@ export class ActivityPubAPI {
         return json;
     }
 
+    async blockDomain(domain: URL): Promise<boolean> {
+        const url = new URL(
+            `.ghost/activitypub/actions/block/domain/${encodeURIComponent(domain.href)}`,
+            this.apiUrl
+        );
+        await this.fetchJSON(url, 'POST');
+        return true;
+    }
+
+    async unblockDomain(domain: URL): Promise<boolean> {
+        const url = new URL(
+            `.ghost/activitypub/actions/unblock/domain/${encodeURIComponent(domain.href)}`,
+            this.apiUrl
+        );
+        await this.fetchJSON(url, 'POST');
+        return true;
+    }
+
     async block(id: URL): Promise<boolean> {
         const url = new URL(
             `.ghost/activitypub/actions/block/${encodeURIComponent(id.href)}`,

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -23,6 +23,7 @@ export interface Account {
     followsMe: boolean;
     followedByMe: boolean;
     blockedByMe: boolean;
+    domainBlockedByMe: boolean;
     attachment: { name: string; value: string }[];
 }
 

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -300,6 +300,62 @@ export function useUnlikeMutationForUser(handle: string) {
     });
 }
 
+export function useBlockDomainMutationForUser(handle: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        async mutationFn(account: Account) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.blockDomain(new URL(account.apId));
+        },
+        onMutate: (account: Account) => {
+            queryClient.setQueryData(
+                QUERY_KEYS.account(account.handle),
+                (currentAccount?: Account) => {
+                    if (!currentAccount) {
+                        return currentAccount;
+                    }
+                    return {
+                        ...currentAccount,
+                        domainBlockedByMe: true,
+                        followedByMe: false,
+                        followsMe: false
+                    };
+                }
+            );
+        }
+    });
+}
+
+export function useUnblockDomainMutationForUser(handle: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        async mutationFn(account: Account) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.unblockDomain(new URL(account.apId));
+        },
+        onMutate: (account: Account) => {
+            queryClient.setQueryData(
+                QUERY_KEYS.account(account.handle),
+                (currentAccount?: Account) => {
+                    if (!currentAccount) {
+                        return currentAccount;
+                    }
+                    return {
+                        ...currentAccount,
+                        domainBlockedByMe: false
+                    };
+                }
+            );
+        }
+    });
+}
+
 export function useBlockMutationForUser(handle: string) {
     const queryClient = useQueryClient();
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-697

These allow the domain level block feature to start being wired up to the API. We introduce a new property `domainBlockedByMe` to the account, which can be used to determine if an account is blocked at the domain level. It is currently not persisted, it's only in memory of the current session.
