### PR TITLE
Added Post Analytics Growth totals

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -60,12 +60,26 @@ export type PostReferrersResponseType = {
     meta: Meta;
 };
 
+export type PostGrowthStatItem = {
+    post_id: string;
+    free_members: number;
+    paid_members: number;
+    mrr: number;
+};
+
+export type PostGrowthStatsResponseType = {
+    stats: PostGrowthStatItem[];
+    meta: Meta;
+};
+
 // Requests
 
 const dataType = 'TopContentResponseType';
 const memberCountHistoryDataType = 'MemberCountHistoryResponseType';
 const topPostsStatsDataType = 'TopPostsStatsResponseType';
 const postReferrersDataType = 'PostReferrersResponseType';
+const postGrowthStatsDataType = 'PostGrowthStatsResponseType';
+
 export const useTopContent = createQuery<TopContentResponseType>({
     dataType,
     path: '/stats/top-content/'
@@ -84,4 +98,9 @@ export const useTopPostsStats = createQuery<TopPostsStatsResponseType>({
 export const usePostReferrers = createQueryWithId<PostReferrersResponseType>({
     dataType: postReferrersDataType,
     path: id => `/stats/posts/${id}/top-referrers`
+});
+
+export const usePostGrowthStats = createQueryWithId<PostGrowthStatsResponseType>({
+    dataType: postGrowthStatsDataType,
+    path: id => `/stats/posts/${id}/growth`
 });

--- a/apps/posts/src/hooks/usePostReferrers.ts
+++ b/apps/posts/src/hooks/usePostReferrers.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {usePostReferrers as usePostReferrersAPI, usePostGrowthStats as usePostGrowthStatsAPI} from '@tryghost/admin-x-framework/api/stats';
+import {usePostGrowthStats as usePostGrowthStatsAPI, usePostReferrers as usePostReferrersAPI} from '@tryghost/admin-x-framework/api/stats';
 
 export const usePostReferrers = (postId: string) => {
     const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId);

--- a/apps/posts/src/hooks/usePostReferrers.ts
+++ b/apps/posts/src/hooks/usePostReferrers.ts
@@ -1,12 +1,28 @@
 import {useMemo} from 'react';
-import {usePostReferrers as usePostReferrersAPI} from '@tryghost/admin-x-framework/api/stats';
+import {usePostReferrers as usePostReferrersAPI, usePostGrowthStats as usePostGrowthStatsAPI} from '@tryghost/admin-x-framework/api/stats';
 
 export const usePostReferrers = (postId: string) => {
-    const {data: postReferrerResponse, isLoading} = usePostReferrersAPI(postId);
+    const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId);
+    const {data: postGrowthStatsResponse, isLoading: isPostGrowthStatsLoading} = usePostGrowthStatsAPI(postId);
+
     const stats = useMemo(() => postReferrerResponse?.stats || [], [postReferrerResponse]);
+    const totals = useMemo(() => {
+        if (postGrowthStatsResponse?.stats.length === 0) {
+            return {
+                free_members: 0,
+                paid_members: 0,
+                mrr: 0
+            };
+        } else {
+            return postGrowthStatsResponse?.stats[0];
+        }
+    }, [postGrowthStatsResponse]);
+
+    const isLoading = useMemo(() => isPostReferrersLoading || isPostGrowthStatsLoading, [isPostReferrersLoading, isPostGrowthStatsLoading]);
 
     return {
         isLoading,
-        stats
+        stats,
+        totals
     };
 };

--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -13,7 +13,8 @@ interface postAnalyticsProps {}
 const Growth: React.FC<postAnalyticsProps> = () => {
     // const {isLoading: isConfigLoading} = useGlobalData();
     const {postId} = useParams();
-    const {stats: postReferrers, isLoading} = usePostReferrers(postId || '');
+    const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '');
+
     // const {range} = useGlobalData();
 
     return (
@@ -33,21 +34,21 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     <LucideIcon.User strokeWidth={1.5} />
                                 </KpiCardIcon>
                                 <KpiCardLabel>Free members</KpiCardLabel>
-                                <KpiCardValue>{formatNumber(22)}</KpiCardValue>
+                                <KpiCardValue>{formatNumber(totals?.free_members || 0)}</KpiCardValue>
                             </KpiCard>
                             <KpiCard>
                                 <KpiCardIcon>
                                     <LucideIcon.Wallet strokeWidth={1.5} />
                                 </KpiCardIcon>
                                 <KpiCardLabel>Paid members</KpiCardLabel>
-                                <KpiCardValue>{formatNumber(8)}</KpiCardValue>
+                                <KpiCardValue>{formatNumber(totals?.paid_members || 0)}</KpiCardValue>
                             </KpiCard>
                             <KpiCard>
                                 <KpiCardIcon>
                                     <LucideIcon.CircleDollarSign strokeWidth={1.5} />
                                 </KpiCardIcon>
                                 <KpiCardLabel>MRR</KpiCardLabel>
-                                <KpiCardValue>+${formatNumber(180)}</KpiCardValue>
+                                <KpiCardValue>+${formatNumber(totals?.mrr || 0)}</KpiCardValue>
                             </KpiCard>
                         </div>
                         <Card>

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -206,6 +206,38 @@ const controller = {
         async query(frame) {
             return await statsService.api.getReferrersForPost(frame.data.id, frame.options);
         }
+    },
+    postGrowthStats: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'id'
+        ],
+        validation: {
+            data: {
+                id: {
+                    type: 'string',
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'postGrowthStats',
+                data: {
+                    id: frame.data.id
+                }
+            };
+        },
+        async query(frame) {
+            return await statsService.api.getGrowthStatsForPost(frame.data.id);
+        }
     }
 };
 

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -90,6 +90,13 @@ class StatsService {
     }
 
     /**
+     * @param {string} postId
+     */
+    async getGrowthStatsForPost(postId) {
+        return await this.posts.getGrowthStatsForPost(postId);
+    }
+
+    /**
      * @param {object} deps
      *
      * @returns {StatsService}

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -159,6 +159,7 @@ module.exports = function apiRoutes() {
         router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
         router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
         router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
+        router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
     }
 
     // ## Labels

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -262,4 +262,16 @@ describe('Stats API', function () {
                 });
         });
     });
+
+    describe('Post Growth Stats', function () {
+        it('Can fetch post growth stats', async function () {
+            await agent
+                .get(`/stats/posts/${fixtureManager.get('posts', 1).id}/growth`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.ok(body.stats, 'Response should contain a stats property');
+                    assert.ok(Array.isArray(body.stats), 'body.stats should be an array');
+                });
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -484,4 +484,20 @@ describe('PostsStatsService', function () {
             assert.equal(result.data[1].source, 'referrer_2');
         });
     });
+
+    describe('getGrowthStatsForPost', function () {
+        it('returns growth stats for a post', async function () {
+            await _createFreeSignup('post1', 'referrer_1');
+            await _createPaidSignup('post1', 500, 'referrer_1');
+            await _createPaidConversion('post1', 'post2', 500, 'referrer_1');
+
+            const result = await service.getGrowthStatsForPost('post1');
+
+            const expectedResults = [
+                {post_id: 'post1', free_members: 2, paid_members: 1, mrr: 500}
+            ];
+
+            assert.deepEqual(result.data, expectedResults, 'Results should match expected order and counts for free_members desc');
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1542/adjust-conversion-attribution-to-reflect-free-members-and-paid-members

On the Post Analytics Growth tab, we want to show total free and paid members + MRR attributed to the post. I'd initially planned on just summing the result of the `stats/posts/:id/top-referrers/` response on the frontend, but there is a limit on this endpoint so that wouldn't work.

This commit adds a new endpoint explicitly for calculating the totals, and wires it up to the frontend view.