### PR TITLE
Added links to top performing posts table in the Stats Growth tab

### DIFF
--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -316,7 +316,7 @@ const Growth: React.FC = () => {
                             <TableBody>
                                 {topPosts.map(post => (
                                     <TableRow key={post.post_id}>
-                                        <TableCell className="font-medium"><a href={`/ghost/#/posts/analytics/${post.post_id}`}>{post.title}</a></TableCell>
+                                        <TableCell className="font-medium"><a href={`/ghost/#/posts/analytics/${post.post_id}/growth`}>{post.title}</a></TableCell>
                                         <TableCell className={`text-right font-mono text-sm ${post.free_members === 0 && 'text-gray-700'}`}>
                                             {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
                                         </TableCell>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -316,7 +316,7 @@ const Growth: React.FC = () => {
                             <TableBody>
                                 {topPosts.map(post => (
                                     <TableRow key={post.post_id}>
-                                        <TableCell className="font-medium">{post.title}</TableCell>
+                                        <TableCell className="font-medium"><a href={`/ghost/#/posts/analytics/${post.post_id}`}>{post.title}</a></TableCell>
                                         <TableCell className={`text-right font-mono text-sm ${post.free_members === 0 && 'text-gray-700'}`}>
                                             {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
                                         </TableCell>


### PR DESCRIPTION
no refs

On the Site wide stats growth tab, there is a table of the top performing posts. This change adds a link to each post title, which leads to the Post Analytics for the post