### PR TITLE
Fixed failing coverage CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
       - run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
 
       - uses: actions/upload-artifact@v4
-        if: startsWith(matrix.node, '18')
+        if: startsWith(matrix.node, '20')
         with:
           name: unit-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
@@ -582,7 +582,7 @@ jobs:
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
-        if: startsWith(matrix.node, '18') && contains(matrix.env.DB, 'mysql')
+        if: startsWith(matrix.node, '20') && contains(matrix.env.DB, 'mysql')
         with:
           name: e2e-coverage
           path: |


### PR DESCRIPTION
no issue

- we were uploading test coverage reports for node 18 only in order to upload them once, but we don't run CI on node 18 anymore
