### PR TITLE
Improved Growth tabs in Traffic Analytics

### DIFF
--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -5,10 +5,10 @@ import React, {useMemo, useState} from 'react';
 import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
-import {Navigate} from '@tryghost/admin-x-framework';
+import {Navigate, useNavigate} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -112,7 +112,7 @@ const GrowthKPIs: React.FC<{
             processedData = sanitizedData.map(item => ({
                 ...item,
                 value: centsToDollars(item.mrr),
-                formattedValue: `$${centsToDollars(item.mrr)}`,
+                formattedValue: `$${formatNumber(centsToDollars(item.mrr))}`,
                 label: 'MRR'
             }));
             break;
@@ -126,7 +126,7 @@ const GrowthKPIs: React.FC<{
         }
 
         return processedData;
-    }, [currentTab, allChartData, mrr, range]);
+    }, [currentTab, allChartData, range]);
 
     if (!labs.trafficAnalyticsAlpha) {
         return <Navigate to='/' />;
@@ -178,7 +178,7 @@ const GrowthKPIs: React.FC<{
                         diffDirection={directions.mrr}
                         diffValue={percentChanges.mrr}
                         label="MRR"
-                        value={`$${centsToDollars(mrr)}`}
+                        value={`$${formatNumber(centsToDollars(mrr))}`}
                     />
                 </KpiTabTrigger>
             </TabsList>
@@ -266,6 +266,7 @@ const GrowthKPIs: React.FC<{
 const Growth: React.FC = () => {
     const {range} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopPostsOrder>('free_members desc');
+    const navigate = useNavigate();
 
     // Get stats from custom hook once
     const {isLoading, chartData, totals} = useGrowthStats(range);
@@ -322,7 +323,24 @@ const Growth: React.FC = () => {
                             <TableBody>
                                 {topPosts.map(post => (
                                     <TableRow key={post.post_id}>
-                                        <TableCell className="font-medium"><a href={`/ghost/#/posts/analytics/${post.post_id}/growth`}>{post.title}</a></TableCell>
+                                        <TableCell className="font-medium">
+                                            <div className='group/link inline-flex items-center gap-2'>
+                                                {post.post_id ?
+                                                    <Button className='h-auto p-0 hover:!underline' title="View post analytics" variant='link' onClick={() => {
+                                                        navigate(`/posts/analytics/${post.post_id}`, {crossApp: true});
+                                                    }}>
+                                                        {post.title}
+                                                    </Button>
+                                                    :
+                                                    <>
+                                                        {post.title}
+                                                    </>
+                                                }
+                                                {/* <a className='-mx-2 inline-flex min-h-6 items-center gap-1 rounded-sm px-2 opacity-0 hover:underline group-hover/link:opacity-75' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
+                                                    <LucideIcon.SquareArrowOutUpRight size={12} strokeWidth={2.5} />
+                                                </a> */}
+                                            </div>
+                                        </TableCell>
                                         <TableCell className={`text-right font-mono text-sm ${post.free_members === 0 && 'text-gray-700'}`}>
                                             {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
                                         </TableCell>

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -5,13 +5,14 @@ import PostMenu from './components/PostMenu';
 import React, {useState} from 'react';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatDuration, formatNumber, formatPercentage, formatQueryDate} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
 import {TB_VERSION} from '@src/config/stats-config';
 import {calculateYAxisWidth, getPeriodText, getRangeDates, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@src/config/stats-config';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {useQuery} from '@tinybirdco/charts';
 import {useTopContent} from '@tryghost/admin-x-framework/api/stats';
 
@@ -224,6 +225,7 @@ const Web:React.FC = () => {
     const {isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
+    const navigate = useNavigate();
 
     // Include essential query parameters that change frequently
     // Server will use defaults for other values
@@ -284,10 +286,22 @@ const Web:React.FC = () => {
                                     return (
                                         <TableRow key={row.pathname}>
                                             <TableCell className="font-medium">
-                                                <a className='group/link -mx-2 inline-flex min-h-6 items-center gap-1 px-2 hover:underline' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
-                                                    {row.title || row.pathname}
-                                                    <LucideIcon.SquareArrowOutUpRight className='opacity-0 group-hover/link:opacity-100' size={12} strokeWidth={2.5} />
-                                                </a>
+                                                <div className='group/link inline-flex items-center gap-2'>
+                                                    {row.post_id ?
+                                                        <Button className='h-auto p-0 hover:!underline' title="View post analytics" variant='link' onClick={() => {
+                                                            navigate(`/posts/analytics/${row.post_id}`, {crossApp: true});
+                                                        }}>
+                                                            {row.title || row.pathname}
+                                                        </Button>
+                                                        :
+                                                        <>
+                                                            {row.title || row.pathname}
+                                                        </>
+                                                    }
+                                                    <a className='-mx-2 inline-flex min-h-6 items-center gap-1 rounded-sm px-2 opacity-0 hover:underline group-hover/link:opacity-75' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
+                                                        <LucideIcon.SquareArrowOutUpRight size={12} strokeWidth={2.5} />
+                                                    </a>
+                                                </div>
                                             </TableCell>
                                             <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
                                             <TableCell className='text-center text-gray-700 hover:text-black'>

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -2294,6 +2294,10 @@ span.dropdown .gh-post-list-cta > span {
     border-bottom: 1px solid var(--whitegrey);
 }
 
+.feature-trafficAnalytics .gh-tabs-analytics.no-tabs .tab-panel-selected {
+    margin: 0 24px;
+}
+
 .feature-trafficAnalytics .gh-tabs-analytics.no-tabs {
     padding: 20px 0;
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-657/add-growth-tab-to-sitewide-context

- A couple of minor details on the Traffic Analytics Growth tab were off: thousand separator was missing, padding on post analytics page was off etc.