### PR TITLE
Improved empty view of sources in Post Analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -58,36 +58,43 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                             </CardHeader>
                             <CardContent>
                                 <Separator />
-                                <Table>
-                                    <TableHeader>
-                                        <TableRow>
-                                            <TableHead>Source</TableHead>
-                                            <TableHead className='w-[110px] text-right'>Free members</TableHead>
-                                            <TableHead className='w-[110px] text-right'>Paid members</TableHead>
-                                            <TableHead className='w-[110px] text-right'>MRR</TableHead>
-                                        </TableRow>
-                                    </TableHeader>
-                                    <TableBody>
-                                        {postReferrers?.map(row => (
-                                            <TableRow key={row.source}>
-                                                <TableCell>
-                                                    <a className='inline-flex items-center gap-2 font-medium' href={`https://${row.source}`} rel="noreferrer" target='_blank'>
-                                                        <img
-                                                            className="size-4"
-                                                            src={`https://www.faviconextractor.com/favicon/${row.source || 'direct'}?larger=true`}
-                                                            onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                                e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
-                                                            }} />
-                                                        <span>{row.source || 'Direct'}</span>
-                                                    </a>
-                                                </TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.free_members)}</TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.paid_members)}</TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>+${formatNumber(row.mrr)}</TableCell>
+                                {postReferrers.length > 1
+                                    ?
+                                    <Table>
+                                        <TableHeader>
+                                            <TableRow>
+                                                <TableHead>Source</TableHead>
+                                                <TableHead className='w-[110px] text-right'>Free members</TableHead>
+                                                <TableHead className='w-[110px] text-right'>Paid members</TableHead>
+                                                <TableHead className='w-[110px] text-right'>MRR</TableHead>
                                             </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
+                                        </TableHeader>
+                                        <TableBody>
+                                            {postReferrers?.map(row => (
+                                                <TableRow key={row.source}>
+                                                    <TableCell>
+                                                        <a className='inline-flex items-center gap-2 font-medium' href={`https://${row.source}`} rel="noreferrer" target='_blank'>
+                                                            <img
+                                                                className="size-4"
+                                                                src={`https://www.faviconextractor.com/favicon/${row.source || 'direct'}?larger=true`}
+                                                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                                    e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
+                                                                }} />
+                                                            <span>{row.source || 'Direct'}</span>
+                                                        </a>
+                                                    </TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.free_members)}</TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.paid_members)}</TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>+${formatNumber(row.mrr)}</TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                    :
+                                    <div className='py-20 text-center text-sm text-gray-700'>
+                                    No source data available for this post.
+                                    </div>
+                                }
                             </CardContent>
                         </Card>
                     </div>

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -3,7 +3,7 @@ import {cn} from '@tryghost/shade';
 
 export const KpiCardIcon: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('flex size-11 rounded-full items-center justify-center bg-gray-100 text-blue-500 mb-5 [&_svg]:size-5', className)} {...props}>
+        <div className={cn('flex size-11 rounded-full items-center justify-center bg-gray-200 text-blue-500 mb-2 [&_svg]:size-5', className)} {...props}>
             {children}
         </div>
     );
@@ -11,7 +11,7 @@ export const KpiCardIcon: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({chi
 
 export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('text-base tracking-tight font-semibold', className)} {...props}>
+        <div className={cn('text-base text-gray-700 tracking-tight font-semibold', className)} {...props}>
             {children}
         </div>
     );
@@ -27,7 +27,7 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
 
 const KpiCard: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('rounded-md border p-5', className)} {...props}>
+        <div className={cn('rounded-md bg-muted/50 px-6 py-4', className)} {...props}>
             {children}
         </div>
     );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-658/add-growth-tab-to-post-analytics-context

- If there were not sources information available for a post the table was simply empty instead of showing an appropriate message.