### PR TITLE
Added loader to Stripe cancel/resume buttons in Member details

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -65,7 +65,7 @@
                             data-test-input="member-note"
                         />
                         <GhErrorMessage @errors={{this.member.errors}} @property="note" />
-                        <p> Maximum: <b>500</b> characters. You’ve used
+                        <p> Maximum: <b>500</b> characters. You've used
                             {{gh-count-down-characters this.scratchMember.note 500}}</p>
                     </GhFormGroup>
                 </div>
@@ -168,6 +168,7 @@
                                                     <li>
                                                         <button
                                                             type="button"
+                                                            class="{{if (eq this.loadingSubscriptionId (concat 'complimentary-' (or tier.id tier.tier_id))) 'is-loading' ''}}"
                                                             {{on "click" (fn this.removeComplimentary (or tier.id tier.tier_id))}}
                                                             data-test-button="remove-complimentary"
                                                         >
@@ -199,11 +200,11 @@
                                                     <li>
                                                     {{#if (not-eq sub.status "canceled")}}
                                                         {{#if sub.cancel_at_period_end}}
-                                                            <button type="button" {{on "click" (fn this.continueSubscription sub.id)}}>
+                                                            <button type="button" class="{{if (eq this.loadingSubscriptionId sub.id) 'is-loading' ''}}" {{on "click" (fn this.continueSubscription sub.id)}}>
                                                                 <span>Continue subscription</span>
                                                             </button>
                                                         {{else}}
-                                                            <button type="button" {{on "click" (fn this.cancelSubscription sub.id)}}>
+                                                            <button type="button" class="{{if (eq this.loadingSubscriptionId sub.id) 'is-loading' ''}}" {{on "click" (fn this.cancelSubscription sub.id)}}>
                                                                 <span class="red">Cancel subscription</span>
                                                             </button>
                                                         {{/if}}
@@ -241,7 +242,12 @@
                                                 </GhDropdownButton>
                                                 <GhDropdown @name="subscription-menu-complimentary" @tagName="ul" @classNames="tier-actions-menu dropdown-menu dropdown-align-right">
                                                     <li>
-                                                        <button type="button" {{on "click" (fn this.removeComplimentary tier.id)}}>
+                                                        <button
+                                                            type="button"
+                                                            class="{{if (eq this.loadingSubscriptionId (concat 'complimentary-' (or tier.id tier.tier_id))) 'is-loading' ''}}"
+                                                            {{on "click" (fn this.removeComplimentary (or tier.id tier.tier_id))}}
+                                                            data-test-button="remove-complimentary"
+                                                        >
                                                             <span class="red">Remove complimentary subscription</span>
                                                         </button>
                                                     </li>

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -200,7 +200,7 @@
                                                     <li>
                                                     {{#if (not-eq sub.status "canceled")}}
                                                         {{#if sub.cancel_at_period_end}}
-                                                            <button type="button" class="{{if (eq this.loadingSubscriptionId sub.id) 'is-loading' ''}}" {{on "click" (fn this.continueSubscription sub.id)}}>
+                                                            <button type="button" class="is-loading {{if (eq this.loadingSubscriptionId sub.id) 'is-loading' ''}}" {{on "click" (fn this.continueSubscription sub.id)}}>
                                                                 <span>Continue subscription</span>
                                                             </button>
                                                         {{else}}

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -157,14 +157,12 @@ export default class extends Component {
 
     @action
     continueSubscription(subscriptionId) {
-        console.log('continueSubscription', subscriptionId);
         this.loadingSubscriptionId = subscriptionId;
         this.continueSubscriptionTask.perform(subscriptionId);
     }
 
     @task({drop: true})
     *cancelSubscriptionTask(subscriptionId) {
-        console.log('cancelSubscriptionTask', subscriptionId);
         try {
             let url = this.ghostPaths.url.api('members', this.member.get('id'), 'subscriptions', subscriptionId);
 

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -22,6 +22,7 @@ export default class extends Component {
     @tracked showMemberTierModal = false;
     @tracked tiersList;
     @tracked newslettersList;
+    @tracked loadingSubscriptionId = null;
 
     get isAddComplimentaryAllowed() {
         if (!this.membersUtils.paidMembersEnabled) {
@@ -144,68 +145,85 @@ export default class extends Component {
 
     @action
     cancelSubscription(subscriptionId) {
+        this.loadingSubscriptionId = subscriptionId;
         this.cancelSubscriptionTask.perform(subscriptionId);
     }
 
     @action
     removeComplimentary(tierId) {
+        this.loadingSubscriptionId = `complimentary-${tierId}`;
         this.removeComplimentaryTask.perform(tierId);
     }
 
     @action
     continueSubscription(subscriptionId) {
+        console.log('continueSubscription', subscriptionId);
+        this.loadingSubscriptionId = subscriptionId;
         this.continueSubscriptionTask.perform(subscriptionId);
     }
 
     @task({drop: true})
     *cancelSubscriptionTask(subscriptionId) {
-        let url = this.ghostPaths.url.api('members', this.member.get('id'), 'subscriptions', subscriptionId);
+        console.log('cancelSubscriptionTask', subscriptionId);
+        try {
+            let url = this.ghostPaths.url.api('members', this.member.get('id'), 'subscriptions', subscriptionId);
 
-        let response = yield this.ajax.put(url, {
-            data: {
-                cancel_at_period_end: true
-            }
-        });
+            let response = yield this.ajax.put(url, {
+                data: {
+                    cancel_at_period_end: true
+                }
+            });
 
-        this.store.pushPayload('member', response);
-        return response;
+            this.store.pushPayload('member', response);
+            return response;
+        } finally {
+            this.loadingSubscriptionId = null;
+        }
     }
 
     @task({drop: true})
     *removeComplimentaryTask(tierId) {
-        let url = this.ghostPaths.url.api(`members/${this.member.get('id')}`);
-        let tiers = this.member.get('tiers') || [];
+        try {
+            let url = this.ghostPaths.url.api(`members/${this.member.get('id')}`);
+            let tiers = this.member.get('tiers') || [];
 
-        const updatedTiers = tiers
-            .filter(tier => tier.id !== tierId)
-            .map(tier => ({id: tier.id}));
+            const updatedTiers = tiers
+                .filter(tier => tier.id !== tierId)
+                .map(tier => ({id: tier.id}));
 
-        let response = yield this.ajax.put(url, {
-            data: {
-                members: [{
-                    id: this.member.get('id'),
-                    email: this.member.get('email'),
-                    tiers: updatedTiers
-                }]
-            }
-        });
+            let response = yield this.ajax.put(url, {
+                data: {
+                    members: [{
+                        id: this.member.get('id'),
+                        email: this.member.get('email'),
+                        tiers: updatedTiers
+                    }]
+                }
+            });
 
-        this.store.pushPayload('member', response);
-        return response;
+            this.store.pushPayload('member', response);
+            return response;
+        } finally {
+            this.loadingSubscriptionId = null;
+        }
     }
 
     @task({drop: true})
     *continueSubscriptionTask(subscriptionId) {
-        let url = this.ghostPaths.url.api('members', this.member.get('id'), 'subscriptions', subscriptionId);
+        try {
+            let url = this.ghostPaths.url.api('members', this.member.get('id'), 'subscriptions', subscriptionId);
 
-        let response = yield this.ajax.put(url, {
-            data: {
-                cancel_at_period_end: false
-            }
-        });
+            let response = yield this.ajax.put(url, {
+                data: {
+                    cancel_at_period_end: false
+                }
+            });
 
-        this.store.pushPayload('member', response);
-        return response;
+            this.store.pushPayload('member', response);
+            return response;
+        } finally {
+            this.loadingSubscriptionId = null;
+        }
     }
 
     @task({drop: true})

--- a/ghost/admin/app/styles/components/loading-indicator.css
+++ b/ghost/admin/app/styles/components/loading-indicator.css
@@ -41,6 +41,28 @@
     z-index: 10;
 }
 
+.gh-loading-spinner-small {
+    position: relative;
+    display: inline-block;
+    box-sizing: border-box;
+    width: 18px;
+    height: 18px;
+    border: rgba(0,0,0,0.1) solid 1px;
+    border-radius: 100px;
+    animation: spin 1s linear infinite;
+}
+
+.gh-loading-spinner-small:before {
+    content: "";
+    display: block;
+    margin-top: 3px;
+    width: 3px;
+    height: 3px;
+    background: #4C5156;
+    border-radius: 100px;
+    z-index: 10;
+}
+
 @keyframes spin {
     from {
         transform: rotate(0deg);

--- a/ghost/admin/app/styles/patterns/buttons.css
+++ b/ghost/admin/app/styles/patterns/buttons.css
@@ -731,8 +731,8 @@ Usage: CTA buttons grouped together horizontally.
     top: 0;
     bottom: 0;
     margin: auto;
-    border: 2px solid var(--lightgrey);
-    border-top-color: var(--blue);
+    border: 2px solid var(--midlightgrey);
+    border-top-color: var(--black);
     border-radius: 100%;
     animation: spinner 1s linear infinite;
 }

--- a/ghost/admin/app/styles/patterns/buttons.css
+++ b/ghost/admin/app/styles/patterns/buttons.css
@@ -715,3 +715,37 @@ Usage: CTA buttons grouped together horizontally.
     border-radius: 999px !important;
     border: 1px solid var(--main-bg-color);
 }
+
+/* Spinner for loading state */
+.is-loading {
+    position: relative;
+    opacity: 0.8;
+}
+
+.is-loading::before {
+    content: '';
+    position: absolute;
+    height: 12px;
+    width: 12px;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    border: 2px solid var(--lightgrey);
+    border-top-color: var(--blue);
+    border-radius: 100%;
+    animation: spinner 1s linear infinite;
+}
+
+.is-loading span {
+    padding-left: 18px !important;
+    padding-right: 18px !important;
+}
+
+.is-loading::after {
+    content: none;
+}
+
+@keyframes spinner {
+    to {transform: rotate(360deg);}
+}

--- a/ghost/admin/app/styles/patterns/icons.css
+++ b/ghost/admin/app/styles/patterns/icons.css
@@ -7,6 +7,14 @@
 
 .gh-icon-spinner {
     stroke: #fff;
+    animation: rotate-360 1s linear infinite;
+    width: 14px;
+    height: 14px;
+}
+
+/* Spinner for dropdown menus */
+.gh-btn-text .gh-icon-spinner {
+    stroke: #333;
 }
 
 /*

--- a/ghost/core/core/server/services/webhooks/listen.js
+++ b/ghost/core/core/server/services/webhooks/listen.js
@@ -3,7 +3,6 @@ const limitService = require('../../services/limits');
 const WebhookTrigger = require('./WebhookTrigger');
 const models = require('../../models');
 const payload = require('./payload');
-const logging = require('@tryghost/logging');
 
 // The webhook system is fundamentally built on top of our model event system
 const events = require('../../lib/common/events');

--- a/ghost/core/core/server/services/webhooks/listen.js
+++ b/ghost/core/core/server/services/webhooks/listen.js
@@ -63,7 +63,6 @@ const listen = async () => {
                 return;
             }
 
-            logging.info(`Webhook event triggered: ${event}`);
             webhookTrigger.trigger(event, model);
         });
     });

--- a/ghost/core/core/server/services/webhooks/listen.js
+++ b/ghost/core/core/server/services/webhooks/listen.js
@@ -3,6 +3,7 @@ const limitService = require('../../services/limits');
 const WebhookTrigger = require('./WebhookTrigger');
 const models = require('../../models');
 const payload = require('./payload');
+const logging = require('@tryghost/logging');
 
 // The webhook system is fundamentally built on top of our model event system
 const events = require('../../lib/common/events');
@@ -62,6 +63,7 @@ const listen = async () => {
                 return;
             }
 
+            logging.info(`Webhook event triggered: ${event}`);
             webhookTrigger.trigger(event, model);
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-920/

Users have reported the Cancel Subscription button as not working. While this may be the case, it's also clearly true that this is not a responsive button and shows nothing to the user that there's background activity. So far we haven't determined that the Stripe side is actually failing, so adding responsiveness to the frontend seems like a good option for the moment while we investigate that further.