### PR TITLE
Removed alpha flags from Stats and Post Analytics Growth tabs

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -26,14 +26,12 @@ const Sidebar:React.FC = () => {
                     <LucideIcon.MousePointer size={16} strokeWidth={1.25} />
                     Web
                 </RightSidebarMenuLink>
-                {labs.trafficAnalyticsAlpha &&
-                    <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}/growth`} onClick={() => {
-                        navigate(`/analytics/${postId}/growth`);
-                    }}>
-                        <LucideIcon.Sprout size={16} strokeWidth={1.25} />
-                    Growth
-                    </RightSidebarMenuLink>
-                }
+                <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}/growth`} onClick={() => {
+                    navigate(`/analytics/${postId}/growth`);
+                }}>
+                    <LucideIcon.Sprout size={16} strokeWidth={1.25} />
+                Growth
+                </RightSidebarMenuLink>
             </RightSidebarMenu>
         </div>
     );

--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import {LucideIcon, RightSidebarMenu, RightSidebarMenuLink} from '@tryghost/shade';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useLocation, useNavigate, useParams} from '@tryghost/admin-x-framework';
 
 const Sidebar:React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const {postId} = useParams();
-    const {settings} = useGlobalData();
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
     return (
         <div className='grow border-l py-8 pl-6 pr-0'>

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -128,10 +128,6 @@ const GrowthKPIs: React.FC<{
         return processedData;
     }, [currentTab, allChartData, range]);
 
-    if (!labs.trafficAnalyticsAlpha) {
-        return <Navigate to='/' />;
-    }
-
     const chartConfig = {
         value: {
             label: currentTab === 'mrr' ? 'MRR' : 'Members'

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -8,10 +8,9 @@ import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {KpiTabTrigger, KpiTabValue} from './components/KpiTab';
-import {Navigate, useNavigate} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
 
 // TODO: Move to @tryghost/shade
@@ -56,8 +55,7 @@ const GrowthKPIs: React.FC<{
     totals: Totals;
 }> = ({chartData: allChartData, totals}) => {
     const [currentTab, setCurrentTab] = useState('total-members');
-    const {settings, range} = useGlobalData();
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
+    const {range} = useGlobalData();
 
     const {totalMembers, freeMembers, paidMembers, mrr, percentChanges, directions} = totals;
 

--- a/apps/stats/src/views/Stats/layout/Sidebar.tsx
+++ b/apps/stats/src/views/Stats/layout/Sidebar.tsx
@@ -33,14 +33,12 @@ const Sidebar:React.FC = () => {
                 Locations
                 </RightSidebarMenuLink>
 
-                {labs.trafficAnalyticsAlpha &&
-                    <RightSidebarMenuLink active={location.pathname === '/growth/'} onClick={() => {
-                        navigate('/growth/');
-                    }}>
-                        <LucideIcon.Sprout size={16} strokeWidth={1.25} />
-                    Growth
-                    </RightSidebarMenuLink>
-                }
+                <RightSidebarMenuLink active={location.pathname === '/growth/'} onClick={() => {
+                    navigate('/growth/');
+                }}>
+                    <LucideIcon.Sprout size={16} strokeWidth={1.25} />
+                Growth
+                </RightSidebarMenuLink>
             </RightSidebarMenu>
         </div>
     );

--- a/apps/stats/src/views/Stats/layout/Sidebar.tsx
+++ b/apps/stats/src/views/Stats/layout/Sidebar.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import {LucideIcon, RightSidebarMenu, RightSidebarMenuLink} from '@tryghost/shade';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useLocation, useNavigate} from '@tryghost/admin-x-framework';
 
 const Sidebar:React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {settings} = useGlobalData();
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
     return (
         <div className='grow border-l px-6 py-8'>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-657/add-growth-tab-to-sitewide-context
ref https://linear.app/ghost/issue/PROD-658/add-growth-tab-to-post-analytics-context

We've been working on these Growth tabs behind an additional alpha flag so we can iterate on them without releasing them to the Beta just yet. We're now getting ready to ship these new tabs to the Beta, so this commit removes the conditionals on the `trafficAnalyticsAlpha` flag, which will show these tabs to anyone with the beta enabled.