### PR TITLE
Wired up the date range filter to the Post Analytics Growth tab

### DIFF
--- a/apps/posts/src/hooks/usePostReferrers.ts
+++ b/apps/posts/src/hooks/usePostReferrers.ts
@@ -1,8 +1,37 @@
+import moment from 'moment';
 import {useMemo} from 'react';
 import {usePostGrowthStats as usePostGrowthStatsAPI, usePostReferrers as usePostReferrersAPI} from '@tryghost/admin-x-framework/api/stats';
 
-export const usePostReferrers = (postId: string) => {
-    const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId);
+// Helper function to convert range to date parameters
+export const getRangeDates = (rangeInDays: number) => {
+    // Always use UTC to stay aligned with the backend's date arithmetic
+    const endDate = moment.utc().format('YYYY-MM-DD');
+    let dateFrom;
+
+    if (rangeInDays === 1) {
+        // Today
+        dateFrom = endDate;
+    } else if (rangeInDays === 1000) {
+        // All time - use a far past date
+        dateFrom = '2010-01-01';
+    } else {
+        // Specific range
+        // Guard against invalid ranges
+        const safeRange = Math.max(1, rangeInDays);
+        dateFrom = moment.utc().subtract(safeRange - 1, 'days').format('YYYY-MM-DD');
+    }
+
+    return {dateFrom, endDate};
+};
+
+export const usePostReferrers = (postId: string, range: number) => {
+    const {dateFrom} = useMemo(() => getRangeDates(range), [range]);
+    const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId, {
+        searchParams: {
+            date_from: dateFrom
+        }
+    });
+    // API doesn't support date_from yet, so we fetch all data and filter on the client for now
     const {data: postGrowthStatsResponse, isLoading: isPostGrowthStatsLoading} = usePostGrowthStatsAPI(postId);
 
     const stats = useMemo(() => postReferrerResponse?.stats || [], [postReferrerResponse]);

--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -6,6 +6,8 @@ import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber} from '@tryghost/shade';
 import {useParams} from '@tryghost/admin-x-framework';
 import {usePostReferrers} from '../../hooks/usePostReferrers';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
+
 const STATS_DEFAULT_SOURCE_ICON_URL = 'https://static.ghost.org/v5.0.0/images/globe-icon.svg';
 
 interface postAnalyticsProps {}
@@ -13,9 +15,9 @@ interface postAnalyticsProps {}
 const Growth: React.FC<postAnalyticsProps> = () => {
     // const {isLoading: isConfigLoading} = useGlobalData();
     const {postId} = useParams();
-    const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '');
+    const {range} = useGlobalData();
+    const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '', range);
 
-    // const {range} = useGlobalData();
 
     return (
         <PostAnalyticsLayout>

--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -4,9 +4,9 @@ import PostAnalyticsContent from './components/PostAnalyticsContent';
 import PostAnalyticsHeader from './components/PostAnalyticsHeader';
 import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber} from '@tryghost/shade';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useParams} from '@tryghost/admin-x-framework';
 import {usePostReferrers} from '../../hooks/usePostReferrers';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
 const STATS_DEFAULT_SOURCE_ICON_URL = 'https://static.ghost.org/v5.0.0/images/globe-icon.svg';
 
@@ -17,7 +17,6 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {postId} = useParams();
     const {range} = useGlobalData();
     const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '', range);
-
 
     return (
         <PostAnalyticsLayout>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1643/fix-the-date-range-selector-in-post-analytics-growth-tab

The date range selector in the Post Analytics Growth tab wasn't wired up to the API — this fixes that.