### PR TITLE
Fixed y-axis width on Stats Growth KPIs chart

### DIFF
--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -236,7 +236,18 @@ const GrowthKPIs: React.FC<{
                             }}
                             tickLine={false}
                             ticks={getYTicks(chartData)}
-                            width={calculateYAxisWidth(getYTicks(chartData), formatNumber)}
+                            width={calculateYAxisWidth(getYTicks(chartData), (value) => {
+                                switch (currentTab) {
+                                case 'total-members':
+                                case 'free-members':
+                                case 'paid-members':
+                                    return formatNumber(value);
+                                case 'mrr':
+                                    return `$${value}`;
+                                default:
+                                    return value.toLocaleString();
+                                }
+                            })}
                         />
                         <ChartTooltip
                             content={<CustomTooltipContent range={range} />}


### PR DESCRIPTION
no ref

The y-axis width was being calculated based on the `formatNumber` formatting, which works for the members metrics but underestimates the width needed for the MRR tab, since it includes the `$`. This commit fixes the width so it's correct for all the different value formats.