### PR TITLE
Updated copy for Post Analytics Growth tab empty state

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -93,7 +93,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     </Table>
                                     :
                                     <div className='py-20 text-center text-sm text-gray-700'>
-                                    No source data available for this post.
+                                    Once someone signs up on this post, sources will show here.
                                     </div>
                                 }
                             </CardContent>


### PR DESCRIPTION
no refs

Updating the copy for the empty state of the Post Analytics Growth tab to be more user-friendly