### PR TITLE
Fixed `stats/top-posts` endpoint status filtering

### DIFF
--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -79,7 +79,8 @@ class PostsStatsService {
                 .from('posts as p')
                 .leftJoin('free', 'p.id', 'free.post_id')
                 .leftJoin('paid', 'p.id', 'paid.post_id')
-                .leftJoin('mrr', 'p.id', 'mrr.post_id');
+                .leftJoin('mrr', 'p.id', 'mrr.post_id')
+                .where('p.status', 'published');
 
             const results = await query
                 .orderBy(orderField, orderDirection)

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -39,8 +39,8 @@ describe('PostsStatsService', function () {
     let memberIdCounter = 0;
     let subscriptionIdCounter = 0;
 
-    async function _createPost(id, title) {
-        await db('posts').insert({id, title});
+    async function _createPost(id, title, status = 'published') {
+        await db('posts').insert({id, title, status});
     }
 
     async function _createFreeSignupEvent(postId, memberId, referrerSource, createdAt = new Date()) {
@@ -116,6 +116,7 @@ describe('PostsStatsService', function () {
         await db.schema.createTable('posts', function (table) {
             table.string('id').primary();
             table.string('title');
+            table.string('status');
         });
 
         await db.schema.createTable('members_created_events', function (table) {
@@ -157,6 +158,7 @@ describe('PostsStatsService', function () {
         await _createPost('post2', 'Post 2');
         await _createPost('post3', 'Post 3');
         await _createPost('post4', 'Post 4');
+        await _createPost('post5', 'Post 5', 'draft');
     });
 
     afterEach(async function () {


### PR DESCRIPTION
no refs

The newly added `/stats/top-posts/` endpoint returns posts along with some growth metrics like free members, paid members and MRR attributed each post. These metrics only make sense for posts that are published, but the endpoint is currently returning all posts, including drafts.

This commit filters to only posts with `status=published`