### PR TITLE
Fixed cors issues in Admin Preview

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/browser.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/browser.hbs
@@ -2,14 +2,14 @@
     <div class="modal-body modal-preview-email-content gh-pe-mobile-container gh-post-preview-container h-auto overflow-auto {{unless @skipAnimation "fade-in"}}">
         <div class="gh-pe-mobile-bezel">
             <div class="gh-pe-mobile-screen">
-                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupIframe}}></iframe>
+                <iframe class="gh-post-preview-iframe" src={{@previewUrl}} title="Mobile browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupPreview}}></iframe>
             </div>
         </div>
     </div>
 {{else}}
     <div class="gh-post-preview-container gh-post-preview-browser-container {{unless @skipAnimation "fade-in"}}">
         <div class="gh-browserpreview-iframecontainer">
-            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupIframe}}></iframe>
+            <iframe class="gh-pe-iframe" src={{@previewUrl}} title="Desktop browser post preview" {{close-dropdowns-on-click}} {{on "load" this.setupPreview}}></iframe>
         </div>
     </div>
 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -2,31 +2,23 @@ import Component from '@glimmer/component';
 import {action} from '@ember/object';
 
 export default class ModalPostPreviewBrowserComponent extends Component {
+    escapePressHandler = null;
+    
     @action
-    setupIframe(event) {
-        const iframe = event.target;
-
-        // Add keydown event listener to the iframe's contentWindow
-        iframe.contentWindow.addEventListener('keydown', (e) => {
+    setupPreview() {
+        // Set up a handler on the document
+        this.escapePressHandler = (e) => {
             if (e.key === 'Escape') {
-                // Prevent the default behavior in the iframe
-                e.preventDefault();
-                e.stopPropagation();
+                // Only handle if we have a modal to close
+                if (this.args.closeModal) {
+                    // Prevent the default behavior
+                    e.preventDefault();
+                    e.stopPropagation();
 
-                // Create and dispatch a new ESC key event to the parent window
-                const escEvent = new KeyboardEvent('keydown', {
-                    key: 'Escape',
-                    code: 'Escape',
-                    keyCode: 27,
-                    which: 27,
-                    bubbles: true,
-                    cancelable: true,
-                    composed: true
-                });
-
-                // Dispatch the event on the document instead of window
-                document.dispatchEvent(escEvent);
+                    // Close the modal directly without creating a new event
+                    this.args.closeModal();
+                }
             }
-        });
+        };
     }
 }


### PR DESCRIPTION
ref https://ghost-foundation.sentry.io/issues/6586234746/?environment=production
ref https://github.com/TryGhost/Ghost/commit/ca6ee64f5835a2e38c06a7c68dd024816c863337

Adding a listener to the iframe violates the security policy. We can likely accomplish the same task (Esc key = close preview) by manipulating the modal within Ember.