### PR TITLE
Fixed top sources not showing in Post Analytics Growth tab

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -63,7 +63,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                             </CardHeader>
                             <CardContent>
                                 <Separator />
-                                {postReferrers.length > 1
+                                {postReferrers.length > 0
                                     ?
                                     <Table>
                                         <TableHeader>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1654/qa-source-chart-not-populating-in-post-analytics-even-though

The "Sources" table on the Post Analytics Growth tab wasn't displaying any rows in the table if there was only one row. This commit fixes that.