### PR TITLE
Removed date range filter from Post Analytics Growth tab

### DIFF
--- a/apps/posts/src/hooks/usePostReferrers.ts
+++ b/apps/posts/src/hooks/usePostReferrers.ts
@@ -24,13 +24,8 @@ export const getRangeDates = (rangeInDays: number) => {
     return {dateFrom, endDate};
 };
 
-export const usePostReferrers = (postId: string, range: number) => {
-    const {dateFrom} = useMemo(() => getRangeDates(range), [range]);
-    const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId, {
-        searchParams: {
-            date_from: dateFrom
-        }
-    });
+export const usePostReferrers = (postId: string) => {
+    const {data: postReferrerResponse, isLoading: isPostReferrersLoading} = usePostReferrersAPI(postId);
     // API doesn't support date_from yet, so we fetch all data and filter on the client for now
     const {data: postGrowthStatsResponse, isLoading: isPostGrowthStatsLoading} = usePostGrowthStatsAPI(postId);
 

--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -19,16 +19,12 @@ interface postAnalyticsProps {}
 const Growth: React.FC<postAnalyticsProps> = () => {
     // const {isLoading: isConfigLoading} = useGlobalData();
     const {postId} = useParams();
-    const {range} = useGlobalData();
-    const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '', range);
+    const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '');
 
     return (
         <PostAnalyticsLayout>
             <ViewHeader className='items-end pb-4'>
                 <PostAnalyticsHeader currentTab='Growth' />
-                <ViewHeaderActions className='mb-2'>
-                    <DateRangeSelect />
-                </ViewHeaderActions>
             </ViewHeader>
             <PostAnalyticsContent>
                 {isLoading ? 'Loading' :

--- a/apps/posts/src/views/PostAnalytics/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth.tsx
@@ -1,10 +1,8 @@
-import DateRangeSelect from './components/DateRangeSelect';
 import KpiCard, {KpiCardIcon, KpiCardLabel, KpiCardValue} from './components/KpiCard';
 import PostAnalyticsContent from './components/PostAnalyticsContent';
 import PostAnalyticsHeader from './components/PostAnalyticsHeader';
 import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber} from '@tryghost/shade';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, formatNumber} from '@tryghost/shade';
 import {useParams} from '@tryghost/admin-x-framework';
 import {usePostReferrers} from '../../hooks/usePostReferrers';
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1655/qa-remove-time-filter-from-post-analytics-growth-tab-default-to-all

The Post Analytics Growth tab is a little bit confusing in its current form, because the top-level summary metrics don't have any date filter applied to them, while the "Sources" table does. This commit removes the date filter from the Growth tab's UI and from the "Sources" table.