### PR TITLE
Fixed MRR chart in Post Analytics Growth tab

### DIFF
--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -191,7 +191,7 @@ export const useGrowthStats = (range: number) => {
             return memberCountResponse;
         }
         return [];
-    }, [memberCountResponse, dateFrom]);
+    }, [memberCountResponse]);
 
     const mrrData = useMemo(() => {
         // HACK: We should do this filtering on the backend, but the API doesn't support it yet

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -191,7 +191,7 @@ export const useGrowthStats = (range: number) => {
             return memberCountResponse;
         }
         return [];
-    }, [memberCountResponse]);
+    }, [memberCountResponse, dateFrom]);
 
     const mrrData = useMemo(() => {
         // HACK: We should do this filtering on the backend, but the API doesn't support it yet
@@ -202,7 +202,7 @@ export const useGrowthStats = (range: number) => {
             });
         }
         return [];
-    }, [mrrHistoryResponse]);
+    }, [mrrHistoryResponse, dateFrom]);
 
     // Calculate totals
     const totalsData = useMemo(() => calculateTotals(memberData, mrrData), [memberData, mrrData]);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1658/qa-mrr-on-scope-of-work-not-matching-mrr-dashboard-for-same-time

The MRR chart on the Post Analytics Growth tab wasn't updating correctly when the date filter was changed. This commit recalculates the chart data whenever the date filter changes, fixing the MRR chart.