### PR TITLE
Removed blocked users from suggested profiles

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -29,7 +29,7 @@ export interface Account {
 
 export type AccountSearchResult = Pick<
     Account,
-    'id' | 'name' | 'handle' | 'avatarUrl' | 'followedByMe' | 'followerCount'
+    'id' | 'name' | 'handle' | 'avatarUrl' | 'followedByMe' | 'followerCount' | 'blockedByMe' | 'domainBlockedByMe'
 >;
 
 export interface SearchResults {

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -2,7 +2,7 @@ import APAvatar from '@components/global/APAvatar';
 import ActivityItem from '@components/activities/ActivityItem';
 import FollowButton from '@components/global/FollowButton';
 import React, {useEffect, useRef} from 'react';
-import {H4, LucideIcon} from '@tryghost/shade';
+import {Button, H4, LucideIcon} from '@tryghost/shade';
 import {LoadingIndicator, NoValueLabel, TextField} from '@tryghost/admin-x-design-system';
 import {SuggestedProfiles} from '../global/SuggestedProfiles';
 import {useDebounce} from 'use-debounce';
@@ -16,6 +16,8 @@ interface AccountSearchResult {
     avatarUrl: string;
     followerCount: number;
     followedByMe: boolean;
+    blockedByMe: boolean;
+    domainBlockedByMe: boolean;
 }
 
 interface AccountSearchResultItemProps {
@@ -60,14 +62,17 @@ const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
                 <span className='line-clamp-1 font-semibold text-black dark:text-white'>{account.name}</span>
                 <span className='line-clamp-1 text-sm text-gray-700 dark:text-gray-600'>{account.handle}</span>
             </div>
-            <FollowButton
-                className='ml-auto'
-                following={account.followedByMe}
-                handle={account.handle}
-                type='secondary'
-                onFollow={onFollow}
-                onUnfollow={onUnfollow}
-            />
+            {account.blockedByMe || account.domainBlockedByMe ?
+                <Button className='pointer-events-none ml-auto min-w-[90px]' variant='destructive'>Blocked</Button> :
+                <FollowButton
+                    className='ml-auto'
+                    following={account.followedByMe}
+                    handle={account.handle}
+                    type='secondary'
+                    onFollow={onFollow}
+                    onUnfollow={onUnfollow}
+                />
+            }
         </ActivityItem>
     );
 };

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -899,15 +899,23 @@ export function useSuggestedProfilesForUser(handle: string, limit = 3) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);
 
+            // Get more handles than we need initially, since some might be filtered out as blocked
+            const fetchLimit = Math.min(limit * 2, suggestedHandles.length);
+
             return Promise.allSettled(
                 suggestedHandles
                     .sort(() => Math.random() - 0.5)
-                    .slice(0, limit)
+                    .slice(0, fetchLimit)
                     .map(suggestedHandle => api.getAccount(suggestedHandle))
             ).then((results) => {
-                return results
+                const accounts = results
                     .filter((result): result is PromiseFulfilledResult<Account> => result.status === 'fulfilled')
-                    .map(result => result.value);
+                    .map(result => result.value)
+                    // Filter out blocked accounts
+                    .filter(account => !account.blockedByMe && !account.domainBlockedByMe);
+
+                // Return only the requested limit of accounts after filtering
+                return accounts.slice(0, limit);
             });
         }
     });


### PR DESCRIPTION
ref PROD-1570

- Filtered out blocked users and domains from profile suggestions
- Ensured users won't see suggestions for accounts they've blocked at either user or domain level