### PR TITLE
Updated release-apps script

### DIFF
--- a/.github/scripts/release-apps.js
+++ b/.github/scripts/release-apps.js
@@ -129,7 +129,31 @@ async function getChangelog(newVersion) {
     });
 
     if (indexOfLastRelease === -1) {
-        console.warn(`Could not find commit for previous release.`);
+        console.warn(`Could not find commit for previous release. Will include recent commits affecting this app.`);
+        
+        // Fallback: get recent commits for this app (last 20)
+        const recentCommits = await safeExec(`git log -n 20 --pretty=format:"%h%n%B__SPLIT__" -- .`);
+        if (recentCommits.stderr) {
+            console.error(`There was an error getting recent commits`);
+            process.exit(1);
+        }
+        
+        const recentCommitsList = recentCommits.stdout.split('__SPLIT__');
+        
+        const recentCommitsWhichMentionLinear = recentCommitsList.filter((commitBlock) => {
+            return commitBlock.includes('https://linear.app/ghost');
+        });
+        
+        const commitChangelogItems = recentCommitsWhichMentionLinear.map((commitBlock) => {
+            const lines = commitBlock.split('\n');
+            if (!lines.length || !lines[0].trim()) {
+                return null; // Skip entries with no hash
+            }
+            const hash = lines[0].trim();
+            return `https://github.com/TryGhost/Ghost/commit/${hash}`;
+        }).filter(Boolean); // Filter out any null entries
+        
+        changelogItems.push(...commitChangelogItems);
     } else {
         const lastReleaseCommit = lastFiftyCommitsList[indexOfLastRelease];
         const lastReleaseCommitHash = lastReleaseCommit.slice(0, 10);

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -30,8 +30,7 @@
     "test:unit": "yarn test:ci",
     "lint": "eslint src --ext .js --cache",
     "preship": "yarn lint",
-    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; fi",
-    "postship": "git push ${GHOST_UPSTREAM:-origin} --follow-tags && npm publish",
+    "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "yarn build"
   },
   "eslintConfig": {


### PR DESCRIPTION
no ref
- bumped announcement bar
- added announcement-bar to the new-ish release-apps script
- updated release-apps script to not dump empty commits when checking the last 50

This contains changes to the `release-apps` script. This *may have some problems* as it's a little difficult to test without making additional changes to the apps. I will try to do this next time there's changes, the problem currently is that I just shipped all of them, and the script only looks at the last 50 commits. Announcement-bar hasn't been shipped in a long time so we don't expect any to fall in that window.

The reason for the change to the script is that it was dumping 50 entries of links to commits w/o a hash (commits that didn't actually touch the repo), which was erroneous and bothersome.