### PR TITLE
Improved the Dockerfile for faster incremental builds

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,8 +3,18 @@ ARG NODE_VERSION=20.15.1
 # --------------------
 # Base Image
 # --------------------
-FROM node:$NODE_VERSION-alpine AS base
-RUN apk add --no-cache python3 make g++ linux-headers git
+FROM node:$NODE_VERSION-bullseye-slim AS base
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    curl \
+    jq \
+    libjemalloc2 \
+    python3 \
+    tar  \
+    git && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean
 
 # --------------------
 # Development Base

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,7 +7,7 @@ FROM node:$NODE_VERSION-alpine AS base
 RUN apk add --no-cache python3 make g++ linux-headers git
 
 # --------------------
-# Development
+# Development Base
 # --------------------
 FROM base AS development-base
 WORKDIR /home/ghost

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -94,18 +94,6 @@ RUN yarn nx run-many -t build:ts
 
 WORKDIR $WORKDIR
 
-# Expose the ports
-EXPOSE 2368
-EXPOSE 4200
-EXPOSE 4201
-EXPOSE 4175
-EXPOSE 4176
-EXPOSE 4177
-EXPOSE 4178
-EXPOSE 6174
-EXPOSE 7173
-EXPOSE 7174
-
 ## Start the dev server
 CMD ["yarn", "dev"]
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,5 @@
 ARG NODE_VERSION=20.15.1
-ARG WORKDIR=/home/ghost
 
-# Base Image used for all targets
-## This stage includes the OS, Node and a few apt packages
 FROM node:$NODE_VERSION-bullseye-slim AS base
 RUN apt-get update && \
     apt-get install -y \
@@ -15,11 +12,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 
-# Development Base Image
-## This stage adds development specific packages like the Stripe CLI, zsh, playwright, etc.
-## It does not include the source code or node_modules
 FROM base AS development-base
-ARG WORKDIR=/home/ghost
+WORKDIR /home/ghost
 RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
     apt update && \
@@ -30,12 +24,9 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 
-# DevContainer Stage: Install dependencies and copy the code
-## This stage is used for local development
-## It includes the source code and all development dependencies
+
 FROM development-base AS development
-ARG WORKDIR=/home/ghost
-WORKDIR $WORKDIR
+WORKDIR /home/ghost
 
 ## Add github to known hosts
 ### Without this, git submodule updates fail inside the container
@@ -85,32 +76,19 @@ COPY ghost/security/package.json ghost/security/package.json
 
 ## Install dependencies
 RUN yarn install --frozen-lockfile --prefer-offline
-
-## Copy the rest of the code
 COPY . .
-
-## Build typescript packages
 RUN yarn nx run-many -t build:ts
-
-WORKDIR $WORKDIR
-
-## Start the dev server
 CMD ["yarn", "dev"]
 
-FROM development AS tinybird
 
+FROM development AS tinybird
 RUN apt update && apt install -y \
     parallel \
     python3-pip
-
-# Install the tinybird CLI
 WORKDIR /home/ghost/ghost/web-analytics
 RUN pip install -r requirements.txt
 
+
 FROM development AS browser-tests
-
-## Install playwright w/ dependencies
 RUN npx -y playwright install --with-deps
-
-## Run the browser tests
 CMD ["yarn", "test:browser"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,18 +3,8 @@ ARG NODE_VERSION=20.15.1
 # --------------------
 # Base Image
 # --------------------
-FROM node:$NODE_VERSION-bullseye-slim AS base
-RUN apt-get update && \
-    apt-get install -y \
-    build-essential \
-    curl \
-    jq \
-    libjemalloc2 \
-    python3 \
-    tar  \
-    git && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt clean
+FROM node:$NODE_VERSION-alpine AS base
+RUN apk add --no-cache python3 make g++ linux-headers git
 
 # --------------------
 # Development

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,8 @@
 ARG NODE_VERSION=20.15.1
 
+# --------------------
+# Base Image
+# --------------------
 FROM node:$NODE_VERSION-bullseye-slim AS base
 RUN apt-get update && \
     apt-get install -y \
@@ -8,38 +11,16 @@ RUN apt-get update && \
     jq \
     libjemalloc2 \
     python3 \
-    tar && \
+    tar  \
+    git && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 
+# --------------------
+# Development
+# --------------------
 FROM base AS development-base
 WORKDIR /home/ghost
-RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
-    apt update && \
-    apt install -y \
-    git \
-    stripe \
-    procps && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt clean
-
-
-FROM development-base AS development
-WORKDIR /home/ghost
-
-## Add github to known hosts
-### Without this, git submodule updates fail inside the container
-RUN mkdir -p /root/.ssh && \
-    ssh-keyscan github.com >> /root/.ssh/known_hosts
-
-# Enable the NX Daemon
-ENV NX_DAEMON=true
-
-# Disable NX rejection of unknown local cache
-ENV NX_REJECT_UNKNOWN_LOCAL_CACHE=false
-
-# Copy the package.json and yarn.lock files
 COPY package.json yarn.lock ./
 
 # Copy all package.json files
@@ -74,13 +55,21 @@ COPY ghost/mw-vhost/package.json ghost/mw-vhost/package.json
 COPY ghost/prometheus-metrics/package.json ghost/prometheus-metrics/package.json
 COPY ghost/security/package.json ghost/security/package.json
 
-## Install dependencies
-RUN yarn install --frozen-lockfile --prefer-offline
+RUN --mount=type=cache,target=/home/ghost/.yarn-cache \
+    yarn config set cache-folder /home/ghost/.yarn-cache && \
+    yarn install --frozen-lockfile --prefer-offline
+
+# --------------------
+# Development
+# --------------------
+FROM development-base AS development
 COPY . .
 RUN yarn nx run-many -t build:ts
 CMD ["yarn", "dev"]
 
-
+# --------------------
+# Tinybird CLI
+# --------------------
 FROM development AS tinybird
 RUN apt update && apt install -y \
     parallel \
@@ -88,7 +77,16 @@ RUN apt update && apt install -y \
 WORKDIR /home/ghost/ghost/web-analytics
 RUN pip install -r requirements.txt
 
-
+# --------------------
+# Browser Tests
+# --------------------
 FROM development AS browser-tests
+RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
+    apt update && \
+    apt install -y \
+    stripe && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean
 RUN npx -y playwright install --with-deps
 CMD ["yarn", "test:browser"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -17,10 +17,37 @@ RUN apt-get update && \
     apt clean
 
 # --------------------
+# Playwright Version
+# --------------------
+# Cache Optimization: Extract the playwright version from package.json
+FROM base AS playwright-version
+WORKDIR /tmp
+COPY ghost/core/package.json ./
+RUN jq -r '.devDependencies."@playwright/test"' ./package.json > playwright-version.txt
+
+# --------------------
+# Playwright
+# --------------------
+# Cache Optimization: Playwright install is slow. Copy the version from the previous stage.
+# This way we only bust build cache when the playwright version changes.
+FROM base AS playwright
+RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
+    apt update && \
+    apt install -y \
+    stripe && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean
+WORKDIR /home/ghost
+COPY --from=playwright-version tmp/playwright-version.txt /tmp/playwright-version.txt
+RUN npx playwright@$(cat /tmp/playwright-version.txt) install --with-deps
+
+# --------------------
 # Development Base
 # --------------------
-FROM base AS development-base
+FROM playwright AS development-base
 WORKDIR /home/ghost
+
 COPY package.json yarn.lock ./
 
 # Copy all package.json files
@@ -76,17 +103,3 @@ RUN apt update && apt install -y \
     python3-pip
 WORKDIR /home/ghost/ghost/web-analytics
 RUN pip install -r requirements.txt
-
-# --------------------
-# Browser Tests
-# --------------------
-FROM development AS browser-tests
-RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee -a /etc/apt/sources.list.d/stripe.list && \
-    apt update && \
-    apt install -y \
-    stripe && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt clean
-RUN npx -y playwright install --with-deps
-CMD ["yarn", "test:browser"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,28 @@
 node_modules
 
 .nxcache
-.nx/workspace-data
+.nx
 
 **/*.log
 
 build
 dist
+
 coverage
+
 .eslintcache
+
 test-results
+
 tsconfig.tsbuildinfo
+
+Dockerfile
+.dockerignore
+
+.git
+.vscode
+.editorconfig
+compose.yml
+
+.docker
+!.docker/development.entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@ node_modules
 .nx/workspace-data
 
 **/*.log
+
+build
+dist
+coverage
+.eslintcache
+test-results
+tsconfig.tsbuildinfo


### PR DESCRIPTION
no refs

This commit makes a number of improvements to the monorepo's development Dockerfile, with an overall goal of improving the build time and build caching.

Here are the highlights:
- Moves the Playwright install to the top of the file, so this step will be cached unless the playwright version we're using changes. Previously the playwright install ran after everything else, which means we had to reinstall playwright if any code or package.json changed.
- Adds a cache mount for the `yarn install` step. This reduces the `yarn install` time on warm builds from ~90 seconds to ~30 seconds from my testing, by caching the downloaded packages in a volume that is managed by Docker.
- It also adds a few additional directories to the `.dockerignore` file, which significantly reduced the size of the final image by ~50%