### PR TITLE
Changed flag checks to maintain path in Stats

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -100,10 +100,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     ];
 
-    if (!labs.trafficAnalyticsAlpha) {
-        return <Navigate to='/web/' />;
-    }
-
     return (
         <PostAnalyticsLayout>
             <ViewHeader className='items-end pb-4'>

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -100,6 +100,10 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     ];
 
+    if (!labs.trafficAnalyticsAlpha) {
+        return <Navigate to='/web/' />;
+    }
+
     return (
         <PostAnalyticsLayout>
             <ViewHeader className='items-end pb-4'>

--- a/apps/stats/src/hooks/useFeatureFlag.tsx
+++ b/apps/stats/src/hooks/useFeatureFlag.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Navigate} from '@tryghost/admin-x-framework';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';

--- a/apps/stats/src/hooks/useFeatureFlag.tsx
+++ b/apps/stats/src/hooks/useFeatureFlag.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {Navigate} from '@tryghost/admin-x-framework';
+import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
+
+/**
+ * Custom hook to check if a feature flag is enabled
+ * Handles loading states to prevent premature redirects
+ * 
+ * @param flagName The name of the feature flag to check
+ * @param fallbackPath The path to redirect to if feature flag is disabled
+ * @returns An object containing the feature flag status and optional component to render
+ */
+export const useFeatureFlag = (flagName: string, fallbackPath: string) => {
+    const {isLoading, settings} = useGlobalData();
+    
+    // Parse labs settings
+    const labsJSON = getSettingValue<string>(settings, 'labs') || '{}';
+    const labs = JSON.parse(labsJSON);
+    
+    // Check if the feature flag is enabled
+    const isEnabled = labs[flagName] === true;
+    
+    // If loading, don't make a decision yet
+    if (isLoading) {
+        return {
+            isEnabled: false,
+            isLoading: true,
+            redirect: null
+        };
+    }
+    
+    // If feature flag is disabled, return redirect component
+    if (!isEnabled) {
+        return {
+            isEnabled: false,
+            isLoading: false,
+            redirect: <Navigate to={fallbackPath} />
+        };
+    }
+    
+    // Feature flag is enabled
+    return {
+        isEnabled: true,
+        isLoading: false,
+        redirect: null
+    };
+}; 

--- a/apps/stats/src/hooks/withFeatureFlag.tsx
+++ b/apps/stats/src/hooks/withFeatureFlag.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import StatsLayout from '@src/views/Stats/layout/StatsLayout';
+import StatsView from '@src/views/Stats/layout/StatsView';
+import {H1, ViewHeader} from '@tryghost/shade';
+import {useFeatureFlag} from './useFeatureFlag';
+
+/**
+ * Higher-Order Component that wraps a component with feature flag checking
+ * 
+ * @param Component The component to wrap
+ * @param flagName The name of the feature flag to check
+ * @param fallbackPath The path to redirect to if feature flag is disabled
+ * @param title The title to display in the loading state
+ * @returns A new component wrapped with feature flag checking
+ */
+export const withFeatureFlag = <P extends object>(
+    Component: React.ComponentType<P>,
+    flagName: string,
+    fallbackPath: string,
+    title: string
+) => {
+    const WrappedComponent = (props: P) => {
+        const {isLoading, redirect} = useFeatureFlag(flagName, fallbackPath);
+        
+        // If we have a redirect component, render it
+        if (redirect) {
+            return redirect;
+        }
+        
+        // If we're loading, render a loading state
+        if (isLoading) {
+            return (
+                <StatsLayout>
+                    <ViewHeader className='before:hidden'>
+                        <H1>{title}</H1>
+                    </ViewHeader>
+                    <StatsView data={[]} isLoading={true}>
+                        <div>{/* Loading placeholder */}</div>
+                    </StatsView>
+                </StatsLayout>
+            );
+        }
+        
+        // Otherwise render the wrapped component
+        return <Component {...props} />;
+    };
+    
+    // Set display name for debugging
+    WrappedComponent.displayName = `withFeatureFlag(${Component.displayName || Component.name || 'Component'})`;
+    
+    return WrappedComponent;
+}; 

--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -4,34 +4,42 @@ import Newsletters from './views/Stats/Newsletters';
 import Sources from './views/Stats/Sources';
 import Web from './views/Stats/Web';
 import {RouteObject} from '@tryghost/admin-x-framework';
+import {withFeatureFlag} from './hooks/withFeatureFlag';
 
 export const APP_ROUTE_PREFIX = '/stats';
+
+// Wrap all components with feature flag protection
+const ProtectedWeb = withFeatureFlag(Web, 'trafficAnalyticsAlpha', '/web/', 'Web');
+const ProtectedSources = withFeatureFlag(Sources, 'trafficAnalyticsAlpha', '/web/', 'Sources');
+const ProtectedLocations = withFeatureFlag(Locations, 'trafficAnalyticsAlpha', '/web/', 'Locations');
+const ProtectedGrowth = withFeatureFlag(Growth, 'trafficAnalyticsAlpha', '/web/', 'Growth');
+const ProtectedNewsletters = withFeatureFlag(Newsletters, 'trafficAnalyticsAlpha', '/web/', 'Newsletters');
 
 export const routes: RouteObject[] = [
     {
         path: '',
         index: true,
-        element: <Web />
+        element: <ProtectedWeb />
     },
     {
         path: '/web/',
-        element: <Web />
+        element: <ProtectedWeb />
     },
     {
         path: '/sources/',
-        element: <Sources />
+        element: <ProtectedSources />
     },
     {
         path: '/locations/',
-        element: <Locations />
+        element: <ProtectedLocations />
     },
     {
         path: '/growth/',
-        element: <Growth />
+        element: <ProtectedGrowth />
     }
     ,
     {
         path: '/newsletters/',
-        element: <Newsletters />
+        element: <ProtectedNewsletters />
     }
 ];

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -6,10 +6,9 @@ import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
-import {Navigate, useNavigate} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useNavigate} from '@tryghost/admin-x-framework';
 import {useNewsletterStatsWithRange, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 
@@ -294,9 +293,7 @@ const Newsletters: React.FC = () => {
     const {range} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
-    const {settings} = useGlobalData();
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
-
+    
     // Get stats from real data using the new hooks
     const {data: newsletterStatsData, isLoading: isStatsLoading} = useNewsletterStatsWithRange(range);
     const {data: subscriberStatsData, isLoading: isSubscriberStatsLoading} = useSubscriberCountWithRange(range);
@@ -370,10 +367,6 @@ const Newsletters: React.FC = () => {
     }, [subscriberStatsData]);
 
     const isLoading = isStatsLoading || isSubscriberStatsLoading;
-
-    if (!labs.trafficAnalyticsAlpha) {
-        return <Navigate to='/web/' />;
-    }
 
     // Convert string dates to Date objects for AvgsDataItem compatibility
     const avgsData: AvgsDataItem[] = newsletterStats.map(stat => ({
@@ -466,4 +459,5 @@ const Newsletters: React.FC = () => {
     );
 };
 
+// Export the component directly now that we handle the feature flag in routes.tsx
 export default Newsletters;


### PR DESCRIPTION
no ref

The stats page would always push the user to `/stats/web/` on refresh because it was loading the alpha flag. This is annoying. I've instead introduced a higher order component to wrap each view that allows us to set a redirect if needed. Now we'll wait for the flag before loading the tab instead of pushing the user to `/web/` and still not loading it.