### PR TITLE
Fixed browser tests running locally in docker

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -83,16 +83,6 @@ services:
     profiles: [ tinybird ]
     tty: true
 
-  browser-tests:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile
-      target: browser-tests
-    command: [ "yarn", "test:browser" ]
-    profiles: [ browser-tests ]
-    tty: true
-
   mysql:
     image: mysql:8.4.5
     container_name: ghost-mysql

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
     "docker:sleep:stop": "docker stop ghost-devcontainer",
     "docker:test:unit": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm --no-deps ghost yarn test:unit",
-    "docker:test:browser": "COMPOSE_PROFILES=browser-tests docker compose up browser-tests --no-log-prefix --force-recreate",
+    "docker:test:browser": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm ghost yarn test:browser",
     "docker:test:all": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm ghost yarn nx run ghost:test:all",
     "docker:reset": "docker compose down -v && docker compose up -d --wait",
     "docker:restart": "docker compose down && docker compose up -d --wait",


### PR DESCRIPTION
no refs

The `yarn docker:test:browser` command was broken when the `browser-tests` target was removed from the Dockerfile. This updates the command so it works without the `browser-tests` target. It also switches back to using `docker run ...` to run the browser tests, rather than the `browser-tests` profile in the compose file.