### PR TITLE
Fixed ProfileMenu component crash when account data isn't fully loaded in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.12"
+  "version": "0.7.12",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -20,7 +20,7 @@ import {
 import {useFeatureFlags} from '@src/lib/feature-flags';
 
 interface ProfileMenuProps {
-    account: Account,
+    account?: Account,
     trigger: React.ReactNode;
     onCopyHandle: () => void;
     onBlockAccount: () => void;
@@ -59,8 +59,8 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
         onBlockDomain();
     };
 
-    const handle = account.handle;
-    const domain = handle.split('@').filter(Boolean)[1];
+    const handle = account?.handle;
+    const domain = handle?.split('@').filter(Boolean)[1];
 
     const renderBlockView = () => (
         <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -98,7 +98,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
     );
 
     const renderUnblockView = () => (
-        <UnblockDialog
+        account && <UnblockDialog
             handle={account.handle}
             isDomainBlocked={account.domainBlockedByMe}
             isOpen={dialogOpen}


### PR DESCRIPTION
ref PROD-1661

- Made `account` prop optional in ProfileMenu component
- Prevented app crashes that occurred when account data wasn't yet available