### PR TITLE
Added blocked indicator to following and followers lists in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -67,7 +67,7 @@ export type AccountFollowsType = 'following' | 'followers';
 
 type GetAccountResponse = Account
 
-export type FollowAccount = Pick<Account, 'id' | 'name' | 'handle' | 'avatarUrl'> & {isFollowing: true};
+export type FollowAccount = Pick<Account, 'id' | 'name' | 'handle' | 'avatarUrl' | 'blockedByMe' | 'domainBlockedByMe'> & {isFollowing: true};
 
 export interface GetAccountFollowsResponse {
     accounts: FollowAccount[];

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {Activity} from '@src/api/activitypub';
 import {useAccountFollowsForUser, useAccountForUser, usePostsByAccount, usePostsLikedByAccount} from '@hooks/use-activity-pub-queries';
 import {useParams} from '@tryghost/admin-x-framework';
-import { isValidDomain } from '@tryghost/shade';
 
 export type ProfileTab = 'posts' | 'likes' | 'following' | 'followers';
 

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {Activity} from '@src/api/activitypub';
 import {useAccountFollowsForUser, useAccountForUser, usePostsByAccount, usePostsLikedByAccount} from '@hooks/use-activity-pub-queries';
 import {useParams} from '@tryghost/admin-x-framework';
+import { isValidDomain } from '@tryghost/shade';
 
 export type ProfileTab = 'posts' | 'likes' | 'following' | 'followers';
 
@@ -73,7 +74,9 @@ const FollowingTab: React.FC<{handle: string}> = ({handle}) => {
                         url: account.avatarUrl
                     }
                 },
-                isFollowing: account.isFollowing
+                isFollowing: account.isFollowing,
+                blockedByMe: account.blockedByMe,
+                domainBlockedByMe: account.domainBlockedByMe
             }));
         }
         return [];

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -73,7 +73,7 @@ const ActorList: React.FC<ActorListProps> = ({
                                     >
                                         <APAvatar author={actor} />
                                         <div>
-                                            <div className='break-anywhere text-gray-600'>
+                                            <div className='text-gray-600 break-anywhere'>
                                                 <span className='mr-1 line-clamp-1 font-bold text-black dark:text-white'>{getName(actor)}</span>
                                                 <div className='line-clamp-1 text-sm'>{actor.handle || getUsername(actor)}</div>
                                             </div>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -5,6 +5,7 @@ import React, {useEffect, useRef} from 'react';
 import getName from '@src/utils/get-name';
 import getUsername from '@src/utils/get-username';
 import {Actor} from '@src/api/activitypub';
+import {Button} from '@tryghost/shade';
 import {List, LoadingIndicator, NoValueLabel} from '@tryghost/admin-x-design-system';
 import {handleProfileClickRR} from '@src/utils/handle-profile-click';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -62,7 +63,7 @@ const ActorList: React.FC<ActorListProps> = ({
                     </NoValueLabel>
                 ) : (
                     <List>
-                        {actors.map(({actor, isFollowing}) => {
+                        {actors.map(({actor, isFollowing, blockedByMe, domainBlockedByMe}) => {
                             return (
                                 <React.Fragment key={actor.id}>
                                     <ActivityItem key={actor.id}
@@ -72,17 +73,20 @@ const ActorList: React.FC<ActorListProps> = ({
                                     >
                                         <APAvatar author={actor} />
                                         <div>
-                                            <div className='text-gray-600 break-anywhere'>
+                                            <div className='break-anywhere text-gray-600'>
                                                 <span className='mr-1 line-clamp-1 font-bold text-black dark:text-white'>{getName(actor)}</span>
                                                 <div className='line-clamp-1 text-sm'>{actor.handle || getUsername(actor)}</div>
                                             </div>
                                         </div>
-                                        <FollowButton
-                                            className='ml-auto'
-                                            following={isFollowing}
-                                            handle={actor.handle || getUsername(actor)}
-                                            type='secondary'
-                                        />
+                                        {blockedByMe || domainBlockedByMe ?
+                                            <Button className='pointer-events-none ml-auto min-w-[90px]' variant='destructive'>Blocked</Button> :
+                                            <FollowButton
+                                                className='ml-auto'
+                                                following={isFollowing}
+                                                handle={actor.handle || getUsername(actor)}
+                                                type='secondary'
+                                            />
+                                        }
                                     </ActivityItem>
                                 </React.Fragment>
                             );


### PR DESCRIPTION
ref PROD-1570

- Extended blocked user visibility to following and followers sections
- Implemented visual indicators that show when a user or domain is blocked in these lists