### PR TITLE
Improved further design details of notifications in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -213,6 +213,7 @@ const Notifications: React.FC = () => {
                                 {notificationGroups.map((group, index) => (
                                     <React.Fragment key={group.id || `${group.type}_${index}`}>
                                         <NotificationItem
+                                            centerAlign={group.actors.length < 2 && group.type === 'follow'}
                                             className='hover:bg-gray-75 dark:hover:bg-gray-950'
                                             isGrouped={group.actors.length > 1}
                                             onClick={() => handleNotificationClick(group, index)}
@@ -307,8 +308,12 @@ const Notifications: React.FC = () => {
                                                         </> :
                                                         <div className='flex items-center gap-1'>
                                                             <span className='truncate'><NotificationGroupDescription group={group} /></span>
-                                                            <span className='mt-px text-[8px] text-gray-700 dark:text-gray-600'>&bull;</span>
-                                                            <span className='mt-0.5 text-sm text-gray-700 dark:text-gray-600'>{renderTimestamp(group, false)}</span>
+                                                            {group.actors.length < 2 &&
+                                                                <>
+                                                                    <span className='mt-px text-[8px] text-gray-700 dark:text-gray-600'>&bull;</span>
+                                                                    <span className='mt-0.5 text-sm text-gray-700 dark:text-gray-600'>{renderTimestamp(group, false)}</span>
+                                                                </>
+                                                            }
                                                         </div>
                                                     }
                                                 </div>
@@ -334,7 +339,7 @@ const Notifications: React.FC = () => {
                                                 )}
                                             </NotificationItem.Content>
                                         </NotificationItem>
-                                        {index < notificationGroups.length - 1 && group.type !== 'reply' &&
+                                        {index < notificationGroups.length - 1 &&
                                             <div className='pl-[52px]'><Separator /></div>
                                         }
                                     </React.Fragment>

--- a/apps/admin-x-activitypub/src/views/Notifications/components/NotificationIcon.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/components/NotificationIcon.tsx
@@ -19,7 +19,7 @@ const NotificationIcon: React.FC<NotificationIconProps> = ({notificationType, si
 
     switch (notificationType) {
     case 'follow':
-        icon = <LucideIcon.UserRoundCheck className='-mr-0.5 -mt-0.5' color={iconColor} size={iconSize} strokeWidth={strokeWidth} />;
+        icon = <LucideIcon.UserRoundCheck className={`-mr-0.5 -mt-0.5 ${size === 'sm' && 'size-[11px]'}`} color={iconColor} size={iconSize} strokeWidth={strokeWidth} />;
         badgeColor = 'bg-blue-600';
         break;
     case 'like':

--- a/apps/admin-x-activitypub/src/views/Notifications/components/NotificationItem.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/components/NotificationItem.tsx
@@ -12,16 +12,17 @@ const NotificationContext = React.createContext<NotificationContextType | undefi
 // Root component
 interface NotificationItemProps {
     isGrouped?: boolean;
+    centerAlign?: boolean;
     children: React.ReactNode;
     onClick?: () => void;
     url?: string;
     className?: string;
 }
 
-const NotificationItem = ({isGrouped, children, onClick, url, className}: NotificationItemProps) => {
+const NotificationItem = ({isGrouped, centerAlign, children, onClick, url, className}: NotificationItemProps) => {
     return (
         <NotificationContext.Provider value={{onClick, url}}>
-            <div className={`group relative -mx-4 -my-px ${isGrouped ? 'grid' : 'flex'} cursor-pointer grid-cols-[auto_1fr] items-start gap-x-4 gap-y-2.5 rounded-lg px-4 py-5 text-left break-anywhere hover:bg-gray-75 ${className}`}
+            <div className={`group relative -mx-4 -my-px ${isGrouped ? 'grid' : 'flex'} ${centerAlign ? 'items-center' : 'items-start'} cursor-pointer grid-cols-[auto_1fr] gap-x-4 gap-y-2.5 rounded-lg px-4 py-5 text-left break-anywhere hover:bg-gray-75 ${className}`}
                 role='button'
                 onClick={onClick}
             >


### PR DESCRIPTION
ref PROD-708

- Removed timestamps from grouped notifications for real as it wasn't included in the previous update
- Center align singular follow notifications as it only has one row of text
- Added back the separator below the reply notifications for better layout organization