### PR TITLE
Improved blocked user modal with clearer unblock options in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/components/UnblockDialog.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/UnblockDialog.tsx
@@ -8,7 +8,9 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
     AlertDialogTrigger,
-    Button
+    Button,
+    H4,
+    LucideIcon
 } from '@tryghost/shade';
 import {showToast} from '@tryghost/admin-x-design-system';
 
@@ -38,10 +40,25 @@ const UnblockDialog: React.FC<UnblockDialogProps> = ({
     onOpenChange: externalOnOpenChange
 }) => {
     const [internalDialogOpen, setInternalDialogOpen] = useState(false);
-    const [dialogState, setDialogState] = useState({
-        mode: 'idle' as DialogMode,
-        userUnblocked: false,
-        domainUnblocked: false
+    const [dialogState, setDialogState] = useState(() => {
+        const bothBlocked = isUserBlocked && isDomainBlocked;
+        const userOnlyBlocked = isUserBlocked && !isDomainBlocked;
+        const domainOnlyBlocked = !isUserBlocked && isDomainBlocked;
+
+        let mode: DialogMode = 'idle';
+        if (bothBlocked) {
+            mode = 'dual';
+        } else if (userOnlyBlocked) {
+            mode = 'userOnly';
+        } else if (domainOnlyBlocked) {
+            mode = 'domainOnly';
+        }
+
+        return {
+            mode,
+            userUnblocked: false,
+            domainUnblocked: false
+        };
     });
 
     const isControlled = externalIsOpen !== undefined;
@@ -63,11 +80,12 @@ const UnblockDialog: React.FC<UnblockDialogProps> = ({
             mode = 'domainOnly';
         }
 
-        setDialogState({
+        setDialogState(prev => ({
+            ...prev,
             mode,
             userUnblocked: false,
             domainUnblocked: false
-        });
+        }));
     }, [isUserBlocked, isDomainBlocked]);
 
     useEffect(() => {
@@ -141,26 +159,36 @@ const UnblockDialog: React.FC<UnblockDialogProps> = ({
         <>
             <AlertDialogHeader>
                 <AlertDialogTitle className='mb-1 flex flex-col gap-1'>
-                    Unblock user or domain?
+                    Unblock
                 </AlertDialogTitle>
-                <AlertDialogDescription>
-                    <span className='font-semibold text-black'>{handle}</span> and everyone from <span className='font-semibold text-black'>{domain}</span> are currently blocked. Which would you like to unblock?
+                <AlertDialogDescription className='!mt-4' asChild>
+                    <div className='flex flex-col rounded-md border'>
+                        <div className='flex justify-between gap-6 p-5'>
+                            <div className='flex flex-col gap-1'>
+                                <H4>Block user</H4>
+                                <p><span className='font-semibold text-black'>{handle}</span> will be able to follow you and engage with your public posts.</p>
+                            </div>
+                            <Button className={`gap-1 ${dialogState.userUnblocked ? 'pointer-events-none border-green bg-green text-white hover:bg-green hover:text-white' : 'text-red hover:text-red-400'}`} variant='outline' onClick={handleUnblock}>
+                                <LucideIcon.User />
+                                {dialogState.userUnblocked ? 'User unblocked' : 'Unblock user'}
+                            </Button>
+                        </div>
+                        <div className='border-t' />
+                        <div className='flex justify-between gap-6 p-5'>
+                            <div className='flex flex-col gap-1'>
+                                <H4>Block domain</H4>
+                                <p>Users from <span className='font-semibold text-black'>{domain}</span> will be able to follow you and engage with your public posts.</p>
+                            </div>
+                            <Button className={`gap-1 ${dialogState.domainUnblocked ? 'pointer-events-none border-green bg-green text-white hover:bg-green hover:text-white' : 'text-red hover:text-red-400'}`} variant='outline' onClick={handleDomainUnblock}>
+                                <LucideIcon.Globe />
+                                {dialogState.domainUnblocked ? 'Domain unblocked' : 'Unblock domain'}
+                            </Button>
+                        </div>
+                    </div>
                 </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-                <AlertDialogCancel className='mr-auto'>Cancel</AlertDialogCancel>
-                <Button
-                    className={`${dialogState.userUnblocked && 'pointer-events-none bg-green hover:bg-green'}`}
-                    onClick={handleUnblock}
-                >
-                    {dialogState.userUnblocked ? 'User unblocked' : 'Unblock user'}
-                </Button>
-                <Button
-                    className={`${dialogState.domainUnblocked && 'pointer-events-none bg-green hover:bg-green'}`}
-                    onClick={handleDomainUnblock}
-                >
-                    {dialogState.domainUnblocked ? 'Domain unblocked' : 'Unblock domain'}
-                </Button>
+                <Button onClick={() => handleDialogClose(false)}>OK</Button>
             </AlertDialogFooter>
         </>
     );
@@ -198,7 +226,7 @@ const UnblockDialog: React.FC<UnblockDialogProps> = ({
                     {trigger}
                 </AlertDialogTrigger>
             )}
-            <AlertDialogContent>
+            <AlertDialogContent className={`${dialogState.mode === 'dual' && 'max-w-[600px]'}`}>
                 {dialogState.mode === 'dual' ? renderDualView() : renderSingleView()}
             </AlertDialogContent>
         </AlertDialog>

--- a/apps/shade/src/components/ui/alert-dialog.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.tsx
@@ -79,7 +79,7 @@ const AlertDialogTitle = React.forwardRef<
 >(({className, ...props}, ref) => (
     <AlertDialogPrimitive.Title
         ref={ref}
-        className={cn('text-[1.6rem] font-semibold', className)}
+        className={cn('text-xl font-semibold', className)}
         {...props}
     />
 ));
@@ -91,7 +91,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({className, ...props}, ref) => (
     <AlertDialogPrimitive.Description
         ref={ref}
-        className={cn('text-base text-muted-foreground', className)}
+        className={cn('text-base', className)}
         {...props}
     />
 ));


### PR DESCRIPTION
ref PROD-697

- Redesigned the blocking modal for users blocked at both user and domain levels
- Created visual distinction between "Unblock user" and "Unblock domain" actions