### PR TITLE
Fixed search modal not closing from profile view in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/global/SuggestedProfiles.tsx
+++ b/apps/admin-x-activitypub/src/components/global/SuggestedProfiles.tsx
@@ -36,6 +36,7 @@ export const SuggestedProfile: React.FC<SuggestedProfileProps & {
         <ActivityItem
             key={profile.id}
             onClick={() => {
+                onOpenChange?.(false);
                 navigate(`/profile/${profile.handle}`);
             }}
         >

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -27,7 +27,7 @@ interface AccountSearchResultItemProps {
 
 const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
     onOpenChange?: (open: boolean) => void;
-}> = ({account, update}) => {
+}> = ({account, update, onOpenChange}) => {
     const onFollow = () => {
         update(account.id, {
             followedByMe: true,
@@ -48,6 +48,7 @@ const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
         <ActivityItem
             key={account.id}
             onClick={() => {
+                onOpenChange?.(false);
                 navigate(`/profile/${account.handle}`);
             }}
         >


### PR DESCRIPTION
ref PROD-1669

- Resolved issue where search modal remained open after clicking search results or suggested profiles
- Fixed bug that only occurred when search was initiated from profile view