### PR TITLE
Removed search cache in `admin-x-activitypub`

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -746,6 +746,7 @@ export function useSearchForUser(handle: string, query: string) {
     const searchQuery = useQuery({
         queryKey,
         enabled: query.length > 0,
+        refetchOnMount: 'always',
         async queryFn() {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1669

Removed the search cache in `admin-x-activitypub` to allow for easier maintenance of accounts that appear in search results when updating the status of an account (follow, block, etc.)