### PR TITLE
Ensured `inbox` and `feed` cache gets invalidated on block in activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -382,6 +382,8 @@ export function useBlockMutationForUser(handle: string) {
                     };
                 }
             );
+            queryClient.invalidateQueries({queryKey: QUERY_KEYS.feed});
+            queryClient.invalidateQueries({queryKey: QUERY_KEYS.inbox});
         }
     });
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1669

Ensured that the `inbox` and `feed` caches get invalidated for the current user when they block an account. This is so that any content in the `inbox` / `feed` from the blocked account gets removed if it has already been cached by tanstack query