### PR TITLE
Added `emailCustomizationAlpha` labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -16,6 +16,10 @@ const features = [{
     description: 'Adding more control over the newsletter template',
     flag: 'emailCustomization'
 }, {
+    title: 'Email customization (internal alpha)',
+    description: 'Wired up settings and updated email content',
+    flag: 'emailCustomizationAlpha'
+}, {
     title: 'Import Member Tier',
     description: 'Enables tier to be specified when importing members',
     flag: 'importMemberTier'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -46,6 +46,7 @@ const PRIVATE_FEATURES = [
     'importMemberTier',
     'urlCache',
     'emailCustomization',
+    'emailCustomizationAlpha',
     'mailEvents',
     'collectionsCard',
     'lexicalIndicators',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -19,6 +19,7 @@ Object {
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,
+      "emailCustomizationAlpha": true,
       "explore": true,
       "i18n": true,
       "importMemberTier": true,


### PR DESCRIPTION
no issue

- flag for internal testing of wired up newsletter customization settings
