### PR TITLE
Removed `new-note-format` flag in admin-x-activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['new-note-format'] as const;
+export const FEATURE_FLAGS = [] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;


### PR DESCRIPTION
no ref 

Removed the `new-note-format` flag in `admin-x-activitypub` which will
enable the note API handle the new response for everyone. 