### PR TITLE
Wired up top links table in Post Analytics > Newsletter tab

### DIFF
--- a/apps/admin-x-framework/src/api/links.ts
+++ b/apps/admin-x-framework/src/api/links.ts
@@ -1,0 +1,24 @@
+import {Meta, createQuery} from '../utils/api/hooks';
+
+export type LinkResponseType = {
+    links: LinkItem[];
+    meta: Meta;
+}
+
+export type LinkItem = {
+    post_id: string;
+    link: {
+        link_id: string;
+        from: string;
+        to: string;
+        edited: boolean;
+    },
+    count: {
+        clicks: number;
+    }
+}
+
+export const useTopLinks = createQuery<LinkResponseType>({
+    dataType: 'LinkResponseType',
+    path: '/links/'
+});

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -28,7 +28,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
     const {isLoading: isConfigLoading} = useGlobalData();
 
-    const {stats, averageStats, isLoading: isPostLoading} = usePostNewsletterStats(postId || '');
+    const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading} = usePostNewsletterStats(postId || '');
 
     const handleEdit = (url: string) => {
         setEditingUrl(url);
@@ -64,7 +64,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     }, [editingUrl, originalUrl, editedUrl]);
 
-    const isLoading = isPostLoading || isConfigLoading;
+    const isLoading = isNewsletterStatsLoading || isConfigLoading;
 
     const barDomain = [0, 1];
     const barTicks = [0, 0.25, 0.5, 0.75, 1];
@@ -82,25 +82,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
             color: 'hsl(var(--chart-gray))'
         }
     } satisfies ChartConfig;
-
-    const mockLinks = [
-        {
-            url: 'https://google.com',
-            clicks: 199
-        },
-        {
-            url: 'https://ghost.org/docs/content-api/javascript/',
-            clicks: 74
-        },
-        {
-            url: 'https://bsky.app/',
-            clicks: 12
-        },
-        {
-            url: 'https://activitypub.ghost.org/you-think-youre-following-us-but-you-might-not-be/',
-            clicks: 1
-        }
-    ];
 
     if (!labs.trafficAnalyticsAlpha) {
         return <Navigate to='/web/' />;
@@ -216,7 +197,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                             </CardHeader>
                             <CardContent>
                                 <Separator />
-                                {mockLinks.length > 0
+                                {topLinks.length > 0
                                     ?
                                     <Table>
                                         <TableHeader>
@@ -226,7 +207,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                             </TableRow>
                                         </TableHeader>
                                         <TableBody>
-                                            {mockLinks?.map(row => (
+                                            {topLinks?.map(row => (
                                                 <TableRow key={row.url}>
                                                     <TableCell>
                                                         <div className='flex items-center gap-2'>

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -41,6 +41,9 @@ describe('usePostNewsletterStats', () => {
             }),
             http.get('/ghost/api/admin/stats/newsletter-stats/', () => {
                 return HttpResponse.json({stats: []});
+            }),
+            http.get('/ghost/api/admin/links/', () => {
+                return HttpResponse.json({links: []});
             })
         );
 
@@ -66,6 +69,7 @@ describe('usePostNewsletterStats', () => {
             openedRate: 0,
             clickedRate: 0
         });
+        expect(result.current.topLinks).toEqual([]);
     });
 
     it('calculates stats correctly from post data', async () => {
@@ -99,6 +103,23 @@ describe('usePostNewsletterStats', () => {
                     ],
                     meta: {}
                 });
+            }),
+            http.get('/ghost/api/admin/links/', () => {
+                return HttpResponse.json({
+                    links: [{
+                        post_id: 'post-id',
+                        link: {
+                            link_id: 'link-1',
+                            from: 'https://example.com/from',
+                            to: 'https://example.com/to',
+                            edited: false
+                        },
+                        count: {
+                            clicks: 10
+                        }
+                    }],
+                    meta: {}
+                });
             })
         );
         const {result} = renderHook(() => usePostNewsletterStats('post-id'), {wrapper});
@@ -119,6 +140,11 @@ describe('usePostNewsletterStats', () => {
             openedRate: 0.55,
             clickedRate: 0.3
         });
+
+        expect(result.current.topLinks).toEqual([{
+            url: 'https://example.com/to',
+            clicks: 10
+        }]);
     });
 
     it('handles missing email data', async () => {
@@ -138,6 +164,9 @@ describe('usePostNewsletterStats', () => {
                     stats: [],
                     meta: {}
                 });
+            }),
+            http.get('/ghost/api/admin/links/', () => {
+                return HttpResponse.json({links: []});
             })
         );
 
@@ -154,6 +183,7 @@ describe('usePostNewsletterStats', () => {
             openedRate: 0,
             clickedRate: 0
         });
+        expect(result.current.topLinks).toEqual([]);
     });
 
     it('handles missing count data', async () => {
@@ -174,6 +204,9 @@ describe('usePostNewsletterStats', () => {
                     stats: [],
                     meta: {}
                 });
+            }),
+            http.get('/ghost/api/admin/links/', () => {
+                return HttpResponse.json({links: []});
             })
         );
 
@@ -190,6 +223,7 @@ describe('usePostNewsletterStats', () => {
             openedRate: 0.5,
             clickedRate: 0
         });
+        expect(result.current.topLinks).toEqual([]);
     });
 
     it('handles missing newsletter stats', async () => {
@@ -211,6 +245,9 @@ describe('usePostNewsletterStats', () => {
             }),
             http.get('/ghost/api/admin/stats/newsletter-stats/', () => {
                 return HttpResponse.json({stats: undefined});
+            }),
+            http.get('/ghost/api/admin/links/', () => {
+                return HttpResponse.json({links: []});
             })
         );
 
@@ -224,5 +261,6 @@ describe('usePostNewsletterStats', () => {
             openedRate: 0,
             clickedRate: 0
         });
+        expect(result.current.topLinks).toEqual([]);
     });
 }); 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1670/wire-up-the-email-links-endpoint-to-the-top-links-table-in-post

On the Post Analytics > Newsletters tab, we display a list of the most clicked links. So far this has been a static dataset, this commit wires the table up to the API endpoint to get the actual top links for the post.