### PR TITLE
Implemented link editing in Post Analytics > Newsletter tab

### DIFF
--- a/apps/admin-x-framework/src/api/links.ts
+++ b/apps/admin-x-framework/src/api/links.ts
@@ -1,4 +1,4 @@
-import {Meta, createQuery} from '../utils/api/hooks';
+import {Meta, createQuery, createMutation} from '../utils/api/hooks';
 
 export type LinkResponseType = {
     links: LinkItem[];
@@ -18,7 +18,45 @@ export type LinkItem = {
     }
 }
 
+export type BulkEditLinksResponseType = {
+    bulk: {
+        action: string;
+        meta: {
+            stats: {
+                successful: number;
+                unsuccessful: number;
+            }
+            errors: []
+            unsuccessfulData: []
+        }
+    }
+}
+
+export type useBulkEditLinksParameters = {
+    postId: string;
+    originalUrl: string;
+    editedUrl: string;
+}
+
 export const useTopLinks = createQuery<LinkResponseType>({
     dataType: 'LinkResponseType',
     path: '/links/'
+});
+
+export const useBulkEditLinks = createMutation<BulkEditLinksResponseType, useBulkEditLinksParameters>({
+    method: 'PUT',
+    path: () => '/links/bulk/',
+    body: ({editedUrl}) => ({
+        bulk: {
+            action: 'updateLink',
+            meta: {
+                link: {
+                    to: editedUrl
+                }
+            }
+        }
+    }),
+    searchParams: ({originalUrl, postId}) => ({
+        filter: `post_id:'${postId}'+to:'${originalUrl}'`
+    })
 });

--- a/apps/posts/src/hooks/useEditLinks.ts
+++ b/apps/posts/src/hooks/useEditLinks.ts
@@ -1,0 +1,10 @@
+import {useBulkEditLinks as useEditLinksApi} from '@tryghost/admin-x-framework/api/links';
+
+export const useEditLinks = () => {
+    const {mutateAsync: editLinks, isLoading: isEditLinksLoading} = useEditLinksApi();
+
+    return {
+        editLinks,
+        isEditLinksLoading
+    };
+}

--- a/apps/posts/src/hooks/useEditLinks.ts
+++ b/apps/posts/src/hooks/useEditLinks.ts
@@ -7,4 +7,4 @@ export const useEditLinks = () => {
         editLinks,
         isEditLinksLoading
     };
-}
+};

--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -53,9 +53,9 @@ export const usePostNewsletterStats = (postId: string) => {
     }, [newsletterStatsResponse]);
 
     // Fetch the top clicked links for the post
-    const {data: topLinksResponse, isLoading: isTopLinksLoading} = useTopLinks({
+    const {data: topLinksResponse, isLoading: isTopLinksLoading, refetch: refetchTopLinks} = useTopLinks({
         searchParams: {
-            filter: `post_id:${postId}`
+            filter: `post_id:'${postId}'`
         }
     });
 
@@ -66,7 +66,8 @@ export const usePostNewsletterStats = (postId: string) => {
 
         return topLinksResponse.links.sort((a, b) => b.count.clicks - a.count.clicks).map(link => ({
             url: link.link.to,
-            clicks: link.count.clicks
+            clicks: link.count.clicks,
+            edited: link.link.edited
         }));
     }, [topLinksResponse]);
 
@@ -75,6 +76,7 @@ export const usePostNewsletterStats = (postId: string) => {
         post,
         stats,
         averageStats,
-        topLinks
+        topLinks,
+        refetchTopLinks
     };
 };

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -7,10 +7,10 @@ import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Chart
 import {Navigate, useParams} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth} from '@src/utils/chart-helpers';
 import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
+import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useRef, useState} from 'react';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
-import {useEditLinks} from '@src/hooks/useEditLinks';
 
 interface postAnalyticsProps {}
 
@@ -32,7 +32,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading, refetchTopLinks} = usePostNewsletterStats(postId || '');
     const {editLinks} = useEditLinks();
 
-
     const handleEdit = (url: string) => {
         setEditingUrl(url);
         setEditedUrl(url);
@@ -51,11 +50,8 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                 setEditedUrl('');
                 setOriginalUrl('');
                 refetchTopLinks();
-            },
-            onError: (error) => {
-                console.error(error);
             }
-        })
+        });
     };
 
     useEffect(() => {

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -38,7 +38,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         setOriginalUrl(url);
     };
 
-    // TODO: API calls to update URL
     const handleUpdate = () => {
         editLinks({
             originalUrl,

--- a/apps/posts/test/unit/hooks/useEditLinks.test.tsx
+++ b/apps/posts/test/unit/hooks/useEditLinks.test.tsx
@@ -1,0 +1,171 @@
+import GlobalDataProvider from '../../../src/providers/GlobalDataProvider';
+import React from 'react';
+import {HttpResponse, http} from 'msw';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import {setupServer} from 'msw/node';
+import {useEditLinks} from '../../../src/hooks/useEditLinks';
+
+const server = setupServer();
+
+const createTestQueryClient = () => new QueryClient({
+    defaultOptions: {
+        queries: {
+            retry: false,
+            suspense: false
+        }
+    }
+});
+
+describe('useEditLinks', () => {
+    beforeAll(() => server.listen());
+    afterEach(() => {
+        server.resetHandlers();
+        vi.resetAllMocks();
+    });
+    afterAll(() => server.close());
+
+    const wrapper = ({children}: {children: React.ReactNode}) => {
+        const queryClient = createTestQueryClient();
+        return (
+            <QueryClientProvider client={queryClient}>
+                <GlobalDataProvider>{children}</GlobalDataProvider>
+            </QueryClientProvider>
+        );
+    };
+
+    it('initial state is correct', () => {
+        const {result} = renderHook(() => useEditLinks(), {wrapper});
+        expect(result.current.isEditLinksLoading).toBe(false);
+    });
+
+    it('calls the API and updates loading state on successful edit', async () => {
+        const mockSuccessResponse = {
+            bulk: {
+                action: 'updateLink',
+                meta: {
+                    stats: {successful: 1, unsuccessful: 0},
+                    errors: [],
+                    unsuccessfulData: []
+                }
+            }
+        };
+
+        server.use(
+            http.put('/ghost/api/admin/links/bulk/', async ({request}) => {
+                const url = new URL(request.url);
+                expect(url.searchParams.get('filter')).toBe('post_id:\'test-post-id\'+to:\'https://original.com\'');
+                
+                const body = await request.json();
+                expect(body).toEqual({
+                    bulk: {
+                        action: 'updateLink',
+                        meta: {
+                            link: {
+                                to: 'https://edited.com'
+                            }
+                        }
+                    }
+                });
+                return HttpResponse.json(mockSuccessResponse);
+            })
+        );
+
+        const {result} = renderHook(() => useEditLinks(), {wrapper});
+
+        expect(result.current.isEditLinksLoading).toBe(false);
+
+        // Use act to wrap state updates
+        await act(async () => {
+            result.current.editLinks({
+                postId: 'test-post-id',
+                originalUrl: 'https://original.com',
+                editedUrl: 'https://edited.com'
+            });
+        });
+        
+        // isLoading should be true immediately after calling editLinks (before promise resolves)
+        // but due to act and async nature, checking after await for it to be false.
+        // If we need to check true state, it requires more granular control or callbacks.
+
+        await waitFor(() => {
+            expect(result.current.isEditLinksLoading).toBe(false);
+        });
+    });
+
+    it('handles API error and updates loading state', async () => {
+        server.use(
+            http.put('/ghost/api/admin/links/bulk/', () => {
+                return new HttpResponse(null, {status: 500});
+            })
+        );
+
+        const {result} = renderHook(() => useEditLinks(), {wrapper});
+        expect(result.current.isEditLinksLoading).toBe(false);
+
+        let mutationError: Error | null = null;
+        try {
+            await act(async () => {
+               await result.current.editLinks({
+                    postId: 'test-post-id',
+                    originalUrl: 'https://original.com',
+                    editedUrl: 'https://edited.com'
+                });
+            });
+        } catch (e) {
+            mutationError = e as Error;
+        }
+        
+        // For TanStack Query v5, mutateAsync throws on error by default
+        // Depending on global/hook-level error handling, this might not be needed
+        // or the error should be caught and asserted.
+        // Here, we'll assume the hook itself doesn't suppress the error.
+
+        await waitFor(() => {
+            expect(result.current.isEditLinksLoading).toBe(false);
+        });
+         // We expect an error to be thrown by mutateAsync
+        expect(mutationError).toBeInstanceOf(Error);
+    });
+
+    it('correctly sets loading state during API call', async () => {
+        let resolveRequest: (value: unknown) => void;
+        const requestPromise = new Promise((resolve) => {
+            resolveRequest = resolve;
+        });
+
+        server.use(
+            http.put('/ghost/api/admin/links/bulk/', async () => {
+                await requestPromise; // Hold the request
+                return HttpResponse.json({}); 
+            })
+        );
+
+        const {result} = renderHook(() => useEditLinks(), {wrapper});
+
+        expect(result.current.isEditLinksLoading).toBe(false);
+
+        act(() => {
+            // Don't await here to check intermediate loading state
+            result.current.editLinks({
+                postId: 'test-post-id',
+                originalUrl: 'https://original.com',
+                editedUrl: 'https://edited.com'
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.isEditLinksLoading).toBe(true);
+        });
+
+        // Allow the request to complete
+        act(() => {
+            resolveRequest({});
+        });
+        
+        await waitFor(() => {
+            expect(result.current.isEditLinksLoading).toBe(false);
+        });
+    });
+});

--- a/apps/posts/test/unit/hooks/useEditLinks.test.tsx
+++ b/apps/posts/test/unit/hooks/useEditLinks.test.tsx
@@ -1,10 +1,9 @@
 import GlobalDataProvider from '../../../src/providers/GlobalDataProvider';
-import React from 'react';
+import React, {act} from 'react';
 import {HttpResponse, http} from 'msw';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {renderHook, waitFor} from '@testing-library/react';
-import {act} from 'react';
 import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import {renderHook, waitFor} from '@testing-library/react';
 import {setupServer} from 'msw/node';
 import {useEditLinks} from '../../../src/hooks/useEditLinks';
 

--- a/apps/posts/test/unit/hooks/useEditLinks.test.tsx
+++ b/apps/posts/test/unit/hooks/useEditLinks.test.tsx
@@ -107,7 +107,7 @@ describe('useEditLinks', () => {
         let mutationError: Error | null = null;
         try {
             await act(async () => {
-               await result.current.editLinks({
+                await result.current.editLinks({
                     postId: 'test-post-id',
                     originalUrl: 'https://original.com',
                     editedUrl: 'https://edited.com'
@@ -125,7 +125,7 @@ describe('useEditLinks', () => {
         await waitFor(() => {
             expect(result.current.isEditLinksLoading).toBe(false);
         });
-         // We expect an error to be thrown by mutateAsync
+        // We expect an error to be thrown by mutateAsync
         expect(mutationError).toBeInstanceOf(Error);
     });
 

--- a/apps/posts/test/unit/hooks/useEditLinks.test.tsx
+++ b/apps/posts/test/unit/hooks/useEditLinks.test.tsx
@@ -2,7 +2,8 @@ import GlobalDataProvider from '../../../src/providers/GlobalDataProvider';
 import React from 'react';
 import {HttpResponse, http} from 'msw';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {act, renderHook, waitFor} from '@testing-library/react';
+import {renderHook, waitFor} from '@testing-library/react';
+import {act} from 'react';
 import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import {setupServer} from 'msw/node';
 import {useEditLinks} from '../../../src/hooks/useEditLinks';
@@ -84,11 +85,6 @@ describe('useEditLinks', () => {
                 editedUrl: 'https://edited.com'
             });
         });
-        
-        // isLoading should be true immediately after calling editLinks (before promise resolves)
-        // but due to act and async nature, checking after await for it to be false.
-        // If we need to check true state, it requires more granular control or callbacks.
-
         await waitFor(() => {
             expect(result.current.isEditLinksLoading).toBe(false);
         });
@@ -116,16 +112,10 @@ describe('useEditLinks', () => {
         } catch (e) {
             mutationError = e as Error;
         }
-        
-        // For TanStack Query v5, mutateAsync throws on error by default
-        // Depending on global/hook-level error handling, this might not be needed
-        // or the error should be caught and asserted.
-        // Here, we'll assume the hook itself doesn't suppress the error.
 
         await waitFor(() => {
             expect(result.current.isEditLinksLoading).toBe(false);
         });
-        // We expect an error to be thrown by mutateAsync
         expect(mutationError).toBeInstanceOf(Error);
     });
 

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -143,7 +143,8 @@ describe('usePostNewsletterStats', () => {
 
         expect(result.current.topLinks).toEqual([{
             url: 'https://example.com/to',
-            clicks: 10
+            clicks: 10,
+            edited: false
         }]);
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1671/post-analytics-newsletter-wire-link-editing-to-the-api

On the Post Analytics > Newsletter tab, the user should be able to edit the links. This was implemented in the UI, but not wired up to the API yet. This hooks up this functionality to the API for editing links.
