### PR TITLE
Fixed Post Analytics > Newsletter tab premature redirect

### DIFF
--- a/apps/posts/src/hooks/useFeatureFlag.tsx
+++ b/apps/posts/src/hooks/useFeatureFlag.tsx
@@ -1,0 +1,47 @@
+import {Navigate} from '@tryghost/admin-x-framework';
+import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
+
+/**
+ * Custom hook to check if a feature flag is enabled
+ * Handles loading states to prevent premature redirects
+ * 
+ * @param flagName The name of the feature flag to check
+ * @param fallbackPath The path to redirect to if feature flag is disabled
+ * @returns An object containing the feature flag status and optional component to render
+ */
+export const useFeatureFlag = (flagName: string, fallbackPath: string) => {
+    const {isLoading, settings} = useGlobalData();
+    
+    // Parse labs settings
+    const labsJSON = getSettingValue<string>(settings, 'labs') || '{}';
+    const labs = JSON.parse(labsJSON);
+
+    // Check if the feature flag is enabled
+    const isEnabled = labs[flagName] === true;
+    
+    // If loading, don't make a decision yet
+    if (isLoading) {
+        return {
+            isEnabled: false,
+            isLoading: true,
+            redirect: null
+        };
+    }
+    
+    // If feature flag is disabled, return redirect component
+    if (!isEnabled) {
+        return {
+            isEnabled: false,
+            isLoading: false,
+            redirect: <Navigate to={fallbackPath} />
+        };
+    }
+    
+    // Feature flag is enabled
+    return {
+        isEnabled: true,
+        isLoading: false,
+        redirect: null
+    };
+}; 

--- a/apps/posts/src/hooks/withFeatureFlag.tsx
+++ b/apps/posts/src/hooks/withFeatureFlag.tsx
@@ -1,0 +1,52 @@
+import PostAnalyticsLayout from '@src/views/PostAnalytics/layout/PostAnalyticsLayout';
+import PostAnalyticsView from '@src/views/PostAnalytics/components/PostAnalyticsView';
+import React from 'react';
+import {H1, ViewHeader} from '@tryghost/shade';
+import {useFeatureFlag} from './useFeatureFlag';
+
+/**
+ * Higher-Order Component that wraps a component with feature flag checking
+ * 
+ * @param Component The component to wrap
+ * @param flagName The name of the feature flag to check
+ * @param fallbackPath The path to redirect to if feature flag is disabled
+ * @param title The title to display in the loading state
+ * @returns A new component wrapped with feature flag checking
+ */
+export const withFeatureFlag = <P extends object>(
+    Component: React.ComponentType<P>,
+    flagName: string,
+    fallbackPath: string,
+    title: string
+) => {
+    const WrappedComponent = (props: P) => {
+        const {isLoading, redirect} = useFeatureFlag(flagName, fallbackPath);
+        
+        // If we have a redirect component, render it
+        if (redirect) {
+            return redirect;
+        }
+        
+        // If we're loading, render a loading state
+        if (isLoading) {
+            return (
+                <PostAnalyticsLayout>
+                    <ViewHeader className='before:hidden'>
+                        <H1>{title}</H1>
+                    </ViewHeader>
+                    <PostAnalyticsView data={[]} isLoading={true}>
+                        <div>{/* Loading placeholder */}</div>
+                    </PostAnalyticsView>
+                </PostAnalyticsLayout>
+            );
+        }
+        
+        // Otherwise render the wrapped component
+        return <Component {...props} />;
+    };
+    
+    // Set display name for debugging
+    WrappedComponent.displayName = `withFeatureFlag(${Component.displayName || Component.name || 'Component'})`;
+    
+    return WrappedComponent;
+}; 

--- a/apps/posts/src/providers/GlobalDataProvider.tsx
+++ b/apps/posts/src/providers/GlobalDataProvider.tsx
@@ -33,7 +33,7 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
 
-    const requests = [config];
+    const requests = [config, settings];
     const error = requests.map(request => request.error).find(Boolean);
     const isLoading = requests.some(request => request.isLoading);
 

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -3,8 +3,12 @@ import Newsletter from './views/PostAnalytics/Newsletter';
 import Web from './views/PostAnalytics/Web';
 import {ErrorPage} from '@tryghost/shade';
 import {Navigate, RouteObject} from '@tryghost/admin-x-framework';
+import {withFeatureFlag} from '@src/hooks/withFeatureFlag';
 
 export const APP_ROUTE_PREFIX = '/posts';
+
+// Wrap the Newsletter component with the feature flag
+const ProtectedNewsletter = withFeatureFlag(Newsletter, 'trafficAnalyticsAlpha', '/analytics/', 'Newsletter');
 
 export const routes: RouteObject[] = [
     {
@@ -30,7 +34,7 @@ export const routes: RouteObject[] = [
             {
                 path: 'analytics/:postId/newsletter',
                 index: true,
-                element: <Newsletter />
+                element: <ProtectedNewsletter />
             },
             {
                 path: '*',

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -4,12 +4,10 @@ import PostAnalyticsContent from './components/PostAnalyticsContent';
 import PostAnalyticsHeader from './components/PostAnalyticsHeader';
 import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber, formatPercentage} from '@tryghost/shade';
-import {Navigate, useParams} from '@tryghost/admin-x-framework';
 import {calculateYAxisWidth} from '@src/utils/chart-helpers';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useRef, useState} from 'react';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useParams} from '@tryghost/admin-x-framework';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
 interface postAnalyticsProps {}
@@ -25,9 +23,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const [originalUrl, setOriginalUrl] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    const {settings} = useGlobalData();
-    const {isLoading: isConfigLoading} = useGlobalData();
-    const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
 
     const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading, refetchTopLinks} = usePostNewsletterStats(postId || '');
     const {editLinks} = useEditLinks();
@@ -74,7 +69,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     }, [editingUrl, originalUrl, editedUrl]);
 
-    const isLoading = isNewsletterStatsLoading || isConfigLoading;
+    const isLoading = isNewsletterStatsLoading;
 
     const barDomain = [0, 1];
     const barTicks = [0, 0.25, 0.5, 0.75, 1];
@@ -92,10 +87,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
             color: 'hsl(var(--chart-gray))'
         }
     } satisfies ChartConfig;
-
-    if (!labs.trafficAnalyticsAlpha) {
-        return <Navigate to='/web/' />;
-    }
 
     return (
         <PostAnalyticsLayout>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
     "docker:build": "yarn docker:clean && docker compose build ghost",
     "docker:clean": "echo \"Deleting node_modules volumes...\" && COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose down --remove-orphans && docker volume ls -q -f name=ghost_node_modules | xargs -I{} docker volume rm {}",
-    "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
+    "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm -it ghost /bin/bash",
     "docker:mysql": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up mysql -d --wait && docker compose exec mysql mysql -u root -proot ghost",
     "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
     "docker:sleep:stop": "docker stop ghost-devcontainer",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
     "docker:build": "yarn docker:clean && docker compose build ghost",
     "docker:clean": "echo \"Deleting node_modules volumes...\" && COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose down --remove-orphans && docker volume ls -q -f name=ghost_node_modules | xargs -I{} docker volume rm {}",
-    "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} NX_DAEMON=false docker compose run --rm -it ghost /bin/bash",
+    "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
     "docker:mysql": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up mysql -d --wait && docker compose exec mysql mysql -u root -proot ghost",
     "docker:sleep": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run -d --name ghost-devcontainer --rm -it ghost /bin/bash -c 'sleep infinity'",
     "docker:sleep:stop": "docker stop ghost-devcontainer",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1672/post-analytics-newsletter-tab-fails-to-load-frequently

The Newsletter tab in the Post Analytics view was prematurely redirecting because the `trafficAnalyticsAlpha` flag hadn't been loaded yet. The redirect was occurring before the settings were loaded from the server, so unless the `posts` app had already been loaded and cached the settings, the Newsletter tab would redirect to the `/web/` route. This `/web/` route doesn't really exist, so it shows the "Loading interrupted" error.

This follows the same pattern we have in the `stats` app using a `withFeatureFlag` higher order component to put the whole route behind the flag, and critically it waits for the settings to load before redirecting. 

Note: this duplicates the `withFeatureFlag` and `useFeatureFlag` hook from `stats` into `posts`. We should either merge these apps together, or most these into `admin-x-framework` to remove the duplication. 