### PR TITLE
Fixed types for mw-vhost

### DIFF
--- a/ghost/mw-vhost/lib/vhost.js
+++ b/ghost/mw-vhost/lib/vhost.js
@@ -34,7 +34,7 @@ var ESCAPE_REPLACE = '\\$1';
  *
  * @param {string|RegExp} hostname
  * @param {function} handle
- * @return {Function}
+ * @return {import('express').RequestHandler}
  * @public
  */
 


### PR DESCRIPTION
- we are returning an Express RequestHandler here and not a plain function, so anywhere that uses this middleware was showing typing errors