### PR TITLE
Fixed minor bugs in Traffic Analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -193,8 +193,8 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                         </Card>
                         <Card>
                             <CardHeader>
-                                <CardTitle>Email clicks</CardTitle>
-                                <CardDescription>Which links got the most clicks</CardDescription>
+                                <CardTitle>Newsletter clicks</CardTitle>
+                                <CardDescription>Which links resonated with your readers</CardDescription>
                             </CardHeader>
                             <CardContent>
                                 <Separator />

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -203,14 +203,14 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                     <Table>
                                         <TableHeader>
                                             <TableRow>
-                                                <TableHead>Link</TableHead>
-                                                <TableHead className='text-right'>No. of members</TableHead>
+                                                <TableHead className='w-full'>Link</TableHead>
+                                                <TableHead className='w-[0%] text-nowrap text-right'>No. of members</TableHead>
                                             </TableRow>
                                         </TableHeader>
                                         <TableBody>
                                             {topLinks?.map(row => (
                                                 <TableRow key={row.url}>
-                                                    <TableCell>
+                                                    <TableCell className='max-w-0'>
                                                         <div className='flex items-center gap-2'>
                                                             {editingUrl === row.url ? (
                                                                 <div ref={containerRef} className='flex w-full items-center gap-2'>
@@ -230,7 +230,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                             ) : (
                                                                 <>
                                                                     <Button
-                                                                        className='bg-background'
+                                                                        className='shrink-0 bg-background'
                                                                         size='sm'
                                                                         variant='outline'
                                                                         onClick={() => handleEdit(row.url)}
@@ -238,12 +238,13 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                         <LucideIcon.Pen />
                                                                     </Button>
                                                                     <a
-                                                                        className='inline-flex items-center gap-2 font-medium hover:underline'
+                                                                        className='block truncate font-medium hover:underline'
                                                                         href={row.url}
                                                                         rel="noreferrer"
                                                                         target='_blank'
+                                                                        title={row.url}
                                                                     >
-                                                                        <span>{sanitizeUrl(row.url)}</span>
+                                                                        {sanitizeUrl(row.url)}
                                                                     </a>
                                                                     {row.edited && (
                                                                         <span className='text-xs text-gray-500'>(edited)</span>

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -1,9 +1,9 @@
-import AudienceSelect from './components/AudienceSelect';
+// import AudienceSelect from './components/AudienceSelect';
 import KpiCard, {KpiCardContent, KpiCardIcon, KpiCardLabel, KpiCardValue} from './components/KpiCard';
 import PostAnalyticsContent from './components/PostAnalyticsContent';
 import PostAnalyticsHeader from './components/PostAnalyticsHeader';
 import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, ViewHeaderActions, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, formatNumber, formatPercentage} from '@tryghost/shade';
 import {calculateYAxisWidth} from '@src/utils/chart-helpers';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useRef, useState} from 'react';
@@ -92,9 +92,9 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         <PostAnalyticsLayout>
             <ViewHeader className='items-end pb-4'>
                 <PostAnalyticsHeader currentTab='Newsletter' />
-                <ViewHeaderActions className='mb-2'>
+                {/* <ViewHeaderActions className='mb-2'>
                     <AudienceSelect />
-                </ViewHeaderActions>
+                </ViewHeaderActions> */}
             </ViewHeader>
             <PostAnalyticsContent>
                 {isLoading ? 'Loading' :

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -178,12 +178,14 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                             barSize={48}
                                             dataKey="current"
                                             fill="var(--color-current)"
+                                            minPointSize={2}
                                             radius={0}
                                         />
                                         <Recharts.Bar
                                             barSize={48}
                                             dataKey="average"
                                             fill="var(--color-average)"
+                                            minPointSize={2}
                                             radius={0}
                                         />
                                         <ChartLegend content={<ChartLegendContent />} />

--- a/apps/posts/src/views/PostAnalytics/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter.tsx
@@ -3,7 +3,7 @@ import KpiCard, {KpiCardContent, KpiCardIcon, KpiCardLabel, KpiCardValue} from '
 import PostAnalyticsContent from './components/PostAnalyticsContent';
 import PostAnalyticsHeader from './components/PostAnalyticsHeader';
 import PostAnalyticsLayout from './layout/PostAnalyticsLayout';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, ViewHeader, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, ViewHeader, formatNumber, formatPercentage} from '@tryghost/shade';
 import {calculateYAxisWidth} from '@src/utils/chart-helpers';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useRef, useState} from 'react';
@@ -259,6 +259,16 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                 </TableRow>
                                             ))}
                                         </TableBody>
+                                        <TableFooter className='bg-transparent'>
+                                            <TableRow>
+                                                <TableCell className='group-hover:bg-transparent' colSpan={2}>
+                                                    <div className='ml-2 mt-1 flex items-center gap-2 text-green'>
+                                                        <LucideIcon.ArrowUp size={20} strokeWidth={1.5} />
+                                                        Sent a broken link? You can update it!
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        </TableFooter>
                                     </Table>
                                     :
                                     <div className='py-20 text-center text-sm text-gray-700'>

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -6,7 +6,7 @@ import SortButton from './components/SortButton';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H1, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, ViewHeader, ViewHeaderActions, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
-import {calculateYAxisWidth, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
+import {calculateYAxisWidth, getPeriodText, getYRange, getYTicks, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useNewsletterStatsWithRange, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
@@ -392,7 +392,7 @@ const Newsletters: React.FC = () => {
                 <Card>
                     <CardHeader>
                         <CardTitle>Top newsletters</CardTitle>
-                        <CardDescription>Which newsletters performed best in this period</CardDescription>
+                        <CardDescription>Performance of newsletters sent {getPeriodText(range)}</CardDescription>
                     </CardHeader>
                     <CardContent>
                         <Separator/>

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -1,4 +1,4 @@
-import AudienceSelect from './components/AudienceSelect';
+// import AudienceSelect from './components/AudienceSelect';
 import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import DateRangeSelect from './components/DateRangeSelect';
 import React, {useMemo, useState} from 'react';
@@ -51,7 +51,7 @@ const BarTooltipContent = ({active, payload}: BarTooltipProps) => {
     }
 
     const currentItem = payload[0].payload;
-    const sendDate = typeof currentItem.send_date === 'string' ? 
+    const sendDate = typeof currentItem.send_date === 'string' ?
         new Date(currentItem.send_date) : currentItem.send_date;
 
     return (
@@ -125,7 +125,7 @@ const NewsletterKPIs: React.FC<{
 
         // Convert deltas to cumulative counts
         let runningTotal = totalSubscribers;
-        
+
         // Go backwards through the array to calculate cumulative values
         // Starting from the current total and subtracting deltas
         const cumulativeData = [...sanitizedData]
@@ -293,26 +293,26 @@ const Newsletters: React.FC = () => {
     const {range} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
-    
+
     // Get stats from real data using the new hooks
     const {data: newsletterStatsData, isLoading: isStatsLoading} = useNewsletterStatsWithRange(range);
     const {data: subscriberStatsData, isLoading: isSubscriberStatsLoading} = useSubscriberCountWithRange(range);
-    
+
     // Prepare the data - wrap in useMemo to avoid dependency changes
     const newsletterStats = useMemo(() => {
         if (!newsletterStatsData?.stats || newsletterStatsData?.stats.length === 0) {
             return [];
         }
-        
+
         // Clone the data for sorting
         const stats = [...newsletterStatsData.stats];
-        
+
         // Apply client-side sorting
         const [field, direction = 'desc'] = sortBy.split(' ');
-        
+
         return stats.sort((a, b) => {
             let valueA, valueB;
-            
+
             // Handle different sort fields
             if (field === 'date') {
                 valueA = new Date(a.send_date).getTime();
@@ -326,12 +326,12 @@ const Newsletters: React.FC = () => {
             } else {
                 return 0;
             }
-            
+
             // Apply sort direction
             return direction === 'desc' ? valueB - valueA : valueA - valueB;
         });
     }, [newsletterStatsData, sortBy]);
-    
+
     // Calculate totals
     const totals = useMemo(() => {
         if (!newsletterStatsData?.stats || newsletterStatsData.stats.length === 0) {
@@ -344,11 +344,11 @@ const Newsletters: React.FC = () => {
 
         // Use all stats for calculating averages, not just the sorted/limited ones
         const allStats = newsletterStatsData.stats;
-        
+
         // Calculate average open and click rates from all stats
         const totalOpenRate = allStats.reduce((sum, stat) => sum + (stat.open_rate || 0), 0);
         const totalClickRate = allStats.reduce((sum, stat) => sum + (stat.click_rate || 0), 0);
-        
+
         return {
             totalSubscribers: subscriberStatsData?.stats?.[0]?.total || 0,
             avgOpenRate: totalOpenRate / allStats.length,
@@ -379,7 +379,7 @@ const Newsletters: React.FC = () => {
             <ViewHeader className='before:hidden'>
                 <H1>Newsletters</H1>
                 <ViewHeaderActions>
-                    <AudienceSelect />
+                    {/* <AudienceSelect /> */}
                     <DateRangeSelect />
                 </ViewHeaderActions>
             </ViewHeader>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1674/qa-remove-audience-dropdown-from-newsletter-tabs
ref https://linear.app/ghost/issue/PROD-1680/qa-copy-for-newsletter-clicks-table
ref https://linear.app/ghost/issue/PROD-1679/qa-should-we-add-a-tiny-blue-line-1px-to-indicate-zero-blank-looks
ref https://linear.app/ghost/issue/PROD-1677/qa-add-back-sent-a-broken-link-copy-on-newletter-clicks-table

- Audience filter dropdown hasn't been wired up yet so it had to be temporarily hidden
- Copy was outdated in the Post Analytics / Newsletter tab
- URLs had to be truncated in Post Analytics / Newsletter tab's link table
- Newsletter bar chart looked broken when the value was 0–needed a min height
- "Sent a broken link?..." copy on newletter clicks table was missing