### PR TITLE
Passed newsletter settings to lexical email renderer

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -74,7 +74,9 @@ module.exports = {
                     && typeof storage.getStorage('images').saveRaw === 'function';
             },
             feature: {
-                contentVisibility: labs.isSet('contentVisibility')
+                contentVisibility: labs.isSet('contentVisibility'),
+                emailCustomization: labs.isSet('emailCustomization'),
+                emailCustomizationAlpha: labs.isSet('emailCustomizationAlpha')
             }
         }, userOptions);
 

--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -314,13 +314,26 @@ class EmailRenderer {
         return allowedSegments;
     }
 
-    async renderPostBaseHtml(post) {
+    async renderPostBaseHtml(post, newsletter) {
         const postUrl = this.#getPostUrl(post);
+
+        const renderOptions = {
+            target: 'email',
+            postUrl
+        };
+
+        if (this.getLabs()?.isSet('emailCustomizationAlpha')) {
+            renderOptions.design = {
+                buttonCorners: newsletter?.get('button_corners')
+            };
+        }
+
         let html;
         if (post.get('lexical')) {
             // only lexical's renderer is async
             html = await this.#renderers.lexical.render(
-                post.get('lexical'), {target: 'email', postUrl}
+                post.get('lexical'),
+                renderOptions
             );
         } else {
             html = this.#renderers.mobiledoc.render(
@@ -339,7 +352,7 @@ class EmailRenderer {
      * @returns {Promise<EmailBody>}
      */
     async renderBody(post, newsletter, segment, options) {
-        let html = await this.renderPostBaseHtml(post);
+        let html = await this.renderPostBaseHtml(post, newsletter);
 
         // We don't allow the usage of the %%{uuid}%% replacement in the email body (only in links and special cases)
         // So we need to filter them before we introduce the real %%{uuid}%%

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1160,14 +1160,16 @@ describe('Email renderer', function () {
         let renderedPost;
         let postUrl = 'http://example.com';
         let customSettings = {};
+        let renderersStub;
         let emailRenderer;
         let basePost;
+        let baseNewsletter;
         let addTrackingToUrlStub;
         let labsEnabled;
 
         beforeEach(function () {
             renderedPost = '<p>Lexical Test</p><img class="is-light-background" src="test-dark" /><img class="is-dark-background" src="test-light" />';
-            labsEnabled = true; // TODO: odd default because it means we're testing the unused email-customization template
+            labsEnabled = false;
             basePost = {
                 lexical: '{}',
                 visibility: 'public',
@@ -1185,12 +1187,27 @@ describe('Email renderer', function () {
                 }),
                 loaded: ['posts_meta']
             };
+            baseNewsletter = {
+                header_image: null,
+                name: 'Test Newsletter',
+                show_badge: false,
+                feedback_enabled: true,
+                show_post_title_section: true
+            };
             postUrl = 'http://example.com';
             customSettings = {};
             addTrackingToUrlStub = sinon.stub();
             addTrackingToUrlStub.callsFake((u, _post, uuid) => {
                 return new URL('http://tracked-link.com/?m=' + encodeURIComponent(uuid) + '&url=' + encodeURIComponent(u.href));
             });
+            renderersStub = {
+                lexical: {
+                    render: sinon.stub().callsFake(() => (renderedPost))
+                },
+                mobiledoc: {
+                    render: sinon.stub().returns('<p> Mobiledoc Test</p>')
+                }
+            };
             emailRenderer = new EmailRenderer({
                 audienceFeedbackService: {
                     buildLink: (_uuid, _postId, score, key) => {
@@ -1230,18 +1247,7 @@ describe('Email renderer', function () {
                 getPostUrl: () => {
                     return postUrl;
                 },
-                renderers: {
-                    lexical: {
-                        render: () => {
-                            return renderedPost;
-                        }
-                    },
-                    mobiledoc: {
-                        render: () => {
-                            return '<p> Mobiledoc Test</p>';
-                        }
-                    }
-                },
+                renderers: renderersStub,
                 linkReplacer,
                 memberAttributionService: {
                     addPostAttributionTracking: (u) => {
@@ -1273,8 +1279,7 @@ describe('Email renderer', function () {
             });
         });
 
-        it('Renders with labs disabled', async function () {
-            labsEnabled = false;
+        it('Renders', async function () {
             const post = createModel(basePost);
             const newsletter = createModel({
                 header_image: null,
@@ -2063,6 +2068,50 @@ describe('Email renderer', function () {
 
                 response.html.should.not.containEql('post-excerpt-wrapper');
             });
+        });
+
+        it('passes expected data through to lexical renderer', async function () {
+            const post = createModel(basePost);
+            const newsletter = createModel(baseNewsletter);
+            const segment = null;
+            const options = {};
+
+            await emailRenderer.renderBody(post, newsletter, segment, options);
+
+            sinon.assert.calledOnce(renderersStub.lexical.render);
+            sinon.assert.calledWithMatch(renderersStub.lexical.render,
+                post.get('lexical'),
+                {
+                    target: 'email',
+                    postUrl: 'http://example.com'
+                }
+            );
+        });
+
+        it('passes expected data through to lexical renderer (emailCustomizationAlpha)', async function () {
+            labsEnabled = {emailCustomizationAlpha: true};
+
+            const post = createModel(basePost);
+            const newsletter = createModel({
+                ...baseNewsletter,
+                button_corners: 'square'
+            });
+            const segment = null;
+            const options = {};
+
+            await emailRenderer.renderBody(post, newsletter, segment, options);
+
+            sinon.assert.calledOnce(renderersStub.lexical.render);
+            sinon.assert.calledWithMatch(renderersStub.lexical.render,
+                post.get('lexical'),
+                {
+                    target: 'email',
+                    postUrl: 'http://example.com',
+                    design: {
+                        buttonCorners: 'square'
+                    }
+                }
+            );
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1688

- added email customization labs flag passthrough to base lexical renderer calls to make sure the card renderers can branch to different versions for alpha/beta development
- added passthrough of a `design` options object to the renderer when rendering emails to allow conditionally changing card render output based on newsletter design settings