### PR TITLE
Added alpha newsletter design screen with button corners setting

### DIFF
--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -19,6 +19,7 @@ import HistoryModal from '../../settings/advanced/HistoryModal';
 import InviteUserModal from '../../settings/general/InviteUserModal';
 import NavigationModal from '../../settings/site/NavigationModal';
 import NewsletterDetailModal from '../../settings/email/newsletters/NewsletterDetailModal';
+import NewsletterDetailModalAlpha from '../../settings/email/newsletters/NewsletterDetailModalAlpha';
 import NewsletterDetailModalLabs from '../../settings/email/newsletters/NewsletterDetailModalLabs';
 import OfferSuccess from '../../settings/growth/offers/OfferSuccess';
 // import OffersModal from '../../settings/growth/offers/OffersIndex';
@@ -34,10 +35,13 @@ import ZapierModal from '../../settings/advanced/integrations/ZapierModal';
 
 // Wrapper component to conditionally render based on feature flag
 const ConditionalNewsletterDetailModal: ModalComponent = (props) => {
-    const hasEmailCustomization = useFeatureFlag('emailCustomization');
+    const showPrototypeSettings = useFeatureFlag('emailCustomization');
+    const showAlphaSettings = useFeatureFlag('emailCustomizationAlpha');
 
-    if (hasEmailCustomization) {
+    if (showPrototypeSettings) {
         return <NewsletterDetailModalLabs {...props} />;
+    } else if (showAlphaSettings) {
+        return <NewsletterDetailModalAlpha {...props} />;
     } else {
         return <NewsletterDetailModal {...props} />;
     }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
@@ -1,0 +1,557 @@
+import NewsletterPreview from './NewsletterPreview';
+import NiceModal from '@ebay/nice-modal-react';
+import React, {useCallback, useEffect, useState} from 'react';
+import useSettingGroup from '../../../../hooks/useSettingGroup';
+import validator from 'validator';
+import {Button, ButtonGroup, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, SelectOption, Separator, Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
+import {ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
+import {Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
+import {RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
+import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
+import {renderReplyToEmail, renderSenderEmail} from '../../../../utils/newsletterEmails';
+import {useGlobalData} from '../../../providers/GlobalDataProvider';
+
+const ReplyToEmailField: React.FC<{
+    newsletter: Newsletter;
+    updateNewsletter: (fields: Partial<Newsletter>) => void;
+    errors: ErrorMessages;
+    validate: () => void;
+    clearError: (field: string) => void;
+}> = ({newsletter, updateNewsletter, errors, clearError}) => {
+    const {settings, config} = useGlobalData();
+    const [defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['default_email_address', 'support_email_address']);
+
+    // When editing the senderReplyTo, we use a state, so we don't cause jumps when the 'rendering' method decides to change the value
+    // Because 'newsletter' 'support' or an empty value can be mapped to a default value, we don't want those changes to happen when entering text
+    const [senderReplyTo, setSenderReplyTo] = useState(renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress) || '');
+
+    let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
+
+    const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setSenderReplyTo(e.target.value);
+        updateNewsletter({sender_reply_to: e.target.value || 'newsletter'});
+    }, [updateNewsletter, setSenderReplyTo]);
+
+    const onBlur = () => {
+        // Update the senderReplyTo to the rendered value again
+        const rendered = renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress) || '';
+        setSenderReplyTo(rendered);
+    };
+
+    // Pro users without custom sending domains
+    return (
+        <TextField
+            error={Boolean(errors.sender_reply_to)}
+            hint={errors.sender_reply_to}
+            maxLength={191}
+            placeholder={newsletterAddress || ''}
+            title="Reply-to email"
+            value={senderReplyTo}
+            onBlur={onBlur}
+            onChange={onChange}
+            onKeyDown={() => clearError('sender_reply_to')}
+        />
+    );
+};
+
+const Sidebar: React.FC<{
+    newsletter: Newsletter;
+    onlyOne: boolean;
+    updateNewsletter: (fields: Partial<Newsletter>) => void;
+    validate: () => void;
+    errors: ErrorMessages;
+    clearError: (field: string) => void;
+}> = ({newsletter, onlyOne, updateNewsletter, validate, errors, clearError}) => {
+    const {updateRoute} = useRouting();
+    const {mutateAsync: editNewsletter} = useEditNewsletter();
+    const limiter = useLimiter();
+    const {settings, config} = useGlobalData();
+    const [defaultEmailAddress] = getSettingValues<string>(settings, ['default_email_address']);
+    const {mutateAsync: uploadImage} = useUploadImage();
+    const [selectedTab, setSelectedTab] = useState('generalSettings');
+    const {localSettings} = useSettingGroup();
+    const [siteTitle] = getSettingValues(localSettings, ['title']) as string[];
+    const handleError = useHandleError();
+    const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
+    const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled') || '');
+
+    let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
+    const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
+    const activeNewsletters = newsletters.filter(n => n.status === 'active');
+
+    useEffect(() => {
+        setNewsletters(apiNewsletters || []);
+    }, [apiNewsletters]);
+
+    const fontOptions: SelectOption[] = [
+        {value: 'serif', label: 'Elegant serif', className: 'font-serif'},
+        {value: 'sans_serif', label: 'Clean sans-serif'}
+    ];
+
+    const confirmStatusChange = async () => {
+        if (newsletter.status === 'active') {
+            NiceModal.show(ConfirmationModal, {
+                title: 'Archive newsletter',
+                prompt: <>
+                    <div className="mb-6">Your newsletter <strong>{newsletter.name}</strong> will no longer be visible to members or available as an option when publishing new posts.</div>
+                    <div>Existing posts previously sent as this newsletter will remain unchanged.</div>
+                </>,
+                okLabel: 'Archive',
+                okColor: 'red',
+                onOk: async (modal) => {
+                    try {
+                        await editNewsletter({...newsletter, status: 'archived'});
+                        modal?.remove();
+                        showToast({
+                            type: 'success',
+                            message: 'Newsletter archived'
+                        });
+                    } catch (e) {
+                        handleError(e);
+                    }
+                }
+            });
+        } else {
+            try {
+                await limiter?.errorIfWouldGoOverLimit('newsletters');
+            } catch (error) {
+                if (error instanceof HostLimitError) {
+                    NiceModal.show(LimitModal, {
+                        prompt: error.message || `Your current plan doesn't support more newsletters.`,
+                        onOk: () => updateRoute({route: '/pro', isExternal: true})
+                    });
+                    return;
+                } else {
+                    throw error;
+                }
+            }
+
+            NiceModal.show(ConfirmationModal, {
+                title: 'Reactivate newsletter',
+                prompt: <>
+                        Reactivating <strong>{newsletter.name}</strong> will immediately make it visible to members and re-enable it as an option when publishing new posts.
+                </>,
+                okLabel: 'Reactivate',
+                onOk: async (modal) => {
+                    await editNewsletter({...newsletter, status: 'active'});
+                    modal?.remove();
+                    showToast({
+                        type: 'success',
+                        message: 'Newsletter reactivated'
+                    });
+                }
+            });
+        }
+    };
+
+    const renderSenderEmailField = () => {
+        // Self-hosters
+        if (!isManagedEmail(config)) {
+            return (
+                <TextField
+                    error={Boolean(errors.sender_email)}
+                    hint={errors.sender_email}
+                    placeholder={newsletterAddress || ''}
+                    title="Sender email address"
+                    value={newsletter.sender_email || ''}
+                    onChange={e => updateNewsletter({sender_email: e.target.value})}
+                    onKeyDown={() => clearError('sender_email')}
+                />
+            );
+        }
+
+        // Pro users with custom sending domains
+        if (hasSendingDomain(config)) {
+            return (
+                <TextField
+                    error={Boolean(errors.sender_email)}
+                    hint={errors.sender_email}
+                    maxLength={191}
+                    placeholder={defaultEmailAddress}
+                    title="Sender email address"
+                    value={newsletter.sender_email || ''}
+                    onChange={(e) => {
+                        updateNewsletter({sender_email: e.target.value});
+                    }}
+                    onKeyDown={() => clearError('sender_email')}
+                />
+            );
+        }
+
+        // Pro users without custom sending domains
+        // We're not showing the field since it's not editable
+    };
+
+    const tabs: Tab[] = [
+        {
+            id: 'generalSettings',
+            title: 'General',
+            contents:
+            <>
+                <Form className='mt-6' gap='sm' margins='lg' title='Name and description'>
+                    <TextField
+                        error={Boolean(errors.name)}
+                        hint={errors.name}
+                        maxLength={191}
+                        placeholder="Weekly Roundup"
+                        title="Name"
+                        value={newsletter.name || ''}
+                        onChange={e => updateNewsletter({name: e.target.value})}
+                        onKeyDown={() => clearError('name')}
+                    />
+                    <TextArea maxLength={2000} rows={2} title="Description" value={newsletter.description || ''} onChange={e => updateNewsletter({description: e.target.value})} />
+                </Form>
+                <Form className='mt-6' gap='sm' margins='lg' title='Email info'>
+                    <TextField maxLength={191} placeholder={siteTitle} title="Sender name" value={newsletter.sender_name || ''} onChange={e => updateNewsletter({sender_name: e.target.value})} />
+                    {renderSenderEmailField()}
+                    <ReplyToEmailField clearError={clearError} errors={errors} newsletter={newsletter} updateNewsletter={updateNewsletter} validate={validate} />
+                </Form>
+                <Form className='mt-6' gap='sm' margins='lg' title='Member settings'>
+                    <Toggle
+                        checked={newsletter.subscribe_on_signup}
+                        direction='rtl'
+                        label='Subscribe new members on signup'
+                        labelStyle='value'
+                        onChange={e => updateNewsletter({subscribe_on_signup: e.target.checked})}
+                    />
+                </Form>
+                <div className='mb-5 mt-10'>
+                    {newsletter.status === 'active' ? (!onlyOne && <Button color='red' disabled={activeNewsletters.length === 1} label='Archive newsletter' link onClick={confirmStatusChange}/>) : <Button color='green' label='Reactivate newsletter' link onClick={confirmStatusChange} />}
+                </div>
+            </>
+        },
+        {
+            id: 'content',
+            title: 'Content',
+            contents:
+            <>
+                <Form className='mt-6' gap='sm' margins='lg' title='Header'>
+                    <div>
+                        <div>
+                            <Heading className="mb-2" level={6}>Header image</Heading>
+                        </div>
+                        <div className='flex-column flex gap-1'>
+                            <ImageUpload
+                                deleteButtonClassName='!top-1 !right-1'
+                                height={newsletter.header_image ? '66px' : '64px'}
+                                id='logo'
+                                imageURL={newsletter.header_image || undefined}
+                                onDelete={() => {
+                                    updateNewsletter({header_image: null});
+                                }}
+                                onUpload={async (file) => {
+                                    try {
+                                        const imageUrl = getImageUrl(await uploadImage({file}));
+                                        updateNewsletter({header_image: imageUrl});
+                                    } catch (e) {
+                                        handleError(e);
+                                    }
+                                }}
+                            >
+                                <Icon colorClass='text-grey-700 dark:text-grey-300' name='picture' />
+                            </ImageUpload>
+                            <Hint>1200x600, optional</Hint>
+                        </div>
+                    </div>
+                    <ToggleGroup>
+                        <Toggle
+                            checked={newsletter.show_header_title}
+                            direction="rtl"
+                            label='Publication title'
+                            onChange={e => updateNewsletter({show_header_title: e.target.checked})}
+                        />
+                        <Toggle
+                            checked={newsletter.show_header_name}
+                            direction="rtl"
+                            label='Newsletter name'
+                            onChange={e => updateNewsletter({show_header_name: e.target.checked})}
+                        />
+                    </ToggleGroup>
+                </Form>
+
+                <Form className='mt-6' gap='xs' margins='lg' title='Title section'>
+                    <Toggle
+                        checked={newsletter.show_post_title_section}
+                        direction="rtl"
+                        label='Post title'
+                        onChange={e => updateNewsletter({show_post_title_section: e.target.checked})}
+                    />
+                    {newsletter.show_post_title_section &&
+                        <Toggle
+                            checked={newsletter.show_excerpt}
+                            direction="rtl"
+                            label="Post excerpt"
+                            onChange={e => updateNewsletter({show_excerpt: e.target.checked})}
+                        />
+                    }
+                    <Toggle
+                        checked={newsletter.show_feature_image}
+                        direction="rtl"
+                        label='Feature image'
+                        onChange={e => updateNewsletter({show_feature_image: e.target.checked})}
+                    />
+                </Form>
+
+                <Form className='mt-6' gap='sm' margins='lg' title='Footer'>
+                    <ToggleGroup gap='lg'>
+                        <Toggle
+                            checked={newsletter.feedback_enabled}
+                            direction="rtl"
+                            label='Ask your readers for feedback'
+                            onChange={e => updateNewsletter({feedback_enabled: e.target.checked})}
+                        />
+                        {commentsEnabled && <Toggle
+                            checked={newsletter.show_comment_cta}
+                            direction="rtl"
+                            label='Add a link to your comments'
+                            onChange={e => updateNewsletter({show_comment_cta: e.target.checked})}
+                        />}
+                        <Toggle
+                            checked={newsletter.show_latest_posts}
+                            direction="rtl"
+                            label='Share your latest posts'
+                            onChange={e => updateNewsletter({show_latest_posts: e.target.checked})}
+                        />
+                        <Toggle
+                            checked={newsletter.show_subscription_details}
+                            direction="rtl"
+                            label='Show subscription details'
+                            onChange={e => updateNewsletter({show_subscription_details: e.target.checked})}
+                        />
+                    </ToggleGroup>
+                    <HtmlField
+                        hint='Any extra information or legal text'
+                        nodes='MINIMAL_NODES'
+                        placeholder=' '
+                        title='Email footer'
+                        value={newsletter.footer_content || ''}
+                        onChange={html => updateNewsletter({footer_content: html})}
+                    />
+                </Form>
+                <Separator />
+                <div className='my-5 flex w-full items-start'>
+                    <span>
+                        <Icon className='mr-2 mt-[-1px]' colorClass='text-red' name='heart'/>
+                    </span>
+                    <Form marginBottom={false}>
+                        <Toggle
+                            checked={newsletter.show_badge}
+                            direction='rtl'
+                            label={
+                                <div className='flex flex-col gap-0.5'>
+                                    <span className='text-sm md:text-base'>Promote independent publishing</span>
+                                    <span className='text-[11px] leading-tight text-grey-700 md:text-xs md:leading-tight'>Show you&apos;re a part of the indie publishing movement with a small badge in the footer</span>
+                                </div>
+                            }
+                            labelStyle='value'
+                            onChange={e => updateNewsletter({show_badge: e.target.checked})}
+                        />
+                    </Form>
+                </div>
+            </>
+        },
+        {
+            id: 'design',
+            title: 'Design',
+            contents:
+            <>
+                <Form className='mt-6' gap='xs' margins='lg' title='Typography'>
+                    <Select
+                        disabled={!newsletter.show_post_title_section}
+                        options={fontOptions}
+                        selectedOption={fontOptions.find(option => option.value === newsletter.title_font_category)}
+                        title='Heading font'
+                        onSelect={option => updateNewsletter({title_font_category: option?.value})}
+                    />
+                    <Select
+                        options={fontOptions}
+                        selectedOption={fontOptions.find(option => option.value === newsletter.body_font_category)}
+                        testId='body-font-select'
+                        title='Body font'
+                        onSelect={option => updateNewsletter({body_font_category: option?.value})}
+                    />
+                </Form>
+
+                <Form className='mt-6' gap='xs' margins='lg' title='Elements'>
+                    <div className='flex w-full justify-between'>
+                        <div>Title alignment</div>
+                        <ButtonGroup activeKey={newsletter.title_alignment} buttons={[
+                            {
+                                key: 'left',
+                                icon: 'align-left',
+                                label: 'Align left',
+                                tooltip: 'Left',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({title_alignment: 'left'}),
+                                disabled: !newsletter.show_post_title_section
+                            },
+                            {
+                                key: 'center',
+                                icon: 'align-center',
+                                label: 'Align center',
+                                tooltip: 'Center',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({title_alignment: 'center'}),
+                                disabled: !newsletter.show_post_title_section
+                            }
+                        ]} clearBg={false} />
+                    </div>
+                    <div className='flex w-full justify-between'>
+                        <div>Button corners</div>
+                        <ButtonGroup activeKey={newsletter.button_corners || 'rounded'} buttons={[
+                            {
+                                key: 'square',
+                                icon: 'square',
+                                label: 'Square',
+                                tooltip: 'Squared',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({button_corners: 'square'})
+                            },
+                            {
+                                key: 'rounded',
+                                icon: 'squircle',
+                                label: 'Rounded',
+                                tooltip: 'Rounded',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({button_corners: 'rounded'})
+                            },
+                            {
+                                key: 'pill',
+                                icon: 'circle',
+                                label: 'Pill',
+                                tooltip: 'Pill',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({button_corners: 'pill'})
+                            }
+                        ]} clearBg={false} />
+                    </div>
+                </Form>
+            </>
+        }
+    ];
+
+    const handleTabChange = (id: string) => {
+        setSelectedTab(id);
+    };
+
+    return (
+        <div className='flex flex-col'>
+            <div className='px-7 pb-7 pt-0'>
+                <TabView selectedTab={selectedTab} stickyHeader={true} tabs={tabs} onTabChange={handleTabChange} />
+            </div>
+        </div>
+    );
+};
+
+const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: boolean;}> = ({newsletter, onlyOne}) => {
+    const {config} = useGlobalData();
+    const {mutateAsync: editNewsletter} = useEditNewsletter();
+    const {updateRoute} = useRouting();
+    const handleError = useHandleError();
+
+    const {formState, saveState, updateForm, setFormState, handleSave, validate, errors, clearError, okProps} = useForm({
+        initialState: newsletter,
+        savingDelay: 500,
+        onSave: async () => {
+            const {meta: {sent_email_verification: [emailToVerify] = []} = {}} = await editNewsletter(formState); ``;
+            let toastMessage;
+
+            if (emailToVerify && emailToVerify === 'sender_email') {
+                toastMessage = <div>We&lsquo;ve sent a confirmation email to the new address.</div>;
+            } else if (emailToVerify && emailToVerify === 'sender_reply_to') {
+                toastMessage = <div>We&lsquo;ve sent a confirmation email to the new address.</div>;
+            }
+
+            if (toastMessage) {
+                showToast({
+                    icon: 'email',
+                    message: toastMessage,
+                    type: 'info'
+                });
+            }
+        },
+        onSaveError: handleError,
+        onValidate: () => {
+            const newErrors: Record<string, string> = {};
+
+            if (!formState.name) {
+                newErrors.name = 'A name is required for your newsletter';
+            }
+
+            if (formState.sender_email && !validator.isEmail(formState.sender_email)) {
+                newErrors.sender_email = 'Enter a valid email address';
+            } else if (formState.sender_email && hasSendingDomain(config) && formState.sender_email.split('@')[1] !== sendingDomain(config)) {
+                newErrors.sender_email = `Email address must end with @${sendingDomain(config)}`;
+            }
+
+            if (formState.sender_reply_to && !validator.isEmail(formState.sender_reply_to) && !['newsletter', 'support'].includes(formState.sender_reply_to)) {
+                newErrors.sender_reply_to = 'Enter a valid email address';
+            }
+
+            return newErrors;
+        }
+    });
+
+    const updateNewsletter = (fields: Partial<Newsletter>) => {
+        updateForm(state => ({...state, ...fields}));
+    };
+
+    useEffect(() => {
+        setFormState(() => newsletter);
+    }, [setFormState, newsletter]);
+
+    const preview = <NewsletterPreview newsletter={formState} />;
+    const sidebar = <Sidebar clearError={clearError} errors={errors} newsletter={formState} onlyOne={onlyOne} updateNewsletter={updateNewsletter} validate={validate} />;
+
+    return <PreviewModalContent
+        afterClose={() => updateRoute('newsletters')}
+        buttonsDisabled={okProps.disabled}
+        cancelLabel='Close'
+        deviceSelector={false}
+        dirty={saveState === 'unsaved'}
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save'}
+        preview={preview}
+        previewBgColor={'grey'}
+        previewToolbar={false}
+        sidebar={sidebar}
+        sidebarPadding={false}
+        testId='newsletter-modal'
+        title='Newsletter'
+        onOk={async () => {
+            await handleSave({fakeWhenUnchanged: true});
+        }}
+    />;
+};
+
+const NewsletterDetailModalLabs: React.FC<RoutingModalProps> = ({params}) => {
+    const {data: {newsletters, isEnd} = {}, fetchNextPage} = useBrowseNewsletters();
+    const newsletter = newsletters?.find(({id}) => id === params?.id);
+
+    useEffect(() => {
+        if (!newsletter && !isEnd) {
+            fetchNextPage();
+        }
+    }, [fetchNextPage, isEnd, newsletter]);
+
+    if (newsletter) {
+        return <NewsletterDetailModalContent newsletter={newsletter} onlyOne={newsletters!.length === 1} />;
+    } else {
+        return null;
+    }
+};
+
+export default NiceModal.create(NewsletterDetailModalLabs);

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -98,6 +98,7 @@ const NewsletterPreviewContent: React.FC<{
     const showHeader = headerIcon || headerTitle;
     const {config} = useGlobalData();
     const hasEmailCustomization = useFeatureFlag('emailCustomization');
+    const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
 
     const currentDate = new Date().toLocaleDateString('default', {
         year: 'numeric',
@@ -305,6 +306,33 @@ const NewsletterPreviewContent: React.FC<{
                                         <p className="mb-6" style={{color: textColor}}>This is what your content will look like when you send one of your posts as an email newsletter to your subscribers.</p>
                                         <p className="mb-6" style={{color: textColor}}>Over there on the right you&apos;ll see some settings that allow you to customize the look and feel of this template to make it perfectly suited to your brand. Email templates are exceptionally finnicky to make, but we&apos;ve spent a long time optimising this one to make it work beautifully across devices, email clients and content types.</p>
                                         <p className="mb-6" style={{color: textColor}}>So, you can trust that every email you send with Ghost will look great and work well. Just like the rest of your site.</p>
+                                        {hasEmailCustomizationAlpha && (
+                                            <button
+                                                className={clsx(
+                                                    'px-[18px] py-2 font-sans text-[15px]',
+                                                    buttonCorners === 'rounded' && 'rounded-[6px]',
+                                                    buttonCorners === 'pill' && 'rounded-full',
+                                                    buttonCorners === 'square' && 'rounded-none',
+                                                    buttonStyle === 'outline'
+                                                        ? 'border bg-transparent'
+                                                        : 'text-white',
+                                                    linkStyle === 'bold' && 'font-bold'
+                                                )}
+                                                style={
+                                                    buttonStyle === 'outline'
+                                                        ? {
+                                                            borderColor: buttonColor || accentColor,
+                                                            color: buttonColor || accentColor
+                                                        }
+                                                        : {
+                                                            backgroundColor: buttonColor || accentColor
+                                                        }
+                                                }
+                                                type="button"
+                                            >
+                                            Upgrade now
+                                            </button>
+                                        )}
                                     </>
                                 )}
                             </div>

--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -964,6 +964,8 @@ class EmailRenderer {
      * @private
      */
     async getTemplateData({post, newsletter, html, addPaywall, segment}) {
+        const labs = this.getLabs();
+
         let accentColor = this.#settingsCache.get('accent_color') || '#15212A';
         let adjustedAccentColor;
         let adjustedAccentContrastColor;
@@ -983,6 +985,16 @@ class EmailRenderer {
         const textColor = textColorForBackgroundColor(backgroundColor).hex();
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
         const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
+
+        let buttonBorderRadius = '6px';
+
+        if (labs.isSet('emailCustomizationAlpha')) {
+            if (newsletter.get('button_corners') === 'square') {
+                buttonBorderRadius = '0';
+            } else if (newsletter.get('button_corners') === 'pill') {
+                buttonBorderRadius = '9999px';
+            }
+        }
 
         const {href: headerImage, width: headerImageWidth} = await this.limitImageWidth(newsletter.get('header_image'));
         const {href: postFeatureImage, width: postFeatureImageWidth, height: postFeatureImageHeight} = await this.limitImageWidth(post.get('feature_image'));
@@ -1126,6 +1138,7 @@ class EmailRenderer {
             textColor: textColor,
             secondaryTextColor: secondaryTextColor,
             linkColor: linkColor,
+            buttonBorderRadius,
 
             headerImage,
             headerImageWidth,

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -1151,7 +1151,7 @@ img.kg-cta-image {
 
 .kg-cta-minimal table.kg-cta-button-wrapper td {
     padding: 6px 18px 8px;
-    border-radius: 6px;
+    border-radius: {{buttonBorderRadius}};
 }
 
 .kg-cta-minimal table.kg-cta-button-wrapper td.kg-style-accent {
@@ -1160,7 +1160,7 @@ img.kg-cta-image {
 
 .kg-cta-immersive .kg-cta-button-wrapper {
     padding: 8px 20px 9px;
-    border-radius: 6px;
+    border-radius: {{buttonBorderRadius}};
     text-align: center;
 }
 
@@ -1191,7 +1191,7 @@ img.kg-cta-image {
     font-weight: 500;
     text-align: center;
     text-decoration: none;
-    border-radius: 6px;
+    border-radius: {{buttonBorderRadius}};
 }
 
 .kg-cta-immersive a.kg-cta-button.kg-style-accent {
@@ -1282,6 +1282,9 @@ img.kg-cta-image {
     margin-top: 1.75em;
     background: #ffffff;
     border-radius: 5px;
+    {{#hasFeature "emailCustomizationAlpha"}}
+    border-radius: {{buttonBorderRadius}};
+    {{/hasFeature}}
     box-sizing: border-box;
     cursor: pointer;
     display: inline-block;
@@ -1523,6 +1526,9 @@ img.kg-cta-image {
 .btn table td {
     background-color: #ffffff;
     border-radius: 5px;
+    {{#hasFeature "emailCustomizationAlpha"}}
+    border-radius: {{buttonBorderRadius}};
+    {{/hasFeature}}
     text-align: center;
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
 }
@@ -1531,6 +1537,9 @@ img.kg-cta-image {
     background-color: #ffffff;
     border: solid 1px #3498db;
     border-radius: 5px;
+    {{#hasFeature "emailCustomizationAlpha"}}
+    border-radius: {{buttonBorderRadius}};
+    {{/hasFeature}}
     box-sizing: border-box;
     color: #3498db;
     cursor: pointer;

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -2117,14 +2117,14 @@ describe('Email renderer', function () {
 
     describe('getTemplateData', function () {
         let settings = {};
-        let labsEnabled = true;
+        let labsEnabled = false;
         let emailRenderer;
 
         beforeEach(function () {
             settings = {
                 timezone: 'Etc/UTC'
             };
-            labsEnabled = true;
+            labsEnabled = false;
             emailRenderer = new EmailRenderer({
                 audienceFeedbackService: {
                     buildLink: (_uuid, _postId, score) => {
@@ -2546,6 +2546,41 @@ describe('Email renderer', function () {
                         url: 'http://example.com'
                     }
                 ]);
+        });
+
+        async function testButtonBorderRadius(buttonCorners, expectedRadius) {
+            labsEnabled = true;
+            const html = '';
+            const post = createModel({
+                posts_meta: createModel({}),
+                loaded: ['posts_meta'],
+                published_at: new Date(0)
+            });
+            const newsletter = createModel({
+                title_font_category: 'serif',
+                title_alignment: 'left',
+                body_font_category: 'sans_serif',
+                show_latest_posts: true,
+                button_corners: buttonCorners
+            });
+            const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+            assert.equal(data.buttonBorderRadius, expectedRadius);
+        }
+
+        it('sets buttonBorderRadius to correct default (emailCustomizationAlpha)', async function () {
+            await testButtonBorderRadius(null, '6px');
+        });
+
+        it('sets buttonBorderRadius to correct rounded value (emailCustomizationAlpha)', async function () {
+            await testButtonBorderRadius('rounded', '6px');
+        });
+
+        it('sets buttonBorderRadius to correct square value (emailCustomizationAlpha)', async function () {
+            await testButtonBorderRadius('square', '0');
+        });
+
+        it('sets buttonBorderRadius to correct pill value (emailCustomizationAlpha)', async function () {
+            await testButtonBorderRadius('pill', '9999px');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1688

- added duplicate of the newsletter detail modal so we can move settings over from the prototype modal once they are ready
- copied prototype button content from the prototype preview content to the non-prototype preview content to show impact of button corners setting
- updated `EmailRenderer` to add `buttonBorderRadius` to the data passed through to the handlebars template
- updated handlebars template styles partial to use `buttonBorderRadius` in all button related styles
- we had some inconsistent button radius' with some at 5px and others at 6px. When the `emailCustomizationAlpha` flag is enabled we now standardize on 6px