### PR TITLE
🌵 SPIKE: use single user tokens to pass selected newsletters from portal to Ghost, instead of the Checkout Session's metadata field

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -361,7 +361,7 @@ module.exports = class RouterController {
             }
             if (options.metadata.newsletters) {
                 tokenData.newsletters = await this._validateNewsletters(JSON.parse(options.metadata.newsletters));
-                delete options.metadata.newsletters;
+                options.metadata.newsletters = undefined;
             }
             // Create a signup link if there is no member with this email address
             options.successUrl = await this._magicLinkService.getMagicLink({

--- a/ghost/core/core/server/services/stripe/StripeService.js
+++ b/ghost/core/core/server/services/stripe/StripeService.js
@@ -108,6 +108,9 @@ module.exports = class StripeService {
                     },
                     tokenData: {}
                 });
+            },
+            getTokenDataFromMagicLinkToken(token){
+                return membersService.api.getTokenDataFromMagicLinkToken(token);
             }
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-939/support-escalation-re-unable-to-initiate-checkout-error-message

When a new member signs up for a paid subscription right off the bat, they are able to select the newsletters they want to subscribe to before initiating the Stripe checkout session. Currently we add the newsletters the user selects to the Stripe checkout session's `metadata` field. When we receive the `checkout.session.completed` event, we then grab the list of newsletters from the `metadata` on the session, and update the member's newsletters accordingly.

However, the `metadata` field in Stripe has a limit of 500 characters. If a site has a lot of newsletters, we can exceed this limit, which leads to a 400 error from Stripe, and Ghost/portal failing to launch the checkout session. There are a few things we could do to reduce the amount of data we put in the `metadata` field, but ultimately there will always be a point where sites with lots of newsletters could hit this limit.

This PR/spike aims to change how we pass this type of data from the checkout session in portal to the webhook controller. We already create a single use token (in the `tokens` table) when the member first creates their Stripe Checkout session. The single use token allows us to tie a data payload to it as well, in `tokens.data` column. This token is then set in a query parameter in the `success_url` that we pass to the Stripe Checkout. Then, when Ghost receives the `checkout.session.completed` event, we parse the token from the `success_url`, get the data associated with the token from the `tokens` table, and update the `newsletters` that way.

This same pattern could be applied for our other current uses of the `metadata` field, like attribution and the member's name. While this is technically slightly less direct — parsing the token from the session, then getting the data from the DB, rather than just getting the data from `session.metadata`, it is much more in our own control. The token table's data field has a maxlength of 2000, which gives us a lot more room to run, and since its our own DB we can always increase this if needed.