### PR TITLE
🐛 Fixed new paid member signup error for sites with many newsletters

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -649,7 +649,7 @@ module.exports = class RouterController {
             labels: req.body.labels,
             name: req.body.name,
             reqIp: req.ip ?? undefined,
-            newsletters: await this._validateNewsletters(req),
+            newsletters: await this._validateNewsletters(req.body?.newsletters ?? []),
             attribution: await this._memberAttributionService.getAttribution(req.body.urlHistory)
         };
 
@@ -671,9 +671,13 @@ module.exports = class RouterController {
         return await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, referrer});
     }
 
-    async _validateNewsletters(req) {
-        const {newsletters: requestedNewsletters} = req.body;
-
+    /**
+     * Validates the newsletters in the request body
+     * @param {object[]} requestedNewsletters
+     * @param {string} requestedNewsletters[].name
+     * @returns {Promise<object[] | undefined>} The validated newsletters
+     */
+    async _validateNewsletters(requestedNewsletters) {
         if (!requestedNewsletters || requestedNewsletters.length === 0) {
             return undefined;
         }

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -508,6 +508,7 @@ module.exports = class RouterController {
 
         // Store attribution data in the metadata
         await this._setAttributionMetadata(metadata);
+        metadata.newsletters = await this._validateNewsletters(metadata.newsletters ?? []);
 
         // Build options
         const options = {

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -508,7 +508,10 @@ module.exports = class RouterController {
 
         // Store attribution data in the metadata
         await this._setAttributionMetadata(metadata);
-        metadata.newsletters = await this._validateNewsletters(metadata.newsletters ?? []);
+
+        if (metadata.newsletters) {
+            metadata.newsletters = JSON.stringify(await this._validateNewsletters(JSON.parse(metadata.newsletters)));
+        }
 
         // Build options
         const options = {

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -369,9 +369,9 @@ module.exports = class RouterController {
 
         if (member) {
             options.successUrl = this._generateSuccessUrl(options.successUrl, tier.welcomePageURL);
-            
+
             const restrictCheckout = member.get('status') === 'paid';
-            
+
             if (restrictCheckout) {
                 // This member is already subscribed to a paid tier
                 // We don't want to create a duplicate subscription
@@ -413,17 +413,17 @@ module.exports = class RouterController {
         try {
             // Create URL objects
             const siteUrl = this._urlUtils.getSiteUrl();
-            
+
             // This will throw if welcomePageURL is invalid
             const welcomeUrl = new URL(
-                welcomePageURL.startsWith('http') ? welcomePageURL : welcomePageURL, 
+                welcomePageURL.startsWith('http') ? welcomePageURL : welcomePageURL,
                 siteUrl
             );
-            
+
             // Add success parameters
             welcomeUrl.searchParams.set('success', 'true');
             welcomeUrl.searchParams.set('action', 'signup');
-            
+
             return welcomeUrl.href;
         } catch (err) {
             logging.warn(`Invalid welcome page URL "${welcomePageURL}", using original success URL`, err);
@@ -674,39 +674,45 @@ module.exports = class RouterController {
     async _validateNewsletters(req) {
         const {newsletters: requestedNewsletters} = req.body;
 
-        if (requestedNewsletters && requestedNewsletters.length > 0 && requestedNewsletters.every(newsletter => newsletter.name !== undefined)) {
-            const newsletterNames = requestedNewsletters.map(newsletter => newsletter.name);
-            const newsletterNamesFilter = newsletterNames.map(newsletter => `'${newsletter.replace(/("|')/g, '\\$1')}'`);
-            const newsletters = (await this._newslettersService.getAll({
-                filter: `name:[${newsletterNamesFilter}]`,
-                columns: ['id','name','status']
-            }));
-
-            // Check for invalid newsletters
-            if (newsletters.length !== newsletterNames.length) {
-                const validNewsletters = newsletters.map(newsletter => newsletter.name);
-                const invalidNewsletters = newsletterNames.filter(newsletter => !validNewsletters.includes(newsletter));
-
-                throw new errors.BadRequestError({
-                    message: tpl(messages.invalidNewsletters, {newsletters: invalidNewsletters})
-                });
-            }
-
-            // Check for archived newsletters
-            const archivedNewsletters = newsletters
-                .filter(newsletter => newsletter.status === 'archived')
-                .map(newsletter => newsletter.name);
-
-            if (archivedNewsletters && archivedNewsletters.length > 0) {
-                throw new errors.BadRequestError({
-                    message: tpl(messages.archivedNewsletters, {newsletters: archivedNewsletters})
-                });
-            }
-
-            return newsletters
-                .filter(newsletter => newsletter.status === 'active')
-                .map(newsletter => ({id: newsletter.id}));
+        if (!requestedNewsletters || requestedNewsletters.length === 0) {
+            return undefined;
         }
+
+        if (requestedNewsletters.some(newsletter => !newsletter.name)) {
+            return undefined;
+        }
+
+        const requestedNewsletterNames = requestedNewsletters.map(newsletter => newsletter.name);
+        const requestedNewsletterNamesFilter = requestedNewsletterNames.map(newsletter => `'${newsletter.replace(/("|')/g, '\\$1')}'`);
+        const matchedNewsletters = (await this._newslettersService.getAll({
+            filter: `name:[${requestedNewsletterNamesFilter}]`,
+            columns: ['id','name','status']
+        }));
+
+        // Check for invalid newsletters
+        if (matchedNewsletters.length !== requestedNewsletterNames.length) {
+            const validNewsletterNames = matchedNewsletters.map(newsletter => newsletter.name);
+            const invalidNewsletterNames = requestedNewsletterNames.filter(newsletter => !validNewsletterNames.includes(newsletter));
+
+            throw new errors.BadRequestError({
+                message: tpl(messages.invalidNewsletters, {newsletters: invalidNewsletterNames})
+            });
+        }
+
+        // Check for archived newsletters
+        const requestedArchivedNewsletters = matchedNewsletters
+            .filter(newsletter => newsletter.status === 'archived')
+            .map(newsletter => newsletter.name);
+
+        if (requestedArchivedNewsletters && requestedArchivedNewsletters.length > 0) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.archivedNewsletters, {newsletters: requestedArchivedNewsletters})
+            });
+        }
+
+        return matchedNewsletters
+            .filter(newsletter => newsletter.status === 'active')
+            .map(newsletter => ({id: newsletter.id}));
     }
 };
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
@@ -998,7 +998,7 @@ describe('RouterController', function () {
             const requestedNewsletters = [
                 {name: 'Newsletter 1'},
                 {name: 'Newsletter 2'},
-                {name: 'Newsletter 3'},
+                {name: 'Newsletter 3'}
             ];
 
             try {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
@@ -121,15 +121,17 @@ describe('RouterController', function () {
                 settingsCache,
                 newslettersService: newslettersServiceStub
             });
+            const newsletters = [
+                {id: 'abc123', name: 'Newsletter 1'},
+                {id: 'def456', name: 'Newsletter 2'}
+            ];
+            const newslettersString = JSON.stringify(newsletters);
             const req = {
                 body: {
                     tierId: 'tier_123',
                     cadence: 'month',
                     metadata: {
-                        newsletters: [
-                            {id: 'abc123', name: 'Newsletter 1'},
-                            {id: 'def456', name: 'Newsletter 2'}
-                        ]
+                        newsletters: newslettersString
                     }
                 }
             };
@@ -139,14 +141,13 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
+            const expectedNewsletters = JSON.stringify([{id: 'abc123'}, {id: 'def456'}]);
+
             getPaymentLinkSpy.calledOnce.should.be.true();
 
             getPaymentLinkSpy.calledWith(sinon.match({
                 metadata: {
-                    newsletters: [
-                        {id: 'abc123'},
-                        {id: 'def456'}
-                    ]
+                    newsletters: expectedNewsletters
                 }
             })).should.be.true();
         });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
@@ -72,6 +72,10 @@ describe('RouterController', function () {
         };
     });
 
+    afterEach(function () {
+        sinon.restore();
+    });
+
     describe('createCheckoutSession', function (){
         it('passes offer metadata to payment link method', async function (){
             const routerController = new RouterController({
@@ -821,7 +825,7 @@ describe('RouterController', function () {
 
             const originalUrl = 'https://example.com/success';
             const result = routerController._generateSuccessUrl(originalUrl, null);
-            
+
             assert.equal(result, originalUrl);
         });
 
@@ -833,7 +837,7 @@ describe('RouterController', function () {
             const originalUrl = 'https://example.com/success';
             const welcomePageURL = '/welcome-paid-members/';
             const result = routerController._generateSuccessUrl(originalUrl, welcomePageURL);
-            
+
             assert.equal(result, 'https://example.com/welcome-paid-members/?success=true&action=signup');
         });
 
@@ -845,7 +849,7 @@ describe('RouterController', function () {
             const originalUrl = 'https://example.com/success';
             const welcomePageURL = 'https://external-site.com/welcome';
             const result = routerController._generateSuccessUrl(originalUrl, welcomePageURL);
-            
+
             assert.equal(result, 'https://external-site.com/welcome?success=true&action=signup');
         });
 
@@ -858,8 +862,105 @@ describe('RouterController', function () {
             // Using a URL that would throw an error when trying to create a URL object
             const welcomePageURL = 'http://invalid-url:-with-bad-port';
             const result = routerController._generateSuccessUrl(originalUrl, welcomePageURL);
-            
+
             assert.equal(result, originalUrl);
+        });
+    });
+
+    describe('_validateNewsletters', function () {
+        let newslettersServiceStub;
+        let routerController;
+        beforeEach(function () {
+            newslettersServiceStub = {
+                getAll: sinon.stub()
+            };
+            newslettersServiceStub.getAll.resolves([
+                {id: 'abc123', name: 'Newsletter 1', status: 'active'},
+                {id: 'def456', name: 'Newsletter 2', status: 'active'},
+                {id: 'ghi789', name: 'Newsletter 3', status: 'active'}
+            ]);
+            routerController = new RouterController({
+                tiersService,
+                paymentsService,
+                offersAPI,
+                stripeAPIService,
+                labsService,
+                settingsCache,
+                newslettersService: newslettersServiceStub
+            });
+        });
+
+        it('validates newsletters', async function () {
+            const req = { body: { newsletters: [
+                {name: 'Newsletter 1'},
+                {name: 'Newsletter 2'},
+                {name: 'Newsletter 3'}
+            ]}};
+            const result = await routerController._validateNewsletters(req);
+            result.should.eql([
+                {id: 'abc123'},
+                {id: 'def456'},
+                {id: 'ghi789'}
+            ]);
+        });
+
+        it('returns undefined if newsletters is an empty array', async function () {
+            const req = { body: { newsletters: [] } };
+            const result = await routerController._validateNewsletters(req);
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined if newsletters is undefined', async function () {
+            const req = { body: { } };
+            const result = await routerController._validateNewsletters(req);
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined if any newsletter is missing a name', async function () {
+            const req = { body: { newsletters: [
+                {name: 'Newsletter 1'},
+                {id: 'def456'}
+            ]}};
+            const result = await routerController._validateNewsletters(req);
+            assert.equal(result, undefined);
+        });
+
+        it('throws an error if an invalid newsletter is provided', async function () {
+            const req = { body: { newsletters: [
+                {name: 'Newsletter 1'},
+                {name: 'Newsletter 2'},
+                {name: 'Newsletter 3'},
+                {name: 'fake newsletter'}
+            ]}};
+            try {
+                await routerController._validateNewsletters(req);
+                assert.fail('Expected function to throw BadRequestError');
+            } catch (error) {
+                assert(error instanceof errors.BadRequestError, 'Error should be an instance of BadRequestError');
+                assert.equal(error.message, 'Cannot subscribe to invalid newsletters fake newsletter');
+            }
+        });
+
+        it('throws an error if an archived newsletter is provided', async function () {
+            newslettersServiceStub.getAll.resolves([
+                {id: 'abc123', name: 'Newsletter 1', status: 'active'},
+                {id: 'def456', name: 'Newsletter 2', status: 'archived'},
+                {id: 'ghi789', name: 'Newsletter 3', status: 'active'}
+            ]);
+
+            const req = { body: { newsletters: [
+                {name: 'Newsletter 1'},
+                {name: 'Newsletter 2'},
+                {name: 'Newsletter 3'},
+            ]}};
+
+            try {
+                await routerController._validateNewsletters(req);
+                assert.fail('Expected function to throw BadRequestError');
+            } catch (error) {
+                assert(error instanceof errors.BadRequestError, 'Error should be an instance of BadRequestError');
+                assert.equal(error.message, 'Cannot subscribe to archived newsletters Newsletter 2');
+            }
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router.test.js
@@ -891,12 +891,12 @@ describe('RouterController', function () {
         });
 
         it('validates newsletters', async function () {
-            const req = { body: { newsletters: [
+            const requestedNewsletters = [
                 {name: 'Newsletter 1'},
                 {name: 'Newsletter 2'},
                 {name: 'Newsletter 3'}
-            ]}};
-            const result = await routerController._validateNewsletters(req);
+            ];
+            const result = await routerController._validateNewsletters(requestedNewsletters);
             result.should.eql([
                 {id: 'abc123'},
                 {id: 'def456'},
@@ -905,35 +905,35 @@ describe('RouterController', function () {
         });
 
         it('returns undefined if newsletters is an empty array', async function () {
-            const req = { body: { newsletters: [] } };
-            const result = await routerController._validateNewsletters(req);
+            const requestedNewsletters = [];
+            const result = await routerController._validateNewsletters(requestedNewsletters);
             assert.equal(result, undefined);
         });
 
         it('returns undefined if newsletters is undefined', async function () {
-            const req = { body: { } };
-            const result = await routerController._validateNewsletters(req);
+            const requestedNewsletters = undefined;
+            const result = await routerController._validateNewsletters(requestedNewsletters);
             assert.equal(result, undefined);
         });
 
         it('returns undefined if any newsletter is missing a name', async function () {
-            const req = { body: { newsletters: [
+            const requestedNewsletters = [
                 {name: 'Newsletter 1'},
                 {id: 'def456'}
-            ]}};
-            const result = await routerController._validateNewsletters(req);
+            ];
+            const result = await routerController._validateNewsletters(requestedNewsletters);
             assert.equal(result, undefined);
         });
 
         it('throws an error if an invalid newsletter is provided', async function () {
-            const req = { body: { newsletters: [
+            const requestedNewsletters = [
                 {name: 'Newsletter 1'},
                 {name: 'Newsletter 2'},
                 {name: 'Newsletter 3'},
                 {name: 'fake newsletter'}
-            ]}};
+            ];
             try {
-                await routerController._validateNewsletters(req);
+                await routerController._validateNewsletters(requestedNewsletters);
                 assert.fail('Expected function to throw BadRequestError');
             } catch (error) {
                 assert(error instanceof errors.BadRequestError, 'Error should be an instance of BadRequestError');
@@ -948,14 +948,14 @@ describe('RouterController', function () {
                 {id: 'ghi789', name: 'Newsletter 3', status: 'active'}
             ]);
 
-            const req = { body: { newsletters: [
+            const requestedNewsletters = [
                 {name: 'Newsletter 1'},
                 {name: 'Newsletter 2'},
                 {name: 'Newsletter 3'},
-            ]}};
+            ];
 
             try {
-                await routerController._validateNewsletters(req);
+                await routerController._validateNewsletters(requestedNewsletters);
                 assert.fail('Expected function to throw BadRequestError');
             } catch (error) {
                 assert(error instanceof errors.BadRequestError, 'Error should be an instance of BadRequestError');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-939/support-escalation-bytetree-members-cannot-checkout-via-offer

Portal sends newsletter names and ids in the request it makes to `/members/api/create-stripe-checkout-session/` when a new member signs up for a paid account. Ghost then adds the list of newsletters to the checkout session's `metadata` field, including the names and ids. 

For sites with enough newsletters, this can exceed the character limit of the checkout session's `metadata` field. This commit changes Ghost's handling so it only adds the newsletter `ids` to the `metadata` field, which gives sites with a lot of newsletters a little more breathing room to stay under this limit. If the limit is reached, Stripe will return a 400 error, preventing new members from starting paid accounts.