### PR TITLE
🐛 Fixed comments UI showing incorrect avatar for comments by a deleted member

### DIFF
--- a/apps/comments-ui/src/AppContext.ts
+++ b/apps/comments-ui/src/AppContext.ts
@@ -8,7 +8,7 @@ export type Member = {
     id: string,
     uuid: string,
     name: string,
-    avatar: string,
+    avatar_image: string,
     expertise: string
 }
 

--- a/apps/comments-ui/src/components/content/Avatar.test.tsx
+++ b/apps/comments-ui/src/components/content/Avatar.test.tsx
@@ -1,0 +1,48 @@
+import {AppContext} from '../../AppContext';
+import {Avatar} from './Avatar';
+import {buildDeletedMember, buildMember} from '../../../test/utils/fixtures';
+import {render, screen} from '@testing-library/react';
+
+const contextualRender = (ui, {appContext, ...renderOptions}) => {
+    const contextWithDefaults = {
+        commentsEnabled: 'all',
+        comments: [],
+        openCommentForms: [],
+        member: null,
+        t: str => str,
+        ...appContext
+    };
+
+    return render(
+        <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>,
+        renderOptions
+    );
+};
+
+describe('<AvatarComponent>', function () {
+    it('renders provided member\'s avatar if provided', function () {
+        const member = buildMember({
+            name: 'John Doe'
+        });
+        const appContext = {};
+
+        contextualRender(<Avatar member={member} />, {appContext});
+
+        expect(screen.getByText('JD')).toBeInTheDocument();
+    });
+
+    it('renders blank avatar if member is null', function () {
+        const appContext = {};
+
+        contextualRender(<Avatar member={null} />, {appContext});
+
+        expect(screen.getByTestId('blank-avatar')).toBeInTheDocument();
+    });
+
+    it('renders blank avator if member is deleted', function () {
+        const member = buildDeletedMember();
+        const appContext = {};
+
+        contextualRender(<Avatar member={member} />, {appContext});
+    });
+});

--- a/apps/comments-ui/src/components/content/Avatar.tsx
+++ b/apps/comments-ui/src/components/content/Avatar.tsx
@@ -1,6 +1,6 @@
 import {ReactComponent as AvatarIcon} from '../../images/icons/avatar.svg';
-import {Comment, Member, useAppContext} from '../../AppContext';
-import {getInitials, getMemberInitialsFromComment} from '../../utils/helpers';
+import {Member, useAppContext} from '../../AppContext';
+import {getInitials, getMemberName} from '../../utils/helpers';
 
 function getDimensionClasses() {
     return 'w-8 h-8';
@@ -9,7 +9,7 @@ function getDimensionClasses() {
 export const BlankAvatar = () => {
     const dimensionClasses = getDimensionClasses();
     return (
-        <figure className={`relative ${dimensionClasses}`}>
+        <figure className={`relative ${dimensionClasses}`} data-testid="blank-avatar">
             <div className={`flex items-center justify-center rounded-full bg-black/5 text-neutral-900/25 dark:bg-white/15 dark:text-white/30 ${dimensionClasses}`}>
                 <AvatarIcon className="h-7 w-7 opacity-80" />
             </div>
@@ -18,16 +18,13 @@ export const BlankAvatar = () => {
 };
 
 type AvatarProps = {
-    comment?: Comment;
-    member?: Member;
+    member: Member | null;
 };
 
-export const Avatar: React.FC<AvatarProps> = ({comment, member: propMember}) => {
-    const {member: contextMember, avatarSaturation, t} = useAppContext();
+export const Avatar: React.FC<AvatarProps> = ({member}) => {
+    const {avatarSaturation, t} = useAppContext();
     const dimensionClasses = getDimensionClasses();
-
-    const activeMember = propMember || comment?.member || contextMember;
-    const memberName = activeMember?.name;
+    const memberName = getMemberName(member, t);
 
     const getHashOfString = (str: string) => {
         let hash = 0;
@@ -43,7 +40,7 @@ export const Avatar: React.FC<AvatarProps> = ({comment, member: propMember}) => 
     };
 
     const generateHSL = (): [number, number, number] => {
-        if (!activeMember || !activeMember.name) {
+        if (!memberName) {
             return [0,0,10];
         }
 
@@ -54,7 +51,7 @@ export const Avatar: React.FC<AvatarProps> = ({comment, member: propMember}) => 
         const lRangeBottom = lRangeTop - 20;
         const lRange = [lRangeBottom, lRangeTop];
 
-        const hash = getHashOfString(activeMember.name);
+        const hash = getHashOfString(memberName);
         const h = normalizeHash(hash, hRange[0], hRange[1]);
         const l = normalizeHash(hash, lRange[0], lRange[1]);
 
@@ -65,8 +62,7 @@ export const Avatar: React.FC<AvatarProps> = ({comment, member: propMember}) => 
         return `hsl(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%)`;
     };
 
-    const memberInitials = (comment && getMemberInitialsFromComment(comment, t)) ||
-        (activeMember && getInitials(activeMember.name || '')) || '';
+    const memberInitials = (getInitials(memberName));
 
     const bgColor = HSLtoString(generateHSL());
     const avatarStyle = {
@@ -82,9 +78,14 @@ export const Avatar: React.FC<AvatarProps> = ({comment, member: propMember}) => 
                 (<div className={`flex items-center justify-center rounded-full bg-neutral-900 dark:bg-white/70 ${dimensionClasses}`} data-testid="avatar-background">
                     <AvatarIcon className="stroke-white dark:stroke-black/60" />
                 </div>)}
-            {activeMember?.avatar_image && <img alt="Avatar" className={`absolute left-0 top-0 rounded-full ${dimensionClasses}`} data-testid="avatar-image" src={activeMember.avatar_image} />}
+            {member?.avatar_image && <img alt="Avatar" className={`absolute left-0 top-0 rounded-full ${dimensionClasses}`} data-testid="avatar-image" src={member.avatar_image} />}
         </>
     );
+
+    // if member is null, render blank avatar
+    if (!member) {
+        return <BlankAvatar />;
+    }
 
     return (
         <figure className={`relative ${dimensionClasses}`} data-testid="avatar">

--- a/apps/comments-ui/src/components/content/Comment.tsx
+++ b/apps/comments-ui/src/components/content/Comment.tsx
@@ -123,7 +123,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, ope
     }, [comment, parent, openForm, dispatchAction]);
 
     const hasReplies = displayReplyForm || (comment.replies && comment.replies.length > 0);
-    const avatar = (<Avatar comment={comment} />);
+    const avatar = (<Avatar member={comment.member} />);
 
     return (
         <CommentLayout avatar={avatar} className={hiddenClass} hasReplies={hasReplies} memberUuid={comment.member?.uuid}>
@@ -161,7 +161,7 @@ const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEdi
     const {admin, openCommentForms, t} = useAppContext();
 
     const avatar = (admin && comment.status !== 'deleted')
-        ? <Avatar comment={comment} />
+        ? <Avatar member={comment.member} />
         : <BlankAvatar />;
     const hasReplies = comment.replies && comment.replies.length > 0;
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-599/in-comments-the-deleted-member-avatar-is-replaced-with-the-avatar-of

The avatar displayed for a comment made by a deleted member was defaulting to the currently logged in member's Avatar, which is confusing and incorrect. The Avatar component accepted either a comment or a member, and it would fallback to displaying the logged-in member's avatar if `comment.member` wasn't truthy, as is the case for a deleted member where `comment.member` is `null`. 

This commit simplifies the Avatar component to only accept a member prop, rather than accepting either a member or a comment prop. This simplifies the logic in the Avatar component, which can now just render the avatar for the member provided, or a blank avatar if the provided member is `null`, without any fallback logic. It's currently only used in two places, so it's easy enough to update the uses where it was previously provided a comment.