### PR TITLE
Removed unused .kg-product classes from email styles partial

### DIFF
--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -1351,20 +1351,6 @@ img.kg-cta-image {
     font-weight: 500;
 }
 
-.kg-product-card {
-    width: 100%;
-    margin: 0 0 1.5em;
-    padding: 20px;
-    border-radius: 3px;
-    border: 1px solid #e0e7eb;
-}
-.kg-product-card-image {
-    width: 100%;
-}
-.kg-product-rating img {
-    width: 96px;
-    border: none;
-}
 .kg-audio-card {
     width: auto;
     width: 100%;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1747

- these styles were added in a previously abandoned email customisation project and they are no longer used inside the product card renderer
- removing now to give a cleaner base for a future product card style refactor
