### PR TITLE
Fixed trailing spaces in email template styles.hbs

### DIFF
--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -522,7 +522,7 @@ figure blockquote p {
     color: #15212A;
     font-size: 13px !important;
     font-weight: 500;
-    margin: 1em 0 0 0; 
+    margin: 1em 0 0 0;
     line-height: 1.4em;
     word-break: break-word;
 }
@@ -1170,7 +1170,7 @@ img.kg-cta-image {
 }
 
 .kg-cta-minimal a.kg-cta-button {
-    display: inline-block; 
+    display: inline-block;
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
     font-size: 0.85em;
     font-weight: 600;
@@ -1184,7 +1184,7 @@ img.kg-cta-image {
 }
 
 .kg-cta-immersive a.kg-cta-button {
-    display: inline-block; 
+    display: inline-block;
     width: 100%;
     font-size: 0.9em;
     font-weight: 600;
@@ -1996,7 +1996,7 @@ img.kg-cta-image {
     table.body .kg-cta-minimal .kg-cta-content-inner {
         display: inline-block !important;
         width: 100% !important;
-        padding: 0 !important; 
+        padding: 0 !important;
     }
 
     table.body .kg-cta-minimal img.kg-cta-image {


### PR DESCRIPTION
no issue

- our default editor config when set up correctly trims trailing spaces on save but at some point this file has been saved with trailing spaces meaning "untouched" lines keep appearing in commits to this file
- committing cleanup separately to avoid unrelated noise in a different PR
