### PR TITLE
Improved test coverage for @tryghost/email-addresses parser

### DIFF
--- a/ghost/email-addresses/test/EmailAddressParser.test.ts
+++ b/ghost/email-addresses/test/EmailAddressParser.test.ts
@@ -1,0 +1,96 @@
+import assert from 'assert/strict';
+import {EmailAddressParser} from '../src/EmailAddressParser';
+
+describe('EmailAddressParser', function () {
+    describe('parse', function () {
+        it('should parse an email address', function () {
+            const email = EmailAddressParser.parse('test@example.com');
+
+            assert.ok(email);
+            assert.deepEqual(email, {
+                address: 'test@example.com',
+                name: undefined
+            });
+        });
+
+        it('should parse an email address with a name', function () {
+            const email = EmailAddressParser.parse('"Test User" <test@example.com>');
+
+            assert.ok(email);
+            assert.deepEqual(email, {
+                address: 'test@example.com',
+                name: 'Test User'
+            });
+        });
+
+        it('should parse an email address with a name and a comment', function () {
+            const email = EmailAddressParser.parse('"Test User" <test@example.com> (Comment)');
+
+            assert.ok(email);
+            assert.deepEqual(email, {
+                address: 'test@example.com',
+                name: 'Test User'
+            });
+        });
+
+        it('should handle an invalid email address', function () {
+            const email = EmailAddressParser.parse('invalid');
+            assert.deepEqual(email, {
+                address: '',
+                name: 'invalid'
+            });
+        });
+
+        it('should handle an invalid email address with a name', function () {
+            const email = EmailAddressParser.parse('"Test User" <invalid>');
+            assert.deepEqual(email, {
+                address: 'invalid',
+                name: 'Test User'
+            });
+        });
+
+        it('should return null for empty input', function () {
+            const email = EmailAddressParser.parse('');
+            assert.equal(email, null);
+        });
+
+        it('should return null for null input', function () {
+            // @ts-ignore - Testing null input
+            const email = EmailAddressParser.parse(null);
+            assert.equal(email, null);
+        });
+
+        it('should return null for undefined input', function () {
+            // @ts-ignore - Testing undefined input
+            const email = EmailAddressParser.parse(undefined);
+            assert.equal(email, null);
+        });
+
+        it('should return null for multiple email addresses', function () {
+            const email = EmailAddressParser.parse('test1@example.com, test2@example.com');
+            assert.equal(email, null);
+        });
+
+        it('should return null for group format', function () {
+            const email = EmailAddressParser.parse('My Group: test@example.com;');
+            assert.equal(email, null);
+        });
+    });
+
+    describe('stringify', function () {
+        it('should stringify an email address', function () {
+            const email = EmailAddressParser.stringify({
+                address: 'test@example.com',
+                name: 'Test User'
+            });
+            assert.equal(email, '"Test User" <test@example.com>');
+        });
+
+        it('should stringify an email address without a name', function () {
+            const email = EmailAddressParser.stringify({
+                address: 'test@example.com'
+            });
+            assert.equal(email, 'test@example.com');
+        });
+    });
+});

--- a/ghost/email-addresses/test/hello.test.ts
+++ b/ghost/email-addresses/test/hello.test.ts
@@ -1,8 +1,0 @@
-import assert from 'assert/strict';
-
-describe('Hello world', function () {
-    it('Runs a test', function () {
-        // TODO: Write me!
-        assert.ok(require('../'));
-    });
-});


### PR DESCRIPTION
- this lib had no tests so this commit adds some basic tests to cover the functionality of the parser
