### PR TITLE
Fixed email and preview routes not displaying CTAs

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/email-post.js
+++ b/ghost/core/core/frontend/services/routing/controllers/email-post.js
@@ -51,8 +51,6 @@ module.exports = function emailPostController(req, res, next) {
                 return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
-            post.access = !!post.html;
-
             return renderer.renderEntry(req, res)(post);
         })
         .catch(renderer.handleError(next));

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -60,8 +60,6 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
             }
 
-            post.access = !!post.html;
-
             return renderer.renderEntry(req, res)(post);
         })
         .catch(renderer.handleError(next));


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-930/support-escalation-re-freepaywalls-on-web-versions-of-email-only-posts
ref https://linear.app/ghost/issue/ONC-921/oss-issue-content-cta-does-not-display-on-preview-when-it-should

Need to add tests for this. Kind of surprised nothing broke by deleting these lines, which makes me feel uneasy. For now I'm just raising this PR so I can manually test on staging thoroughly. Assuming this hasn't broken anything, I'll circle back and make this PR properly, with tests and all that good stuff.

# Context
This line was initially added in https://github.com/TryGhost/Ghost/commit/638b4fc2f213c64e6dd30081b1489eb1b3ea57f6 as a bug fix, which unfortunately didn't have any tests or a ton of context. This commit is from 6 years ago, immediately following the 3.0 release. The `post.access` flag wasn't being set at all in the preview controller at that point, so this line was added to force it to `true` in the preview controller. At this point, it seems that the `access` property was basically a placeholder, and we didn't yet have any actual post gating implemented. This same logic was also used in the `entry` controller in a commit (https://github.com/TryGhost/Ghost/commit/d6b0db39c0dd3c4b54883b776cb6d3ba206f4cc2) a few weeks prior, which means all posts effectively had `access: true` at this point. 

Later on, this [commit](https://github.com/TryGhost/Ghost/commit/fa91c6c9545a9107ba9b938f545c674ff70a462c#diff-42f164398878ef21b6e9ab8e68f273a167fe1f5e85f4b3fe0036d92ab8128e94) removed these same lines from the `entry` controller, and added the `access` logic in the API in the `post-gating` util: https://github.com/TryGhost/Ghost/blob/df88c1f6b847051f945519f95c1010039c2dbe47/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/post-gating.js#L116-L118. However, this change wasn't carried over into the preview or email controller at the time, hence this bug.

Given that the `access` param is now set within `post-gating.js` `forPost` function, which is now also called in the [`email-posts`](https://github.com/TryGhost/Ghost/blob/6ab862568c47f9bb9bad84aaa299b19be4a02791/ghost/core/core/server/api/endpoints/utils/serializers/output/email-posts.js#L30) and [`preview`](https://github.com/TryGhost/Ghost/blob/6ab862568c47f9bb9bad84aaa299b19be4a02791/ghost/core/core/server/api/endpoints/utils/serializers/output/previews.js#L29) output serializers.