### PR TITLE
Fixed mention notification display for all mention types in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -122,9 +122,7 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
         }
         break;
     case 'mention':
-        if (group.inReplyTo && typeof group.inReplyTo !== 'string') {
-            return <>{actorText} mentioned you in a {group.inReplyTo?.type === 'article' ? 'post' : 'note'}</>;
-        }
+        return <>{actorText} mentioned you in a {group.inReplyTo?.type === 'article' ? 'post' : 'note'}</>;
     }
 
     return <></>;
@@ -202,7 +200,7 @@ const Notifications: React.FC = () => {
             }
             break;
         case 'mention':
-            if (group.post && group.inReplyTo) {
+            if (group.post) {
                 navigate(`/feed/${encodeURIComponent(group.post.id)}`);
             }
             break;
@@ -332,7 +330,7 @@ const Notifications: React.FC = () => {
                                                     }
                                                 </div>
                                                 {(
-                                                    ((group.type === 'reply' || group.type === 'mention') && group.inReplyTo) ||
+                                                    ((group.type === 'reply' && group.inReplyTo) || group.type === 'mention') ||
                                                     (group.type === 'like' && !group.post?.name && group.post?.content) ||
                                                     (group.type === 'repost' && !group.post?.name && group.post?.content)
                                                 ) && (


### PR DESCRIPTION
ref PROD-1748

- Extended mention notification rendering to include standalone mentions
- Previously only showed mentions that were replies to other notes
- Now properly displays mentions in any context, including new posts