### PR TITLE
Wired up alpha button style setting

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
@@ -404,6 +404,31 @@ const Sidebar: React.FC<{
                         ]} clearBg={false} />
                     </div>
                     <div className='flex w-full justify-between'>
+                        <div>Button style</div>
+                        <ButtonGroup activeKey={newsletter.button_style || 'fill'} buttons={[
+                            {
+                                key: 'fill',
+                                icon: 'squircle-fill',
+                                label: 'Fill',
+                                tooltip: 'Fill',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({button_style: 'fill'})
+                            },
+                            {
+                                key: 'outline',
+                                icon: 'squircle',
+                                label: 'Outline',
+                                tooltip: 'Outline',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({button_style: 'outline'})
+                            }
+                        ]} clearBg={false} />
+                    </div>
+                    <div className='flex w-full justify-between'>
                         <div>Button corners</div>
                         <ButtonGroup activeKey={newsletter.button_corners || 'rounded'} buttons={[
                             {

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -324,7 +324,8 @@ class EmailRenderer {
 
         if (this.getLabs()?.isSet('emailCustomizationAlpha')) {
             renderOptions.design = {
-                buttonCorners: newsletter?.get('button_corners')
+                buttonCorners: newsletter?.get('button_corners'),
+                buttonStyle: newsletter?.get('button_style')
             };
         }
 
@@ -996,6 +997,11 @@ class EmailRenderer {
             }
         }
 
+        let hasOutlineButtons = false;
+        if (labs.isSet('emailCustomizationAlpha') && newsletter.get('button_style') === 'outline') {
+            hasOutlineButtons = true;
+        }
+
         const {href: headerImage, width: headerImageWidth} = await this.limitImageWidth(newsletter.get('header_image'));
         const {href: postFeatureImage, width: postFeatureImageWidth, height: postFeatureImageHeight} = await this.limitImageWidth(post.get('feature_image'));
 
@@ -1149,6 +1155,7 @@ class EmailRenderer {
             showHeaderName: newsletter.get('show_header_name'),
             showFeatureImage: newsletter.get('show_feature_image') && !!postFeatureImage,
             footerContent: newsletter.get('footer_content'),
+            hasOutlineButtons,
 
             classes: {
                 title: 'post-title' + ` ` + (post.get('custom_excerpt') ? 'post-title-with-excerpt' : 'post-title-no-excerpt') + (newsletter.get('title_font_category') === 'serif' ? ` post-title-serif` : ``) + (newsletter.get('title_alignment') === 'left' ? ` post-title-left` : ``),

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2094,7 +2094,8 @@ describe('Email renderer', function () {
             const post = createModel(basePost);
             const newsletter = createModel({
                 ...baseNewsletter,
-                button_corners: 'square'
+                button_corners: 'square',
+                button_style: 'outline'
             });
             const segment = null;
             const options = {};
@@ -2108,7 +2109,8 @@ describe('Email renderer', function () {
                     target: 'email',
                     postUrl: 'http://example.com',
                     design: {
-                        buttonCorners: 'square'
+                        buttonCorners: 'square',
+                        buttonStyle: 'outline'
                     }
                 }
             );
@@ -2548,8 +2550,9 @@ describe('Email renderer', function () {
                 ]);
         });
 
-        async function testButtonBorderRadius(buttonCorners, expectedRadius) {
-            labsEnabled = true;
+        async function testDataProperty(newsletterSettings, property, expectedValue, options = {labsEnabled: true}) {
+            labsEnabled = options.labsEnabled ?? false;
+
             const html = '';
             const post = createModel({
                 posts_meta: createModel({}),
@@ -2561,10 +2564,16 @@ describe('Email renderer', function () {
                 title_alignment: 'left',
                 body_font_category: 'sans_serif',
                 show_latest_posts: true,
-                button_corners: buttonCorners
+                ...newsletterSettings
             });
             const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
-            assert.equal(data.buttonBorderRadius, expectedRadius);
+            assert.equal(data[property], expectedValue);
+        }
+
+        async function testButtonBorderRadius(buttonCorners, expectedRadius) {
+            return await testDataProperty({
+                button_corners: buttonCorners
+            }, 'buttonBorderRadius', expectedRadius, {labsEnabled: true});
         }
 
         it('sets buttonBorderRadius to correct default (emailCustomizationAlpha)', async function () {
@@ -2581,6 +2590,24 @@ describe('Email renderer', function () {
 
         it('sets buttonBorderRadius to correct pill value (emailCustomizationAlpha)', async function () {
             await testButtonBorderRadius('pill', '9999px');
+        });
+
+        async function testHasOutlineButtons(buttonStyle, expectedValue) {
+            return await testDataProperty({
+                button_style: buttonStyle
+            }, 'hasOutlineButtons', expectedValue, {labsEnabled: true});
+        }
+
+        it('sets hasOutlineButtons to correct default (emailCustomizationAlpha)', async function () {
+            await testHasOutlineButtons(null, false);
+        });
+
+        it('sets hasOutlineButtons to correct fill value (emailCustomizationAlpha)', async function () {
+            await testHasOutlineButtons('fill', false);
+        });
+
+        it('sets hasOutlineButtons to correct outline value (emailCustomizationAlpha)', async function () {
+            await testHasOutlineButtons('outline', true);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1717

- copied style setting from prototype to alpha newsletter details modal
- updated EmailRenderer data fetching/passthrough to include setting
  - can be used with `{{#if hasOutlineButtons}}` in the main template/partials where we don't have string matching available in handlebars
  - full setting value is passed through to cards under the `design.buttonStyle` option
