### PR TITLE
Fixed all `withArgs` typing errors

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -8,11 +8,12 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
     };
 
     let model;
+    let modelGetStub;
 
     beforeEach(function () {
         model = sinon.stub();
-        model.get = sinon.stub();
-        model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
+        modelGetStub = sinon.stub(model, 'get');
+        modelGetStub.withArgs('plaintext').returns(new Array(5000).join('A'));
     });
 
     describe('for post', function () {
@@ -26,15 +27,15 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             const attrs = {};
 
             extraAttrsUtil.forPost(options, model, attrs);
-            assert.ok(model.get.called);
+            assert.ok(modelGetStub.called);
             assert.equal(attrs.excerpt, new Array(501).join('A'));
         });
 
         it('has excerpt when plaintext is null', function () {
-            model.get.withArgs('plaintext').returns(null);
+            modelGetStub.withArgs('plaintext').returns(null);
             const attrs = {};
             extraAttrsUtil.forPost(options, model, attrs);
-            assert.ok(model.get.called);
+            assert.ok(modelGetStub.called);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'excerpt'), true);
             assert.equal(attrs.excerpt, null);
         });
@@ -44,7 +45,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             extraAttrsUtil.forPost({
                 columns: ['plaintext']
             }, model, attrs);
-            assert.ok(model.get.called);
+            assert.ok(modelGetStub.called);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'plaintext'), true);
         });
 
@@ -53,14 +54,14 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             extraAttrsUtil.forPost({
                 formats: ['plaintext']
             }, model, attrs);
-            assert.ok(model.get.called);
+            assert.ok(modelGetStub.called);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'plaintext'), true);
         });
 
         it('has excerpt when no columns are passed', function () {
             const attrs = {};
             extraAttrsUtil.forPost({}, model, attrs);
-            assert.ok(model.get.called);
+            assert.ok(modelGetStub.called);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'excerpt'), true);
         });
 

--- a/ghost/core/test/unit/frontend/apps/amp/router.test.js
+++ b/ghost/core/test/unit/frontend/apps/amp/router.test.js
@@ -111,7 +111,7 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlServiceGetPermalinkByUrlStub.withArgs('/welcome/').returns('/:slug/');
 
-            dataService.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}})
+            entryLookupStub.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}})
                 .resolves({
                     entry: post
                 });
@@ -128,7 +128,7 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlServiceGetPermalinkByUrlStub.withArgs('/welcome/').returns('/:slug/');
 
-            dataService.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}}).resolves({
+            entryLookupStub.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}}).resolves({
                 entry: post
             });
 
@@ -143,7 +143,7 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlServiceGetPermalinkByUrlStub.withArgs('/welcome/').returns('/:slug/');
 
-            dataService.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}})
+            entryLookupStub.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'postsPublic', resource: 'posts'}})
                 .rejects(new errors.NotFoundError());
 
             ampController.getPostData(req, res, function (err) {

--- a/ghost/core/test/unit/frontend/meta/amp-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/amp-url.test.js
@@ -8,6 +8,8 @@ let getAmpUrl = rewire('../../../../core/frontend/meta/amp-url');
 
 describe('getAmpUrl', function () {
     let getUrlStub;
+    let urlJoinStub;
+    let urlForStub;
 
     beforeEach(function () {
         getUrlStub = sinon.stub();
@@ -15,8 +17,8 @@ describe('getAmpUrl', function () {
         getAmpUrl = rewire('../../../../core/frontend/meta/amp-url');
         getAmpUrl.__set__('getUrl', getUrlStub);
 
-        sinon.stub(urlUtils, 'urlJoin');
-        sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
+        urlJoinStub = sinon.stub(urlUtils, 'urlJoin');
+        urlForStub = sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
     });
 
     afterEach(function () {
@@ -30,12 +32,12 @@ describe('getAmpUrl', function () {
         post.context = ['post'];
 
         getUrlStub.withArgs(post, false).returns('url');
-        urlUtils.urlJoin.withArgs('http://localhost:9999', 'url', 'amp/').returns('url');
+        urlJoinStub.withArgs('http://localhost:9999', 'url', 'amp/').returns('url');
 
         should.exist(getAmpUrl(post));
 
-        urlUtils.urlJoin.calledOnce.should.be.true();
-        urlUtils.urlFor.calledOnce.should.be.true();
+        urlJoinStub.calledOnce.should.be.true();
+        urlForStub.calledOnce.should.be.true();
         getUrlStub.calledOnce.should.be.true();
     });
 
@@ -47,8 +49,8 @@ describe('getAmpUrl', function () {
 
         should.not.exist(getAmpUrl(tag));
 
-        urlUtils.urlJoin.called.should.be.false();
-        urlUtils.urlFor.called.should.be.false();
+        urlJoinStub.called.should.be.false();
+        urlForStub.called.should.be.false();
         getUrlStub.called.should.be.false();
     });
 
@@ -60,8 +62,8 @@ describe('getAmpUrl', function () {
 
         should.not.exist(getAmpUrl(author));
 
-        urlUtils.urlJoin.called.should.be.false();
-        urlUtils.urlFor.called.should.be.false();
+        urlJoinStub.called.should.be.false();
+        urlForStub.called.should.be.false();
         getUrlStub.called.should.be.false();
     });
 
@@ -73,8 +75,8 @@ describe('getAmpUrl', function () {
 
         should.not.exist(getAmpUrl(post));
 
-        urlUtils.urlJoin.called.should.be.false();
-        urlUtils.urlFor.called.should.be.false();
+        urlJoinStub.called.should.be.false();
+        urlForStub.called.should.be.false();
         getUrlStub.called.should.be.false();
     });
 });

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -5,8 +5,11 @@ const urlService = require('../../../../core/server/services/url');
 const getAuthorUrl = require('../../../../core/frontend/meta/author-url');
 
 describe('getAuthorUrl', function () {
+    /** @type {import('sinon').SinonStub} */
+    let urlServiceGetUrlByResourceIdStub;
+
     beforeEach(function () {
-        sinon.stub(urlService, 'getUrlByResourceId');
+        urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
@@ -21,7 +24,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({
@@ -38,7 +41,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: true, withSubdirectory: true})
+        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
         should.exist(getAuthorUrl({
@@ -55,7 +58,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({
@@ -70,7 +73,7 @@ describe('getAuthorUrl', function () {
             slug: 'test-author'
         };
 
-        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
+        urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({

--- a/ghost/core/test/unit/frontend/meta/canonical-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/canonical-url.test.js
@@ -8,6 +8,8 @@ let getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
 
 describe('getCanonicalUrl', function () {
     let getUrlStub;
+    let urlJoinStub;
+    let urlForStub;
 
     beforeEach(function () {
         getUrlStub = sinon.stub();
@@ -15,8 +17,8 @@ describe('getCanonicalUrl', function () {
         getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
         getCanonicalUrl.__set__('getUrl', getUrlStub);
 
-        sinon.stub(urlUtils, 'urlJoin');
-        sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
+        urlJoinStub = sinon.stub(urlUtils, 'urlJoin');
+        urlForStub = sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
     });
 
     afterEach(function () {
@@ -27,12 +29,12 @@ describe('getCanonicalUrl', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
         getUrlStub.withArgs(post, false).returns('/post-url/');
-        urlUtils.urlJoin.withArgs('http://localhost:9999', '/post-url/').returns('canonical url');
+        urlJoinStub.withArgs('http://localhost:9999', '/post-url/').returns('canonical url');
 
         getCanonicalUrl(post).should.eql('canonical url');
 
-        urlUtils.urlJoin.calledOnce.should.be.true();
-        urlUtils.urlFor.calledOnce.should.be.true();
+        urlJoinStub.calledOnce.should.be.true();
+        urlForStub.calledOnce.should.be.true();
         getUrlStub.calledOnce.should.be.true();
     });
 
@@ -51,23 +53,23 @@ describe('getCanonicalUrl', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
         getUrlStub.withArgs(post, false).returns('/post-url/amp/');
-        urlUtils.urlJoin.withArgs('http://localhost:9999', '/post-url/amp/').returns('*/amp/');
+        urlJoinStub.withArgs('http://localhost:9999', '/post-url/amp/').returns('*/amp/');
 
         getCanonicalUrl(post).should.eql('*/');
 
-        urlUtils.urlJoin.calledOnce.should.be.true();
-        urlUtils.urlFor.calledOnce.should.be.true();
+        urlJoinStub.calledOnce.should.be.true();
+        urlForStub.calledOnce.should.be.true();
         getUrlStub.calledOnce.should.be.true();
     });
 
     it('should return home if empty secure data', function () {
         getUrlStub.withArgs({secure: true}, false).returns('/');
-        urlUtils.urlJoin.withArgs('http://localhost:9999', '/').returns('canonical url');
+        urlJoinStub.withArgs('http://localhost:9999', '/').returns('canonical url');
 
         getCanonicalUrl({secure: true}).should.eql('canonical url');
 
-        urlUtils.urlJoin.calledOnce.should.be.true();
-        urlUtils.urlFor.calledOnce.should.be.true();
+        urlJoinStub.calledOnce.should.be.true();
+        urlForStub.calledOnce.should.be.true();
         getUrlStub.calledOnce.should.be.true();
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -14,6 +14,9 @@ describe('Unit - services/routing/controllers/entry', function () {
     let res;
     let entryLookUpStub;
     let renderStub;
+    let urlUtilsRedirect301Stub;
+    let routerManagerGetResourceByIdStub;
+    let urlUtilsRedirectToAdminStub;
     let post;
 
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('Unit - services/routing/controllers/entry', function () {
             return renderStub;
         });
 
-        sinon.stub(urlUtils, 'redirectToAdmin');
-        sinon.stub(urlUtils, 'redirect301');
-        sinon.stub(routerManager, 'getResourceById');
+        urlUtilsRedirectToAdminStub = sinon.stub(urlUtils, 'redirectToAdmin');
+        urlUtilsRedirect301Stub = sinon.stub(urlUtils, 'redirect301');
+        routerManagerGetResourceByIdStub = sinon.stub(routerManager, 'getResourceById');
 
         req = {
             path: '/',
@@ -73,7 +76,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
         res.routerOptions.resourceType = 'posts';
 
-        routerManager.getResourceById.withArgs(post.id).returns({
+        routerManagerGetResourceByIdStub.withArgs(post.id).returns({
             config: {
                 type: 'posts'
             }
@@ -114,7 +117,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                     entry: post
                 });
 
-            urlUtils.redirectToAdmin.callsFake(function (statusCode, _res, editorUrl) {
+            urlUtilsRedirectToAdminStub.callsFake(function (statusCode, _res, editorUrl) {
                 statusCode.should.eql(302);
                 editorUrl.should.eql(EDITOR_URL + post.id);
                 done();
@@ -136,14 +139,14 @@ describe('Unit - services/routing/controllers/entry', function () {
                     entry: post
                 });
 
-            urlUtils.redirectToAdmin.callsFake(async function () {
+            urlUtilsRedirectToAdminStub.callsFake(async function () {
                 await configUtils.restore();
                 done(new Error('redirectToAdmin was called'));
             });
 
             controllers.entry(req, res, async (err) => {
                 await configUtils.restore();
-                urlUtils.redirectToAdmin.called.should.eql(false);
+                urlUtilsRedirectToAdminStub.called.should.eql(false);
                 should.not.exist(err);
                 done(err);
             });
@@ -153,7 +156,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             req.path = post.url;
             res.routerOptions.resourceType = 'posts';
 
-            routerManager.getResourceById.withArgs(post.id).returns({
+            routerManagerGetResourceByIdStub.withArgs(post.id).returns({
                 config: {
                     type: 'pages'
                 }
@@ -177,7 +180,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
             res.routerOptions.resourceType = 'posts';
 
-            routerManager.getResourceById.withArgs(post.id).returns({
+            routerManagerGetResourceByIdStub.withArgs(post.id).returns({
                 config: {
                     type: 'posts'
                 }
@@ -188,7 +191,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                     entry: post
                 });
 
-            urlUtils.redirect301.callsFake(function (_res, postUrl) {
+            urlUtilsRedirect301Stub.callsFake(function (_res, postUrl) {
                 postUrl.should.eql(post.url);
                 done();
             });
@@ -206,7 +209,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
             res.routerOptions.resourceType = 'posts';
 
-            routerManager.getResourceById.withArgs(post.id).returns({
+            routerManagerGetResourceByIdStub.withArgs(post.id).returns({
                 config: {
                     type: 'posts'
                 }
@@ -217,7 +220,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                     entry: post
                 });
 
-            urlUtils.redirect301.callsFake(function (_res, postUrl) {
+            urlUtilsRedirect301Stub.callsFake(function (_res, postUrl) {
                 postUrl.should.eql(post.url + '?query=true');
                 done();
             });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
@@ -19,6 +19,7 @@ describe('Unit - services/routing/controllers/rss', function () {
     let req;
     let res;
     let fetchDataStub;
+    let rssServiceRenderStub;
     let posts;
 
     beforeEach(function () {
@@ -47,11 +48,11 @@ describe('Unit - services/routing/controllers/rss', function () {
 
         sinon.stub(security.string, 'safe').returns('safe');
 
-        sinon.stub(rssService, 'render');
+        rssServiceRenderStub = sinon.stub(rssService, 'render');
 
-        sinon.stub(settingsCache, 'get');
-        settingsCache.get.withArgs('title').returns('Ghost');
-        settingsCache.get.withArgs('description').returns('Ghost is cool!');
+        const settingsCacheGetStub = sinon.stub(settingsCache, 'get');
+        settingsCacheGetStub.withArgs('title').returns('Ghost');
+        settingsCacheGetStub.withArgs('description').returns('Ghost is cool!');
     });
 
     afterEach(function () {
@@ -63,7 +64,7 @@ describe('Unit - services/routing/controllers/rss', function () {
             posts: posts
         });
 
-        rssService.render.callsFake(function (_res, baseUrl, data) {
+        rssServiceRenderStub.callsFake(function (_res, baseUrl, data) {
             baseUrl.should.eql('/rss/');
             data.posts.should.eql(posts);
             data.title.should.eql('Ghost');

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -9,6 +9,7 @@ const generateFeed = require('../../../../../core/frontend/services/rss/generate
 describe('RSS: Generate Feed', function () {
     const data = {};
     let baseUrl;
+    let routerManagerGetUrlByResourceIdStub;
 
     // Static set of posts
     let posts;
@@ -43,7 +44,7 @@ describe('RSS: Generate Feed', function () {
     });
 
     beforeEach(function () {
-        sinon.stub(routerManager, 'getUrlByResourceId');
+        routerManagerGetUrlByResourceIdStub = sinon.stub(routerManager, 'getUrlByResourceId');
 
         baseUrl = '/rss/';
 
@@ -92,7 +93,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = posts;
 
             _.each(data.posts, function (post) {
-                routerManager.getUrlByResourceId.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             generateFeed(baseUrl, data).then(function (xmlData) {
@@ -204,7 +205,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[0]];
 
             _.each(data.posts, function (post) {
-                routerManager.getUrlByResourceId.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
+                routerManagerGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://my-ghost-blog.com/' + post.slug + '/');
             });
 
             generateFeed(baseUrl, data).then(function (xmlData) {

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -37,6 +37,10 @@ describe('Themes middleware', function () {
     let fakeSiteData;
     let fakeLabsData;
     let fakeCustomThemeSettingsData;
+    let activeThemeGetStub;
+    let settingsCacheGetStub;
+    let hbsUpdateTemplateOptionsStub;
+    let hbsUpdateLocalTemplateOptionsStub;
 
     beforeEach(function () {
         req = {app: {}, header: () => {}};
@@ -65,10 +69,10 @@ describe('Themes middleware', function () {
             header_typography: 'Sans-Serif'
         };
 
-        sandbox.stub(activeTheme, 'get')
+        activeThemeGetStub = sandbox.stub(activeTheme, 'get')
             .returns(fakeActiveTheme);
 
-        sandbox.stub(settingsCache, 'get')
+        settingsCacheGetStub = sandbox.stub(settingsCache, 'get')
             .withArgs('active_theme').returns(fakeActiveThemeName);
 
         sandbox.stub(labs, 'getAll').returns(fakeLabsData);
@@ -79,8 +83,8 @@ describe('Themes middleware', function () {
         sandbox.stub(customThemeSettingsCache, 'getAll')
             .returns(fakeCustomThemeSettingsData);
 
-        sandbox.stub(hbs, 'updateTemplateOptions');
-        sandbox.stub(hbs, 'updateLocalTemplateOptions');
+        hbsUpdateTemplateOptionsStub = sandbox.stub(hbs, 'updateTemplateOptions');
+        hbsUpdateLocalTemplateOptionsStub = sandbox.stub(hbs, 'updateLocalTemplateOptions');
     });
 
     it('mounts active theme if not yet mounted', function (done) {
@@ -117,8 +121,8 @@ describe('Themes middleware', function () {
     });
 
     it('throws error if theme is missing', function (done) {
-        activeTheme.get.restore();
-        sandbox.stub(activeTheme, 'get')
+        activeThemeGetStub.restore();
+        activeThemeGetStub = sandbox.stub(activeTheme, 'get')
             .returns(undefined);
 
         executeMiddleware(middleware, req, res, function next(err) {
@@ -127,7 +131,7 @@ describe('Themes middleware', function () {
                 should.exist(err);
                 err.message.should.eql('The currently active theme "bacon-sensation" is missing.');
 
-                activeTheme.get.called.should.be.true();
+                activeThemeGetStub.called.should.be.true();
                 fakeActiveTheme.mount.called.should.be.false();
 
                 done();
@@ -145,8 +149,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    hbsUpdateTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'labs', 'config', 'custom');
@@ -182,12 +186,11 @@ describe('Themes middleware', function () {
         });
 
         it('switches @site.signup_url to RSS when signup is disabled', function (done) {
-            settingsCache.get
-                .withArgs('members_signup_access').returns('none');
+            settingsCacheGetStub.withArgs('members_signup_access').returns('none');
 
             executeMiddleware(middleware, req, res, function next() {
                 try {
-                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
                     should.exist(data.site.signup_url);
@@ -212,8 +215,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site');
@@ -239,8 +242,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site');
@@ -268,8 +271,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');
@@ -295,8 +298,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');
@@ -323,8 +326,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');
@@ -349,8 +352,8 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
+                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -6,11 +6,15 @@ const bridge = require('../../../../../core/bridge');
 const RouteSettings = require('../../../../../core/server/services/route-settings/RouteSettings');
 
 describe('UNIT > Settings Service DefaultSettingsManager:', function () {
+    let fsReadFileStub;
+    let fsCopyStub;
+    let bridgeReloadFrontendStub;
+
     beforeEach(function () {
-        sinon.stub(fs, 'readFile');
+        fsReadFileStub = sinon.stub(fs, 'readFile');
         sinon.stub(fs, 'readFileSync');
-        sinon.stub(fs, 'copy');
-        sinon.stub(bridge, 'reloadFrontend');
+        fsCopyStub = sinon.stub(fs, 'copy');
+        bridgeReloadFrontendStub = sinon.stub(bridge, 'reloadFrontend');
     });
 
     afterEach(function () {
@@ -23,12 +27,12 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             const backupFilePath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-backup.yaml');
             const incomingSettingsPath = path.join(__dirname, '../../../../utils/fixtures/settings/routes-incoming.yaml');
 
-            fs.readFile.withArgs(routesSettingsPath, 'utf8').resolves('content');
-            fs.copy.withArgs(backupFilePath, routesSettingsPath).resolves();
-            fs.copy.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
+            fsReadFileStub.withArgs(routesSettingsPath, 'utf8').resolves('content');
+            fsCopyStub.withArgs(backupFilePath, routesSettingsPath).resolves();
+            fsCopyStub.withArgs(incomingSettingsPath, routesSettingsPath).resolves();
 
             // simulate a parsing error during frontend reload
-            bridge.reloadFrontend.throws(new Error('YAMLException: bad indentation of a mapping entry'));
+            bridgeReloadFrontendStub.throws(new Error('YAMLException: bad indentation of a mapping entry'));
 
             const defaultSettingsManager = new RouteSettings({
                 settingsLoader: {},

--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -112,10 +112,11 @@ describe('Slack', function () {
         let settingsCacheStub;
         let slackReset;
         let makeRequestStub;
+        let urlServiceGetUrlByResourceIdStub;
         const ping = slack.__get__('ping');
 
         beforeEach(function () {
-            sinon.stub(urlService, 'getUrlByResourceId');
+            urlServiceGetUrlByResourceIdStub = sinon.stub(urlService, 'getUrlByResourceId');
 
             settingsCacheStub = sinon.stub(settingsCache, 'get');
 
@@ -140,7 +141,7 @@ describe('Slack', function () {
                 slug: 'webhook-test',
                 html: `<p>Hello World!</p><p>This is a test post.</p><!--members-only--><p>This is members only content.</p>`
             });
-            urlService.getUrlByResourceId.withArgs(post.id, {absolute: true}).returns('http://myblog.com/' + post.slug + '/');
+            urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true}).returns('http://myblog.com/' + post.slug + '/');
 
             settingsCacheStub.withArgs('slack_url').returns(slackURL);
 
@@ -149,7 +150,7 @@ describe('Slack', function () {
 
             // assertions
             makeRequestStub.calledOnce.should.be.true();
-            urlService.getUrlByResourceId.calledOnce.should.be.true();
+            urlServiceGetUrlByResourceIdStub.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack_url').should.be.true();
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -177,7 +178,7 @@ describe('Slack', function () {
 
             // assertions
             makeRequestStub.calledOnce.should.be.true();
-            urlService.getUrlByResourceId.called.should.be.false();
+            urlServiceGetUrlByResourceIdStub.called.should.be.false();
             settingsCacheStub.calledWith('slack_url').should.be.true();
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -217,7 +218,7 @@ describe('Slack', function () {
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
-            urlService.getUrlByResourceId.calledOnce.should.be.true();
+            urlServiceGetUrlByResourceIdStub.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack_url').should.be.true();
         });
 
@@ -230,7 +231,7 @@ describe('Slack', function () {
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
-            urlService.getUrlByResourceId.calledOnce.should.be.true();
+            urlServiceGetUrlByResourceIdStub.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack_url').should.be.true();
         });
 
@@ -243,7 +244,7 @@ describe('Slack', function () {
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
-            urlService.getUrlByResourceId.called.should.be.true();
+            urlServiceGetUrlByResourceIdStub.called.should.be.true();
             settingsCacheStub.calledWith('slack_url').should.be.true();
         });
     });

--- a/ghost/core/test/unit/server/services/stripe/StripeAPI.test.js
+++ b/ghost/core/test/unit/server/services/stripe/StripeAPI.test.js
@@ -15,6 +15,7 @@ describe('StripeAPI', function () {
     const api = new StripeAPI({labs: mockLabs});
 
     let mockStripe;
+    let mockLabsIsSet;
 
     describe('createCheckoutSession', function () {
         beforeEach(function () {
@@ -25,7 +26,7 @@ describe('StripeAPI', function () {
                     }
                 }
             };
-            sinon.stub(mockLabs, 'isSet');
+            mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
             const mockStripeConstructor = sinon.stub().returns(mockStripe);
             StripeAPI.__set__('Stripe', mockStripeConstructor);
             api.configure({
@@ -48,7 +49,7 @@ describe('StripeAPI', function () {
         });
 
         it('Sends no payment methods if labs flag is enabled', async function () {
-            mockLabs.isSet.withArgs('additionalPaymentMethods').returns(true);
+            mockLabsIsSet.withArgs('additionalPaymentMethods').returns(true);
             await api.createCheckoutSession('priceId', null, {});
 
             should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.payment_method_types, undefined);
@@ -192,7 +193,7 @@ describe('StripeAPI', function () {
                     }
                 }
             };
-            sinon.stub(mockLabs, 'isSet');
+            mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
             const mockStripeConstructor = sinon.stub().returns(mockStripe);
             StripeAPI.__set__('Stripe', mockStripeConstructor);
             api.configure({
@@ -216,14 +217,14 @@ describe('StripeAPI', function () {
         });
 
         it('createCheckoutSetupSession does not send currency if additionalPaymentMethods flag is off', async function () {
-            mockLabs.isSet.withArgs('additionalPaymentMethods').returns(false);
+            mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
             await api.createCheckoutSetupSession('priceId', {currency: 'usd'});
 
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);
         });
 
         it('createCheckoutSetupSession sends currency if additionalPaymentMethods flag is on', async function () {
-            mockLabs.isSet.withArgs('additionalPaymentMethods').returns(true);
+            mockLabsIsSet.withArgs('additionalPaymentMethods').returns(true);
             await api.createCheckoutSetupSession('priceId', {currency: 'usd'});
 
             should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.currency, 'usd');
@@ -382,8 +383,8 @@ describe('StripeAPI', function () {
                         create: sinon.stub().resolves()
                     }
                 };
-                sinon.stub(mockLabs, 'isSet');
-                mockLabs.isSet.withArgs('stripeAutomaticTax').returns(true);
+                mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
+                mockLabsIsSet.withArgs('stripeAutomaticTax').returns(true);
                 const mockStripeConstructor = sinon.stub().returns(mockStripe);
                 StripeAPI.__set__('Stripe', mockStripeConstructor);
                 api.configure({
@@ -475,7 +476,7 @@ describe('StripeAPI', function () {
             });
 
             it('createDonationCheckoutSession does not send currency if additionalPaymentMethods flag is off', async function () {
-                mockLabs.isSet.withArgs('additionalPaymentMethods').returns(false);
+                mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
                 await api.createDonationCheckoutSession('priceId', {currency: 'usd'});
 
                 should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);


### PR DESCRIPTION
- we weren't using the stubbed instance in many places, so `withArgs` would be invalid because it's not a property on the plain method
- we can fix that by storing the stubbed version in a variable and switching to that
- this fixes a few dozen typing errors
