### PR TITLE
Removed "restart mode" from `startGhost` test utils

### DIFF
--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -25,7 +25,7 @@ describe('Advanced URL Configurations', function () {
             urlUtils.stubUrlUtilsFromConfig();
             mockManager.mockMail();
 
-            await testUtils.startGhost({forceStart: true});
+            await testUtils.startGhost();
 
             request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
         });

--- a/ghost/core/test/e2e-frontend/custom_routes.test.js
+++ b/ghost/core/test/e2e-frontend/custom_routes.test.js
@@ -19,7 +19,6 @@ describe('Custom Frontend routing', function () {
         const routesFilePath = path.join(configUtils.config.get('paths:appRoot'), 'test/utils/fixtures/settings/newroutes.yaml');
 
         await testUtils.startGhost({
-            forceStart: true,
             routesFilePath
         });
         request = supertest.agent(configUtils.config.get('url'));

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -164,14 +164,14 @@ describe('Default Frontend routing', function () {
             before(async function () {
                 configUtils.set('admin:redirects', false);
 
-                await testUtils.startGhost({forceStart: true});
+                await testUtils.startGhost();
                 request = supertest.agent(configUtils.config.get('url'));
             });
 
             after(async function () {
                 await configUtils.restore();
 
-                await testUtils.startGhost({forceStart: true});
+                await testUtils.startGhost();
                 request = supertest.agent(configUtils.config.get('url'));
             });
 

--- a/ghost/core/test/e2e-frontend/middleware.test.js
+++ b/ghost/core/test/e2e-frontend/middleware.test.js
@@ -12,7 +12,7 @@ describe('Middleware Execution', function () {
         loadMemberSessionMiddlewareSpy = sinon.spy(membersService.middleware, 'loadMemberSession');
 
         // Ensure we do a forced start so that spy is in place when the server starts
-        await testUtils.startGhost({forceStart: true});
+        await testUtils.startGhost();
 
         request = supertest.agent(configUtils.config.get('url'));
     });

--- a/ghost/core/test/e2e-frontend/site_id_middleware.test.js
+++ b/ghost/core/test/e2e-frontend/site_id_middleware.test.js
@@ -11,7 +11,7 @@ describe('Site id middleware execution', function () {
             configUtils.set('hostSettings:siteId', '123123');
 
             // Ensure we do a forced start so that spy is in place when the server starts
-            await testUtils.startGhost({forceStart: true});
+            await testUtils.startGhost();
 
             request = supertest.agent(configUtils.config.get('url'));
         });
@@ -82,7 +82,7 @@ describe('Site id middleware execution', function () {
             configUtils.set('hostSettings:siteId', undefined);
 
             // Ensure we do a forced start so that spy is in place when the server starts
-            await testUtils.startGhost({forceStart: true});
+            await testUtils.startGhost();
 
             request = supertest.agent(configUtils.config.get('url'));
         });

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -84,7 +84,7 @@ describe('Admin Routing', function () {
             configUtils.set('url', 'https://localhost:2390');
             urlUtils.stubUrlUtilsFromConfig();
 
-            await testUtils.startGhost({forceStart: true});
+            await testUtils.startGhost();
             request = supertest.agent(config.get('server:host') + ':' + config.get('server:port'));
         });
 

--- a/ghost/core/test/regression/api/admin/redirects.test.js
+++ b/ghost/core/test/regression/api/admin/redirects.test.js
@@ -31,8 +31,7 @@ describe('Redirects API', function () {
                 return startGhost({
                     frontend: true,
                     redirectsFile: false,
-                    contentFolder: contentFolder,
-                    forceStart: true
+                    contentFolder: contentFolder
                 })
                     .then(() => {
                         return request

--- a/ghost/core/test/regression/site/dynamic_routing.test.js
+++ b/ghost/core/test/regression/site/dynamic_routing.test.js
@@ -215,7 +215,7 @@ describe('Dynamic Routing', function () {
             before(function () {
                 configUtils.set('admin:redirects', false);
 
-                return testUtils.startGhost({forceStart: true})
+                return testUtils.startGhost()
                     .then(function () {
                         sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(5);
                         request = supertest.agent(config.get('url'));
@@ -225,7 +225,7 @@ describe('Dynamic Routing', function () {
             after(async function () {
                 await configUtils.restore();
 
-                await testUtils.startGhost({forceStart: true});
+                await testUtils.startGhost();
                 sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(5);
                 request = supertest.agent(config.get('url'));
             });
@@ -415,7 +415,7 @@ describe('Dynamic Routing', function () {
             before(function () {
                 configUtils.set('admin:redirects', false);
 
-                return testUtils.startGhost({forceStart: true})
+                return testUtils.startGhost()
                     .then(function () {
                         sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(5);
                         request = supertest.agent(config.get('url'));
@@ -425,7 +425,7 @@ describe('Dynamic Routing', function () {
             after(async function () {
                 await configUtils.restore();
 
-                await testUtils.startGhost({forceStart: true});
+                await testUtils.startGhost();
                 sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(5);
                 request = supertest.agent(config.get('url'));
             });

--- a/ghost/core/test/regression/site/frontend.test.js
+++ b/ghost/core/test/regression/site/frontend.test.js
@@ -198,14 +198,14 @@ describe('Frontend Routing', function () {
                 before(async function () {
                     configUtils.set('admin:redirects', false);
 
-                    await testUtils.startGhost({forceStart: true});
+                    await testUtils.startGhost();
                     request = supertest.agent(config.get('url'));
                     await addPosts();
                 });
 
                 after(async function () {
                     configUtils.restore();
-                    await testUtils.startGhost({forceStart: true});
+                    await testUtils.startGhost();
                     request = supertest.agent(config.get('url'));
                     await addPosts();
                 });

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -94,15 +94,9 @@ const prepareContentFolder = async (options) => {
     await fs.writeFile(path.join(contentFolderForTests, 'images', '2022', '05', 'test.jpg'), GIF1x1);
 };
 
-// CASE: Ghost Server needs Starting
-// In this case we need to ensure that Ghost is started cleanly:
-// - ensure the DB is reset
-// - CASE: If we are in force start mode the server is already running so we
-//      - stop the server (if we are in force start mode it will be running)
-//      - reload affected services - just settings and not the frontend!?
-// - Start Ghost: Uses OLD Boot process
-const freshModeGhostStart = async (options) => {
-    // Stop the server
+// Stop Ghost if it's running, reset the DB, and start Ghost
+const _startGhost = async (options) => {
+    // Stop the server -- noops if it's not running
     await stopGhost();
 
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
@@ -159,7 +153,7 @@ const startGhost = async (options) => {
     // @TODO: tidy up the tmp folders after tests
     await prepareContentFolder(options);
 
-    await freshModeGhostStart(options);
+    await _startGhost(options);
 
     // Expose fixture data, wrap-up and return
     await exposeFixtures();


### PR DESCRIPTION
no refs

In our e2e test utils, the `startGhost` function has two modes: "Restart mode" and "Fresh mode". The "Restart mode" is run when Ghost is already running, and "Fresh mode" is used when it's not, or when the `forceStart` option is passed.

These test utils have been moved around quite a bit so I haven't been able to unearth the full history of why these two versions of the `startGhost` util were created in the first place, but my assumption is that it was intended as a performance improvement — why fully restart Ghost if we can just reset the DB and some other internal state instead?

However:
1. This leads to unpredictable behavior in our tests that is a huge pain to debug — if Test A starts Ghost and changes some internal state that isn't reset by the "Restart mode", and Test B just starts Ghost, the server could be in an unexpected state, leading to test errors. A good example of this currently in the codebase is if you add a `return testUtils.stopGhost();` line in this [`email_routes.test.js`](https://github.com/TryGhost/Ghost/blob/89493893d1f86c81da90f2387a2b485922efc76b/ghost/core/test/e2e-frontend/email_routes.test.js#L37-L39) after hook to stop the server, and run `yarn test:e2e`, now you'll see test failures in `e2e-frontend/members.test.js`. Adding the `forceStart` in the members test file fixes the problem, but:

2. From my own testing, defaulting to the "restart mode" only saves us ~1 second total when running database tests in CI, or running `yarn test:all` locally in `ghost/core`, which is <1% performance improvement.

This PR removes the "restart mode", and always uses "fresh start mode" — this means whenever you call `testUtils.startGhost()`, it will first stop the Ghost server if it's running, before restarting. It also removes the `forceStart` option and all instances of it, since it doesn't change any behavior anymore, and renames the `freshModeGhostStart` internal function to simply `_startGhost`, since there's now only 1 version.