### PR TITLE
Removed await from explore ping service

### DIFF
--- a/ghost/core/core/server/services/explore-ping/index.js
+++ b/ghost/core/core/server/services/explore-ping/index.js
@@ -27,5 +27,6 @@ module.exports.init = async function init() {
 
     // The final intention is to have this run on a schedule
     // For the initial version, we'll just ping when the server starts
-    await explorePingService.ping();
+    // Without waiting for the response
+    explorePingService.ping();
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- We don't want to wait for the request to complete during boot time
- It doesn't matter at all if this fails, so fire and forget
