### PR TITLE
Added e2e testing for staff tokens

### DIFF
--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -1,0 +1,72 @@
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const assert = require('assert/strict');
+
+describe('Admin API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+    });
+
+    function assertMatchesFixture(fixtureId, response) {
+        const user = response.users[0];
+        const expected = fixtureManager.get('users', fixtureId);
+        assert.equal(user.name, expected.name);
+        assert.equal(user.email, expected.email);
+        assert.equal(user.slug, expected.slug);
+    }
+
+    // The intention of these tests is to generally demonstrate that the staff token is working
+    describe('Staff Tokens - Can fetch own data', function () {
+        it('Owner', async function () {
+            await agent.useStaffTokenForOwner();
+            await agent
+                .get('users/me')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assertMatchesFixture(0, body);
+                });
+        });
+
+        it('Admin', async function () {
+            await agent.useStaffTokenForAdmin();
+            await agent
+                .get('users/me')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assertMatchesFixture(1, body);
+                });
+        });
+
+        it('Editor', async function () {
+            await agent.useStaffTokenForEditor();
+            await agent
+                .get('users/me')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assertMatchesFixture(2, body);
+                });
+        });
+
+        it('Author', async function () {
+            await agent.useStaffTokenForAuthor();
+            await agent
+                .get('users/me')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assertMatchesFixture(3, body);
+                });
+        });
+
+        it('Contributor', async function () {
+            await agent.useStaffTokenForContributor();
+            await agent
+                .get('users/me')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assertMatchesFixture(4, body);
+                });
+        });
+    });
+});

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -257,6 +257,11 @@ const fixtures = {
                 }
 
                 return models.User.edit(user, _.merge({id: ownerUser.id}, context.internal));
+            })
+            .then((ownerUser) => {
+                const userApiKey = {...DataGenerator.Content.user_api_keys[0], user_id: ownerUser.id};
+                // Insert a new API key for the owner user
+                return models.ApiKey.add(userApiKey, context.internal);
             });
     },
 

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -748,6 +748,14 @@ DataGenerator.Content = {
         }
     ],
 
+    user_api_keys: [
+        {
+            id: ObjectId().toHexString(),
+            type: 'admin',
+            secret: _.repeat('f', 64)
+        }
+    ],
+
     emails: [
         {
             id: ObjectId().toHexString(),

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -748,14 +748,6 @@ DataGenerator.Content = {
         }
     ],
 
-    user_api_keys: [
-        {
-            id: ObjectId().toHexString(),
-            type: 'admin',
-            secret: _.repeat('f', 64)
-        }
-    ],
-
     emails: [
         {
             id: ObjectId().toHexString(),
@@ -1511,6 +1503,45 @@ DataGenerator.forKnex = (function () {
         }
     ];
 
+    const user_api_keys = [
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[0].id, // owner
+            type: 'admin',
+            secret: _.repeat('0', 64)
+        },
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[1].id, // admin
+            type: 'admin',
+            secret: _.repeat('1', 64)
+        },
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[2].id, // editor
+            type: 'admin',
+            secret: _.repeat('2', 64)
+        },
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[3].id, // author
+            type: 'admin',
+            secret: _.repeat('3', 64)
+        },
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[7].id, // contributor
+            type: 'admin',
+            secret: _.repeat('4', 64)
+        },
+        {
+            id: ObjectId().toHexString(),
+            user_id: DataGenerator.Content.users[9].id,
+            type: 'admin',
+            secret: _.repeat('5', 64)
+        }
+    ];
+
     const posts_meta = [
         {
             id: ObjectId().toHexString(),
@@ -1995,6 +2026,7 @@ DataGenerator.forKnex = (function () {
         roles,
         users,
         roles_users,
+        user_api_keys,
         webhooks,
         integrations,
         api_keys,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2148/improve-staff-token-api-access

- With the addition of device verification, User Authentication really becomes _only_ for "on-session" usage. For everything else, staff or integration tokens need to be used
- ATM our staff tokens don't have enough permissions to be useful
- This PR wires up all the testing tooling so we can start to use staff tokens for testing instead of user auth, as well as demonstrating that they are working as we expect
- Have made some pretty unpleasant changes to our fixture tooling to make this work - this needs a review and an attempt at simplification. For today, I just want to get the tools to work and have some basic tests in place and then I'll know if I've broken anything :) 