### PR TITLE
Removed build step from admin-x-design-system test:unit command

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.declaration.json && vite build",
     "prepare": "yarn build",
     "test": "yarn test:unit",
-    "test:unit": "yarn test:types && yarn nx build && vitest run",
+    "test:unit": "yarn test:types && vitest run",
     "test:types": "tsc --noEmit",
     "lint:code": "eslint --ext .js,.ts,.cjs,.tsx src/ --cache",
     "lint": "yarn lint:code && yarn lint:test",


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1747315171428959

We've had some flaky results in our CI pipeline's unit tests. It seems that `admin-x-design-system` is the culprit, causing other apps that depend on it to fail. In these logs, the @tryghost/posts app's unit tests fail because it can't find imports from `admin-x-design-system`. Since this problem seems to come and go, I can't be sure that this change will fix it, but my hypothesis is that:
1. admin-x-design-system's build files are cached by NX, so @tryghost/posts unit tests are able to start right away
2. admin-x-design-system then starts running its unit tests simultaneously
3. in the admin-x-design-system's `test:unit` command, it explicitly runs another `yarn nx build` for itself
4. this clears the build files momentarily, which is enough to cause its dependent packages, like @tryghost/posts, to fail

```
🔁 > nx run @tryghost/shade:build  [local cache]
🔁 > nx run @tryghost/admin-x-design-system:build  [local cache]
🔁 > nx run @tryghost/admin-x-framework:build  [local cache]
✅ > nx run ghost:"build:assets"
✅ > nx run @tryghost/stats:"test:unit"
❌ > nx run @tryghost/posts:"test:unit"
✅ > nx run @tryghost/admin-x-design-system:"test:unit"
🔁 > nx run @tryghost/admin-x-design-system:build  [local cache]
```

```
   FAIL  test/unit/hooks/useEditLinks.test.tsx [ test/unit/hooks/useEditLinks.test.tsx ]
   FAIL  test/unit/hooks/usePostNewsletterStats.test.tsx [ test/unit/hooks/usePostNewsletterStats.test.tsx ]
  Error: Cannot find module '/@fs/home/runner/work/Ghost/Ghost/apps/admin-x-design-system/es/settings/SettingGroupHeader.js' imported from '/home/runner/work/Ghost/Ghost/apps/admin-x-design-system/es/settings/SettingGroup.js'
```