### PR TITLE
Updated dependencies for posts app

### DIFF
--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -26,12 +26,23 @@
         "preview": "vite preview"
     },
     "devDependencies": {
+        "@tanstack/react-query": "4.36.1",
         "@testing-library/react": "14.3.1",
+        "@types/jest": "29.5.14",
         "@types/react": "18.3.21",
-        "@types/react-dom": "18.3.7",
         "msw": "2.8.3",
         "vite": "4.5.14",
         "vitest": "0.34.3"
+    },
+    "dependencies": {
+        "@tinybirdco/charts": "0.2.4",
+        "@tryghost/admin-x-framework": "0.0.0",
+        "@tryghost/shade": "0.0.0",
+        "i18n-iso-countries": "7.14.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "moment-timezone": "0.5.45",
+        "moment": "2.24.0"
     },
     "nx": {
         "targets": {
@@ -51,12 +62,5 @@
                 ]
             }
         }
-    },
-    "dependencies": {
-        "@tinybirdco/charts": "0.2.4",
-        "@tryghost/admin-x-framework": "0.0.0",
-        "@tryghost/shade": "0.0.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
     }
 }


### PR DESCRIPTION
no refs

This commit adds dependencies that were being used in the posts app, but weren't declared as dependencies. It also removes a few packages that were declared, but not used.