### PR TITLE
Removed yarn cache from docker build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -70,9 +70,7 @@ COPY ghost/admin/package.json ghost/admin/package.json
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 
-RUN --mount=type=cache,target=/home/ghost/.yarn-cache \
-    yarn config set cache-folder /home/ghost/.yarn-cache && \
-    yarn install --frozen-lockfile --prefer-offline
+RUN yarn install --frozen-lockfile --prefer-offline
 
 # --------------------
 # Development


### PR DESCRIPTION
no refs

A few people have experienced some consistent and difficult to debug dependency errors this past week. I've also run into a few similar issues when changing branches frequently, and removing this cache seems to resolve them for me. Hopefully this will also solve the issues that others have been seeing, at the cost of slightly longer build times.