### PR TITLE
Added `yarn build` step to Docker build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -77,4 +77,5 @@ RUN yarn install --frozen-lockfile --prefer-offline
 # --------------------
 FROM development-base AS development
 COPY . .
+RUN yarn build
 CMD ["yarn", "dev"]


### PR DESCRIPTION
no refs

We used to have a `build:ts` step here, which would build all the typescript packages in the monorepo. Since we no longer have typescript packages in `ghost/*`, we removed that step.

However, we do have apps that should be built. The builds for these apps would be triggered automatically when running `yarn dev` in the container (i.e. with `docker compose up`), but really we should build these packages at build time, rather than run time, so we know they are all built when running other targets in the container (i.e. tests).

This will make the Docker build take a bit longer, but the container should be more stable as everything should be fully built and ready after the docker build now.
