### PR TITLE
Updated dependencies for stats apps

### DIFF
--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -31,11 +31,12 @@
     "devDependencies": {
         "@svg-maps/world": "1.0.1",
         "@testing-library/react": "14.3.1",
+        "@testing-library/jest-dom": "6.6.3",
         "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-framework": "0.0.0",
         "@tryghost/shade": "0.0.0",
+        "@types/jest": "29.5.14",
         "@types/react": "18.3.21",
-        "@types/react-dom": "18.3.7",
         "@types/react-svg-map": "2.1.4",
         "@vitejs/plugin-react": "4.4.1",
         "moment-timezone": "^0.5.48",
@@ -44,6 +45,16 @@
         "react-svg-map": "2.2.0",
         "vite": "4.5.14",
         "vitest": "0.34.3"
+    },
+    "dependencies": {
+        "@svg-maps/world": "1.0.1",
+        "@tryghost/admin-x-framework": "0.0.0",
+        "@tryghost/shade": "0.0.0",
+        "i18n-iso-countries": "7.14.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "react-svg-map": "2.2.0",
+        "moment": "2.24.0"
     },
     "nx": {
         "targets": {
@@ -63,17 +74,5 @@
                 ]
             }
         }
-    },
-    "dependencies": {
-        "@radix-ui/react-form": "0.1.6",
-        "@svg-maps/world": "1.0.1",
-        "@tryghost/admin-x-framework": "0.0.0",
-        "@tryghost/shade": "0.0.0",
-        "clsx": "2.1.1",
-        "i18n-iso-countries": "7.14.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
-        "react-svg-map": "2.2.0",
-        "use-debounce": "10.0.4"
     }
 }

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -29,32 +29,26 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@svg-maps/world": "1.0.1",
         "@testing-library/react": "14.3.1",
-        "@testing-library/jest-dom": "6.6.3",
-        "@tinybirdco/charts": "0.2.4",
-        "@tryghost/admin-x-framework": "0.0.0",
-        "@tryghost/shade": "0.0.0",
+        "@testing-library/jest-dom": "5.17.0",
         "@types/jest": "29.5.14",
         "@types/react": "18.3.21",
         "@types/react-svg-map": "2.1.4",
         "@vitejs/plugin-react": "4.4.1",
-        "moment-timezone": "^0.5.48",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
-        "react-svg-map": "2.2.0",
         "vite": "4.5.14",
         "vitest": "0.34.3"
     },
     "dependencies": {
         "@svg-maps/world": "1.0.1",
+        "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-framework": "0.0.0",
         "@tryghost/shade": "0.0.0",
         "i18n-iso-countries": "7.14.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-svg-map": "2.2.0",
-        "moment": "2.24.0"
+        "moment": "2.24.0",
+        "moment-timezone": "0.5.45"
     },
     "nx": {
         "targets": {


### PR DESCRIPTION
no refs

Added dependencies that are used in the stats app, but not declared in the package.json. Also removed a few dependencies that aren't actually used. Also moves some dependencies from `devDependencies` to `dependencies`, since they are used in the apps source code.

Modern package managers like pnpm and yarn 4 don't allow undeclared dependencies, so this is the first step in migrating to a more modern package manager, plus it's just good practice in general.
