### PR TITLE
Added `yarn install` to docker entrypoint if yarn.lock has changed

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -50,6 +50,10 @@ WORKDIR /home/ghost
 
 COPY package.json yarn.lock ./
 
+# Calculate a hash of the yarn.lock file
+## See development.entrypoint.sh for more info
+RUN mkdir -p .yarnhash && md5sum yarn.lock | awk '{print $1}' > .yarnhash/yarn.lock.md5
+
 # Copy all package.json files
 COPY apps/stats/package.json apps/stats/package.json
 COPY apps/admin-x-activitypub/package.json apps/admin-x-activitypub/package.json

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Runs `yarn install` if `yarn.lock` has changed to avoid a full `docker build` when changing branches/dependencies
 ## Dockerfile calculates a hash and stores it in `.yarnhash/yarn.lock.md5`
 ## compose.yml mounts a named volume to persist the `.yarnhash` directory
 yarn_lock_hash_file_path=".yarnhash/yarn.lock.md5"
+calculated_hash=$(md5sum yarn.lock | awk '{print $1}')
+
 if [ -f "$yarn_lock_hash_file_path" ]; then
     stored_hash=$(cat "$yarn_lock_hash_file_path")
-    calculated_hash=$(md5sum yarn.lock | awk '{print $1}')
     if [ "$calculated_hash" != "$stored_hash" ]; then
         echo "INFO: yarn.lock has changed. Running yarn install..."
-        yarn install
+        yarn install --frozen-lockfile
+        echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi
 else
     echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
-    yarn install
+    yarn install --frozen-lockfile
+    echo "$calculated_hash" > "$yarn_lock_hash_file_path"
 fi
-
 yarn nx reset
 
 # Execute the CMD

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Runs `yarn install` if `yarn.lock` has changed to avoid a full `docker build` when changing branches/dependencies
+## Dockerfile calculates a hash and stores it in `.yarnhash/yarn.lock.md5`
+## compose.yml mounts a named volume to persist the `.yarnhash` directory
+yarn_lock_hash_file_path=".yarnhash/yarn.lock.md5"
+if [ -f "$yarn_lock_hash_file_path" ]; then
+    stored_hash=$(cat "$yarn_lock_hash_file_path")
+    calculated_hash=$(md5sum yarn.lock | awk '{print $1}')
+    if [ "$calculated_hash" != "$stored_hash" ]; then
+        echo "INFO: yarn.lock has changed. Running yarn install..."
+        yarn install
+    fi
+else
+    echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
+    yarn install
+fi
+
 yarn nx reset
 
 # Execute the CMD

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ temp*.sql
 # Docker Yarn Cache
 .yarncache
 .yarncachecopy
+.yarnhash

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ x-service-template: &service-template
     - .:/home/ghost
     - ${SSH_AUTH_SOCK}:/ssh-agent
     - ${HOME}/.gitconfig:/root/.gitconfig:ro
+    - node_modules_yarn_lock_hash:/home/ghost/.yarnhash:delegated
     - node_modules_ghost_root:/home/ghost/node_modules:delegated
     - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
     - node_modules_ghost_core:/home/ghost/ghost/core/node_modules:delegated
@@ -135,6 +136,7 @@ services:
 volumes:
   mysql-data: {}
   redis-data: {}
+  node_modules_yarn_lock_hash: {}
   node_modules_ghost_root: {}
   node_modules_ghost_admin: {}
   node_modules_ghost_core: {}


### PR DESCRIPTION
no refs

Currently when you change branches or pull from main and the dependencies have changed, you either have to do a full docker build (which takes a few minutes to complete) or you have to open a shell into the container and run `yarn install` to get the updated dependencies reflected in your container. This commit aims to do this automatically so you can more easily switch branches and have your dependencies updated, without having to do a full rebuild or otherwise intervene manually.

It does so by:
- Calculating a hash of the `yarn.lock` file in the docker build, and persisting it in a file in the image at `.yarnhash/yarn.lock.md5`
- In the development entrypoint, calculating a hash of the current `yarn.lock` and comparing it to the one persisted at `.yarnhash/yarn.lock.md5`. If there is a mismatch, this indicates the `yarn.lock` has changed, so it runs `yarn install` to update the dependencies. If they match, it does nothing.

The hash is persisted in a named volume in the `compose.yml` file, so it will have the same life-cycle as the `node_modules` volumes. Running `yarn docker:build` will delete these volumes, including the hash, thus providing a fully fresh install. 

Every time the image is run (i.e. using `yarn docker:dev` or `yarn docker:shell`), this check will run to ensure you have the correct dependencies installed in the `node_modules` volumes. 