### PR TITLE
Refactored ProfileMenu to use children as trigger in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.31",
+  "version": "0.7.32",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -20,7 +20,7 @@ import {
 
 interface ProfileMenuProps {
     account?: Account,
-    trigger: React.ReactNode;
+    children: React.ReactNode;
     onCopyHandle: () => void;
     onBlockAccount: () => void;
     onBlockDomain: () => void;
@@ -31,7 +31,7 @@ interface ProfileMenuProps {
 
 const ProfileMenu: React.FC<ProfileMenuProps> = ({
     account,
-    trigger,
+    children,
     onCopyHandle,
     onBlockAccount,
     onBlockDomain,
@@ -111,7 +111,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
         <>
             <Popover>
                 <PopoverTrigger disabled={disabled} asChild onClick={e => e.stopPropagation()}>
-                    {trigger}
+                    {children}
                 </PopoverTrigger>
                 <PopoverContent align="end" className='p-2'>
                     <div className='flex w-48 flex-col'>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -203,11 +203,12 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                             account={account}
                                             isBlocked={isBlocked}
                                             isDomainBlocked={isDomainBlocked}
-                                            trigger={<Button aria-label='Open profile menu' variant='outline'><LucideIcon.Ellipsis /></Button>}
                                             onBlockAccount={handleBlock}
                                             onBlockDomain={handleDomainBlock}
                                             onCopyHandle={handleCopy}
-                                        />
+                                        >
+                                            <Button aria-label='Open profile menu' variant='outline'><LucideIcon.Ellipsis /></Button>
+                                        </ProfileMenu>
                                     </div>
                                 }
                                 {isCurrentUser && !isLoadingAccount &&


### PR DESCRIPTION
no issues

- Replaced trigger prop with children pattern for ProfileMenu component
- Improved flexibility by allowing any element to serve as the menu trigger and making it more composable at the same time