### PR TITLE
Fixed docker entrypoint error when a working directory is specified

### DIFF
--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -18,6 +18,7 @@ if [ -f "$yarn_lock_hash_file_path" ]; then
 else
     echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
     yarn install --frozen-lockfile
+    mkdir -p .yarnhash
     echo "$calculated_hash" > "$yarn_lock_hash_file_path"
 fi
 yarn nx reset

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -5,23 +5,27 @@ set -euo pipefail
 # Runs `yarn install` if `yarn.lock` has changed to avoid a full `docker build` when changing branches/dependencies
 ## Dockerfile calculates a hash and stores it in `.yarnhash/yarn.lock.md5`
 ## compose.yml mounts a named volume to persist the `.yarnhash` directory
-yarn_lock_hash_file_path=".yarnhash/yarn.lock.md5"
-calculated_hash=$(md5sum yarn.lock | awk '{print $1}')
+(
+    cd /home/ghost
+    yarn_lock_hash_file_path=".yarnhash/yarn.lock.md5"
+    calculated_hash=$(md5sum yarn.lock | awk '{print $1}')
 
-if [ -f "$yarn_lock_hash_file_path" ]; then
-    stored_hash=$(cat "$yarn_lock_hash_file_path")
-    if [ "$calculated_hash" != "$stored_hash" ]; then
-        echo "INFO: yarn.lock has changed. Running yarn install..."
+    if [ -f "$yarn_lock_hash_file_path" ]; then
+        stored_hash=$(cat "$yarn_lock_hash_file_path")
+        if [ "$calculated_hash" != "$stored_hash" ]; then
+            echo "INFO: yarn.lock has changed. Running yarn install..."
+            yarn install --frozen-lockfile
+            mkdir -p .yarnhash
+            echo "$calculated_hash" > "$yarn_lock_hash_file_path"
+        fi
+    else
+        echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
         yarn install --frozen-lockfile
+        mkdir -p .yarnhash
         echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi
-else
-    echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
-    yarn install --frozen-lockfile
-    mkdir -p .yarnhash
-    echo "$calculated_hash" > "$yarn_lock_hash_file_path"
-fi
-yarn nx reset
+    yarn nx reset
+)
 
 # Execute the CMD
 exec "$@"

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -24,8 +24,9 @@ set -euo pipefail
         mkdir -p .yarnhash
         echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi
-    yarn nx reset
 )
+
+yarn nx reset
 
 # Execute the CMD
 exec "$@"


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/c7449a1a8953e3b1a1c25160479d23feb51f1556

The above commit added a script to the docker entrypoint to update dependencies when the `yarn.lock` file changes. This commit adds two things to prevent potential errors:

1. Runs the `yarn.lock` hash & comparison in a sub-shell, so we can first `cd` into the root of the repo. This is necessary when passing a working directory to the container that ins't the root of the repo.
2. Creates the `.yarnhash` directory if it doesn't exist yet, preventing an error when trying to write to the directory. 
