### PR TITLE
Updated stats newsletters to show only one newsletter

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -154,12 +154,76 @@ export const useMrrHistory = createQuery<MrrHistoryResponseType>({
     path: '/stats/mrr/'
 });
 
+export interface NewsletterStatsSearchParams {
+    newsletterId?: string;
+    date_from?: string;
+    date_to?: string;
+    order?: string;
+    limit?: number;
+}
+
+export interface SubscriberCountSearchParams {
+    newsletterId?: string;
+    date_from?: string;
+    date_to?: string;
+}
+
 export const useNewsletterStats = createQuery<NewsletterStatsResponseType>({
     dataType: newsletterStatsDataType,
-    path: '/stats/newsletter-stats/'
+    path: '/stats/newsletter-stats/',
+    defaultSearchParams: {
+        // Empty default params, will be filled by the hook
+    }
 });
+
+// Hook wrapper to accept a newsletterId parameter
+export const useNewsletterStatsByNewsletterId = (newsletterId?: string, options: Partial<NewsletterStatsSearchParams> = {}) => {
+    const searchParams: Record<string, string> = {};
+    
+    if (newsletterId) {
+        searchParams.newsletter_id = newsletterId;
+    }
+    
+    // Add any additional search params
+    if (options.date_from) {
+        searchParams.date_from = options.date_from;
+    }
+    if (options.date_to) {
+        searchParams.date_to = options.date_to;
+    }
+    if (options.order) {
+        searchParams.order = options.order;
+    }
+    if (options.limit) {
+        searchParams.limit = options.limit.toString();
+    }
+    
+    return useNewsletterStats({searchParams});
+};
 
 export const useSubscriberCount = createQuery<NewsletterSubscriberStatsResponseType>({
     dataType: newsletterSubscriberStatsDataType,
-    path: '/stats/subscriber-count/'
+    path: '/stats/subscriber-count/',
+    defaultSearchParams: {
+        // Empty default params, will be filled by the hook
+    }
 });
+
+// Hook wrapper to accept a newsletterId parameter
+export const useSubscriberCountByNewsletterId = (newsletterId?: string, options: Partial<SubscriberCountSearchParams> = {}) => {
+    const searchParams: Record<string, string> = {};
+    
+    if (newsletterId) {
+        searchParams.newsletter_id = newsletterId;
+    }
+    
+    // Add any additional search params
+    if (options.date_from) {
+        searchParams.date_from = options.date_from;
+    }
+    if (options.date_to) {
+        searchParams.date_to = options.date_to;
+    }
+    
+    return useSubscriberCount({searchParams});
+};

--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -51,7 +51,7 @@ export const usePostNewsletterStats = (postId: string) => {
     const {data: newsletterStatsResponse, isLoading: isNewsletterStatsLoading} = useNewsletterStatsByNewsletterId(newsletterId);
 
     // Get the top 5 link clicks from this post
-    const {data: clicksResponse, isLoading: isClicksLoading} = useTopLinks({
+    const {data: clicksResponse, isLoading: isClicksLoading, refetch: refetchTopLinks} = useTopLinks({
         searchParams: {
             post_id: postId,
             limit: '5',
@@ -114,6 +114,7 @@ export const usePostNewsletterStats = (postId: string) => {
         stats,
         averageStats,
         topLinks,
+        refetchTopLinks,
         isLoading: isPostLoading || isNewsletterStatsLoading || isClicksLoading
     };
 };

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -18,6 +18,9 @@ export const getRangeDates = (rangeInDays: number) => {
     } else if (rangeInDays === 1000) {
         // All time - use a far past date
         dateFrom = '2010-01-01';
+    } else if (rangeInDays === -1) {
+        // Year to date - use January 1st of current year
+        dateFrom = moment.utc().startOf('year').format('YYYY-MM-DD');
     } else {
         // Specific range
         // Guard against invalid ranges

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -1,6 +1,6 @@
 import {getRangeDates} from './useGrowthStats';
 import {useMemo} from 'react';
-import {useNewsletterStats, useSubscriberCount} from '@tryghost/admin-x-framework/api/stats';
+import {useNewsletterStatsByNewsletterId, useSubscriberCountByNewsletterId} from '@tryghost/admin-x-framework/api/stats';
 
 /**
  * Represents the possible fields to order top newsletters by.
@@ -13,29 +13,22 @@ export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate d
  *
  * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
  * @param order - The field and direction to order by (e.g., 'open_rate desc'). Defaults to 'date desc'.
+ * @param newsletterId - Optional ID of the specific newsletter to get stats for
  */
-export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslettersOrder) => {
+export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslettersOrder, newsletterId?: string) => {
     // Default range and order
     const currentRange = range ?? 30;
     const currentOrder = order ?? 'date desc'; // Default to date descending
 
     // Calculate date strings using the helper, memoize for stability
     const {dateFrom, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
-
-    // Construct searchParams including the order parameter
-    const searchParams = {
+    
+    // Call the hook with the parameters
+    return useNewsletterStatsByNewsletterId(newsletterId, {
         date_from: dateFrom,
         date_to: endDate,
         order: currentOrder
-    };
-
-    // Filter out undefined values
-    const filteredSearchParams = Object.fromEntries(
-        Object.entries(searchParams).filter(([, value]) => value !== undefined)
-    );
-    
-    // Call the hook with the filtered parameters
-    return useNewsletterStats({searchParams: filteredSearchParams});
+    });
 };
 
 /**
@@ -43,25 +36,18 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
  * to API query parameters.
  * 
  * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
+ * @param newsletterId - Optional ID of the specific newsletter to get stats for
  */
-export const useSubscriberCountWithRange = (range?: number) => {
+export const useSubscriberCountWithRange = (range?: number, newsletterId?: string) => {
     // Default range
     const currentRange = range ?? 30;
 
     // Calculate date strings using the helper, memoize for stability
     const {dateFrom, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
-
-    // Construct searchParams for date range
-    const searchParams = {
+    
+    // Call the hook with the parameters
+    return useSubscriberCountByNewsletterId(newsletterId, {
         date_from: dateFrom,
         date_to: endDate
-    };
-
-    // Filter out undefined values
-    const filteredSearchParams = Object.fromEntries(
-        Object.entries(searchParams).filter(([, value]) => value !== undefined)
-    );
-    
-    // Call the hook with the filtered parameters
-    return useSubscriberCount({searchParams: filteredSearchParams});
+    });
 }; 

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -4,7 +4,7 @@ import {STATS_DEFAULT_RANGE_KEY, STATS_RANGE_OPTIONS} from '@src/utils/constants
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig} from '@tryghost/admin-x-framework';
 
-type GlobalDataContextType = {
+interface GlobalData {
     data: Config | undefined;
     statsConfig: StatsConfig | undefined;
     isLoading: boolean;
@@ -12,14 +12,16 @@ type GlobalDataContextType = {
     audience: number;
     setAudience: (value: number) => void;
     setRange: (value: number) => void;
-    settings: Setting[]
+    settings: Setting[];
+    selectedNewsletterId: string | null;
+    setSelectedNewsletterId: (id: string | null) => void;
 }
 
-const GlobalDataContext = createContext<GlobalDataContextType | undefined>(undefined);
+const GlobalDataContext = createContext<GlobalData | undefined>(undefined);
 
 export const useGlobalData = () => {
     const context = useContext(GlobalDataContext);
-    if (!context) {
+    if (context === undefined) {
         throw new Error('useGlobalData must be used within a GlobalDataProvider');
     }
     return context;
@@ -31,6 +33,7 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
+    const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
     const requests = [config, settings];
     const error = requests.map(request => request.error).find(Boolean);
@@ -48,7 +51,9 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
         setRange,
         audience,
         setAudience,
-        settings: settings.data?.settings || []
+        settings: settings.data?.settings || [],
+        selectedNewsletterId,
+        setSelectedNewsletterId
     }}>
         {children}
     </GlobalDataContext.Provider>;

--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -97,7 +97,16 @@ export const calculateYAxisWidth = (ticks: number[], formatter: (value: number) 
 export const getRangeDates = (range: number) => {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const endDate = moment().tz(timezone).endOf('day');
-    const startDate = moment().tz(timezone).subtract(range - 1, 'days').startOf('day');
+    let startDate;
+    
+    if (range === -1) {
+        // Year to date - use January 1st of current year
+        startDate = moment().tz(timezone).startOf('year');
+    } else {
+        // Regular range calculation
+        startDate = moment().tz(timezone).subtract(range - 1, 'days').startOf('day');
+    }
+    
     return {startDate, endDate, timezone};
 };
 
@@ -132,7 +141,7 @@ export const getPeriodText = (range: number): string => {
 /**
  * Sanitizes chart data based on the date range
  * - For ranges between 91-356 days: shows weekly changes
- * - For ranges above 356 days: shows monthly changes
+ * - For ranges above 356 days or YTD: shows monthly changes  
  * - For other ranges: keeps data as is
  * @param data The chart data to sanitize
  * @param range The date range in days
@@ -144,7 +153,95 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
         return [];
     }
 
-    if (range >= 91 && range <= 356) {
+    // Helper function to detect potential bulk import events
+    const detectBulkImports = (items: Array<T>) => {
+        if (items.length <= 1) {
+            return items;
+        }
+
+        // Calculate average and standard deviation
+        const values = items.map(item => Number(item[fieldName]));
+        const avg = values.reduce((sum, val) => sum + val, 0) / values.length;
+        const stdDev = Math.sqrt(
+            values.reduce((sum, val) => sum + Math.pow(val - avg, 2), 0) / values.length
+        );
+
+        // Consider values that are more than 3 standard deviations from mean as outliers
+        const threshold = avg + (3 * stdDev);
+        
+        return items.map((item) => {
+            const value = Number(item[fieldName]);
+            // If value is an outlier, mark it with a flag
+            return {
+                ...item,
+                _isOutlier: value > threshold && value > avg * 5 // Ensure it's both statistically significant and at least 5x average
+            };
+        });
+    };
+
+    // Calculate the actual date span to determine appropriate aggregation
+    const dateSpan = data.length > 1 ? 
+        moment(data[data.length - 1].date).diff(moment(data[0].date), 'days') : 0;
+
+    // For YTD, use weekly aggregation if more than 60 days, or monthly if more than 150 days
+    if (range === -1) {
+        if (dateSpan > 150) {
+            range = 400; // Force monthly aggregation
+        } else if (dateSpan > 60) {
+            range = 100; // Force weekly aggregation
+        }
+    }
+
+    // For 'exact' aggregation type (like subscriber counts), always use month-end or key points approach
+    if (aggregationType === 'exact' && (range > 356 || (range === -1 && dateSpan > 150))) {
+        // For long ranges with cumulative data, we'll use a smarter approach
+        // that preserves important data points while reducing noise
+        
+        const importantPoints = new Map<string, T>();
+        
+        // First, identify month boundaries (first/last day of each month)
+        data.forEach((item) => {
+            const itemDate = moment(item.date);
+            const monthKey = itemDate.format('YYYY-MM');
+            
+            // Keep the first day of each month
+            const firstDayKey = `${monthKey}-first`;
+            if (!importantPoints.has(firstDayKey) || 
+                moment(item.date).isBefore(moment(importantPoints.get(firstDayKey)!.date))) {
+                importantPoints.set(firstDayKey, {...item});
+            }
+            
+            // Keep the last day of each month
+            const lastDayKey = `${monthKey}-last`;
+            if (!importantPoints.has(lastDayKey) || 
+                moment(item.date).isAfter(moment(importantPoints.get(lastDayKey)!.date))) {
+                importantPoints.set(lastDayKey, {...item});
+            }
+        });
+        
+        // Also identify significant changes (>2% increase from previous)
+        let lastValue = Number(data[0][fieldName]);
+        data.forEach((item) => {
+            const currentValue = Number(item[fieldName]);
+            // If there's a significant increase from the last captured value
+            if (currentValue > lastValue * 1.02) { // 2% threshold
+                importantPoints.set(`significant-${item.date}`, {...item});
+                lastValue = currentValue;
+            }
+        });
+        
+        // Always include first and last points in the dataset
+        importantPoints.set('first', {...data[0]});
+        importantPoints.set('last', {...data[data.length - 1]});
+        
+        // Convert to sorted array
+        const result = Array.from(importantPoints.values())
+            .sort((a, b) => moment(a.date).diff(moment(b.date)));
+            
+        return detectBulkImports(result);
+    }
+    
+    if ((range >= 91 && range <= 356) || (range === -1 && dateSpan > 60 && dateSpan <= 150)) {
         // Weekly changes
         const weeklyData: T[] = [];
         let currentWeek = moment(data[0].date).startOf('week');
@@ -187,8 +284,8 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
             }
         });
 
-        return weeklyData;
-    } else if (range > 356) {
+        return detectBulkImports(weeklyData);
+    } else if (range > 356 || (range === -1 && dateSpan > 150)) {
         // Monthly changes
         const monthlyData: T[] = [];
         let currentMonth = moment(data[0].date).startOf('month');
@@ -196,27 +293,58 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
         let monthCount = 0;
         let lastValue = 0;
 
+        // For cumulative data like subscriber counts, we take the last value for each month
+        if (aggregationType === 'exact') {
+            const monthMap = new Map<string, T>();
+            
+            // Group by month and keep the latest entry for each month
+            data.forEach((item) => {
+                const itemDate = moment(item.date);
+                const monthKey = itemDate.format('YYYY-MM');
+                
+                if (!monthMap.has(monthKey) || moment(item.date).isAfter(moment(monthMap.get(monthKey)!.date))) {
+                    monthMap.set(monthKey, {...item});
+                }
+            });
+            
+            // Convert map to sorted array
+            const sortedMonths = Array.from(monthMap.entries())
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([, value]) => value);
+                
+            return detectBulkImports(sortedMonths);
+        }
+        
+        // For non-cumulative data (sum/avg)
         data.forEach((item, index) => {
             const itemDate = moment(item.date);
+            const value = Number(item[fieldName]);
+            
             if (itemDate.isSame(currentMonth, 'month')) {
-                monthTotal += Number(item[fieldName]);
-                monthCount += 1;
-                lastValue = Number(item[fieldName]);
+                // Simple heuristic to detect bulk imports
+                const isLikelyOutlier = aggregationType === 'sum' && value > 10000;
+                if (!isLikelyOutlier) {
+                    monthTotal += value;
+                    monthCount += 1;
+                }
+                lastValue = value;
             } else {
                 // Add the value for the previous month
                 monthlyData.push({
                     ...data[index - 1],
                     date: currentMonth.format('YYYY-MM-DD'),
-                    [fieldName]: aggregationType === 'sum' ? monthTotal :
-                        aggregationType === 'avg' ? (monthCount > 0 ? monthTotal / monthCount : 0) :
-                            lastValue
+                    [fieldName]: aggregationType === 'sum' 
+                        ? monthTotal // Use the accumulated total
+                        : aggregationType === 'avg' 
+                            ? (monthCount > 0 ? monthTotal / monthCount : 0) 
+                            : lastValue
                 } as T);
 
                 // Start new month
                 currentMonth = itemDate.startOf('month');
-                monthTotal = Number(item[fieldName]);
+                monthTotal = value;
                 monthCount = 1;
-                lastValue = Number(item[fieldName]);
+                lastValue = value;
             }
 
             // Handle the last item
@@ -224,18 +352,20 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
                 monthlyData.push({
                     ...item,
                     date: currentMonth.format('YYYY-MM-DD'),
-                    [fieldName]: aggregationType === 'sum' ? monthTotal :
-                        aggregationType === 'avg' ? (monthCount > 0 ? monthTotal / monthCount : 0) :
-                            lastValue
+                    [fieldName]: aggregationType === 'sum' 
+                        ? monthTotal
+                        : aggregationType === 'avg' 
+                            ? (monthCount > 0 ? monthTotal / monthCount : 0) 
+                            : lastValue
                 } as T);
             }
         });
 
-        return monthlyData;
+        return detectBulkImports(monthlyData);
     }
 
-    // Return original data for ranges < 91 days
-    return data;
+    // Return data as is for other ranges
+    return detectBulkImports(data);
 };
 
 /**

--- a/apps/stats/src/utils/constants.ts
+++ b/apps/stats/src/utils/constants.ts
@@ -3,7 +3,7 @@ export const STATS_RANGE_OPTIONS = [
     {name: 'Last 7 days', value: 7},
     {name: 'Last 30 days', value: 30 + 1},
     {name: 'Last 3 months', value: 90 + 1},
-    {name: 'Year to date', value: 365 + 1},
+    {name: 'Year to date', value: -1},
     {name: 'Last 12 months', value: 12 * (30 + 1)},
     {name: 'All time', value: 1000}
 ];

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -124,7 +124,7 @@ const NewsletterKPIs: React.FC<{
 
         // First sanitize the data based on range
         sanitizedData = sanitizeChartData(allSubscribersData, range, 'value', 'exact');
-        
+
         // Convert from deltas to running count (backwards from total)
         let runningTotal = totalSubscribers;
         const cumulativeData = [...sanitizedData].reverse().map((item) => {
@@ -162,7 +162,7 @@ const NewsletterKPIs: React.FC<{
 
     return (
         <Tabs defaultValue="total-subscribers" variant='kpis'>
-            <TabsList className="-mx-6 grid grid-cols-5">
+            <TabsList className="-mx-6 grid grid-cols-3">
                 <KpiTabTrigger value="total-subscribers" onClick={() => {
                     setCurrentTab('total-subscribers');
                 }}>
@@ -265,6 +265,7 @@ const NewsletterKPIs: React.FC<{
                                 fill="hsl(var(--chart-1))"
                                 isAnimationActive={false}
                                 maxBarSize={32}
+                                minPointSize={2}
                                 radius={0}>
                                 {avgsData.map(entry => (
                                     <Recharts.Cell
@@ -292,12 +293,12 @@ const Newsletters: React.FC = () => {
 
     // Get stats from real data using the new hooks with selected newsletter
     const {data: newsletterStatsData, isLoading: isStatsLoading} = useNewsletterStatsWithRange(
-        range, 
-        sortBy, 
+        range,
+        sortBy,
         selectedNewsletterId || undefined
     );
     const {data: subscriberStatsData, isLoading: isSubscriberStatsLoading} = useSubscriberCountWithRange(
-        range, 
+        range,
         selectedNewsletterId || undefined
     );
 

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -1,0 +1,53 @@
+import React, {useEffect, useMemo} from 'react';
+import {Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue} from '@tryghost/shade';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
+
+const NewsletterSelect: React.FC = () => {
+    const {selectedNewsletterId, setSelectedNewsletterId} = useGlobalData();
+    const {data: {newsletters} = {}} = useBrowseNewsletters();
+
+    // Filter only active newsletters
+    const activeNewsletters = useMemo(() => {
+        return newsletters?.filter(newsletter => newsletter.status === 'active') || [];
+    }, [newsletters]);
+
+    // Default to the first active newsletter when the component loads or when activeNewsletters changes
+    useEffect(() => {
+        if (activeNewsletters.length > 0 && !selectedNewsletterId) {
+            // You could look for a "primary" flag here if available
+            // For now, select the first active newsletter
+            setSelectedNewsletterId(activeNewsletters[0].id);
+        }
+    }, [activeNewsletters, selectedNewsletterId, setSelectedNewsletterId]);
+
+    // Handle no newsletters case
+    if (!activeNewsletters.length) {
+        return null;
+    }
+
+    return (
+        <Select 
+            value={selectedNewsletterId || ''} 
+            onValueChange={(value) => {
+                setSelectedNewsletterId(value);
+            }}
+        >
+            <SelectTrigger>
+                <SelectValue placeholder="Select a newsletter" />
+            </SelectTrigger>
+            <SelectContent align='end'>
+                <SelectGroup>
+                    <SelectLabel>Newsletters</SelectLabel>
+                    {activeNewsletters.map(newsletter => (
+                        <SelectItem key={newsletter.id} value={newsletter.id}>
+                            {newsletter.name}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SelectContent>
+        </Select>
+    );
+};
+
+export default NewsletterSelect; 

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -12,12 +12,19 @@ const NewsletterSelect: React.FC = () => {
         return newsletters?.filter(newsletter => newsletter.status === 'active') || [];
     }, [newsletters]);
 
-    // Default to the first active newsletter when the component loads or when activeNewsletters changes
+    // Default to the default newsletter (sort_order = 1) when the component loads
     useEffect(() => {
         if (activeNewsletters.length > 0 && !selectedNewsletterId) {
-            // You could look for a "primary" flag here if available
-            // For now, select the first active newsletter
-            setSelectedNewsletterId(activeNewsletters[0].id);
+            // First try to find the default newsletter (sort_order = 1)
+            const defaultNewsletter = activeNewsletters.find(newsletter => newsletter.sort_order === 1);
+            
+            // If we found a default newsletter, use it
+            if (defaultNewsletter) {
+                setSelectedNewsletterId(defaultNewsletter.id);
+            } else {
+                // Otherwise fall back to the first active newsletter
+                setSelectedNewsletterId(activeNewsletters[0].id);
+            }
         }
     }, [activeNewsletters, selectedNewsletterId, setSelectedNewsletterId]);
 

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo} from 'react';
-import {Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue} from '@tryghost/shade';
+import {LucideIcon, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue} from '@tryghost/shade';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
@@ -17,7 +17,7 @@ const NewsletterSelect: React.FC = () => {
         if (activeNewsletters.length > 0 && !selectedNewsletterId) {
             // First try to find the default newsletter (sort_order = 1)
             const defaultNewsletter = activeNewsletters.find(newsletter => newsletter.sort_order === 1);
-            
+
             // If we found a default newsletter, use it
             if (defaultNewsletter) {
                 setSelectedNewsletterId(defaultNewsletter.id);
@@ -34,13 +34,14 @@ const NewsletterSelect: React.FC = () => {
     }
 
     return (
-        <Select 
-            value={selectedNewsletterId || ''} 
+        <Select
+            value={selectedNewsletterId || ''}
             onValueChange={(value) => {
                 setSelectedNewsletterId(value);
             }}
         >
             <SelectTrigger>
+                <LucideIcon.Mails className='mr-2' size={16} strokeWidth={1.5} />
                 <SelectValue placeholder="Select a newsletter" />
             </SelectTrigger>
             <SelectContent align='end'>
@@ -57,4 +58,4 @@ const NewsletterSelect: React.FC = () => {
     );
 };
 
-export default NewsletterSelect; 
+export default NewsletterSelect;

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -177,7 +177,8 @@ const controller = {
             'limit',
             'date_from',
             'date_to',
-            'timezone'
+            'timezone',
+            'newsletter_id'
         ],
         permissions: {
             docName: 'posts',
@@ -192,7 +193,8 @@ const controller = {
                     limit: frame.options.limit,
                     date_from: frame.options.date_from,
                     date_to: frame.options.date_to,
-                    timezone: frame.options.timezone
+                    timezone: frame.options.timezone,
+                    newsletter_id: frame.options.newsletter_id
                 }
             };
         },
@@ -206,7 +208,8 @@ const controller = {
         },
         options: [
             'date_from',
-            'date_to'
+            'date_to',
+            'newsletter_id'
         ],
         permissions: {
             docName: 'posts',
@@ -218,7 +221,8 @@ const controller = {
                 method: 'getNewsletterSubscriberStats',
                 options: {
                     date_from: frame.options.date_from,
-                    date_to: frame.options.date_to
+                    date_to: frame.options.date_to,
+                    newsletter_id: frame.options.newsletter_id
                 }
             };
         },

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -108,15 +108,15 @@ class StatsService {
      */
     async getNewsletterStats(options = {}) {
         // Extract newsletter_id from options
-        const {newsletter_id, ...otherOptions} = options;
+        const {newsletter_id: newsletterId, ...otherOptions} = options;
         
-        // If no newsletter_id is provided, we can't get specific stats
-        if (!newsletter_id) {
+        // If no newsletterId is provided, we can't get specific stats
+        if (!newsletterId) {
             return {data: []};
         }
         
         // Return newsletter stats for the specific newsletter
-        const result = await this.posts.getNewsletterStats(newsletter_id, otherOptions);
+        const result = await this.posts.getNewsletterStats(newsletterId, otherOptions);
         return result;
     }
 
@@ -131,14 +131,14 @@ class StatsService {
      */
     async getNewsletterSubscriberStats(options = {}) {
         // Extract newsletter_id from options
-        const {newsletter_id, ...otherOptions} = options;
+        const {newsletter_id: newsletterId, ...otherOptions} = options;
         
-        // If no newsletter_id is provided, we can't get specific stats
-        if (!newsletter_id) {
+        // If no newsletterId is provided, we can't get specific stats
+        if (!newsletterId) {
             return {data: [{total: 0, deltas: []}]};
         }
         
-        const result = await this.posts.getNewsletterSubscriberStats(newsletter_id, otherOptions);
+        const result = await this.posts.getNewsletterSubscriberStats(newsletterId, otherOptions);
         return result;
     }
 

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -99,6 +99,7 @@ class StatsService {
     /**
      * Get newsletter stats for sent posts
      * @param {Object} options
+     * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
      * @param {string} [options.order='published_at desc'] - Order field and direction
      * @param {number} [options.limit=20] - Max number of results to return
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
@@ -106,8 +107,16 @@ class StatsService {
      * @returns {Promise<{data: Object[]}>}
      */
     async getNewsletterStats(options = {}) {
-        // Return newsletter stats from posts with newsletter_id not null
-        const result = await this.posts.getNewsletterStats(options);
+        // Extract newsletter_id from options
+        const {newsletter_id, ...otherOptions} = options;
+        
+        // If no newsletter_id is provided, we can't get specific stats
+        if (!newsletter_id) {
+            return {data: []};
+        }
+        
+        // Return newsletter stats for the specific newsletter
+        const result = await this.posts.getNewsletterStats(newsletter_id, otherOptions);
         return result;
     }
 
@@ -115,12 +124,21 @@ class StatsService {
      * Get newsletter subscriber statistics including total count and daily deltas
      * 
      * @param {Object} options
+     * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
      * @returns {Promise<{data: Object}>}
      */
     async getNewsletterSubscriberStats(options = {}) {
-        const result = await this.posts.getNewsletterSubscriberStats(options);
+        // Extract newsletter_id from options
+        const {newsletter_id, ...otherOptions} = options;
+        
+        // If no newsletter_id is provided, we can't get specific stats
+        if (!newsletter_id) {
+            return {data: [{total: 0, deltas: []}]};
+        }
+        
+        const result = await this.posts.getNewsletterSubscriberStats(newsletter_id, otherOptions);
         return result;
     }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1752/

We are unable to show some stats for all newsletters in a reasonable amount of time given our database structure. For example here, we only store member subscription events by member-subscription in the `members_subscribe_events` table. This is a one-multiple relationship that causes performance issues when trying to answer the question of subscriber count over time. It's much simpler to look at subscriber count over time _by newsletter_, as we don't need to crawl the `members_subscribe_events` table with a few subqueries to determine when a particular member subscribed to _their first newsletter_ or unsubscribed from their _last newsletter_. 

We'd need to create a view or additional event+table to calculate this. 

For now we'll limit the newsletter tab to a particular newsletter. If we move these events in to Tinybird at some point down the road, it'll be far simpler to create a materialized view, or simply leverage the speed of an analytical db vs. our operational db.