### PR TITLE
Implemented link style newsletter setting

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalAlpha.tsx
@@ -476,6 +476,41 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    <div className='flex w-full justify-between'>
+                        <div>Link style</div>
+                        <ButtonGroup activeKey={newsletter.link_style || 'underline'} buttons={[
+                            {
+                                key: 'underline',
+                                icon: 'text-underline',
+                                label: 'Underline',
+                                tooltip: 'Underline',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({link_style: 'underline'})
+                            },
+                            {
+                                key: 'regular',
+                                icon: 'text-regular',
+                                label: 'Regular',
+                                tooltip: 'Regular',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({link_style: 'regular'})
+                            },
+                            {
+                                key: 'bold',
+                                icon: 'text-bold',
+                                label: 'Bold',
+                                tooltip: 'Bold',
+                                hideLabel: true,
+                                link: false,
+                                size: 'sm',
+                                onClick: () => updateNewsletter({link_style: 'bold'})
+                            }
+                        ]} clearBg={false} />
+                    </div>
                 </Form>
             </>
         }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -305,11 +305,12 @@ const NewsletterPreviewContent: React.FC<{
                                     </>
                                 ) : (
                                     <>
-                                        <p className="mb-6" style={{color: textColor}}>This is what your content will look like when you send one of your posts as an email newsletter to your subscribers.</p>
-                                        <p className="mb-6" style={{color: textColor}}>Over there on the right you&apos;ll see some settings that allow you to customize the look and feel of this template to make it perfectly suited to your brand. Email templates are exceptionally finnicky to make, but we&apos;ve spent a long time optimising this one to make it work beautifully across devices, email clients and content types.</p>
-                                        <p className="mb-6" style={{color: textColor}}>So, you can trust that every email you send with Ghost will look great and work well. Just like the rest of your site.</p>
-                                        {hasEmailCustomizationAlpha && (
+                                        {hasEmailCustomizationAlpha ? (
                                             <>
+                                                <p className="mb-6" style={{color: textColor}}>The promise of delivery apps is simple: tap a button, and your favorite meal arrives at your door within minutes. But behind the scenes, these platforms are <a className={clsx(linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} href="#" style={{color: linkColor || accentColor}}>reshaping local economies</a> in ways few people realize.</p>
+                                                <p className="mb-6" style={{color: textColor}}>Across the country, small restaurants are grappling with rising fees—sometimes up to 30% per order—cutting into already-thin profit margins. In some cases, beloved neighborhood spots have had to shut their doors, unable to keep up with the financial strain. Meanwhile, delivery workers, the backbone of these services, often face unpredictable wages and challenging working conditions.</p>
+                                                <hr className={clsx('my-6 border-[#e0e7eb]', dividerStyle === 'dashed' && 'border-dashed', dividerStyle === 'dotted' && 'border-b-2 border-t-0 border-dotted')} style={{borderColor: dividerColor}} />
+                                                <p className="mb-6" style={{color: textColor}}>If you enjoy this piece and want more deep dives like it, consider upgrading your membership. Paid subscribers get <a className={clsx(linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} href="#" style={{color: linkColor || accentColor}}>exclusive reports</a>, early access to new features, and a behind-the-scenes look at how we put these stories together. Your support helps us continue delivering thoughtful, in-depth journalism straight to you.</p>
                                                 <button
                                                     className={clsx(
                                                         'px-[18px] py-2 font-sans text-[15px]',
@@ -363,6 +364,12 @@ const NewsletterPreviewContent: React.FC<{
                                                     style={{color: sectionTitleColor}}>Reimagining How We Eat</h3>
                                                 <p className="mb-6" style={{color: textColor}}>Consumers are also starting to pay more attention. There&apos;s a growing movement toward mindful eating—not just in terms of ingredients, but in how we support the systems that bring food to our tables. Choosing to pick up instead of ordering in, tipping delivery drivers fairly, or subscribing to local restaurant coalitions can all make a difference.</p>
                                                 <p className="mb-6" style={{color: textColor}}>Ultimately, the story of delivery apps isn’t just about technology or convenience—it’s about the kind of communities we want to live in. And that future depends, in part, on the choices we make every day.</p>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <p className="mb-6" style={{color: textColor}}>This is what your content will look like when you send one of your posts as an email newsletter to your subscribers.</p>
+                                                <p className="mb-6" style={{color: textColor}}>Over there on the right you&apos;ll see some settings that allow you to customize the look and feel of this template to make it perfectly suited to your brand. Email templates are exceptionally finnicky to make, but we&apos;ve spent a long time optimising this one to make it work beautifully across devices, email clients and content types.</p>
+                                                <p className="mb-6" style={{color: textColor}}>So, you can trust that every email you send with Ghost will look great and work well. Just like the rest of your site.</p>
                                             </>
                                         )}
                                     </>

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -326,7 +326,8 @@ class EmailRenderer {
             renderOptions.design = {
                 titleFontWeight: newsletter?.get('title_font_weight'),
                 buttonCorners: newsletter?.get('button_corners'),
-                buttonStyle: newsletter?.get('button_style')
+                buttonStyle: newsletter?.get('button_style'),
+                linkStyle: newsletter?.get('link_style')
             };
         }
 
@@ -975,7 +976,7 @@ class EmailRenderer {
             return weights.bold;
         }
 
-        /** @type {'normal' | 'bold' | string | null} */
+        /** @type {'normal' | 'medium' | 'semibold' | 'bold' | string | null} */
         const settingValue = newsletter.get('title_font_weight');
 
         return weights[settingValue] || weights.bold;
@@ -994,6 +995,25 @@ class EmailRenderer {
             return '700';
         } else {
             return '800';
+        }
+    }
+
+    #getLinkStyles(newsletter) {
+        const labs = this.getLabs();
+
+        if (!labs.isSet('emailCustomizationAlpha')) {
+            return 'text-decoration: underline;';
+        }
+
+        /** @type {'underline' | 'regular' | 'bold' | string | null} */
+        const settingValue = newsletter.get('link_style');
+
+        if (settingValue === 'regular') {
+            return 'text-decoration: none;';
+        } else if (settingValue === 'bold') {
+            return 'text-decoration: none; font-weight: 700;';
+        } else {
+            return 'text-decoration: underline;';
         }
     }
 
@@ -1024,6 +1044,7 @@ class EmailRenderer {
         const textColor = textColorForBackgroundColor(backgroundColor).hex();
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
         const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
+        const linkStyles = this.#getLinkStyles(newsletter);
 
         let buttonBorderRadius = '6px';
 
@@ -1184,6 +1205,7 @@ class EmailRenderer {
             textColor,
             secondaryTextColor,
             linkColor,
+            linkStyles,
             buttonBorderRadius,
 
             headerImage,

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -661,7 +661,7 @@ figure blockquote p {
 .post-content a,
 .post-content-sans-serif a {
     color: {{accentColor}};
-    text-decoration: underline;
+    {{linkStyles}}
 }
 
 a[data-flickr-embed] img {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2638,6 +2638,31 @@ describe('Email renderer', function () {
                 assert.equal(data.titleStrongWeight, titleStrongWeight);
             });
         });
+
+        [
+            ['normal', 'text-decoration: underline;', {labsEnabled: false}],
+            ['underline', 'text-decoration: underline;', {labsEnabled: true}],
+            ['regular', 'text-decoration: none;', {labsEnabled: true}],
+            ['bold', 'text-decoration: none; font-weight: 700;', {labsEnabled: true}],
+            [null, 'text-decoration: underline;', {labsEnabled: true}]
+        ].forEach(([settingValue, linkStyles, options]) => {
+            it(`link styles for ${settingValue || '`null`'} are correct${options.labsEnabled ? ' (emailCustomizationAlpha)' : ''}`, async function () {
+                labsEnabled = options.labsEnabled ?? false;
+
+                const html = '';
+                const post = createModel({
+                    posts_meta: createModel({}),
+                    loaded: ['posts_meta'],
+                    published_at: new Date(0)
+                });
+                const newsletter = createModel({
+                    link_style: settingValue
+                });
+                const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+
+                assert.equal(data.linkStyles, linkStyles);
+            });
+        });
     });
 
     describe('createUnsubscribeUrl', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1729

- copied UI for setting from prototype to alpha
- updated `EmailRenderer` to pass an additional `linkStyles` data property to the template, where the value has text decoration and font-weight applied as appropriate for the `newsletter.link_style` value
- updated `styles.hbs` partial to use `{{linkSyles}}` for body content links
  - other links in the template outside of the body content area are left as underlined to match the newsletter design preview
