### PR TITLE
Fixed broken link editing in Post Analytics beta newsletter tab

### DIFF
--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -53,7 +53,7 @@ export const usePostNewsletterStats = (postId: string) => {
     // Get the top 5 link clicks from this post
     const {data: clicksResponse, isLoading: isClicksLoading, refetch: refetchTopLinks} = useTopLinks({
         searchParams: {
-            post_id: postId,
+            filter: `post_id:'${postId}'`,
             limit: '5'
         }
     });

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -73,6 +73,8 @@ describe('usePostNewsletterStats', () => {
     });
 
     it('calculates stats correctly from post data', async () => {
+        let linksRequestUrl: URL | undefined;
+
         server.use(
             http.get('/ghost/api/admin/posts/:id/', () => {
                 return HttpResponse.json({
@@ -104,7 +106,8 @@ describe('usePostNewsletterStats', () => {
                     meta: {}
                 });
             }),
-            http.get('/ghost/api/admin/links/', () => {
+            http.get('/ghost/api/admin/links/', ({request}) => {
+                linksRequestUrl = new URL(request.url);
                 return HttpResponse.json({
                     links: [{
                         post_id: 'post-id',
@@ -146,6 +149,9 @@ describe('usePostNewsletterStats', () => {
             clicks: 10,
             edited: false
         }]);
+
+        expect(linksRequestUrl?.searchParams.get('filter')).toBe('post_id:\'post-id\'');
+        expect(linksRequestUrl?.searchParams.get('limit')).toBe('5');
     });
 
     it('handles missing email data', async () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1802/editing-links-in-posts-newsletter-tab-is-broken

When editing a link in the Post Analytics > Newsletter tab, the link is not successfully updated.

This is happening because the top links that we are fetching from the API are not properly filtered by post_id, therefore the links in the table are not all links from the current post.

When we try to edit a link, we pass the `post_id` as a filter to the bulkEdit API, and since the link most likely belongs to another post, the link is not found and is not updated.

This commit fixes the filter we pass to the GET /ghost/api/admin/links/ endpoint, so that we only fetch links that belong to the current post. It also modifies the usePostNewsletterStats hook's tests to ensure we are sending the right parameters to the API to prevent this regression in the future.
