### PR TITLE
Fixed editing links that have attribution query params in Post Analytics beta

### DIFF
--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -1,8 +1,8 @@
+import {type CleanedLink, cleanTrackedUrl} from '@src/utils/link-helpers';
 import {getPost} from '@tryghost/admin-x-framework/api/posts';
 import {useMemo} from 'react';
 import {useNewsletterStatsByNewsletterId} from '@tryghost/admin-x-framework/api/stats';
 import {useTopLinks} from '@tryghost/admin-x-framework/api/links';
-import {cleanTrackedUrl} from '@src/utils/link-helpers';
 
 // Extend the Post type to include newsletter property
 type PostWithNewsletter = {
@@ -93,7 +93,7 @@ export const usePostNewsletterStats = (postId: string) => {
     }, [newsletterStatsResponse]);
 
     const topLinks = useMemo(() => {
-        let cleanedLinks = links.map((link) => {
+        const cleanedLinks = links.map((link) => {
             return {
                 ...link,
                 link: {
@@ -102,27 +102,20 @@ export const usePostNewsletterStats = (postId: string) => {
                     to: cleanTrackedUrl(link.link.to, false),
                     title: cleanTrackedUrl(link.link.to, true)
                 }
-            }
+            };
         });
 
-        console.log('cleanedLinks',cleanedLinks);
-
-        const linksByTitle = cleanedLinks.reduce((acc: Record<string, any>, link: any) => {
+        const linksByTitle = cleanedLinks.reduce((acc: Record<string, CleanedLink>, link: CleanedLink) => {
             if (!acc[link.link.title]) {
                 acc[link.link.title] = link;
             } else {
                 if (!acc[link.link.title].count) {
-                    acc[link.link.title].count = {clicks: 0};
+                    acc[link.link.title].count = 0;
                 }
-                if (!acc[link.link.title].count.clicks) {
-                    acc[link.link.title].count.clicks = 0;
-                }
-                acc[link.link.title].count.clicks += (link.count?.clicks ?? 0);
+                acc[link.link.title].count += (link.count ?? 0);
             }
             return acc;
         }, {});
-
-        console.log('linksByTitle',linksByTitle);
 
         return Object.values(linksByTitle).sort((a, b) => {
             const aClicks = a.count || 0;

--- a/apps/posts/src/utils/link-helpers.ts
+++ b/apps/posts/src/utils/link-helpers.ts
@@ -11,19 +11,24 @@ export type CleanedLink = {
 }
 
 export const cleanTrackedUrl = (url: string, display = false): string => {
-    const removeParams = ['ref', 'attribution_id', 'attribution_type'];
-    const urlObj = new URL(url);
-    for (const param of removeParams) {
-        urlObj.searchParams.delete(param);
-    }
+    try {
+        const removeParams = ['ref', 'attribution_id', 'attribution_type'];
+        const urlObj = new URL(url);
+        for (const param of removeParams) {
+            urlObj.searchParams.delete(param);
+        }
 
-    if (!display) {
-        return urlObj.toString();
+        if (!display) {
+            return urlObj.toString();
+        }
+        // Return URL without protocol
+        const urlWithoutProtocol = urlObj.host + (urlObj.pathname === '/' && !urlObj.search ? '' : urlObj.pathname) + (urlObj.search ? urlObj.search : '') + (urlObj.hash ? urlObj.hash : '');
+        // remove www. from the start of the URL
+        return urlWithoutProtocol.replace(/^www\./, '');
+    } catch (error) {
+        // return the original url if there is an error
+        return url;
     }
-    // Return URL without protocol
-    const urlWithoutProtocol = urlObj.host + (urlObj.pathname === '/' && !urlObj.search ? '' : urlObj.pathname) + (urlObj.search ? urlObj.search : '') + (urlObj.hash ? urlObj.hash : '');
-    // remove www. from the start of the URL
-    return urlWithoutProtocol.replace(/^www\./, '');
 };
 
 export const getLinkById = (links: CleanedLink[], linkId: string) => {

--- a/apps/posts/src/utils/link-helpers.ts
+++ b/apps/posts/src/utils/link-helpers.ts
@@ -1,25 +1,15 @@
-export const sanitizeUrl = (url: string): string => {
-    return url.replace(/^https?:\/\//, '');
-};
-
-export const cleanTrackedUrl = (url: string, showTitle = false): string => {
-    // Extract the URL before the ? but keep the hash part
-    const [urlPart, queryPart] = url.split('?');
-
-    if (!queryPart) {
-        // Check if the urlPart itself has a hash
-        const hashIndex = urlPart.indexOf('#');
-        if (hashIndex > -1) {
-            return showTitle ? urlPart.substring(0, hashIndex) : urlPart;
-        }
-        return urlPart;
+export const cleanTrackedUrl = (url: string, display = false): string => {
+    const removeParams = ['ref', 'attribution_id', 'attribution_type'];
+    const urlObj = new URL(url);
+    for (const param of removeParams) {
+        urlObj.searchParams.delete(param);
     }
 
-    // If there's a hash in the query part, preserve it
-    const hashMatch = queryPart.match(/#(.+)$/);
-    if (hashMatch) {
-        return showTitle ? urlPart : `${urlPart}#${hashMatch[1]}`;
+    if (!display) {
+        return urlObj.toString();
     }
-
-    return urlPart;
+    // Return URL without protocol
+    const urlWithoutProtocol = urlObj.host + (urlObj.pathname === '/' && !urlObj.search ? '' : urlObj.pathname) + (urlObj.search ? urlObj.search : '') + (urlObj.hash ? urlObj.hash : '');
+    // remove www. from the start of the URL
+    return urlWithoutProtocol.replace(/^www\./, '');
 };

--- a/apps/posts/src/utils/link-helpers.ts
+++ b/apps/posts/src/utils/link-helpers.ts
@@ -1,3 +1,15 @@
+export type CleanedLink = {
+    count: number;
+    link: {
+        link_id: string;
+        to: string;
+        title: string;
+        originalTo: string;
+        from: string;
+        edited: boolean;
+    }
+}
+
 export const cleanTrackedUrl = (url: string, display = false): string => {
     const removeParams = ['ref', 'attribution_id', 'attribution_type'];
     const urlObj = new URL(url);
@@ -12,4 +24,8 @@ export const cleanTrackedUrl = (url: string, display = false): string => {
     const urlWithoutProtocol = urlObj.host + (urlObj.pathname === '/' && !urlObj.search ? '' : urlObj.pathname) + (urlObj.search ? urlObj.search : '') + (urlObj.hash ? urlObj.hash : '');
     // remove www. from the start of the URL
     return urlWithoutProtocol.replace(/^www\./, '');
+};
+
+export const getLinkById = (links: CleanedLink[], linkId: string) => {
+    return links.find(link => link.link.link_id === linkId);
 };

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -3,9 +3,8 @@ import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer,ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, Tabs, TabsContent, TabsList, TabsTrigger, calculateYAxisWidth, formatNumber, formatPercentage} from '@tryghost/shade';
-import {cleanTrackedUrl, sanitizeUrl} from '@src/utils/link-helpers';
 import {useEditLinks} from '@src/hooks/useEditLinks';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useParams} from '@tryghost/admin-x-framework';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
@@ -147,46 +146,49 @@ const FunnelArrow: React.FC = () => {
 
 const Newsletter: React.FC<postAnalyticsProps> = () => {
     const {postId} = useParams();
-    const [editingUrl, setEditingUrl] = useState<string | null>(null);
+    const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
     const [editedUrl, setEditedUrl] = useState('');
-    const [originalUrl, setOriginalUrl] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading, refetchTopLinks} = usePostNewsletterStats(postId || '');
     const {editLinks} = useEditLinks();
 
-    const handleEdit = (url: string) => {
-        setEditingUrl(url);
-        setEditedUrl(url);
-        setOriginalUrl(url);
+    const handleEdit = (link_id: string) => {
+        const link = topLinks.find(link => link.link.link_id === link_id);
+        if (link) {
+            setEditingLinkId(link_id);
+            setEditedUrl(link.link.to);
+        }
     };
 
     const handleUpdate = () => {
-        editLinks({
-            originalUrl,
-            editedUrl,
-            postId: postId || ''
-        }, {
-            onSuccess: () => {
-                setEditingUrl(null);
-                setEditedUrl('');
-                setOriginalUrl('');
-                refetchTopLinks();
-            }
-        });
+        const link = topLinks.find(link => link.link.link_id === editingLinkId);
+        if (link) {
+            editLinks({
+                originalUrl: link.link.originalTo,
+                editedUrl: editedUrl,
+                postId: postId || ''
+            }, {
+                onSuccess: () => {
+                    setEditingLinkId(null);
+                    setEditedUrl('');
+                    refetchTopLinks();
+                }
+            });
+        }
     };
 
     useEffect(() => {
-        if (editingUrl && inputRef.current) {
+        if (editingLinkId && inputRef.current) {
             inputRef.current.focus();
+            const link = topLinks.find(link => link.link.link_id === editingLinkId);
 
             const handleClickOutside = (event: MouseEvent) => {
                 if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-                    if (editedUrl === originalUrl) {
-                        setEditingUrl(null);
+                    if (editedUrl === link?.link.to) {
+                        setEditingLinkId(null);
                         setEditedUrl('');
-                        setOriginalUrl('');
                     }
                 }
             };
@@ -196,7 +198,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                 document.removeEventListener('mousedown', handleClickOutside);
             };
         }
-    }, [editingUrl, originalUrl, editedUrl]);
+    }, [editingLinkId, editedUrl]);
 
     const barDomain = [0, 1];
     const barTicks = [0, 0.25, 0.5, 0.75, 1];
@@ -217,31 +219,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     } satisfies ChartConfig;
 
     const isLoading = isNewsletterStatsLoading;
-
-    // Memoize link processing to avoid unnecessary recomputation on renders
-    const displayLinks = useMemo(() => {
-        // Process links data to group by URL
-        const processedLinks = topLinks.reduce<Record<string, GroupedLinkData>>((acc, link) => {
-            // For grouping, we use the clean URL (path only with hash)
-            const cleanUrl = cleanTrackedUrl(link.url, false);
-
-            if (!acc[cleanUrl]) {
-                acc[cleanUrl] = {
-                    url: cleanUrl,
-                    clicks: 0,
-                    edited: false
-                };
-            }
-
-            acc[cleanUrl].clicks += link.clicks;
-            acc[cleanUrl].edited = acc[cleanUrl].edited || link.edited;
-
-            return acc;
-        }, {});
-
-        // Sort by click count
-        return Object.values(processedLinks).sort((a, b) => b.clicks - a.clicks);
-    }, [topLinks]); // Only recalculate when topLinks changes
 
     // "Sent" Chart
     // const sentChartData: NewsletterRadialChartData[] = [
@@ -498,15 +475,17 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                             </TableRow>
                                         </TableHeader>
                                         <TableBody>
-                                            {displayLinks.map((row) => {
-                                                const url = row.url;
+                                            {topLinks.map((row) => {
+                                                const link_id = row.link.link_id;
+                                                const title = row.link.title;
+                                                const url = row.link.to;
                                                 const edited = row.edited;
 
                                                 return (
-                                                    <TableRow key={url}>
+                                                    <TableRow key={link_id}>
                                                         <TableCell className='max-w-0'>
                                                             <div className='flex items-center gap-2'>
-                                                                {editingUrl === url ? (
+                                                                {editingLinkId === link_id ? (
                                                                     <div ref={containerRef} className='flex w-full items-center gap-2'>
                                                                         <Input
                                                                             ref={inputRef}
@@ -527,7 +506,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                             className='shrink-0 bg-background'
                                                                             size='sm'
                                                                             variant='outline'
-                                                                            onClick={() => handleEdit(url)}
+                                                                            onClick={() => handleEdit(link_id)}
                                                                         >
                                                                             <LucideIcon.Pen />
                                                                         </Button>
@@ -536,9 +515,9 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                             href={url}
                                                                             rel="noreferrer"
                                                                             target='_blank'
-                                                                            title={url}
+                                                                            title={title}
                                                                         >
-                                                                            {sanitizeUrl(url)}
+                                                                            {title}
                                                                         </a>
                                                                         {edited && (
                                                                             <span className='text-xs text-gray-500'>(edited)</span>
@@ -547,7 +526,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                 )}
                                                             </div>
                                                         </TableCell>
-                                                        <TableCell className='text-right font-mono text-sm'>{formatNumber(row.clicks)}</TableCell>
+                                                        <TableCell className='text-right font-mono text-sm'>{formatNumber(row.count)}</TableCell>
                                                     </TableRow>
                                                 );
                                             })}

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -161,19 +161,26 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
             return;
         }
         const link = getLinkById(topLinks, editingLinkId);
-        if (link) {
-            editLinks({
-                originalUrl: link.link.originalTo,
-                editedUrl: editedUrl,
-                postId: postId || ''
-            }, {
-                onSuccess: () => {
-                    setEditingLinkId(null);
-                    setEditedUrl('');
-                    refetchTopLinks();
-                }
-            });
+        if (!link) {
+            return;
         }
+        const trimmedUrl = editedUrl.trim();
+        if (trimmedUrl === '' || trimmedUrl === link.link.to) {
+            setEditingLinkId(null);
+            setEditedUrl('');
+            return;
+        }
+        editLinks({
+            originalUrl: link.link.originalTo,
+            editedUrl: editedUrl,
+            postId: postId || ''
+        }, {
+            onSuccess: () => {
+                setEditingLinkId(null);
+                setEditedUrl('');
+                refetchTopLinks();
+            }
+        });
     };
 
     useEffect(() => {

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,7 +1,5 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {BarChartLoadingIndicator, ChartConfig, ChartContainer, LucideIcon, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
-import {GroupedLinkData} from '../../Newsletter/Newsletter';
-import {cleanTrackedUrl, sanitizeUrl} from '@src/utils/link-helpers';
 import {useParams} from '@tryghost/admin-x-framework';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
@@ -28,33 +26,6 @@ const NewsletterOverview:React.FC = () => {
             color: 'hsl(var(--chart-green))'
         }
     } satisfies ChartConfig;
-
-    // Memoize link processing to avoid unnecessary recomputation on renders
-    const displayLinks = useMemo(() => {
-        // Process links data to group by URL
-        const processedLinks = topLinks.reduce<Record<string, GroupedLinkData>>((acc, link) => {
-            // For grouping, we use the clean URL (path only with hash)
-            const cleanUrl = cleanTrackedUrl(link.url, false);
-
-            if (!acc[cleanUrl]) {
-                acc[cleanUrl] = {
-                    url: cleanUrl,
-                    clicks: 0,
-                    edited: false
-                };
-            }
-
-            acc[cleanUrl].clicks += link.clicks;
-            acc[cleanUrl].edited = acc[cleanUrl].edited || link.edited;
-
-            return acc;
-        }, {});
-
-        // Sort by click count and take only top 5
-        return Object.values(processedLinks)
-            .sort((a, b) => b.clicks - a.clicks)
-            .slice(0, 5);
-    }, [topLinks]); // Only recalculate when topLinks changes
 
     const radialBarChartClassName = 'mx-auto aspect-square w-full min-h-[200px] max-w-[200px]';
 
@@ -192,21 +163,21 @@ const NewsletterOverview:React.FC = () => {
                             {topLinks.length > 0
                                 ?
                                 <TableBody>
-                                    {displayLinks.map((row) => {
+                                    {topLinks.map((row) => {
                                         return (
-                                            <TableRow key={row.url}>
+                                            <TableRow key={row.link.link_id}>
                                                 <TableCell className='max-w-0 group-hover:!bg-transparent'>
                                                     <a
                                                         className='block truncate font-medium hover:underline'
-                                                        href={row.url}
+                                                        href={row.link.to}
                                                         rel="noreferrer"
                                                         target='_blank'
-                                                        title={row.url}
+                                                        title={row.link.title}
                                                     >
-                                                        {sanitizeUrl(row.url)}
+                                                        {row.link.title}
                                                     </a>
                                                 </TableCell>
-                                                <TableCell className='w-[10%] text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(row.clicks)}</TableCell>
+                                                <TableCell className='w-[10%] text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(row.count)}</TableCell>
                                             </TableRow>
                                         );
                                     })}

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -114,11 +114,22 @@ describe('usePostNewsletterStats', () => {
                         link: {
                             link_id: 'link-1',
                             from: 'https://example.com/from',
-                            to: 'https://example.com/to',
+                            to: 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test',
                             edited: false
                         },
                         count: {
                             clicks: 10
+                        }
+                    }, {
+                        post_id: 'post-id',
+                        link: {
+                            link_id: 'link-2',
+                            from: 'https://example.com/from',
+                            to: 'https://google.com/?ref=test&attribution_id=test&attribution_type=test',
+                            edited: false
+                        },
+                        count: {
+                            clicks: 20
                         }
                     }],
                     meta: {}
@@ -145,9 +156,25 @@ describe('usePostNewsletterStats', () => {
         });
 
         expect(result.current.topLinks).toEqual([{
-            url: 'https://example.com/to',
-            clicks: 10,
-            edited: false
+            "count": 20,
+            "link": {
+                "link_id": "link-2",
+                "from": "https://example.com/from",
+                "originalTo": "https://google.com/?ref=test&attribution_id=test&attribution_type=test",
+                "title": "google.com",
+                "to": "https://google.com/",
+                "edited": false
+            }
+        },{
+            "count": 10,
+            "link": {
+                "link_id": "link-1",
+                "from": "https://example.com/from",
+                "originalTo": "https://example.com/to?ref=test&attribution_id=test&attribution_type=test",
+                "title": "example.com/to",
+                "to": "https://example.com/to",
+                "edited": false
+            }
         }]);
 
         expect(linksRequestUrl?.searchParams.get('filter')).toBe('post_id:\'post-id\'');

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -156,24 +156,24 @@ describe('usePostNewsletterStats', () => {
         });
 
         expect(result.current.topLinks).toEqual([{
-            "count": 20,
-            "link": {
-                "link_id": "link-2",
-                "from": "https://example.com/from",
-                "originalTo": "https://google.com/?ref=test&attribution_id=test&attribution_type=test",
-                "title": "google.com",
-                "to": "https://google.com/",
-                "edited": false
+            count: 20,
+            link: {
+                link_id: 'link-2',
+                from: 'https://example.com/from',
+                originalTo: 'https://google.com/?ref=test&attribution_id=test&attribution_type=test',
+                title: 'google.com',
+                to: 'https://google.com/',
+                edited: false
             }
-        },{
-            "count": 10,
-            "link": {
-                "link_id": "link-1",
-                "from": "https://example.com/from",
-                "originalTo": "https://example.com/to?ref=test&attribution_id=test&attribution_type=test",
-                "title": "example.com/to",
-                "to": "https://example.com/to",
-                "edited": false
+        }, {
+            count: 10,
+            link: {
+                link_id: 'link-1',
+                from: 'https://example.com/from',
+                originalTo: 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test',
+                title: 'example.com/to',
+                to: 'https://example.com/to',
+                edited: false
             }
         }]);
 

--- a/apps/posts/test/unit/utils/link-helpers.test.ts
+++ b/apps/posts/test/unit/utils/link-helpers.test.ts
@@ -1,0 +1,26 @@
+import {cleanTrackedUrl} from '@src/utils/link-helpers';
+describe('link-helpers', () => {
+    it('should clean tracked url', () => {
+        const url = 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test';
+        const cleanedUrl = cleanTrackedUrl(url, false);
+        expect(cleanedUrl).toBe('https://example.com/to');
+    });
+
+    it('should clean tracked url and return display url', () => {
+        const url = 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test';
+        const cleanedUrl = cleanTrackedUrl(url, true);
+        expect(cleanedUrl).toBe('example.com/to');
+    });
+
+    it('should clean tracked url and return display url without www', () => {
+        const url = 'https://www.example.com/to?ref=test&attribution_id=test&attribution_type=test';
+        const cleanedUrl = cleanTrackedUrl(url, true);
+        expect(cleanedUrl).toBe('example.com/to');
+    });
+
+    it('should not remove extraneous params', () => {
+        const url = 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test&utm_source=test';
+        const cleanedUrl = cleanTrackedUrl(url, true);
+        expect(cleanedUrl).toBe('example.com/to?utm_source=test');
+    });
+});

--- a/apps/posts/test/unit/utils/link-helpers.test.tsx
+++ b/apps/posts/test/unit/utils/link-helpers.test.tsx
@@ -1,4 +1,6 @@
 import {cleanTrackedUrl} from '@src/utils/link-helpers';
+import {describe, expect, it} from 'vitest';
+
 describe('link-helpers', () => {
     it('should clean tracked url', () => {
         const url = 'https://example.com/to?ref=test&attribution_id=test&attribution_type=test';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1802/editing-links-in-posts-newsletter-tab-is-broken

In the new Post Analytics beta Newsletter views, editing a link that had any `ref`, `attribution_id`, or `attribution_type` query parameters was failing. Our API calls to edit the link were not returning any edited links because we were passing the _cleaned_ `to` field of the link as a filter, when we needed to pass the original, uncleaned `to` field, since that's what the API matches the links against in the DB.  