### PR TITLE
Added useEffect to handle profile link clicks in all FeedItems

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -230,6 +230,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
     const [isTruncated, setIsTruncated] = useState(false);
 
     const deleteMutation = useDeleteMutationForUser('index');
+    const navigate = useNavigate();
 
     useEffect(() => {
         const element = contentRef.current;
@@ -237,6 +238,35 @@ const FeedItem: React.FC<FeedItemProps> = ({
             setIsTruncated(element.scrollHeight > element.clientHeight);
         }
     }, [object?.content]);
+
+    // useEffect to handle profile link clicks
+    useEffect(() => {
+        const element = contentRef.current;
+        if (!element) {
+            return;
+        }
+
+        const handleProfileLinkClick = (e: MouseEvent) => {
+            const target = e.target as HTMLElement;
+            const link = target.closest('a[data-profile]');
+            
+            if (link) {
+                const handle = link.getAttribute('data-profile')?.trim();
+                const isValidHandle = /^@([\w.-]+)@([\w-]+\.[\w.-]+[a-zA-Z])$/.test(handle || '');
+
+                if (isValidHandle && handle) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleProfileClickRR(handle, navigate);
+                }
+            }
+        };
+
+        element.addEventListener('click', handleProfileLinkClick);
+        return () => {
+            element.removeEventListener('click', handleProfileLinkClick);
+        };
+    }, [navigate, object?.content]);
 
     const onLikeClick = () => {
         // Do API req or smth
@@ -279,8 +309,6 @@ const FeedItem: React.FC<FeedItemProps> = ({
             <LucideIcon.Ellipsis />
         </Button>
     );
-
-    const navigate = useNavigate();
 
     const {
         lightboxState,
@@ -434,7 +462,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {object.name && <Heading className='mb-1 leading-tight break-anywhere' level={4} data-test-activity-heading>{object.name}</Heading>}
-                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>
+                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>
                                         {renderFeedAttachment(object, openLightbox)}
                                         <div className='space-between ml-[-7px] mt-3 flex'>
                                             {showStats && <FeedItemStats
@@ -502,7 +530,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='flex flex-col items-start'>
                                         {(object.type === 'Article') && renderFeedAttachment(object, openLightbox)}
                                         {object.name && <Heading className='my-1 text-pretty leading-tight break-anywhere' level={5} data-test-activity-heading>{object.name}</Heading>}
-                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>}
+                                        {(object.preview && object.type === 'Article') ? <div className='line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>}
                                         {(object.type === 'Note') && renderFeedAttachment(object, openLightbox)}
                                         {(object.type === 'Article') && <ButtonX
                                             className={`mt-3 self-start text-gray-900 transition-all hover:opacity-60`}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1786/

- When clicking on a mention `@user@host` in a note, it should open the profile in our admin profile viewer, not in a new tab
- We have added a `data-profile` attribute with the social web handle, when generating the hyperlink in the backend
- Added this change to override the default on-click behaviour based on this `data-profile` attribute