### PR TITLE
Fixed country assignment in ghost-stats script

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import timezoneData from '@tryghost/timezone-data';
+import { getCountryForTimezone } from 'countries-and-timezones';
 import { getReferrer, parseReferrer } from '../utils/url-attribution';
 import { getSessionId, setSessionId, getStorageObject } from '../utils/session-storage';
 import { processPayload } from '../utils/privacy';
@@ -137,14 +137,19 @@ import { processPayload } from '../utils/privacy';
      */
     function _getLocationInfo() {
         try {
-            // Get timezone and map to country
+            // Get timezone from browser
             const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            const country = timezone ? timezoneData[timezone] : null;
+            
+            // Get country from timezone using countries-and-timezones
+            const countryData = timezone ? getCountryForTimezone(timezone) : null;
             
             // Get locale, falling back gracefully
             const locale = navigator.languages?.[0] || navigator.language || 'en';
             
-            return { country, locale };
+            return { 
+                country: countryData ? countryData.name : null,  // Returns full country name like "United States of America"
+                locale 
+            };
         } catch (error) {
             return { country: null, locale: 'en' };
         }

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -133,6 +133,7 @@
     "cookie-session": "2.1.0",
     "cookies": "0.9.1",
     "cors": "2.8.5",
+    "countries-and-timezones": "^3.8.0",
     "csso": "5.0.5",
     "csv-writer": "1.6.0",
     "date-fns": "2.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13284,6 +13284,11 @@ cosmiconfig@^8.1.3, cosmiconfig@^8.2.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
 
+countries-and-timezones@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/countries-and-timezones/-/countries-and-timezones-3.8.0.tgz#8b04d0211af3a9dda379cb3bbdcb8d73530ca438"
+  integrity sha512-+Ze9h5f4dQpUwbzTm0DEkiPiZyim9VHV4/mSnT4zNYJnrnfwsKjAZPtnp7J5VzejCDgySs+2SSc6MDdCnD43GA==
+
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1747741412015619?thread_ts=1747082051.901019&cid=C07HTEJMR2R

The move to ghost/timezone-data didn't do us any favors with country matching. We knew this and wanted better tz matching, and intended to do server-side geolocation, but for now we'll use a better client side library.