### PR TITLE
Added safer number handling to post analytics kpis

### DIFF
--- a/apps/posts/src/utils/kpi-helpers.ts
+++ b/apps/posts/src/utils/kpi-helpers.ts
@@ -14,20 +14,27 @@ export const getWebKpiValues = (data: KpiDataItem[] | null | undefined) => {
         return {visits: 0, views: 0, bounceRate: 0, duration: 0};
     }
 
+    // Convert data values to numbers and handle NaN values safely
+    const safeNumber = (value: string | number | null | undefined): number => {
+        const parsed = Number(value);
+        return isNaN(parsed) ? 0 : parsed;
+    };
+
+    const totalVisits = data.reduce((sum, item) => sum + safeNumber(item.visits), 0);
+    const totalViews = data.reduce((sum, item) => sum + safeNumber(item.pageviews), 0);
+    
     // Sum total KPI value from the trend, weighting using sessions
     const _weightedKPIsTotal = (kpi: keyof KpiDataItem) => {
         if (totalVisits === 0) {
             return 0;
         }
         return data.reduce((prev, curr) => {
-            const currValue = Number(curr[kpi] ?? 0);
-            const currVisits = Number(curr.visits);
+            const currValue = safeNumber(curr[kpi]);
+            const currVisits = safeNumber(curr.visits);
             return prev + (currValue * currVisits / totalVisits);
         }, 0);
     };
 
-    const totalVisits = data.reduce((sum, item) => sum + Number(item.visits), 0);
-    const totalViews = data.reduce((sum, item) => sum + Number(item.pageviews), 0);
     const avgBounceRate = _weightedKPIsTotal('bounce_rate');
     const avgDuration = _weightedKPIsTotal('avg_session_sec');
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1822/qa-overview-tab-showing-nan-for-web-traffic-data

I've added some extra type checking and number handling to try to prevent NaN display in the kpi header component.