### PR TITLE
Hid newsletter content for non-newsletters in post analytics

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -36,6 +36,11 @@
             "require": "./dist/api/*.cjs",
             "types": "./types/api/*.d.ts"
         },
+        "./utils/post-utils": {
+            "import": "./dist/utils/post-utils.js",
+            "require": "./dist/utils/post-utils.cjs",
+            "types": "./types/utils/post-utils.d.ts"
+        },
         "./vite": {
             "import": "./dist/vite.js",
             "require": "./dist/vite.cjs",

--- a/apps/admin-x-framework/src/api/posts.ts
+++ b/apps/admin-x-framework/src/api/posts.ts
@@ -3,7 +3,8 @@ import {Meta, createQuery, createQueryWithId} from '../utils/api/hooks';
 export type Email = {
     opened_count: number;
     email_count: number;
-}
+    status?: string;
+};
 
 export type Post = {
     id: string;
@@ -16,6 +17,15 @@ export type Post = {
         clicks?: number;
     };
     email?: Email;
+    status?: string;
+    published_at?: string;
+    newsletter_id?: string;
+    newsletter?: object;
+    email_only?: boolean;
+    email_segment?: string;
+    email_recipient_filter?: string;
+    send_email_when_published?: boolean;
+    email_stats?: object;
 };
 
 export interface PostsResponseType {

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -5,6 +5,9 @@ export {FrameworkProvider, useFramework} from './providers/FrameworkProvider';
 // Stats utilities
 export {getStatEndpointUrl, getToken} from './utils/stats-config';
 
+// Post utilities
+export {hasBeenEmailed} from './utils/post-utils';
+
 // Routing
 export type {RouteObject} from 'react-router';
 export type {RouterProviderProps} from './providers/RouterProvider';

--- a/apps/admin-x-framework/src/utils/post-utils.ts
+++ b/apps/admin-x-framework/src/utils/post-utils.ts
@@ -1,0 +1,29 @@
+import {Post} from '../api/posts';
+
+/**
+ * Determines if a post has been sent as a newsletter
+ * 
+ * This follows the same logic as the Ember app's 'hasBeenEmailed' computed property:
+ * https://github.com/TryGhost/Ghost/blob/main/ghost/admin/app/models/post.js
+ * 
+ * @param post - The post to check
+ * @returns true if the post has been sent as a newsletter
+ */
+export function hasBeenEmailed(post: Post): boolean {
+    // We're only checking posts, not pages
+    const isPost = true;
+    
+    // Check if the post is published or sent
+    const isPublished = post?.status === 'published';
+    const isSent = post?.status === 'sent';
+    
+    // A post has been emailed if:
+    // 1. It's a post (not a page)
+    // 2. It's either published or sent
+    // 3. It has an email object
+    // 4. The email status is not 'failed'
+    return isPost 
+        && (isSent || isPublished)
+        && Boolean(post?.email) 
+        && post.email?.status !== 'failed';
+} 

--- a/apps/admin-x-framework/src/utils/post-utils.ts
+++ b/apps/admin-x-framework/src/utils/post-utils.ts
@@ -6,6 +6,8 @@ import {Post} from '../api/posts';
  * This follows the same logic as the Ember app's 'hasBeenEmailed' computed property:
  * https://github.com/TryGhost/Ghost/blob/main/ghost/admin/app/models/post.js
  * 
+ * But also handles the case where emails exist but might not have a proper status field.
+ * 
  * @param post - The post to check
  * @returns true if the post has been sent as a newsletter
  */
@@ -17,13 +19,23 @@ export function hasBeenEmailed(post: Post): boolean {
     const isPublished = post?.status === 'published';
     const isSent = post?.status === 'sent';
     
+    // Check for email data and valid status
+    const hasEmail = Boolean(post?.email);
+    const validEmailStatus = post?.email?.status !== 'failed';
+    
+    // Enhanced check for email data:
+    // - Check if email_count > 0, which means emails have been sent
+    const hasEmailCount = typeof post?.email?.email_count === 'number' && post.email.email_count > 0;
+    
     // A post has been emailed if:
     // 1. It's a post (not a page)
     // 2. It's either published or sent
     // 3. It has an email object
-    // 4. The email status is not 'failed'
+    // 4. AND EITHER:
+    //    a. The email status is not 'failed' 
+    //    b. OR the email_count > 0 (indicating emails have been sent)
     return isPost 
         && (isSent || isPublished)
-        && Boolean(post?.email) 
-        && post.email?.status !== 'failed';
+        && hasEmail 
+        && (validEmailStatus || hasEmailCount);
 } 

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -23,6 +23,7 @@
         "lint": "yarn run lint:code && yarn run lint:test",
         "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
         "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx --cache test",
+        "lint:fix": "eslint --ext .js,.ts,.cjs,.tsx --cache src --fix",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -3,18 +3,14 @@ import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, Input, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, Tabs, TabsContent, TabsList, TabsTrigger, calculateYAxisWidth, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {getLinkById} from '@src/utils/link-helpers';
+import {hasBeenEmailed, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useRef, useState} from 'react';
-import {hasBeenEmailed, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
-import {useBrowsePosts, Post} from '@tryghost/admin-x-framework/api/posts';
 
 interface postAnalyticsProps {}
-
-interface PostWithEmail extends Post {
-    // Email already defined in Post type
-}
 
 type NewsletterRadialChartData = {
     datatype: string,
@@ -120,7 +116,7 @@ const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
                             return (
                                 <div className='flex items-center gap-1'>
                                     <div className='size-2.5 rounded-[2px]' style={{backgroundColor: props.payload?.fill}}></div>
-                                    <div className='text-xs capitalize text-muted-foreground'>{props.payload?.datatype}</div>
+                                    <div className='text-muted-foreground text-xs capitalize'>{props.payload?.datatype}</div>
                                     <div className='ml-3 font-mono text-xs'>{value}%</div>
                                 </div>
                             );
@@ -137,7 +133,7 @@ const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
 
 const FunnelArrow: React.FC = () => {
     return (
-        <div className='absolute right-[-13px] top-1/2 flex size-[25px] -translate-y-1/2 items-center justify-center rounded-full border bg-background text-muted-foreground'>
+        <div className='bg-background text-muted-foreground absolute right-[-13px] top-1/2 flex size-[25px] -translate-y-1/2 items-center justify-center rounded-full border'>
             <LucideIcon.ChevronRight className='ml-0.5' size={16} strokeWidth={1.5}/>
         </div>
     );
@@ -158,7 +154,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     });
 
-    const typedPost = post as PostWithEmail;
+    const typedPost = post as Post;
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(typedPost);
 
@@ -338,7 +334,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.opened)}</KpiCardValue>
-                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.openedRate)} open rate</span>
+                                            <span className='text-muted-foreground mt-0.5 text-sm'>{formatPercentage(stats.openedRate)} open rate</span>
                                         </KpiCardContent>
                                         <FunnelArrow />
                                     </KpiCard>
@@ -350,7 +346,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.clicked)}</KpiCardValue>
-                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.clickedRate)} click rate</span>
+                                            <span className='text-muted-foreground mt-0.5 text-sm'>{formatPercentage(stats.clickedRate)} click rate</span>
                                         </KpiCardContent>
                                     </KpiCard>
                                 </div>
@@ -443,7 +439,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                                 style={{backgroundColor: color}}
                                                                             />
                                                                             {barChartConfig[name as keyof typeof barChartConfig]?.label || name}
-                                                                            <div className="ml-auto flex items-baseline gap-0.5 pl-2 font-mono font-medium tabular-nums text-foreground">
+                                                                            <div className="text-foreground ml-auto flex items-baseline gap-0.5 pl-2 font-mono font-medium tabular-nums">
                                                                                 {formatPercentage(value)}
                                                                             </div>
                                                                         </>
@@ -519,7 +515,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                     <div ref={containerRef} className='flex w-full items-center gap-2'>
                                                                         <Input
                                                                             ref={inputRef}
-                                                                            className="h-7 w-full border-border bg-background text-sm"
+                                                                            className="border-border bg-background h-7 w-full text-sm"
                                                                             value={editedUrl}
                                                                             onChange={e => setEditedUrl(e.target.value)}
                                                                         />
@@ -533,7 +529,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                 ) : (
                                                                     <>
                                                                         <Button
-                                                                            className='shrink-0 bg-background'
+                                                                            className='bg-background shrink-0'
                                                                             size='sm'
                                                                             variant='outline'
                                                                             onClick={() => handleEdit(linkId)}
@@ -564,7 +560,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         <TableFooter className='bg-transparent'>
                                             <TableRow>
                                                 <TableCell className='group-hover:bg-transparent' colSpan={2}>
-                                                    <div className='ml-2 mt-1 flex items-center gap-2 text-green'>
+                                                    <div className='text-green ml-2 mt-1 flex items-center gap-2'>
                                                         <LucideIcon.ArrowUp size={20} strokeWidth={1.5} />
                                                         Sent a broken link? You can update it!
                                                     </div>

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -116,7 +116,7 @@ const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
                             return (
                                 <div className='flex items-center gap-1'>
                                     <div className='size-2.5 rounded-[2px]' style={{backgroundColor: props.payload?.fill}}></div>
-                                    <div className='text-muted-foreground text-xs capitalize'>{props.payload?.datatype}</div>
+                                    <div className='text-xs capitalize text-muted-foreground'>{props.payload?.datatype}</div>
                                     <div className='ml-3 font-mono text-xs'>{value}%</div>
                                 </div>
                             );
@@ -133,7 +133,7 @@ const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
 
 const FunnelArrow: React.FC = () => {
     return (
-        <div className='bg-background text-muted-foreground absolute right-[-13px] top-1/2 flex size-[25px] -translate-y-1/2 items-center justify-center rounded-full border'>
+        <div className='absolute right-[-13px] top-1/2 flex size-[25px] -translate-y-1/2 items-center justify-center rounded-full border bg-background text-muted-foreground'>
             <LucideIcon.ChevronRight className='ml-0.5' size={16} strokeWidth={1.5}/>
         </div>
     );
@@ -334,7 +334,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.opened)}</KpiCardValue>
-                                            <span className='text-muted-foreground mt-0.5 text-sm'>{formatPercentage(stats.openedRate)} open rate</span>
+                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.openedRate)} open rate</span>
                                         </KpiCardContent>
                                         <FunnelArrow />
                                     </KpiCard>
@@ -346,7 +346,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.clicked)}</KpiCardValue>
-                                            <span className='text-muted-foreground mt-0.5 text-sm'>{formatPercentage(stats.clickedRate)} click rate</span>
+                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.clickedRate)} click rate</span>
                                         </KpiCardContent>
                                     </KpiCard>
                                 </div>
@@ -439,7 +439,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                                 style={{backgroundColor: color}}
                                                                             />
                                                                             {barChartConfig[name as keyof typeof barChartConfig]?.label || name}
-                                                                            <div className="text-foreground ml-auto flex items-baseline gap-0.5 pl-2 font-mono font-medium tabular-nums">
+                                                                            <div className="ml-auto flex items-baseline gap-0.5 pl-2 font-mono font-medium tabular-nums text-foreground">
                                                                                 {formatPercentage(value)}
                                                                             </div>
                                                                         </>
@@ -515,7 +515,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                     <div ref={containerRef} className='flex w-full items-center gap-2'>
                                                                         <Input
                                                                             ref={inputRef}
-                                                                            className="border-border bg-background h-7 w-full text-sm"
+                                                                            className="h-7 w-full border-border bg-background text-sm"
                                                                             value={editedUrl}
                                                                             onChange={e => setEditedUrl(e.target.value)}
                                                                         />
@@ -529,7 +529,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                 ) : (
                                                                     <>
                                                                         <Button
-                                                                            className='bg-background shrink-0'
+                                                                            className='shrink-0 bg-background'
                                                                             size='sm'
                                                                             variant='outline'
                                                                             onClick={() => handleEdit(linkId)}
@@ -560,7 +560,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         <TableFooter className='bg-transparent'>
                                             <TableRow>
                                                 <TableCell className='group-hover:bg-transparent' colSpan={2}>
-                                                    <div className='text-green ml-2 mt-1 flex items-center gap-2'>
+                                                    <div className='ml-2 mt-1 flex items-center gap-2 text-green'>
                                                         <LucideIcon.ArrowUp size={20} strokeWidth={1.5} />
                                                         Sent a broken link? You can update it!
                                                     </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -65,7 +65,7 @@ const Overview: React.FC = () => {
     return (
         <>
             <PostAnalyticsHeader currentTab='Overview'>
-                <div className='flex items-center gap-1 rounded-full bg-green/10 px-3 py-px pr-4 text-nowrap text-xs text-green-600'>
+                <div className='flex items-center gap-1 text-nowrap rounded-full bg-green/10 px-3 py-px pr-4 text-xs text-green-600'>
                     <LucideIcon.FlaskConical size={16} strokeWidth={1.5} />
                     Viewing Analytics (beta)
                     <Button className='pl-1 pr-0 text-green-600 !underline' size='sm' variant='link' onClick={() => {

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -14,6 +14,19 @@ import {useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 import {useQuery} from '@tinybirdco/charts';
 
+// Extended Email type to include status field
+interface ExtendedEmail {
+    opened_count: number;
+    email_count: number;
+    status?: string;
+}
+
+// Extended Post type with the ExtendedEmail
+interface PostWithEmail {
+    uuid?: string;
+    email?: ExtendedEmail;
+}
+
 const Overview: React.FC = () => {
     const {postId} = useParams();
     const navigate = useNavigate();
@@ -24,7 +37,7 @@ const Overview: React.FC = () => {
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid'
+            fields: 'title,slug,published_at,uuid,email'
         }
     });
 
@@ -56,11 +69,13 @@ const Overview: React.FC = () => {
     const kpiValues = getWebKpiValues(data as unknown as KpiDataItem[] | null);
 
     const kpiIsLoading = isLoading || isConfigLoading || loading;
+    const typedPost = post as PostWithEmail;
+    const hasBeenEmailed = typedPost?.email && typedPost.email.status !== 'failed';
 
     return (
         <>
             <PostAnalyticsHeader currentTab='Overview'>
-                <div className='flex items-center gap-1 text-nowrap rounded-full bg-green/10 px-3 py-px pr-4 text-xs text-green-600'>
+                <div className='flex items-center gap-1 rounded-full bg-green/10 px-3 py-px pr-4 text-nowrap text-xs text-green-600'>
                     <LucideIcon.FlaskConical size={16} strokeWidth={1.5} />
                     Viewing Analytics (beta)
                     <Button className='pl-1 pr-0 text-green-600 !underline' size='sm' variant='link' onClick={() => {
@@ -126,24 +141,26 @@ const Overview: React.FC = () => {
                         }
                     </CardContent>
                 </Card>
-                <Card className='group/card'>
-                    <div className='flex items-center justify-between gap-6'>
-                        <CardHeader>
-                            <CardTitle>Newsletter performance</CardTitle>
-                            <CardDescription>How members interacted with this email</CardDescription>
-                        </CardHeader>
-                        <Button className='mr-6 opacity-0 transition-all group-hover/card:opacity-100' variant='outline' onClick={() => {
-                            navigate(`/analytics/beta/${postId}/newsletter`);
-                        }}>
-                                View more
-                            <LucideIcon.ArrowRight />
-                        </Button>
-                    </div>
-                    <CardContent>
-                        <Separator />
-                        <NewsletterOverview />
-                    </CardContent>
-                </Card>
+                {hasBeenEmailed && (
+                    <Card className='group/card'>
+                        <div className='flex items-center justify-between gap-6'>
+                            <CardHeader>
+                                <CardTitle>Newsletter performance</CardTitle>
+                                <CardDescription>How members interacted with this email</CardDescription>
+                            </CardHeader>
+                            <Button className='mr-6 opacity-0 transition-all group-hover/card:opacity-100' variant='outline' onClick={() => {
+                                navigate(`/analytics/beta/${postId}/newsletter`);
+                            }}>
+                                    View more
+                                <LucideIcon.ArrowRight />
+                            </Button>
+                        </div>
+                        <CardContent>
+                            <Separator />
+                            <NewsletterOverview />
+                        </CardContent>
+                    </Card>
+                )}
                 <Card className='group/card'>
                     <div className='flex items-center justify-between gap-6'>
                         <CardHeader>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -14,27 +14,6 @@ import {useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 import {useQuery} from '@tinybirdco/charts';
 
-// Extended Email type to include status field
-interface ExtendedEmail {
-    opened_count: number;
-    email_count: number;
-    status?: string;
-}
-
-// Extended Post type with the ExtendedEmail and additional fields
-interface PostWithEmail {
-    uuid?: string;
-    email?: ExtendedEmail;
-    newsletter_id?: string;
-    newsletter?: object;
-    status?: string;
-    email_only?: boolean;
-    email_segment?: string;
-    email_recipient_filter?: string;
-    send_email_when_published?: boolean;
-    email_stats?: object;
-}
-
 const Overview: React.FC = () => {
     const {postId} = useParams();
     const navigate = useNavigate();
@@ -78,10 +57,10 @@ const Overview: React.FC = () => {
     const kpiValues = getWebKpiValues(data as unknown as KpiDataItem[] | null);
 
     const kpiIsLoading = isLoading || isConfigLoading || loading;
-    const typedPost = post as PostWithEmail;
+    const typedPost = post as Post;
     
     // Use the utility function from admin-x-framework
-    const showNewsletterSection = hasBeenEmailed(typedPost as Post);
+    const showNewsletterSection = hasBeenEmailed(typedPost);
 
     return (
         <>

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -43,7 +43,8 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid,feature_image,url,email,status'
+            fields: 'title,slug,published_at,uuid,feature_image,url,email,status',
+            include: 'email'
         }
     });
 

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -8,6 +8,18 @@ interface PostWithPublishedAt extends Post {
     published_at?: string;
 }
 
+// Extended Email type to include status field
+interface ExtendedEmail {
+    opened_count: number;
+    email_count: number;
+    status?: string;
+}
+
+// Extended Post type with the ExtendedEmail
+interface PostWithEmail extends PostWithPublishedAt {
+    email?: ExtendedEmail;
+}
+
 interface PostAnalyticsHeaderProps {
     currentTab?: string;
     children?: React.ReactNode;
@@ -23,11 +35,12 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid,feature_image,url'
+            fields: 'title,slug,published_at,uuid,feature_image,url,email'
         }
     });
 
-    const typedPost = post as PostWithPublishedAt;
+    const typedPost = post as PostWithEmail;
+    const hasBeenEmailed = typedPost?.email && typedPost.email.status !== 'failed';
 
     return (
         <>
@@ -110,11 +123,13 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         }}>
                             Web stats
                         </TabsTrigger>
-                        <TabsTrigger value="Newsletter" onClick={() => {
-                            navigate(`/analytics/beta/${postId}/newsletter`);
-                        }}>
-                            Newsletter
-                        </TabsTrigger>
+                        {hasBeenEmailed && (
+                            <TabsTrigger value="Newsletter" onClick={() => {
+                                navigate(`/analytics/beta/${postId}/newsletter`);
+                            }}>
+                                Newsletter
+                            </TabsTrigger>
+                        )}
                         <TabsTrigger value="Growth" onClick={() => {
                             navigate(`/analytics/beta/${postId}/growth`);
                         }}>

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -8,26 +8,6 @@ interface PostWithPublishedAt extends Post {
     published_at?: string;
 }
 
-// Extended Email type to include status field
-interface ExtendedEmail {
-    opened_count: number;
-    email_count: number;
-    status?: string;
-}
-
-// Extended Post type with the ExtendedEmail and additional fields
-interface PostWithEmail extends PostWithPublishedAt {
-    email?: ExtendedEmail;
-    newsletter_id?: string;
-    newsletter?: object;
-    status?: string;
-    email_only?: boolean;
-    email_segment?: string;
-    email_recipient_filter?: string;
-    send_email_when_published?: boolean;
-    email_stats?: object;
-}
-
 interface PostAnalyticsHeaderProps {
     currentTab?: string;
     children?: React.ReactNode;
@@ -48,9 +28,9 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
         }
     });
 
-    const typedPost = post as PostWithEmail;
+    const typedPost = post as PostWithPublishedAt;
     // Use the utility function from admin-x-framework
-    const showNewsletterTab = hasBeenEmailed(typedPost as Post);
+    const showNewsletterTab = hasBeenEmailed(typedPost);
 
     return (
         <>

--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -2,7 +2,28 @@ import React from 'react';
 import {LucideIcon, RightSidebarMenu, RightSidebarMenuLink} from '@tryghost/shade';
 // import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 // import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {useLocation, useNavigate, useParams} from '@tryghost/admin-x-framework';
+
+// Extended Email type to include status field
+interface ExtendedEmail {
+    opened_count: number;
+    email_count: number;
+    status?: string;
+}
+
+// Extended Post type with the ExtendedEmail and additional fields
+interface PostWithEmail extends Post {
+    email?: ExtendedEmail;
+    newsletter_id?: string;
+    newsletter?: object;
+    status?: string;
+    email_only?: boolean;
+    email_segment?: string;
+    email_recipient_filter?: string;
+    send_email_when_published?: boolean;
+    email_stats?: object;
+}
 
 const Sidebar:React.FC = () => {
     const navigate = useNavigate();
@@ -10,6 +31,23 @@ const Sidebar:React.FC = () => {
     const {postId} = useParams();
     // const {settings} = useGlobalData();
     // const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
+
+    const {data: {posts: [post]} = {posts: []}} = useBrowsePosts({
+        searchParams: {
+            filter: `id:${postId}`,
+            fields: 'email,status,email_only,email_segment,newsletter,newsletter_id'
+        }
+    });
+
+    const typedPost = post as PostWithEmail;
+    
+    // In the Ember app, a post has been emailed if:
+    // 1. It has an email object with non-failed status, or
+    // 2. It has email_only flag set
+    const hasBeenEmailed = Boolean(
+        (typedPost?.email && typedPost.email.status !== 'failed') || 
+        typedPost?.email_only
+    );
 
     return (
         <div className='grow py-8 pr-0'>
@@ -27,12 +65,14 @@ const Sidebar:React.FC = () => {
                     Web
                 </RightSidebarMenuLink>
 
-                <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/newsletter`} onClick={() => {
-                    navigate(`/analytics/beta/${postId}/newsletter`);
-                }}>
-                    <LucideIcon.Mail size={16} strokeWidth={1.25} />
-                    Newsletter
-                </RightSidebarMenuLink>
+                {hasBeenEmailed && (
+                    <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/newsletter`} onClick={() => {
+                        navigate(`/analytics/beta/${postId}/newsletter`);
+                    }}>
+                        <LucideIcon.Mail size={16} strokeWidth={1.25} />
+                        Newsletter
+                    </RightSidebarMenuLink>
+                )}
 
                 <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/growth`} onClick={() => {
                     navigate(`/analytics/beta/${postId}/growth`);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1825

It doesn't make sense to display newsletter-specific components (or routes/tabs) if we don't expect any data to be there. This change adds a helper that copies the logic from the Ember app to admin-x-framework to be used in consuming apps like posts and stats.