### PR TITLE
Added config option to disable stripe donations

### DIFF
--- a/apps/admin-x-framework/src/test/responses/settings.json
+++ b/apps/admin-x-framework/src/test/responses/settings.json
@@ -309,6 +309,10 @@
             "value": true
         },
         {
+            "key": "donations_enabled",
+            "value": true
+        },
+        {
             "key": "members_invite_only",
             "value": false
         },

--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -97,7 +97,7 @@ const Sidebar: React.FC = () => {
     }, [filter]);
 
     const {settings, config} = useGlobalData();
-    const [hasTipsAndDonations] = getSettingValues(settings, ['enable_donations']) as [string];
+    const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
     const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
 

--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -97,6 +97,7 @@ const Sidebar: React.FC = () => {
     }, [filter]);
 
     const {settings, config} = useGlobalData();
+    const [hasTipsAndDonations] = getSettingValues(settings, ['enable_donations']) as [string];
     const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
 
@@ -183,7 +184,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='heart' keywords={growthSearchKeywords.recommendations} navid='recommendations' title="Recommendations" onClick={handleSectionClick} />
                     <NavItem icon='emailfield' keywords={growthSearchKeywords.embedSignupForm} navid='embed-signup-form' title="Embeddable signup form" onClick={handleSectionClick} />
                     {hasStripeEnabled && <NavItem icon='discount' keywords={growthSearchKeywords.offers} navid='offers' title="Offers" onClick={handleSectionClick} />}
-                    {hasStripeEnabled && <NavItem icon='piggybank' keywords={growthSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
+                    {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={growthSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                 </SettingNavSection>
 
                 <SettingNavSection isVisible={checkVisible(Object.values(emailSearchKeywords).flat())} title="Email newsletter">

--- a/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Recommendations from './Recommendations';
 import SearchableSection from '../../SearchableSection';
 import TipsAndDonations from './TipsAndDonations';
-import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
+import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 
 export const searchKeywords = {
@@ -16,6 +16,7 @@ export const searchKeywords = {
 
 const GrowthSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
+    const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
 
     return (
@@ -23,7 +24,7 @@ const GrowthSettings: React.FC = () => {
             <Recommendations keywords={searchKeywords.recommendations} />
             <EmbedSignupForm keywords={searchKeywords.embedSignupForm} />
             {hasStripeEnabled && <Offers keywords={searchKeywords.offers} />}
-            {hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
+            {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>
     );
 };

--- a/apps/portal/src/components/pages/SupportPage.js
+++ b/apps/portal/src/components/pages/SupportPage.js
@@ -35,7 +35,12 @@ const SupportPage = () => {
             }
         }
 
-        checkoutDonation();
+        if (site && site.donations_enabled === false) {
+            setDisabledFeatureError(t('This site is not accepting donations at the moment.'));
+            setLoading(false);
+        } else {
+            checkoutDonation();
+        }
 
     // Do it once
     // eslint-disable-next-line

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -168,7 +168,7 @@ class SettingsHelpers {
     }
 
     areDonationsEnabled() {
-        return this.isStripeConnected();
+        return this.isStripeConnected() && this.config.get('enableTipsAndDonations');
     }
 
     createUnsubscribeUrl(uuid, options = {}) {

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -195,6 +195,7 @@
     "sendWelcomeEmail": true,
     "stripeDirect": false,
     "enableStripePromoCodes": false,
+    "enableTipsAndDonations": true,
     "emailAnalytics": true,
     "linkClickTrackingCacheMemberUuid": false,
     "backgroundJobs": {

--- a/ghost/core/core/shared/settings-cache/public.js
+++ b/ghost/core/core/shared/settings-cache/public.js
@@ -28,6 +28,7 @@ module.exports = {
     twitter_description: 'twitter_description',
     members_support_address: 'members_support_address',
     members_enabled: 'members_enabled',
+    donations_enabled: 'donations_enabled',
     allow_self_signup: 'allow_self_signup',
     members_invite_only: 'members_invite_only',
     members_signup_access: 'members_signup_access',

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -12,6 +12,7 @@ Object {
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "default_email_address": "noreply@127.0.0.1",
     "description": "Thoughts, stories and ideas",
+    "donations_enabled": true,
     "editor_default_email_recipients": "visibility",
     "facebook": "ghost",
     "firstpromoter_account": null,

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Hierdie webwerf is slegs op uitnodiging, kontak die eienaar vir toegang.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Om die registrasie te voltooi, kliek op die bevestigingskakel in jou inboks. As dit nie binne 3 minute aankom nie, kontroleer asseblief jou spam-vouer!",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": ".حدث خطأ أثناء معالجة دفعك، يرجى المحاولة مرة أخرى",
     "There was an error sending the email, please try again": ".حدث خطأ أثناء إرسال البريد الاكتروني، يرجى المحاولة مرة أخرى",
     "This site is invite-only, contact the owner for access.": "هذا الموقع للمشتركين فقط، تواصل مع ادارة الموقع للحصول على اشتراك.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "هذا الموقع لا يقبل المدفوعات في الوقت الحالي",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "لاكمال انشاء حسابك، استخدم رابط التأكيد المرسل الى بريد. اذا لم تتلقى الرسالة خلال 3 دقائق، برجاء التأكد من مجلد المهملات.",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Възникна грешка при обработката на вашето плащане. Моля, опитайте отново.",
     "There was an error sending the email, please try again": "Възникна грешка при изпращане на имейл, опитайте отново",
     "This site is invite-only, contact the owner for access.": "Сайтът е само с покани. Свържете се със собственика за да получите достъп.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "В момента сайтът не приема плащания.",
     "This site only accepts paid members.": "Този сайт приема само плащащи потребители.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "За да приключите регистрацията, последвайте препратката в съобщението, изпратено Ви по имейл. Ако не пристигне до 3 минути, проверете дали не е категоризирано като нежелано писмо.",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "এই সাইটটি কেবল আমন্ত্রণের মাধ্যমে, প্রবেশাধিকার পেতে মালিকের সাথে যোগাযোগ করুন।",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "সাইন আপ সম্পূর্ণ করতে, আপনার ইনবক্সে নিশ্চিতকরণ লিঙ্কে ক্লিক করুন। যদি এটি ৩ মিনিটের মধ্যে না আসে, তবে আপনার স্প্যাম ফোল্ডার চেক করুন!",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Ova je stranica samo na poziv, kontaktiraj vlasnika za pristup.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Za nastavak procesa registracije, klikni na potvrdni link u svom inboxu. Ako ne stigne u roku od 3 minute, provjeri spam folder!",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Hi ha hagut un problema processant el teu pagament. Torna-ho a provar.",
     "There was an error sending the email, please try again": "Hi ha hagut un problema en enviar el correu. Torna-ho a provar.",
     "This site is invite-only, contact the owner for access.": "Aquest lloc web és accessible només per invitació, contacta amb el propietari per obtenir-hi accés.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Aquest lloc web no està acceptant pagaments en aquests moments.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Per completar el registre, fes clic sobre l'enllaç de confirmació al teu correu electrònic. Si no t'arriba en 3 minuts, revisa la teva carpeta de correu brossa!",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -256,6 +256,7 @@
     "This comment has been removed.": "Text for a comment thas was removed",
     "This email address will not be used.": "This is in the footer of signup verification emails, and comes right after 'If you did not make this request, you can simply delete this message.'",
     "This site is invite-only, contact the owner for access.": "A message on the member login screen indicating that a site is not-open to public signups",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "An error message shown when a tips or donations link is opened but the site has donations disabled",
     "This site only accepts paid members.": "error message for sign-up",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "A confirmation message displayed during the signup process, indicating that the person signing up needs to go and check their email - and reminding them to check their spam folder, too",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Při zpracování vaší platby došlo k chybě. Zkuste to prosím znovu.",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Tento web je pouze pro pozvané, kontaktujte provozovatele pro přístup.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Tento web momentálně nepřijímá platby.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pro dokončení registrace klikněte na potvrzovací odkaz ve vaší e-mailové schránce. Pokud nepřijde do 3 minut, zkontrolujte prosím složku nevyžádaných zpráv (spam)!",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Der opstod en fejl under behandlingen af din betaling. Prøv venligst igen.",
     "There was an error sending the email, please try again": "Der opstod en fejl under afsendelse af e-mailen, prøv venligst igen.",
     "This site is invite-only, contact the owner for access.": "Denne sider kræver at du skal være inviteret. Kontakt ejeres for at få adgang.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne side accepterer ikke betalinger i øjeblikket.",
     "This site only accepts paid members.": "Denne side er kun tilgængelig for betalende medlemmer.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "For at gennemføre oprettelsen af din konto, skal du klikke på bekræftelseslinket i din e-mail indbakke. Hvis det ikke kommer indenfor 3 minutter, så tjek venligst din spam mappe!",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Bei der Verarbeitung Ihrer Zahlung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     "There was an error sending the email, please try again": "Beim Versand der E-Mail ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     "This site is invite-only, contact the owner for access.": "Der Zugang zu diesem Inhalt ist eingeschränkt. Bitte kontaktieren Sie uns, wenn Sie Zugang wünschen.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Diese Seite nimmt momentan keine Zahlungen entgegen.",
     "This site only accepts paid members.": "Diese Seite ist exklusiv für zahlende Mitglieder.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Um Ihre Registrierung abzuschliessen, klicken Sie auf den Bestätigungslink in der E-Mail, die wir Ihnen gesendet haben. Falls Sie nach drei Minuten noch keine E-Mail erhalten haben, überprüfen Sie bitte Ihren Spam-Ordner.",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Bei der Verarbeitung deiner Zahlung gab es einen Fehler. Bitte versuche es noch einmal.",
     "There was an error sending the email, please try again": "Beim Versand der E-Mail ist ein Fehler aufgetreten. Bitte versuche es erneut.",
     "This site is invite-only, contact the owner for access.": "Für diese Seite benötigst du eine Einladung. Bitte kontaktiere den Inhaber.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Diese Website nimmt zur Zeit keine Zahlungen entgegen.",
     "This site only accepts paid members.": "Diese Seite ist exklusiv für zahlende Mitglieder.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Um deine Registrierung abzuschließen, klicke auf den Bestätigungslink in deinem Posteingang. Falls die E-Mail nicht innerhalb von 3 Minuten ankommt, überprüfe bitte deinen Spam-Ordner!",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Αυτός ο ιστότοπος είναι μόνο με πρόσκληση, επικοινωνήστε με τον ιδιοκτήτη για πρόσβαση.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Για να ολοκληρώσετε την εγγραφή, κάντε κλικ στον σύνδεσμο επιβεβαίωσης στα εισερχόμενά σας. Αν δεν φτάσει εντός 3 λεπτών, ελέγξτε τον φάκελο ανεπιθύμητης αλληλογραφίας!",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Ĉi tiu retejo estas nur por invitiĝuloj, kontaktu la proprietulo por alireblo.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Por kompletigi aliĝon, premu la konfirman ligilon en via enirkesto. Se ĝi ne alvenas ene de 3 minutoj, kontrolu vian trudmesaĝdosieron!",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Hubo un error procesando tu pago. Intentalo de nuevvo por favor.",
     "There was an error sending the email, please try again": "Hubo un error enviando el correo electrónico, intentalo de nuevo por favor.",
     "This site is invite-only, contact the owner for access.": "Este sitio es solo por invitación, contacta al propietario para obtener acceso.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Este sitio no acepta pagos en este momento.",
     "This site only accepts paid members.": "Este sitio es sólo para miembros pagando.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Para completar el registro, haz clic en el enlace de confirmación en tu correo electrónico. Si no llega en 3 minutos, ¡revisa tu carpeta de spam!",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "See sait on ainult kutsetega, juurdepääsu saamiseks võtke ühendust omanikuga.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Registreerimise lõpetamiseks klõpsake oma postkastis kinnituslingile. Kui see ei saabu 3 minuti jooksul, kontrollige oma rämpsposti kausta!",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "دسترسی به این وب\u200cسایت نیازمند دعوت\u200cنامه است، با مالک آن برای دریافت دسترسی تماس بگیرید.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "برای تکمیل ثبت نام، برروی پیوند تأیید در صندوق ورودی ایمیل خود کلیک کنید. در صورتی که به دست شما نرسید، پوشه اسپم خود را برررسی کنید!",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Tämä sivu on vain kutsutuille, ota yhteyttä omistajaan saadaksesi pääsyoikeuden.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Viimeistelläksesi rekisteröitymisen, klikkaa vahvistuslinkkiä sähköpostissasi. Jos sitä ei saavu 3 minuutin kuluessa, tarkista roskapostikansiosi!",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Une erreur s'est produite lors du traitement de votre paiement. Veuillez réessayer.",
     "There was an error sending the email, please try again": "Une erreur s'est produite lors de l'envoi de l'e-mail, veuillez réessayer.",
     "This site is invite-only, contact the owner for access.": "Ce site est réservé aux invités. Veuillez écrire au propriétaire pour en demander l'accès.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ce site n'accepte pas les paiements pour le moment.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pour confirmer votre inscription, veuillez cliquer le lien de confirmation dans l'e-mail que vous allez recevoir. S’il ne vous parvient pas dans les 3 minutes, vérifiez votre dossier d'indésirables !",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Thachair mearachd fhad 's a bhathar a' làimhseachadh a' phàighidh agad. Feuch a-rithist.",
     "There was an error sending the email, please try again": "Thachair mearachd agus dh'fhàillig cur a' phuist-d, feuch a-rithist.",
     "This site is invite-only, contact the owner for access.": "Feumar cuireadh airson an làrach-lìn seo, leig fios dhan rianaire ma tha thu ag iarraidh cothrom-inntrigidh.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Chan eil an làrach seo a' gabhail ri phàighidhean an-dràsta.",
     "This site only accepts paid members.": "Chan fhaighear don làrach seo ach buill a tha air pàigheadh.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Dèan briog air a’ cheangal dearbhaidh a chaidh a chur dhan phost-d agad gus crìoch a chur an an clàradh agad. Thoir sùil air a’ phasgan spama mura faigh thu taobh a-staigh 3 mionaidean e.",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "שגיאה בעיבוד התשלום שלכם. נסו שוב.",
     "There was an error sending the email, please try again": "שגיאה בשליחת המייל, נסו שוב",
     "This site is invite-only, contact the owner for access.": "אתר זה פתוח למוזמנים בלבד, פנו לבעל האתר לגישה.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "אתר זה לא מקבל תשלומים כרגע.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "כדי לסיים את הרשמתכם, לחצו על לינק האישור בתיבת המייל שלכם. במידה ולא הגיע תוך 3 דקות, בדקו את תיבת הספאם!",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "यह साइट केवल निमंत्रण द्वारा है, पहुँच के लिए मालिक से संपर्क करें।",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "साइनअप पूरा करने के लिए, अपने इनबॉक्स में पुष्टिकरण लिंक पर क्लिक करें। यदि यह 3 मिनट के भीतर नहीं आता है, तो अपना स्पैम फ़ोल्डर जांचें!",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Došlo je do greške prilikom obrade uplate. Pokušajte ponovno.",
     "There was an error sending the email, please try again": "Došlo je do greške prilikom slanja poruke e-pošte, pokušajte ponovno",
     "This site is invite-only, contact the owner for access.": "Ove stranice su samo za članove, kontaktirajte vlasnika kako biste dobili pristup.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ova stranica trenutno ne prihvaća uplate.",
     "This site only accepts paid members.": "Ova stranica je dostupna samo korisnicima sa plaćenom pretplatom.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Kliknite na link za završetak registracije. Ako poruku niste dobili za 3 minute, provjerite spam folder!",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Hiba történt a fizetési folyamatnál. Kérjük, próbáld újra.",
     "There was an error sending the email, please try again": "Hiba történt az e-mail küldésénél. Kérjük, próbáld újra.",
     "This site is invite-only, contact the owner for access.": "A weboldal csak meghívóval látogatható. Meghívóért lépj kapcsolatba a weboldal tulajdonosával.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "A weboldal jelenleg nem fogad el fizetést.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "A regisztráció befejezéséhez kérjük, kattints az e-mailben kapott linkre. Ha a link nem érkezik meg 3 percen belül, kérjük, ellenőrizd a spam mappát.",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Terjadi kesalahan saat memproses pembayaran Anda. Harap coba lagi.",
     "There was an error sending the email, please try again": "Terjadi kesalahan saat mengirim email, harap coba lagi",
     "This site is invite-only, contact the owner for access.": "Situs ini hanya untuk yang diundang, hubungi pemiliknya untuk mendapatkan akses.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Situs ini tidak menerima pembayaran saat ini.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Untuk menyelesaikan pendaftaran, klik tautan konfirmasi di kotak masuk Anda. Jika tidak diterima dalam waktu 3 menit, pastikan untuk memeriksa folder spam Anda!",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Aðgangur krefst boðsmiða, hafið samband við eiganda síðunnar til að fá aðgang.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Til að ljúka nýskráningu skaltu smella á staðfestingarhlekkinn sem var sendur á netfangið þitt. Ef hann er ekki kominn innan 3 mínútna skaltu athuga spam-möppuna.",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "C'è stato un errore durante l’elaborazione del tuo pagamento. Riprova per favore.",
     "There was an error sending the email, please try again": "C'è stato un errore nell'invio dell'e-mail, per favore riprova",
     "This site is invite-only, contact the owner for access.": "Questo sito è accessibile solo su invito, contatta il proprietario per poter accedere.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Questo sito non accetta pagamenti al momento.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Per completare l'iscrizione, clicca il link di conferma inviato alla tua email. Se non lo ricevi entro 3 minuti, controlla nello spam!",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "このサイトは招待制です。アクセスするにはオーナーに連絡してください。",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "新規登録を完了するには、受信トレイの確認リンクをクリックしてください。3分経っても届かない場合は、スパムフォルダを確認してください。",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "결제 처리 중 오류가 발생했어요. 다시 시도해 주세요.",
     "There was an error sending the email, please try again": "이메일 전송 중 오류가 발생했어요. 다시 시도해 주세요",
     "This site is invite-only, contact the owner for access.": "위 사이트는 초대된 사용자만 사용이 가능해요. 접근을 위해서는 관리자에게 연락해 주세요.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "현재 이 사이트는 결제를 받지 않고 있어요.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "가입을 완료하려면 이메일의 확인 링크를 클릭해 주세요. 3분 이내에 도착하지 않으면 스팸 폴더를 확인해 주세요!",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Бұл сайтқа тек шақырту бойынша кіруге болады, рұқсат алу үшін иесіне хабарласыңыз.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "іркелуді аяқтау үшін, кіріс жәшігіңіздегі растау сілтемесін басыңыз. Егер ол 3 минут ішінде келмесе, спам қалтасын тексеріңіз!",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Ši svetainė pasiekiama tik su pakvietimu, susisiekite su savininku dėl prieigos. ",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Jei norite užbaigti registraciją, gautame el. laiške spustelėkite patvirtinimo nuorodą. Jei laiško negaunate per 3 minutes, patikrinkite šlamšto (spam) aplanką!",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Apstrādājot jūsu maksājumu, radās kļūda. Lūdzu, mēģiniet vēlreiz.",
     "There was an error sending the email, please try again": "Nosūtot e-pasta ziņojumu, radās kļūda. Lūdzu, mēģiniet vēlreiz",
     "This site is invite-only, contact the owner for access.": "Šī vietne ir paredzēta tikai ielūgumam. Lai iegūtu piekļuvi, sazinieties ar īpašnieku.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Šī vietne pašlaik nepieņem maksājumus.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Lai pabeigtu reģistrāciju, iesūtnē noklikšķiniet uz apstiprinājuma saites. Ja tas nepienāk 3 minūšu laikā, pārbaudiet savu surogātpasta mapi!",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Оваа страница е достапна само со покана. За пристап контактирајте го сопственикот.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "За да ја завршите регистрацијата, кликнете на линкот за потврда испратен на вашата email адреса. Ако не пристигне во рок од 3 минути, проверте во спам!",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Таны төлбөрийг боловсруулахад алдаа гарлаа. Дахин оролдоно уу.",
     "There was an error sending the email, please try again": "Имэйл илгээхэд алдаа гарлаа, дахин оролдоно уу",
     "This site is invite-only, contact the owner for access.": "Энэхүү сайт руу зөвхөн урилгаар нэвтрэх боломжтой тул та админд нь хандана уу.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Энэхүү сайт одоогоор төлбөр хүлээн авахгүй байна.",
     "This site only accepts paid members.": "Энэхүү сайт зөвхөн төлбөртэй гишүүдийг хүлээн авдаг.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Тан руу илгээсэн баталгаажуулах холбоос дээр дарж бүртгэлээ дуусгана уу. Хэрвээ 3 минутын дотор ирэхгүй бол спамаа шалгана уу!",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Laman web ini hanya untuk jemputan, hubungi pemilik untuk akses.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Untuk melengkapkan pendaftaran, klik pautan pengesahan di peti masuk anda. Jika ia tidak tiba dalam masa 3 minit, semak folder spam anda!",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Det oppsto en feil under behandling av betalingen din. Vennligst prøv igjen.",
     "There was an error sending the email, please try again": "En feil oppstod ved sending av e-posten, vennligst prøv igjen",
     "This site is invite-only, contact the owner for access.": "Denne nettsiden er kun for inviterte. Kontakt eieren for invitasjon.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Denne nettsiden godtar ikke betalinger for øyeblikket.",
     "This site only accepts paid members.": "Denne nettsiden er kun for betalende medlemmer.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "For å fullføre registreringen, klikk på bekreftelseslenken i innboksen din. Hvis den ikke kommer innen 3 minutter, må du sjekke søppelposten din!",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Er was een fout bij het verwerken van je betaling, probeer het opnieuw.",
     "There was an error sending the email, please try again": "Er was een fout bij het verzenden van de e-mail, probeer het opnieuw",
     "This site is invite-only, contact the owner for access.": "Deze site is alleen toegankelijk op uitnodiging, neem contact op met de eigenaar.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Deze site accepteert momenteel geen betalingen.",
     "This site only accepts paid members.": "Deze site accepteert alleen betalende leden.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Klik op de bevestigingslink in de e-mail om je registratie af te ronden. Check ook je spamfolder als hij niet binnen de 3 minuten aankomt.",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Denne sida er kun for inviterte, ta kontakt med eigaren for tilgang.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Klikk på bekreftelseslenka i innboksen din for å fullføra registreringa. Sjekk spam-mappa di om lenka ikkje har kome innan 3 minutt.",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "ਤੁਹਾਡੇ ਭੁਗਤਾਨ ਦੀ ਪ੍ਰਕਿਰਿਆ ਕਰਨ ਵਿੱਚ ਇੱਕ ਗਲਤੀ ਆਈ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।",
     "There was an error sending the email, please try again": "ਈਮੇਲ ਭੇਜਣ ਵਿੱਚ ਇੱਕ ਗਲਤੀ ਆਈ, ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ",
     "This site is invite-only, contact the owner for access.": "ਇਹ ਸਾਈਟ ਸਿਰਫ਼ ਸੱਦਾ-ਪੱਤਰ 'ਤੇ ਹੈ, ਪਹੁੰਚ ਲਈ ਮਾਲਕ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "ਇਹ ਸਾਈਟ ਇਸ ਸਮੇਂ ਭੁਗਤਾਨ ਸਵੀਕਾਰ ਨਹੀਂ ਕਰ ਰਹੀ ਹੈ।",
     "This site only accepts paid members.": "ਇਹ ਸਾਈਟ ਸਿਰਫ਼ ਭੁਗਤਾਨਸ਼ੁਦਾ ਮੈਂਬਰਾਂ ਨੂੰ ਸਵੀਕਾਰ ਕਰਦੀ ਹੈ।",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "ਸਾਈਨ-ਅੱਪ ਪੂਰਾ ਕਰਨ ਲਈ, ਆਪਣੇ ਇਨਬਾਕਸ ਵਿੱਚ ਪੁਸ਼ਟੀਕਰਨ ਲਿੰਕ 'ਤੇ ਕਲਿੱਕ ਕਰੋ। ਜੇਕਰ ਇਹ 3 ਮਿੰਟਾਂ ਦੇ ਅੰਦਰ ਨਹੀਂ ਆਉਂਦਾ, ਤਾਂ ਆਪਣਾ ਸਪੈਮ ਫੋਲਡਰ ਚੈੱਕ ਕਰੋ!",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Wystąpił błąd podczas przetwarzania płatności. Spróbuj ponownie.",
     "There was an error sending the email, please try again": "Wystąpił błąd podczas wysyłania wiadomości e-mail. Spróbuj ponownie.",
     "This site is invite-only, contact the owner for access.": "Ta strona posiada zamknięty dostęp. Skontaktuj się z właścicielem, aby uzyskać dostęp.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Ta strona nie przyjmuje obecnie płatności.",
     "This site only accepts paid members.": "Ta strona akceptuje tylko płatne członkostwa.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Aby dokończyć rejestrację, kliknij w link przesłany na twoją skrzynkę pocztową. Jeśli nie dotrze w ciągu 3 minut, sprawdź folder spamu!",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Houve um erro ao processar seu pagamento. Por favor, tente novamente.",
     "There was an error sending the email, please try again": "Houve um erro ao enviar o e-mail, por favor, tente novamente.",
     "This site is invite-only, contact the owner for access.": "Este site é apenas para convidados. Contate o proprietário para obter acesso.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Este site não está aceitando pagamentos no momento.",
     "This site only accepts paid members.": "Este site aceita apenas membros pagantes",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Para completar o cadastro, clique no link de confirmação enviado para sua caixa de entrada. Se o link não chegar dentro de 3 minutos, confira a pasta de spam!",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Houve um problema ao processar o seu pagamento. Tente novamente por favor.",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "O acesso a este site é feito apenas por convite. Entre em contacto com o proprietário para obter acesso.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Este site não está a aceitar pagamentos de momento",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Para completar o registo, clique no link de confirmação enviado para a sua caixa de entrada. Se não o receber dentro de 3 minutos, verifique a sua pasta de spam!",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Acest site este disponibil doar pe bază de invitație, contactează proprietarul pentru acces.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pentru a finaliza înregistrarea, apasă pe link-ul de confirmare din inbox-ul tău. Dacă nu ajunge în 3 minute, verifică folderul de spam!",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Произошла ошибка при обработке вашего платежа. Попробуйте ещё раз.",
     "There was an error sending the email, please try again": "Произошла ошибка при отправке письма. Попробуйте ещё раз.",
     "This site is invite-only, contact the owner for access.": "Доступ к материалам этого сайта возможен только по приглашению. Для получения доступа свяжитесь с владельцем сайта.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "В данный момент сайт не принимает платежи.",
     "This site only accepts paid members.": "Этот сайт доступен только для платных участников.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Чтобы завершить регистрацию, нажмите на ссылку подтверждения в электронном письме, которое мы прислали. Если письмо не пришло в течение 3 минут, проверьте папку «Спам»!",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "මෙම වෙබ් අඩවිය ආරාධිතයන් සඳහා පමණි, ප්\u200dරවේශ වීම සඳහා හිමිකරු අමතන්න.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Signup වීම සම්පූර්ණ කිරීම සඳහා, ඔබ\u200dගේ inbox එකට ලැබුණු email එකෙහි ඇති confirmation link එක click කරන්න. එය මිනිත්තු 3ක් ඇතුලත නොපැමිණියේ නම්, spam folder එක පරීක්ෂා කරන්න!",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Pri spracovaní vašej platby došlo k chybe. Skúste to prosím znova.",
     "There was an error sending the email, please try again": "Pri odosielaní e-mailu došlo k chybe, skúste to prosím znova",
     "This site is invite-only, contact the owner for access.": "Táto stránka je iba pre pozvaných úžívateľov, kontaktujte vlastníka stránky.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Táto stránka momentálne neprijíma platby.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Ak chcete dokončiť registráciu, kliknite na potvrdzujúci odkaz v doručenej pošte. Ak vám nepríde do 3 minút, skontrolujte priečinok so spamom!",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Prišlo je do napake pri obdelavi vaše plačljive transakcije. Prosimo, poskusite znova.",
     "There was an error sending the email, please try again": "Prišlo je do napake pri pošiljanju e-pošte, prosimo, poskusite znova",
     "This site is invite-only, contact the owner for access.": "To spletno mesto je dostopno samo s povabilom, obrnite se na lastnika.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "To spletno mesto trenutno ne sprejema plačil.",
     "This site only accepts paid members.": "To spletno mesto sprejema samo plačljive člane.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Za dokončanje prijave kliknite potrditveno povezavo v vaši e-pošti. Če ne prispe v 3 minutah, preverite mapo za neželeno pošto!",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Kjo faqe eshte vetem me ftesa, kontaktoni zoteruesin per akses.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Për të përfunduar regjistrimin, klikoni lidhjen e konfirmimit në kutinë tuaj hyrëse. Nëse nuk arrin brenda 3 minutash, kontrolloni dosjen tuaj të postës elektronike!",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Дошло је до грешке при обради ваше уплате. Молимо вас покушајте поново.",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Овај сајт је само на позив, контактирајте власника ради приступа.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Овај сајт тренутно не прихвата уплате.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Да бисте завршили пријаву, кликните на линк за потврду у свом сандучету. Ако не стигне у року од 3 минута, проверите фасциклу за нежељену пошту!",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Ovaj sajt je samo za članove, kontaktirajte vlasnika kako bi dobili pristup.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Kliknite na link da biste završili registraciju. Ukoliko ne stigne za 3 minuta proverite spam folder!",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Det blev fel när din betalning skulle behandlas, vänligen försök igen",
     "There was an error sending the email, please try again": "Det blev ett fel när e-posten skulle skickas, vänligen försök igen",
     "This site is invite-only, contact the owner for access.": "Den här sidan är endast för inbjudna, kontakta ägaren för åtkomst.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Den här webbsidan accepterar inte betalningar för tillfället",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "För att slutföra registreringen, klicka på bekräftelselänken i din inkorg. Om den inte kommer fram inom 3 minuter, kolla din skräppostmapp!",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Tovuti hii ni ya mialiko pekee, wasiliana na mmiliki kupata ufikiaji.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Kukamilisha usajili, bonyeza kiungo cha uthibitisho kwenye kikasha chako. Kama hakifiki ndani ya dakika 3, kagua folda yako ya spam!",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "உங்கள் கட்டணத்தை செயலாக்குவதில் பிழை ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.",
     "There was an error sending the email, please try again": "மின்னஞ்சலை அனுப்புவதில் பிழை ஏற்பட்டது, மீண்டும் முயற்சிக்கவும்",
     "This site is invite-only, contact the owner for access.": "இந்த தளம் அழைப்பு மட்டுமே, அணுகலுக்கு உரிமையாளரைத் தொடர்பு கொள்ளவும்.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "இந்த தளம் தற்போது கட்டணங்களை ஏற்கவில்லை.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "பதிவை முடிக்க, உங்கள் உள்பெட்டியில் உள்ள உறுதிப்படுத்தல் இணைப்பைக் கிளிக் செய்யவும். 3 நிமிடங்களுக்குள் அது வரவில்லை என்றால், உங்கள் ஸ்பாம் கோப்புறையைச் சரிபார்க்கவும்!",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "เว็บไซต์นี้สำหรับผู้ได้รับเชิญเท่านั้น โปรดติดต่อเจ้าของเพื่อเข้าถึง",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "เพื่อทำการลงทะเบียนให้เสร็จสิ้น คลิกลิงก์ยืนยันในกล่องจดหมายของคุณ หากไม่ได้รับภายใน 3 นาที ให้ตรวจสอบโฟลเดอร์สแปมของคุณ!",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Ödemeniz işlenirken bir hata oluştu. Lütfen tekrar deneyiniz.",
     "There was an error sending the email, please try again": "E-posta gönderilirken bir hata oluştu, lütfen tekrar deneyin.",
     "This site is invite-only, contact the owner for access.": "Bu site sadece davetiyesi olanlar içindir, erişim için site sahibiyle iletişime geç.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Bu site şu anda ödeme kabul etmemektedir.",
     "This site only accepts paid members.": "Bu site sadece ücretli üye kabul etmektedir.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Kaydınızı tamamlamak için gelen kutunuzdaki onay bağlantısına tıklayın. Eğer 3 dakika içinde gelmezse, spam klasörünüzü kontrol edin!",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Під час обробки вашого платежу сталася помилка. Спробуйте ще раз.",
     "There was an error sending the email, please try again": "Під час надсилання листа сталася помилка. Повторіть спробу",
     "This site is invite-only, contact the owner for access.": "Цей сайт доступний тільки за запрошенням, звернись до власника сайта для доступу.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Цей сайт на даний момент не приймає платежі.",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Щоб завершити реєстрацію, натисни посилання в своїй електронній пошті для підтвердження. Якщо електронний лист не прийде протягом 3 хвилин, перевір папку спам!",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "یہ سائٹ صرف دعوتی ہے، دستیابی کے لئے مالک سے رابطہ کریں۔",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "سائن اپ مکمل کرنے کے لئے، اپنے ان باکس میں تصدیق کے لنک پر کلک کریں۔ اگر 3 منٹ کے اندر نہ آئے تو، اپنا اسپیم فولڈر چیک کریں!",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "Bu saytda faqat taklif qilinadi, kirish uchun egasiga murojaat qiling.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Ro‘yxatdan o‘tishni yakunlash uchun pochta qutingizdagi tasdiqlash havolasini bosing. Agar u 3 daqiqada kelmasa, spam jildini tekshiring!",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "Xảy ra lỗi khi tiến hành thanh toán. Hãy thử lại sau.",
     "There was an error sending the email, please try again": "Xảy ra lỗi khi gửi email, vui lòng thử lại",
     "This site is invite-only, contact the owner for access.": "Trang web này chỉ dành cho những người được mời, hãy liên hệ với chủ sở hữu để cấp quyền truy cập.",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "Trang web này hiện chưa chấp nhận thanh toán.",
     "This site only accepts paid members.": "Trang web này chỉ dành cho thành viên trả phí.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Để hoàn tất đăng ký, nhấn vào liên kết xác nhận được gửi tới email của bạn. Sau 3 phút mà không thấy, hãy kiểm tra hộp thư spam!",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "處理您的付款時發生錯誤，請您再試一次。",
     "There was an error sending the email, please try again": "寄送 email 時發生錯誤，請您再試一次。",
     "This site is invite-only, contact the owner for access.": "此網站僅限受邀請者觀看，請聯繫網站擁有者取得存取權限。",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "此網站目前無付款方式。",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "要完成註冊，請點擊您收件匣中的確認連結。如果在 3 分鐘內沒有收到，請檢查您的垃圾郵件。",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -169,6 +169,7 @@
     "There was an error processing your payment. Please try again.": "您的付款处理失败，请重试。",
     "There was an error sending the email, please try again": "",
     "This site is invite-only, contact the owner for access.": "此网站仅限邀请，联系网站所有者以获取访问",
+    "This site is not accepting donations at the moment.": "",
     "This site is not accepting payments at the moment.": "本网站目前暂不接受付款。",
     "This site only accepts paid members.": "",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "要完成注册，请点击您收件箱中的确认链接。如果在3分钟内没有收到，请检查一下您的垃圾邮件文件夹！",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-911/support-escalation-turn-off-donations-entirely

- When you connect stripe, the tips and donations feature is automatically enabled
- In some contexts (e.g. political) having this available is not desirable
- This adds a config-only option to disable the feature as the case is rare and doesn't warrant a setting in UI
- Instead we hide the UI if this config flag is disabled

