### PR TITLE
Added limit for newsletter link clicks endpoint

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -150,14 +150,15 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid,email,status'
+            fields: 'title,slug,published_at,uuid,status',
+            include: 'email'
         }
     });
 
     const typedPost = post as Post;
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(typedPost);
-
+    
     useEffect(() => {
         // Redirect to overview if the post wasn't sent as a newsletter
         if (!isPostLoading && !showNewsletterSection) {

--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -75,7 +75,7 @@
                             </li>
                             {{#if (and (gh-user-can-admin this.session.user) this.config.stats)}}
                                 <li>
-                                    <LinkTo class="edit-post" @route="posts-x" @model={{this.post.id}}>Switch to Ghost Analytics (beta)</LinkTo>
+                                    <LinkTo class="edit-post" @route="posts-x" @model={{this.post.id}}>Switch to Analytics (beta)</LinkTo>
                                 </li>
                             {{/if}}
                             <li>

--- a/ghost/core/core/server/api/endpoints/links.js
+++ b/ghost/core/core/server/api/endpoints/links.js
@@ -9,7 +9,8 @@ const controller = {
             cacheInvalidate: false
         },
         options: [
-            'filter'
+            'filter',
+            'limit'
         ],
         permissions: true,
         async query(frame) {

--- a/ghost/core/core/server/models/redirect.js
+++ b/ghost/core/core/server/models/redirect.js
@@ -36,7 +36,7 @@ const Redirect = ghostBookshelf.Model.extend({
     permittedOptions(methodName) {
         let options = ghostBookshelf.Model.permittedOptions.call(this, methodName);
         const validOptions = {
-            findAll: ['filter', 'columns', 'withRelated'],
+            findAll: ['filter', 'columns', 'withRelated', 'limit'],
             edit: ['importing']
         };
 

--- a/ghost/core/core/server/services/link-tracking/LinkClickTrackingService.js
+++ b/ghost/core/core/server/services/link-tracking/LinkClickTrackingService.js
@@ -36,7 +36,7 @@ const moment = require('moment');
 /**
  * @typedef {object} IPostLinkRepository
  * @prop {(postLink: PostLink) => Promise<void>} save
- * @prop {({filter: string}) => Promise<FullPostLink[]>} getAll
+ * @prop {(options: {filter: string, limit?: string}) => Promise<FullPostLink[]>} getAll
  * @prop {(linkIds: array, data, options) => Promise<FullPostLink[]>} updateLinks
  */
 
@@ -88,12 +88,14 @@ class LinkClickTrackingService {
 
     /**
      * @param {object} options
-     * @param {string} options.filter
+     * @param {string} [options.filter]
+     * @param {string} [options.limit]
      * @return {Promise<FullPostLink[]>}
      */
-    async getLinks(options) {
+    async getLinks(options = {}) {
         return await this.#postLinkRepository.getAll({
-            filter: options.filter
+            filter: options.filter || '',
+            limit: options.limit
         });
     }
 

--- a/ghost/core/test/unit/server/services/link-tracking/LinkClickTrackingService.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/LinkClickTrackingService.test.js
@@ -37,8 +37,8 @@ describe('LinkClickTrackingService', function () {
             });
             const links = await service.getLinks({filter: 'post_id:1'});
 
-            // Check called with filter
-            assert.ok(getAll.calledOnceWithExactly({filter: 'post_id:1'}));
+            // Check called with filter and empty limit
+            assert.ok(getAll.calledOnceWithExactly({filter: 'post_id:1', limit: undefined}));
 
             // Check returned value
             assert.deepEqual(links, ['test']);


### PR DESCRIPTION
ref 9919ba0b70db384ee389aa3088a7df3f8a5c334e
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1747752723214079?thread_ts=1747749260.023719&cid=C07HTEJMR2R

Added limit support to post links endpoint so we can limit the click results to 5 on the Posts > Overview tab for the beta analytics page. Includes minor copy update and fix to Newsletter tab logic.