### PR TITLE
Added `split` docker compose profile with standalone server and admin services

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,8 +35,51 @@ x-service-template: &service-template
     - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
 
 services:
+  server:
+    <<: *service-template
+    image: ghost-monorepo:latest
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+      target: development
+    entrypoint: [ "/home/ghost/.docker/development.entrypoint.sh" ]
+    working_dir: /home/ghost/ghost/core
+    command: [ "yarn", "dev" ]
+    ports:
+      - "2368:2368"
+    profiles: [ split ]
+    tty: true
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      - DEBUG=${DEBUG:-}
+      - SSH_AUTH_SOCK=/ssh-agent
+      - NX_DAEMON=false
+      - GHOST_DEV_IS_DOCKER=true
+      - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
+      - GHOST_UPSTREAM=${GHOST_UPSTREAM:-}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
+      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
+
+  admin:
+    <<: *service-template
+    image: ghost-monorepo:latest
+    entrypoint: [ "/home/ghost/.docker/development.entrypoint.sh" ]
+    working_dir: /home/ghost/ghost/admin
+    command: [ "yarn", "dev" ]
+    ports:
+      - "4200:4200"
+      - "4201:4201"
+    profiles: [ split ]
+    tty: true
+
   ghost:
     <<: *service-template
+    image: ghost-monorepo:latest
     build:
       context: .
       dockerfile: ./.docker/Dockerfile


### PR DESCRIPTION
no refs

The current `ghost` profile in our `compose.yml` builds the whole monorepo and then runs `yarn dev`, which in turn runs `.github/scripts/dev.js`. This script runs _all the things_ in parallel using concurrently. This commit adds a new `split` profile to the `compose.yml`, which has a standalone `server` service (for Ghost's backend server) and `admin` service, for watching & rebuilding the admin files. I _think_ this is likely going to eventually replace the current all-in-one `ghost` service, but for now I've added it as a separate profile so as to avoid breaking anything in anyone's current workflow.

Another motivation for this is to remove the need to run the `nx daemon` in the docker container, which is currently required by the `dev.js` script. If we instead run all the subprocesses in their own container (or potentially with some reasonable degree of consolidation), we don't need the NX daemon to run in Docker at all, which should eliminate a whole class of annoying errors.

I plan to keep adding to this `split` profile to cover everything else that `dev.js` does — particularly the other frontend apps like portal, comments and the other admin micro-frontends like settings, posts and stats, in addition to probably an nginx service to act as a gateway to all these different services. This commit is just the first step toward that future.