### PR TITLE
Refactored link limit handling for stats redesign 

### DIFF
--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -20,7 +20,7 @@ type PostWithNewsletter = {
     [key: string]: unknown;
 };
 
-export const usePostNewsletterStats = (postId: string) => {
+export const usePostNewsletterStats = (postId: string, linksLimit?: string) => {
     const {data: postResponse, isLoading: isPostLoading} = getPost(postId);
 
     // Fetch the post to get top level stats
@@ -51,12 +51,17 @@ export const usePostNewsletterStats = (postId: string) => {
     // Fetch the last 20 newsletters and calculate the average open and click rates
     const {data: newsletterStatsResponse, isLoading: isNewsletterStatsLoading} = useNewsletterStatsByNewsletterId(newsletterId);
 
-    // Get the top 5 link clicks from this post
+    // Get link clicks from this post, with optional limit
+    const searchParams: Record<string, string> = {
+        filter: `post_id:'${postId}'`
+    };
+    
+    if (linksLimit) {
+        searchParams.limit = linksLimit;
+    }
+    
     const {data: clicksResponse, isLoading: isClicksLoading, refetch: refetchTopLinks} = useTopLinks({
-        searchParams: {
-            filter: `post_id:'${postId}'`,
-            limit: '5'
-        }
+        searchParams
     });
 
     const links = useMemo(() => {

--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -20,7 +20,7 @@ type PostWithNewsletter = {
     [key: string]: unknown;
 };
 
-export const usePostNewsletterStats = (postId: string, linksLimit?: string) => {
+export const usePostNewsletterStats = (postId: string) => {
     const {data: postResponse, isLoading: isPostLoading} = getPost(postId);
 
     // Fetch the post to get top level stats
@@ -51,17 +51,11 @@ export const usePostNewsletterStats = (postId: string, linksLimit?: string) => {
     // Fetch the last 20 newsletters and calculate the average open and click rates
     const {data: newsletterStatsResponse, isLoading: isNewsletterStatsLoading} = useNewsletterStatsByNewsletterId(newsletterId);
 
-    // Get link clicks from this post, with optional limit
-    const searchParams: Record<string, string> = {
-        filter: `post_id:'${postId}'`
-    };
-    
-    if (linksLimit) {
-        searchParams.limit = linksLimit;
-    }
-    
+    // Get the top links from this post
     const {data: clicksResponse, isLoading: isClicksLoading, refetch: refetchTopLinks} = useTopLinks({
-        searchParams
+        searchParams: {
+            filter: `post_id:'${postId}'`
+        }
     });
 
     const links = useMemo(() => {

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -5,7 +5,7 @@ import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
 const NewsletterOverview:React.FC = () => {
     const {postId} = useParams();
-    const {stats, topLinks, isLoading: isNewsletterStatsLoading} = usePostNewsletterStats(postId || '');
+    const {stats, topLinks, isLoading: isNewsletterStatsLoading} = usePostNewsletterStats(postId || '', '5');
 
     const opensChartData = [
         {opens: Number((stats?.opened && stats?.sent ? (stats.opened / stats.sent) : 0).toFixed(2)), fill: 'var(--color-opens)'}

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -5,7 +5,7 @@ import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
 const NewsletterOverview:React.FC = () => {
     const {postId} = useParams();
-    const {stats, topLinks, isLoading: isNewsletterStatsLoading} = usePostNewsletterStats(postId || '', '5');
+    const {stats, topLinks, isLoading: isNewsletterStatsLoading} = usePostNewsletterStats(postId || '');
 
     const opensChartData = [
         {opens: Number((stats?.opened && stats?.sent ? (stats.opened / stats.sent) : 0).toFixed(2)), fill: 'var(--color-opens)'}
@@ -163,7 +163,7 @@ const NewsletterOverview:React.FC = () => {
                             {topLinks.length > 0
                                 ?
                                 <TableBody>
-                                    {topLinks.map((row) => {
+                                    {topLinks.slice(0, 5).map((row) => {
                                         return (
                                             <TableRow key={row.link.link_id}>
                                                 <TableCell className='max-w-0 group-hover:!bg-transparent'>

--- a/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
+++ b/apps/posts/test/unit/hooks/usePostNewsletterStats.test.tsx
@@ -178,7 +178,6 @@ describe('usePostNewsletterStats', () => {
         }]);
 
         expect(linksRequestUrl?.searchParams.get('filter')).toBe('post_id:\'post-id\'');
-        expect(linksRequestUrl?.searchParams.get('limit')).toBe('5');
     });
 
     it('handles missing email data', async () => {

--- a/ghost/core/core/server/api/endpoints/links.js
+++ b/ghost/core/core/server/api/endpoints/links.js
@@ -9,8 +9,7 @@ const controller = {
             cacheInvalidate: false
         },
         options: [
-            'filter',
-            'limit'
+            'filter'
         ],
         permissions: true,
         async query(frame) {

--- a/ghost/core/core/server/models/redirect.js
+++ b/ghost/core/core/server/models/redirect.js
@@ -36,7 +36,7 @@ const Redirect = ghostBookshelf.Model.extend({
     permittedOptions(methodName) {
         let options = ghostBookshelf.Model.permittedOptions.call(this, methodName);
         const validOptions = {
-            findAll: ['filter', 'columns', 'withRelated', 'limit'],
+            findAll: ['filter', 'columns', 'withRelated'],
             edit: ['importing']
         };
 

--- a/ghost/core/core/server/services/link-tracking/LinkClickTrackingService.js
+++ b/ghost/core/core/server/services/link-tracking/LinkClickTrackingService.js
@@ -36,7 +36,7 @@ const moment = require('moment');
 /**
  * @typedef {object} IPostLinkRepository
  * @prop {(postLink: PostLink) => Promise<void>} save
- * @prop {(options: {filter: string, limit?: string}) => Promise<FullPostLink[]>} getAll
+ * @prop {(options: {filter: string}) => Promise<FullPostLink[]>} getAll
  * @prop {(linkIds: array, data, options) => Promise<FullPostLink[]>} updateLinks
  */
 
@@ -89,13 +89,11 @@ class LinkClickTrackingService {
     /**
      * @param {object} options
      * @param {string} [options.filter]
-     * @param {string} [options.limit]
      * @return {Promise<FullPostLink[]>}
      */
     async getLinks(options = {}) {
         return await this.#postLinkRepository.getAll({
-            filter: options.filter || '',
-            limit: options.limit
+            filter: options.filter || ''
         });
     }
 

--- a/ghost/core/core/server/services/link-tracking/PostLinkRepository.js
+++ b/ghost/core/core/server/services/link-tracking/PostLinkRepository.js
@@ -41,14 +41,6 @@ module.exports = class PostLinkRepository {
             qb.orderByRaw('`count__clicks` DESC, `to` DESC');
         });
         
-        // Apply limit directly to the query if provided
-        if (options.limit) {
-            const limitNumber = parseInt(options.limit, 10);
-            if (!isNaN(limitNumber) && limitNumber > 0) {
-                itemCollection.query('limit', limitNumber);
-            }
-        }
-        
         // Fetch the collection with the applied query modifications
         const collection = await itemCollection.fetchAll({withRelated: ['count.clicks']});
 
@@ -56,7 +48,7 @@ module.exports = class PostLinkRepository {
 
         for (const model of collection.models) {
             const link = this.#linkRedirectRepository.fromModel(model);
-
+            
             result.push(
                 new FullPostLink({
                     post_id: model.get('post_id'),
@@ -67,7 +59,7 @@ module.exports = class PostLinkRepository {
                 })
             );
         }
-
+        
         return result;
     }
 

--- a/ghost/core/test/unit/server/services/link-tracking/LinkClickTrackingService.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/LinkClickTrackingService.test.js
@@ -37,8 +37,8 @@ describe('LinkClickTrackingService', function () {
             });
             const links = await service.getLinks({filter: 'post_id:1'});
 
-            // Check called with filter and empty limit
-            assert.ok(getAll.calledOnceWithExactly({filter: 'post_id:1', limit: undefined}));
+            // Check called with filter
+            assert.ok(getAll.calledOnceWithExactly({filter: 'post_id:1'}));
 
             // Check returned value
             assert.deepEqual(links, ['test']);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/3f5f9c030adba21c0f8d14d003c39bdb1046d717

Although I was trying to do this 'the right way' by not fetching too much from the backend, we do frontend manipulation to group URLs (which, again, should be on the backend...) that caused unexpected results when applying a limit if the returned entries were ones that would be stacked/grouped.

I've torn all this out for a naive implementation and simple array.slice...