### PR TITLE
Added nginx to docker compose `split` profile

### DIFF
--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -1,0 +1,39 @@
+events {}
+
+http {
+    error_log stderr notice;
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://server:2368;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /ghost/ {
+            proxy_pass http://admin:4200/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /ghost/api/ {
+            proxy_pass http://server:2368;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Error page location, accessible by any other location block
+        location = /50x.html {
+            root /usr/share/nginx/html; # Default Nginx error page location
+            internal;
+        }
+    }
+}

--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -6,6 +6,7 @@ http {
     server {
         listen 80;
 
+        # Ghost server
         location / {
             proxy_pass http://server:2368;
             proxy_set_header Host $host;
@@ -14,6 +15,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Ghost admin
         location /ghost/ {
             proxy_pass http://admin:4200/;
             proxy_set_header Host $host;
@@ -22,7 +24,26 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Ghost admin - Ember CLI live reload
+        location /ember-cli-live-reload.js {
+            proxy_pass http://admin:4200;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Ghost API
         location /ghost/api/ {
+            proxy_pass http://server:2368;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Ghost assets
+        location /ghost/assets/ {
             proxy_pass http://server:2368;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/compose.yml
+++ b/compose.yml
@@ -77,6 +77,19 @@ services:
     profiles: [ split ]
     tty: true
 
+  nginx:
+    image: nginx:latest
+    profiles: [ split ]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./.docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    restart: always
+    depends_on:
+      - server
+      - admin
+
   ghost:
     <<: *service-template
     image: ghost-monorepo:latest

--- a/compose.yml
+++ b/compose.yml
@@ -184,7 +184,7 @@ services:
   mailhog:
     image: mailhog/mailhog:latest
     container_name: ghost-mailhog
-    profiles: [ ghost ]
+    profiles: [ ghost, split ]
     ports:
       - "1025:1025" # SMTP server
       - "8025:8025" # Web interface


### PR DESCRIPTION
no refs

This commit adds an `nginx` service with a basic starter config that is compatible with the `server` and `admin` services in the docker compose `split` profile. This provides a really basic starting point that we can expand on to include other services, and start to create a more production-like development environment locally.