### PR TITLE
Migrated NoValueLabel component to Shade design system

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/modals/Search.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/Search.tsx
@@ -2,9 +2,9 @@ import APAvatar from '@components/global/APAvatar';
 import ActivityItem from '@components/activities/ActivityItem';
 import FollowButton from '@components/global/FollowButton';
 import React, {useEffect, useRef} from 'react';
-import {Button, H4, LoadingIndicator, LucideIcon} from '@tryghost/shade';
-import {NoValueLabel, TextField} from '@tryghost/admin-x-design-system';
+import {Button, H4, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon} from '@tryghost/shade';
 import {SuggestedProfiles} from '../global/SuggestedProfiles';
+import {TextField} from '@tryghost/admin-x-design-system';
 import {useDebounce} from 'use-debounce';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useSearchForUser} from '@hooks/use-activity-pub-queries';
@@ -156,7 +156,8 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                 )}
                 {showNoResults && (
                     <div className='flex h-full items-center justify-center pb-8'>
-                        <NoValueLabel icon='user'>
+                        <NoValueLabel>
+                            <NoValueLabelIcon><LucideIcon.UserRound /></NoValueLabelIcon>
                             No users matching this handle or account URL
                         </NoValueLabel>
                     </div>

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Moderation.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Moderation.tsx
@@ -3,8 +3,8 @@ import ActivityItem from '@src/components/activities/ActivityItem';
 import Layout from '@src/components/layout';
 import React, {useState} from 'react';
 import {Account} from '@src/api/activitypub';
-import {Button, H2, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade';
-import {NoValueLabel, showToast} from '@tryghost/admin-x-design-system';
+import {Button, H2, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade';
+import {showToast} from '@tryghost/admin-x-design-system';
 import {useBlockDomainMutationForUser, useBlockMutationForUser, useBlockedAccountsForUser, useBlockedDomainsForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@hooks/use-activity-pub-queries';
 
 const Moderation: React.FC = () => {
@@ -102,7 +102,8 @@ const Moderation: React.FC = () => {
                         </TabsList>
                         <TabsContent className='mt-2' value="blocked_users">
                             {!blockedAccountsLoading && blockedAccounts.length === 0 ? (
-                                <NoValueLabel icon='block'>
+                                <NoValueLabel>
+                                    <NoValueLabelIcon><LucideIcon.Ban /></NoValueLabelIcon>
                                     <div className='mt-2 flex max-w-[400px] flex-col items-center gap-1 text-center'>
                                         <p>When you block someone, they won&apos;t be able to follow you or interact with your content on the social web.</p>
                                     </div>
@@ -153,7 +154,8 @@ const Moderation: React.FC = () => {
                         </TabsContent>
                         <TabsContent className='mt-[11px]' value="blocked_domains">
                             {!blockedDomainsLoading && blockedDomains.length === 0 ? (
-                                <NoValueLabel icon='block'>
+                                <NoValueLabel>
+                                    <NoValueLabelIcon><LucideIcon.Ban /></NoValueLabelIcon>
                                     <div className='mt-2 flex max-w-[400px] flex-col items-center gap-1 text-center'>
                                         <p>When you block a domain, all users from that domain won&apos;t be able to follow you or interact with your content.</p>
                                     </div>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -5,8 +5,8 @@ import React, {useEffect, useRef} from 'react';
 import getName from '@src/utils/get-name';
 import getUsername from '@src/utils/get-username';
 import {Actor} from '@src/api/activitypub';
-import {Button, LoadingIndicator} from '@tryghost/shade';
-import {List, NoValueLabel} from '@tryghost/admin-x-design-system';
+import {Button, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon} from '@tryghost/shade';
+import {List} from '@tryghost/admin-x-design-system';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -58,7 +58,8 @@ const ActorList: React.FC<ActorListProps> = ({
         <div className='pt-3'>
             {
                 hasNextPage === false && actors.length === 0 ? (
-                    <NoValueLabel icon='user-add'>
+                    <NoValueLabel>
+                        <NoValueLabelIcon><LucideIcon.UserRoundPlus /></NoValueLabelIcon>
                         {noResultsMessage}
                     </NoValueLabel>
                 ) : (

--- a/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
@@ -1,7 +1,6 @@
 import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
-import {LoadingIndicator, Separator} from '@tryghost/shade';
-import {NoValueLabel} from '@tryghost/admin-x-design-system';
+import {LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon, Separator} from '@tryghost/shade';
 import {useEffect, useRef} from 'react';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -57,7 +56,8 @@ const Likes: React.FC<LikesProps> = ({
     return (
         <>
             {hasNextPage === false && posts.length === 0 && (
-                <NoValueLabel icon='heart'>
+                <NoValueLabel>
+                    <NoValueLabelIcon><LucideIcon.Heart /></NoValueLabelIcon>
                     You haven&apos;t liked anything yet.
                 </NoValueLabel>
             )}

--- a/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
@@ -1,7 +1,6 @@
 import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
-import {LoadingIndicator, Separator} from '@tryghost/shade';
-import {NoValueLabel} from '@tryghost/admin-x-design-system';
+import {LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon, Separator} from '@tryghost/shade';
 import {useEffect, useRef} from 'react';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -59,7 +58,8 @@ const Posts: React.FC<PostsProps> = ({
     return (
         <>
             {hasNextPage === false && posts.length === 0 && (
-                <NoValueLabel icon='pen'>
+                <NoValueLabel>
+                    <NoValueLabelIcon><LucideIcon.Pencil /></NoValueLabelIcon>
                     {noResultsMessage}
                 </NoValueLabel>
             )}

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -5,8 +5,8 @@ import Layout from '@src/components/layout';
 import ProfileMenu from './ProfileMenu';
 import UnblockButton from './UnblockButton';
 import {Account} from '@src/api/activitypub';
-import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LucideIcon, Skeleton} from '@tryghost/shade';
-import {Heading, Icon, NoValueLabel, Tab, TabView, showToast} from '@tryghost/admin-x-design-system';
+import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton} from '@tryghost/shade';
+import {Heading, Icon, Tab, TabView, showToast} from '@tryghost/admin-x-design-system';
 import {ProfileTab} from '../Profile';
 import {SettingAction} from '@src/views/Preferences/components/Settings';
 import {useAccountForUser, useBlockDomainMutationForUser, useBlockMutationForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@src/hooks/use-activity-pub-queries';
@@ -97,7 +97,8 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
             id: 'posts',
             title: 'Posts',
             contents: ((isBlocked || isDomainBlocked) && !viewBlockedPosts) ?
-                <NoValueLabel icon='block'>
+                <NoValueLabel>
+                    <NoValueLabelIcon><LucideIcon.Ban /></NoValueLabelIcon>
                     <div className='mt-2 flex flex-col items-center gap-0.5'>
                         <H4>{account.name} is blocked</H4>
                         <p>You can view the posts, but it won&apos;t unblock the user.</p>
@@ -147,8 +148,9 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
             <div className='z-0 -mx-8 -mt-9 flex flex-col items-center pb-16'>
                 <div className='mx-auto w-full'>
                     {!isLoadingAccount && !account && (
-                        <NoValueLabel icon='user-add'>
-                        Profile not found
+                        <NoValueLabel>
+                            <NoValueLabelIcon><LucideIcon.UserRoundPlus /></NoValueLabelIcon>
+                            Profile not found
                         </NoValueLabel>
                     )}
                     <>

--- a/apps/shade/src/components/ui/loading-indicator.stories.tsx
+++ b/apps/shade/src/components/ui/loading-indicator.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {LoadingIndicator} from './loading-indicator';
 
 const meta = {
-    title: 'Components / LoadingIndicator',
+    title: 'Components / Loading indicator',
     component: LoadingIndicator,
     tags: ['autodocs']
 } satisfies Meta<typeof LoadingIndicator>;

--- a/apps/shade/src/components/ui/no-value-label.stories.tsx
+++ b/apps/shade/src/components/ui/no-value-label.stories.tsx
@@ -1,0 +1,24 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {NoValueLabel, NoValueLabelIcon} from './no-value-label';
+import {Ban} from 'lucide-react';
+
+const meta = {
+    title: 'Components / No value label',
+    component: NoValueLabel,
+    tags: ['autodocs']
+} satisfies Meta<typeof NoValueLabel>;
+
+export default meta;
+type Story = StoryObj<typeof NoValueLabel>;
+
+export const Default: Story = {
+    args: {},
+    render: () => (
+        <NoValueLabel>
+            <NoValueLabelIcon>
+                <Ban />
+            </NoValueLabelIcon>
+            You blocked this domain.
+        </NoValueLabel>
+    )
+};

--- a/apps/shade/src/components/ui/no-value-label.tsx
+++ b/apps/shade/src/components/ui/no-value-label.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {LucideIcon} from 'lucide-react';
+
+interface NoValueLabelProps {
+    className?: string;
+    children: React.ReactNode;
+}
+
+const NoValueLabel: React.FC<NoValueLabelProps> = ({className = '', children}) => {
+    return (
+        <div className={`my-10 flex flex-col items-center gap-1 text-sm text-grey-600 ${className}`}>
+            {children}
+        </div>
+    );
+};
+
+interface NoValueLabelIconProps {
+    className?: string;
+    children: React.ReactElement<React.ComponentProps<LucideIcon>>;
+}
+
+const NoValueLabelIcon: React.FC<NoValueLabelIconProps> = ({className = '', children}) => {
+    return (
+        <div className={`text-grey-500 [&>svg]:size-8 [&>svg]:stroke-[1px] ${className}`}>
+            {children}
+        </div>
+    );
+};
+
+export {
+    NoValueLabel,
+    NoValueLabelIcon
+};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/ui/input';
 export * from './components/ui/label';
 export * from './components/ui/loading-indicator';
 export * from './components/ui/navbar';
+export * from './components/ui/no-value-label';
 export * from './components/ui/popover';
 export * from './components/ui/right-sidebar';
 export * from './components/ui/separator';


### PR DESCRIPTION
ref PROD-1839

- Moved NoValueLabel component from legacy design system to Shade
- Replaced all instances of old NoValueLabel throughout ActivityPub project