### PR TITLE
Removed old TabView and List components from admin-x-activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -6,7 +6,6 @@ import getName from '@src/utils/get-name';
 import getUsername from '@src/utils/get-username';
 import {Actor} from '@src/api/activitypub';
 import {Button, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon} from '@tryghost/shade';
-import {List} from '@tryghost/admin-x-design-system';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -63,7 +62,7 @@ const ActorList: React.FC<ActorListProps> = ({
                         {noResultsMessage}
                     </NoValueLabel>
                 ) : (
-                    <List>
+                    <div className='flex flex-col'>
                         {actors.map(({actor, isFollowing, blockedByMe, domainBlockedByMe}) => {
                             return (
                                 <React.Fragment key={actor.id}>
@@ -92,7 +91,7 @@ const ActorList: React.FC<ActorListProps> = ({
                                 </React.Fragment>
                             );
                         })}
-                    </List>
+                    </div>
                 )
             }
             <div ref={loadMoreRef} className='h-1'></div>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -5,9 +5,8 @@ import Layout from '@src/components/layout';
 import ProfileMenu from './ProfileMenu';
 import UnblockButton from './UnblockButton';
 import {Account} from '@src/api/activitypub';
-import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H2, H4, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton} from '@tryghost/shade';
-import {Icon, Tab, TabView, showToast} from '@tryghost/admin-x-design-system';
-import {ProfileTab} from '../Profile';
+import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H2, H4, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount} from '@tryghost/shade';
+import {Icon, showToast} from '@tryghost/admin-x-design-system';
 import {SettingAction} from '@src/views/Preferences/components/Settings';
 import {useAccountForUser, useBlockDomainMutationForUser, useBlockMutationForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useRef, useState} from 'react';
@@ -37,13 +36,8 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     followingTab,
     followersTab
 }) => {
-    const [selectedTab, setSelectedTab] = useState<ProfileTab>('posts');
     const params = useParams();
     const {canGoBack} = useNavigationStack();
-
-    useEffect(() => {
-        setSelectedTab('posts');
-    }, [params.handle]);
 
     const blockMutation = useBlockMutationForUser('index');
     const unblockMutation = useUnblockMutationForUser('index');
@@ -91,41 +85,6 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
             type: 'success'
         });
     };
-
-    const tabs = [
-        {
-            id: 'posts',
-            title: 'Posts',
-            contents: ((isBlocked || isDomainBlocked) && !viewBlockedPosts) ?
-                <NoValueLabel>
-                    <NoValueLabelIcon><LucideIcon.Ban /></NoValueLabelIcon>
-                    <div className='mt-2 flex flex-col items-center gap-0.5'>
-                        <H4>{account.name} is blocked</H4>
-                        <p>You can view the posts, but it won&apos;t unblock the user.</p>
-                        <Button className='mt-4' variant='secondary' onClick={() => setViewBlockedPosts(true)}>View posts</Button>
-                    </div>
-                </NoValueLabel> :
-                postsTab
-        },
-        !params.handle && {
-            id: 'likes',
-            title: 'Likes',
-            contents: likesTab,
-            counter: account?.likedCount || 0
-        },
-        {
-            id: 'following',
-            title: 'Following',
-            contents: followingTab,
-            counter: account?.followingCount || '0'
-        },
-        {
-            id: 'followers',
-            title: 'Followers',
-            contents: followersTab,
-            counter: account?.followerCount || '0'
-        }
-    ].filter(Boolean) as Tab<ProfileTab>[];
 
     const [isExpanded, setisExpanded] = useState(false);
     const [isEditingProfile, setIsEditingProfile] = useState(false);
@@ -255,12 +214,45 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                     onClick={toggleExpand}
                                 >{isExpanded ? 'Show less' : 'Show all'}</Button>}
                             </div>)}
-                            <TabView<ProfileTab>
-                                containerClassName='mt-6'
-                                selectedTab={selectedTab}
-                                tabs={tabs}
-                                onTabChange={setSelectedTab}
-                            />
+                            <Tabs className='mt-5' defaultValue='posts' variant='underline'>
+                                <TabsList>
+                                    <TabsTrigger value="posts">Posts</TabsTrigger>
+                                    {!params.handle && <TabsTrigger value="likes">
+                                        Likes
+                                        <TabsTriggerCount>{account?.likedCount || 0}</TabsTriggerCount>
+                                    </TabsTrigger>}
+                                    <TabsTrigger value="following">
+                                        Following
+                                        <TabsTriggerCount>{account?.followingCount || 0}</TabsTriggerCount>
+                                    </TabsTrigger>
+                                    <TabsTrigger value="followers">
+                                        Followers
+                                        <TabsTriggerCount>{account?.followerCount || 0}</TabsTriggerCount>
+                                    </TabsTrigger>
+                                </TabsList>
+                                <TabsContent value='posts'>
+                                    {((isBlocked || isDomainBlocked) && !viewBlockedPosts) ?
+                                        <NoValueLabel>
+                                            <NoValueLabelIcon><LucideIcon.Ban /></NoValueLabelIcon>
+                                            <div className='mt-2 flex flex-col items-center gap-0.5'>
+                                                <H4>{account.name} is blocked</H4>
+                                                <p>You can view the posts, but it won&apos;t unblock the user.</p>
+                                                <Button className='mt-4' variant='secondary' onClick={() => setViewBlockedPosts(true)}>View posts</Button>
+                                            </div>
+                                        </NoValueLabel> :
+                                        postsTab
+                                    }
+                                </TabsContent>
+                                {!params.handle && <TabsContent value='likes'>
+                                    {likesTab}
+                                </TabsContent>}
+                                <TabsContent value='following'>
+                                    {followingTab}
+                                </TabsContent>
+                                <TabsContent value='followers'>
+                                    {followersTab}
+                                </TabsContent>
+                            </Tabs>
                         </div>
                     </>
                 </div>

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -118,7 +118,7 @@ interface TabsTriggerCountProps {
 const TabsTriggerCount: React.FC<TabsTriggerCountProps> = ({className = '', children}) => {
     return (
         <span className={`ml-1.5 mt-px flex h-5 items-center justify-center rounded-full bg-gray-200 px-1.5 py-0 text-xs font-semibold leading-[21px] text-gray-800 dark:bg-gray-900 dark:text-gray-300 ${className}`}>{children}</span>
-    )
+    );
 };
 TabsTriggerCount.displayName = 'TabsTriggerCount';
 

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -49,7 +49,7 @@ const tabsListVariants = cva(
             variant: {
                 segmented: 'h-[34px] rounded-lg bg-muted px-[3px]',
                 button: 'gap-2',
-                underline: 'w-full gap-5 border-b border-b-gray-200 pb-1 dark:border-gray-950',
+                underline: 'w-full gap-5 border-b border-b-gray-200 dark:border-gray-950',
                 navbar: 'h-[52px] items-end gap-6',
                 pill: '-ml-0.5 h-[30px] gap-px',
                 kpis: 'border-b'
@@ -83,7 +83,7 @@ const tabsTriggerVariants = cva(
             variant: {
                 segmented: 'h-7 rounded-md text-sm font-medium data-[state=active]:shadow-md',
                 button: 'h-[34px] gap-1.5 rounded-md border border-input py-2 text-sm font-medium hover:bg-muted/50 data-[state=active]:bg-muted/70 data-[state=active]:font-semibold',
-                underline: 'relative h-[34px] px-0 text-md font-semibold text-foreground/70 after:absolute after:inset-x-0 after:bottom-[-5px] after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:text-foreground hover:after:opacity-10 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:!opacity-100',
+                underline: 'relative h-[36px] px-0 text-md font-semibold text-gray-700 after:absolute after:inset-x-0 after:bottom-[-1px] after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:after:opacity-10 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:!opacity-100',
                 navbar: 'relative h-[52px] px-px text-md font-semibold text-muted-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:!opacity-100',
                 pill: 'relative h-[30px] rounded-full px-3 text-md font-medium text-gray-800 hover:text-foreground data-[state=active]:bg-muted data-[state=active]:font-semibold data-[state=active]:text-foreground dark:text-gray-500 dark:data-[state=active]:text-foreground',
                 kpis: 'relative rounded-none border-border bg-transparent px-6 py-5 text-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] first:rounded-tl-md last:rounded-tr-md hover:bg-muted/50 data-[state=active]:bg-transparent data-[state=active]:after:opacity-100 [&:not(:last-child)]:border-r'
@@ -109,6 +109,18 @@ const TabsTrigger = React.forwardRef<
     );
 });
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+interface TabsTriggerCountProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+const TabsTriggerCount: React.FC<TabsTriggerCountProps> = ({className = '', children}) => {
+    return (
+        <span className={`ml-1.5 mt-px flex h-5 items-center justify-center rounded-full bg-gray-200 px-1.5 py-0 text-xs font-semibold leading-[21px] text-gray-800 dark:bg-gray-900 dark:text-gray-300 ${className}`}>{children}</span>
+    )
+};
+TabsTriggerCount.displayName = 'TabsTriggerCount';
 
 const tabsContentVariants = cva(
     'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
@@ -199,4 +211,4 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({color, label, value, diffDirec
     );
 };
 
-export {Tabs, TabsList, TabsTrigger, TabsContent, KpiTabTrigger, KpiTabValue, tabsVariants};
+export {Tabs, TabsList, TabsTrigger, TabsTriggerCount, TabsContent, KpiTabTrigger, KpiTabValue, tabsVariants};


### PR DESCRIPTION
ref PROD-1839

- Eliminated all tab related components from the old design system
throughout the `admin-x-activitypub` project, replaced them with the ones from Shade
- We were using List component from the old design system only for a div with `flex flex-col` classes, so got rid of it and used plain div instead