### PR TITLE
Added rounded image border logic to CTA styles

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1103,10 +1103,21 @@ table.kg-cta-content-wrapper:not(.kg-cta-bg-none.kg-cta-no-dividers table.kg-cta
     padding-bottom: 0;
 }
 
+/* -------------------------------------
+    When removing emailCustomizationAlpha,
+    also remove border-radius: 6px;
+------------------------------------- */
 img.kg-cta-image {
     display: block;
     border-radius: 6px;
     border: 0;
+    {{#hasFeature "emailCustomizationAlpha"}}
+    {{#if imageCorners}}
+    {{imageCorners}};
+    {{else}}
+    border-radius: 0 !important;
+    {{/if}}
+    {{/hasFeature}}
 }
 
 .kg-cta-minimal img.kg-cta-image {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1835/qa-should-non-rounded-images-apply-in-cta-cards

- By default CTA images are rounded. This ensure that when images are set to be square in Email Customisation, we can remove the radius.
