### PR TITLE
Improved Newsletters tab in site-wide analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -35,7 +35,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     return (
         <>
             <header className='z-50 -mx-8 bg-white/70 backdrop-blur-md dark:bg-black'>
-                <div className='relative flex min-h-[102px] w-full items-start justify-between gap-5 p-8 pb-0'>
+                <div className='relative flex min-h-[102px] w-full items-start justify-between gap-5 px-8 pb-0 pt-8'>
                     <div className='flex w-full flex-col gap-5'>
                         <div className='flex w-full items-center justify-between'>
                             <Breadcrumb>

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -5,7 +5,7 @@ import {useNewsletterStatsByNewsletterId, useSubscriberCountByNewsletterId} from
 /**
  * Represents the possible fields to order top newsletters by.
  */
-export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate desc';
+export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate desc' | 'sent_to desc';
 
 /**
  * Hook to fetch Newsletter Stats, handling the conversion from a numeric range
@@ -22,7 +22,7 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
 
     // Calculate date strings using the helper, memoize for stability
     const {dateFrom, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
-    
+
     // Call the hook with the parameters
     return useNewsletterStatsByNewsletterId(newsletterId, {
         date_from: dateFrom,
@@ -34,7 +34,7 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
 /**
  * Hook to fetch Subscriber Count stats, handling the conversion from a numeric range
  * to API query parameters.
- * 
+ *
  * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
  * @param newsletterId - Optional ID of the specific newsletter to get stats for
  */
@@ -44,10 +44,10 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
 
     // Calculate date strings using the helper, memoize for stability
     const {dateFrom, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
-    
+
     // Call the hook with the parameters
     return useSubscriberCountByNewsletterId(newsletterId, {
         date_from: dateFrom,
         date_to: endDate
     });
-}; 
+};

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -428,17 +428,22 @@ const Newsletters: React.FC = () => {
                                     <TableHead>
                                         Title
                                     </TableHead>
-                                    <TableHead>
+                                    <TableHead className='w-[60px]'>
                                         <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='date desc'>
                                             Date
                                         </SortButton>
                                     </TableHead>
-                                    <TableHead className='w-[10%] text-right'>
-                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='open_rate desc'>
-                                            Open rate
+                                    <TableHead className='w-[90px] text-right'>
+                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='sent_to desc'>
+                                            Sent
                                         </SortButton>
                                     </TableHead>
-                                    <TableHead className='w-[10%] text-right'>
+                                    <TableHead className='w-[90px] text-right'>
+                                        <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='open_rate desc'>
+                                            Opens
+                                        </SortButton>
+                                    </TableHead>
+                                    <TableHead className='w-[90px] text-right'>
                                         <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='click_rate desc'>
                                             Clicks
                                         </SortButton>
@@ -463,14 +468,17 @@ const Newsletters: React.FC = () => {
                                                 }
                                             </div>
                                         </TableCell>
-                                        <TableCell className="text-sm text-muted-foreground">
+                                        <TableCell className="whitespace-nowrap text-sm">
                                             {formatDisplayDate(new Date(post.send_date))}
                                         </TableCell>
-                                        <TableCell className={`text-right font-mono text-sm ${post.total_opens === 0 && 'text-gray-700'}`}>
+                                        <TableCell className='text-right font-mono text-sm'>
+                                            {formatNumber(post.sent_to)}
+                                        </TableCell>
+                                        <TableCell className='text-right font-mono text-sm'>
                                             <span className="group-hover:hidden">{formatPercentage(post.open_rate)}</span>
                                             <span className="hidden group-hover:!visible group-hover:!block">{formatNumber(post.total_opens)}</span>
                                         </TableCell>
-                                        <TableCell className={`text-right font-mono text-sm ${post.total_clicks === 0 && 'text-gray-700'}`}>
+                                        <TableCell className='text-right font-mono text-sm'>
                                             <span className="group-hover:hidden">{formatPercentage(post.click_rate)}</span>
                                             <span className="hidden group-hover:!visible group-hover:!block">{formatNumber(post.total_clicks)}</span>
                                         </TableCell>

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -15,8 +15,8 @@ const NewsletterSelect: React.FC = () => {
     // Default to the default newsletter (sort_order = 1) when the component loads
     useEffect(() => {
         if (activeNewsletters.length > 0 && !selectedNewsletterId) {
-            // First try to find the default newsletter (sort_order = 1)
-            const defaultNewsletter = activeNewsletters.find(newsletter => newsletter.sort_order === 1);
+            // First try to find the default newsletter (sort_order = 0)
+            const defaultNewsletter = activeNewsletters.find(newsletter => newsletter.sort_order === 0);
 
             // If we found a default newsletter, use it
             if (defaultNewsletter) {
@@ -29,7 +29,7 @@ const NewsletterSelect: React.FC = () => {
     }, [activeNewsletters, selectedNewsletterId, setSelectedNewsletterId]);
 
     // Handle no newsletters case
-    if (!activeNewsletters.length) {
+    if (activeNewsletters.length <= 1) {
         return null;
     }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1819/add-sent-count-to-newsletter-tab ref https://linear.app/ghost/issue/PROD-1811/remove-newsletter-filter-if-only-one-newsletter-exists-is-active

- Users couldn't tell how many people received a newsletter on this tab. Since some are sent to paid only, and others sent to everyone, it's better to show that between Date and Open rate.
- If there wasn't an option to choose something else, the newsletter dropdown was irrelevant / only adds mental overhead to understanding what users are looking at.