### PR TITLE
Fixed minor UI bugs in analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -158,7 +158,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const typedPost = post as Post;
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(typedPost);
-    
+
     useEffect(() => {
         // Redirect to overview if the post wasn't sent as a newsletter
         if (!isPostLoading && !showNewsletterSection) {
@@ -335,7 +335,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.opened)}</KpiCardValue>
-                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.openedRate)} open rate</span>
                                         </KpiCardContent>
                                         <FunnelArrow />
                                     </KpiCard>
@@ -347,7 +346,6 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardLabel>
                                         <KpiCardContent>
                                             <KpiCardValue>{formatNumber(stats.clicked)}</KpiCardValue>
-                                            <span className='mt-0.5 text-sm text-muted-foreground'>{formatPercentage(stats.clickedRate)} click rate</span>
                                         </KpiCardContent>
                                     </KpiCard>
                                 </div>

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -111,7 +111,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         <TabsTrigger value="Web" onClick={() => {
                             navigate(`/analytics/beta/${postId}/web`);
                         }}>
-                            Web stats
+                            Web traffic
                         </TabsTrigger>
                         {showNewsletterTab && (
                             <TabsTrigger value="Newsletter" onClick={() => {

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -415,9 +415,9 @@ const Newsletters: React.FC = () => {
                 </Card>
                 <Card>
                     <CardHeader>
-                        <CardTitle>Newsletter stats</CardTitle>
+                        <CardTitle>Top newsletters</CardTitle>
                         <CardDescription>
-                            Performance of newsletter {getPeriodText(range)}
+                            Your best performing newsletters {getPeriodText(range)}
                         </CardDescription>
                     </CardHeader>
                     <CardContent>

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -143,7 +143,7 @@ const WebKPIs:React.FC = ({}) => {
                 </KpiTabTrigger>
             </TabsList>
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-                {isLoading ? 'Loading' :
+                {isLoading ? '' :
                     <ChartContainer className='-mb-3 h-[16vw] max-h-[320px] w-full' config={chartConfig}>
                         <Recharts.AreaChart
                             data={chartData}

--- a/apps/stats/src/views/Stats/layout/StatsContent.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsContent.tsx
@@ -3,7 +3,7 @@ import {cn} from '@tryghost/shade';
 
 const StatsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <section className={cn('flex grow flex-col items-stretch gap-8 w-full mt-8', className)} {...props}>
+        <section className={cn('flex grow flex-col items-stretch gap-8 w-full mt-8 pb-8', className)} {...props}>
             {children}
         </section>
     );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1824/renaming-post-analytics-web-tab-to-web-traffic
ref https://linear.app/ghost/issue/PROD-1818/newsletter-table-copy-change
ref https://linear.app/ghost/issue/PROD-1815/bottom-of-analytics-pages-need-some-padding

- The web tab label was inconsistent between site-wide and post analytics views
- The copy of the top newsletters table was too technical
- There was a missing padding at the bottom of the site-wide analytics views
- Removed percentage indicators from Newsletter tabs in post analytics