### PR TITLE
Added underline to links in header card

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1383,6 +1383,7 @@ img.kg-cta-image {
 .kg-header-card.kg-v2 .kg-header-card-heading a,
 .kg-header-card.kg-v2 .kg-header-card-subheading a {
     color: inherit;
+    text-decoration: underline;
 }
 {{else}}
 .kg-header-card h2 {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1829/qa-regular-links-do-not-show-in-header-card
- Header links are always the same color as the text. For that reason, even when link style is set to regular, the links are still underlined.