### PR TITLE
Updated ghost stats script to be more testable

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/browser-service.js
+++ b/ghost/core/core/frontend/src/ghost-stats/browser-service.js
@@ -1,0 +1,89 @@
+/**
+ * @typedef {Object} CustomWindow
+ * @property {any} [__nightmare]
+ * @property {any} [Cypress]
+ * @property {any} [Tinybird]
+ */
+
+/**
+ * @typedef {Window & typeof globalThis & CustomWindow} ExtendedWindow
+ */
+
+export class BrowserService {
+    /**
+     * @param {ExtendedWindow} [window]
+     * @param {Document} [document]
+     */
+    constructor(window = globalThis.window, document = globalThis.document) {
+        this.window = window;
+        this.document = document;
+    }
+
+    getNavigator() {
+        return this.window?.navigator;
+    }
+
+    getLocation() {
+        return this.window?.location;
+    }
+
+    getTimezone() {
+        return this.window?.Intl?.DateTimeFormat().resolvedOptions().timeZone;
+    }
+
+    getCurrentScript() {
+        return this.document?.currentScript;
+    }
+
+    getVisibilityState() {
+        return this.document?.visibilityState;
+    }
+
+    setTimeout(callback, delay) {
+        return this.window?.setTimeout(callback, delay);
+    }
+
+    clearTimeout(id) {
+        return this.window?.clearTimeout(id);
+    }
+
+    addEventListener(target, event, callback) {
+        if (target === 'window') {
+            this.window?.addEventListener(event, callback);
+        } else if (target === 'document') {
+            this.document?.addEventListener(event, callback);
+        }
+    }
+
+    removeEventListener(target, event, callback) {
+        if (target === 'window') {
+            this.window?.removeEventListener(event, callback);
+        } else if (target === 'document') {
+            this.document?.removeEventListener(event, callback);
+        }
+    }
+
+    isTestEnvironment() {
+        return !!(
+            this.window && (
+                this.window.__nightmare ||
+                this.window.navigator?.webdriver ||
+                this.window.Cypress
+            )
+        );
+    }
+
+    fetch(url, options) {
+        return this.window?.fetch(url, options);
+    }
+
+    wrapHistoryMethod(method, callback) {
+        const original = this.window?.history?.[method];
+        if (original) {
+            this.window.history[method] = (...args) => {
+                original.apply(this.window.history, args);
+                callback();
+            };
+        }
+    }
+} 

--- a/ghost/core/core/frontend/src/ghost-stats/browser-service.js
+++ b/ghost/core/core/frontend/src/ghost-stats/browser-service.js
@@ -48,6 +48,15 @@ export class BrowserService {
     }
 
     addEventListener(target, event, callback) {
+        const validTargets = ['window', 'document'];
+        if (!validTargets.includes(target)) {
+            /* istanbul ignore next */
+            throw new TypeError(
+                `BrowserService.addEventListener: unknown target "${target}". ` +
+                'Expected "window" or "document".'
+            );
+        }
+
         if (target === 'window') {
             this.window?.addEventListener(event, callback);
         } else if (target === 'document') {
@@ -56,6 +65,15 @@ export class BrowserService {
     }
 
     removeEventListener(target, event, callback) {
+        const validTargets = ['window', 'document'];
+        if (!validTargets.includes(target)) {
+            /* istanbul ignore next */
+            throw new TypeError(
+                `BrowserService.removeEventListener: unknown target "${target}". ` +
+                'Expected "window" or "document".'
+            );
+        }
+
         if (target === 'window') {
             this.window?.removeEventListener(event, callback);
         } else if (target === 'document') {
@@ -78,12 +96,20 @@ export class BrowserService {
     }
 
     wrapHistoryMethod(method, callback) {
+        // Skip if already wrapped
+        if (this.window?.history?.[method]?.__ghostWrapped) {
+            return;
+        }
+
         const original = this.window?.history?.[method];
         if (original) {
             this.window.history[method] = (...args) => {
-                original.apply(this.window.history, args);
+                const result = original.apply(this.window.history, args);
                 callback();
+                return result;
             };
+            // Mark as wrapped to prevent double-wrapping
+            this.window.history[method].__ghostWrapped = true;
         }
     }
 } 

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -33,6 +33,7 @@ let config = {
 export class GhostStats {
     constructor(browserService = new BrowserService()) {
         this.browser = browserService;
+        this.isListenersAttached = false;
     }
 
     get isTestEnv() {
@@ -165,6 +166,10 @@ export class GhostStats {
     }
 
     setupEventListeners() {
+        if (this.isListenersAttached) {
+            return;
+        }
+
         // Track history navigation
         this.browser.addEventListener('window', 'hashchange', () => this.trackPageHit());
         
@@ -186,6 +191,8 @@ export class GhostStats {
             };
             this.browser.addEventListener('document', 'visibilitychange', onVisibilityChange);
         }
+
+        this.isListenersAttached = true;
     }
 
     init() {

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -3,6 +3,7 @@ import { getCountryForTimezone } from 'countries-and-timezones';
 import { getReferrer, parseReferrer } from '../utils/url-attribution';
 import { getSessionId, setSessionId, getStorageObject } from '../utils/session-storage';
 import { processPayload } from '../utils/privacy';
+import { BrowserService } from './browser-service';
 
 /**
  * @typedef {Object} TinybirdApi
@@ -10,57 +11,52 @@ import { processPayload } from '../utils/privacy';
  * @property {function} _trackPageHit - Internal function to track page hits
  */
 
-(function(){
-    // Configuration constants
-    const STORAGE_KEY = 'session-id';
-    const DEFAULT_DATASOURCE = 'analytics_events';
-    const storageMethods = {
-        localStorage: 'localStorage',
-        sessionStorage: 'sessionStorage',
-    };
-    
-    // Runtime configuration (will be set during initialization)
-    let config = {
-        host: null,
-        token: null,
-        domain: null,
-        datasource: DEFAULT_DATASOURCE,
-        storageMethod: storageMethods.localStorage,
-        stringifyPayload: true,
-        globalAttributes: {}
-    };
+// Configuration constants
+const STORAGE_KEY = 'session-id';
+const DEFAULT_DATASOURCE = 'analytics_events';
+const STORAGE_METHODS = {
+    localStorage: 'localStorage',
+    sessionStorage: 'sessionStorage',
+};
 
-    // Detect test environment
-    // @ts-ignore - Custom window properties for test environments
-    const isTestEnv = !!(
-        typeof window !== 'undefined' && (
-            window.__nightmare || 
-            window.navigator.webdriver || 
-            window.Cypress
-        )
-    );
+// Runtime configuration
+let config = {
+    host: null,
+    token: null,
+    domain: null,
+    datasource: DEFAULT_DATASOURCE,
+    storageMethod: STORAGE_METHODS.localStorage,
+    stringifyPayload: true,
+    globalAttributes: {}
+};
 
-    /**
-     * Initialize configuration from script attributes
-     * @returns {boolean} Whether required configuration is present
-     */
-    function _initConfig() {
-        if (!document.currentScript) {
+export class GhostStats {
+    constructor(browserService = new BrowserService()) {
+        this.browser = browserService;
+    }
+
+    get isTestEnv() {
+        return this.browser.isTestEnvironment();
+    }
+
+    initConfig() {
+        const currentScript = this.browser.getCurrentScript();
+        if (!currentScript) {
             return false;
         }
 
         // Get required parameters
-        config.host = document.currentScript.getAttribute('data-host');
-        config.token = document.currentScript.getAttribute('data-token');
-        config.domain = document.currentScript.getAttribute('data-domain');
+        config.host = currentScript.getAttribute('data-host');
+        config.token = currentScript.getAttribute('data-token');
+        config.domain = currentScript.getAttribute('data-domain');
         
         // Get optional parameters
-        config.datasource = document.currentScript.getAttribute('data-datasource') || config.datasource;
-        config.storageMethod = document.currentScript.getAttribute('data-storage') || config.storageMethod;
-        config.stringifyPayload = document.currentScript.getAttribute('data-stringify-payload') !== 'false';
+        config.datasource = currentScript.getAttribute('data-datasource') || config.datasource;
+        config.storageMethod = currentScript.getAttribute('data-storage') || config.storageMethod;
+        config.stringifyPayload = currentScript.getAttribute('data-stringify-payload') !== 'false';
         
         // Get global attributes
-        for (const attr of document.currentScript.attributes) {
+        for (const attr of currentScript.attributes) {
             if (attr.name.startsWith('tb_')) {
                 config.globalAttributes[attr.name.slice(3)] = attr.value;
             }
@@ -70,14 +66,7 @@ import { processPayload } from '../utils/privacy';
         return !!(config.host && config.token);
     }
 
-    /**
-     * Send event to endpoint
-     *
-     * @param  {string} name Event name
-     * @param  {object} payload Event payload
-     * @return {Promise<any>} request response
-     */
-    async function _sendEvent(name, payload) {
+    async trackEvent(name, payload) {
         try {
             // Check if we have required configuration
             if (!config.host || !config.token) {
@@ -103,9 +92,9 @@ import { processPayload } from '../utils/privacy';
 
             // Use fetch with timeout for better error handling
             const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
+            const timeoutId = this.browser.setTimeout(() => controller.abort(), 5000); // 5 second timeout
 
-            const response = await fetch(url, {
+            const response = await this.browser.fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -114,7 +103,7 @@ import { processPayload } from '../utils/privacy';
                 signal: controller.signal
             });
 
-            clearTimeout(timeoutId);
+            this.browser.clearTimeout(timeoutId);
             
             if (!response.ok) {
                 throw new Error(`HTTP error! Status: ${response.status}`);
@@ -124,28 +113,23 @@ import { processPayload } from '../utils/privacy';
         } catch (error) {
             // Silently fail for tracking errors
             // Only log in non-production environments
-            if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+            const location = this.browser.getLocation();
+            if (location?.hostname === 'localhost' || location?.hostname === '127.0.0.1') {
                 console.error('Ghost Stats error:', error);
             }
             return null;
         }
     }
 
-    /**
-     * Get browser locale and country information
-     * @returns {Object} Object containing locale and country
-     */
-    function _getLocationInfo() {
+    getLocationInfo() {
         try {
             // Get timezone from browser
-            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            
+            const timezone = this.browser.getTimezone();
             // Get country from timezone using countries-and-timezones
             const countryData = timezone ? getCountryForTimezone(timezone) : null;
-            
             // Get locale, falling back gracefully
-            const locale = navigator.languages?.[0] || navigator.language || 'en';
-            
+            const navigator = this.browser.getNavigator();
+            const locale = navigator?.languages?.[0] || navigator?.language || 'en';
             return { 
                 country: countryData ? countryData.id : null,  // Returns country code
                 locale 
@@ -155,86 +139,92 @@ import { processPayload } from '../utils/privacy';
         }
     }
 
-    /**
-     * Track page hit
-     */
-    function _trackPageHit() {
+    trackPageHit() {
         // Skip tracking in test environments
-        if (isTestEnv) {
+        if (this.isTestEnv) {
             return;
         }
 
         // Get location information
-        const { country, locale } = _getLocationInfo();
+        const { country, locale } = this.getLocationInfo();
+        const navigator = this.browser.getNavigator();
+        const location = this.browser.getLocation();
 
         // Wait a bit for SPA routers
-        setTimeout(() => {
-            _sendEvent('page_hit', {
-                'user-agent': window.navigator.userAgent,
+        this.browser.setTimeout(() => {
+            this.trackEvent('page_hit', {
+                'user-agent': navigator?.userAgent,
                 locale,
                 location: country,
-                referrer: getReferrer(window.location.href),
-                parsedReferrer: parseReferrer(window.location.href),
-                pathname: window.location.pathname,
-                href: window.location.href,
+                referrer: getReferrer(location?.href),
+                parsedReferrer: parseReferrer(location?.href),
+                pathname: location?.pathname,
+                href: location?.href,
             });
         }, 300);
     }
 
-    /**
-     * Initialize tracking
-     * @returns {boolean} Whether initialization was successful
-     */
-    function _init() {
+    setupEventListeners() {
+        // Track history navigation
+        this.browser.addEventListener('window', 'hashchange', () => this.trackPageHit());
+        
+        // Handle SPA navigation
+        this.browser.wrapHistoryMethod('pushState', () => this.trackPageHit());
+        this.browser.addEventListener('window', 'popstate', () => this.trackPageHit());
+
+        // Handle visibility changes for prerendering
+        if (this.browser.getVisibilityState() !== 'hidden') {
+            // Page is initially visible, track immediately
+            this.trackPageHit();
+        } else {
+            // Page is hidden (possibly prerendering), wait for visibility
+            const onVisibilityChange = () => {
+                if (this.browser.getVisibilityState() === 'visible') {
+                    this.trackPageHit();
+                    this.browser.removeEventListener('document', 'visibilitychange', onVisibilityChange);
+                }
+            };
+            this.browser.addEventListener('document', 'visibilitychange', onVisibilityChange);
+        }
+    }
+
+    init() {
         // Skip in test environments
-        if (isTestEnv) {
+        if (this.isTestEnv) {
             return false;
         }
 
         // Initialize configuration
-        const configInitialized = _initConfig();
+        const configInitialized = this.initConfig();
         if (!configInitialized) {
             console.warn('Ghost Stats: Missing required configuration');
             return false;
         }
 
         // Expose global API
-        // @ts-ignore - Adding custom property to window
-        window.Tinybird = { 
-            trackEvent: _sendEvent,
-            _trackPageHit: _trackPageHit
-        };
-
-        // Track history navigation
-        window.addEventListener('hashchange', _trackPageHit);
-        
-        // Handle SPA navigation
-        const originalPushState = window.history.pushState;
-        if (originalPushState) {
-            window.history.pushState = function() {
-                originalPushState.apply(this, arguments);
-                _trackPageHit();
+        if (this.browser.window) {
+            this.browser.window.Tinybird = { 
+                trackEvent: (name, payload) => this.trackEvent(name, payload),
+                _trackPageHit: () => this.trackPageHit()
             };
-            window.addEventListener('popstate', _trackPageHit);
         }
 
-        // Handle visibility changes for prerendering
-        if (document.visibilityState !== 'hidden') {
-            // Page is initially visible, track immediately
-            _trackPageHit();
-        } else {
-            // Page is hidden (possibly prerendering), wait for visibility
-            document.addEventListener('visibilitychange', function onVisibilityChange() {
-                if (document.visibilityState === 'visible') {
-                    _trackPageHit();
-                    document.removeEventListener('visibilitychange', onVisibilityChange);
-                }
-            });
-        }
-
+        this.setupEventListeners();
         return true;
     }
+}
 
-    // Initialize tracking
-    _init();
-})(); 
+// Create and initialize instance for auto-initialization
+const ghostStats = new GhostStats();
+ghostStats.init();
+
+// Export the class and instance methods for testing
+export const {
+    isTestEnv,
+    initConfig,
+    trackEvent,
+    getLocationInfo,
+    trackPageHit,
+    setupEventListeners,
+    init
+} = ghostStats; 

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -225,13 +225,14 @@ export class GhostStats {
 const ghostStats = new GhostStats();
 ghostStats.init();
 
-// Export the class and instance methods for testing
-export const {
-    isTestEnv,
-    initConfig,
-    trackEvent,
-    getLocationInfo,
-    trackPageHit,
-    setupEventListeners,
-    init
-} = ghostStats; 
+// Export bound methods to maintain this context
+export const isTestEnv = () => ghostStats.isTestEnv;
+export const initConfig = ghostStats.initConfig.bind(ghostStats);
+export const trackEvent = ghostStats.trackEvent.bind(ghostStats);
+export const getLocationInfo = ghostStats.getLocationInfo.bind(ghostStats);
+export const trackPageHit = ghostStats.trackPageHit.bind(ghostStats);
+export const setupEventListeners = ghostStats.setupEventListeners.bind(ghostStats);
+export const init = ghostStats.init.bind(ghostStats);
+
+// Also export the instance for testing
+export const ghostStatsInstance = ghostStats; 

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -1,688 +1,292 @@
-const fs = require('fs');
-const path = require('path');
 const {expect} = require('chai');
-const {createBrowserEnvironment, loadScript} = require('../../../utils/browser-test-utils');
-const {SENSITIVE_ATTRIBUTES, maskSensitiveData} = require('../../../../core/frontend/src/utils/privacy');
-
-/**
- * Test-adapted version of getSessionId from session-storage.js
- */
-function getSessionId(key, storage) {
-    const serializedItem = storage.getItem(key);
-    
-    if (!serializedItem) {
-        return null;
-    }
-    
-    let item = null;
-    try {
-        item = JSON.parse(serializedItem);
-    } catch (error) {
-        return null;
-    }
-    
-    if (typeof item !== 'object' || item === null) {
-        return null;
-    }
-    
-    const now = new Date();
-    if (now.getTime() > item.expiry) {
-        storage.removeItem(key);
-        return null;
-    }
-    
-    return item.value;
-}
-
-/**
- * Test-adapted version of getReferrer which works with our test environment
- */
-function getReferrer(url, referrerValue) {
-    const urlObj = new URL(url);
-    
-    // Check for special url parameters
-    const ref = urlObj.searchParams.get('ref');
-    if (ref) {
-        return ref;
-    }
-    
-    const source = urlObj.searchParams.get('source');
-    if (source) {
-        return source;
-    }
-    
-    const utmSource = urlObj.searchParams.get('utm_source');
-    if (utmSource) {
-        return utmSource;
-    }
-    
-    // Special case for portal hash URLs
-    if (urlObj.hash && urlObj.hash.includes('/portal')) {
-        const hashParts = urlObj.hash.split('?');
-        if (hashParts.length > 1) {
-            const hashParams = new URLSearchParams(hashParts[1]);
-            const hashRef = hashParams.get('ref');
-            if (hashRef) {
-                return hashRef;
-            }
-        }
-    }
-    
-    // Handle same-domain referrer case
-    if (referrerValue) {
-        try {
-            const referrerHost = new URL(referrerValue).hostname;
-            const currentHost = urlObj.hostname;
-            if (referrerHost === currentHost) {
-                return null;
-            }
-        } catch (e) {
-            // If URL parsing fails, just return the referrer
-        }
-    }
-    
-    return referrerValue;
-}
+const sinon = require('sinon');
+const path = require('path');
 
 describe('ghost-stats.js', function () {
-    let env;
-    let scriptContent;
-
-    before(function () {
-        // Read the script content
-        scriptContent = fs.readFileSync(
-            path.join(__dirname, '../../../../core/frontend/public/ghost-stats.min.js'),
-            'utf8'
-        );
-    });
-
-    // Helper function to create a test environment with various options
-    function createTestEnvironment(options = {}) {
-        const defaults = {
-            url: 'https://example.com',
-            referrer: 'https://google.com/',
-            stringifyPayload: true
-        };
-
-        const config = {...defaults, ...options};
-
-        // Create environment
-        const testEnv = createBrowserEnvironment({
-            url: config.url,
-            referrer: config.referrer,
-            html: '<!DOCTYPE html><html><body></body></html>',
-            runScripts: true,
-            storage: {type: 'localStorage'}
-        });
-
-        // Create script element with attributes
-        const scriptElement = testEnv.document.createElement('script');
-        scriptElement.setAttribute('data-host', 'https://e.ghost.org/tb/web_analytics');
-        scriptElement.setAttribute('data-token', 'tb_token');
-        scriptElement.setAttribute('data-domain', 'example.com');
-        
-        if (config.stringifyPayload === false) {
-            scriptElement.setAttribute('data-stringify-payload', 'false');
-        }
-
-        // This is needed for the bundled version to initialize properly
-        testEnv.document.head.appendChild(scriptElement);
-
-        // Initialize a session ID in localStorage
-        if (!testEnv.localStorage.getItem('session-id')) {
-            const sessionId = {
-                value: '00000000-0000-4000-8000-000000000000',
-                expiry: new Date().getTime() + 4 * 3600 * 1000
-            };
-            testEnv.localStorage.setItem('session-id', JSON.stringify(sessionId));
-        }
-
-        // Add Tinybird object and trackPageHit method directly
-        testEnv.window.Tinybird = testEnv.window.Tinybird || {
-            trackEvent: function (name, payload) {
-                // Get or create session ID using our adapted utility
-                let sessionId;
-                try {
-                    sessionId = getSessionId('session-id', testEnv.localStorage);
-                    if (!sessionId) {
-                        sessionId = '11111111-1111-4111-8111-111111111111'; // Different from the default
-                        const newSessionData = {
-                            value: sessionId,
-                            expiry: new Date().getTime() + 4 * 3600 * 1000
-                        };
-                        testEnv.localStorage.setItem('session-id', JSON.stringify(newSessionData));
-                    }
-                } catch (e) {
-                    sessionId = '00000000-0000-4000-8000-000000000000';
-                }
-
-                // Process payload using our adapted utility
-                const processedPayload = config.stringifyPayload 
-                    ? maskSensitiveData(payload, SENSITIVE_ATTRIBUTES)
-                    : maskSensitiveData(payload, SENSITIVE_ATTRIBUTES);
-
-                // Create and send request
-                const xhr = new testEnv.window.XMLHttpRequest();
-                xhr.open('POST', 'https://e.ghost.org/tb/web_analytics', true);
-                xhr.setRequestHeader('Content-Type', 'application/json');
-                
-                const data = {
-                    timestamp: new Date().toISOString(),
-                    action: name,
-                    session_id: sessionId,
-                    payload: processedPayload
-                };
-                
-                xhr.send(JSON.stringify(data));
-                return Promise.resolve(xhr);
-            },
-            _trackPageHit: function () {
-                // Skip if in test environment mode
-                if (testEnv.window.__nightmare || testEnv.window.navigator.webdriver || testEnv.window.Cypress) {
-                    return;
-                }
-                
-                // Get session ID using our adapted utility
-                let sessionId;
-                try {
-                    sessionId = getSessionId('session-id', testEnv.localStorage);
-                } catch (e) {
-                    sessionId = '00000000-0000-4000-8000-000000000000';
-                }
-                
-                // Create and send request
-                const xhr = new testEnv.window.XMLHttpRequest();
-                xhr.open('POST', 'https://e.ghost.org/tb/web_analytics', true);
-                xhr.setRequestHeader('Content-Type', 'application/json');
-                
-                const payloadData = {
-                    'user-agent': testEnv.window.navigator.userAgent,
-                    referrer: getReferrer(config.url, config.referrer),
-                    pathname: testEnv.window.location.pathname,
-                    href: testEnv.window.location.href
-                };
-                
-                const data = {
-                    timestamp: new Date().toISOString(),
-                    action: 'page_hit',
-                    session_id: sessionId,
-                    payload: JSON.stringify(payloadData)
-                };
-                
-                xhr.send(JSON.stringify(data));
-                return Promise.resolve(xhr);
-            }
-        };
-
-        // Setup event listeners for hashchange and history
-        testEnv.window.addEventListener('hashchange', testEnv.window.Tinybird._trackPageHit);
-        
-        // Modify history.pushState
-        const originalPushState = testEnv.window.history.pushState;
-        testEnv.window.history.pushState = function () {
-            originalPushState.apply(this, arguments);
-            testEnv.window.Tinybird._trackPageHit();
-        };
-
-        // Add a stub for console.warn to silence Ghost Stats initialization warnings
-        const originalWarn = testEnv.window.console.warn;
-        testEnv.window.console.warn = function (message) {
-            if (message && message.includes('Ghost Stats')) {
-                // Suppress Ghost Stats warnings
-                return;
-            }
-            originalWarn.apply(console, arguments);
-        };
-
-        // Load the script with appropriate attributes
-        loadScript(testEnv, scriptContent, {
-            dataAttributes: {
-                'data-host': 'https://e.ghost.org/tb/web_analytics',
-                'data-token': 'tb_token',
-                'data-domain': 'example.com'
-            }
-        });
-
-        return testEnv;
-    }
-
-    // Helper function to execute code with immediate timeout
-    function withImmediateTimeout(testEnv, callback) {
-        const originalSetTimeout = testEnv.window.setTimeout;
-        testEnv.window.setTimeout = function (cb) {
-            cb();
-        };
-
-        try {
-            callback();
-        } finally {
-            testEnv.window.setTimeout = originalSetTimeout;
-        }
-    }
-
-    // Helper function to track page hit and run assertions
-    function trackPageHitAndAssert(testEnv, assertions) {
-        withImmediateTimeout(testEnv, () => {
-            // Call tracking function
-            testEnv.window.Tinybird._trackPageHit();
-
-            // Check request
-            const xhr = testEnv.lastXHR();
-            expect(xhr).to.exist;
-            expect(xhr.method).to.equal('POST');
-
-            // Parse and check payload
-            const requestData = JSON.parse(xhr._data);
-            expect(requestData.action).to.equal('page_hit');
-
-            if (assertions) {
-                const payloadObj = JSON.parse(requestData.payload);
-                assertions(payloadObj, requestData);
-            }
-        });
-    }
+    let sandbox;
+    let mockWindow;
+    let mockDocument;
+    let mockFetch;
+    let mockStorage;
+    let browserService;
+    let ghostStats;
 
     beforeEach(function () {
-    // Create default test environment
-        env = createTestEnvironment();
+        sandbox = sinon.createSandbox();
+        
+        // Setup mock fetch
+        mockFetch = sandbox.stub().resolves({ok: true});
+
+        // Setup mock storage
+        mockStorage = {
+            getItem: sandbox.stub(),
+            setItem: sandbox.stub(),
+            removeItem: sandbox.stub(),
+            length: 0,
+            clear: sandbox.stub(),
+            key: sandbox.stub()
+        };
+
+        // Setup mock document with minimal required properties
+        mockDocument = {
+            currentScript: {
+                getAttribute: sandbox.stub(),
+                attributes: []
+            },
+            visibilityState: 'visible',
+            addEventListener: sandbox.stub(),
+            removeEventListener: sandbox.stub(),
+            referrer: 'https://example.com'
+        };
+
+        // Setup mock window with minimal required properties
+        mockWindow = {
+            location: {
+                hostname: 'example.com',
+                pathname: '/test',
+                href: 'https://example.com/test'
+            },
+            navigator: {
+                userAgent: 'test-agent',
+                languages: ['en-US'],
+                language: 'en-US',
+                webdriver: false
+            },
+            history: {
+                pushState: sandbox.stub()
+            },
+            addEventListener: sandbox.stub(),
+            removeEventListener: sandbox.stub(),
+            setTimeout: sandbox.stub().returns(123),
+            clearTimeout: sandbox.stub(),
+            Intl: {
+                DateTimeFormat: () => ({
+                    resolvedOptions: () => ({
+                        timeZone: 'America/New_York'
+                    })
+                })
+            },
+            fetch: mockFetch,
+            localStorage: mockStorage,
+            sessionStorage: mockStorage,
+            document: mockDocument
+        };
+
+        // Setup global mocks for url-attribution.js
+        global.window = mockWindow;
+        global.document = mockDocument;
+        global.localStorage = mockStorage;
+        global.sessionStorage = mockStorage;
+
+        // Create browser service instance with mocks
+        const {BrowserService} = require(path.resolve(__dirname, '../../../../core/frontend/src/ghost-stats/browser-service.js'));
+        browserService = new BrowserService(mockWindow, mockDocument);
+
+        // Create GhostStats instance with mocked browser service
+        const {GhostStats} = require(path.resolve(__dirname, '../../../../core/frontend/src/ghost-stats/ghost-stats.js'));
+        ghostStats = new GhostStats(browserService);
     });
 
-    describe('Tinybird object creation', function () {
-        it('should create a Tinybird object', function () {
-            expect(env.window.Tinybird).to.exist;
-            expect(env.window.Tinybird.trackEvent).to.be.a('function');
+    afterEach(function () {
+        sandbox.restore();
+        delete global.window;
+        delete global.document;
+        delete global.localStorage;
+        delete global.sessionStorage;
+    });
+
+    describe('BrowserService', function () {
+        it('should detect test environments correctly', function () {
+            expect(browserService.isTestEnvironment()).to.be.false;
+
+            Object.defineProperty(mockWindow, 'Cypress', {
+                value: {},
+                configurable: true
+            });
+            expect(browserService.isTestEnvironment()).to.be.true;
+            delete mockWindow.Cypress;
+
+            Object.defineProperty(mockWindow, '__nightmare', {
+                value: true,
+                configurable: true
+            });
+            expect(browserService.isTestEnvironment()).to.be.true;
+            delete mockWindow.__nightmare;
+
+            Object.defineProperty(mockWindow.navigator, 'webdriver', {
+                value: true,
+                configurable: true
+            });
+            expect(browserService.isTestEnvironment()).to.be.true;
+        });
+
+        it('should handle browser APIs safely', function () {
+            expect(browserService.getNavigator()).to.equal(mockWindow.navigator);
+            expect(browserService.getLocation()).to.equal(mockWindow.location);
+            expect(browserService.getTimezone()).to.equal('America/New_York');
+            expect(browserService.getCurrentScript()).to.equal(mockDocument.currentScript);
+            expect(browserService.getVisibilityState()).to.equal('visible');
+        });
+
+        it('should manage event listeners correctly', function () {
+            const callback = () => {};
+            browserService.addEventListener('window', 'test', callback);
+            expect(mockWindow.addEventListener.called && 
+                   mockWindow.addEventListener.firstCall.args[0] === 'test' && 
+                   mockWindow.addEventListener.firstCall.args[1] === callback).to.be.true;
+
+            browserService.addEventListener('document', 'test', callback);
+            expect(mockDocument.addEventListener.called && 
+                   mockDocument.addEventListener.firstCall.args[0] === 'test' && 
+                   mockDocument.addEventListener.firstCall.args[1] === callback).to.be.true;
+
+            browserService.removeEventListener('window', 'test', callback);
+            expect(mockWindow.removeEventListener.called && 
+                   mockWindow.removeEventListener.firstCall.args[0] === 'test' && 
+                   mockWindow.removeEventListener.firstCall.args[1] === callback).to.be.true;
         });
     });
 
-    describe('Session ID generation and storage', function () {
-        it('should generate and store a session ID in localStorage', function () {
-            // Call trackEvent to trigger session ID generation
-            env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-
-            // Check that a session ID was stored in localStorage
-            const sessionId = env.localStorage.getItem('session-id');
-            expect(sessionId).to.exist;
-
-            // Parse the session ID from localStorage
-            const sessionData = JSON.parse(sessionId);
-            expect(sessionData.value).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-        });
-
-        it('should use the same session ID across multiple events', function () {
-            // Call trackEvent twice
-            env.window.Tinybird.trackEvent('test_event1', {test: 'data1'});
-            const sessionId1 = env.localStorage.getItem('session-id');
-            const sessionData1 = JSON.parse(sessionId1);
-
-            env.window.Tinybird.trackEvent('test_event2', {test: 'data2'});
-            const sessionId2 = env.localStorage.getItem('session-id');
-            const sessionData2 = JSON.parse(sessionId2);
-
-            // Check that the same session ID was used
-            expect(sessionData1.value).to.equal(sessionData2.value);
-        });
-
-        it('should handle session ID expiration', function () {
-            // Call trackEvent to generate a session ID
-            env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-
-            // Get the session ID
-            const sessionId = env.localStorage.getItem('session-id');
-            expect(sessionId).to.exist;
-
-            // Parse the session ID and modify its expiry to be in the past
-            const sessionData = JSON.parse(sessionId);
-            sessionData.expiry = new Date().getTime() - 1000; // 1 second ago
-            env.localStorage.setItem('session-id', JSON.stringify(sessionData));
-
-            // Call trackEvent again
-            env.window.Tinybird.trackEvent('test_event2', {test: 'data2'});
-
-            // Get the new session ID
-            const newSessionId = env.localStorage.getItem('session-id');
-            expect(newSessionId).to.exist;
-
-            // Parse the new session ID
-            const newSessionData = JSON.parse(newSessionId);
-
-            // Check that a new session ID was generated
-            expect(newSessionData.value).to.not.equal(sessionData.value);
-        });
-
-        it('should extend session expiry when retrieving session id', function () {
-            // We need to modify the trackEvent implementation to update expiry
-            const originalTrackEvent = env.window.Tinybird.trackEvent;
+    describe('GhostStats Configuration', function () {
+        it('should initialize with required configuration', function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
             
-            // Override the trackEvent function to update session expiry
-            env.window.Tinybird.trackEvent = function (name, payload) {
-                // Get current session
-                const sessionData = JSON.parse(env.localStorage.getItem('session-id'));
-                
-                // Update expiry when retrieving session
-                if (sessionData && sessionData.value) {
-                    sessionData.expiry = new Date().getTime() + 4 * 3600 * 1000;
-                    env.localStorage.setItem('session-id', JSON.stringify(sessionData));
-                }
-                
-                // Call original implementation
-                return originalTrackEvent.call(this, name, payload);
+            expect(ghostStats.initConfig()).to.be.true;
+        });
+
+        it('should handle missing configuration gracefully', function () {
+            expect(ghostStats.initConfig()).to.be.false;
+            
+            mockDocument.currentScript = null;
+            expect(ghostStats.initConfig()).to.be.false;
+        });
+
+        it('should process global attributes', async function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            mockDocument.currentScript.attributes = [
+                {name: 'tb_attr1', value: 'value1'},
+                {name: 'tb_attr2', value: 'value2'}
+            ];
+            
+            ghostStats.initConfig();
+            await ghostStats.trackEvent('test', {});
+            
+            const payload = JSON.parse(mockFetch.lastCall.args[1].body);
+            expect(payload.payload).to.include('attr1');
+            expect(payload.payload).to.include('value1');
+        });
+    });
+
+    describe('GhostStats Event Tracking', function () {
+        beforeEach(function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            ghostStats.initConfig();
+        });
+
+        it('should track custom events with correct data', async function () {
+            await ghostStats.trackEvent('test_event', {data: 'test'});
+            
+            expect(mockFetch.calledOnce).to.be.true;
+            const payload = JSON.parse(mockFetch.firstCall.args[1].body);
+            expect(payload.action).to.equal('test_event');
+            expect(payload.payload).to.include('test');
+        });
+
+        it('should track page hits with location info', function () {
+            ghostStats.trackPageHit();
+            
+            const timeoutCallback = mockWindow.setTimeout.firstCall.args[0];
+            timeoutCallback();
+            
+            expect(mockFetch.calledOnce).to.be.true;
+            const payload = JSON.parse(mockFetch.firstCall.args[1].body);
+            expect(payload.action).to.equal('page_hit');
+            expect(JSON.parse(payload.payload)).to.deep.include({
+                'user-agent': 'test-agent',
+                pathname: '/test',
+                href: 'https://example.com/test',
+                locale: 'en-US',
+                location: 'US'
+            });
+        });
+
+        it('should handle network errors gracefully', async function () {
+            mockFetch.rejects(new Error('Network error'));
+            const consoleSpy = sandbox.spy(console, 'error');
+            
+            mockWindow.location.hostname = 'localhost';
+            await ghostStats.trackEvent('test_event', {});
+            
+            expect(consoleSpy.calledOnce).to.be.true;
+            consoleSpy.restore();
+        });
+    });
+
+    describe('GhostStats Location Detection', function () {
+        it('should detect locale and country correctly', function () {
+            const info = ghostStats.getLocationInfo();
+            expect(info).to.deep.equal({
+                locale: 'en-US',
+                country: 'US'
+            });
+        });
+
+        it('should handle missing language preferences', function () {
+            mockWindow.navigator.languages = undefined;
+            mockWindow.navigator.language = 'en';
+            
+            const info = ghostStats.getLocationInfo();
+            expect(info).to.deep.equal({
+                locale: 'en',
+                country: 'US'
+            });
+        });
+
+        it('should handle timezone resolution errors', function () {
+            mockWindow.Intl.DateTimeFormat = () => { 
+                throw new Error(); 
             };
             
-            try {
-                // Call trackEvent to generate an initial session
-                env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-                
-                // Get initial session data
-                const initialSession = JSON.parse(env.localStorage.getItem('session-id'));
-                const initialExpiry = initialSession.expiry;
-                
-                // Simulate time passing (10 minutes later)
-                const tenMinutesInMs = 10 * 60 * 1000;
-                const currentTime = new Date().getTime();
-                const newTime = currentTime + tenMinutesInMs;
-                
-                // Mock Date.now and Date.prototype.getTime
-                const originalNow = Date.now;
-                Date.now = () => newTime;
-                const originalGetTime = Date.prototype.getTime;
-                Date.prototype.getTime = function () {
-                    return newTime; 
-                };
-                
-                try {
-                    // Call trackEvent again
-                    env.window.Tinybird.trackEvent('test_event2', {test: 'data2'});
-                    
-                    // Get updated session
-                    const updatedSession = JSON.parse(env.localStorage.getItem('session-id'));
-                    
-                    // Verify expiry has been extended
-                    expect(updatedSession.expiry).to.be.above(initialExpiry);
-                    
-                    // Verify new expiry is approximately 4 hours from new time
-                    const expectedExpiry = newTime + (4 * 3600 * 1000);
-                    expect(updatedSession.expiry).to.be.closeTo(expectedExpiry, 100);
-                } finally {
-                    // Restore Date functions
-                    Date.now = originalNow;
-                    Date.prototype.getTime = originalGetTime;
-                }
-            } finally {
-                // Restore original trackEvent
-                env.window.Tinybird.trackEvent = originalTrackEvent;
-            }
-        });
-    });
-
-    describe('Event tracking', function () {
-        it('should send events to the Ghost proxy', function () {
-            // Call trackEvent
-            env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-
-            // Check that an XMLHttpRequest was made
-            const xhrInstance = env.lastXHR();
-            expect(xhrInstance).to.exist;
-            expect(xhrInstance.method).to.equal('POST');
-            expect(xhrInstance.url).to.include('e.ghost.org');
-
-            // Check that the request data contains the event name and data
-            const requestData = JSON.parse(xhrInstance._data);
-            expect(requestData.action).to.equal('test_event');
-            expect(requestData.payload).to.include('"test":"data"');
-        });
-
-        it('should include session ID in event data', function () {
-            // Call trackEvent
-            env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-
-            // Get the session ID from localStorage
-            const sessionId = JSON.parse(env.localStorage.getItem('session-id')).value;
-
-            // Check that an XMLHttpRequest was made
-            const xhrInstance = env.lastXHR();
-            expect(xhrInstance).to.exist;
-
-            // Check that the request data contains the session ID
-            const requestData = JSON.parse(xhrInstance._data);
-            expect(requestData.session_id).to.equal(sessionId);
-        });
-
-        it('should include timestamp in event data', function () {
-            // Call trackEvent
-            env.window.Tinybird.trackEvent('test_event', {test: 'data'});
-
-            // Check that an XMLHttpRequest was made
-            const xhrInstance = env.lastXHR();
-            expect(xhrInstance).to.exist;
-
-            // Check that the request data contains a timestamp
-            const requestData = JSON.parse(xhrInstance._data);
-            expect(requestData.timestamp).to.exist;
-
-            // Check that the timestamp is a valid ISO string
-            const timestamp = new Date(requestData.timestamp);
-            expect(timestamp.toString()).to.not.equal('Invalid Date');
-        });
-    });
-
-    describe('Data masking', function () {
-        function expectMaskedData(payload, fields) {
-            fields.forEach((field) => {
-                expect(payload).to.include(`"${field}":"********"`);
-            });
-        }
-
-        it('should mask sensitive data in events', function () {
-            // Call trackEvent with sensitive data
-            env.window.Tinybird.trackEvent('test_event', {
-                email: 'test@example.com',
-                password: 'secretpassword',
-                token: 'sensitive-token'
-            });
-
-            // Check that an XMLHttpRequest was made
-            const xhrInstance = env.lastXHR();
-            expect(xhrInstance).to.exist;
-
-            // Check that the sensitive data was masked
-            const requestData = JSON.parse(xhrInstance._data);
-            expectMaskedData(requestData.payload, ['email', 'password', 'token']);
-        });
-
-        it('should mask nested sensitive data', function () {
-            // Call trackEvent with nested sensitive data
-            env.window.Tinybird.trackEvent('test_event', {
-                user: {
-                    email: 'test@example.com',
-                    password: 'secretpassword'
-                },
-                order: {
-                    id: '12345',
-                    payment: {
-                        credit_card: '4111111111111111'
-                    }
-                }
-            });
-
-            // Check that an XMLHttpRequest was made
-            const xhrInstance = env.lastXHR();
-            expect(xhrInstance).to.exist;
-
-            // Check that the nested sensitive data was masked
-            const requestData = JSON.parse(xhrInstance._data);
-            expectMaskedData(requestData.payload, ['email', 'password', 'credit_card']);
-        });
-    });
-
-    describe('Referrer handling', function () {
-        it('should use document.referrer when no query params are present', function () {
-            const envWithReferrer = createTestEnvironment();
-
-            trackPageHitAndAssert(envWithReferrer, (payloadObj) => {
-                expect(payloadObj.referrer).to.equal('https://google.com/');
-            });
-        });
-
-        it('should prioritize ref parameter over document.referrer', function () {
-            const envWithRef = createTestEnvironment({
-                url: 'https://example.com/blog?ref=newsletter'
-            });
-
-            trackPageHitAndAssert(envWithRef, (payloadObj) => {
-                expect(payloadObj.referrer).to.equal('newsletter');
-            });
-        });
-
-        it('should prioritize source parameter over utm_source', function () {
-            const envWithSource = createTestEnvironment({
-                url: 'https://example.com/blog?source=blog&utm_source=social'
-            });
-
-            trackPageHitAndAssert(envWithSource, (payloadObj) => {
-                expect(payloadObj.referrer).to.equal('blog');
-            });
-        });
-
-        it('should use utm_source when ref and source are not present', function () {
-            const envWithUtm = createTestEnvironment({
-                url: 'https://example.com/blog?utm_source=social'
-            });
-
-            trackPageHitAndAssert(envWithUtm, (payloadObj) => {
-                expect(payloadObj.referrer).to.equal('social');
-            });
-        });
-
-        it('should extract ref from hash URL when present', function () {
-            const envWithHash = createTestEnvironment({
-                url: 'https://example.com/#/portal/signup?ref=newsletter'
-            });
-
-            trackPageHitAndAssert(envWithHash, (payloadObj) => {
-                expect(payloadObj.referrer).to.equal('newsletter');
+            const info = ghostStats.getLocationInfo();
+            expect(info).to.deep.equal({
+                locale: 'en',
+                country: null
             });
         });
     });
 
-    describe('Page hit tracking', function () {
-        it('should track page hits with correct data', function () {
-            // Set up navigator
-            Object.defineProperty(env.window.navigator, 'userAgent', {
-                value: 'Mozilla/5.0 (Test Browser)',
-                configurable: true
-            });
-
-            trackPageHitAndAssert(env, (payloadObj) => {
-                expect(payloadObj['user-agent']).to.equal('Mozilla/5.0 (Test Browser)');
-                expect(payloadObj.pathname).to.equal('/');
-                expect(payloadObj.href).to.equal('https://example.com/');
-                expect(payloadObj.referrer).to.equal('https://google.com/');
-            });
+    describe('GhostStats Event Listeners', function () {
+        beforeEach(function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            ghostStats.initConfig();
         });
 
-        it('should not track page hits in test environments', function () {
-            // Set up test environment flags
-            env.window.__nightmare = true;
-
-            withImmediateTimeout(env, () => {
-                // Call _trackPageHit
-                env.window.Tinybird._trackPageHit();
-
-                // Check that no XMLHttpRequest was made
-                const xhrInstance = env.lastXHR();
-                expect(xhrInstance).to.not.exist;
-            });
-        });
-    });
-
-    describe('Event-triggered page hit tracking', function () {
-        it('should track page hits on hashchange event', function () {
-            // Set up navigator
-            Object.defineProperty(env.window.navigator, 'userAgent', {
-                value: 'Mozilla/5.0 (Test Browser)',
-                configurable: true
-            });
-
-            withImmediateTimeout(env, () => {
-                // Trigger a hashchange event
-                const event = new env.window.Event('hashchange');
-                env.window.dispatchEvent(event);
-
-                // Check that an XMLHttpRequest was made
-                const xhrInstance = env.lastXHR();
-                expect(xhrInstance).to.exist;
-                expect(xhrInstance.method).to.equal('POST');
-
-                // Check that the request data contains page hit data
-                const requestData = JSON.parse(xhrInstance._data);
-                expect(requestData.action).to.equal('page_hit');
-            });
+        it('should setup navigation tracking', function () {
+            ghostStats.setupEventListeners();
+            
+            expect(mockWindow.addEventListener.calledWith('hashchange')).to.be.true;
+            expect(mockWindow.addEventListener.calledWith('popstate')).to.be.true;
         });
 
-        it('should track page hits on history pushState', function () {
-            // Set up navigator
-            Object.defineProperty(env.window.navigator, 'userAgent', {
-                value: 'Mozilla/5.0 (Test Browser)',
-                configurable: true
-            });
+        it('should handle visibility changes', function () {
+            mockDocument.visibilityState = 'hidden';
+            ghostStats.setupEventListeners();
+            expect(mockDocument.addEventListener.calledWith('visibilitychange')).to.be.true;
 
-            withImmediateTimeout(env, () => {
-                // Execute the modified pushState function directly
-                env.window.history.pushState({}, '', '/new-path');
-
-                // Check that an XMLHttpRequest was made
-                const xhrInstance = env.lastXHR();
-                expect(xhrInstance).to.exist;
-                expect(xhrInstance.method).to.equal('POST');
-
-                // Check that the request data contains page hit data
-                const requestData = JSON.parse(xhrInstance._data);
-                expect(requestData.action).to.equal('page_hit');
-            });
-        });
-
-        it('should track page hits on document visibility change', function () {
-            const visibilityEnv = createTestEnvironment();
-            trackPageHitAndAssert(visibilityEnv);
-        });
-    });
-
-    describe('Referrer edge cases', function () {
-        it('should return null when referrer hostname matches current hostname', function () {
-            const envWithMatchingHostname = createTestEnvironment({
-                url: 'https://example.com/page2',
-                referrer: 'https://example.com/page1'
-            });
-
-            trackPageHitAndAssert(envWithMatchingHostname, (payloadObj) => {
-                expect(payloadObj.referrer).to.be.null;
-            });
-        });
-    });
-
-    describe('Payload formatting', function () {
-        it('should handle when stringifyPayload is set to false', function () {
-            const envWithoutStringify = createTestEnvironment({
-                stringifyPayload: false
-            });
-
-            withImmediateTimeout(envWithoutStringify, () => {
-                // Test with sensitive data
-                envWithoutStringify.window.Tinybird.trackEvent('test_event', {
-                    email: 'test@example.com',
-                    password: 'secretpassword'
-                });
-
-                // Check that an XMLHttpRequest was made
-                const xhrInstance = envWithoutStringify.lastXHR();
-                expect(xhrInstance).to.exist;
-
-                // Simply check that the sensitive data is masked in the raw request
-                const rawData = xhrInstance._data;
-                expect(rawData).to.include('********');
-                expect(rawData).to.not.include('test@example.com');
-                expect(rawData).to.not.include('secretpassword');
-            });
+            const visibilityCallback = mockDocument.addEventListener.firstCall.args[1];
+            mockDocument.visibilityState = 'visible';
+            visibilityCallback();
+            
+            const timeoutCallback = mockWindow.setTimeout.firstCall.args[0];
+            timeoutCallback();
+            
+            expect(mockFetch.calledOnce).to.be.true;
+            const payload = JSON.parse(mockFetch.firstCall.args[1].body);
+            expect(payload.action).to.equal('page_hit');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -320,4 +320,45 @@ describe('ghost-stats.js', function () {
                 .to.equal(firstVisibilityListenerCount);
         });
     });
+
+    describe('GhostStats Initialization', function () {
+        it('should initialize successfully with proper configuration', function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+
+            expect(ghostStats.init()).to.be.true;
+            expect(mockWindow.Tinybird).to.exist;
+            expect(typeof mockWindow.Tinybird.trackEvent).to.equal('function');
+        });
+
+        it('should skip initialization in test environments', function () {
+            // Make it a test environment
+            Object.defineProperty(mockWindow, 'Cypress', {
+                value: {},
+                configurable: true
+            });
+
+            expect(ghostStats.init()).to.be.false;
+            mockWindow.Cypress = undefined;
+        });
+
+        it('should handle missing configuration gracefully', function () {
+            expect(ghostStats.init()).to.be.false;
+        });
+
+        it('should set up global Tinybird API when initialized', function () {
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+
+            ghostStats.init();
+
+            expect(mockWindow.Tinybird).to.exist;
+            expect(typeof mockWindow.Tinybird.trackEvent).to.equal('function');
+            expect(typeof mockWindow.Tinybird._trackPageHit).to.equal('function');
+
+            // Test the global API works
+            mockWindow.Tinybird.trackEvent('test', {data: 'value'});
+            expect(mockFetch.calledOnce).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
no ref

This file was largely testing copies of its own logic rather than the file itself. While I'm not a huge fan of the class-based approach, it's functional and makes it MUCH easier to mock. The tests are now actually calling the code, and the browser-related pieces have been separated into their own service for testing separation.