### PR TITLE
Improved y range on charts in analytics

### DIFF
--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -53,7 +53,7 @@ export {default as useGlobalDirtyState} from './hooks/use-global-dirty-state';
 
 // Utils
 export * from '@/lib/utils';
-export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars} from '@/lib/utils';
+export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, getYRangeWithMinPadding, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars} from '@/lib/utils';
 
 export {default as ShadeApp} from './ShadeApp';
 export type {ShadeAppProps} from './ShadeApp';

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -5,7 +5,7 @@ import SortButton from './components/SortButton';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {AlignedAxisTick, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, centsToDollars, formatDisplayDateWithRange, formatNumber, getYRange} from '@tryghost/shade';
+import {AlignedAxisTick, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, centsToDollars, formatDisplayDateWithRange, formatNumber, getYRange, getYRangeWithMinPadding} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -127,6 +127,7 @@ const GrowthKPIs: React.FC<{
     } satisfies ChartConfig;
 
     const yRange = [getYRange(chartData).min, getYRange(chartData).max];
+    const yRangeWithMinPadding = getYRangeWithMinPadding({min: yRange[0], max: yRange[1]});
 
     const tabConfig = {
         'total-members': {
@@ -215,8 +216,9 @@ const GrowthKPIs: React.FC<{
                             ticks={chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}
                         />
                         <Recharts.YAxis
+                            allowDataOverflow={true}
                             axisLine={false}
-                            domain={yRange}
+                            domain={yRangeWithMinPadding}
                             tickFormatter={(value) => {
                                 switch (currentTab) {
                                 case 'total-members':

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -226,7 +226,7 @@ const GrowthKPIs: React.FC<{
                                 case 'paid-members':
                                     return formatNumber(value);
                                 case 'mrr':
-                                    return `$${value}`;
+                                    return `$${formatNumber(value)}`;
                                 default:
                                     return value.toLocaleString();
                                 }

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -7,7 +7,7 @@ import SortButton from './components/SortButton';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {AlignedAxisTick, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, formatDisplayDate, formatDisplayDateWithRange, formatNumber, formatPercentage, getYRange} from '@tryghost/shade';
+import {AlignedAxisTick, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, formatDisplayDate, formatDisplayDateWithRange, formatNumber, formatPercentage, getYRange, getYRangeWithMinPadding} from '@tryghost/shade';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -148,6 +148,7 @@ const NewsletterKPIs: React.FC<{
     const barTicks = [0, 0.25, 0.5, 0.75, 1];
 
     const yRange = [getYRange(subscribersData).min, getYRange(subscribersData).max];
+    const yRangeWithMinPadding = getYRangeWithMinPadding({min: yRange[0], max: yRange[1]});
 
     const tabConfig = {
         'total-subscribers': {
@@ -220,8 +221,9 @@ const NewsletterKPIs: React.FC<{
                             ticks={subscribersData.length > 0 ? [subscribersData[0].date, subscribersData[subscribersData.length - 1].date] : []}
                         />
                         <Recharts.YAxis
+                            allowDataOverflow={true}
                             axisLine={false}
-                            domain={yRange}
+                            domain={yRangeWithMinPadding}
                             scale="linear"
                             tickFormatter={value => formatNumber(value)}
                             tickLine={false}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1812/all-charts-y-axis-starting-at-0-so-only-seeing-flat-lines
ref https://linear.app/ghost/issue/PROD-1813/mrr-chart-starts-at-dollar0

- All area charts in analytics started from 0 which resulted in flat lines for larger numbers.
- Fixed missing thousands separator on y axis tick numbers