### PR TITLE
Fixed flakey portal signupFlow test

### DIFF
--- a/apps/portal/src/tests/SignupFlow.test.js
+++ b/apps/portal/src/tests/SignupFlow.test.js
@@ -3,12 +3,15 @@ import {fireEvent, appRender, within, waitFor} from '../utils/test-utils';
 import {offer as FixtureOffer, site as FixtureSite} from '../utils/test-fixtures';
 import setupGhostApi from '../utils/api.js';
 
+// Simple deep clone function
+const deepClone = obj => JSON.parse(JSON.stringify(obj));
+
 const offerSetup = async ({site, member = null, offer}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
     ghostApi.init = jest.fn(() => {
         return Promise.resolve({
-            site,
-            member
+            site: deepClone(site),
+            member: member ? deepClone(member) : null
         });
     });
 
@@ -81,8 +84,8 @@ const setup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
     ghostApi.init = jest.fn(() => {
         return Promise.resolve({
-            site,
-            member
+            site: deepClone(site),
+            member: member ? deepClone(member) : null
         });
     });
 
@@ -140,8 +143,8 @@ const multiTierSetup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
     ghostApi.init = jest.fn(() => {
         return Promise.resolve({
-            site,
-            member
+            site: deepClone(site),
+            member: member ? deepClone(member) : null
         });
     });
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/15158575736/job/42619280330
- portal unit tests are regularly failing with the following error: ❯ src/tests/SignupFlow.test.js  (18 tests | 3 failed) 21176ms
     ❯ src/tests/SignupFlow.test.js > Signup > as paid member on single tier site > with default settings on monthly plan
       → Found multiple elements with the text: Limited early adopter pricing #40-1747819910858

  Here are the matching elements:

  Ignored nodes: comments, script, style
  <div
    class="gh-portal-benefit-title"
  >
    Limited early adopter pricing #40-1747819910858
  </div>

  Ignored nodes: comments, script, style
  <div
    class="gh-portal-benefit-title"
  >
    Limited early adopter pricing #40-1747819910858
  </div>
- Somewhere somehow, the benefits array is getting duplicated or rendered duplicate times
- This change ensures that each test has its own copy of the data, to ensure that tests are not modifying data referenced by other tests, to see if this resolves the problem
- There are a few weirdnesses in the code stuch as a setTimeout in handleSelectPlan in SignupPage.js that could lead to the kind of duplicate render and asyncronicity issues we're seeing so those are things to look at next, if we can't rule out this being a test issue

