### PR TITLE
Refactored image corner handling in EmailRenderer to use boolean condition

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1032,21 +1032,8 @@ class EmailRenderer {
     }
 
     #getImageCorners(newsletter) {
-        /** @type {'rounded' | string | null} */
         const value = newsletter.get('image_corners');
-
-        // we need to convert the value to plain css value
-        // eg border-radius: 10px;
-
-        if (value === 'rounded') {
-            return 'border-radius: 6px;';
-        }
-
-        if (value === 'square') {
-            return null;
-        }
-
-        return null;
+        return value;
     }
 
     /**

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1033,7 +1033,10 @@ class EmailRenderer {
 
     #getImageCorners(newsletter) {
         const value = newsletter.get('image_corners');
-        return value;
+        if (value === 'rounded') {
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -1064,7 +1067,7 @@ class EmailRenderer {
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
         const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
         const linkStyles = this.#getLinkStyles(newsletter);
-        const imageCorners = this.#getImageCorners(newsletter);
+        const hasRoundedImageCorners = this.#getImageCorners(newsletter);
 
         let buttonBorderRadius = '6px';
 
@@ -1226,7 +1229,7 @@ class EmailRenderer {
             secondaryTextColor,
             linkColor,
             linkStyles,
-            imageCorners,
+            hasRoundedImageCorners,
             buttonBorderRadius,
 
             headerImage,

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -506,7 +506,11 @@ figure blockquote p {
 
 .feature-image img {
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
     {{/hasFeature}}
 }
 
@@ -714,7 +718,11 @@ a[data-flickr-embed] img {
     height: auto;
     width: auto;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
     {{/hasFeature}}
 }
 
@@ -818,8 +826,8 @@ a[data-flickr-embed] img {
     height: auto !important;
     padding-top: 20px;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if imageCorners}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+    border-radius: 6px;
     padding-top: 0 !important;
     margin-top: 20px !important;
     {{/if}}
@@ -832,7 +840,11 @@ a[data-flickr-embed] img {
     display: block;
     text-decoration: none !important;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
     {{/hasFeature}}
 }
 
@@ -840,7 +852,9 @@ a[data-flickr-embed] img {
     background-size: cover;
     min-height: 200px; /* for when images aren't loaded */
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
+    {{/if}}
     {{/hasFeature}}
     overflow: hidden;
 }
@@ -1117,17 +1131,17 @@ table.kg-cta-content-wrapper:not(.kg-cta-bg-none.kg-cta-no-dividers table.kg-cta
 
 /* -------------------------------------
     When removing emailCustomizationAlpha,
-    also remove border-radius: 6px;
+    also remove border-radius: 6px and border-radius: 0 !important;
 ------------------------------------- */
 img.kg-cta-image {
     display: block;
     border-radius: 6px;
     border: 0;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if imageCorners}}
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
     {{else}}
-    border-radius: 0 !important;
+        border-radius: 0 !important;
     {{/if}}
     {{/hasFeature}}
 }
@@ -1530,7 +1544,9 @@ img.kg-cta-image {
     height: auto;
     padding: 0;
     border: none;
-    {{imageCorners}};
+    {{#if (eq imageCorners 'rounded')}}
+        border-radius: 6px;
+    {{/if}}
 }
 
 .kg-product-title {

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -506,10 +506,8 @@ figure blockquote p {
 
 .feature-image img {
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
-    {{else}}
-        border-radius: 0;
     {{/if}}
     {{/hasFeature}}
 }
@@ -718,10 +716,8 @@ a[data-flickr-embed] img {
     height: auto;
     width: auto;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
-    {{else}}
-        border-radius: 0;
     {{/if}}
     {{/hasFeature}}
 }
@@ -826,7 +822,7 @@ a[data-flickr-embed] img {
     height: auto !important;
     padding-top: 20px;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
     border-radius: 6px;
     padding-top: 0 !important;
     margin-top: 20px !important;
@@ -840,10 +836,8 @@ a[data-flickr-embed] img {
     display: block;
     text-decoration: none !important;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
-    {{else}}
-        border-radius: 0;
     {{/if}}
     {{/hasFeature}}
 }
@@ -852,7 +846,7 @@ a[data-flickr-embed] img {
     background-size: cover;
     min-height: 200px; /* for when images aren't loaded */
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
     {{/if}}
     {{/hasFeature}}
@@ -1131,14 +1125,14 @@ table.kg-cta-content-wrapper:not(.kg-cta-bg-none.kg-cta-no-dividers table.kg-cta
 
 /* -------------------------------------
     When removing emailCustomizationAlpha,
-    also remove border-radius: 6px and border-radius: 0 !important;
+    also remove border-radius: 6px;
 ------------------------------------- */
 img.kg-cta-image {
     display: block;
     border-radius: 6px;
     border: 0;
     {{#hasFeature "emailCustomizationAlpha"}}
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
     {{else}}
         border-radius: 0 !important;
@@ -1544,7 +1538,7 @@ img.kg-cta-image {
     height: auto;
     padding: 0;
     border: none;
-    {{#if (eq imageCorners 'rounded')}}
+    {{#if hasRoundedImageCorners}}
         border-radius: 6px;
     {{/if}}
 }

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2599,10 +2599,10 @@ describe('Email renderer', function () {
             }, 'buttonBorderRadius', expectedRadius, {labsEnabled: true});
         }
 
-        async function testImageCorners(imageCorners, expectedRadius) {
+        async function testImageCorners(imageCorners, expectedBoolean) {
             return await testDataProperty({
                 image_corners: imageCorners
-            }, 'imageCorners', expectedRadius, {labsEnabled: true});
+            }, 'hasRoundedImageCorners', expectedBoolean, {labsEnabled: true});
         }
 
         it('sets buttonBorderRadius to correct default (emailCustomizationAlpha)', async function () {
@@ -2622,14 +2622,13 @@ describe('Email renderer', function () {
         });
 
         it('sets imageCorners to correct rounded value (emailCustomizationAlpha)', async function () {
-            await testImageCorners('rounded', 'rounded');
+            await testImageCorners('rounded', true);
         });
 
-        it('sets imageCorners to correct square value which is null (emailCustomizationAlpha)', async function () {
+        it('sets imageCorners to correct square value which is false (emailCustomizationAlpha)', async function () {
             // null because square has no border radius
-            await testImageCorners('square', 'square');
+            await testImageCorners('square', false);
         });
-
         async function testHasOutlineButtons(buttonStyle, expectedValue) {
             return await testDataProperty({
                 button_style: buttonStyle

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2622,20 +2622,12 @@ describe('Email renderer', function () {
         });
 
         it('sets imageCorners to correct rounded value (emailCustomizationAlpha)', async function () {
-            await testImageCorners('rounded', 'border-radius: 6px;');
+            await testImageCorners('rounded', 'rounded');
         });
 
         it('sets imageCorners to correct square value which is null (emailCustomizationAlpha)', async function () {
             // null because square has no border radius
-            await testImageCorners('square', null);
-        });
-
-        it('sets imageCorners to null if unknown value', async function () {
-            await testImageCorners('unknown', null);
-        });
-
-        it('sets imageCorners to null if null', async function () {
-            await testImageCorners(null, null);
+            await testImageCorners('square', 'square');
         });
 
         async function testHasOutlineButtons(buttonStyle, expectedValue) {


### PR DESCRIPTION
no issue

- Modified EmailRenderer.js to replace string-based `imageCorners` with boolean `hasRoundedImageCorners`
- Updated styles.hbs to apply `border-radius: 6px` conditionally based on `hasRoundedImageCorners`
- Adjusted email-renderer.test.js to test boolean values (`true` for rounded, `false` for square) instead of string-based border radius
- Simplifies logic and ensures consistent border radius application for email images