### PR TITLE
Hid color swatches unless color picker is expanded

### DIFF
--- a/apps/admin-x-design-system/src/global/form/ColorIndicator.tsx
+++ b/apps/admin-x-design-system/src/global/form/ColorIndicator.tsx
@@ -72,11 +72,7 @@ export interface ColorIndicatorProps {
 
 /** Should usually be used via [ColorPickerField](?path=/docs/global-form-color-picker-field--docs) */
 const ColorIndicator: React.FC<ColorIndicatorProps> = ({title, value, swatches, swatchSize = 'md',onSwatchChange, onTogglePicker, isExpanded, picker = true, containerClassName}) => {
-    let selectedSwatch = swatches.find(swatch => swatch.value === value || swatch.hex === value);
-
-    if (isExpanded) {
-        selectedSwatch = undefined;
-    }
+    const selectedSwatch = swatches.find(swatch => swatch.value === value || swatch.hex === value);
 
     containerClassName = clsx(
         'flex flex-col gap-3'
@@ -86,16 +82,18 @@ const ColorIndicator: React.FC<ColorIndicatorProps> = ({title, value, swatches, 
         <div className={containerClassName}>
             {title && <Heading useLabelTag>{title}</Heading>}
             <div className='flex gap-1'>
-                <div className={`flex items-center gap-1`}>
-                    {swatches.map(({customContent, ...swatch}) => (
-                        customContent ? <Fragment key={swatch.title}>{customContent}</Fragment> : <ColorSwatch key={swatch.title} isSelected={selectedSwatch?.title === swatch.title} size={swatchSize} onSelect={onSwatchChange} {...swatch} />
-                    ))}
-                </div>
+                {isExpanded && (
+                    <div className={`flex items-center gap-1`}>
+                        {swatches.map(({customContent, ...swatch}) => (
+                            customContent ? <Fragment key={swatch.title}>{customContent}</Fragment> : <ColorSwatch key={swatch.title} isSelected={selectedSwatch?.title === swatch.title} size={swatchSize} onSelect={onSwatchChange} {...swatch} />
+                        ))}
+                    </div>
+                )}
                 {picker &&
                     <button aria-label="Pick color" className="relative size-6 cursor-pointer rounded-full border border-grey-250 dark:border-grey-800" type="button" onClick={onTogglePicker}>
                         <div className='absolute inset-0 rounded-full bg-[conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))]' />
-                        {value && !selectedSwatch && (
-                            <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor: value}}>
+                        {value && (
+                            <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor: selectedSwatch?.hex || value}}>
                                 {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
                             </div>
                         )}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1865/improve-color-picker-component
- In favour of a calmer UI, we only show the color swatches when the color picker is expanded
