### PR TITLE
Fixed button corners setting UI not showing behind beta flag

### DIFF
--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -19,7 +19,7 @@ import HistoryModal from '../../settings/advanced/HistoryModal';
 import InviteUserModal from '../../settings/general/InviteUserModal';
 import NavigationModal from '../../settings/site/NavigationModal';
 import NewsletterDetailModal from '../../settings/email/newsletters/NewsletterDetailModal';
-import NewsletterDetailModalAlpha from '../../settings/email/newsletters/NewsletterDetailModalAlpha';
+import NewsletterDetailModalLabs from '../../settings/email/newsletters/NewsletterDetailModalLabs';
 import NewsletterDetailModalPrototype from '../../settings/email/newsletters/NewsletterDetailModalPrototype';
 import OfferSuccess from '../../settings/growth/offers/OfferSuccess';
 // import OffersModal from '../../settings/growth/offers/OffersIndex';
@@ -35,13 +35,14 @@ import ZapierModal from '../../settings/advanced/integrations/ZapierModal';
 
 // Wrapper component to conditionally render based on feature flag
 const ConditionalNewsletterDetailModal: ModalComponent = (props) => {
-    const showPrototypeSettings = useFeatureFlag('emailCustomizationPrototype');
-    const showAlphaSettings = useFeatureFlag('emailCustomizationAlpha');
+    const emailCustomizationPrototype = useFeatureFlag('emailCustomizationPrototype');
+    const emailCustomizationBeta = useFeatureFlag('emailCustomization');
+    const emailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
 
-    if (showPrototypeSettings) {
+    if (emailCustomizationPrototype) {
         return <NewsletterDetailModalPrototype {...props} />;
-    } else if (showAlphaSettings) {
-        return <NewsletterDetailModalAlpha {...props} />;
+    } else if (emailCustomizationBeta || emailCustomizationAlpha) {
+        return <NewsletterDetailModalLabs {...props} />;
     } else {
         return <NewsletterDetailModal {...props} />;
     }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
@@ -1,6 +1,7 @@
 import NewsletterPreview from './NewsletterPreview';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
+import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
 import validator from 'validator';
 import {Button, ButtonGroup, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, SelectOption, Separator, Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
@@ -65,6 +66,9 @@ const Sidebar: React.FC<{
     errors: ErrorMessages;
     clearError: (field: string) => void;
 }> = ({newsletter, onlyOne, updateNewsletter, validate, errors, clearError}) => {
+    const hasEmailCustomizationBeta = useFeatureFlag('emailCustomization');
+    const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
+
     const {updateRoute} = useRouting();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const limiter = useLimiter();
@@ -373,12 +377,14 @@ const Sidebar: React.FC<{
                         title='Heading font'
                         onSelect={option => updateNewsletter({title_font_category: option?.value})}
                     />
+                    {hasEmailCustomizationAlpha &&
                     <Select
                         options={fontWeightOptions}
                         selectedOption={fontWeightOptions.find(option => option.value === newsletter.title_font_weight)}
                         title='Heading weight'
                         onSelect={option => updateNewsletter({title_font_weight: option?.value})}
                     />
+                    }
                     <Select
                         options={fontOptions}
                         selectedOption={fontOptions.find(option => option.value === newsletter.body_font_category)}
@@ -416,6 +422,7 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    {hasEmailCustomizationAlpha &&
                     <div className='flex w-full justify-between'>
                         <div>Button style</div>
                         <ButtonGroup activeKey={newsletter.button_style || 'fill'} buttons={[
@@ -441,6 +448,8 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    }
+                    {(hasEmailCustomizationAlpha || hasEmailCustomizationBeta) &&
                     <div className='flex w-full justify-between'>
                         <div>Button corners</div>
                         <ButtonGroup activeKey={newsletter.button_corners || 'rounded'} buttons={[
@@ -476,6 +485,8 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    }
+                    {hasEmailCustomizationAlpha &&
                     <div className='flex w-full justify-between'>
                         <div>Image corners</div>
                         <ButtonGroup activeKey={newsletter.image_corners || 'square'} buttons={[
@@ -501,6 +512,8 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    }
+                    {hasEmailCustomizationAlpha &&
                     <div className='flex w-full justify-between'>
                         <div>Link style</div>
                         <ButtonGroup activeKey={newsletter.link_style || 'underline'} buttons={[
@@ -536,6 +549,7 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
+                    }
                 </Form>
             </>
         }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -8,13 +8,13 @@ import {textColorForBackgroundColor} from '@tryghost/color-utils';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 
 const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => {
-    const hasEmailCustomizationFlag = useFeatureFlag('emailCustomization');
-    const hasEmailCustomizationAlphaFlag = useFeatureFlag('emailCustomizationAlpha');
-    const hasEmailCustomizationPrototypeFlag = useFeatureFlag('emailCustomizationPrototype');
+    const hasEmailCustomization = useFeatureFlag('emailCustomization');
+    const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
+    const hasEmailCustomizationPrototype = useFeatureFlag('emailCustomizationPrototype');
     const {currentUser, settings, siteData, config} = useGlobalData();
     const [title, icon, commentsEnabled, supportEmailAddress, defaultEmailAddress] = getSettingValues<string>(settings, ['title', 'icon', 'comments_enabled', 'support_email_address', 'default_email_address']);
 
-    const hasEmailCustomization = hasEmailCustomizationFlag || hasEmailCustomizationAlphaFlag || hasEmailCustomizationPrototypeFlag;
+    const hasAnyEmailCustomization = hasEmailCustomization || hasEmailCustomizationAlpha || hasEmailCustomizationPrototype;
 
     let headerTitle: string | null = null;
     if (newsletter.show_header_title) {
@@ -173,7 +173,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
     const headerTextColor = headerColor() === 'transparent' ? textColor : textColorForBackgroundColor(headerColor()).hex();
     const secondaryHeaderTextColor = headerColor() === 'transparent' ? secondaryTextColor : textColorForBackgroundColor(headerColor()).alpha(0.5).toString();
 
-    const colors = hasEmailCustomization ? {
+    const colors = hasEmailCustomizationPrototype ? {
         backgroundColor: backgroundColor(),
         headerColor: headerColor(),
         borderColor: borderColor() || undefined,
@@ -192,19 +192,19 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
     return <NewsletterPreviewContent
         accentColor={siteData.accent_color}
         authorPlaceholder={currentUser.name || currentUser.email}
-        backgroundColor={colors.backgroundColor || '#ffffff'}
+        backgroundColor={hasEmailCustomizationPrototype && colors.backgroundColor || '#ffffff'}
         bodyFontCategory={newsletter.body_font_category}
-        buttonCorners={newsletter.button_corners || 'squircle'}
-        buttonStyle={newsletter.button_style || 'fill'}
+        buttonCorners={hasAnyEmailCustomization && newsletter.button_corners || 'rounded'}
+        buttonStyle={(hasEmailCustomizationPrototype || hasEmailCustomizationAlpha) && newsletter.button_style || 'fill'}
         dividerStyle={newsletter.divider_style || 'solid'}
         footerContent={newsletter.footer_content}
-        headerColor={colors.headerColor || headerColor()}
+        headerColor={hasEmailCustomizationPrototype ? (colors.headerColor || headerColor()) : 'transparent'}
         headerIcon={newsletter.show_header_icon ? icon : undefined}
         headerImage={newsletter.header_image}
         headerSubtitle={headerSubtitle}
         headerTitle={headerTitle}
-        imageCorners={newsletter.image_corners || 'square'}
-        linkStyle={newsletter.link_style || 'underline'}
+        imageCorners={(hasEmailCustomizationPrototype || hasEmailCustomizationAlpha) ? (newsletter.image_corners || 'square') : 'square'}
+        linkStyle={(hasEmailCustomizationPrototype || hasEmailCustomizationAlpha) && newsletter.link_style || 'underline'}
         senderEmail={renderSenderEmail(newsletter, config, defaultEmailAddress)}
         senderName={newsletter.sender_name || title}
         senderReplyTo={renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress)}
@@ -219,7 +219,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         siteTitle={title}
         titleAlignment={newsletter.title_alignment}
         titleFontCategory={newsletter.title_font_category}
-        titleFontWeight={newsletter.title_font_weight}
+        titleFontWeight={(hasEmailCustomizationPrototype || hasEmailCustomizationAlpha) && newsletter.title_font_weight || 'bold'}
         {...colors}
     />;
 };

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -101,6 +101,9 @@ const NewsletterPreviewContent: React.FC<{
     const {config} = useGlobalData();
     const hasEmailCustomizationPrototype = useFeatureFlag('emailCustomizationPrototype');
     const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
+    const hasEmailCustomization = useFeatureFlag('emailCustomization');
+
+    const hasAnyEmailCustomization = hasEmailCustomization || hasEmailCustomizationAlpha || hasEmailCustomizationPrototype;
 
     const currentDate = new Date().toLocaleDateString('default', {
         year: 'numeric',
@@ -172,7 +175,7 @@ const NewsletterPreviewContent: React.FC<{
                             )}
                             {showPostTitleSection && (
                                 <div className={clsx('flex flex-col py-8', titleAlignment === 'center' ? 'items-center' : 'items-start')}>
-                                    {hasEmailCustomizationPrototype || hasEmailCustomizationAlpha ? (
+                                    {hasAnyEmailCustomization ? (
                                         <>
                                             <h2 className={clsx(
                                                 'text-4xl font-bold leading-supertight text-black',
@@ -207,11 +210,11 @@ const NewsletterPreviewContent: React.FC<{
                                         'flex w-full justify-between text-center text-md leading-none text-grey-700',
                                         titleAlignment === 'center' ? 'flex-col gap-1' : 'flex-row'
                                     )}>
-                                        <p className="pb-1 text-[1.3rem]" style={{color: hasEmailCustomizationPrototype ? secondaryHeaderTextColor : secondaryTextColor}}>
+                                        <p className="pb-1 text-[1.3rem]" style={{color: hasAnyEmailCustomization ? secondaryHeaderTextColor : secondaryTextColor}}>
                                             By {authorPlaceholder}
                                             <span className="before:pl-0.5 before:pr-1 before:content-['•']">{currentDate}</span>
                                         </p>
-                                        <p className="pb-1 text-[1.3rem] underline" style={{color: hasEmailCustomizationPrototype ? secondaryHeaderTextColor : secondaryTextColor}}><span>View in browser</span></p>
+                                        <p className="pb-1 text-[1.3rem] underline" style={{color: hasAnyEmailCustomization ? secondaryHeaderTextColor : secondaryTextColor}}><span>View in browser</span></p>
                                     </div>
                                 </div>
                             )}
@@ -222,15 +225,15 @@ const NewsletterPreviewContent: React.FC<{
                                     <div className={clsx(
                                         'w-full max-w-[600px] bg-cover bg-no-repeat',
                                         showPostTitleSection ? '' : 'pt-6',
-                                        hasEmailCustomizationPrototype ? 'h-[unset]' : 'h-[300px]'
+                                        hasAnyEmailCustomization ? 'h-[unset]' : 'h-[300px]'
                                     )}>
                                         <img alt="Feature" className={clsx(
                                             'min-h-full min-w-full shrink-0',
                                             imageCorners === 'square' && 'rounded-none',
                                             imageCorners === 'rounded' && 'rounded-md'
-                                        )} src={hasEmailCustomizationPrototype ? 'https://images.unsplash.com/photo-1526367790999-0150786686a2?q=80&w=2942&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D' : CoverImage} />
+                                        )} src={hasAnyEmailCustomization ? 'https://images.unsplash.com/photo-1526367790999-0150786686a2?q=80&w=2942&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D' : CoverImage} />
                                     </div>
-                                    <div className="mt-1 w-full max-w-[600px] pb-8 text-center text-[1.3rem] text-grey-700" style={{color: hasEmailCustomizationPrototype ? secondaryHeaderTextColor : secondaryTextColor}}>Feature image caption</div>
+                                    <div className="mt-1 w-full max-w-[600px] pb-8 text-center text-[1.3rem] text-grey-700" style={{color: hasAnyEmailCustomization ? secondaryHeaderTextColor : secondaryTextColor}}>Feature image caption</div>
                                 </>
                             )}
                         </div>
@@ -243,7 +246,7 @@ const NewsletterPreviewContent: React.FC<{
                                 bodyFontCategory === 'serif' ? 'font-serif text-[1.8rem]' : 'text-[1.7rem] tracking-tight',
                                 (showFeatureImage || showPostTitleSection) ? '' : 'pt-8'
                             )} style={{borderColor: dividerColor}}>
-                                {hasEmailCustomizationPrototype ? (
+                                {hasAnyEmailCustomization ? (
                                     <>
                                         <p className="mb-6" style={{color: textColor}}>The promise of delivery apps is simple: tap a button, and your favorite meal arrives at your door within minutes. But behind the scenes, these platforms are <a className={clsx(linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} href="#" style={{color: linkColor || accentColor}}>reshaping local economies</a> in ways few people realize.</p>
                                         <p className="mb-6" style={{color: textColor}}>Across the country, small restaurants are grappling with rising fees—sometimes up to 30% per order—cutting into already-thin profit margins. In some cases, beloved neighborhood spots have had to shut their doors, unable to keep up with the financial strain. Meanwhile, delivery workers, the backbone of these services, often face unpredictable wages and challenging working conditions.</p>
@@ -305,73 +308,9 @@ const NewsletterPreviewContent: React.FC<{
                                     </>
                                 ) : (
                                     <>
-                                        {hasEmailCustomizationAlpha ? (
-                                            <>
-                                                <p className="mb-6" style={{color: textColor}}>The promise of delivery apps is simple: tap a button, and your favorite meal arrives at your door within minutes. But behind the scenes, these platforms are <a className={clsx(linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} href="#" style={{color: linkColor || accentColor}}>reshaping local economies</a> in ways few people realize.</p>
-                                                <p className="mb-6" style={{color: textColor}}>Across the country, small restaurants are grappling with rising fees—sometimes up to 30% per order—cutting into already-thin profit margins. In some cases, beloved neighborhood spots have had to shut their doors, unable to keep up with the financial strain. Meanwhile, delivery workers, the backbone of these services, often face unpredictable wages and challenging working conditions.</p>
-                                                <hr className={clsx('my-6 border-[#e0e7eb]', dividerStyle === 'dashed' && 'border-dashed', dividerStyle === 'dotted' && 'border-b-2 border-t-0 border-dotted')} style={{borderColor: dividerColor}} />
-                                                <p className="mb-6" style={{color: textColor}}>If you enjoy this piece and want more deep dives like it, consider upgrading your membership. Paid subscribers get <a className={clsx(linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} href="#" style={{color: linkColor || accentColor}}>exclusive reports</a>, early access to new features, and a behind-the-scenes look at how we put these stories together. Your support helps us continue delivering thoughtful, in-depth journalism straight to you.</p>
-                                                <button
-                                                    className={clsx(
-                                                        'px-[18px] py-2 font-sans text-[15px]',
-                                                        buttonCorners === 'rounded' && 'rounded-[6px]',
-                                                        buttonCorners === 'pill' && 'rounded-full',
-                                                        buttonCorners === 'square' && 'rounded-none',
-                                                        buttonStyle === 'outline'
-                                                            ? 'border bg-transparent'
-                                                            : 'text-white',
-                                                        linkStyle === 'bold' && 'font-bold'
-                                                    )}
-                                                    style={
-                                                        buttonStyle === 'outline'
-                                                            ? {
-                                                                borderColor: buttonColor || accentColor,
-                                                                color: buttonColor || accentColor
-                                                            }
-                                                            : {
-                                                                backgroundColor: buttonColor || accentColor
-                                                            }
-                                                    }
-                                                    type="button"
-                                                >
-                                                    Upgrade now
-                                                </button>
-                                                <hr className={clsx('my-6 border-[#e0e7eb]', dividerStyle === 'dashed' && 'border-dashed', dividerStyle === 'dotted' && 'border-b-2 border-t-0 border-dotted')} style={{borderColor: dividerColor}} />
-                                                <p className="mb-6" style={{color: textColor}}>Yet, the convenience factor keeps us coming back. The ease of one-click ordering means fewer people are dining in, changing the social fabric of our communities. Restaurants designed for shared experiences are evolving into ghost kitchens, optimized for delivery rather than connection.</p>
-                                                <h3
-                                                    className={clsx(
-                                                        'mb-[13px] mt-[39px] text-[2.6rem] leading-supertight',
-                                                        titleFontCategory === 'serif' && 'font-serif',
-                                                        titleFontCategory === 'sans_serif' && 'font-sans',
-                                                        titleFontWeight === 'normal' && 'font-normal',
-                                                        titleFontWeight === 'medium' && 'font-medium',
-                                                        titleFontWeight === 'semibold' && 'font-semibold',
-                                                        titleFontWeight === 'bold' && 'font-bold'
-                                                    )}
-                                                    style={{color: sectionTitleColor}}>When Convenience Comes at a Cost</h3>
-                                                <p className="mb-6" style={{color: textColor}}>So, what’s the future of food culture in an on-demand world? Can these platforms adapt to better support small businesses and workers? Or will we wake up one day to find that the places we once loved have vanished?</p>
-                                                <p className="mb-6" style={{color: textColor}}>Some cities are beginning to push back. In San Francisco, legislation has been proposed to cap delivery app fees and ensure a fairer share of profits for restaurants. Other local governments are exploring ways to offer support to brick-and-mortar establishments, whether through grants, tax relief, or public campaigns that encourage residents to dine in more often.</p>
-                                                <h3
-                                                    className={clsx(
-                                                        'mb-[13px] mt-[39px] text-[2.6rem] leading-supertight',
-                                                        titleFontCategory === 'serif' && 'font-serif',
-                                                        titleFontCategory === 'sans_serif' && 'font-sans',
-                                                        titleFontWeight === 'normal' && 'font-normal',
-                                                        titleFontWeight === 'medium' && 'font-medium',
-                                                        titleFontWeight === 'semibold' && 'font-semibold',
-                                                        titleFontWeight === 'bold' && 'font-bold'
-                                                    )}
-                                                    style={{color: sectionTitleColor}}>Reimagining How We Eat</h3>
-                                                <p className="mb-6" style={{color: textColor}}>Consumers are also starting to pay more attention. There&apos;s a growing movement toward mindful eating—not just in terms of ingredients, but in how we support the systems that bring food to our tables. Choosing to pick up instead of ordering in, tipping delivery drivers fairly, or subscribing to local restaurant coalitions can all make a difference.</p>
-                                                <p className="mb-6" style={{color: textColor}}>Ultimately, the story of delivery apps isn’t just about technology or convenience—it’s about the kind of communities we want to live in. And that future depends, in part, on the choices we make every day.</p>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <p className="mb-6" style={{color: textColor}}>This is what your content will look like when you send one of your posts as an email newsletter to your subscribers.</p>
-                                                <p className="mb-6" style={{color: textColor}}>Over there on the right you&apos;ll see some settings that allow you to customize the look and feel of this template to make it perfectly suited to your brand. Email templates are exceptionally finnicky to make, but we&apos;ve spent a long time optimising this one to make it work beautifully across devices, email clients and content types.</p>
-                                                <p className="mb-6" style={{color: textColor}}>So, you can trust that every email you send with Ghost will look great and work well. Just like the rest of your site.</p>
-                                            </>
-                                        )}
+                                        <p className="mb-6" style={{color: textColor}}>This is what your content will look like when you send one of your posts as an email newsletter to your subscribers.</p>
+                                        <p className="mb-6" style={{color: textColor}}>Over there on the right you&apos;ll see some settings that allow you to customize the look and feel of this template to make it perfectly suited to your brand. Email templates are exceptionally finnicky to make, but we&apos;ve spent a long time optimising this one to make it work beautifully across devices, email clients and content types.</p>
+                                        <p className="mb-6" style={{color: textColor}}>So, you can trust that every email you send with Ghost will look great and work well. Just like the rest of your site.</p>
                                     </>
                                 )}
                             </div>
@@ -417,7 +356,7 @@ const NewsletterPreviewContent: React.FC<{
                                             <h4
                                                 className={clsx(
                                                     'mt-0.5 text-[1.9rem] text-black',
-                                                    hasEmailCustomizationPrototype && titleFontCategory === 'serif' && 'font-serif',
+                                                    hasAnyEmailCustomization && titleFontCategory === 'serif' && 'font-serif',
                                                     titleFontWeight === 'normal' && 'font-normal',
                                                     titleFontWeight === 'medium' && 'font-medium',
                                                     titleFontWeight === 'semibold' && 'font-semibold',
@@ -438,7 +377,7 @@ const NewsletterPreviewContent: React.FC<{
                                             <h4
                                                 className={clsx(
                                                     'mt-0.5 text-[1.9rem] text-black',
-                                                    hasEmailCustomizationPrototype && titleFontCategory === 'serif' && 'font-serif',
+                                                    hasAnyEmailCustomization && titleFontCategory === 'serif' && 'font-serif',
                                                     titleFontWeight === 'normal' && 'font-normal',
                                                     titleFontWeight === 'medium' && 'font-medium',
                                                     titleFontWeight === 'semibold' && 'font-semibold',
@@ -458,7 +397,7 @@ const NewsletterPreviewContent: React.FC<{
                                             <h4
                                                 className={clsx(
                                                     'mt-0.5 text-[1.9rem] text-black',
-                                                    hasEmailCustomizationPrototype && titleFontCategory === 'serif' && 'font-serif',
+                                                    hasAnyEmailCustomization && titleFontCategory === 'serif' && 'font-serif',
                                                     titleFontWeight === 'normal' && 'font-normal',
                                                     titleFontWeight === 'medium' && 'font-medium',
                                                     titleFontWeight === 'semibold' && 'font-semibold',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1691

Although the setting value was taking effect with the beta flag enabled, the UI for changing the setting was never shown.

- renamed `NewsletterDetailModalAlpha` to `NewsletterDetailModalLabs` to better reflect it's use for both alpha and beta flags
- updated `modals.tsx` to use `NewsletterDetailModalLabs` for both alpha and beta flags
- updated `NewsletterDetailModalAlpha` to conditionally show each setting based on the enabled flags
- simplified `NewsletterPreviewContent` to show the new content no matter which newsletter customisation flag is enabled
- updated `NewsletterPreview` to provide the standard defaults values to `NewsletterPreviewContent` when the appropriate flag isn't enabled so we don't see unexpected preview changes when switching between alpha/beta flags
