### PR TITLE
Refactored EmailRenderer `newsletter.link_style` usage

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1012,25 +1012,6 @@ class EmailRenderer {
         }
     }
 
-    #getLinkStyles(newsletter) {
-        const labs = this.getLabs();
-
-        if (!labs.isSet('emailCustomizationAlpha')) {
-            return 'text-decoration: underline;';
-        }
-
-        /** @type {'underline' | 'regular' | 'bold' | string | null} */
-        const settingValue = newsletter.get('link_style');
-
-        if (settingValue === 'regular') {
-            return 'text-decoration: none;';
-        } else if (settingValue === 'bold') {
-            return 'text-decoration: none; font-weight: 700;';
-        } else {
-            return 'text-decoration: underline;';
-        }
-    }
-
     #getImageCorners(newsletter) {
         const value = newsletter.get('image_corners');
         if (value === 'rounded') {
@@ -1066,7 +1047,6 @@ class EmailRenderer {
         const textColor = textColorForBackgroundColor(backgroundColor).hex();
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
         const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
-        const linkStyles = this.#getLinkStyles(newsletter);
         const hasRoundedImageCorners = this.#getImageCorners(newsletter);
 
         let buttonBorderRadius = '6px';
@@ -1177,6 +1157,11 @@ class EmailRenderer {
             excerptFontClass = 'post-excerpt-serif-sans';
         }
 
+        let linkStyle = 'underline';
+        if (labs.isSet('emailCustomizationAlpha')) {
+            linkStyle = newsletter.get('link_style') || 'underline';
+        }
+
         const data = {
             site: {
                 title: this.#settingsCache.get('title'),
@@ -1228,7 +1213,6 @@ class EmailRenderer {
             textColor,
             secondaryTextColor,
             linkColor,
-            linkStyles,
             hasRoundedImageCorners,
             buttonBorderRadius,
 
@@ -1241,6 +1225,7 @@ class EmailRenderer {
             showHeaderName: newsletter.get('show_header_name'),
             showFeatureImage: newsletter.get('show_feature_image') && !!postFeatureImage,
             footerContent: newsletter.get('footer_content'),
+            linkStyle,
             hasOutlineButtons,
 
             classes: {

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -678,7 +678,14 @@ h3.latest-posts-header {
 .post-content a,
 .post-content-sans-serif a {
     color: {{accentColor}};
-    {{linkStyles}}
+    {{#if (eq linkStyle "regular")}}
+    text-decoration: none;
+    {{else if (eq linkStyle "bold")}}
+    text-decoration: none;
+    font-weight: 700;
+    {{else}}
+    text-decoration: underline;
+    {{/if}}
 }
 
 a[data-flickr-embed] img {

--- a/ghost/core/core/server/services/email-service/helpers/register-helpers.js
+++ b/ghost/core/core/server/services/email-service/helpers/register-helpers.js
@@ -44,6 +44,10 @@ module.exports = {
             return false;
         });
 
+        handlebars.registerHelper('eq', function (a, b) {
+            return a === b;
+        });
+
         handlebars.registerHelper('hasFeature', function (flag, options) {
             if (labs.isSet(flag)) {
                 return options.fn(this);
@@ -51,6 +55,7 @@ module.exports = {
                 return options.inverse(this);
             }
         });
+
         handlebars.registerHelper('t', function (key, options) {
             let hash = options?.hash;
             return thist(key, hash || options || {});

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2629,6 +2629,7 @@ describe('Email renderer', function () {
             // null because square has no border radius
             await testImageCorners('square', false);
         });
+
         async function testHasOutlineButtons(buttonStyle, expectedValue) {
             return await testDataProperty({
                 button_style: buttonStyle
@@ -2675,29 +2676,22 @@ describe('Email renderer', function () {
             });
         });
 
-        [
-            ['normal', 'text-decoration: underline;', {labsEnabled: false}],
-            ['underline', 'text-decoration: underline;', {labsEnabled: true}],
-            ['regular', 'text-decoration: none;', {labsEnabled: true}],
-            ['bold', 'text-decoration: none; font-weight: 700;', {labsEnabled: true}],
-            [null, 'text-decoration: underline;', {labsEnabled: true}]
-        ].forEach(([settingValue, linkStyles, options]) => {
-            it(`link styles for ${settingValue || '`null`'} are correct${options.labsEnabled ? ' (emailCustomizationAlpha)' : ''}`, async function () {
-                labsEnabled = options.labsEnabled ?? false;
+        function testLinkStyle(settingValue, expectedValue, options = {labsEnabled: true}) {
+            testDataProperty({
+                link_style: settingValue
+            }, 'linkStyle', expectedValue, options);
+        }
 
-                const html = '';
-                const post = createModel({
-                    posts_meta: createModel({}),
-                    loaded: ['posts_meta'],
-                    published_at: new Date(0)
-                });
-                const newsletter = createModel({
-                    link_style: settingValue
-                });
-                const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+        it('uses correct default when emailCustomizationAlpha is not enabled', async function () {
+            await testLinkStyle('normal', 'underline', {labsEnabled: false});
+        });
 
-                assert.equal(data.linkStyles, linkStyles);
-            });
+        it('sets linkStyle to correct default (emailCustomizationAlpha)', async function () {
+            await testLinkStyle(null, 'underline', {labsEnabled: true});
+        });
+
+        it('passes newsletter link_style through (emailCustomizationAlpha)', async function () {
+            await testLinkStyle('normal', 'normal', {labsEnabled: false});
         });
     });
 


### PR DESCRIPTION
no issue

`getTemplateData()` returning `linkStyles` value as a CSS rule string was an exception to our other data properties which contain either values or booleans to be used  in the template. We want to keep CSS rules inside the styles template as much as possible so there's no need to switch back and forth between contexts when updating the template.

- added `eq` handlebars helper so we can compare against property values
- updated `EmailRenderer` to pass `linkStyle` as a data property containing the setting value to be used in the template
- moved previous conditionals that built up style rules from `#getLinkStyles()` to `styles.hbs` using the new `eq` helper and `{{linkStyle}}` data property
