### PR TITLE
Added e2e testing for integration tokens

### DIFF
--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -69,4 +69,51 @@ describe('Admin API', function () {
                 });
         });
     });
+
+    describe('Integration Tokens', function () {
+        describe('Zapier', function () {
+            before(async function () {
+                await agent.useZapierAdminAPIKey();
+            });
+
+            it('Request to user/me will 404 as there is no user associated with the token', async function () {
+                await agent
+                    .get('users/me')
+                    .expectStatus(404);
+            });
+
+            it('Request to list users will succeed', async function () {
+                await agent
+                    .get('users')
+                    .expectStatus(200);
+            });
+        });
+
+        describe('Backup Integration', function () {
+            before(async function () {
+                await agent.useBackupAdminAPIKey();
+            });
+
+            it('Request to user/me will 403 because the backup integration has restricted permissions', async function () {
+                await agent
+                    .get('users/me')
+                    .expectStatus(403);
+            });
+
+            it('Request to list users will also 403 due to restricted permissions', async function () {
+                await agent
+                    .get('users')
+                    .expectStatus(403);
+            });
+        });
+    });
+
+    describe('User Authentication', function () {
+        it('Double check we can do user auth after a token is used', async function () {
+            await agent.loginAsOwner();
+            await agent
+                .get('users/me')
+                .expectStatus(200);
+        });
+    });
 });

--- a/ghost/core/test/utils/agents/test-agent.js
+++ b/ghost/core/test/utils/agents/test-agent.js
@@ -18,6 +18,19 @@ class TestAgent extends Agent {
             queryParams: options.queryParams
         });
     }
+
+    /**
+     * Reset the authorization header.
+     * Authorization header is set when using token authentication.
+     * We need to reset the authorization header when logging in with username/password.
+     *
+     * @returns {void}
+     */
+    resetAuth() {
+        if (this.defaults.headers.Authorization) {
+            delete this.defaults.headers.Authorization;
+        }
+    }
 }
 
 module.exports = TestAgent;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2148/improve-staff-token-api-access ref https://github.com/TryGhost/Ghost/commit/2320aff94c33dbb71fce17ea798939275fbbecaf ref https://github.com/TryGhost/Ghost-CLI/issues/1952

- With the addition of device verification, User Authentication really becomes _only_ for "on-session" usage. For everything else, staff or integration tokens need to be used
- This change builds on a previous change to make it easier to start doing e2e testing with staff tokens instead of user auth
- We're making it easier to test using one of the built in integration tokens
- In particular, we want to be able to test the special permissions of the backup integration, compared to other authentication methods
