### PR TITLE
Improved table of contents UX in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref PROD-775

- Changed display trigger to hover instead of click for more intuitive interaction
- Eliminated flash of active heading indicator when navigating between sections
- Limited heading text to two lines with ellipsis for cleaner visual presentation