### PR TITLE
Added cacheInvalidation helpers to e2e framework

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
@@ -1338,7 +1338,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": Any<String>,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -1443,7 +1443,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": Any<String>,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -2105,7 +2105,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": Any<String>,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -2323,7 +2323,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": Any<String>,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;
@@ -2541,7 +2541,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": Any<String>,
+  "x-cache-invalidate": StringMatching /\\^\\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=anonymous, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=free, \\\\/p\\\\/\\[a-z0-9-\\]\\+\\\\/\\\\\\?member_status=paid\\$/,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/pages.test.js
+++ b/ghost/core/test/e2e-api/admin/pages.test.js
@@ -1,8 +1,7 @@
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 const models = require('../../../core/server/models');
-const {agentProvider, fixtureManager, mockManager, matchers, assertions} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
 const {anyArray, anyBoolean, anyContentVersion, anyEtag, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyUuid, stringMatching} = matchers;
-const {cacheInvalidateHeaderSetToWildcard} = assertions;
 
 const tierSnapshot = {
     id: anyObjectId,

--- a/ghost/core/test/e2e-api/admin/pages.test.js
+++ b/ghost/core/test/e2e-api/admin/pages.test.js
@@ -1,7 +1,8 @@
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 const models = require('../../../core/server/models');
-const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
-const {anyArray, anyBoolean, anyContentVersion, anyEtag, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyUuid} = matchers;
+const {agentProvider, fixtureManager, mockManager, matchers, assertions} = require('../../utils/e2e-framework');
+const {anyArray, anyBoolean, anyContentVersion, anyEtag, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyUuid, stringMatching} = matchers;
+const {cacheInvalidateHeaderSetToWildcard} = assertions;
 
 const tierSnapshot = {
     id: anyObjectId,
@@ -136,7 +137,7 @@ describe('Pages API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag,
-                    'x-cache-invalidate': anyString
+                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                 });
         });
 
@@ -182,7 +183,7 @@ describe('Pages API', function () {
                         .matchHeaderSnapshot({
                             'content-version': anyContentVersion,
                             etag: anyEtag,
-                            'x-cache-invalidate': anyString
+                            'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                         })
                         .matchBodySnapshot({
                             pages: [Object.assign({}, matchPageShallowIncludes, {

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const {agentProvider, fixtureManager, mockManager, matchers, assertions} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
 const {anyArray, anyContentVersion, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyStringNumber, anyUuid, stringMatching} = matchers;
 const models = require('../../../core/server/models');
 const escapeRegExp = require('lodash/escapeRegExp');

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,5 +1,5 @@
 const should = require('should');
-const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager, matchers, assertions} = require('../../utils/e2e-framework');
 const {anyArray, anyContentVersion, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyStringNumber, anyUuid, stringMatching} = matchers;
 const models = require('../../../core/server/models');
 const escapeRegExp = require('lodash/escapeRegExp');
@@ -465,7 +465,7 @@ describe('Posts API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag,
-                    'x-cache-invalidate': anyString
+                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                 });
 
             // mobiledoc revisions are created
@@ -519,7 +519,7 @@ describe('Posts API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag,
-                    'x-cache-invalidate': anyString
+                    'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                 });
 
             // post revisions are created
@@ -614,7 +614,7 @@ describe('Posts API', function () {
                         .matchHeaderSnapshot({
                             'content-version': anyContentVersion,
                             etag: anyEtag,
-                            'x-cache-invalidate': anyString
+                            'x-cache-invalidate': stringMatching(/^\/p\/[a-z0-9-]+\/, \/p\/[a-z0-9-]+\/\?member_status=anonymous, \/p\/[a-z0-9-]+\/\?member_status=free, \/p\/[a-z0-9-]+\/\?member_status=paid$/)
                         })
                         .matchBodySnapshot({
                             posts: [Object.assign({}, matchPostShallowIncludes, {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert/strict');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils, dbUtils} = require('../../utils/e2e-framework');
-const {nullable, anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyErrorId, anyUuid, anyNumber, anyBoolean} = matchers;
+const {nullable, anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyErrorId, anyUuid, anyNumber, anyBoolean, stringMatching} = matchers;
 const should = require('should');
 const models = require('../../../core/server/models');
 const moment = require('moment-timezone');
@@ -215,7 +215,7 @@ function testPostComment({post_id, html, parent_id, in_reply_to_id}, {status = 2
         .matchHeaderSnapshot({
             etag: anyEtag,
             location: anyLocationFor('comments'),
-            'x-cache-invalidate': matchers.stringMatching(
+            'x-cache-invalidate': stringMatching(
                 parent_id
                     ? new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/replies/')
                     : new RegExp('/api/members/comments/post/[0-9a-f]{24}/')
@@ -995,7 +995,7 @@ describe('Comments API', function () {
                     .expectStatus(204)
                     .matchHeaderSnapshot({
                         etag: anyEtag,
-                        'x-cache-invalidate': matchers.stringMatching(
+                        'x-cache-invalidate': stringMatching(
                             new RegExp('/api/members/comments/post/[0-9a-f]{24}/, /api/members/comments/[0-9a-f]{24}/replies/')
                         )
                     })

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -22,6 +22,8 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
+const assert = require('assert/strict');
+
 const fixtureUtils = require('./fixture-utils');
 const redirectsUtils = require('./redirects');
 const configUtils = require('./configUtils');
@@ -444,6 +446,37 @@ class Nullable extends AsymmetricMatcher {
     }
 }
 
+/*
+ * Assertion Helpers
+ */
+
+/**
+ * Assert that the x-cache-invalidate header not set
+ * @returns {Function}
+ */
+function cacheInvalidateHeaderNotSet() {
+    return ({headers}) => {
+        // Assert header should not exist
+        assert.equal(
+            headers['x-cache-invalidate'],
+            undefined,
+            'x-cache-invalidate header should not be present');
+    };
+}
+
+/**
+ * Assert that the x-cache-invalidate header is set to /*
+ * @returns {Function}
+ */
+function cacheInvalidateHeaderSetToWildcard() {
+    return ({headers}) => {
+        assert.equal(
+            headers['x-cache-invalidate'],
+            '/*',
+            'x-cache-invalidate header should be set to /*');
+    };
+}
+
 module.exports = {
     // request agent
     agentProvider: {
@@ -501,6 +534,11 @@ module.exports = {
         //        An ideal solution would be removal of this matcher altogether.
         anyLocalURL: stringMatching(/http:\/\/127.0.0.1:2369\/[A-Za-z0-9_-]+\//),
         stringMatching
+    },
+
+    assertions: {
+        cacheInvalidateHeaderNotSet,
+        cacheInvalidateHeaderSetToWildcard
     },
 
     // utilities


### PR DESCRIPTION

- The main thing in this change is adding some assertion helpers
- I want to make cache invalidation expected behaviour more explicit
- Especially when it should not be set, which is hard to grok with snapshot tests
- I can see this is something in some of the tests that haven't yet been migrated
  to the new framework
- This is a bit experimental and inconsistent I'm not sure it's the right pattern yet