### PR TITLE
SPIKE - Extracted Koenig button renderer into Ghost

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -7,6 +7,7 @@ const storage = require('../adapters/storage');
 
 let nodes;
 let lexicalHtmlRenderer;
+let customRenderers;
 let urlTransformMap;
 let postsService;
 let serializePosts;
@@ -52,6 +53,18 @@ module.exports = {
         return lexicalHtmlRenderer;
     },
 
+    get customRenderers() {
+        if (!labs.isSet('emailCustomizationAlpha')) {
+            return undefined;
+        }
+
+        if (!customRenderers) {
+            customRenderers = require('../services/koenig/renderers');
+        }
+
+        return customRenderers;
+    },
+
     async render(lexical, userOptions = {}) {
         if (!postsService) {
             const getPostServiceInstance = require('../services/posts/posts-service');
@@ -77,7 +90,8 @@ module.exports = {
                 contentVisibility: labs.isSet('contentVisibility'),
                 emailCustomization: labs.isSet('emailCustomization'),
                 emailCustomizationAlpha: labs.isSet('emailCustomizationAlpha')
-            }
+            },
+            renderers: this.customRenderers
         }, userOptions);
 
         return await this.lexicalHtmlRenderer.render(lexical, options);

--- a/ghost/core/core/server/services/koenig/renderer-partials/email-button.js
+++ b/ghost/core/core/server/services/koenig/renderer-partials/email-button.js
@@ -1,0 +1,39 @@
+const clsx = require('clsx');
+const {html} = require('../renderer-utils/tagged-template-fns');
+
+/**
+ * @param {Object} options
+ * @param {string} [options.alignment]
+ * @param {string} [options.color='accent']
+ * @param {string} [options.text='']
+ * @param {string} [options.textColor]
+ * @param {string} [options.url='']
+ * @returns {string}
+ */
+function renderEmailButton({
+    alignment = '',
+    color = 'accent',
+    text = '',
+    url = ''
+} = {}) {
+    const buttonClasses = clsx(
+        'btn',
+        color === 'accent' && 'btn-accent'
+    );
+
+    return html`
+        <table class="${buttonClasses}" border="0" cellspacing="0" cellpadding="0" align="${alignment}">
+            <tbody>
+                <tr>
+                    <td align="center">
+                        <a href="${url}">${text} CUSTOM</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+}
+
+module.exports = {
+    renderEmailButton
+};

--- a/ghost/core/core/server/services/koenig/renderer-utils/add-create-document-option.js
+++ b/ghost/core/core/server/services/koenig/renderer-utils/add-create-document-option.js
@@ -1,0 +1,27 @@
+// If we're in a browser environment, we can use the global document object,
+// but if we're in a non-browser environment, we need to be passed a `createDocument` function
+function addCreateDocumentOption(options) {
+    if (!options.createDocument && options.dom) {
+        options.createDocument = function () {
+            return options.dom.window.document;
+        };
+    }
+
+    if (!options.createDocument) {
+        /* c8 ignore start */
+        let document = typeof window !== 'undefined' && window.document;
+
+        if (!document) {
+            throw new Error('Must be passed a `createDocument` function as an option when used in a non-browser environment'); // eslint-disable-line
+        }
+
+        options.createDocument = function () {
+            return document;
+        };
+        /* c8 ignore end */
+    }
+}
+
+module.exports = {
+    addCreateDocumentOption
+};

--- a/ghost/core/core/server/services/koenig/renderer-utils/render-empty-container.js
+++ b/ghost/core/core/server/services/koenig/renderer-utils/render-empty-container.js
@@ -1,0 +1,16 @@
+/*
+ * Renders an empty container element
+ * In the returned object, `type: 'inner'` is picked up by the `@tryghost/kg-lexical-html-renderer` package
+ * to render the inner content of the container element (in this case, nothing)
+ *
+ * @see @tryghost/kg-lexical-html-renderer package
+ * @see https://github.com/TryGhost/Koenig/blob/e14c008e176f7a1036fe3f3deb924ed69a69191f/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js#L29
+ */
+function renderEmptyContainer(document) {
+    const emptyContainer = document.createElement('span');
+    return {element: emptyContainer, type: 'inner'};
+}
+
+module.exports = {
+    renderEmptyContainer
+};

--- a/ghost/core/core/server/services/koenig/renderer-utils/tagged-template-fns.js
+++ b/ghost/core/core/server/services/koenig/renderer-utils/tagged-template-fns.js
@@ -1,0 +1,21 @@
+const oneline = function (strings, ...values) {
+    // Handle case where a plain string is passed
+    if (typeof strings === 'string') {
+        return strings.replace(/\n\s+/g, '').trim();
+    }
+
+    // Handle tagged template literal case
+    const result = strings.reduce((acc, str, i) => {
+        return acc + str + (values[i] || '');
+    }, '');
+    // Remove newline+indentation patterns while preserving intentional whitespace
+    return result.replace(/\n\s+/g, '').trim();
+};
+
+// Using `html` as a synonym for `oneline` in order to get syntax highlighting in editors
+const html = oneline;
+
+module.exports = {
+    oneline,
+    html
+};

--- a/ghost/core/core/server/services/koenig/renderer-utils/tagged-template-fns.mjs
+++ b/ghost/core/core/server/services/koenig/renderer-utils/tagged-template-fns.mjs
@@ -1,0 +1,21 @@
+const oneline = function (strings, ...values) {
+    // Handle case where a plain string is passed
+    if (typeof strings === 'string') {
+        return strings.replace(/\n\s+/g, '').trim();
+    }
+
+    // Handle tagged template literal case
+    const result = strings.reduce((acc, str, i) => {
+        return acc + str + (values[i] || '');
+    }, '');
+    // Remove newline+indentation patterns while preserving intentional whitespace
+    return result.replace(/\n\s+/g, '').trim();
+};
+
+// Using `html` as a synonym for `oneline` in order to get syntax highlighting in editors
+const html = oneline;
+
+module.exports = {
+    oneline,
+    html
+};

--- a/ghost/core/core/server/services/koenig/renderers/button-renderer.js
+++ b/ghost/core/core/server/services/koenig/renderers/button-renderer.js
@@ -1,0 +1,111 @@
+const {addCreateDocumentOption} = require('../renderer-utils/add-create-document-option');
+const {renderEmptyContainer} = require('../renderer-utils/render-empty-container');
+const {renderEmailButton} = require('../renderer-partials/email-button');
+const {html} = require('../renderer-utils/tagged-template-fns');
+
+function renderButtonNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (!node.buttonUrl || node.buttonUrl.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    if (options.target === 'email') {
+        return emailTemplate(node, options, document);
+    } else {
+        return frontendTemplate(node, document);
+    }
+}
+
+function frontendTemplate(node, document) {
+    const cardClasses = getCardClasses(node);
+
+    const cardDiv = document.createElement('div');
+    cardDiv.setAttribute('class', cardClasses);
+
+    const button = document.createElement('a');
+    button.setAttribute('href', node.buttonUrl);
+    button.setAttribute('class', 'kg-btn kg-btn-accent');
+    button.textContent = `${node.buttonText} CUSTOM` || 'Button Title';
+
+    cardDiv.appendChild(button);
+    return {element: cardDiv};
+}
+
+function emailTemplate(node, options, document) {
+    const {buttonUrl, buttonText} = node;
+
+    let cardHtml;
+    if (options.feature?.emailCustomization) {
+        cardHtml = html`
+        <table border="0" cellpadding="0" cellspacing="0">
+            <tr>
+                <td>
+                    <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
+                        <tr>
+                            <td align="center">
+                                <a href="${buttonUrl}">${buttonText}</a>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>`;
+
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    } else if (options.feature?.emailCustomizationAlpha) {
+        const buttonHtml = renderEmailButton({
+            alignment: node.alignment,
+            color: 'accent',
+            url: buttonUrl,
+            text: buttonText
+        });
+
+        cardHtml = html`
+        <table border="0" cellpadding="0" cellspacing="0">
+            <tbody>
+                <tr>
+                    <td>
+                        ${buttonHtml}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        `;
+
+        const element = document.createElement('div');
+        element.innerHTML = cardHtml;
+        return {element, type: 'inner'};
+    } else {
+        cardHtml = html`
+        <div class="btn btn-accent">
+            <table border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
+                <tr>
+                    <td align="center">
+                        <a href="${buttonUrl}">${buttonText}</a>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        `;
+
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    }
+}
+
+function getCardClasses(node) {
+    let cardClasses = ['kg-card kg-button-card'];
+
+    if (node.alignment) {
+        cardClasses.push(`kg-align-${node.alignment}`);
+    }
+
+    return cardClasses.join(' ');
+}
+
+module.exports = renderButtonNode;

--- a/ghost/core/core/server/services/koenig/renderers/index.js
+++ b/ghost/core/core/server/services/koenig/renderers/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    button: require('./button-renderer')
+};

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -126,6 +126,7 @@
     "chalk": "4.1.2",
     "charset": "1.0.1",
     "cheerio": "0.22.0",
+    "clsx": "2.1.1",
     "cluster-key-slot": "1.1.2",
     "common-tags": "1.8.2",
     "compression": "1.8.0",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1784

- added `ghost/core/server/services/koenig` directory
- copied button-related renderer files over from Koenig and converted from ES6 modules to CJS
- updated call to our lexical renderer to pass our custom renderers object as an option
- NOTE: currently adds "CUSTOM" to text of all buttons to provide a visual indication of the custom renderer being used
