### PR TITLE
Fixed browser tests not running against local apps

### DIFF
--- a/ghost/core/test/e2e-browser/fixtures/ghost-test.js
+++ b/ghost/core/test/e2e-browser/fixtures/ghost-test.js
@@ -111,6 +111,12 @@ module.exports = base.test.extend({
         configUtils.set('database:connection:filename', process.env.database__connection__filename);
         configUtils.set('server:port', port);
         configUtils.set('url', `http://127.0.0.1:${port}`);
+        configUtils.set('portal:url', 'http://127.0.0.1:4175/portal.min.js');
+        configUtils.set('comments:url', 'http://127.0.0.1:7173/comments-ui.min.js');
+        configUtils.set('signupForm:url', 'http://127.0.0.1:6174/signup-form.min.js');
+        configUtils.set('announcementBar:url', 'http://127.0.0.1:4177/announcement-bar.min.js');
+        configUtils.set('sodoSearch:url', 'http://127.0.0.1:4178/sodo-search.min.js');
+        configUtils.set('sodoSearch:styles', 'http://127.0.0.1:4178/main.css');
 
         const stripeAccountId = await getStripeAccountId();
         const stripeIntegrationToken = await generateStripeIntegrationToken(stripeAccountId);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/625c89e37f2c1b6827cf5d7a2759077e5d83fff1
ref https://ghost.slack.com/archives/C02G9E68C/p1748267437735519

# Problem
Our browser test suite is currently running with portal, comments, etc all using the version from the jsDelivr CDN, rather than against the locally built version of these apps. This makes it impossible to test Ghost against any new changes in these apps without first publishing the apps to NPM, but that is clearly backwards — we should be able to run the tests _before_ publishing the changes.

In the referenced commit above, we changed the browser tests command so that we run portal and all the other apps locally before running the tests, but I'm not sure if this ever actually worked. This command sets the configured url for each app in the `dev.js` script, but only for the instance of Ghost that is run by the `dev.js` script itself. Since the browser test suite manages the lifecycle of the Ghost app using the e2e-framework, the configuration parameters set in `dev.js` aren't passed to the instances of Ghost that the browser tests are running against.

# Solution
This commit updates the `ghost-test` fixture to pass the appropriate local URLs for all the apps that are started in `dev.js` to the instances of Ghost that the browser tests start. This way the browser tests will run against the locally built versions of portal, comments, etc.