### PR TITLE
Removed build step from shade test:unit command

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -89,5 +89,24 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-  }
+  },
+  "nx": {
+        "targets": {
+            "build": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
+            "dev": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
+            "test:unit": {
+                "dependsOn": [
+                    "^build"
+                ]
+            }
+        }
+    }
 }

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -107,6 +107,11 @@
     },
     "nx": {
         "targets": {
+            "build": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "dev": {
                 "dependsOn": [
                     "^build"
@@ -114,9 +119,7 @@
             },
             "test:unit": {
                 "dependsOn": [
-                    "test:unit",
-                    "^build",
-                    "@tryghost/admin-x-design-system:test:unit"
+                    "^build"
                 ]
             }
         }

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.declaration.json && vite build",
         "prepare": "yarn build",
-        "test": "yarn test:types && yarn nx build && vitest run --coverage",
+        "test": "yarn test:types && vitest run --coverage",
         "test:unit": "yarn test:types && yarn nx build && vitest run",
         "test:types": "tsc --noEmit",
         "lint:code": "eslint --ext .js,.ts,.cjs,.tsx src/ --cache",

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -12,7 +12,7 @@
         "build": "tsc -p tsconfig.declaration.json && vite build",
         "prepare": "yarn build",
         "test": "yarn test:types && vitest run --coverage",
-        "test:unit": "yarn test:types && yarn nx build && vitest run",
+        "test:unit": "yarn test:types && vitest run",
         "test:types": "tsc --noEmit",
         "lint:code": "eslint --ext .js,.ts,.cjs,.tsx src/ --cache",
         "lint": "yarn lint:code && yarn lint:test",

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -107,5 +107,24 @@
     "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+    },
+    "nx": {
+        "targets": {
+            "build": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
+            "dev": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
+            "test:unit": {
+                "dependsOn": [
+                    "^build"
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/32e9afb06971c5892e04e5b3f121b24a951ade19

We've seen some flaky test runs in CI lately following a similar pattern:

```
🔁 > nx run @tryghost/shade:build  [local cache]
🔁 > nx run @tryghost/admin-x-design-system:build  [local cache]
🔁 > nx run @tryghost/admin-x-framework:build  [local cache]
✅ > nx run ghost:"build:assets"
✅ > nx run @tryghost/stats:"test:unit"
❌ > nx run @tryghost/posts:"test:unit"
✅ > nx run @tryghost/admin-x-design-system:"test:unit"
✅ > nx run @tryghost/shade:"test:unit"
🔁 > nx run @tryghost/shade:build  [local cache]
```
In this run, the @tryghost/posts tests are failing with the following error:

```
   FAIL  test/unit/utils/kpi-helpers.test.tsx [ test/unit/utils/kpi-helpers.test.tsx ]
  Error: Failed to load url /home/runner/work/Ghost/Ghost/apps/shade/es/components/ui/alert-dialog.js (resolved id: /home/runner/work/Ghost/Ghost/apps/shade/es/components/ui/alert-dialog.js) in /home/runner/work/Ghost/Ghost/apps/shade/es/index.js. Does the file exist?
   ❯ loadAndTransform ../../node_modules/vite/dist/node/chunks/dep-827b23df.js:55077:21
```

The issue seems to be that @tryghost/shade is running it's `build` target before running its own unit tests, which is baked into the `test:unit` command for that package. Even though the build is cached, this momentarily clears the built files from @tryghost/shade. If the @tryghost/posts, or any other package that depends on @tryghost/shade, is running unit tests while this happens, they may see these missing dependency errors. 

This commit removes the explicit `build` step from the `@tryghost/shade:test:unit` script, which should prevent this from occurring in CI. It also adds/refines the "nx" configuration for @tryghost/shade, @tryghost/admin-x-settings, and @tryghost/admin-x-design-system to describe the `test:unit` dependency on the `build` step in a way that NX can understand and optimize for.