### PR TITLE
🐛 Fixed preview rendering when member status is not specified

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -59,6 +59,11 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
             }
 
+            // Preserve the old behavior of assuming the user has access to the post if member_status is not provided
+            if (!req.query?.member_status) {
+                post.access = !!post.html;
+            }
+
             return renderer.renderEntry(req, res)(post);
         })
         .catch(renderer.handleError(next));

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -20,15 +20,15 @@ function assertCorrectFrontendHeaders(res) {
 }
 
 function assertPaywallRendered(res) {
-    res.text.should.match(/Before paywall/);
-    res.text.should.not.match(/After paywall/);
-    res.text.should.match(/This post is for/);
+    res.text.should.match(/Before paywall/, 'Content before paywall should be rendered');
+    res.text.should.not.match(/After paywall/, 'Content after paywall should not be rendered');
+    res.text.should.match(/This post is for/, 'Paywall should be rendered');
 }
 
 function assertNoPaywallRendered(res) {
-    res.text.should.match(/Before paywall/);
-    res.text.should.match(/After paywall/);
-    res.text.should.not.match(/This post is for/);
+    res.text.should.match(/Before paywall/, 'Content before paywall should be rendered');
+    res.text.should.match(/After paywall/, 'Content after paywall should be rendered');
+    res.text.should.not.match(/This post is for/, 'Paywall should not be rendered');
 }
 
 describe('Frontend Routing: Preview Routes', function () {
@@ -76,6 +76,14 @@ describe('Frontend Routing: Preview Routes', function () {
                 // $('body.post-template').length.should.equal(1);
                 // $('article.post').length.should.equal(1);
             });
+    });
+
+    it('should assume the user has access to the post if member_status is not provided', async function () {
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c905/')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertNoPaywallRendered);
     });
 
     it('should render draft as an anonymous user with ?member_status=anonymous', async function () {

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -19,6 +19,18 @@ function assertCorrectFrontendHeaders(res) {
     should.exist(res.headers.date);
 }
 
+function assertPaywallRendered(res) {
+    res.text.should.match(/Before paywall/);
+    res.text.should.not.match(/After paywall/);
+    res.text.should.match(/This post is for/);
+}
+
+function assertNoPaywallRendered(res) {
+    res.text.should.match(/Before paywall/);
+    res.text.should.match(/After paywall/);
+    res.text.should.not.match(/This post is for/);
+}
+
 describe('Frontend Routing: Preview Routes', function () {
     async function addPosts() {
         await testUtils.teardownDb();
@@ -66,16 +78,20 @@ describe('Frontend Routing: Preview Routes', function () {
             });
     });
 
+    it('should render draft as an anonymous user with ?member_status=anonymous', async function () {
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c905/?member_status=anonymous')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertPaywallRendered);
+    });
+
     it('should render draft as free member with ?member_status=free', async function () {
         await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c905/?member_status=free')
             .expect('Content-Type', /html/)
             .expect(200)
             .expect(assertCorrectFrontendHeaders)
-            .expect((res) => {
-                res.text.should.match(/Before paywall/);
-                res.text.should.not.match(/After paywall/);
-                res.text.should.match(/This post is for/);
-            });
+            .expect(assertPaywallRendered);
     });
 
     it('should render draft as paid member with ?member_status=paid', async function () {
@@ -83,11 +99,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect('Content-Type', /html/)
             .expect(200)
             .expect(assertCorrectFrontendHeaders)
-            .expect((res) => {
-                res.text.should.match(/Before paywall/);
-                res.text.should.match(/After paywall/);
-                res.text.should.not.match(/This post is for/);
-            });
+            .expect(assertNoPaywallRendered);
     });
 
     it('should redirect draft posts accessed via uuid and edit to admin post edit screen', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-974/post-previews-without-the-member-status-query-parameter-are-not
ref https://github.com/TryGhost/Ghost/issues/23506

Historically the post preview route has explicitly assumed that the viewer had full access to the post, including any paywalled content, by always setting `post.access = true` before rendering. Recently we added the ability to preview the post as either a public visitor, free member or paid member. The initial implementation did not properly render paywalls, so last week we merged this fix, which removed the explicit `post.access = true` statement: https://github.com/TryGhost/Ghost/commit/d6b380d26a4cf579fb2ebf9af422e450bd3e22dc.

The fix was effective when `member_status` was specified, however it inadvertently broke the expectations on the preview route when the `member_status` query parameter is not set. Currently it will render the full post content as if the viewer has access to the post, but `post.access` will be set to "no", which doesn't make sense. This only impacts sites with custom themes that explicitly change the styling or functionality depending on the value of `post.access`. 

This commit carves out an exception when `member_status` is not set, in which case Ghost will default to `post.access = "yes"`, to preserve the expected/legacy behavior. 