### PR TITLE
🐛 Fixed previews for tier gated posts

### DIFF
--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -1,7 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
-const ALLOWED_INCLUDES = ['authors', 'tags'];
+const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 const ALLOWED_MEMBER_STATUSES = ['anonymous', 'free', 'paid'];
 
 const messages = {
@@ -10,7 +10,7 @@ const messages = {
 
 // Simulate serving content as different member states by setting the minimal
 // member context needed for content gating to function
-const _addMemberContextToFrame = (frame) => {
+const _addMemberContextToFrame = async (frame) => {
     if (!frame?.options?.member_status) {
         return;
     }
@@ -29,8 +29,22 @@ const _addMemberContextToFrame = (frame) => {
     }
 
     if (frame.options?.member_status === 'paid') {
+        // For member_status=paid, add all paid tiers to the member context
+        let memberProducts = [];
+        const paidProducts = await models.Product.findAll({
+            status: 'active',
+            type: 'paid'
+        });
+        if (paidProducts.length > 0) {
+            memberProducts = paidProducts.map((product) => {
+                return {
+                    slug: product.get('slug')
+                };
+            });
+        }
         frame.original.context.member = {
-            status: 'paid'
+            status: 'paid',
+            products: memberProducts
         };
     }
 };
@@ -67,7 +81,7 @@ const controller = {
             }
         },
         async query(frame) {
-            _addMemberContextToFrame(frame);
+            await _addMemberContextToFrame(frame);
 
             const model = await models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options);
             if (!model) {

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -35,6 +35,7 @@ describe('Frontend Routing: Preview Routes', function () {
     async function addPosts() {
         await testUtils.teardownDb();
         await testUtils.initData();
+        await testUtils.fixtures.insertExtraTiers();
         await testUtils.fixtures.insertPostsAndTags();
         await testUtils.fixtures.insertGatedPosts();
     }
@@ -92,6 +93,14 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(200)
             .expect(assertCorrectFrontendHeaders)
             .expect(assertPaywallRendered);
+    });
+
+    it('should render draft as a member with access to the post if visibility is tiers and member_status is paid', async function () {
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertNoPaywallRendered);
     });
 
     it('should render draft as free member with ?member_status=free', async function () {

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -95,7 +95,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(assertPaywallRendered);
     });
 
-    it('should render draft as a member with access to the post if visibility is tiers and member_status is paid', async function () {
+    it('should render draft as a member with access to the post if visibility is tiers and ?member_status=paid', async function () {
         await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid')
             .expect('Content-Type', /html/)
             .expect(200)

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -10,6 +10,9 @@ describe('Previews controller', function () {
 
     beforeEach(function () {
         sinon.stub(models.Post, 'findOne').resolves({});
+        sinon.stub(models.Product, 'findAll').resolves([{
+            get: sinon.stub().returns('silver')
+        }]);
     });
 
     afterEach(function () {
@@ -17,37 +20,39 @@ describe('Previews controller', function () {
     });
 
     describe('#read', function () {
-        it('sets frame.apiType to content when a member_status is provided', function () {
+        it('sets frame.apiType to content when a member_status is provided', async function () {
             const frame = {options: {member_status: 'free'}};
-            previewsController.read.query(frame);
+            await previewsController.read.query(frame);
 
             assert.equal(frame.apiType, 'content');
         });
 
-        it('does not set frame.apiType when no member_status is provided', function () {
+        it('does not set frame.apiType when no member_status is provided', async function () {
             const frame = {options: {}};
-            previewsController.read.query(frame);
+            await previewsController.read.query(frame);
 
             assert.equal(frame.apiType, undefined);
         });
 
-        it('sets frame.original.context.member.status to free when member_status is free', function () {
+        it('sets frame.original.context.member.status to free when member_status is free', async function () {
             const frame = {options: {member_status: 'free'}};
-            previewsController.read.query(frame);
+            await previewsController.read.query(frame);
 
             assert.equal(frame.original.context.member.status, 'free');
         });
 
-        it('sets frame.original.context.member.status to paid when member_status is paid', function () {
+        it('sets frame.original.context.member.status to paid when member_status is paid', async function () {
             const frame = {options: {member_status: 'paid'}};
-            previewsController.read.query(frame);
+            await previewsController.read.query(frame);
 
             assert.equal(frame.original.context.member.status, 'paid');
+            assert.equal(frame.original.context.member.products.length, 1);
+            assert.equal(frame.original.context.member.products[0].slug, 'silver');
         });
 
-        it('sets frame.apiType but does not set member context when member_status is anonymous', function () {
+        it('sets frame.apiType but does not set member context when member_status is anonymous', async function () {
             const frame = {options: {member_status: 'anonymous'}};
-            previewsController.read.query(frame);
+            await previewsController.read.query(frame);
 
             assert.equal(frame.apiType, 'content');
             assert.equal(frame.original.context.member, undefined);

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -160,6 +160,19 @@ const fixtures = {
             mobiledoc: DataGenerator.markdownToMobiledoc('Before paywall\n\n<!--members-only-->\n\nAfter paywall'),
             visibility: 'paid',
             authors: [owner.toJSON()]
+        }, {
+            id: '618ba1ffbe2896088840a6ff',
+            title: 'This has a tiered paywall',
+            slug: 'paywall-tiered',
+            lexical: '',
+            status: 'draft',
+            uuid: 'd52c42ae-2755-455c-80ec-70b2ec55c906',
+            visibility: 'tiers',
+            tiers: [{
+                slug: 'silver'
+            }],
+            mobiledoc: DataGenerator.markdownToMobiledoc('Before paywall\n\n<!--members-only-->\n\nAfter paywall'),
+            authors: [owner.toJSON()]
         }];
 
         for (const post of gatedPosts) {

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -149,6 +149,7 @@ const fixtures = {
 
     insertGatedPosts: async function insertGatedPosts() {
         const owner = await models.User.getOwnerUser(context.internal);
+        const tier = await models.Product.findOne({slug: 'silver'}, context.internal);
 
         const gatedPosts = [{
             id: '618ba1ffbe2896088840a6ef',
@@ -168,9 +169,7 @@ const fixtures = {
             status: 'draft',
             uuid: 'd52c42ae-2755-455c-80ec-70b2ec55c906',
             visibility: 'tiers',
-            tiers: [{
-                slug: 'silver'
-            }],
+            tiers: [tier.toJSON()],
             mobiledoc: DataGenerator.markdownToMobiledoc('Before paywall\n\n<!--members-only-->\n\nAfter paywall'),
             authors: [owner.toJSON()]
         }];
@@ -548,7 +547,7 @@ const fixtures = {
 
     insertExtraTiers: async function insertExtraTiers() {
         const extraTier = DataGenerator.forKnex.createProduct({});
-        const extraTier2 = DataGenerator.forKnex.createProduct({slug: 'silver', name: 'Silver'});
+        const extraTier2 = DataGenerator.forKnex.createProduct({id: '6834edbcd2e19501e29e9537', slug: 'silver', name: 'Silver'});
         await models.Product.add(extraTier, context.internal);
         await models.Product.add(extraTier2, context.internal);
     },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-975/preview-for-a-post-with-visibilitytiers-only-shows-paywalled-content

If post visibility for a draft post is set to "Specific Tiers", it is currently not possible to preview the entire post, as a member who does have access to the post. This commit adds all active paid tiers to the `context.member` object on the preview route if `member_status=paid`, which allows a user to preview the entire post, without the paywall, when selecting "Paid member" from the dropdown in admin.