### PR TITLE
Updated `compose.yml` to allow development against local dependencies in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,5 @@ temp*.sql
 .yarnhash
 
 # yalc — for linking local packages in a docker compatible way
-yalc
 yalc.lock
 .yalc

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,8 @@ temp*.sql
 .yarncache
 .yarncachecopy
 .yarnhash
+
+# yalc — for linking local packages in a docker compatible way
+yalc
+yalc.lock
+.yalc

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ x-service-template: &service-template
     - .:/home/ghost
     - ${SSH_AUTH_SOCK}:/ssh-agent
     - ${HOME}/.gitconfig:/root/.gitconfig:ro
+    - ${HOME}/.yalc:/root/.yalc
     - node_modules_yarn_lock_hash:/home/ghost/.yarnhash:delegated
     - node_modules_ghost_root:/home/ghost/node_modules:delegated
     - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated


### PR DESCRIPTION
no refs

When developing locally, we can use `yarn link` to test out changes in one of Ghost's dependencies in our local instance of Ghost, without first having to publish the dependency. For example, we can make some changes in `@tryghost/logging` locally, and test those changes out in Ghost locally without having to first publish `@tryghost/logging` to NPM. Unfortunately this `yarn link` workflow relies on symlinks in your local filesystem, which don't play nicely with Docker.

However, it is possible to use a similar workflow using a package called `yalc` ([link](https://www.npmjs.com/package/yalc)). Yalc allows you to "publish" a package to a local directory, and then install it in another local project. By default when you run `yalc publish` in a package, it "publishes" it to `${HOME}/.yalc`. You can then install it into another project using `yalc link {package name}`, which _copies_ the published package into a `.yalc` directory in the consuming package, and somehow, someway, yarn manages to resolve the dependency to this local version of it. 

This commit enables this workflow in the `compose.yml` file by:
1. Adding the `.yalc` directory and `yalc.lock` file that is generated to `.gitignore`, so we don't accidentally commit them.
2. Adding a bind mount volume to the `compose.yml`, which mounts your local `{$HOME}/.yalc` directory into the Docker container.

For a more in-depth guide detailing how to do this with the Ghost container, see https://www.notion.so/ghost/Getting-started-with-Docker-e804ee5a68d14cb78ba82b6237597f6c?pvs=4#20051439c030808989e7ea347eaa0f77