### PR TITLE
Updated KPI cards on site-wide stats overview

### DIFF
--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -176,7 +176,7 @@ const KpiCardHeaderLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({chi
 
 interface KpiCardValueProps {
     value: string | number;
-    diffDirection?: 'up' | 'down' | 'same';
+    diffDirection?: 'up' | 'down' | 'same' | 'empty';
     diffValue?: string | number;
 }
 
@@ -192,7 +192,7 @@ const KpiCardHeaderValue: React.FC<KpiCardValueProps> = ({value, diffDirection, 
             <div className='text-[2.3rem] font-semibold leading-none tracking-tight xl:text-[2.6rem] xl:tracking-[-0.04em]'>
                 {value}
             </div>
-            {diffValue &&
+            {diffDirection &&
             <>
                 <div className={diffContainerClassName}>
                     {diffDirection === 'up' &&

--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -166,14 +166,6 @@ const KpiCardHeader: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children
     );
 };
 
-const KpiCardHeaderContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
-    return (
-        <div className={cn('flex flex-col gap-1', className)} {...props}>
-            {children}
-        </div>
-    );
-};
-
 const KpiCardHeaderLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
         <div className={cn('[&_svg]:size-4 flex items-center gap-1.5 text-base text-muted-foreground h-[22px] font-medium', className)} {...props}>
@@ -225,7 +217,6 @@ export {
     CardDescription,
     CardContent,
     KpiCardHeader,
-    KpiCardHeaderContent,
     KpiCardHeaderLabel,
     KpiCardHeaderValue,
     cardVariants

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -1,10 +1,10 @@
-import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
+import AreaChart from './components/AreaChart';
 import DateRangeSelect from './components/DateRangeSelect';
 import React from 'react';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {AlignedAxisTick, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, H3, KpiCardHeader, KpiCardHeaderContent, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Recharts, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatDisplayDateWithRange, formatNumber, formatQueryDate, getRangeDates, getYRange, sanitizeChartData} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, H3, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
 import {getAudienceQueryParam} from './components/AudienceSelect';
 import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -43,18 +43,16 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
                 <CardTitle>{title}</CardTitle>
                 <CardDescription>{description}</CardDescription>
             </CardHeader>
-            <KpiCardHeader className='grow border-none pb-2'>
+            <KpiCardHeader className='grow gap-2 border-none pb-2'>
                 <KpiCardHeaderLabel>
                     {IconComponent && <IconComponent size={16} strokeWidth={1.5} />}
                     {title}
                 </KpiCardHeaderLabel>
-                <KpiCardHeaderContent>
-                    <KpiCardHeaderValue
-                        diffDirection={diffDirection}
-                        diffValue={diffValue}
-                        value={formattedValue}
-                    />
-                </KpiCardHeaderContent>
+                <KpiCardHeaderValue
+                    diffDirection={diffDirection}
+                    diffValue={diffValue}
+                    value={formattedValue}
+                />
             </KpiCardHeader>
             <CardContent>
                 {children}
@@ -94,98 +92,6 @@ interface HelpCardProps {
     url: string;
     children?: React.ReactNode;
 }
-
-interface OverviewChartProps {
-    data: Array<{
-        date: string;
-        value: number;
-        formattedValue: string;
-        label: string;
-    }>;
-    range: number;
-    color?: string;
-    id: string;
-}
-
-const OverviewChart: React.FC<OverviewChartProps> = ({
-    data,
-    range,
-    color = 'hsl(var(--chart-blue))',
-    id
-}) => {
-    const yRange = [getYRange(data).min, getYRange(data).max];
-    const chartConfig = {
-        value: {
-            label: data[0]?.label || 'Value'
-        }
-    } satisfies ChartConfig;
-
-    return (
-        <ChartContainer className='-mb-3 h-[10vw] max-h-[240px] w-full' config={chartConfig}>
-            <Recharts.AreaChart
-                data={data}
-                margin={{
-                    left: 4,
-                    right: 4,
-                    top: 0
-                }}
-            >
-                <Recharts.CartesianGrid horizontal={false} vertical={false} />
-                <Recharts.XAxis
-                    axisLine={{stroke: 'hsl(var(--border))', strokeWidth: 1}}
-                    dataKey="date"
-                    interval={0}
-                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(value, range)} />}
-                    tickFormatter={value => formatDisplayDateWithRange(value, range)}
-                    tickLine={false}
-                    tickMargin={10}
-                    ticks={data && data.length > 0 ? [data[0].date, data[data.length - 1].date] : []}
-                />
-                <Recharts.YAxis
-                    axisLine={false}
-                    domain={yRange}
-                    scale="linear"
-                    tickFormatter={(value: number) => {
-                        return formatNumber(value);
-                    }}
-                    tickLine={false}
-                    ticks={[]}
-                    width={0}
-                />
-                <ChartTooltip
-                    content={<CustomTooltipContent color={color} range={range} />}
-                    cursor={true}
-                    isAnimationActive={false}
-                    position={{y: 10}}
-                />
-                <defs>
-                    <linearGradient id={`fillChart-${id}`} x1="0" x2="0" y1="0" y2="1">
-                        <stop
-                            offset="5%"
-                            stopColor={color}
-                            stopOpacity={0.8}
-                        />
-                        <stop
-                            offset="95%"
-                            stopColor={color}
-                            stopOpacity={0.1}
-                        />
-                    </linearGradient>
-                </defs>
-                <Recharts.Area
-                    dataKey="value"
-                    fill={`url(#fillChart-${id})`}
-                    fillOpacity={0.2}
-                    isAnimationActive={false}
-                    stackId="a"
-                    stroke={color}
-                    strokeWidth={2}
-                    type="linear"
-                />
-            </Recharts.AreaChart>
-        </ChartContainer>
-    );
-};
 
 const HelpCard: React.FC<HelpCardProps> = ({
     className,
@@ -262,6 +168,8 @@ const Overview: React.FC = () => {
 
     const kpiValues = getKpiValues();
 
+    const areaChartClassName = '-mb-3 h-[10vw] max-h-[240px]';
+
     return (
         <StatsLayout>
             <StatsHeader>
@@ -278,7 +186,8 @@ const Overview: React.FC = () => {
                         linkto='/web/'
                         title='Unique visitors'
                     >
-                        <OverviewChart
+                        <AreaChart
+                            className={areaChartClassName}
                             color='hsl(var(--chart-blue))'
                             data={visitorsChartData}
                             id="visitors"
@@ -295,7 +204,8 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='Members'
                     >
-                        <OverviewChart
+                        <AreaChart
+                            className={areaChartClassName}
                             color='hsl(var(--chart-green))'
                             data={visitorsChartData}
                             id="members"
@@ -312,7 +222,8 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='MRR'
                     >
-                        <OverviewChart
+                        <AreaChart
+                            className={areaChartClassName}
                             color='hsl(var(--chart-orange))'
                             data={visitorsChartData}
                             id="mrr"

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -186,7 +186,7 @@ const Overview: React.FC = () => {
             date: item.date,
             value: item.free + item.paid + item.comped,
             formattedValue: formatNumber(item.free + item.paid + item.comped),
-            label: 'Total members'
+            label: 'Members'
         }));
 
         return processedData;
@@ -255,6 +255,7 @@ const Overview: React.FC = () => {
                             data={visitorsChartData}
                             id="visitors"
                             range={range}
+                            syncId="overview-charts"
                             yAxisRange={visitorsYRange}
                         />
                     </OverviewKPICard>
@@ -274,6 +275,7 @@ const Overview: React.FC = () => {
                             data={membersChartData}
                             id="members"
                             range={range}
+                            syncId="overview-charts"
                         />
                     </OverviewKPICard>
 
@@ -292,6 +294,7 @@ const Overview: React.FC = () => {
                             data={mrrChartData}
                             id="mrr"
                             range={range}
+                            syncId="overview-charts"
                         />
                     </OverviewKPICard>
                 </div>

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -17,7 +17,7 @@ interface OverviewKPICardProps {
     title: string;
     iconName: keyof typeof LucideIcon;
     description: string;
-    diffDirection?: 'up' | 'down' | 'same';
+    diffDirection?: 'up' | 'down' | 'same' | 'empty';
     diffValue?: string;
     color?: string;
     formattedValue: string;
@@ -166,6 +166,7 @@ const Overview: React.FC = () => {
             };
         });
     }, [visitorsData, range]);
+    const visitorsYRange: [number, number] = [0, Math.max(...(visitorsChartData?.map((item: AreaChartDataItem) => item.value) || [0]))];
 
     /* Get members
     /* ---------------------------------------------------------------------- */
@@ -231,7 +232,7 @@ const Overview: React.FC = () => {
     }, [visitorsData]);
 
     const isLoading = isConfigLoading || isVisitorsLoading || isGrowthStatsLoading;
-    const areaChartClassName = '-mb-3 h-[10vw] max-h-[240px]';
+    const areaChartClassName = '-mb-3 h-[10vw] max-h-[200px]';
 
     return (
         <StatsLayout>
@@ -242,8 +243,7 @@ const Overview: React.FC = () => {
                 <div className='grid grid-cols-1 gap-8 lg:grid-cols-3'>
                     <OverviewKPICard
                         description='Number of individual people who visited your website'
-                        diffDirection='down'
-                        diffValue='-2.4%'
+                        diffDirection='empty'
                         formattedValue={kpiValues.visits}
                         iconName='MousePointer'
                         linkto='/web/'
@@ -255,13 +255,14 @@ const Overview: React.FC = () => {
                             data={visitorsChartData}
                             id="visitors"
                             range={range}
+                            yAxisRange={visitorsYRange}
                         />
                     </OverviewKPICard>
 
                     <OverviewKPICard
                         description='How number of members of your publication changed over time'
-                        diffDirection='up'
-                        diffValue='1.1%'
+                        diffDirection={growthTotals.directions.total}
+                        diffValue={growthTotals.percentChanges.total}
                         formattedValue={formatNumber(growthTotals.totalMembers)}
                         iconName='User'
                         linkto='/growth/'
@@ -278,8 +279,8 @@ const Overview: React.FC = () => {
 
                     <OverviewKPICard
                         description='Monthly recurring revenue changes over time'
-                        diffDirection='up'
-                        diffValue='1.2%'
+                        diffDirection={growthTotals.directions.mrr}
+                        diffValue={growthTotals.percentChanges.mrr}
                         formattedValue={`$${formatNumber(centsToDollars(growthTotals.mrr))}`}
                         iconName='DollarSign'
                         linkto='/growth/'

--- a/apps/stats/src/views/Stats/components/AreaChart.tsx
+++ b/apps/stats/src/views/Stats/components/AreaChart.tsx
@@ -12,6 +12,7 @@ export type AreaChartDataItem = {
 interface AreaChartProps {
     data: AreaChartDataItem[];
     range: number;
+    yAxisRange?: [number, number],
     color?: string;
     id: string;
     className?: string;
@@ -20,11 +21,12 @@ interface AreaChartProps {
 const AreaChart: React.FC<AreaChartProps> = ({
     data,
     range,
+    yAxisRange,
     color = 'hsl(var(--chart-blue))',
     id,
     className
 }) => {
-    const yRange = [getYRange(data).min, getYRange(data).max];
+    const yRange = yAxisRange || [getYRange(data).min, getYRange(data).max];
     const chartConfig = {
         value: {
             label: data[0]?.label || 'Value'
@@ -40,7 +42,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
                 margin={{
                     left: 4,
                     right: 4,
-                    top: 0
+                    top: 4
                 }}
             >
                 <Recharts.CartesianGrid horizontal={false} vertical={false} />

--- a/apps/stats/src/views/Stats/components/AreaChart.tsx
+++ b/apps/stats/src/views/Stats/components/AreaChart.tsx
@@ -2,13 +2,15 @@ import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
 import React from 'react';
 import {AlignedAxisTick, ChartConfig, ChartContainer, ChartTooltip, Recharts, cn, formatDisplayDateWithRange, formatNumber, getYRange} from '@tryghost/shade';
 
+export type AreaChartDataItem = {
+    date: string;
+    value: number;
+    formattedValue: string;
+    label: string;
+}
+
 interface AreaChartProps {
-    data: Array<{
-        date: string;
-        value: number;
-        formattedValue: string;
-        label: string;
-    }>;
+    data: AreaChartDataItem[];
     range: number;
     color?: string;
     id: string;

--- a/apps/stats/src/views/Stats/components/AreaChart.tsx
+++ b/apps/stats/src/views/Stats/components/AreaChart.tsx
@@ -1,0 +1,101 @@
+import CustomTooltipContent from '@src/components/chart/CustomTooltipContent';
+import React from 'react';
+import {AlignedAxisTick, ChartConfig, ChartContainer, ChartTooltip, Recharts, cn, formatDisplayDateWithRange, formatNumber, getYRange} from '@tryghost/shade';
+
+interface AreaChartProps {
+    data: Array<{
+        date: string;
+        value: number;
+        formattedValue: string;
+        label: string;
+    }>;
+    range: number;
+    color?: string;
+    id: string;
+    className?: string;
+}
+
+const AreaChart: React.FC<AreaChartProps> = ({
+    data,
+    range,
+    color = 'hsl(var(--chart-blue))',
+    id,
+    className
+}) => {
+    const yRange = [getYRange(data).min, getYRange(data).max];
+    const chartConfig = {
+        value: {
+            label: data[0]?.label || 'Value'
+        }
+    } satisfies ChartConfig;
+
+    return (
+        <ChartContainer className={
+            cn('w-full', className)
+        } config={chartConfig}>
+            <Recharts.AreaChart
+                data={data}
+                margin={{
+                    left: 4,
+                    right: 4,
+                    top: 0
+                }}
+            >
+                <Recharts.CartesianGrid horizontal={false} vertical={false} />
+                <Recharts.XAxis
+                    axisLine={{stroke: 'hsl(var(--border))', strokeWidth: 1}}
+                    dataKey="date"
+                    interval={0}
+                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(value, range)} />}
+                    tickFormatter={value => formatDisplayDateWithRange(value, range)}
+                    tickLine={false}
+                    tickMargin={10}
+                    ticks={data && data.length > 0 ? [data[0].date, data[data.length - 1].date] : []}
+                />
+                <Recharts.YAxis
+                    axisLine={false}
+                    domain={yRange}
+                    scale="linear"
+                    tickFormatter={(value: number) => {
+                        return formatNumber(value);
+                    }}
+                    tickLine={false}
+                    ticks={[]}
+                    width={0}
+                />
+                <ChartTooltip
+                    content={<CustomTooltipContent color={color} range={range} />}
+                    cursor={true}
+                    isAnimationActive={false}
+                    position={{y: 10}}
+                />
+                <defs>
+                    <linearGradient id={`fillChart-${id}`} x1="0" x2="0" y1="0" y2="1">
+                        <stop
+                            offset="5%"
+                            stopColor={color}
+                            stopOpacity={0.8}
+                        />
+                        <stop
+                            offset="95%"
+                            stopColor={color}
+                            stopOpacity={0.1}
+                        />
+                    </linearGradient>
+                </defs>
+                <Recharts.Area
+                    dataKey="value"
+                    fill={`url(#fillChart-${id})`}
+                    fillOpacity={0.2}
+                    isAnimationActive={false}
+                    stackId="a"
+                    stroke={color}
+                    strokeWidth={2}
+                    type="linear"
+                />
+            </Recharts.AreaChart>
+        </ChartContainer>
+    );
+};
+
+export default AreaChart;

--- a/apps/stats/src/views/Stats/components/AreaChart.tsx
+++ b/apps/stats/src/views/Stats/components/AreaChart.tsx
@@ -16,6 +16,7 @@ interface AreaChartProps {
     color?: string;
     id: string;
     className?: string;
+    syncId?: string;
 }
 
 const AreaChart: React.FC<AreaChartProps> = ({
@@ -24,7 +25,8 @@ const AreaChart: React.FC<AreaChartProps> = ({
     yAxisRange,
     color = 'hsl(var(--chart-blue))',
     id,
-    className
+    className,
+    syncId
 }) => {
     const yRange = yAxisRange || [getYRange(data).min, getYRange(data).max];
     const chartConfig = {
@@ -44,6 +46,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
                     right: 4,
                     top: 4
                 }}
+                syncId={syncId}
             >
                 <Recharts.CartesianGrid horizontal={false} vertical={false} />
                 <Recharts.XAxis


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1893/wire-up-dashboard-kpis

- The KPI data on stats-wide analytics overview was so far static.
