### PR TITLE
Moved all apps packages to vitest

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-tailwindcss": "3.18.0",
     "jsdom": "24.1.3",
     "lodash-es": "4.17.21",
-    "mocha": "10.8.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "rollup-plugin-node-builtins": "2.1.2",

--- a/apps/admin-x-design-system/test/unit/hello.test.js
+++ b/apps/admin-x-design-system/test/unit/hello.test.js
@@ -1,8 +1,0 @@
-import assert from 'assert/strict';
-
-describe('Hello world', function () {
-    it('Runs a test', function () {
-        // TODO: Write me!
-        assert.equal(1, 1);
-    });
-});

--- a/apps/admin-x-design-system/test/unit/hooks/usePagination.test.ts
+++ b/apps/admin-x-design-system/test/unit/hooks/usePagination.test.ts
@@ -1,8 +1,9 @@
+import {describe, it} from 'vitest';
 import {expect} from 'chai';
 import {renderHook, act} from '@testing-library/react-hooks';
 import {usePagination, PaginationMeta, PaginationData} from '../../../src/hooks/usePagination';
 
-describe('usePagination', function () {
+describe('usePagination', () => {
     const initialMeta: PaginationMeta = {
         limit: 10,
         pages: 5,
@@ -11,7 +12,7 @@ describe('usePagination', function () {
         prev: null
     };
 
-    it('should initialize with the given meta and page', function () {
+    it('should initialize with the given meta and page', () => {
         const {result} = renderHook(() => usePagination({
             meta: initialMeta,
             limit: 10,
@@ -33,7 +34,7 @@ describe('usePagination', function () {
         expect(result.current).to.deep.equal(expectedData);
     });
 
-    it('should update page correctly when nextPage and prevPage are called', function () {
+    it('should update page correctly when nextPage and prevPage are called', () => {
         let currentPage = 1;
         const setPage = (newPage: number) => {
             currentPage = newPage;
@@ -60,7 +61,7 @@ describe('usePagination', function () {
         expect(currentPage).to.equal(1);
     });
 
-    it('should update page correctly when setPage is called', function () {
+    it('should update page correctly when setPage is called', () => {
         let currentPage = 3;
         const setPage = (newPage: number) => {
             currentPage = newPage;
@@ -83,7 +84,7 @@ describe('usePagination', function () {
         expect(currentPage).to.equal(newPage);
     });
 
-    it('should handle edge cases where meta.pages < page when setting meta', function () {
+    it('should handle edge cases where meta.pages < page when setting meta', () => {
         let currentPage = 5;
         const setPage = (newPage: number) => {
             currentPage = newPage;

--- a/apps/admin-x-design-system/test/unit/hooks/useSortableIndexedList.test.ts
+++ b/apps/admin-x-design-system/test/unit/hooks/useSortableIndexedList.test.ts
@@ -1,9 +1,10 @@
+import {describe, it} from 'vitest';
 import {expect} from 'chai';
 import {renderHook, act} from '@testing-library/react-hooks';
 import useSortableIndexedList from '../../../src/hooks/useSortableIndexedList';
 import sinon from 'sinon';
 
-describe('useSortableIndexedList', function () {
+describe('useSortableIndexedList', () => {
     // Mock initial items and blank item
     const initialItems = [{name: 'Item 1'}, {name: 'Item 2'}];
     const blankItem = {name: ''};
@@ -11,7 +12,7 @@ describe('useSortableIndexedList', function () {
     // Mock canAddNewItem function
     const canAddNewItem = (item: { name: string }) => !!item.name;
 
-    it('should initialize with the given items', function () {
+    it('should initialize with the given items', () => {
         const setItems = sinon.spy();
 
         const {result} = renderHook(() => useSortableIndexedList({
@@ -26,7 +27,7 @@ describe('useSortableIndexedList', function () {
         expect(result.current.items).to.deep.equal(initialItems.map((item, index) => ({item, id: index.toString()})));
     });
 
-    it('should add a new item', function () {
+    it('should add a new item', () => {
         let items = initialItems;
         const setItems = (newItems: any[]) => {
             items = newItems;
@@ -49,7 +50,7 @@ describe('useSortableIndexedList', function () {
         expect(items).to.deep.equal([...initialItems, {name: 'New Item'}]);
     });
 
-    it('should update an item', function () {
+    it('should update an item', () => {
         let items = initialItems;
         const setItems = (newItems: any[]) => {
             items = newItems;
@@ -71,7 +72,7 @@ describe('useSortableIndexedList', function () {
         expect(items[0]).to.deep.equal({name: 'Updated Item 1'});
     });
 
-    it('should remove an item', function () {
+    it('should remove an item', () => {
         let items = initialItems;
         const setItems = (newItems: any[]) => {
             items = newItems;
@@ -93,7 +94,7 @@ describe('useSortableIndexedList', function () {
         expect(items).to.deep.equal([initialItems[1]]);
     });
 
-    it('should move an item', function () {
+    it('should move an item', () => {
         let items = initialItems;
         const setItems = (newItems: any[]) => {
             items = newItems;
@@ -115,7 +116,7 @@ describe('useSortableIndexedList', function () {
         expect(items).to.deep.equal([initialItems[1], initialItems[0]]);
     });
 
-    it('should not setItems for deeply equal items regardless of property order', function () {
+    it('should not setItems for deeply equal items regardless of property order', () => {
         const setItems = sinon.spy();
         const initialItem = [{name: 'Item 1', url: 'http://example.com'}];
         const blankItem1 = {name: '', url: ''};

--- a/apps/admin-x-design-system/test/unit/utils/formatUrl.test.ts
+++ b/apps/admin-x-design-system/test/unit/utils/formatUrl.test.ts
@@ -1,68 +1,69 @@
+import {describe, it} from 'vitest';
 import * as assert from 'assert/strict';
 import {formatUrl} from '../../../src/utils/formatUrl';
 
-describe('formatUrl', function () {
-    it('displays empty string if the input is empty and nullable is true', function () {
+describe('formatUrl', () => {
+    it('displays empty string if the input is empty and nullable is true', () => {
         const formattedUrl = formatUrl('', undefined, true);
         assert.deepEqual(formattedUrl, {save: null, display: ''});
     });
 
-    it('displays empty string value if the input has only whitespace', function () {
+    it('displays empty string value if the input has only whitespace', () => {
         const formattedUrl = formatUrl('');
         assert.deepEqual(formattedUrl, {save: '', display: ''});
     });
 
-    it('displays base value if the input has only whitespace and base url is available', function () {
+    it('displays base value if the input has only whitespace and base url is available', () => {
         const formattedUrl = formatUrl('', 'http://example.com');
         assert.deepEqual(formattedUrl, {save: '/', display: 'http://example.com'});
     });
 
-    it('displays a mailto address for an email address', function () {
+    it('displays a mailto address for an email address', () => {
         const formattedUrl = formatUrl('test@example.com');
         assert.deepEqual(formattedUrl, {save: 'mailto:test@example.com', display: 'mailto:test@example.com'});
     });
 
-    it('displays an anchor link without formatting', function () {
+    it('displays an anchor link without formatting', () => {
         const formattedUrl = formatUrl('#section');
         assert.deepEqual(formattedUrl, {save: '#section', display: '#section'});
     });
 
-    it('displays a protocol-relative link without formatting', function () {
+    it('displays a protocol-relative link without formatting', () => {
         const formattedUrl = formatUrl('//example.com');
         assert.deepEqual(formattedUrl, {save: '//example.com', display: '//example.com'});
     });
 
-    it('adds https:// automatically', function () {
+    it('adds https:// automatically', () => {
         const formattedUrl = formatUrl('example.com');
         assert.deepEqual(formattedUrl, {save: 'https://example.com/', display: 'https://example.com/'});
     });
 
-    it('saves a relative URL if the input is a pathname', function () {
+    it('saves a relative URL if the input is a pathname', () => {
         const formattedUrl = formatUrl('/path', 'http://example.com');
         assert.deepEqual(formattedUrl, {save: '/path/', display: 'http://example.com/path/'});
     });
 
-    it('saves a relative URL if the input is a pathname, even if the base url has an non-empty pathname', function () {
+    it('saves a relative URL if the input is a pathname, even if the base url has an non-empty pathname', () => {
         const formattedUrl = formatUrl('/path', 'http://example.com/blog');
         assert.deepEqual(formattedUrl, {save: '/path/', display: 'http://example.com/blog/path/'});
     });
 
-    it('saves a relative URL if the input includes the base url', function () {
+    it('saves a relative URL if the input includes the base url', () => {
         const formattedUrl = formatUrl('http://example.com/path', 'http://example.com');
         assert.deepEqual(formattedUrl, {save: '/path/', display: 'http://example.com/path/'});
     });
 
-    it('saves a relative URL if the input includes the base url, even if the base url has an non-empty pathname', function () {
+    it('saves a relative URL if the input includes the base url, even if the base url has an non-empty pathname', () => {
         const formattedUrl = formatUrl('http://example.com/blog/path', 'http://example.com/blog');
         assert.deepEqual(formattedUrl, {save: '/path/', display: 'http://example.com/blog/path/'});
     });
 
-    it('saves an absolute URL if the input has a different pathname to the base url', function () {
+    it('saves an absolute URL if the input has a different pathname to the base url', () => {
         const formattedUrl = formatUrl('http://example.com/path', 'http://example.com/blog');
         assert.deepEqual(formattedUrl, {save: 'http://example.com/path', display: 'http://example.com/path'});
     });
 
-    it('saves an absolte URL if the input has a different hostname to the base url', function () {
+    it('saves an absolte URL if the input has a different hostname to the base url', () => {
         const formattedUrl = formatUrl('http://another.com/path', 'http://example.com');
         assert.deepEqual(formattedUrl, {save: 'http://another.com/path', display: 'http://another.com/path'});
     });

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -74,12 +74,11 @@
     ],
     "devDependencies": {
         "@testing-library/react": "14.3.1",
-        "@types/mocha": "10.0.10",
+        "@testing-library/jest-dom": "5.17.0",
         "c8": "8.0.1",
         "eslint-plugin-react-hooks": "4.6.2",
         "eslint-plugin-react-refresh": "0.4.20",
         "jsdom": "24.1.3",
-        "mocha": "10.8.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "sinon": "17.0.1",

--- a/apps/admin-x-framework/test/.eslintrc.cjs
+++ b/apps/admin-x-framework/test/.eslintrc.cjs
@@ -3,10 +3,8 @@ module.exports = {
     extends: [
         'plugin:ghost/ts-test'
     ],
-    env: {
-        'vitest-globals/env': true
-    },
     rules: {
-        'ghost/mocha/no-arrow-functions': 'off'
+        'ghost/mocha/no-mocha-arrows': 'off',
+        '@typescript-eslint/no-explicit-any': 'off'
     }
 };

--- a/apps/admin-x-framework/test/.eslintrc.cjs
+++ b/apps/admin-x-framework/test/.eslintrc.cjs
@@ -2,5 +2,11 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts-test'
-    ]
+    ],
+    env: {
+        'vitest-globals/env': true
+    },
+    rules: {
+        'ghost/mocha/no-arrow-functions': 'off'
+    }
 };

--- a/apps/admin-x-framework/test/setup.ts
+++ b/apps/admin-x-framework/test/setup.ts
@@ -1,0 +1,4 @@
+/// <reference types="vitest/globals" />
+import '@testing-library/jest-dom';
+
+// This file ensures TypeScript knows about vitest globals 

--- a/apps/admin-x-framework/test/unit/hooks/useForm.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useForm.test.ts
@@ -2,9 +2,9 @@ import {act, renderHook} from '@testing-library/react';
 import * as assert from 'assert/strict';
 import useForm from '../../../src/hooks/useForm';
 
-describe('useForm', function () {
-    describe('formState', function () {
-        it('returns the initial form state', function () {
+describe('useForm', () => {
+    describe('formState', () => {
+        it('returns the initial form state', () => {
             const {result} = renderHook(() => useForm({
                 initialState: {a: 1},
                 onSave: () => {}
@@ -14,8 +14,8 @@ describe('useForm', function () {
         });
     });
 
-    describe('updateForm', function () {
-        it('updates the form state', function () {
+    describe('updateForm', () => {
+        it('updates the form state', () => {
             const {result} = renderHook(() => useForm({
                 initialState: {a: 1},
                 onSave: () => {}
@@ -26,7 +26,7 @@ describe('useForm', function () {
             assert.deepEqual(result.current.formState, {a: 1, b: 2});
         });
 
-        it('sets the saveState to unsaved', function () {
+        it('sets the saveState to unsaved', () => {
             const {result} = renderHook(() => useForm({
                 initialState: {a: 1},
                 onSave: () => {}
@@ -38,8 +38,8 @@ describe('useForm', function () {
         });
     });
 
-    describe('handleSave', function () {
-        it('does nothing when the state has not changed', async function () {
+    describe('handleSave', () => {
+        it('does nothing when the state has not changed', async () => {
             let onSaveCalled = false;
 
             const {result} = renderHook(() => useForm({
@@ -55,7 +55,7 @@ describe('useForm', function () {
             assert.equal(onSaveCalled, false);
         });
 
-        it('calls the onSave callback when the state has changed', async function () {
+        it('calls the onSave callback when the state has changed', async () => {
             let onSaveCalled = false;
 
             const {result} = renderHook(() => useForm({

--- a/apps/admin-x-framework/test/unit/utils/api/fetchApi.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/fetchApi.test.tsx
@@ -24,8 +24,8 @@ const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
     </FrameworkProvider>
 );
 
-describe('useFetchApi', function () {
-    it('makes an API request', async function () {
+describe('useFetchApi', () => {
+    it('makes an API request', async () => {
         await withMockFetch({
             json: {test: 1}
         }, async (mock) => {

--- a/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
@@ -36,13 +36,13 @@ const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
     </FrameworkProvider>
 );
 
-describe('API hooks', function () {
-    describe('createQuery', function () {
-        afterEach(function () {
+describe('API hooks', () => {
+    describe('createQuery', () => {
+        afterEach(() => {
             queryClient.clear();
         });
 
-        it('makes an API request', async function () {
+        it('makes an API request', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -73,7 +73,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can add custom headers', async function () {
+        it('can add custom headers', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -106,7 +106,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('sends default query params', async function () {
+        it('sends default query params', async () => {
             await withMockFetch({}, async (mock) => {
                 const useTestQuery = createQuery({
                     dataType: 'test',
@@ -123,7 +123,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can override default query params', async function () {
+        it('can override default query params', async () => {
             await withMockFetch({}, async (mock) => {
                 const useTestQuery = createQuery({
                     dataType: 'test',
@@ -140,7 +140,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can transform return data', async function () {
+        it('can transform return data', async () => {
             await withMockFetch({json: {test: 1}}, async () => {
                 const useTestQuery = createQuery({
                     dataType: 'test',
@@ -157,12 +157,12 @@ describe('API hooks', function () {
         });
     });
 
-    describe('createPaginatedQuery', function () {
-        afterEach(function () {
+    describe('createPaginatedQuery', () => {
+        afterEach(() => {
             queryClient.clear();
         });
 
-        it('makes a paginated API request', async function () {
+        it('makes a paginated API request', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -191,7 +191,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('sends default query params', async function () {
+        it('sends default query params', async () => {
             await withMockFetch({}, async (mock) => {
                 const useTestQuery = createPaginatedQuery({
                     dataType: 'test',
@@ -208,7 +208,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can override default query params', async function () {
+        it('can override default query params', async () => {
             await withMockFetch({}, async (mock) => {
                 const useTestQuery = createPaginatedQuery({
                     dataType: 'test',
@@ -225,7 +225,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can transform return data', async function () {
+        it('can transform return data', async () => {
             await withMockFetch({json: {test: 1}}, async () => {
                 const useTestQuery = createPaginatedQuery({
                     dataType: 'test',
@@ -241,7 +241,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('exposes pagination metadata', async function () {
+        it('exposes pagination metadata', async () => {
             await withMockFetch({json: {meta: {pagination: {pages: 2, total: 100}}}}, async () => {
                 const useTestQuery = createPaginatedQuery({
                     dataType: 'test',
@@ -260,7 +260,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('supports navigating pages', async function () {
+        it('supports navigating pages', async () => {
             await withMockFetch({json: {meta: {pagination: {pages: 2}}}}, async (mock) => {
                 const useTestQuery = createPaginatedQuery({
                     dataType: 'test',
@@ -295,12 +295,12 @@ describe('API hooks', function () {
         });
     });
 
-    describe('createInfiniteQuery', function () {
-        afterEach(function () {
+    describe('createInfiniteQuery', () => {
+        afterEach(() => {
             queryClient.clear();
         });
 
-        it('makes a paginated API request', async function () {
+        it('makes a paginated API request', async () => {
             await withMockFetch({
                 json: {test: 1, pagination: {next: 2}}
             }, async (mock) => {
@@ -346,12 +346,12 @@ describe('API hooks', function () {
         });
     });
 
-    describe('createQueryWithId', function () {
-        afterEach(function () {
+    describe('createQueryWithId', () => {
+        afterEach(() => {
             queryClient.clear();
         });
 
-        it('fills in the ID in the request', async function () {
+        it('fills in the ID in the request', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -372,12 +372,12 @@ describe('API hooks', function () {
         });
     });
 
-    describe('createMutation', function () {
-        afterEach(function () {
+    describe('createMutation', () => {
+        afterEach(() => {
             queryClient.clear();
         });
 
-        it('makes a request', async function () {
+        it('makes a request', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -405,7 +405,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('computes path, body, searchParams', async function () {
+        it('computes path, body, searchParams', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -436,7 +436,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can invalidate queries in the cache', async function () {
+        it('can invalidate queries in the cache', async () => {
             await withMockFetch({
                 json: {test: 1}
             }, async (mock) => {
@@ -460,7 +460,7 @@ describe('API hooks', function () {
             });
         });
 
-        it('can update queries in the cache', async function () {
+        it('can update queries in the cache', async () => {
             await withMockFetch({
                 json: {test: 10}
             }, async (mock) => {

--- a/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/settings.test.tsx
@@ -1,8 +1,8 @@
 import {getSettingValue, getSettingValues, isSettingReadOnly} from '../../../../src/api/settings';
 
-describe('settings utils', function () {
-    describe('getSettingValue', function () {
-        it('returns the value of a setting', function () {
+describe('settings utils', () => {
+    describe('getSettingValue', () => {
+        it('returns the value of a setting', () => {
             const settings = [
                 {key: 'test_key', value: 'test_value'}
             ];
@@ -10,15 +10,15 @@ describe('settings utils', function () {
             expect(value).toEqual('test_value');
         });
 
-        it('returns null if settings is null', function () {
+        it('returns null if settings is null', () => {
             const settings = undefined;
             const value = getSettingValue(settings, 'test_key');
             expect(value).toEqual(null);
         });
     });
 
-    describe('getSettingValues', function () {
-        it('returns the values of multiple settings', function () {
+    describe('getSettingValues', () => {
+        it('returns the values of multiple settings', () => {
             const settings = [
                 {key: 'test_key', value: 'test_value'},
                 {key: 'test_key_2', value: 'test_value_2'}
@@ -27,14 +27,14 @@ describe('settings utils', function () {
             expect(values).toEqual(['test_value', 'test_value_2']);
         });
 
-        it('returns undefined for missing keys', function () {
+        it('returns undefined for missing keys', () => {
             const values = getSettingValues([], ['test_key', 'test_key_2']);
             expect(values).toEqual([undefined, undefined]);
         });
     });
 
-    describe('isSettingReadOnly', function () {
-        it('returns true if the setting has an override', function () {
+    describe('isSettingReadOnly', () => {
+        it('returns true if the setting has an override', () => {
             const settings = [
                 {key: 'test_key', is_read_only: true, value: 'test_value'}
             ];
@@ -42,7 +42,7 @@ describe('settings utils', function () {
             expect(value).toEqual(true);
         });
 
-        it('returns false if the setting does not have an override', function () {
+        it('returns false if the setting does not have an override', () => {
             const settings = [
                 {key: 'test_key', is_read_only: false, value: 'test_value'}
             ];
@@ -50,7 +50,7 @@ describe('settings utils', function () {
             expect(value).toEqual(false);
         });
 
-        it('returns undefined if settings is falsy', function () {
+        it('returns undefined if settings is falsy', () => {
             const settings = undefined;
             const value = isSettingReadOnly(settings, 'test_key');
             expect(value).toEqual(undefined);

--- a/apps/admin-x-framework/test/unit/utils/api/updateQueries.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/api/updateQueries.test.ts
@@ -1,8 +1,8 @@
 import {deleteFromQueryCache, insertToQueryCache, updateQueryCache} from '../../../../src/utils/api/updateQueries';
 
-describe('cache update functions', function () {
-    describe('insertToQueryCache', function () {
-        it('appends records from the new data', function () {
+describe('cache update functions', () => {
+    describe('insertToQueryCache', () => {
+        it('appends records from the new data', () => {
             const newData = {
                 posts: [{id: '2'}]
             };
@@ -18,7 +18,7 @@ describe('cache update functions', function () {
             });
         });
 
-        it('appends to the last page for paginated queries', function () {
+        it('appends to the last page for paginated queries', () => {
             const newData = {
                 posts: [{id: '3'}]
             };
@@ -35,8 +35,8 @@ describe('cache update functions', function () {
         });
     });
 
-    describe('updateQueryCache', function () {
-        it('updates based on the ID', function () {
+    describe('updateQueryCache', () => {
+        it('updates based on the ID', () => {
             const newData = {
                 posts: [{id: '2', title: 'New Title'}]
             };
@@ -52,7 +52,7 @@ describe('cache update functions', function () {
             });
         });
 
-        it('updates nested records in paginated queries', function () {
+        it('updates nested records in paginated queries', () => {
             const newData = {
                 posts: [{id: '2', title: 'New Title'}]
             };
@@ -69,8 +69,8 @@ describe('cache update functions', function () {
         });
     });
 
-    describe('deleteFromQueryCache', function () {
-        it('deletes based on the ID', function () {
+    describe('deleteFromQueryCache', () => {
+        it('deletes based on the ID', () => {
             const currentData = {
                 posts: [{id: '1'}, {id: '2'}]
             };
@@ -82,7 +82,7 @@ describe('cache update functions', function () {
             });
         });
 
-        it('deletes nested records in paginated queries', function () {
+        it('deletes nested records in paginated queries', () => {
             const currentData = {
                 pages: [{posts: [{id: '1'}]}, {posts: [{id: '2'}]}]
             };

--- a/apps/admin-x-framework/test/utils/mockFetch.ts
+++ b/apps/admin-x-framework/test/utils/mockFetch.ts
@@ -1,4 +1,4 @@
-import {MockContext, vi} from 'vitest';
+/// <reference types="vitest/globals" />
 
 const originalFetch = global.fetch;
 
@@ -6,7 +6,7 @@ type FetchArgs = Parameters<typeof global.fetch>;
 
 export const withMockFetch = async (
     {json = {}, headers = {}, status = 200, ok = true}: {json?: unknown; headers?: Record<string, string>; status?: number; ok?: boolean},
-    callback: (mock: MockContext<FetchArgs, Promise<Response>>) => void | Promise<void>
+    callback: (mock: any) => void | Promise<void>
 ) => {
     const mockFetch = vi.fn<FetchArgs, Promise<Response>>(() => Promise.resolve({
         json: () => Promise.resolve(json),

--- a/apps/admin-x-framework/tsconfig.json
+++ b/apps/admin-x-framework/tsconfig.json
@@ -4,7 +4,7 @@
       "lib": ["DOM", "DOM.Iterable", "ESNext"],
       "module": "ESNext",
       "skipLibCheck": true,
-      "types": ["vite/client"],
+      "types": ["vite/client", "jest"],
 
       /* Bundler mode */
       "moduleResolution": "bundler",
@@ -18,6 +18,6 @@
       "noUnusedParameters": true,
       "noFallthroughCasesInSwitch": true
     },
-    "include": ["src"],
+    "include": ["src", "test"],
     "references": [{ "path": "./tsconfig.node.json" }]
   }

--- a/apps/admin-x-framework/vite.config.ts
+++ b/apps/admin-x-framework/vite.config.ts
@@ -57,6 +57,7 @@ export default (function viteConfig() {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
             include: ['./test/unit/**/*'],
+            setupFiles: ['./test/setup.ts'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
                 minThreads: 1,

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -49,7 +49,6 @@
         "eslint-plugin-tailwindcss": "3.18.0",
         "jsdom": "24.1.3",
         "lodash-es": "4.17.21",
-        "mocha": "10.8.2",
         "vitest": "0.34.3"
     },
     "dependencies": {

--- a/apps/shade/tsconfig.json
+++ b/apps/shade/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["DOM", "DOM.Iterable", "ESNext"],
         "module": "ESNext",
         "skipLibCheck": true,
-        "types": ["vite/client", "mocha"],
+        "types": ["vite/client", "vitest/globals"],
 
         /* Bundler mode */
         "moduleResolution": "bundler",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8275,11 +8275,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mocha@10.0.10":
-  version "10.0.10"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.10.tgz#91f62905e8d23cbd66225312f239454a23bebfa0"
-  integrity sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==
-
 "@types/ms@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"


### PR DESCRIPTION
no ref

We're trying to unify the testing approaches for the /apps/, in particular those using admin-x-framework. Part of the fuzziness here is that we had a split mocha+vitest implementation, with some packages importing mocha without even using it. This is attempting to clean that up.

todo: We need to update vitest. 0.34.3 is almost two years old. Updating this might less us remove jest, as there's type issues causing problems that seemed to require this as a workaround.