### PR TITLE
Fixed post analytics navigation bug

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -205,7 +205,7 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) this.config.stats)}}
+        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics Beta"}}

--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -73,7 +73,7 @@
                             <li>
                                 <a class="view-browser" href="{{this.post.url}}" target="_blank" rel="noopener noreferrer">View in browser</a>
                             </li>
-                            {{#if (and (gh-user-can-admin this.session.user) this.config.stats)}}
+                            {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
                                 <li>
                                     <LinkTo class="edit-post" @route="posts-x" @model={{this.post.id}}>Switch to Analytics (beta)</LinkTo>
                                 </li>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-978/support-escalation-re-analytics-button

- Customers were unable to access their post analytics at the moment. Clicking the chart icon from the post list lead to the dashboard, instead of the expected post analytics.