### PR TITLE
🎨 Added a configuration option for the paging parameter name

### DIFF
--- a/ghost/core/core/frontend/meta/paginated-url.js
+++ b/ghost/core/core/frontend/meta/paginated-url.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const urlUtils = require('../../shared/url-utils');
+const getPageParam = require('../services/routing/page-param-config');
 
 function getPaginatedUrl(page, data, absolute) {
     // If we don't have enough information, return null right away
@@ -7,12 +8,12 @@ function getPaginatedUrl(page, data, absolute) {
         return null;
     }
 
-    // routeKeywords.page: 'page'
-    const pagePath = urlUtils.urlJoin('/page/');
+    const pageParam = getPageParam();
+
+    const pagePath = urlUtils.urlJoin('/' + pageParam + '/');
 
     // Try to match the base url, as whatever precedes the pagePath
-    // routeKeywords.page: 'page'
-    const baseUrlPattern = new RegExp('(.+)?(/page/\\d+/)');
+    const baseUrlPattern = new RegExp('(.+)?(/' + pageParam + '/\\d+/)');
 
     const baseUrlMatch = data.relativeUrl.match(baseUrlPattern);
 

--- a/ghost/core/core/frontend/services/rendering/context.js
+++ b/ghost/core/core/frontend/services/rendering/context.js
@@ -16,8 +16,12 @@ const privatePattern = new RegExp('^\\/private\\/');
 
 const homePattern = new RegExp('^\\/$');
 
+const getPageParam = require('../routing/page-param-config');
+
 function setResponseContext(req, res, data) {
-    const pageParam = req.params && req.params.page !== undefined ? parseInt(req.params.page, 10) : 1;
+    const pageParam = getPageParam();
+    const pageParamValue = req.params && req.params[pageParam] !== undefined
+        ? parseInt(req.params[pageParam], 10) : 1;
 
     res.locals = res.locals || {};
     res.locals.context = [];
@@ -29,7 +33,7 @@ function setResponseContext(req, res, data) {
     }
 
     // Paged context - special rule
-    if (!isNaN(pageParam) && pageParam > 1) {
+    if (!isNaN(pageParamValue) && pageParamValue > 1) {
         res.locals.context.push('paged');
     }
 

--- a/ghost/core/core/frontend/services/rendering/templates.js
+++ b/ghost/core/core/frontend/services/rendering/templates.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const path = require('path');
 const url = require('url');
 const config = require('../../../shared/config');
+const getPageParam = require('../routing/page-param-config');
 const themeEngine = require('../theme-engine');
 const _private = {};
 
@@ -181,10 +182,12 @@ module.exports.setTemplate = function setTemplate(req, res, data) {
         return;
     }
 
+    const pageParam = getPageParam();
+
     if (['channel', 'collection'].indexOf(res.routerOptions.type) !== -1) {
         res._template = _private.getTemplateForEntries(res.routerOptions, {
             path: url.parse(req.url).pathname,
-            page: req.params.page,
+            page: req.params[pageParam],
             slugParam: req.params.slug
         });
     } else if (res.routerOptions.type === 'custom') {

--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -1,5 +1,6 @@
 const debug = require('@tryghost/debug')('routing:collection-router');
 const urlUtils = require('../../../shared/url-utils');
+const getPageParam = require('./page-param-config');
 const ParentRouter = require('./parent-router');
 
 const controllers = require('./controllers');
@@ -70,8 +71,9 @@ class CollectionRouter extends ParentRouter {
         this.mountRoute(this.route.value, controllers.collection);
 
         // REGISTER: enable pagination by default
-        this.router().param('page', middleware.pageParam);
-        this.mountRoute(urlUtils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers.collection);
+        const pageParam = getPageParam();
+        this.router().param(pageParam, middleware.pageParam);
+        this.mountRoute(urlUtils.urlJoin(this.route.value, pageParam, `:${pageParam}(\\d+)`), controllers.collection);
 
         // REGISTER: is rss enabled?
         if (this.rss) {

--- a/ghost/core/core/frontend/services/routing/controllers/channel.js
+++ b/ghost/core/core/frontend/services/routing/controllers/channel.js
@@ -5,6 +5,7 @@ const security = require('@tryghost/security');
 const themeEngine = require('../../theme-engine');
 const dataService = require('../../data');
 const renderer = require('../../rendering');
+const getPageParam = require('../page-param-config');
 
 const messages = {
     pageNotFound: 'Page not found.'
@@ -23,8 +24,10 @@ const messages = {
 module.exports = function channelController(req, res, next) {
     debug('channelController', req.params, res.routerOptions);
 
+    const pageParam = getPageParam();
+
     const pathOptions = {
-        page: req.params.page !== undefined ? req.params.page : 1,
+        page: req.params[pageParam] !== undefined ? req.params[pageParam] : 1,
         slug: req.params.slug ? security.string.safe(req.params.slug) : undefined
     };
 

--- a/ghost/core/core/frontend/services/routing/controllers/collection.js
+++ b/ghost/core/core/frontend/services/routing/controllers/collection.js
@@ -7,6 +7,7 @@ const {routerManager} = require('../');
 const themeEngine = require('../../theme-engine');
 const renderer = require('../../rendering');
 const dataService = require('../../data');
+const getPageParam = require('../page-param-config');
 
 const messages = {
     pageNotFound: 'Page not found.'
@@ -22,8 +23,10 @@ const messages = {
 module.exports = function collectionController(req, res, next) {
     debug('collectionController beging', req.params, res.routerOptions);
 
+    const pageParam = getPageParam();
+
     const pathOptions = {
-        page: req.params.page !== undefined ? req.params.page : 1,
+        page: req.params[pageParam] !== undefined ? req.params[pageParam] : 1,
         slug: req.params.slug ? security.string.safe(req.params.slug) : undefined
     };
 

--- a/ghost/core/core/frontend/services/routing/middleware/page-param.js
+++ b/ghost/core/core/frontend/services/routing/middleware/page-param.js
@@ -1,6 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../../shared/url-utils');
+const getPageParam = require('../page-param-config');
 
 const messages = {
     pageNotFound: 'Page not found.'
@@ -8,6 +9,7 @@ const messages = {
 
 /**
  * @description Middleware, which validates and interprets the page param e.g. /page/1
+ * The name of the page parameter may have been modified in the config to something other than 'page'.
  * @param {Object} req
  * @param {Object} res
  * @param {Function} next
@@ -15,8 +17,8 @@ const messages = {
  * @returns {*}
  */
 module.exports = function handlePageParam(req, res, next, page) {
-    // routeKeywords.page: 'page'
-    const pageRegex = new RegExp('/page/(.*)?/');
+    const pageParam = getPageParam();
+    const pageRegex = new RegExp('/' + pageParam + '/(.*)?/');
 
     page = parseInt(page, 10);
 
@@ -28,7 +30,7 @@ module.exports = function handlePageParam(req, res, next, page) {
             message: tpl(messages.pageNotFound)
         }));
     } else {
-        req.params.page = page;
+        req.params[pageParam] = page;
         return next();
     }
 };

--- a/ghost/core/core/frontend/services/routing/page-param-config.js
+++ b/ghost/core/core/frontend/services/routing/page-param-config.js
@@ -1,0 +1,70 @@
+const DEFAULT_PAGE_PARAM = 'page';
+
+// Segments that already carry routing meaning and must not be reused as the
+// pagination segment.
+const RESERVED_SEGMENTS = ['tag', 'author', 'rss', 'amp', 'private', 'edit', 'unsubscribe'];
+
+const INVALID_CHARACTERS = /[/?#:\s]/;
+
+let currentPageParam = DEFAULT_PAGE_PARAM;
+
+/**
+ * @description Validates a candidate pagination segment, falling back to "page".
+ * @param {*} value
+ * @returns {string}
+ */
+function validatePageParam(value) {
+    if (typeof value !== 'string') {
+        return DEFAULT_PAGE_PARAM;
+    }
+
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+        return DEFAULT_PAGE_PARAM;
+    }
+
+    if (INVALID_CHARACTERS.test(trimmed)) {
+        return DEFAULT_PAGE_PARAM;
+    }
+
+    if (RESERVED_SEGMENTS.includes(trimmed.toLowerCase())) {
+        return DEFAULT_PAGE_PARAM;
+    }
+
+    return trimmed;
+}
+
+/**
+ * @description Returns the active pagination URL segment (e.g. "page").
+ *
+ * The value originates from the top-level `pagination` key in routes.yaml and is
+ * pushed in via {@link setPageParam} when the routers are (re)built. It is a
+ * site-wide global because the non-routing consumers (paginated-url, context,
+ * templates, page-param middleware) have no routing context to derive it from.
+ *
+ * @returns {string}
+ */
+function getPageParam() {
+    return currentPageParam;
+}
+
+/**
+ * @description Sets the active pagination segment from the loaded route settings.
+ *
+ * Called by the router manager on (re)build so a routes.yaml change takes effect
+ * without a restart. The value is validated against unsafe characters and
+ * reserved segments, falling back to "page" when invalid or absent.
+ *
+ * @param {*} value the raw `pagination` value from route settings
+ * @returns {string} the validated segment that was stored
+ */
+function setPageParam(value) {
+    currentPageParam = validatePageParam(value);
+    return currentPageParam;
+}
+
+module.exports = getPageParam;
+module.exports.setPageParam = setPageParam;
+module.exports.validatePageParam = validatePageParam;
+module.exports.DEFAULT_PAGE_PARAM = DEFAULT_PAGE_PARAM;

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -8,6 +8,7 @@ const PreviewRouter = require('./preview-router');
 const ParentRouter = require('./parent-router');
 const EmailRouter = require('./email-router');
 const UnsubscribeRouter = require('./unsubscribe-router');
+const {setPageParam} = require('./page-param-config');
 
 // This emits its own routing events
 const events = require('../../../server/lib/common/events');
@@ -100,6 +101,10 @@ class RouterManager {
     start(routerSettings) {
         debug('routing start', routerSettings);
         const RESOURCE_CONFIG = require(`./config`);
+
+        // Resolve the pagination URL segment from routes.yaml before any router
+        // is built — routers read it at construction via getPageParam().
+        setPageParam(routerSettings.pagination);
 
         const unsubscribeRouter = new UnsubscribeRouter();
         this.siteRouter.mountRouter(unsubscribeRouter.router());

--- a/ghost/core/core/frontend/services/routing/static-routes-router.js
+++ b/ghost/core/core/frontend/services/routing/static-routes-router.js
@@ -1,6 +1,7 @@
 const debug = require('@tryghost/debug')('routing:static-routes-router');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
+const getPageParam = require('./page-param-config');
 const RSSRouter = require('./rss-router');
 const controllers = require('./controllers');
 const middleware = require('./middleware');
@@ -59,8 +60,9 @@ class StaticRoutesRouter extends ParentRouter {
         this.mountRoute(this.route.value, controllers[this.controller]);
 
         // REGISTER: pagination
-        this.router().param('page', middleware.pageParam);
-        this.mountRoute(urlUtils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers[this.controller]);
+        const pageParam = getPageParam();
+        this.router().param(pageParam, middleware.pageParam);
+        this.mountRoute(urlUtils.urlJoin(this.route.value, pageParam, `:${pageParam}(\\d+)`), controllers[this.controller]);
 
         this.routerCreated(this);
     }

--- a/ghost/core/core/frontend/services/routing/taxonomy-router.js
+++ b/ghost/core/core/frontend/services/routing/taxonomy-router.js
@@ -1,5 +1,6 @@
 const debug = require('@tryghost/debug')('routing:taxonomy-router');
 const config = require('../../../shared/config');
+const getPageParam = require('./page-param-config');
 const ParentRouter = require('./parent-router');
 const RSSRouter = require('./rss-router');
 const urlUtils = require('../../../shared/url-utils');
@@ -51,8 +52,9 @@ class TaxonomyRouter extends ParentRouter {
         this.mountRoute(this.permalinks.getValue(), controllers.channel);
 
         // REGISTER: enable pagination for each taxonomy by default
-        this.router().param('page', middleware.pageParam);
-        this.mountRoute(urlUtils.urlJoin(this.permalinks.value, 'page', ':page(\\d+)'), controllers.channel);
+        const pageParam = getPageParam();
+        this.router().param(pageParam, middleware.pageParam);
+        this.mountRoute(urlUtils.urlJoin(this.permalinks.value, pageParam, `:${pageParam}(\\d+)`), controllers.channel);
 
         // REGISTER: edit redirect to admin client e.g. /tag/:slug/edit
         if (config.get('admin:redirects')) {

--- a/ghost/core/core/server/services/route-settings/default-routes.yaml
+++ b/ghost/core/core/server/services/route-settings/default-routes.yaml
@@ -1,5 +1,8 @@
 routes:
 
+# Optional: rename the pagination URL segment site-wide (default: page)
+# pagination: page
+
 collections:
   /:
     permalink: /{slug}/

--- a/ghost/core/core/server/services/route-settings/validate.js
+++ b/ghost/core/core/server/services/route-settings/validate.js
@@ -4,6 +4,10 @@ const errors = require('@tryghost/errors');
 const _private = {};
 let RESOURCE_CONFIG;
 
+// Keep in sync with frontend/services/routing/page-param-config.js
+const PAGINATION_INVALID_CHARACTERS = /[/?#:\s]/;
+const PAGINATION_RESERVED_SEGMENTS = ['tag', 'author', 'rss', 'amp', 'private', 'edit', 'unsubscribe'];
+
 const messages = {
     validationError: 'The following definition "{at}" is invalid: {reason}',
     invalidResourceError: 'Resource key not supported. {resourceKey}',
@@ -407,6 +411,40 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
     return taxonomies;
 };
 
+_private.validatePagination = function validatePagination(pagination) {
+    if (typeof pagination !== 'string' || pagination.trim().length === 0) {
+        throw new errors.ValidationError({
+            message: tpl(messages.validationError, {
+                at: pagination,
+                reason: '`pagination` must be a non-empty string.'
+            }),
+            help: 'e.g. pagination: seite'
+        });
+    }
+
+    const trimmed = pagination.trim();
+
+    if (PAGINATION_INVALID_CHARACTERS.test(trimmed)) {
+        throw new errors.ValidationError({
+            message: tpl(messages.validationError, {
+                at: trimmed,
+                reason: '`pagination` must not contain / ? # : or whitespace.'
+            })
+        });
+    }
+
+    if (PAGINATION_RESERVED_SEGMENTS.includes(trimmed.toLowerCase())) {
+        throw new errors.ValidationError({
+            message: tpl(messages.validationError, {
+                at: trimmed,
+                reason: `\`pagination\` must not be a reserved segment (${PAGINATION_RESERVED_SEGMENTS.join(', ')}).`
+            })
+        });
+    }
+
+    return trimmed;
+};
+
 /**
  * Validate and sanitize the routing object.
  * NOTE: mutates the object even if it's a valid configuration
@@ -435,6 +473,11 @@ module.exports = function validate(object) {
     object.routes = _private.validateRoutes(object.routes);
     object.collections = _private.validateCollections(object.collections);
     object.taxonomies = _private.validateTaxonomies(object.taxonomies);
+
+    // CASE: optional top-level pagination segment. Absent => routers default to "page".
+    if (Object.prototype.hasOwnProperty.call(object, 'pagination')) {
+        object.pagination = _private.validatePagination(object.pagination);
+    }
 
     return object;
 };

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -338,8 +338,5 @@
         "batchSize": 1000,
         "captureLinkClickBadMemberUuid": false
     },
-    "disableJSBackups": false,
-    "pagination": {
-        "pageParameter": "page"
-    }
+    "disableJSBackups": false
 }

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -338,5 +338,8 @@
         "batchSize": 1000,
         "captureLinkClickBadMemberUuid": false
     },
-    "disableJSBackups": false
+    "disableJSBackups": false,
+    "pagination": {
+        "pageParameter": "page"
+    }
 }

--- a/ghost/core/test/unit/frontend/meta/paginated-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/paginated-url.test.js
@@ -2,6 +2,8 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const getPaginatedUrl = require('../../../../core/frontend/meta/paginated-url');
 const configUtils = require('../../../utils/config-utils');
+const sinon = require('sinon');
+const config = require('../../../../core/shared/config');
 
 describe('getPaginatedUrl', function () {
     let data;
@@ -164,6 +166,52 @@ describe('getPaginatedUrl', function () {
             assert.equal(urls.page1, '/blog/featured/');
             assert.equal(urls.page5, '/blog/featured/page/5/');
             assert.equal(urls.page10, '/blog/featured/page/10/');
+        });
+    });
+
+    describe('custom paging page parameter', function () {
+        let configStub;
+
+        before(function () {
+            configStub = sinon.stub(config, 'get');
+            configStub.callThrough();
+            configStub.withArgs('pagination:pageParameter').returns('seite');
+        });
+
+        after(function () {
+            configStub.restore();
+        });
+
+        it('should calculate correct urls of an index collection', function () {
+            // Setup tests
+            data.relativeUrl = '/';
+            data.pagination = {prev: null, next: 2};
+
+            // Execute test
+            const urls = getTestUrls();
+
+            // Check results
+            assert.equal(urls.next, `${siteUrl()}/seite/2/`);
+            assert.equal(urls.prev, null);
+            assert.equal(urls.page1, '/');
+            assert.equal(urls.page5, '/seite/5/');
+            assert.equal(urls.page10, '/seite/10/');
+        });
+
+        it('should calculate correct urls for the last page of another collection', function () {
+            // Setup tests
+            data.relativeUrl = '/featured/seite/10/';
+            data.pagination = {prev: 9, next: null};
+
+            // Execute test
+            const urls = getTestUrls();
+
+            // Check results
+            assert.equal(urls.next, null);
+            assert.equal(urls.prev, `${siteUrl()}/featured/seite/9/`);
+            assert.equal(urls.page1, '/featured/');
+            assert.equal(urls.page5, '/featured/seite/5/');
+            assert.equal(urls.page10, '/featured/seite/10/');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/paginated-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/paginated-url.test.js
@@ -2,8 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const getPaginatedUrl = require('../../../../core/frontend/meta/paginated-url');
 const configUtils = require('../../../utils/config-utils');
-const sinon = require('sinon');
-const config = require('../../../../core/shared/config');
+const {setPageParam, DEFAULT_PAGE_PARAM} = require('../../../../core/frontend/services/routing/page-param-config');
 
 describe('getPaginatedUrl', function () {
     let data;
@@ -170,16 +169,12 @@ describe('getPaginatedUrl', function () {
     });
 
     describe('custom paging page parameter', function () {
-        let configStub;
-
-        before(function () {
-            configStub = sinon.stub(config, 'get');
-            configStub.callThrough();
-            configStub.withArgs('pagination:pageParameter').returns('seite');
+        beforeAll(function () {
+            setPageParam('seite');
         });
 
-        after(function () {
-            configStub.restore();
+        afterAll(function () {
+            setPageParam(DEFAULT_PAGE_PARAM);
         });
 
         it('should calculate correct urls of an index collection', function () {

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -7,6 +7,7 @@ const themeEngine = require('../../../../../../core/frontend/services/theme-engi
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
+const config = require('../../../../../../core/shared/config');
 
 describe('Unit - services/routing/controllers/channel', function () {
     let req;
@@ -82,6 +83,32 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('pass page param', async function () {
         let next = sinon.stub();
         req.params.page = 2;
+
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
+            .resolves({
+                posts: posts,
+                meta: {
+                    pagination: {
+                        pages: 5
+                    }
+                }
+            });
+
+        await controllers.channel(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.notCalled(next);
+    });
+
+    it('pass custom page param', async function () {
+        let next = sinon.stub();
+
+        const configStub = sinon.stub(config, 'get');
+        configStub.callThrough();
+        configStub.withArgs('pagination:pageParameter').returns('seite');
+
+        req.params.seite = 2;
 
         fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -7,7 +7,7 @@ const themeEngine = require('../../../../../../core/frontend/services/theme-engi
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
-const config = require('../../../../../../core/shared/config');
+const {setPageParam, DEFAULT_PAGE_PARAM} = require('../../../../../../core/frontend/services/routing/page-param-config');
 
 describe('Unit - services/routing/controllers/channel', function () {
     let req;
@@ -58,6 +58,7 @@ describe('Unit - services/routing/controllers/channel', function () {
 
     afterEach(function () {
         sinon.restore();
+        setPageParam(DEFAULT_PAGE_PARAM);
     });
 
     it('no params', async function () {
@@ -104,9 +105,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('pass custom page param', async function () {
         let next = sinon.stub();
 
-        const configStub = sinon.stub(config, 'get');
-        configStub.callThrough();
-        configStub.withArgs('pagination:pageParameter').returns('seite');
+        setPageParam('seite');
 
         req.params.seite = 2;
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -8,7 +8,7 @@ const routerManager = require('../../../../../../core/frontend/services/routing/
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
-const config = require('../../../../../../core/shared/config');
+const {setPageParam, DEFAULT_PAGE_PARAM} = require('../../../../../../core/frontend/services/routing/page-param-config');
 
 describe('Unit - services/routing/controllers/collection', function () {
     let req;
@@ -67,6 +67,7 @@ describe('Unit - services/routing/controllers/collection', function () {
 
     afterEach(function () {
         sinon.restore();
+        setPageParam(DEFAULT_PAGE_PARAM);
     });
 
     it('no params', async function () {
@@ -110,9 +111,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     });
 
     it('pass custom page param', async function () {
-        const configStub = sinon.stub(config, 'get');
-        configStub.callThrough();
-        configStub.withArgs('pagination:pageParameter').returns('seite');
+        setPageParam('seite');
 
         req.params.seite = 2;
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -8,6 +8,7 @@ const routerManager = require('../../../../../../core/frontend/services/routing/
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const dataService = require('../../../../../../core/frontend/services/data');
+const config = require('../../../../../../core/shared/config');
 
 describe('Unit - services/routing/controllers/collection', function () {
     let req;
@@ -89,6 +90,31 @@ describe('Unit - services/routing/controllers/collection', function () {
 
     it('pass page param', async function () {
         req.params.page = 2;
+
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
+            .resolves({
+                posts: posts,
+                meta: {
+                    pagination: {
+                        pages: 5
+                    }
+                }
+            });
+
+        await controllers.collection(req, res, next);
+        sinon.assert.calledOnce(themeEngine.getActive);
+        sinon.assert.notCalled(security.string.safe);
+        sinon.assert.calledOnce(fetchDataStub);
+        sinon.assert.calledOnce(ownsResourceStub);
+        sinon.assert.notCalled(next);
+    });
+
+    it('pass custom page param', async function () {
+        const configStub = sinon.stub(config, 'get');
+        configStub.callThrough();
+        configStub.withArgs('pagination:pageParameter').returns('seite');
+
+        req.params.seite = 2;
 
         fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({

--- a/ghost/core/test/unit/frontend/services/routing/page-param-config.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/page-param-config.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict');
+const getPageParam = require('../../../../../core/frontend/services/routing/page-param-config');
+const {setPageParam, DEFAULT_PAGE_PARAM} = getPageParam;
+
+describe('UNIT - services/routing/page-param-config', function () {
+    afterEach(function () {
+        setPageParam(DEFAULT_PAGE_PARAM);
+    });
+
+    it('returns "page" by default', function () {
+        setPageParam('page');
+        assert.equal(getPageParam(), 'page');
+    });
+
+    it('returns a valid custom value', function () {
+        setPageParam('seite');
+        assert.equal(getPageParam(), 'seite');
+    });
+
+    it('trims surrounding whitespace from a valid value', function () {
+        setPageParam('  seite  ');
+        assert.equal(getPageParam(), 'seite');
+    });
+
+    it('falls back to "page" for an empty value', function () {
+        setPageParam('');
+        assert.equal(getPageParam(), 'page');
+    });
+
+    it('falls back to "page" for a whitespace-only value', function () {
+        setPageParam('   ');
+        assert.equal(getPageParam(), 'page');
+    });
+
+    it('falls back to "page" for a non-string value', function () {
+        setPageParam(undefined);
+        assert.equal(getPageParam(), 'page');
+    });
+
+    it('falls back to "page" for values with unsafe url characters', function () {
+        ['foo/bar', 'foo?bar', 'foo#bar', 'foo:bar', 'foo bar'].forEach((value) => {
+            setPageParam(value);
+            assert.equal(getPageParam(), 'page', `expected fallback for "${value}"`);
+        });
+    });
+
+    it('falls back to "page" for reserved route segments', function () {
+        ['tag', 'author', 'rss', 'amp', 'TAG'].forEach((value) => {
+            setPageParam(value);
+            assert.equal(getPageParam(), 'page', `expected fallback for "${value}"`);
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/routing/page-parameter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/page-parameter.test.js
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const express = require('express');
+const request = require('supertest');
+
+const events = require('../../../../../core/server/lib/common/events');
+const controllers = require('../../../../../core/frontend/services/routing/controllers');
+const {setPageParam, DEFAULT_PAGE_PARAM} = require('../../../../../core/frontend/services/routing/page-param-config');
+
+const RESOURCE_CONFIG = {QUERY: {post: {controller: 'posts', resource: 'posts'}}};
+
+// Builds an express app with a freshly constructed CollectionRouter mounted on it.
+// The pagination segment comes from the route settings (pushed via setPageParam),
+// which mimics what router-manager.start() does at construction time.
+function buildApp(pagination) {
+    setPageParam(pagination);
+
+    const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
+
+    const router = new CollectionRouter('/', {permalink: '/:slug/', rss: false}, RESOURCE_CONFIG, () => {});
+
+    const app = express();
+    app.use(router.router());
+    app.use((err, _req, res, _next) => {
+        void _next;
+        res.status(err.statusCode || 404).json({errorType: err.name});
+    });
+
+    return app;
+}
+
+describe('UNIT - services/routing pagination page parameter', function () {
+    beforeEach(function () {
+        sinon.stub(events, 'emit');
+        sinon.stub(events, 'on');
+
+        const collectionStub = sinon.fake((req, res) => {
+            res.json({params: req.params});
+        });
+        sinon.stub(controllers, 'collection').get(() => collectionStub);
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        // Reset the global segment back to the default for the next test.
+        setPageParam(DEFAULT_PAGE_PARAM);
+    });
+
+    describe('default route settings (page)', function () {
+        it('serves /page/2/ and exposes the page param', async function () {
+            const app = buildApp(undefined);
+
+            const {body} = await request(app).get('/page/2/').expect(200);
+            assert.equal(body.params.page, 2);
+        });
+
+        it('redirects /page/1/ to / without a loop', async function () {
+            const app = buildApp(undefined);
+
+            await request(app)
+                .get('/page/1/')
+                .expect(301)
+                .expect('Location', '/');
+        });
+
+        it('does not serve a custom segment', async function () {
+            const app = buildApp(undefined);
+
+            await request(app).get('/seite/2/').expect(404);
+        });
+    });
+
+    describe('custom route settings (seite)', function () {
+        it('serves /seite/2/ and exposes the param under the configured name', async function () {
+            const app = buildApp('seite');
+
+            const {body} = await request(app).get('/seite/2/').expect(200);
+            assert.equal(body.params.seite, 2);
+        });
+
+        it('redirects /seite/1/ to / without a loop', async function () {
+            const app = buildApp('seite');
+
+            await request(app)
+                .get('/seite/1/')
+                .expect(301)
+                .expect('Location', '/');
+        });
+
+        it('no longer serves the default /page/ segment', async function () {
+            const app = buildApp('seite');
+
+            await request(app).get('/page/2/').expect(404);
+        });
+    });
+
+    describe('invalid route settings', function () {
+        function expectFallbackToPage(value) {
+            const app = buildApp(value);
+            return Promise.all([
+                request(app).get('/page/2/').expect(200),
+                request(app).get('/page/1/').expect(301).expect('Location', '/')
+            ]);
+        }
+
+        it('falls back to page for an empty value', async function () {
+            await expectFallbackToPage('');
+        });
+
+        it('falls back to page for a value containing a slash', async function () {
+            await expectFallbackToPage('foo/bar');
+        });
+
+        it('falls back to page for a reserved segment', async function () {
+            await expectFallbackToPage('tag');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/validate.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/validate.test.js
@@ -769,4 +769,38 @@ describe('UNIT: services/settings/validate', function () {
             throw new Error('should fail');
         });
     });
+
+    describe('pagination', function () {
+        it('omits pagination when the key is absent', function () {
+            const object = validate({});
+
+            assert.equal(Object.prototype.hasOwnProperty.call(object, 'pagination'), false);
+        });
+
+        it('accepts a valid custom segment and trims it', function () {
+            const object = validate({pagination: '  seite  '});
+
+            assert.equal(object.pagination, 'seite');
+        });
+
+        it('throws for a non-string value', function () {
+            assert.throws(() => validate({pagination: 5}), errors.ValidationError);
+        });
+
+        it('throws for an empty value', function () {
+            assert.throws(() => validate({pagination: '   '}), errors.ValidationError);
+        });
+
+        it('throws for unsafe url characters', function () {
+            ['foo/bar', 'foo?bar', 'foo#bar', 'foo:bar', 'foo bar'].forEach((value) => {
+                assert.throws(() => validate({pagination: value}), errors.ValidationError, `expected throw for "${value}"`);
+            });
+        });
+
+        it('throws for reserved route segments', function () {
+            ['tag', 'author', 'rss', 'amp', 'TAG'].forEach((value) => {
+                assert.throws(() => validate({pagination: value}), errors.ValidationError, `expected throw for "${value}"`);
+            });
+        });
+    });
 });


### PR DESCRIPTION
I created this PR as I want to use Ghost for my German website and the option to configure the name of the paging parameter was missing. Currently I have to live with www.geist.de/page/1 when I would rather use www.geist.de/seite/1 as that matches the language of my site. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable `pagination.pageParameter` and updates URL generation, routing, and template logic to use it.
> 
> - **Config**:
>   - Adds `pagination.pageParameter` (default: `"page"`) in `core/shared/config/defaults.json`.
> - **Frontend**:
>   - **URL Generation**: `core/frontend/meta/paginated-url.js` builds paginated URLs using configured page parameter and regex.
>   - **Routing Middleware**: `services/routing/middleware/page-param.js` validates/redirects using custom parameter and sets `req.params[<param>]`.
>   - **Controllers**: `services/routing/controllers/{channel,collection}.js` read `req.params[<param>]` to compute `page` and limits.
>   - **Rendering**:
>     - `services/rendering/context.js` detects `paged` context via custom parameter.
>     - `services/rendering/templates.js` passes `req.params[<param>]` to template resolution.
> - **Tests**:
>   - Extend unit tests to stub `config.get('pagination:pageParameter')` (e.g., `"seite"`) and verify URL/build/render behavior across `paginated-url`, `channel`, and `collection`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 188037c0b47d88914d4628c63aab0cb1e8b7054a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->