### PR TITLE
Fixed emailed button card missing bottom spacing

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -690,6 +690,10 @@ a[data-flickr-embed] img {
     height: auto;
 }
 
+td.kg-card-spacing {
+    padding: 0 0 1.5em 0;
+}
+
 /* Any card with altered visibility is wrapped in a div with the .kg-visibility-wrapper class */
 .kg-visibility-wrapper + * {
     margin-top: 1.5em !important;

--- a/ghost/core/core/server/services/koenig/node-renderers/button-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/button-renderer.js
@@ -65,10 +65,10 @@ function emailTemplate(node, options, document) {
         });
 
         cardHtml = html`
-        <table border="0" cellpadding="0" cellspacing="0">
+        <table class="kg-card kg-button-card" border="0" cellpadding="0" cellspacing="0">
             <tbody>
                 <tr>
-                    <td>
+                    <td class="kg-card-spacing">
                         ${buttonHtml}
                     </td>
                 </tr>

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/button-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/button-renderer.test.js
@@ -110,10 +110,10 @@ describe('services/koenig/node-renderers/button-renderer', function () {
             assert.ok(result.html);
 
             assertPrettifiesTo(result.html, html`
-                <table border="0" cellpadding="0" cellspacing="0">
+                <table class="kg-card kg-button-card" border="0" cellpadding="0" cellspacing="0">
                     <tbody>
                         <tr>
-                            <td>
+                            <td class="kg-card-spacing">
                                 <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
                                     <tbody>
                                         <tr>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1709

- after fixing the invalid HTML where we were wrapping a `<table>` with `<p>` we lost the "auto-corrected" `<p></p>` that clients added after the `<table>` which broke spacing below button cards
- added an explicit `kg-card-spacing` class to the card's `<td>` that wraps the button table
  - uses a re-usable class name as it may prove useful for fixing spacing in other cards
  - applies padding to the `<td>` rather than targeting the outer table to cater for Outlook
