### PR TITLE
Changed color indicator logic to hide swatches when not expanded

### DIFF
--- a/apps/admin-x-design-system/src/global/form/ColorIndicator.tsx
+++ b/apps/admin-x-design-system/src/global/form/ColorIndicator.tsx
@@ -37,7 +37,7 @@ const ColorSwatch: React.FC<{
         <button
             ref={ref}
             className={clsx(
-                `relative flex shrink-0 cursor-pointer items-center rounded-full border border-grey-250 dark:border-grey-800`,
+                `relative flex shrink-0 cursor-pointer items-center rounded-full border border-grey-300 dark:border-grey-800`,
                 sizeClass,
                 isSelected && 'outline outline-2 outline-green'
             )}
@@ -71,36 +71,41 @@ export interface ColorIndicatorProps {
 }
 
 /** Should usually be used via [ColorPickerField](?path=/docs/global-form-color-picker-field--docs) */
-const ColorIndicator: React.FC<ColorIndicatorProps> = ({title, value, swatches, swatchSize = 'md',onSwatchChange, onTogglePicker, isExpanded, picker = true, containerClassName}) => {
-    let selectedSwatch = swatches.find(swatch => swatch.value === value || swatch.hex === value);
-
-    if (isExpanded) {
-        selectedSwatch = undefined;
-    }
+const ColorIndicator: React.FC<ColorIndicatorProps> = ({title, value, swatches, swatchSize = 'md', onSwatchChange, onTogglePicker, isExpanded, picker = true, containerClassName}) => {
+    const selectedSwatch = swatches.find(swatch => swatch.value === value || swatch.hex === value);
 
     containerClassName = clsx(
         'flex flex-col gap-3'
     );
 
+    const showSwatches = isExpanded || !picker;
+
     return (
         <div className={containerClassName}>
             {title && <Heading useLabelTag>{title}</Heading>}
             <div className='flex gap-1'>
-                <div className={`flex items-center gap-1`}>
-                    {swatches.map(({customContent, ...swatch}) => (
-                        customContent ? <Fragment key={swatch.title}>{customContent}</Fragment> : <ColorSwatch key={swatch.title} isSelected={selectedSwatch?.title === swatch.title} size={swatchSize} onSelect={onSwatchChange} {...swatch} />
-                    ))}
-                </div>
-                {picker &&
+                {showSwatches && (
+                    <div className={`flex items-center gap-1`}>
+                        {swatches.map(({customContent, ...swatch}) => (
+                            customContent ? <Fragment key={swatch.title}>{customContent}</Fragment> : <ColorSwatch key={swatch.title} isSelected={selectedSwatch?.title === swatch.title} size={swatchSize} onSelect={onSwatchChange} {...swatch} />
+                        ))}
+                    </div>
+                )}
+                {picker && (
                     <button aria-label="Pick color" className="relative size-6 cursor-pointer rounded-full border border-grey-250 dark:border-grey-800" type="button" onClick={onTogglePicker}>
                         <div className='absolute inset-0 rounded-full bg-[conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))]' />
-                        {value && !selectedSwatch && (
+                        {selectedSwatch && (
+                            <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor: selectedSwatch.hex}}>
+                                {selectedSwatch.hex === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
+                            </div>
+                        )}
+                        {!selectedSwatch && value && (
                             <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor: value}}>
                                 {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
                             </div>
                         )}
                     </button>
-                }
+                )}
             </div>
         </div>
     );

--- a/apps/admin-x-settings/src/components/settings/growth/embedSignup/EmbedSignupSidebar.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embedSignup/EmbedSignupSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, ColorIndicator, ColorPicker, Form, Heading, LoadMultiSelectOptions, MultiSelect, MultiSelectOption, Radio, StickyFooter, TextArea, debounce} from '@tryghost/admin-x-design-system';
+import {Button, ButtonGroup, ColorPickerField, Form, Heading, LoadMultiSelectOptions, MultiSelect, MultiSelectOption, StickyFooter, TextArea, debounce} from '@tryghost/admin-x-design-system';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 import {MultiValue} from 'react-select';
 import {useFilterableApi} from '@tryghost/admin-x-framework/hooks';
@@ -33,8 +33,6 @@ const EmbedSignupSidebar: React.FC<SidebarProps> = ({selectedLayout,
     embedScript,
     handleLayoutSelect,
     handleCopyClick,
-    customColor,
-    setCustomColor,
     isCopied}) => {
     const {loadData} = useFilterableApi<Label>({path: '/labels/', filterKey: 'name', responseKey: 'labels'});
 
@@ -46,70 +44,57 @@ const EmbedSignupSidebar: React.FC<SidebarProps> = ({selectedLayout,
     return (
         <div className='flex h-[calc(100vh-16vmin)] max-h-[645px] flex-col justify-between overflow-y-scroll border-l border-grey-200 p-6 pb-0 dark:border-grey-900'>
             <div>
-                <Heading className='mb-4' level={4}>Embed signup form</Heading>
-                <Form>
-                    <Radio
-                        id='embed-layout'
-                        options={[
-                            {
-                                label: 'Branded',
-                                value: 'all-in-one'
-                            },
-                            {
-                                label: 'Minimal',
-                                value: 'minimal'
-                            }
-                        ]}
-                        selectedOption={selectedLayout}
-                        title='Layout'
-                        onSelect={(value) => {
-                            handleLayoutSelect(value);
-                        }}
-                    />
+                <Heading className='mb-8' level={4}>Embed signup form</Heading>
+                <Form gap='sm'>
+                    <div className='flex w-full items-center justify-between'>
+                        <div>Layout</div>
+                        <ButtonGroup 
+                            activeKey={selectedLayout} 
+                            buttons={[
+                                {
+                                    key: 'all-in-one',
+                                    label: 'Branded',
+                                    size: 'md',
+                                    className: 'w-auto !px-3',
+                                    onClick: () => handleLayoutSelect('all-in-one')
+                                },
+                                {
+                                    key: 'minimal',
+                                    label: 'Minimal',
+                                    size: 'md',
+                                    className: 'w-auto !px-3',
+                                    onClick: () => handleLayoutSelect('minimal')
+                                }
+                            ]} 
+                            clearBg={false}
+                        />
+                    </div>
                     {
                         selectedLayout === 'all-in-one' &&
-                        <ColorIndicator
-                            isExpanded={false}
+                        <ColorPickerField
+                            direction='rtl'
+                            eyedropper={true}
                             swatches={[
                                 {
                                     hex: '#08090c',
-                                    title: 'Dark'
+                                    title: 'Dark',
+                                    value: '#08090c'
                                 },
                                 {
                                     hex: '#ffffff',
-                                    title: 'Light'
+                                    title: 'Light',
+                                    value: '#ffffff'
                                 },
                                 {
                                     hex: (accentColor || '#d74780'),
-                                    title: 'Accent'
+                                    title: 'Accent',
+                                    value: (accentColor || '#d74780')
                                 }
                             ]}
-                            swatchSize='lg'
                             title='Background color'
                             value={selectedColor}
-                            onSwatchChange={(e) => {
-                                if (e && setCustomColor) {
-                                    handleColorToggle(e);
-                                    setCustomColor({active: false});
-                                }
-                            }}
-                            onTogglePicker={() => {
-                                if (setCustomColor) {
-                                    setCustomColor({active: true});
-                                }
-                            }}
-                        />
-                    }
-
-                    {
-                        selectedLayout === 'all-in-one' && customColor?.active &&
-                        <ColorPicker
-                            containerClassName='!-mt-4'
-                            eyedropper={false}
-                            hexValue={selectedColor || '#d74780'}
                             onChange={(e) => {
-                                if (setCustomColor && e) {
-                                    setCustomColor({active: true});
+                                if (e) {
                                     handleColorToggle(e);
                                 }
                             }}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1865/improve-color-picker-component
- Swatches are now hidden by default, and only shown when the color picker is expanded. This makes the UI a lot cleaner on a page with a lot of settings. The exception to this is when there's no custom color picker (like in the announcement bar settings) and only swatches – in that case they are permanently visible.
- The embed signup form settings now use the ColorPickerField and its logic rather than using the ColorIndicator and relying on custom logic.
- As the layout for the color picker setting changes in the embed signup form, the layout setting has been switched from radio buttons to a button group.
- The border color for the color indicator has been changed to grey-300 as it was nearly invisible.