### PR TITLE
🐛 Fix portal interpolation errors.

### DIFF
--- a/apps/portal/src/components/common/PopupNotification.js
+++ b/apps/portal/src/components/common/PopupNotification.js
@@ -6,7 +6,6 @@ import {ReactComponent as WarningIcon} from '../../images/icons/warning-fill.svg
 import {getSupportAddress} from '../../utils/helpers';
 import {clearURLParams} from '../../utils/notifications';
 import Interpolate from '@doist/react-interpolate';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 
 export const PopupNotificationStyles = `
     .gh-portal-popupnotification {
@@ -45,7 +44,6 @@ const NotificationText = ({message, site, t}) => {
     return (
         <p>
             <Interpolate
-                syntax={SYNTAX_I18NEXT}
                 string={t('An unexpected error occured. Please try again or <a>contact support</a> if the error persists.')}
                 mapping={{
                     a: <a href={supportAddressMail} onClick={() => {

--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -5,7 +5,6 @@ import {getCurrencySymbol, getPriceString, getStripeAmount, getMemberActivePrice
 import AppContext from '../../AppContext';
 import calculateDiscount from '../../utils/discount';
 import Interpolate from '@doist/react-interpolate';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 
 export const ProductsSectionStyles = () => {
     // const products = getSiteProducts({site});
@@ -746,13 +745,7 @@ function ProductCardButton({selectedProduct, product, disabled, noOfProducts, tr
 
     if (trialDays > 0) {
         return (
-            <Interpolate
-                syntax={SYNTAX_I18NEXT}
-                string={t('Start {amount}-day free trial')}
-                mapping={{
-                    amount: trialDays
-                }}
-            />
+            t('Start {amount}-day free trial', {amount: trialDays})
         );
     }
 

--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -745,7 +745,12 @@ function ProductCardButton({selectedProduct, product, disabled, noOfProducts, tr
 
     if (trialDays > 0) {
         return (
-            t('Start {amount}-day free trial', {amount: trialDays})
+            <Interpolate
+                string={t('Start {amount}-day free trial')}
+                mapping={{
+                    amount: trialDays
+                }}
+            />
         );
     }
 

--- a/apps/portal/src/components/pages/AccountEmailPage.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.js
@@ -1,7 +1,6 @@
 import AppContext from '../../AppContext';
 import {useContext, useEffect, useState} from 'react';
 import {isPaidMember, getSiteNewsletters, hasNewsletterSendingEnabled} from '../../utils/helpers';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 import NewsletterManagement from '../common/NewsletterManagement';
 import Interpolate from '@doist/react-interpolate';
 
@@ -45,7 +44,6 @@ export default function AccountEmailPage() {
                 <>
                     <p className={`gh-portal-text-center gh-portal-header-message ${hideClassName}`}>
                         <Interpolate
-                            syntax={SYNTAX_I18NEXT}
                             string={t('{memberEmail} will no longer receive emails when someone replies to your comments.')}
                             mapping={{
                                 memberEmail: <strong>{member?.email}</strong>
@@ -68,7 +66,6 @@ export default function AccountEmailPage() {
             <>
                 <p className={`gh-portal-text-center gh-portal-header-message ${hideClassName}`}>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t('{memberEmail} will no longer receive {newsletterName} newsletter.')}
                         mapping={{
                             memberEmail: <strong>{member?.email}</strong>,

--- a/apps/portal/src/components/pages/AccountPlanPage.js
+++ b/apps/portal/src/components/pages/AccountPlanPage.js
@@ -7,7 +7,6 @@ import {MultipleProductsPlansSection} from '../common/PlansSection';
 import {getDateString} from '../../utils/date-time';
 import {allowCompMemberUpgrade, formatNumber, getAvailablePrices, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 
 export const AccountPlanPageStyles = `
     .account-plan.full-size .gh-portal-main-title {
@@ -161,7 +160,6 @@ const PlanConfirmationSection = ({plan, type, onConfirm}) => {
             <div className="gh-portal-logged-out-form-container gh-portal-cancellation-form">
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`If you cancel your subscription now, you will continue to have access until {periodEnd}.`)}
                         mapping={{
                             periodEnd: <strong>{getDateString(subscription.current_period_end)}</strong>

--- a/apps/portal/src/components/pages/AccountPlanPage.test.js
+++ b/apps/portal/src/components/pages/AccountPlanPage.test.js
@@ -69,10 +69,18 @@ describe('Account Plan Page', () => {
 
     test('can cancel subscription for member on hidden tier', async () => {
         const overrides = generateAccountPlanFixture();
-        const {queryByRole} = customSetup(overrides);
+        const {queryByRole, queryByText} = customSetup(overrides);
         const cancelButton = queryByRole('button', {name: 'Cancel subscription'});
         expect(cancelButton).toBeInTheDocument();
         fireEvent.click(cancelButton);
+
+        // Check that the cancellation message is present
+        const cancellationMessage = queryByText(/If you cancel your subscription now, you will continue to have access until/i);
+        expect(cancellationMessage).toBeInTheDocument();
+
+        // Ensure the message doesn't contain the raw interpolation placeholder
+        expect(cancellationMessage.textContent).not.toContain('{periodEnd}');
+
         const confirmCancelButton = queryByRole('button', {name: 'Confirm cancellation'});
         expect(confirmCancelButton).toBeInTheDocument();
     });

--- a/apps/portal/src/components/pages/EmailReceivingFAQ.js
+++ b/apps/portal/src/components/pages/EmailReceivingFAQ.js
@@ -4,7 +4,6 @@ import BackButton from '../../components/common/BackButton';
 import CloseButton from '../../components/common/CloseButton';
 import {getDefaultNewsletterSender, getSupportAddress} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 
 export default function EmailReceivingPage() {
     const {brandColor, onAction, site, lastPage, member, t, pageData} = useContext(AppContext);
@@ -38,7 +37,6 @@ export default function EmailReceivingPage() {
 
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`The email address we have for you is {memberEmail} — if that's not correct, you can update it in your <button>account settings area</button>.`)}
                         mapping={{
                             memberEmail: <strong>{member.email}</strong>,
@@ -55,7 +53,6 @@ export default function EmailReceivingPage() {
 
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`In your email client add {senderEmail} to your contacts list. This signals to your mail provider that emails sent from this address should be trusted.`)}
                         mapping={{
                             senderEmail: <strong>{defaultNewsletterSenderEmail}</strong>
@@ -67,7 +64,6 @@ export default function EmailReceivingPage() {
 
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.`)}
                         mapping={{
                             senderEmail: <strong>{defaultNewsletterSenderEmail}</strong>
@@ -79,7 +75,6 @@ export default function EmailReceivingPage() {
 
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`If you have a corporate or government email account, reach out to your IT department and ask them to allow emails to be received from {senderEmail}`)}
                         mapping={{
                             senderEmail: <strong>{defaultNewsletterSenderEmail}</strong>
@@ -91,7 +86,6 @@ export default function EmailReceivingPage() {
 
                 <p>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t(`If you've completed all these checks and you're still not receiving emails, you can reach out to get support by contacting {supportAddress}.`)}
                         mapping={{
                             supportAddress: <a href={supportAddress} onClick={() => {

--- a/apps/portal/src/components/pages/UnsubscribePage.js
+++ b/apps/portal/src/components/pages/UnsubscribePage.js
@@ -6,7 +6,6 @@ import NewsletterManagement from '../common/NewsletterManagement';
 import CloseButton from '../common/CloseButton';
 import {ReactComponent as WarningIcon} from '../../images/icons/warning-fill.svg';
 import Interpolate from '@doist/react-interpolate';
-import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 import LoadingPage from './LoadingPage';
 
 function SiteLogo() {
@@ -188,7 +187,6 @@ export default function UnsubscribePage() {
                 <div>
                     <p className='gh-portal-text-center'>
                         <Interpolate
-                            syntax={SYNTAX_I18NEXT}
                             string={t('{memberEmail} will no longer receive this newsletter.')}
                             mapping={{
                                 memberEmail: <strong>{member?.email}</strong>
@@ -197,7 +195,6 @@ export default function UnsubscribePage() {
                     </p>
                     <p className='gh-portal-text-center'>
                         <Interpolate
-                            syntax={SYNTAX_I18NEXT}
                             string={t('Didn\'t mean to do this? Manage your preferences <button>here</button>.')}
                             mapping={{
                                 button: <button
@@ -221,7 +218,6 @@ export default function UnsubscribePage() {
                 <>
                     <p className={`gh-portal-text-center gh-portal-header-message ${hideClassName}`}>
                         <Interpolate
-                            syntax={SYNTAX_I18NEXT}
                             string={t('{memberEmail} will no longer receive emails when someone replies to your comments.')}
                             mapping={{
                                 memberEmail: <strong>{member?.email}</strong>
@@ -244,7 +240,6 @@ export default function UnsubscribePage() {
             <>
                 <p className={`gh-portal-text-center gh-portal-header-message ${hideClassName}`}>
                     <Interpolate
-                        syntax={SYNTAX_I18NEXT}
                         string={t('{memberEmail} will no longer receive {newsletterName} newsletter.')}
                         mapping={{
                             memberEmail: <strong>{member?.email}</strong>,


### PR DESCRIPTION

no ref

The Interpolate component used in some spots of Portal used SYNTAX_I18NEXT from @doist/react-interpolate, which expected double {{ instead of single. Since the default is single braces and we're now using single braces, I just needed to remove the syntax line.
