### PR TITLE
Fixed `oneline` tagged template handling of attrs on separate lines

### DIFF
--- a/ghost/core/core/server/services/koenig/render-utils/tagged-template-fns.js
+++ b/ghost/core/core/server/services/koenig/render-utils/tagged-template-fns.js
@@ -1,7 +1,15 @@
+function _oneline(string) {
+    return string
+        .replace(/\n\s+/g, ' ') // Replace newlines + whitespace with single space
+        .replace(/>\s+</g, '><') // Remove spaces between closing and opening tags
+        .replace(/\s+>/g, '>') // Remove unnecessary whitespace inside tag
+        .trim();
+}
+
 const oneline = function (strings, ...values) {
     // Handle case where a plain string is passed
     if (typeof strings === 'string') {
-        return strings.replace(/\n\s+/g, '').trim();
+        return _oneline(strings);
     }
 
     // Handle tagged template literal case
@@ -9,7 +17,7 @@ const oneline = function (strings, ...values) {
         return acc + str + (values[i] || '');
     }, '');
     // Remove newline+indentation patterns while preserving intentional whitespace
-    return result.replace(/\n\s+/g, '').trim();
+    return _oneline(result);
 };
 
 // Using `html` as a synonym for `oneline` in order to get syntax highlighting in editors

--- a/ghost/core/test/unit/server/services/koenig/render-utils/tagged-template-fns.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/tagged-template-fns.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert/strict');
+const {oneline} = require('../../../../../../core/server/services/koenig/render-utils/tagged-template-fns');
+
+describe('services/koenig/render-utils/tagged-template-fns', function () {
+    describe('oneline', function () {
+        it('removes indentation and normalizes whitespace', function () {
+            const buttonUrl = 'http://example.com';
+            const buttonText = 'Click me';
+            const alignment = 'center';
+
+            const result = oneline`
+                <div class="btn btn-accent">
+                    <table border="0" cellspacing="0" cellpadding="0" align="${alignment}">
+                        <tr>
+                            <td align="center">
+                                <a href="${buttonUrl}">${buttonText}</a>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            `;
+
+            assert.equal(result, '<div class="btn btn-accent"><table border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center"><a href="http://example.com">Click me</a></td></tr></table></div>');
+        });
+
+        it('works with plain strings', function () {
+            const result = oneline(`
+                <div class="test">
+                    <p>Hello world</p>
+                </div>
+            `);
+
+            assert.equal(result, '<div class="test"><p>Hello world</p></div>');
+        });
+
+        it('handles attributes on new lines', function () {
+            const result = oneline`
+                <div
+                    class="test classes"
+                    data-test="testing"
+                    style="color: red;"
+                >
+                </div>
+            `;
+
+            assert.equal(result, '<div class="test classes" data-test="testing" style="color: red;"></div>');
+        });
+    });
+});


### PR DESCRIPTION
no issue

- edge case discovered whilst working on a renderer template where attributes on their own line were being squashed into the tag name
- copied test over from Koenig and added failing test case
  - original file: https://github.com/TryGhost/Koenig/blob/1018abbf733b66c49667dcae13533fc267df1f44/packages/kg-default-nodes/test/utils/tagged-template-fns.test.mjs
- updated `oneline` function with better handling
