### PR TITLE
Converted header-v1 renderer from DOM to string template

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/header-v1-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v1-renderer.js
@@ -1,6 +1,7 @@
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {renderEmptyContainer} = require('../render-utils/render-empty-container');
 const {slugify} = require('../render-utils/slugify');
+const {html} = require('../render-utils/tagged-template-fns');
 
 function renderHeaderNodeV1(node, options = {}) {
     addCreateDocumentOption(options);
@@ -27,36 +28,34 @@ function renderHeaderNodeV1(node, options = {}) {
         backgroundImageSrc: node.backgroundImageSrc
     };
 
+    const headerHtml = html`
+        <div
+            class="kg-card kg-header-card kg-width-full kg-size-${templateData.size} kg-style-${templateData.style}"
+            data-kg-background-image="${templateData.backgroundImageSrc}"
+            style="${templateData.backgroundImageStyle}"
+        >
+            ${templateData.hasHeader && html`
+                <h2 class="kg-header-card-header" id="${templateData.headerSlug}">
+                    ${templateData.header}
+                </h2>
+            `}
+            ${templateData.hasSubheader && html`
+                <h3 class="kg-header-card-subheader" id="${templateData.subheaderSlug}">
+                    ${templateData.subheader}
+                </h3>
+            `}
+            ${templateData.buttonEnabled && html`
+                <a class="kg-header-card-button" href="${templateData.buttonUrl}">
+                    ${templateData.buttonText}
+                </a>
+            `}
+        </div>
+    `;
+
     const div = document.createElement('div');
-    div.classList.add('kg-card', 'kg-header-card', 'kg-width-full', `kg-size-${templateData.size}`, `kg-style-${templateData.style}`);
-    div.setAttribute('data-kg-background-image', templateData.backgroundImageSrc);
-    div.setAttribute('style', templateData.backgroundImageStyle);
+    div.innerHTML = headerHtml;
 
-    if (templateData.hasHeader) {
-        const headerElement = document.createElement('h2');
-        headerElement.classList.add('kg-header-card-header');
-        headerElement.setAttribute('id', templateData.headerSlug);
-        headerElement.innerHTML = templateData.header;
-        div.appendChild(headerElement);
-    }
-
-    if (templateData.hasSubheader) {
-        const subheaderElement = document.createElement('h3');
-        subheaderElement.classList.add('kg-header-card-subheader');
-        subheaderElement.setAttribute('id', templateData.subheaderSlug);
-        subheaderElement.innerHTML = templateData.subheader;
-        div.appendChild(subheaderElement);
-    }
-
-    if (templateData.buttonEnabled) {
-        const buttonElement = document.createElement('a');
-        buttonElement.classList.add('kg-header-card-button');
-        buttonElement.setAttribute('href', templateData.buttonUrl);
-        buttonElement.textContent = templateData.buttonText;
-        div.appendChild(buttonElement);
-    }
-
-    return {element: div};
+    return {element: div, type: 'inner'};
 }
 
 module.exports = renderHeaderNodeV1;


### PR DESCRIPTION
no issue

- scout rule cleanup to remove manual DOM building in renderers
- 1:1 match with previous output
