### PR TITLE
Updated header-v2 renderer to use emailButton partial

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1943,6 +1943,7 @@ table.btn a {
 table.btn-accent td {
     {{#if hasOutlineButtons}}
     border: 1px solid {{adjustedAccentColor}};
+    background-color: transparent;
     {{else}}
     background-color: {{adjustedAccentColor}};
     {{/if}}

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -1,6 +1,9 @@
+const {renderEmailButton} = require('../render-partials/email-button');
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {slugify} = require('../render-utils/slugify');
 const {getSrcsetAttribute} = require('../render-utils/srcset-attribute');
+
+// TODO: nodeData.buttonTextColor should be calculated on the fly here rather than hardcoded by the editor
 
 function cardTemplate(nodeData, options = {}) {
     const cardClasses = getCardClasses(nodeData).join(' ');
@@ -74,6 +77,8 @@ function emailTemplate(nodeData, options) {
     const backgroundImageStyle = nodeData.backgroundImageSrc ? (nodeData.layout !== 'split' ? `background-image: url(${nodeData.backgroundImageSrc}); background-size: cover; background-position: center center;` : `background-color: ${nodeData.backgroundColor};`) : `background-color: ${nodeData.backgroundColor};`;
     const splitImageStyle = `background-image: url(${nodeData.backgroundImageSrc}); background-size: ${nodeData.backgroundSize !== 'contain' ? 'cover' : '50%'}; background-position: center`;
 
+    const showButton = nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '';
+
     if (
         (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) &&
         options?.design?.buttonStyle === 'outline'
@@ -95,6 +100,14 @@ function emailTemplate(nodeData, options) {
             buttonTextColor = nodeData.buttonColor;
         }
     }
+
+    const buttonHtml = renderEmailButton({
+        url: nodeData.buttonUrl,
+        text: nodeData.buttonText,
+        alignment: nodeData.alignment,
+        color: nodeData.buttonColor,
+        style: options?.design?.buttonStyle
+    });
 
     if (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) {
         return (
@@ -122,15 +135,17 @@ function emailTemplate(nodeData, options) {
                                     </td>
                                 </tr>
                                 <tr>
-                                    ${nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '' ? `
+                                    ${showButton ? `
                                         <td class="kg-header-button-wrapper">
-                                            <table class="btn" border="0" cellspacing="0" cellpadding="0" align="${nodeData.alignment}">
-                                                <tr>
-                                                    <td align="center" style="${buttonStyle} ${buttonAccent}">
-                                                        <a href="${nodeData.buttonUrl}" style="color: ${buttonTextColor};">${nodeData.buttonText}</a>
-                                                    </td>
-                                                </tr>
-                                            </table>
+                                            ${options.feature?.emailCustomizationAlpha ? buttonHtml : `
+                                                <table class="btn" border="0" cellspacing="0" cellpadding="0" align="${nodeData.alignment}">
+                                                    <tr>
+                                                        <td align="center" style="${buttonStyle} ${buttonAccent}">
+                                                            <a href="${nodeData.buttonUrl}" style="color: ${buttonTextColor};">${nodeData.buttonText}</a>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            `}
                                         </td>
                                     ` : ''}
                                 </tr>
@@ -152,7 +167,7 @@ function emailTemplate(nodeData, options) {
             <div class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                 <h2 class="kg-header-card-heading" style="color:${nodeData.textColor};">${nodeData.header}</h2>
                 <p class="kg-header-card-subheading" style="color:${nodeData.textColor};">${nodeData.subheader}</p>
-                ${nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '' ? `
+                ${showButton ? `
                     <a class="kg-header-card-button" href="${nodeData.buttonUrl}" style="color: ${nodeData.buttonTextColor}; ${buttonStyle} ${buttonAccent}">${nodeData.buttonText}</a>
                 ` : ''}
             </div>

--- a/ghost/core/core/server/services/koenig/render-partials/email-button.js
+++ b/ghost/core/core/server/services/koenig/render-partials/email-button.js
@@ -1,34 +1,60 @@
 const clsx = require('clsx');
+const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 const {html} = require('../render-utils/tagged-template-fns.js');
+const stylex = require('../render-utils/stylex.js');
 
 /**
- * @param {Object} options
- * @param {string} [options.alignment]
- * @param {string} [options.color='accent']
- * @param {string} [options.text='']
- * @param {string} [options.textColor]
- * @param {string} [options.url='']
- * @param {string} [options.buttonWidth='']
+ * @typedef {Object} EmailButtonOptions
+ * @property {string} [url=''] - The URL the button links to
+ * @property {string} [text=''] - The text displayed on the button
+ * @property {string} [alignment] - The alignment of the button
+ * @property {string} [buttonWidth=''] - The width of the button
+ * @property {string} [color='accent'] - The color of the button
+ * @property {'fill'|'outline'} [style='fill'] - The style of the button
+ */
+
+const defaultOptions = {
+    url: '',
+    text: '',
+    alignment: '',
+    buttonWidth: '',
+    color: 'accent',
+    style: /** @type {'fill'|'outline'} */ ('fill')
+};
+
+/**
+ * @param {EmailButtonOptions} buttonOptions
+ * @returns {EmailButtonOptions}
+ */
+function _getOptions(buttonOptions = {}) {
+    // merge with defaults
+    // but we don't want undefined values to override default values
+    return {
+        ...defaultOptions,
+        ...Object.fromEntries(
+            Object.entries(buttonOptions).filter(([, value]) => value !== undefined)
+        )
+    };
+}
+
+/**
+ * @param {EmailButtonOptions} buttonOptions
  * @returns {string}
  */
-function renderEmailButton({
-    alignment = '',
-    color = 'accent',
-    text = '',
-    url = '',
-    buttonWidth = ''
-} = {}) {
-    const buttonClasses = clsx(
-        'btn',
-        color === 'accent' && 'btn-accent'
-    );
+function renderEmailButton(buttonOptions = {}) {
+    const options = _getOptions(buttonOptions);
+    const {url, text, alignment, buttonWidth} = options;
+
+    const buttonClasses = _getButtonClasses(options);
+    const buttonStyle = _getButtonStyle(options);
+    const linkStyle = _getLinkStyle(options);
 
     return html`
         <table class="${buttonClasses}" border="0" cellspacing="0" cellpadding="0"${alignment ? ` align="${alignment}"` : ''}>
             <tbody>
                 <tr>
-                    <td align="center"${buttonWidth ? ` width="${buttonWidth}"` : ''}>
-                        <a href="${url}">${text}</a>
+                    <td align="center"${buttonWidth ? ` width="${buttonWidth}"` : ''}${buttonStyle ? ` style="${buttonStyle}"` : ''}>
+                        <a href="${url}"${linkStyle ? ` style="${linkStyle}"` : ''}>${text}</a>
                     </td>
                 </tr>
             </tbody>
@@ -36,6 +62,86 @@ function renderEmailButton({
     `;
 }
 
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {boolean}
+ */
+function _isColoredFill({color, style}) {
+    return color !== 'accent' && color !== 'transparent' && style === 'fill';
+}
+
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {boolean}
+ */
+function _isColoredOutline({color, style}) {
+    return color !== 'accent' && style === 'outline';
+}
+
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {string}
+ */
+function _getTextColor({color, style}) {
+    if (_isColoredFill({color, style})) {
+        return textColorForBackgroundColor(color).hex();
+    }
+
+    return '';
+}
+
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {string}
+ */
+function _getButtonClasses({color}) {
+    return clsx(
+        'btn',
+        color === 'accent' && 'btn-accent'
+    );
+}
+
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {string}
+ */
+function _getButtonStyle({color, style}) {
+    return stylex(
+        _isColoredFill({color, style}) && {
+            backgroundColor: color
+        },
+        _isColoredOutline({color, style}) && {
+            border: `1px solid ${color}`,
+            backgroundColor: 'transparent',
+            color: `${color} !important`
+        }
+    );
+}
+
+/**
+ * @param {EmailButtonOptions} options
+ * @returns {string}
+ */
+function _getLinkStyle({color, style}) {
+    const textColor = _getTextColor({color, style});
+
+    return stylex(
+        _isColoredFill({color, style}) && textColor && {
+            color: `${textColor} !important`
+        },
+        _isColoredOutline({color, style}) && {
+            color: `${color} !important`
+        }
+    );
+}
+
 module.exports = {
-    renderEmailButton
+    renderEmailButton,
+    _getOptions,
+    _isColoredFill,
+    _isColoredOutline,
+    _getTextColor,
+    _getButtonClasses,
+    _getButtonStyle,
+    _getLinkStyle
 };

--- a/ghost/core/core/server/services/koenig/render-utils/stylex.js
+++ b/ghost/core/core/server/services/koenig/render-utils/stylex.js
@@ -1,0 +1,104 @@
+/**
+ * Converts a camelCase string to kebab-case
+ * @param {string} str - The string to convert
+ * @returns {string} The kebab-case string
+ */
+function toKebabCase(str) {
+    return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Formats a CSS value, adding units where necessary
+ * @param {string} key - The CSS property name
+ * @param {*} value - The value to format
+ * @returns {string} The formatted CSS value
+ */
+function formatValue(key, value) {
+    if (value === null || value === undefined || value === '') {
+        return '';
+    }
+
+    // Properties that should get px units for numeric values
+    const needsPx = /^(width|height|top|right|bottom|left|margin|padding|fontSize|borderRadius|marginTop|marginRight|marginBottom|marginLeft|paddingTop|paddingRight|paddingBottom|paddingLeft|borderTopWidth|borderRightWidth|borderBottomWidth|borderLeftWidth)$/;
+
+    // Properties that should never get px units
+    const noPx = /^(lineHeight|opacity|zIndex|flexGrow|flexShrink|order)$/;
+
+    if (typeof value === 'number') {
+        if (needsPx.test(key)) {
+            return `${value}px`;
+        }
+        if (!noPx.test(key)) {
+            return `${value}px`;
+        }
+    }
+
+    return String(value);
+}
+
+/**
+ * Parses a CSS string into an object of style properties
+ * @param {string} cssString - The CSS string to parse
+ * @returns {Object} Object containing style properties
+ */
+function parseCssString(cssString) {
+    if (typeof cssString !== 'string') {
+        return {};
+    }
+
+    const styles = {};
+    const declarations = cssString.split(';').filter(Boolean);
+
+    declarations.forEach((declaration) => {
+        const [property, value] = declaration.split(':').map(part => part.trim());
+        if (property && value) {
+            // Convert kebab-case to camelCase for consistency
+            const camelCaseProperty = property.replace(/-([a-z])/g, g => g[1].toUpperCase());
+            styles[camelCaseProperty] = value;
+        }
+    });
+
+    return styles;
+}
+
+/**
+ * Combines multiple style objects and CSS strings into a single CSS string
+ * @param {...(Object|string)} styles - Style objects or CSS strings to combine
+ * @returns {string} Combined CSS string
+ */
+function stylex(...styles) {
+    const mergedStyles = {};
+
+    // Process each style argument
+    styles.forEach((style) => {
+        if (!style) {
+            return;
+        }
+
+        if (typeof style === 'string') {
+            // Handle CSS strings
+            const parsedStyles = parseCssString(style);
+            Object.assign(mergedStyles, parsedStyles);
+        } else if (typeof style === 'object') {
+            // Handle style objects
+            Object.entries(style).forEach(([key, value]) => {
+                if (value !== null && value !== false) {
+                    mergedStyles[key] = value;
+                }
+            });
+        }
+    });
+
+    // Convert to CSS string with spaces after semicolons
+    const styleString = Object.entries(mergedStyles)
+        .map(([key, value]) => {
+            const formattedValue = formatValue(key, value);
+            return formattedValue ? `${toKebabCase(key)}: ${formattedValue}` : '';
+        })
+        .filter(Boolean)
+        .join('; ');
+
+    return styleString ? styleString + ';' : '';
+}
+
+module.exports = stylex;

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert/strict');
-const {callRenderer, html, assertPrettifiesTo} = require('../test-utils');
+const should = require('should');
+const {callRenderer, html, assertPrettifiesTo, assertPrettifiedIncludes} = require('../test-utils');
 
 describe('services/koenig/node-renderers/header-v2-renderer', function () {
     function getTestData(overrides = {}) {
@@ -249,8 +250,8 @@ describe('services/koenig/node-renderers/header-v2-renderer', function () {
                                                             <tr>
                                                                 <td
                                                                     align="center"
-                                                                    style="background-color: #ffffff; #ffffff">
-                                                                    <a href="https://example.com/" style="color: #000000">The button</a>
+                                                                    style="background-color: #ffffff;">
+                                                                    <a href="https://example.com/" style="color: #000000 !important;">The button</a>
                                                                 </td>
                                                             </tr>
                                                         </tbody>
@@ -264,6 +265,16 @@ describe('services/koenig/node-renderers/header-v2-renderer', function () {
                         </tbody>
                     </table>
                 </div>
+            `);
+        });
+
+        it('has expected button output for outline buttons', function () {
+            const result = renderForEmail(getTestData(), {design: {buttonStyle: 'outline'}, feature: {emailCustomizationAlpha: true}});
+
+            assertPrettifiedIncludes(result.html, html`
+                <td align="center" style="border: 1px solid #ffffff; background-color: transparent; color: #ffffff !important">
+                    <a href="https://example.com/" style="color: #ffffff !important">The button</a>
+                </td>
             `);
         });
     });

--- a/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
@@ -1,0 +1,101 @@
+const assert = require('assert/strict');
+const emailButton = require('../../../../../../core/server/services/koenig/render-partials/email-button');
+
+describe('koenig/services/render-partials/email-button', function () {
+    describe('_getOptions', function () {
+        it('returns default options when no options are provided', function () {
+            const result = emailButton._getOptions();
+            assert.deepEqual(result, {
+                url: '',
+                text: '',
+                alignment: '',
+                buttonWidth: '',
+                color: 'accent',
+                style: 'fill'
+            });
+        });
+        it('returns merged options when options are provided', function () {
+            const result = emailButton._getOptions({text: 'testing', color: 'blue'});
+            assert.deepEqual(result, {
+                url: '',
+                text: 'testing',
+                alignment: '',
+                buttonWidth: '',
+                color: 'blue',
+                style: 'fill'
+            });
+        });
+        it('does not override default options when given undefined', function () {
+            const result = emailButton._getOptions({style: undefined});
+            assert.deepEqual(result, {
+                url: '',
+                text: '',
+                alignment: '',
+                buttonWidth: '',
+                color: 'accent',
+                style: 'fill'
+            });
+        });
+    });
+
+    describe('_getTextColor', function () {
+        it('returns blank string when not a colored fill', function () {
+            const result = emailButton._getTextColor({color: 'accent', style: 'outline'});
+            assert.equal(result, '');
+        });
+        it('returns black for light colored fill', function () {
+            const result = emailButton._getTextColor({color: '#dddddd', style: 'fill'});
+            assert.equal(result, '#000000');
+        });
+        it('returns white for a dark colored fill', function () {
+            const result = emailButton._getTextColor({color: '#222222', style: 'fill'});
+            assert.equal(result, '#FFFFFF');
+        });
+    });
+
+    describe('_getButtonClasses', function () {
+        it('returns btn class', function () {
+            const result = emailButton._getButtonClasses({color: '#ffffff'});
+            assert.equal(result, 'btn');
+        });
+        it('returns btn-accent class for accent color', function () {
+            const result = emailButton._getButtonClasses({color: 'accent'});
+            assert.equal(result, 'btn btn-accent');
+        });
+    });
+
+    describe('_getButtonStyle', function () {
+        it('returns blank string for filled accent button', function () {
+            const result = emailButton._getButtonStyle({color: 'accent', style: 'fill'});
+            assert.equal(result, '');
+        });
+        it('returns blank string for outline accent button', function () {
+            const result = emailButton._getButtonStyle({color: 'accent', style: 'outline'});
+            assert.equal(result, '');
+        });
+        it('returns expected style for filled custom color button', function () {
+            const result = emailButton._getButtonStyle({color: '#222222', style: 'fill'});
+            assert.equal(result, 'background-color: #222222;');
+        });
+        it('returns expected style for outline custom color button', function () {
+            const result = emailButton._getButtonStyle({color: '#222222', style: 'outline'});
+            assert.equal(result, 'border: 1px solid #222222; background-color: transparent; color: #222222 !important;');
+        });
+    });
+
+    describe('_getLinkStyle', function () {
+        it('returns blank string for filled accent button', function () {
+            const result = emailButton._getLinkStyle({color: 'accent', style: 'fill'});
+            assert.equal(result, '');
+        });
+        it('returns expected style for filled custom color button', function () {
+            // white text on dark background
+            const result = emailButton._getLinkStyle({color: '#222222', style: 'fill'});
+            assert.equal(result, 'color: #FFFFFF !important;');
+        });
+        it('returns expected style for outline custom color button', function () {
+            const result = emailButton._getLinkStyle({color: '#222222', style: 'outline'});
+            assert.equal(result, 'color: #222222 !important;');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/koenig/render-utils/stylex.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/stylex.test.js
@@ -1,0 +1,137 @@
+const assert = require('assert/strict');
+const stylex = require('../../../../../../core/server/services/koenig/render-utils/stylex');
+
+describe('stylex', function () {
+    it('combines multiple style objects', function () {
+        const result = stylex(
+            {width: 100, height: 50},
+            {backgroundColor: 'red'},
+            {display: 'flex'}
+        );
+        assert.equal(result, 'width: 100px; height: 50px; background-color: red; display: flex;');
+    });
+
+    it('handles conditional styles', function () {
+        const isActive = true;
+        const isHidden = false;
+
+        const result = stylex(
+            {color: 'black'},
+            isActive && {backgroundColor: 'blue'},
+            isHidden && {display: 'none'}
+        );
+        assert.equal(result, 'color: black; background-color: blue;');
+    });
+
+    it('converts camelCase to kebab-case', function () {
+        const result = stylex({
+            backgroundColor: 'red',
+            fontSize: 16,
+            marginTop: 10,
+            borderBottomWidth: 2
+        });
+        assert.equal(result, 'background-color: red; font-size: 16px; margin-top: 10px; border-bottom-width: 2px;');
+    });
+
+    it('adds px units to numeric values for specific properties', function () {
+        const result = stylex({
+            width: 100,
+            height: 50,
+            margin: 20,
+            padding: 10,
+            fontSize: 16,
+            lineHeight: 1.5,
+            borderRadius: 5
+        });
+        assert.equal(result, 'width: 100px; height: 50px; margin: 20px; padding: 10px; font-size: 16px; line-height: 1.5; border-radius: 5px;');
+    });
+
+    it('handles null, undefined, and empty values', function () {
+        const result = stylex(
+            {color: 'black'},
+            {backgroundColor: null},
+            {display: undefined},
+            {margin: ''}
+        );
+        assert.equal(result, 'color: black;');
+    });
+
+    it('handles non-numeric values without adding units', function () {
+        const result = stylex({
+            width: '100%',
+            height: 'auto',
+            margin: '1em',
+            padding: '2rem',
+            fontSize: 'inherit'
+        });
+        assert.equal(result, 'width: 100%; height: auto; margin: 1em; padding: 2rem; font-size: inherit;');
+    });
+
+    it('handles empty input', function () {
+        assert.equal(stylex(), '');
+        assert.equal(stylex(null), '');
+        assert.equal(stylex(undefined), '');
+        assert.equal(stylex({}), '');
+    });
+
+    it('handles nested style objects', function () {
+        const result = stylex(
+            {color: 'black'},
+            {...{backgroundColor: 'red'}}
+        );
+        assert.equal(result, 'color: black; background-color: red;');
+    });
+
+    it('preserves order of properties', function () {
+        const result = stylex(
+            {width: 100, height: 50},
+            {width: 200} // Should override previous width
+        );
+        assert.equal(result, 'width: 200px; height: 50px;');
+    });
+
+    it('handles plain CSS strings', function () {
+        const result = stylex(
+            'background-color: blue; color: white',
+            {margin: 20}
+        );
+        assert.equal(result, 'background-color: blue; color: white; margin: 20px;');
+    });
+
+    it('handles mixed string and object inputs', function () {
+        const result = stylex(
+            'padding: 10px; border: 1px solid black',
+            {backgroundColor: 'red'},
+            'margin: 20px'
+        );
+        assert.equal(result, 'padding: 10px; border: 1px solid black; background-color: red; margin: 20px;');
+    });
+
+    it('handles malformed CSS strings', function () {
+        const result = stylex(
+            'invalid-css',
+            'color: red;',
+            ';margin: 10px;',
+            {backgroundColor: 'blue'}
+        );
+        assert.equal(result, 'color: red; margin: 10px; background-color: blue;');
+    });
+
+    it('handles whitespace in CSS strings', function () {
+        const result = stylex(
+            '  color  :  red  ;  margin  :  10px  ',
+            {backgroundColor: 'blue'}
+        );
+        assert.equal(result, 'color: red; margin: 10px; background-color: blue;');
+    });
+
+    it('always includes trailing semicolon', function () {
+        const result = stylex({color: 'red'});
+        assert.equal(result, 'color: red;');
+    });
+
+    it('includes space between style name and value', function () {
+        const result = stylex({color: 'red'});
+        assert.equal(result, 'color: red;');
+    });
+});

--- a/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettified-includes.js
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettified-includes.js
@@ -1,0 +1,31 @@
+const assert = require('assert/strict');
+const prettifyHTML = require('./prettify-html');
+
+function normalizeWhitespace(html) {
+    return html
+        .replace(/\s+/g, ' ') // Replace all whitespace sequences with a single space
+        .replace(/>\s+</g, '><') // Remove spaces between tags
+        .trim();
+}
+
+function assertPrettifiedIncludes(actual, expected) {
+    const actualPrettified = prettifyHTML(actual);
+    const expectedPrettified = prettifyHTML(expected);
+
+    const normalizedActual = normalizeWhitespace(actualPrettified);
+    const normalizedExpected = normalizeWhitespace(expectedPrettified);
+
+    const message = [
+        'Expected HTML to include substring:',
+        '',
+        'Received:',
+        actualPrettified,
+        '',
+        'Expected:',
+        expectedPrettified
+    ].join('\n');
+
+    assert.ok(normalizedActual.includes(normalizedExpected), message);
+}
+
+module.exports = assertPrettifiedIncludes;

--- a/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettifies-to.js
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/assert-prettifies-to.js
@@ -1,6 +1,5 @@
-const Prettier = require('@prettier/sync');
 const assert = require('assert/strict');
-const minify = require('html-minifier').minify;
+const prettifyHTML = require('./prettify-html');
 
 /**
  * Asserts that the given HTML string prettifies to match the expected string
@@ -11,13 +10,10 @@ function assertPrettifiesTo(actual, expected) {
     assert.equal(typeof actual, 'string', 'First argument must be a string');
     assert.equal(typeof expected, 'string', 'Second argument must be a string');
 
-    const minifiedExpected = minify(expected, {collapseWhitespace: true, collapseInlineTagWhitespace: true});
-    const expectedStr = Prettier.format(minifiedExpected, {parser: 'html'});
+    const expectedStr = prettifyHTML(expected);
+    const actualStr = prettifyHTML(actual);
 
-    const minified = minify(actual, {collapseWhitespace: true, collapseInlineTagWhitespace: true});
-    const result = Prettier.format(minified, {parser: 'html'});
-
-    assert.equal(result, expectedStr);
+    assert.equal(actualStr, expectedStr);
 }
 
 module.exports = assertPrettifiesTo;

--- a/ghost/core/test/unit/server/services/koenig/test-utils/index.js
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/index.js
@@ -6,5 +6,6 @@ module.exports = {
     assertPrettifiesTo: require('./assert-prettifies-to'),
     callRenderer: require('./build-call-renderer')(dom),
     html: require('./html'),
+    prettifyHTML: require('./prettify-html'),
     visibility: require('./visibility')
 };

--- a/ghost/core/test/unit/server/services/koenig/test-utils/index.js
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/index.js
@@ -3,6 +3,7 @@ const jsdom = require('jsdom');
 const dom = new jsdom.JSDOM();
 
 module.exports = {
+    assertPrettifiedIncludes: require('./assert-prettified-includes'),
     assertPrettifiesTo: require('./assert-prettifies-to'),
     callRenderer: require('./build-call-renderer')(dom),
     html: require('./html'),

--- a/ghost/core/test/unit/server/services/koenig/test-utils/prettify-html.js
+++ b/ghost/core/test/unit/server/services/koenig/test-utils/prettify-html.js
@@ -1,0 +1,11 @@
+const Prettier = require('@prettier/sync');
+const minify = require('html-minifier').minify;
+
+function prettifyHTML(html) {
+    const minified = minify(html, {collapseWhitespace: true, collapseInlineTagWhitespace: true});
+    const prettified = Prettier.format(minified, {parser: 'html'});
+
+    return prettified;
+}
+
+module.exports = prettifyHTML;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1709

- aligns button handling in header-v2 renderer with button and product card renderers
- updates `emailButton` partial to support custom colored outline buttons
- updates `emailButton` to calculate text color based on background color
  - avoids needing to hardcode text color in node data (hardcoding calculated values is an anti-pattern)
- fixed styles to ensure accent outline buttons have transparent backgrounds
- extracts inner functions in `emailButton` partial to facilitate easier unit testing

TODO:
- [ ] ~move `stylex` to separate PR~
- [x] add fill button behaviour to partial function
- [x] move text color calculation to the partial renderer so it adjusts correctly if accent or button color gets changed
  - currently it gets calculated in the editor when button color is chosen but has potential to fail because colors that calculation depends on can be changed at a later date outside of the editor
- [x] add button partial tests
- [x] update header-v2 tests to cover other scenarios (no button, accent/colored fill buttons, accent/colored outline buttons)