### PR TITLE
Improved new note and reply flow UX in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.49",
+  "version": "0.7.50",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.47",
+  "version": "0.7.48",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -324,7 +324,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                         {(type === 'Announce') && <div className='z-10 mb-2 flex items-center gap-1.5 text-gray-700 dark:text-gray-600'>
                             {repostIcon}
                             <div className='flex min-w-0 items-center gap-1 text-sm'>
-                                <span className='break-anywhere truncate hover:underline' title={getUsername(actor)} onClick={(e) => {
+                                <span className='truncate break-anywhere hover:underline' title={getUsername(actor)} onClick={(e) => {
                                     handleProfileClick(actor, navigate, e);
                                 }}>{actor.name}</span>
                                 reposted
@@ -338,7 +338,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         handleProfileClick(author, navigate, e);
                                     }
                                 }}>
-                                    <span className={`break-anywhere min-w-0 truncate font-semibold leading-[normal] ${isCompact ? 'text-lg' : 'text-md'} ${!isPending ? 'hover-underline' : ''} dark:text-white`}
+                                    <span className={`min-w-0 truncate font-semibold leading-[normal] break-anywhere ${isCompact ? 'text-lg' : 'text-md'} ${!isPending ? 'hover-underline' : ''} dark:text-white`}
                                         data-test-activity-heading
                                     >
                                         {!isLoading ? author.name : <Skeleton className='w-24' />}
@@ -364,15 +364,15 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             <div className='relative col-start-2 col-end-3 w-full gap-4 pl-[52px]'>
                                 <div className='flex flex-col'>
                                     <div className=''>
-                                        {(object.type === 'Article') ? <div className='border-gray-150 hover:bg-gray-75 rounded-md border transition-colors dark:border-gray-950 dark:hover:bg-gray-950'>
+                                        {(object.type === 'Article') ? <div className='rounded-md border border-gray-150 transition-colors hover:bg-gray-75 dark:border-gray-950 dark:hover:bg-gray-950'>
                                             {renderFeedAttachment(object, openLightbox)}
                                             <div className='p-5'>
-                                                <div className='break-anywhere mb-1 line-clamp-2 text-pretty text-lg font-semibold leading-tight tracking-tight' data-test-activity-heading>{object.name}</div>
-                                                <div className='break-anywhere line-clamp-3 leading-[1.4em]'>{object.preview?.content}</div>
+                                                <div className='mb-1 line-clamp-2 text-pretty text-lg font-semibold leading-tight tracking-tight break-anywhere' data-test-activity-heading>{object.name}</div>
+                                                <div className='line-clamp-3 leading-[1.4em] break-anywhere'>{object.preview?.content}</div>
                                             </div>
                                         </div> :
                                             <div className='relative'>
-                                                <div className='ap-note-content break-anywhere line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'>
+                                                <div className='ap-note-content line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'>
                                                     {!isLoading ?
                                                         <div dangerouslySetInnerHTML={{
                                                             __html: openLinksInNewTab(object.content || '') ?? ''
@@ -410,7 +410,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                 repostCount={repostCount}
                                                 onLikeClick={onLikeClick}
                                             /> :
-                                            <Skeleton className='w-18 ml-2' />
+                                            <Skeleton className='ml-2 w-18' />
                                         }
                                     </div>
                                 </div>
@@ -436,7 +436,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             <div className={`z-10 -my-1 grid grid-cols-[auto_1fr] grid-rows-[auto_1fr] gap-3 pb-3 pt-4`} data-test-activity>
                                 {(type === 'Announce') && <div className='z-10 col-span-2 mb-2 flex items-center gap-2 text-gray-700 dark:text-gray-600'>
                                     <div>{repostIcon}</div>
-                                    <span className='flex min-w-0 items-center gap-1'><span className='break-anywhere truncate hover:underline' title={getUsername(actor)} onClick={(e) => {
+                                    <span className='flex min-w-0 items-center gap-1'><span className='truncate break-anywhere hover:underline' title={getUsername(actor)} onClick={(e) => {
                                         handleProfileClick(actor, navigate, e);
                                     }}>{actor.name}</span> reposted</span>
                                 </div>}
@@ -450,7 +450,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         }
                                     }}>
                                         <div className='flex w-full'>
-                                            <span className='break-anywhere min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
+                                            <span className='min-w-0 truncate whitespace-nowrap font-semibold break-anywhere after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
                                             <div>{renderTimestamp(object, !object.authored)}</div>
                                         </div>
                                         <div className='flex w-full'>
@@ -460,8 +460,8 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </>}
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
-                                        {object.name && <H4 className='break-anywhere mb-1 leading-tight' data-test-activity-heading>{object.name}</H4>}
-                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large break-anywhere text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>
+                                        {object.name && <H4 className='mb-1 leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
+                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>
                                         {renderFeedAttachment(object, openLightbox)}
                                         <div className='space-between ml-[-8px] mt-3 flex'>
                                             {showStats && <FeedItemStats
@@ -509,7 +509,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         }
                                     }}>
                                         <div className='flex'>
-                                            <span className='break-anywhere min-w-0 truncate whitespace-nowrap font-semibold text-black after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] dark:text-white' data-test-activity-heading>{author.name}</span>
+                                            <span className='min-w-0 truncate whitespace-nowrap font-semibold text-black break-anywhere after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] dark:text-white' data-test-activity-heading>{author.name}</span>
                                             <div>{renderTimestamp(object, (isPending === false && !object.authored))}</div>
                                         </div>
                                         <div className='flex'>
@@ -528,8 +528,8 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className={`relative z-10 col-start-2 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {(object.type === 'Article') && renderFeedAttachment(object, openLightbox)}
-                                        {object.name && <H4 className='break-anywhere mt-2.5 text-pretty leading-tight' data-test-activity-heading>{object.name}</H4>}
-                                        {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content break-anywhere text-pretty tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>}
+                                        {object.name && <H4 className='mt-2.5 text-pretty leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
+                                        {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>}
                                         {(object.type === 'Note') && renderFeedAttachment(object, openLightbox)}
                                         {(object.type === 'Article') && <Button
                                             className='mt-3 w-full'
@@ -569,13 +569,13 @@ const FeedItem: React.FC<FeedItemProps> = ({
         return (
             <>
                 {object && (
-                    <div className='group/article hover:bg-gray-75 relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
+                    <div className='group/article relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 hover:bg-gray-75 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
                         <div className='w-full min-w-0'>
                             <div className='z-10 mb-1.5 flex w-full min-w-0 items-center gap-1.5 text-sm group-hover/article:border-transparent'>
                                 {!isLoading ?
                                     <>
                                         <APAvatar author={author} size='2xs' />
-                                        <span className='break-anywhere min-w-0 truncate font-semibold text-gray-900 hover:underline dark:text-gray-600'
+                                        <span className='min-w-0 truncate font-semibold text-gray-900 break-anywhere hover:underline dark:text-gray-600'
                                             title={getUsername(author)}
                                             data-test-activity-heading
                                             onClick={(e) => {
@@ -593,14 +593,14 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             </div>
                             <div className='flex'>
                                 <div className='flex min-h-[73px] w-full min-w-0 flex-col items-start justify-start gap-1'>
-                                    <H4 className='break-anywhere line-clamp-2 w-full max-w-[600px] text-pretty leading-tight' data-test-activity-heading>
+                                    <H4 className='line-clamp-2 w-full max-w-[600px] text-pretty leading-tight break-anywhere' data-test-activity-heading>
                                         {isLoading ? <Skeleton className='w-full max-w-96' /> : (object.name ? object.name : (
                                             <span dangerouslySetInnerHTML={{
                                                 __html: stripHtml(object.content || '')
                                             }}></span>
                                         ))}
                                     </H4>
-                                    <div className='ap-note-content break-anywhere line-clamp-2 w-full max-w-[600px] text-pretty text-base leading-normal text-gray-800 dark:text-gray-600 [&_p+p]:mt-3'>
+                                    <div className='ap-note-content line-clamp-2 w-full max-w-[600px] text-pretty text-base leading-normal text-gray-800 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'>
                                         {!isLoading ?
                                             <div dangerouslySetInnerHTML={{
                                                 __html: stripHtml(object.preview?.content ?? object.content ?? '')

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -195,8 +195,8 @@ interface FeedItemProps {
     last?: boolean;
     isLoading?: boolean;
     isPending?: boolean;
+    isCompact?: boolean;
     onClick?: () => void;
-    onCommentClick: () => void;
     onDelete?: () => void;
     showStats?: boolean;
 }
@@ -218,8 +218,8 @@ const FeedItem: React.FC<FeedItemProps> = ({
     last,
     isLoading,
     isPending = false,
+    isCompact = false,
     onClick: onClickHandler = noop,
-    onCommentClick,
     onDelete = noop,
     showStats = true
 }) => {
@@ -324,7 +324,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                         {(type === 'Announce') && <div className='z-10 mb-2 flex items-center gap-1.5 text-gray-700 dark:text-gray-600'>
                             {repostIcon}
                             <div className='flex min-w-0 items-center gap-1 text-sm'>
-                                <span className='truncate break-anywhere hover:underline' title={getUsername(actor)} onClick={(e) => {
+                                <span className='break-anywhere truncate hover:underline' title={getUsername(actor)} onClick={(e) => {
                                     handleProfileClick(actor, navigate, e);
                                 }}>{actor.name}</span>
                                 reposted
@@ -338,12 +338,12 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         handleProfileClick(author, navigate, e);
                                     }
                                 }}>
-                                    <span className={`min-w-0 truncate font-semibold leading-[normal] break-anywhere ${!isPending ? 'hover-underline' : ''} dark:text-white`}
+                                    <span className={`break-anywhere min-w-0 truncate font-semibold leading-[normal] ${isCompact ? 'text-lg' : 'text-md'} ${!isPending ? 'hover-underline' : ''} dark:text-white`}
                                         data-test-activity-heading
                                     >
                                         {!isLoading ? author.name : <Skeleton className='w-24' />}
                                     </span>
-                                    <div className='flex w-full text-sm text-gray-700 dark:text-gray-600'>
+                                    <div className={`flex w-full ${isCompact ? 'text-md' : 'text-sm'} text-gray-700 dark:text-gray-600`}>
                                         <span className={`truncate leading-tight ${!isPending ? 'hover-underline' : ''}`}>
                                             {!isLoading ? getUsername(author) : <Skeleton className='w-56' />}
                                         </span>
@@ -364,15 +364,15 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             <div className='relative col-start-2 col-end-3 w-full gap-4 pl-[52px]'>
                                 <div className='flex flex-col'>
                                     <div className=''>
-                                        {(object.type === 'Article') ? <div className='rounded-md border border-gray-150 transition-colors hover:bg-gray-75 dark:border-gray-950 dark:hover:bg-gray-950'>
+                                        {(object.type === 'Article') ? <div className='border-gray-150 hover:bg-gray-75 rounded-md border transition-colors dark:border-gray-950 dark:hover:bg-gray-950'>
                                             {renderFeedAttachment(object, openLightbox)}
                                             <div className='p-5'>
-                                                <div className='mb-1 line-clamp-2 text-pretty text-lg font-semibold leading-tight tracking-tight break-anywhere' data-test-activity-heading>{object.name}</div>
-                                                <div className='line-clamp-3 leading-[1.4em] break-anywhere'>{object.preview?.content}</div>
+                                                <div className='break-anywhere mb-1 line-clamp-2 text-pretty text-lg font-semibold leading-tight tracking-tight' data-test-activity-heading>{object.name}</div>
+                                                <div className='break-anywhere line-clamp-3 leading-[1.4em]'>{object.preview?.content}</div>
                                             </div>
                                         </div> :
                                             <div className='relative'>
-                                                <div className='ap-note-content line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'>
+                                                <div className='ap-note-content break-anywhere line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'>
                                                     {!isLoading ?
                                                         <div dangerouslySetInnerHTML={{
                                                             __html: openLinksInNewTab(object.content || '') ?? ''
@@ -401,16 +401,16 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <div className='space-between relative z-[30] ml-[-8px] mt-1 flex'>
                                         {!isLoading ?
                                             showStats && <FeedItemStats
+                                                actor={author}
                                                 commentCount={commentCount}
                                                 disabled={isPending}
                                                 layout={layout}
                                                 likeCount={1}
                                                 object={object}
                                                 repostCount={repostCount}
-                                                onCommentClick={onCommentClick}
                                                 onLikeClick={onLikeClick}
                                             /> :
-                                            <Skeleton className='ml-2 w-18' />
+                                            <Skeleton className='w-18 ml-2' />
                                         }
                                     </div>
                                 </div>
@@ -436,7 +436,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             <div className={`z-10 -my-1 grid grid-cols-[auto_1fr] grid-rows-[auto_1fr] gap-3 pb-3 pt-4`} data-test-activity>
                                 {(type === 'Announce') && <div className='z-10 col-span-2 mb-2 flex items-center gap-2 text-gray-700 dark:text-gray-600'>
                                     <div>{repostIcon}</div>
-                                    <span className='flex min-w-0 items-center gap-1'><span className='truncate break-anywhere hover:underline' title={getUsername(actor)} onClick={(e) => {
+                                    <span className='flex min-w-0 items-center gap-1'><span className='break-anywhere truncate hover:underline' title={getUsername(actor)} onClick={(e) => {
                                         handleProfileClick(actor, navigate, e);
                                     }}>{actor.name}</span> reposted</span>
                                 </div>}
@@ -450,7 +450,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         }
                                     }}>
                                         <div className='flex w-full'>
-                                            <span className='min-w-0 truncate whitespace-nowrap font-semibold break-anywhere after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
+                                            <span className='break-anywhere min-w-0 truncate whitespace-nowrap font-semibold after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] after:dark:text-gray-600' data-test-activity-heading>{author.name}</span>
                                             <div>{renderTimestamp(object, !object.authored)}</div>
                                         </div>
                                         <div className='flex w-full'>
@@ -460,17 +460,17 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </>}
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
-                                        {object.name && <H4 className='mb-1 leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
-                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>
+                                        {object.name && <H4 className='break-anywhere mb-1 leading-tight' data-test-activity-heading>{object.name}</H4>}
+                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large break-anywhere text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>
                                         {renderFeedAttachment(object, openLightbox)}
                                         <div className='space-between ml-[-8px] mt-3 flex'>
                                             {showStats && <FeedItemStats
+                                                actor={author}
                                                 commentCount={commentCount}
                                                 layout={layout}
                                                 likeCount={1}
                                                 object={object}
                                                 repostCount={repostCount}
-                                                onCommentClick={onCommentClick}
                                                 onLikeClick={onLikeClick}
                                             />}
                                         </div>
@@ -496,7 +496,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
         return (
             <>
                 {object && (
-                    <div className={`group/article relative py-5 ${!isPending ? 'cursor-pointer' : 'pointer-events-none'}`} data-layout='reply' data-object-id={object.id} onClick={onClick}>
+                    <div className={`group/article relative ${isCompact ? 'pb-2' : 'py-5'} ${!isPending ? 'cursor-pointer' : 'pointer-events-none'}`} data-layout='reply' data-object-id={object.id} onClick={onClick}>
                         <div className={`border-1 z-10 flex items-start gap-3 border-b-gray-200`} data-test-activity>
                             <div className='relative z-10 pt-[3px]'>
                                 <APAvatar author={author} disabled={isPending} />
@@ -509,51 +509,51 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                         }
                                     }}>
                                         <div className='flex'>
-                                            <span className='min-w-0 truncate whitespace-nowrap font-semibold text-black break-anywhere after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] dark:text-white' data-test-activity-heading>{author.name}</span>
+                                            <span className='break-anywhere min-w-0 truncate whitespace-nowrap font-semibold text-black after:mx-1 after:font-normal after:text-gray-700 after:content-["·"] dark:text-white' data-test-activity-heading>{author.name}</span>
                                             <div>{renderTimestamp(object, (isPending === false && !object.authored))}</div>
                                         </div>
                                         <div className='flex'>
                                             <span className='truncate text-gray-700'>{getUsername(author)}</span>
                                         </div>
                                     </div>
-                                    <FeedItemMenu
+                                    {!isCompact && <FeedItemMenu
                                         allowDelete={allowDelete}
                                         disabled={isPending}
                                         layout='reply'
                                         trigger={UserMenuTrigger}
                                         onCopyLink={handleCopyLink}
                                         onDelete={handleDelete}
-                                    />
+                                    />}
                                 </div>
                                 <div className={`relative z-10 col-start-2 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {(object.type === 'Article') && renderFeedAttachment(object, openLightbox)}
-                                        {object.name && <H4 className='mt-2.5 text-pretty leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
-                                        {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'></div>}
+                                        {object.name && <H4 className='break-anywhere mt-2.5 text-pretty leading-tight' data-test-activity-heading>{object.name}</H4>}
+                                        {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content break-anywhere text-pretty tracking-[-0.006em] text-gray-900 dark:text-gray-600 [&_p+p]:mt-3'></div>}
                                         {(object.type === 'Note') && renderFeedAttachment(object, openLightbox)}
                                         {(object.type === 'Article') && <Button
                                             className='mt-3 w-full'
                                             id='read-more'
                                             variant='secondary'
                                         >Read more</Button>}
-                                        <div className='space-between ml-[-8px] mt-2 flex'>
+                                        {!isCompact && <div className='space-between ml-[-8px] mt-2 flex'>
                                             {showStats && <FeedItemStats
+                                                actor={author}
                                                 commentCount={commentCount}
                                                 disabled={isPending}
                                                 layout={layout}
                                                 likeCount={1}
                                                 object={object}
                                                 repostCount={repostCount}
-                                                onCommentClick={onCommentClick}
                                                 onLikeClick={onLikeClick}
                                             />}
-                                        </div>
+                                        </div>}
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div className={`absolute -inset-x-3 -inset-y-0 z-0 rounded transition-colors`}></div>
-                        {!last && <div className="absolute bottom-0 left-[18px] top-[6.5rem] z-0 mb-[-13px] w-[2px] rounded-sm bg-gray-200"></div>}
+                        {!last && <div className={`absolute left-[18px] ${isCompact ? 'bottom-[-6px] top-12' : 'bottom-[2px] top-[68px]'} z-0 mb-[-13px] w-[2px] rounded-sm bg-gray-200`}></div>}
                     </div>
                 )}
                 <ImageLightbox
@@ -569,13 +569,13 @@ const FeedItem: React.FC<FeedItemProps> = ({
         return (
             <>
                 {object && (
-                    <div className='group/article relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 hover:bg-gray-75 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
+                    <div className='group/article hover:bg-gray-75 relative -mx-4 -my-px flex min-h-[112px] min-w-0 cursor-pointer items-center justify-between rounded-lg p-6 dark:hover:bg-gray-950/50' data-layout='inbox' data-object-id={object.id} onClick={onClick}>
                         <div className='w-full min-w-0'>
                             <div className='z-10 mb-1.5 flex w-full min-w-0 items-center gap-1.5 text-sm group-hover/article:border-transparent'>
                                 {!isLoading ?
                                     <>
                                         <APAvatar author={author} size='2xs' />
-                                        <span className='min-w-0 truncate font-semibold text-gray-900 break-anywhere hover:underline dark:text-gray-600'
+                                        <span className='break-anywhere min-w-0 truncate font-semibold text-gray-900 hover:underline dark:text-gray-600'
                                             title={getUsername(author)}
                                             data-test-activity-heading
                                             onClick={(e) => {
@@ -593,14 +593,14 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             </div>
                             <div className='flex'>
                                 <div className='flex min-h-[73px] w-full min-w-0 flex-col items-start justify-start gap-1'>
-                                    <H4 className='line-clamp-2 w-full max-w-[600px] text-pretty leading-tight break-anywhere' data-test-activity-heading>
+                                    <H4 className='break-anywhere line-clamp-2 w-full max-w-[600px] text-pretty leading-tight' data-test-activity-heading>
                                         {isLoading ? <Skeleton className='w-full max-w-96' /> : (object.name ? object.name : (
                                             <span dangerouslySetInnerHTML={{
                                                 __html: stripHtml(object.content || '')
                                             }}></span>
                                         ))}
                                     </H4>
-                                    <div className='ap-note-content line-clamp-2 w-full max-w-[600px] text-pretty text-base leading-normal text-gray-800 break-anywhere dark:text-gray-600 [&_p+p]:mt-3'>
+                                    <div className='ap-note-content break-anywhere line-clamp-2 w-full max-w-[600px] text-pretty text-base leading-normal text-gray-800 dark:text-gray-600 [&_p+p]:mt-3'>
                                         {!isLoading ?
                                             <div dangerouslySetInnerHTML={{
                                                 __html: stripHtml(object.preview?.content ?? object.content ?? '')
@@ -615,12 +615,12 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </div>
                                 <div className='invisible absolute right-3 top-8 z-[49] flex -translate-y-1/2 rounded-lg bg-white p-1 shadow-md group-hover/article:visible dark:bg-black'>
                                     {showStats && <FeedItemStats
+                                        actor={author}
                                         commentCount={commentCount}
                                         layout={layout}
                                         likeCount={1}
                                         object={object}
                                         repostCount={repostCount}
-                                        onCommentClick={onCommentClick}
                                         onLikeClick={onLikeClick}
                                     />}
                                     <FeedItemMenu

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -496,7 +496,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
         return (
             <>
                 {object && (
-                    <div className={`group/article relative ${isCompact ? 'pb-2' : 'py-5'} ${!isPending ? 'cursor-pointer' : 'pointer-events-none'}`} data-layout='reply' data-object-id={object.id} onClick={onClick}>
+                    <div className={`group/article relative ${isCompact ? 'pb-6' : 'py-5'} ${!isPending ? 'cursor-pointer' : 'pointer-events-none'}`} data-layout='reply' data-object-id={object.id} onClick={onClick}>
                         <div className={`border-1 z-10 flex items-start gap-3 border-b-gray-200`} data-test-activity>
                             <div className='relative z-10 pt-[3px]'>
                                 <APAvatar author={author} disabled={isPending} />
@@ -553,7 +553,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             </div>
                         </div>
                         <div className={`absolute -inset-x-3 -inset-y-0 z-0 rounded transition-colors`}></div>
-                        {!last && <div className={`absolute left-[18px] ${isCompact ? 'bottom-[-6px] top-12' : 'bottom-[2px] top-[68px]'} z-0 mb-[-13px] w-[2px] rounded-sm bg-gray-200`}></div>}
+                        {!last && <div className={`absolute left-[19px] ${isCompact ? 'bottom-[8px] top-[51px]' : 'bottom-[-7px] top-[71px]'} z-0 w-[2px] rounded-sm bg-gray-200`}></div>}
                     </div>
                 )}
                 <ImageLightbox

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -16,8 +16,8 @@ interface FeedItemStatsProps {
     disabled?: boolean;
     buttonClassName?: string;
     onLikeClick: () => void;
-    onCommentClick?: () => void; // Made optional since we'll handle it internally
-    onReplyCountChange?: (increment: number) => void; // New prop for parent to update reply count
+    onCommentClick?: () => void;
+    onReplyCountChange?: (increment: number) => void;
 }
 
 const FeedItemStats: React.FC<FeedItemStatsProps> = ({

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -4,6 +4,7 @@ import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api
 import {Button, LucideIcon} from '@tryghost/shade';
 import {useAnimatedCounter} from '@hooks/use-animated-counter';
 import {useDerepostMutationForUser, useLikeMutationForUser, useRepostMutationForUser, useUnlikeMutationForUser} from '@hooks/use-activity-pub-queries';
+import {useKeyboardShortcuts} from '@hooks/use-keyboard-shortcuts';
 
 interface FeedItemStatsProps {
     actor: ActorProperties;
@@ -36,13 +37,16 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const [isReposted, setIsReposted] = useState(object.reposted);
     const [showReplyModal, setShowReplyModal] = useState(false);
 
-    // Sync with external changes - Update the liked / reposted state when the object changes
+    useKeyboardShortcuts({
+        isReplyAvailable: !onCommentClick,
+        onOpenReply: () => setShowReplyModal(true)
+    });
+
     useEffect(() => {
         setIsLiked(object.liked);
         setIsReposted(object.reposted);
     }, [object.liked, object.reposted]);
 
-    // Sync with external changes - Update the repost count when the initialRepostCount changes
     useEffect(() => {
         if (repostCount !== initialRepostCount) {
             if (initialRepostCount > repostCount) {
@@ -82,11 +86,9 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const handleCommentClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
 
-        // If there's a custom onCommentClick handler (for special cases), use it
         if (onCommentClick) {
             onCommentClick();
         } else {
-            // Otherwise, open our modal for both Notes and Articles
             setShowReplyModal(true);
         }
     };

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -1,5 +1,5 @@
 import NewNoteModal from '@components/modals/NewNoteModal';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LucideIcon} from '@tryghost/shade';
 import {useAnimatedCounter} from '@hooks/use-animated-counter';
@@ -36,10 +36,12 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
     const [isLiked, setIsLiked] = useState(object.liked);
     const [isReposted, setIsReposted] = useState(object.reposted);
     const [showReplyModal, setShowReplyModal] = useState(false);
+    const statsRef = useRef<HTMLDivElement>(null);
 
     useKeyboardShortcuts({
-        isReplyAvailable: !onCommentClick,
-        onOpenReply: () => setShowReplyModal(true)
+        isReplyAvailable: !onCommentClick && layout !== 'reply',
+        onOpenReply: () => setShowReplyModal(true),
+        componentRef: statsRef
     });
 
     useEffect(() => {
@@ -97,7 +99,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
 
     return (
         <>
-            <div className={`flex ${layout !== 'inbox' && 'gap-1'}`}>
+            <div ref={statsRef} className={`flex ${layout !== 'inbox' && 'gap-1'}`}>
                 <Button
                     className={`${buttonClass} ${isLiked && 'text-pink-500 hover:text-pink-500'}`}
                     disabled={disabled}

--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -1,266 +1,73 @@
-import React, {ChangeEvent, HTMLProps, useEffect, useId, useRef, useState} from 'react';
+import React, {HTMLProps, useState} from 'react';
 
-import * as FormPrimitive from '@radix-ui/react-form';
 import APAvatar from './APAvatar';
-import clsx from 'clsx';
+import NewNoteModal from '@components/modals/NewNoteModal';
 import getUsername from '../../utils/get-username';
 import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {Button, LoadingIndicator, LucideIcon} from '@tryghost/shade';
-import {FILE_SIZE_ERROR_MESSAGE, MAX_FILE_SIZE} from '@utils/image';
-import {toast} from 'sonner';
-import {uploadFile, useReplyMutationForUser, useUserDataForUser} from '@hooks/use-activity-pub-queries';
+import {useUserDataForUser} from '@hooks/use-activity-pub-queries';
 
-export interface APTextAreaProps extends HTMLProps<HTMLTextAreaElement> {
-    title?: string;
-    value?: string;
-    rows?: number;
-    error?: boolean;
-    placeholder?: string;
-    hint?: React.ReactNode;
-    className?: string;
-    onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+export interface APTextAreaProps extends HTMLProps<HTMLDivElement> {
+    object: ObjectProperties;
     onReply?: () => void;
     onReplyError?: () => void;
-    object: ObjectProperties;
-    focused: number;
 }
 
-export const useFocusedState = (initialValue: boolean) => {
-    const [state, setUnderlyingState] = useState(initialValue ? 1 : 0);
-
-    const setState = (value: boolean | ((prev: number) => number)) => {
-        if (value === false) {
-            return setUnderlyingState(0);
-        }
-        setUnderlyingState((prev) => {
-            return prev + 1;
-        });
-    };
-
-    return [state, setState] as const;
-};
-
-const adjustTextareaHeight = (textarea: HTMLTextAreaElement) => {
-    textarea.style.height = 'auto';
-    textarea.style.height = `${textarea.scrollHeight + 2}px`;
-};
-
 const APReplyBox: React.FC<APTextAreaProps> = ({
-    title,
-    value,
-    rows = 1,
-    maxLength,
-    error,
-    hint,
-    className,
     object,
-    focused,
     onReply,
     onReplyError,
+    className,
     ...props
 }) => {
-    const id = useId();
-    const [textValue, setTextValue] = useState(value); // Manage the textarea value with state
-    const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
-
     const {data: user} = useUserDataForUser('index');
-    const replyMutation = useReplyMutationForUser('index', user);
+    const [showReplyModal, setShowReplyModal] = useState(false);
 
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const imageInputRef = useRef<HTMLInputElement>(null);
-    const [imagePreview, setImagePreview] = useState<string | null>(null);
-    const [isImageUploading, setIsImageUploading] = useState(false);
-    const imageButtonRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-        if (textareaRef.current && focused) {
-            textareaRef.current.focus();
-        }
-    }, [focused]);
-
-    async function handleClick() {
-        if (!textValue || !user) {
-            return;
-        }
-
-        replyMutation.mutate({
-            inReplyTo: object.id,
-            content: textValue,
-            imageUrl: uploadedImageUrl || undefined
-        }, {
-            onError() {
-                onReplyError?.();
-            }
-        });
-
-        setTextValue('');
-        setImagePreview(null);
-        setUploadedImageUrl(null);
-        if (imagePreview) {
-            URL.revokeObjectURL(imagePreview);
-        }
-        if (imageInputRef.current) {
-            imageInputRef.current.value = '';
-        }
-
-        onReply?.();
+    if (!user) {
+        return null;
     }
 
-    const [isFocused] = useState(true);
-
-    useEffect(() => {
-        if (textareaRef.current) {
-            adjustTextareaHeight(textareaRef.current);
-        }
-    }, [textValue]);
-
-    function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
-        setTextValue(event.target.value);
-        if (event.target) {
-            adjustTextareaHeight(event.target);
-        }
-    }
-
-    const handleImageUpload = async (file: File) => {
-        try {
-            setIsImageUploading(true);
-            const imageUrl = await uploadFile(file);
-            setUploadedImageUrl(imageUrl);
-        } catch (err) {
-            setImagePreview(null);
-
-            let errorMessage = 'Failed to upload image. Try again.';
-
-            if (err && typeof err === 'object' && 'statusCode' in err) {
-                switch (err.statusCode) {
-                case 413:
-                    errorMessage = 'Image size exceeds limit.';
-                    break;
-                case 415:
-                    errorMessage = 'The file type is not supported.';
-                    break;
-                default:
-                    // Use the default error message
-                }
-            }
-            toast.error(errorMessage);
-        } finally {
-            setIsImageUploading(false);
-        }
-    };
-
-    const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
-        const files = e.target.files;
-
-        if (files && files.length > 0) {
-            const file = files[0];
-
-            if (file.size > MAX_FILE_SIZE) {
-                toast.error(FILE_SIZE_ERROR_MESSAGE);
-                e.target.value = '';
-                return;
-            }
-
-            const previewUrl = URL.createObjectURL(file);
-            setImagePreview(previewUrl);
-
-            await handleImageUpload(file);
-        }
-    };
-
-    const handleClearImage = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setImagePreview(null);
-        setUploadedImageUrl(null);
-        if (imagePreview) {
-            URL.revokeObjectURL(imagePreview);
-        }
-
-        if (imageInputRef.current) {
-            imageInputRef.current.value = '';
-        }
-    };
-
-    useEffect(() => {
-        // Cleanup function to revoke object URLs when component unmounts
-        return () => {
-            if (imagePreview) {
-                URL.revokeObjectURL(imagePreview);
-            }
-        };
-    }, [imagePreview]);
-
-    const styles = clsx(
-        'ap-textarea order-2 w-full resize-none break-words rounded-lg border bg-transparent py-2 pr-3 text-[1.5rem] transition-all dark:text-white',
-        isFocused ? 'min-h-[20px]' : 'min-h-[41px]',
-        (textValue || isFocused) && 'mb-10',
-        error ? 'border-red' : 'border-transparent placeholder:text-gray-500 dark:placeholder:text-gray-800',
-        title && 'mt-1.5',
-        className
-    );
-
-    const buttonDisabled = !textValue || !user;
-
-    let placeholder = 'Reply...';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const attributedTo = (object.attributedTo || {}) as any;
+    let placeholder = 'Reply...';
     if (typeof attributedTo.preferredUsername === 'string' && typeof attributedTo.id === 'string') {
         placeholder = `Reply to ${getUsername(attributedTo)}...`;
     }
 
     return (
-        <div className='flex w-full gap-x-3 py-6'>
-            <APAvatar author={user as ActorProperties} />
-            <div className='relative w-full'>
-                <FormPrimitive.Root asChild>
-                    <div className='flex w-full flex-col'>
-                        <FormPrimitive.Field name={id} asChild>
-                            <FormPrimitive.Control asChild>
-                                <textarea
-                                    ref={textareaRef}
-                                    className={styles}
-                                    id={id}
-                                    maxLength={maxLength}
-                                    placeholder={placeholder}
-                                    rows={rows}
-                                    value={textValue}
-                                    onChange={handleChange}
-                                    {...props}>
-                                </textarea>
-                            </FormPrimitive.Control>
-                        </FormPrimitive.Field>
-                        <FormPrimitive.Field name='image' asChild>
-                            <FormPrimitive.Control asChild>
-                                <input
-                                    ref={imageInputRef}
-                                    accept="image/jpeg,image/png,image/webp"
-                                    className='hidden'
-                                    type="file"
-                                    onChange={handleImageChange}
-                                />
-                            </FormPrimitive.Control>
-                        </FormPrimitive.Field>
-                        {title}
-                        {hint}
+        <>
+            <div
+                className={`flex w-full cursor-pointer gap-x-3 py-6 ${className || ''}`}
+                onClick={() => setShowReplyModal(true)}
+                {...props}
+            >
+                <APAvatar author={user as ActorProperties} />
+                <div className='flex w-full items-center'>
+                    <div className='w-full text-[1.5rem] text-gray-500 transition-colors dark:text-gray-400'>
+                        {placeholder}
                     </div>
-                </FormPrimitive.Root>
-                {imagePreview &&
-                    <div className='group relative -mt-6 flex w-fit grow items-center justify-center'>
-                        <img alt='Image attachment preview' className={`max-h-[420px] w-full rounded-sm object-cover outline outline-1 -outline-offset-1 outline-black/10 ${isImageUploading && 'opacity-10'}`} src={imagePreview} />
-                        {isImageUploading &&
-                            <div className='absolute leading-[0]'>
-                                <LoadingIndicator size='md' />
-                            </div>
-                        }
-                        <Button className='absolute right-3 top-3 size-8 bg-black/60 opacity-0 hover:bg-black/80 group-hover:opacity-100' onClick={handleClearImage}><LucideIcon.Trash2 /></Button>
-                    </div>
-                }
-                <div className={`${imagePreview ? 'mt-4' : 'absolute'} bottom-[3px] right-0 flex justify-end space-x-3 transition-[opacity] duration-150`}>
-                    <Button ref={imageButtonRef} className='w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
-                    <Button className='min-w-20' color='black' disabled={buttonDisabled || isImageUploading} id='post' onClick={handleClick}>Post</Button>
                 </div>
             </div>
-        </div>
+
+            {showReplyModal && (
+                <NewNoteModal
+                    open={showReplyModal}
+                    replyTo={{
+                        object: object,
+                        actor: object.attributedTo as ActorProperties
+                    }}
+                    onOpenChange={(open) => {
+                        setShowReplyModal(open);
+                    }}
+                    onReply={() => {
+                        onReply?.();
+                        setShowReplyModal(false);
+                    }}
+                    onReplyError={() => {
+                        onReplyError?.();
+                    }}
+                />
+            )}
+        </>
     );
 };
 

--- a/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APReplyBox.tsx
@@ -26,10 +26,9 @@ const APReplyBox: React.FC<APTextAreaProps> = ({
         return null;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const attributedTo = (object.attributedTo || {}) as any;
+    const attributedTo = object.attributedTo as ActorProperties | undefined;
     let placeholder = 'Reply...';
-    if (typeof attributedTo.preferredUsername === 'string' && typeof attributedTo.id === 'string') {
+    if (attributedTo?.preferredUsername && attributedTo?.id) {
         placeholder = `Reply to ${getUsername(attributedTo)}...`;
     }
 

--- a/apps/admin-x-activitypub/src/components/layout/Layout.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Layout.tsx
@@ -1,14 +1,18 @@
 import Header from './Header';
+import NewNoteModal from '@components/modals/NewNoteModal';
 import Onboarding, {useOnboardingStatus} from './Onboarding';
 import React, {useRef} from 'react';
 import Sidebar from './Sidebar';
 import {Navigate, ScrollRestoration} from '@tryghost/admin-x-framework';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
+import {useKeyboardShortcuts} from '@hooks/use-keyboard-shortcuts';
 
 const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     const {isOnboarded} = useOnboardingStatus();
     const {data: currentUser, isLoading} = useCurrentUser();
     const containerRef = useRef<HTMLDivElement>(null);
+
+    const {isNewNoteModalOpen, setIsNewNoteModalOpen} = useKeyboardShortcuts();
 
     if (isLoading || !currentUser) {
         return null;
@@ -37,6 +41,11 @@ const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...pr
                     <Onboarding />
                 }
             </div>
+
+            <NewNoteModal
+                open={isNewNoteModalOpen}
+                onOpenChange={setIsNewNoteModalOpen}
+            />
         </div>
     );
 };

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -51,7 +51,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
         if (modalIsOpen) {
             const timer = setTimeout(() => {
                 setIsSticky(true);
-            }, 150);
+            }, 200);
             return () => clearTimeout(timer);
         } else {
             setIsSticky(false);

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -37,6 +37,13 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
     const [isPosting, setIsPosting] = useState(false);
     const navigate = useNavigate();
 
+    // Sync external open prop with internal state
+    useEffect(() => {
+        if (props.open !== undefined) {
+            setIsOpen(props.open);
+        }
+    }, [props.open]);
+
     const isDisabled = !content.trim() || !user || isPosting;
 
     const handlePost = async () => {
@@ -83,6 +90,18 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
             textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
         }
     }, [content]);
+
+    // Focus textarea when modal opens
+    useEffect(() => {
+        const modalIsOpen = props.open !== undefined ? props.open : isOpen;
+        if (modalIsOpen && textareaRef.current) {
+            // Small delay to ensure modal is fully rendered
+            const timeoutId = setTimeout(() => {
+                textareaRef.current?.focus();
+            }, 100);
+            return () => clearTimeout(timeoutId);
+        }
+    }, [isOpen, props.open]);
 
     const handleImageUpload = async (file: File) => {
         try {
@@ -162,7 +181,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
     }
 
     return (
-        <Dialog open={isOpen} onOpenChange={(open) => {
+        <Dialog open={props.open !== undefined ? props.open : isOpen} onOpenChange={(open) => {
             if (open) {
                 setContent('');
                 setImagePreview(null);
@@ -174,8 +193,13 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                     imageInputRef.current.value = '';
                 }
             }
+
             setIsOpen(open);
-        }} {...props}>
+
+            if (props.onOpenChange) {
+                props.onOpenChange(open);
+            }
+        }} {...(props.open !== undefined ? {} : props)}>
             <DialogTrigger asChild>
                 {children}
             </DialogTrigger>

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -35,6 +35,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
     const [content, setContent] = useState('');
     const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
     const [isPosting, setIsPosting] = useState(false);
+    const [isSticky, setIsSticky] = useState(false);
     const navigate = useNavigate();
 
     // Sync external open prop with internal state
@@ -43,6 +44,18 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
             setIsOpen(props.open);
         }
     }, [props.open]);
+
+    useEffect(() => {
+        const modalIsOpen = props.open !== undefined ? props.open : isOpen;
+        if (modalIsOpen) {
+            const timer = setTimeout(() => {
+                setIsSticky(true);
+            }, 150);
+            return () => clearTimeout(timer);
+        } else {
+            setIsSticky(false);
+        }
+    }, [isOpen, props.open]);
 
     const isDisabled = !content.trim() || !user || isPosting;
 
@@ -268,7 +281,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                         <Button className='absolute right-3 top-3 size-8 bg-black/60 opacity-0 hover:bg-black/80 group-hover:opacity-100' onClick={handleClearImage}><LucideIcon.Trash2 /></Button>
                     </div>
                 }
-                <DialogFooter className='sticky bottom-0 bg-background py-6 dark:bg-[#101114]'>
+                <DialogFooter className={`${isSticky ? 'sticky' : 'static'} bottom-0 bg-background py-6 dark:bg-[#101114]`}>
                     <Button className='mr-auto w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
                     <DialogClose>
                         <Button className='min-w-16' variant='outline'>Cancel</Button>

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -19,9 +19,10 @@ interface NewNoteModalProps extends ComponentPropsWithoutRef<typeof Dialog> {
     };
     onReply?: () => void;
     onReplyError?: () => void;
+    onOpenChange?: (open: boolean) => void;
 }
 
-const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, onReplyError, ...props}) => {
+const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, onReplyError, onOpenChange, ...props}) => {
     const {data: user} = useUserDataForUser('index');
     const noteMutation = useNoteMutationForUser('index', user);
     const replyMutation = useReplyMutationForUser('index', user);
@@ -82,6 +83,9 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
             }
 
             setIsOpen(false);
+            if (onOpenChange) {
+                onOpenChange(false);
+            }
             toast.success(replyTo ? 'Reply posted' : 'Note posted');
         } catch (error) {
             if (replyTo) {
@@ -92,7 +96,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
         } finally {
             setIsPosting(false);
         }
-    }, [content, user, replyTo, replyMutation, noteMutation, uploadedImageUrl, onReply, onReplyError, setIsOpen, navigate]);
+    }, [content, user, replyTo, replyMutation, noteMutation, uploadedImageUrl, onReply, onReplyError, setIsOpen, navigate, onOpenChange]);
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         setContent(e.target.value);
@@ -227,8 +231,8 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
 
             setIsOpen(open);
 
-            if (props.onOpenChange) {
-                props.onOpenChange(open);
+            if (onOpenChange) {
+                onOpenChange(open);
             }
         }} {...(props.open !== undefined ? {} : props)}>
             <DialogTrigger asChild>

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -3,7 +3,7 @@ import APAvatar from '@components/global/APAvatar';
 import FeedItem from '@components/feed/FeedItem';
 import getUsername from '@utils/get-username';
 import {ActorProperties, ObjectProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {Button, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 import {ChangeEvent, useCallback, useEffect, useRef, useState} from 'react';
 import {ComponentPropsWithoutRef, ReactNode} from 'react';
 import {FILE_SIZE_ERROR_MESSAGE, MAX_FILE_SIZE} from '@utils/image';
@@ -39,6 +39,8 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
     const [isSticky, setIsSticky] = useState(false);
     const navigate = useNavigate();
 
+    const MAX_CONTENT_LENGTH = 500;
+
     // Sync external open prop with internal state
     useEffect(() => {
         if (props.open !== undefined) {
@@ -58,7 +60,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
         }
     }, [isOpen, props.open]);
 
-    const isDisabled = !content.trim() || !user || isPosting;
+    const isDisabled = !content.trim() || !user || isPosting || content.length > MAX_CONTENT_LENGTH;
 
     const handlePost = useCallback(async () => {
         const trimmedContent = content.trim();
@@ -291,12 +293,14 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                     />
                 )}
                 <div className='flex min-h-24 items-start gap-3'>
-                    <APAvatar author={user as ActorProperties} />
+                    <div className='sticky top-0'>
+                        <APAvatar author={user as ActorProperties} />
+                    </div>
                     <FormPrimitive.Root asChild>
                         <div className='-mt-0.5 flex w-full flex-col gap-0.5'>
                             {isLoadingAccount ?
                                 <Skeleton className='w-10' /> :
-                                <span className='class="break-anywhere dark:text-white" min-w-0 truncate whitespace-nowrap font-semibold text-black'>{account?.name}</span>
+                                <span className='min-w-0 truncate whitespace-nowrap font-semibold text-black break-anywhere dark:text-white'>{account?.name}</span>
                             }
                             <FormPrimitive.Field name='content' asChild>
                                 <FormPrimitive.Control asChild>
@@ -339,12 +343,14 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                 }
                 <DialogFooter className={`${isSticky ? 'sticky' : 'static'} bottom-0 bg-background py-6 dark:bg-[#101114]`}>
                     <Button className='mr-auto w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
-                    <DialogClose>
-                        <Button className='min-w-16' variant='outline'>Cancel</Button>
-                    </DialogClose>
-                    <Button className='min-w-16' disabled={isDisabled || isImageUploading} onClick={handlePost}>
-                        {isPosting ? <LoadingIndicator color='light' size='sm' /> : 'Post'}
-                    </Button>
+                    <div className='flex items-center sm:space-x-3'>
+                        <div className={`text-sm ${content.length >= MAX_CONTENT_LENGTH ? 'text-red-500' : content.length >= MAX_CONTENT_LENGTH * 0.9 ? 'text-yellow-600' : 'text-gray-500'}`}>
+                            {content.length}/{MAX_CONTENT_LENGTH}
+                        </div>
+                        <Button className='min-w-16' disabled={isDisabled || isImageUploading} onClick={handlePost}>
+                            {isPosting ? <LoadingIndicator color='light' size='sm' /> : 'Post'}
+                        </Button>
+                    </div>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -69,6 +69,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
             }
 
             setIsOpen(false);
+            toast.success(replyTo ? 'Reply posted' : 'Note posted');
         } catch (error) {
             if (replyTo) {
                 onReplyError?.();
@@ -203,7 +204,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
             <DialogTrigger asChild>
                 {children}
             </DialogTrigger>
-            <DialogContent className={`max-h-[80vh] min-h-[200px] overflow-y-auto`} onClick={e => e.stopPropagation()}>
+            <DialogContent className={`max-h-[80vh] min-h-[200px] overflow-y-auto pb-0`} onClick={e => e.stopPropagation()}>
                 <DialogHeader className='hidden'>
                     <DialogTitle>{replyTo ? 'Reply' : 'New note'}</DialogTitle>
                     <DialogDescription>Post your thoughts to the Social web</DialogDescription>
@@ -267,7 +268,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                         <Button className='absolute right-3 top-3 size-8 bg-black/60 opacity-0 hover:bg-black/80 group-hover:opacity-100' onClick={handleClearImage}><LucideIcon.Trash2 /></Button>
                     </div>
                 }
-                <DialogFooter>
+                <DialogFooter className='sticky bottom-0 bg-background py-6 dark:bg-[#101114]'>
                     <Button className='mr-auto w-[34px] !min-w-0' variant='outline' onClick={() => imageInputRef.current?.click()}><LucideIcon.Image /></Button>
                     <DialogClose>
                         <Button className='min-w-16' variant='outline'>Cancel</Button>

--- a/apps/admin-x-activitypub/src/hooks/use-keyboard-shortcuts.tsx
+++ b/apps/admin-x-activitypub/src/hooks/use-keyboard-shortcuts.tsx
@@ -1,0 +1,59 @@
+import {useEffect, useState} from 'react';
+import {useLocation} from '@tryghost/admin-x-framework';
+
+interface KeyboardShortcutsOptions {
+    onOpenNewNote?: () => void;
+    onOpenReply?: () => void;
+    isReplyAvailable?: boolean;
+}
+
+export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions = {}) => {
+    const [isNewNoteModalOpen, setIsNewNoteModalOpen] = useState(false);
+    const location = useLocation();
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (
+                e.target instanceof HTMLInputElement ||
+                e.target instanceof HTMLTextAreaElement ||
+                (e.target instanceof HTMLElement && e.target.isContentEditable) ||
+                e.target instanceof HTMLSelectElement
+            ) {
+                return;
+            }
+
+            // Don't trigger if modifier keys are pressed
+            if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) {
+                return;
+            }
+
+            switch (e.key.toLowerCase()) {
+            case 'n':
+                e.preventDefault();
+                if (options.onOpenNewNote) {
+                    options.onOpenNewNote();
+                } else {
+                    setIsNewNoteModalOpen(true);
+                }
+                break;
+            case 'r':
+                if (options.isReplyAvailable && options.onOpenReply) {
+                    const isReaderOrNote = location.pathname.includes('/feed/') || location.pathname.includes('/inbox/');
+                    if (isReaderOrNote) {
+                        e.preventDefault();
+                        options.onOpenReply();
+                    }
+                }
+                break;
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [options, location.pathname]);
+
+    return {
+        isNewNoteModalOpen,
+        setIsNewNoteModalOpen
+    };
+};

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -1,4 +1,5 @@
 import APAvatar from '@src/components/global/APAvatar';
+import APReplyBox from '@src/components/global/APReplyBox';
 import DeletedFeedItem from '@src/components/feed/DeletedFeedItem';
 import FeedItem from '@components/feed/FeedItem';
 import Layout from '@src/components/layout/Layout';
@@ -128,6 +129,11 @@ const Note = () => {
                                                     showHeader={threadParents.length > 0}
                                                     showStats={true}
                                                     type='Note'
+                                                />
+                                                <APReplyBox
+                                                    object={object}
+                                                    onReply={() => handleReplyCountChange(1)}
+                                                    onReplyError={() => handleReplyCountChange(-1)}
                                                 />
                                                 <FeedItemDivider />
                                                 <div ref={repliesRef}>

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -91,9 +91,6 @@ const FeedList:React.FC<FeedListProps> = ({
                                                         onClick={() => {
                                                             navigate(`/feed/${encodeURIComponent(activity.id)}`);
                                                         }}
-                                                        onCommentClick={() => {
-                                                            navigate(`/feed/${encodeURIComponent(activity.id)}?focusReply=true`);
-                                                        }}
                                                     />
                                                     {index < activities.length - 1 && (
                                                         <Separator />

--- a/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
@@ -94,9 +94,6 @@ const InboxList:React.FC<InboxListProps> = ({
                                                         onClick={() => {
                                                             navigate(`/inbox/${encodeURIComponent(activity.id)}`);
                                                         }}
-                                                        onCommentClick={() => {
-                                                            navigate(`/inbox/${encodeURIComponent(activity.id)}?focusReply=true`);
-                                                        }}
                                                     />
                                                     {index < activities.length - 1 && (
                                                         <Separator />

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -7,6 +7,7 @@ import {renderTimestamp} from '../../../utils/render-timestamp';
 import {usePostForUser, useThreadForUser} from '@hooks/use-activity-pub-queries';
 
 import APAvatar from '@src/components/global/APAvatar';
+import APReplyBox from '@src/components/global/APReplyBox';
 import BackButton from '@src/components/global/BackButton';
 import DeletedFeedItem from '@src/components/feed/DeletedFeedItem';
 import FeedItem from '@src/components/feed/FeedItem';
@@ -675,12 +676,6 @@ export const Reader: React.FC<ReaderProps> = ({
                                                 likeCount={1}
                                                 object={object}
                                                 repostCount={object.repostCount ?? 0}
-                                                onCommentClick={() => {
-                                                    repliesRef.current?.scrollIntoView({
-                                                        behavior: 'smooth',
-                                                        block: 'center'
-                                                    });
-                                                }}
                                                 onLikeClick={onLikeClick}
                                                 onReplyCountChange={incrementReplyCount}
                                             />
@@ -689,6 +684,15 @@ export const Reader: React.FC<ReaderProps> = ({
                                     {object.type === 'Tombstone' && (
                                         <DeletedFeedItem last={true} />
                                     )}
+
+                                    <div className='mx-auto w-full border-t border-black/[8%] dark:border-gray-950' style={{maxWidth: currentGridWidth}}>
+                                        <APReplyBox
+                                            object={object}
+                                            onReply={() => incrementReplyCount(1)}
+                                            onReplyError={() => decrementReplyCount(1)}
+                                        />
+                                        <FeedItemDivider />
+                                    </div>
 
                                     {isLoadingThread && <LoadingIndicator size='lg' />}
 

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -189,12 +189,6 @@ const Notifications: React.FC = () => {
         // Don't need to know about setting timeouts or anything like that
     };
 
-    const handleCommentClick = (postId?: string) => {
-        if (postId) {
-            navigate(`/feed/${encodeURIComponent(postId)}`);
-        }
-    };
-
     const maxAvatars = 5;
 
     const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useNotificationsForUser('index');
@@ -319,12 +313,12 @@ const Notifications: React.FC = () => {
                                                                     name: actor.name,
                                                                     handle: actor.handle
                                                                 }}
-                                                                className='-ml-2 !bg-[#F3F3F3] outline outline-2 outline-white group-hover:!bg-[#EDEEF0] group-hover:outline-gray-75 dark:outline-black group-hover:dark:outline-gray-950'
+                                                                className='group-hover:outline-gray-75 -ml-2 !bg-[#F3F3F3] outline outline-2 outline-white group-hover:!bg-[#EDEEF0] dark:outline-black group-hover:dark:outline-gray-950'
                                                                 size='notification'
                                                             />
                                                         ))}
                                                         {group.actors.length > maxAvatars && (!openStates[group.id || `${group.type}_${index}`]) && (
-                                                            <div className='absolute right-[28px] z-10 flex size-9 items-center justify-center rounded-full bg-black/50 text-base font-semibold tracking-tightest text-white'>
+                                                            <div className='tracking-tightest absolute right-[28px] z-10 flex size-9 items-center justify-center rounded-full bg-black/50 text-base font-semibold text-white'>
                                                                 {`+${group.actors.length - maxAvatars}`}
                                                             </div>
                                                         )}
@@ -345,7 +339,7 @@ const Notifications: React.FC = () => {
                                                                 {group.actors.map((actor: ActorProperties) => (
                                                                     <div
                                                                         key={actor.id}
-                                                                        className='flex items-center break-anywhere hover:opacity-80'
+                                                                        className='break-anywhere flex items-center hover:opacity-80'
                                                                         onClick={(e) => {
                                                                             e?.stopPropagation();
                                                                             handleProfileClick(actor.handle, navigate);
@@ -396,7 +390,7 @@ const Notifications: React.FC = () => {
                                                             className='ap-note-content mt-0.5 line-clamp-1 text-pretty text-sm text-gray-700 dark:text-gray-600'
                                                         /> :
                                                         <>
-                                                            <div className='mt-2.5 rounded-md bg-gray-100 px-5 py-[14px] group-hover:bg-gray-200 dark:bg-gray-925/30 group-hover:dark:bg-black/40'>
+                                                            <div className='dark:bg-gray-925/30 mt-2.5 rounded-md bg-gray-100 px-5 py-[14px] group-hover:bg-gray-200 group-hover:dark:bg-black/40'>
                                                                 <ProfileLinkedContent
                                                                     className='ap-note-content text-pretty'
                                                                     content={group.post?.content || ''}
@@ -409,6 +403,14 @@ const Notifications: React.FC = () => {
                                                 {((group.type === 'reply' && group.post) || group.type === 'mention') && (
                                                     <div className="mt-1.5">
                                                         <FeedItemStats
+                                                            actor={{
+                                                                ...group.actors[0],
+                                                                icon: {
+                                                                    url: group.actors[0].avatarUrl || ''
+                                                                },
+                                                                id: group.actors[0].url,
+                                                                preferredUsername: group.actors[0].handle?.replace(/^@([^@]+)@.*$/, '$1') || 'unknown'
+                                                            }}
                                                             buttonClassName='hover:bg-gray-200'
                                                             commentCount={group.post.replyCount || 0}
                                                             layout="notification"
@@ -419,7 +421,6 @@ const Notifications: React.FC = () => {
                                                                 reposted: group.post.repostedByMe
                                                             }}
                                                             repostCount={group.post.repostCount || 0}
-                                                            onCommentClick={() => handleCommentClick(group.post?.id)}
                                                             onLikeClick={handleLikeClick}
                                                         />
                                                     </div>

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -313,12 +313,12 @@ const Notifications: React.FC = () => {
                                                                     name: actor.name,
                                                                     handle: actor.handle
                                                                 }}
-                                                                className='group-hover:outline-gray-75 -ml-2 !bg-[#F3F3F3] outline outline-2 outline-white group-hover:!bg-[#EDEEF0] dark:outline-black group-hover:dark:outline-gray-950'
+                                                                className='-ml-2 !bg-[#F3F3F3] outline outline-2 outline-white group-hover:!bg-[#EDEEF0] group-hover:outline-gray-75 dark:outline-black group-hover:dark:outline-gray-950'
                                                                 size='notification'
                                                             />
                                                         ))}
                                                         {group.actors.length > maxAvatars && (!openStates[group.id || `${group.type}_${index}`]) && (
-                                                            <div className='tracking-tightest absolute right-[28px] z-10 flex size-9 items-center justify-center rounded-full bg-black/50 text-base font-semibold text-white'>
+                                                            <div className='absolute right-[28px] z-10 flex size-9 items-center justify-center rounded-full bg-black/50 text-base font-semibold tracking-tightest text-white'>
                                                                 {`+${group.actors.length - maxAvatars}`}
                                                             </div>
                                                         )}
@@ -339,7 +339,7 @@ const Notifications: React.FC = () => {
                                                                 {group.actors.map((actor: ActorProperties) => (
                                                                     <div
                                                                         key={actor.id}
-                                                                        className='break-anywhere flex items-center hover:opacity-80'
+                                                                        className='flex items-center break-anywhere hover:opacity-80'
                                                                         onClick={(e) => {
                                                                             e?.stopPropagation();
                                                                             handleProfileClick(actor.handle, navigate);
@@ -390,7 +390,7 @@ const Notifications: React.FC = () => {
                                                             className='ap-note-content mt-0.5 line-clamp-1 text-pretty text-sm text-gray-700 dark:text-gray-600'
                                                         /> :
                                                         <>
-                                                            <div className='dark:bg-gray-925/30 mt-2.5 rounded-md bg-gray-100 px-5 py-[14px] group-hover:bg-gray-200 group-hover:dark:bg-black/40'>
+                                                            <div className='mt-2.5 rounded-md bg-gray-100 px-5 py-[14px] group-hover:bg-gray-200 dark:bg-gray-925/30 group-hover:dark:bg-black/40'>
                                                                 <ProfileLinkedContent
                                                                     className='ap-note-content text-pretty'
                                                                     content={group.post?.content || ''}

--- a/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/EditProfile.tsx
@@ -371,7 +371,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                     )}
                 />
                 <DialogFooter>
-                    <DialogClose>
+                    <DialogClose asChild>
                         <Button variant='outline'>Cancel</Button>
                     </DialogClose>
                     <Button disabled={isSubmitting || isProfileImageUploading || isCoverImageUploading} type="submit">Save</Button>

--- a/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
@@ -83,13 +83,6 @@ const Likes: React.FC<LikesProps> = ({
                                     navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
-                            onCommentClick={() => {
-                                if (activity.object.type === 'Note') {
-                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                } else if (activity.object.type === 'Article') {
-                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                }
-                            }}
                         />
                         {index < posts.length - 1 && <Separator />}
                         {index === loadMoreIndex && (

--- a/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
@@ -85,13 +85,6 @@ const Posts: React.FC<PostsProps> = ({
                                     navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
-                            onCommentClick={() => {
-                                if (activity.object.type === 'Note') {
-                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
-                                } else if (activity.object.type === 'Article') {
-                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
-                                }
-                            }}
                         />
                         {index < posts.length - 1 && <Separator />}
                         {index === loadMoreIndex && (

--- a/apps/shade/src/components/ui/dialog.tsx
+++ b/apps/shade/src/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 sm:items-end [&>button]:min-w-20',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 sm:items-end [&_button]:min-w-20',
             className
         )}
         {...props}


### PR DESCRIPTION
ref PROD-1780

- Combined separate new note modal and reply box into one interface
- Created same posting experience for both new posts and replies
- Reduced code by sharing the same components for both uses
- Added keyboard shortcuts — <kbd>n</kbd> for new notes, <kbd>r</kbd> for replies, and <kbd>cmd+enter</kbd> for submitting
- Added <kbd>cmd+v</kbd> support for attaching an image to a note/reply
- Added toast messages on note/reply creation
- Made the modal work with long-form content
- Added character limit of 500 to notes and replies