### PR TITLE
✨ Changed staff token perms to match user auth

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -23,7 +23,7 @@ const notImplemented = function notImplemented(req, res, next) {
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
     if (req.api_key?.get('user_id')) {
-        // Remove trailing slash for consistent comparison
+        // Check if staff token is trying to access blocked endpoints
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
         const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';
 

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -5,7 +5,8 @@ const shared = require('../../../shared');
 const apiMw = require('../../middleware');
 
 const messages = {
-    notImplemented: 'The server does not support the functionality required to fulfill the request.'
+    notImplemented: 'The server does not support the functionality required to fulfill the request.',
+    staffTokenBlocked: 'Staff tokens are not allowed to access this endpoint'
 };
 
 /**
@@ -14,16 +15,34 @@ const messages = {
  * @param {import('express').NextFunction} next
  */
 const notImplemented = function notImplemented(req, res, next) {
-    // CASE: user is logged in, allow
+    // CASE: user is logged in with user auth, skip to permission system
     if (!req.api_key) {
         return next();
     }
 
+    // CASE: user is requesting with staff token, check blocklist, else skip to permission system
+    // Staff tokens have a user_id associated with them, integration tokens don't
+    if (req.api_key && req.api_key.get('user_id')) {
+        // Check if staff token is trying to access blocked endpoints
+        // Remove trailing slash for consistent comparison
+        const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
+        const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';
+
+        if (isDeleteAllContent || isTransferOwnership) {
+            return next(new errors.NoPermissionError({
+                message: tpl(messages.staffTokenBlocked)
+            }));
+        }
+
+        return next();
+    }
+
+    // CASE: god mode is enabled & we're in development, skip to permission system
     if (req.query.god_mode && process.env.NODE_ENV === 'development') {
         return next();
     }
 
-    // @NOTE: integrations & staff tokens have limited access to the API
+    // CASE: we're using an integration token, check allowlist for permitted endpoints
     const allowlisted = {
         site: ['GET'],
         posts: ['GET', 'PUT', 'DELETE', 'POST'],

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -22,7 +22,8 @@ const notImplemented = function notImplemented(req, res, next) {
 
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
-if (req.api_key?.get('user_id')) {
+    if (req.api_key?.get('user_id')) {
+        // Check if staff token is trying to access blocked endpoints
         // Remove trailing slash for consistent comparison
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
         const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -22,7 +22,8 @@ const notImplemented = function notImplemented(req, res, next) {
 
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
-    if (req.api_key && req.api_key.get('user_id')) {
+-    if (req.api_key && req.api_key.get('user_id')) {
++    if (req.api_key?.get('user_id')) {
         // Check if staff token is trying to access blocked endpoints
         // Remove trailing slash for consistent comparison
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -23,7 +23,6 @@ const notImplemented = function notImplemented(req, res, next) {
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
 if (req.api_key?.get('user_id')) {
-        // Check if staff token is trying to access blocked endpoints
         // Remove trailing slash for consistent comparison
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
         const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -22,8 +22,7 @@ const notImplemented = function notImplemented(req, res, next) {
 
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
--    if (req.api_key && req.api_key.get('user_id')) {
-+    if (req.api_key?.get('user_id')) {
+if (req.api_key?.get('user_id')) {
         // Check if staff token is trying to access blocked endpoints
         // Remove trailing slash for consistent comparison
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -23,7 +23,6 @@ const notImplemented = function notImplemented(req, res, next) {
     // CASE: user is requesting with staff token, check blocklist, else skip to permission system
     // Staff tokens have a user_id associated with them, integration tokens don't
     if (req.api_key?.get('user_id')) {
-        // Check if staff token is trying to access blocked endpoints
         // Remove trailing slash for consistent comparison
         const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
         const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';

--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -70,6 +70,7 @@ describe('Admin API', function () {
         });
     });
 
+    // The intention of these tests is to generally demonstrate that integration tokens work with limited access
     describe('Integration Tokens', function () {
         describe('Zapier', function () {
             before(async function () {
@@ -108,12 +109,121 @@ describe('Admin API', function () {
         });
     });
 
+    // Make sure that user auth works in tests, after using a token
     describe('User Authentication', function () {
-        it('Double check we can do user auth after a token is used', async function () {
+        it('can do user auth after a token is used', async function () {
             await agent.loginAsOwner();
             await agent
                 .get('users/me')
                 .expectStatus(200);
+        });
+    });
+
+    // Make sure that staff tokens are blocked from certain endpoints
+    describe('Staff Token Blocklist', function () {
+        describe('DELETE /db endpoint', function () {
+            it('Owner staff token should be blocked', async function () {
+                await agent.useStaffTokenForOwner();
+                await agent
+                    .delete('db')
+                    .expectStatus(403);
+            });
+
+            it('Admin staff token should be blocked', async function () {
+                await agent.useStaffTokenForAdmin();
+                await agent
+                    .delete('db')
+                    .expectStatus(403);
+            });
+
+            it('Editor staff token should be blocked', async function () {
+                await agent.useStaffTokenForEditor();
+                await agent
+                    .delete('db')
+                    .expectStatus(403);
+            });
+
+            it('Regular user authentication should work (if user has permission)', async function () {
+                await agent.loginAsOwner();
+                // Owner actually has permission to delete all content, so this should succeed
+                // The important thing is that it's not blocked by the staff token check
+                await agent
+                    .delete('db')
+                    .expectStatus(204); // Success - owner can delete all content
+            });
+        });
+
+        describe('PUT /users/owner endpoint', function () {
+            it('Owner staff token should be blocked', async function () {
+                await agent.useStaffTokenForOwner();
+                await agent
+                    .put('users/owner')
+                    .body({
+                        owner: [{
+                            id: fixtureManager.get('users', 1).id,
+                            email: fixtureManager.get('users', 1).email
+                        }]
+                    })
+                    .expectStatus(403)
+                    .expect(({body}) => {
+                        assert.equal(body.errors[0].type, 'NoPermissionError');
+                        assert.equal(body.errors[0].message, 'Staff tokens are not allowed to access this endpoint');
+                    });
+            });
+
+            it('Admin staff token should be blocked', async function () {
+                await agent.useStaffTokenForAdmin();
+                await agent
+                    .put('users/owner')
+                    .body({
+                        owner: [{
+                            id: fixtureManager.get('users', 1).id,
+                            email: fixtureManager.get('users', 1).email
+                        }]
+                    })
+                    .expectStatus(403)
+                    .expect(({body}) => {
+                        assert.equal(body.errors[0].type, 'NoPermissionError');
+                        assert.equal(body.errors[0].message, 'Staff tokens are not allowed to access this endpoint');
+                    });
+            });
+
+            it('Regular user authentication should work (if user has permission)', async function () {
+                await agent.loginAsOwner();
+                // Note: This will likely fail with validation or other errors, but not the staff token error
+                await agent
+                    .put('users/owner')
+                    .body({
+                        owner: [{
+                            id: fixtureManager.get('users', 1).id,
+                            email: fixtureManager.get('users', 1).email
+                        }]
+                    })
+                    .expectStatus(200);
+            });
+        });
+
+        describe('Other endpoints should work normally', function () {
+            it('Staff tokens can still access GET /users', async function () {
+                await agent.useStaffTokenForAdmin();
+                await agent
+                    .get('users')
+                    .expectStatus(200);
+            });
+
+            it('Staff tokens can get invites, which integrations cannot', async function () {
+                await agent.useStaffTokenForEditor();
+                await agent
+                    .get('invites')
+                    .expectStatus(200);
+            });
+
+            it('Integrations still cannot access invites', async function () {
+                await agent.useZapierAdminAPIKey();
+                await agent
+                    .get('invites')
+                    .expectStatus(501);
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/web/api/admin/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/admin/middleware.test.js
@@ -1,0 +1,234 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const errors = require('@tryghost/errors');
+
+// Module under test
+const middleware = require('../../../../../../core/server/web/api/endpoints/admin/middleware');
+
+describe('Admin API Middleware', function () {
+    describe('notImplemented', function () {
+        let req, res, next;
+
+        beforeEach(function () {
+            req = {
+                method: 'GET',
+                path: '/posts/',
+                url: '/posts',
+                query: {}
+            };
+            res = {};
+            next = sinon.stub();
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        describe('User Authentication (no API key)', function () {
+            it('should call next() when user is authenticated without API key', function () {
+                req.api_key = null;
+                req.user = {id: 'abcd1234'};
+
+                // Get the notImplemented middleware from the authAdminApi array
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+        });
+
+        describe('Staff Token Authentication', function () {
+            beforeEach(function () {
+                // Mock api_key as a Bookshelf model with get() method
+                req.api_key = {
+                    get: sinon.stub().withArgs('user_id').returns('abcd1234')
+                };
+                req.user = {id: 'abcd1234', role: 'Editor'};
+            });
+
+            it('should allow staff tokens to access regular endpoints', function () {
+                req.path = '/posts/';
+                req.method = 'GET';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should block staff tokens from DELETE /db/ endpoint', function () {
+                req.path = '/db/';
+                req.method = 'DELETE';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
+            });
+
+            it('should block staff tokens from PUT /users/owner/ endpoint', function () {
+                req.path = '/users/owner/';
+                req.method = 'PUT';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
+            });
+
+            it('should allow staff tokens to POST to /db/ endpoint', function () {
+                req.path = '/db/';
+                req.method = 'POST';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should allow staff tokens to GET /users/owner/ endpoint', function () {
+                req.path = '/users/owner/';
+                req.method = 'GET';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should allow staff tokens to access endpoints without trailing slash', function () {
+                req.path = '/posts';
+                req.method = 'GET';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should not block staff tokens from DELETE /db (without trailing slash)', function () {
+                req.path = '/db';
+                req.method = 'DELETE';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                // Should pass through since we're checking for exact match with trailing slash
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+        });
+
+        describe('Integration Token Authentication', function () {
+            beforeEach(function () {
+                // Mock api_key as a Bookshelf model with get() method that returns null for user_id
+                req.api_key = {
+                    get: sinon.stub().withArgs('user_id').returns(null)
+                };
+                req.user = null; // Integration tokens don't have associated users
+            });
+
+            it('should allow integration tokens to access allowlisted endpoints', function () {
+                req.url = '/posts';
+                req.method = 'GET';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should block integration tokens from non-allowlisted endpoints', function () {
+                req.url = '/non-existent';
+                req.method = 'GET';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.InternalServerError, true);
+                assert.equal(error.statusCode, 501);
+            });
+
+            it('should allow integration tokens to POST to /db endpoint', function () {
+                req.url = '/db';
+                req.method = 'POST';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+            });
+
+            it('should block integration tokens from DELETE /db endpoint', function () {
+                req.url = '/db';
+                req.method = 'DELETE';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.InternalServerError, true);
+                assert.equal(error.statusCode, 501);
+            });
+        });
+
+        describe('God Mode', function () {
+            it('should allow access in development with god_mode query param', function () {
+                const originalEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'development';
+
+                req.api_key = {
+                    get: sinon.stub().withArgs('user_id').returns(null)
+                };
+                req.user = null;
+                req.query.god_mode = 'true';
+                req.url = '/non-existent';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                assert.equal(next.firstCall.args.length, 0);
+
+                process.env.NODE_ENV = originalEnv;
+            });
+
+            it('should not allow god mode in production', function () {
+                const originalEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+
+                req.api_key = {
+                    get: sinon.stub().withArgs('user_id').returns(null)
+                };
+                req.user = null;
+                req.query.god_mode = 'true';
+                req.url = '/non-existent';
+
+                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                notImplemented(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.InternalServerError, true);
+
+                process.env.NODE_ENV = originalEnv;
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2148/improve-staff-token-api-access

- Staff tokens were added years ago, but they were given the same permissions as integrations
- Integrations are restricted to "safe" actions and stable endpoints at the moment
- However, staff tokens are intended to give much the same access as if you login with your username and password
- There are two notable exceptions: Transfering Ownership & Deleting all Content. These cannot be done with a token
- This change uses a permission error instead of not implemented error (that needs to change for integrations too)
- It also introduces a full suite of middleware for the "notImplemented" middleware that seems to have flown under the radar
- There are also extensive e2e api tests, because this behaviour is critical and depends on middleware both up and down the stack working well too
