### PR TITLE
Updated backup tests to use latest test framework

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Backup Integration Backup API Backup Integration Can create a DB backup 1: [body] 1`] = `
+Object {
+  "db": Array [
+    Object {
+      "filename": StringMatching /ghost-test\\\\/data\\\\/test\\\\\\.json\\$/,
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Backup Integration Can create a DB backup 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Editor: User authentication Cannot create a DB backup 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "You do not have permission to backupContent db",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Editor: User authentication Cannot create a DB backup 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "236",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Owner: User authentication Can create a DB backup 1: [body] 1`] = `
+Object {
+  "db": Array [
+    Object {
+      "filename": StringMatching /ghost-test\\\\/data\\\\/test\\\\\\.json\\$/,
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Owner: User authentication Can create a DB backup 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Zapier Integration Cannot create a DB backup 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "You do not have permission to backupContent db",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Zapier Integration Cannot create a DB backup 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -1,0 +1,128 @@
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {anyContentLength, anyContentVersion, anyEtag, anyErrorId, stringMatching} = matchers;
+const fs = require('fs-extra');
+const sinon = require('sinon');
+const assert = require('assert/strict');
+
+describe('Backup Integration', function () {
+    let agent, fsStub;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+    });
+
+    beforeEach(function () {
+        fsStub = sinon.stub(fs, 'writeFile').resolves();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('Backup API', function () {
+        describe('Backup Integration', function () {
+            before(async function () {
+                await agent.useBackupAdminAPIKey();
+            });
+
+            it('Can create a DB backup', async function () {
+                await agent
+                    .post('db/backup?filename=test')
+                    .expectStatus(200)
+                    .matchHeaderSnapshot({
+                        'content-length': anyContentLength,
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        db: [{
+                            filename: stringMatching(/ghost-test\/data\/test\.json$/)
+                        }]
+                    });
+
+                sinon.assert.calledOnce(fsStub);
+                const args = fsStub.firstCall.args;
+                const fileJSON = JSON.parse(args[1]);
+
+                assert.match(args[0].toString(), /ghost-test\/data\/test.json$/);
+                // @TODO: make a way do this with snapshots!
+                assert.ok(fileJSON.meta, 'Written file has a property called meta');
+                assert.ok(fileJSON.data, 'Written file has a property called data');
+            });
+        });
+
+        describe('Zapier Integration', function () {
+            before(async function () {
+                await agent.useZapierAdminAPIKey();
+            });
+
+            it('Cannot create a DB backup', async function () {
+                await agent
+                    .post('db/backup?filename=test')
+                    .expectStatus(403)
+                    .matchHeaderSnapshot({
+                        'content-length': anyContentLength,
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        errors: [{
+                            id: anyErrorId
+                        }]
+                    });
+            });
+        });
+
+        describe('Owner: User authentication', function () {
+            before(async function () {
+                await agent.loginAsOwner();
+            });
+
+            it('Can create a DB backup', async function () {
+                await agent
+                    .post('db/backup?filename=test')
+                    .expectStatus(200)
+                    .matchHeaderSnapshot({
+                        'content-length': anyContentLength,
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        db: [{
+                            filename: stringMatching(/ghost-test\/data\/test\.json$/)
+                        }]
+                    });
+
+                sinon.assert.calledOnce(fsStub);
+                const args = fsStub.firstCall.args;
+                const fileJSON = JSON.parse(args[1]);
+
+                assert.match(args[0].toString(), /ghost-test\/data\/test.json$/);
+                // @TODO: make a way do this with snapshots!
+                assert.ok(fileJSON.meta, 'Written file has a property called meta');
+                assert.ok(fileJSON.data, 'Written file has a property called data');
+            });
+        });
+
+        describe('Editor: User authentication', function () {
+            before(async function () {
+                await agent.loginAsEditor();
+            });
+
+            it('Cannot create a DB backup', async function () {
+                await agent.post('db/backup?filename=test')
+                    .expectStatus(403)
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        errors: [{
+                            id: anyErrorId
+                        }]
+                    });
+            });
+        });
+    });
+});


### PR DESCRIPTION
ref https://www.notion.so/ghost/End-to-end-Testing-6a2ef073b1754b18aff42e24a632a007

- We have a more up-to-date testing framework for our API
- We should be using it everywhere and have at least one test for each endpoint
- This change is more of a rewrite than a port, moving the backup tests from our regression suite into the new framework with a cleaner pattern for using various tokens and auth
- This is paving the way for giving our backup integration more permissions

