### PR TITLE
✨ Added member export perms to backup integration

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.121/2025-05-29-08-41-04-add-member-export-permissions-to-backup-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.121/2025-05-29-08-41-04-add-member-export-permissions-to-backup-integration.js
@@ -1,0 +1,6 @@
+const {addPermissionToRole} = require('../../utils');
+
+module.exports = addPermissionToRole({
+    permission: 'Browse Members',
+    role: 'DB Backup Integration'
+});

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -879,7 +879,8 @@
                     "identity": "read"
                 },
                 "DB Backup Integration": {
-                    "db": "all"
+                    "db": "all",
+                    "member": "browse"
                 },
                 "Scheduler Integration": {
                     "post": "publish"

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -51,18 +51,17 @@ describe('Backup Integration', function () {
                 assert.ok(fileJSON.data, 'Written file has a property called data');
             });
 
-            it('Cannot export members CSV', async function () {
+            it('Can export members CSV', async function () {
                 await agent
                     .get('members/upload/?limit=all')
-                    .expectStatus(403)
+                    .expectStatus(200)
+                    .expectEmptyBody()
                     .matchHeaderSnapshot({
                         'content-version': anyContentVersion,
-                        etag: anyEtag
+                        'content-disposition': stringMatching(/attachment; filename="members\./)
                     })
-                    .matchBodySnapshot({
-                        errors: [{
-                            id: anyErrorId
-                        }]
+                    .expect(({text}) => {
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
                     });
             });
         });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -191,7 +191,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 134;
+                const FIXTURE_COUNT = 135;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '7030a2cd09082d8f798a221877a76347';
-    const currentFixturesHash = '0e26f9262320630078b2dcc231db350c';
+    const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
     const currentSettingsHash = '96d23249b355f359c7d349da38ab5f15';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1048,7 +1048,8 @@
                     "identity": "read"
                 },
                 "DB Backup Integration": {
-                    "db": "all"
+                    "db": "all",
+                    "member": "browse"
                 },
                 "Scheduler Integration": {
                     "post": "publish"


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2407/add-member-export-permissions-to-backup-integration ref https://github.com/TryGhost/Ghost-CLI/issues/1952

- We want the DB Backup Integration to be able to do a more complete backup
- There is no explicit export members permission, we use browse members
- Therefore adding the browse members permission allows the DB Backup Integration to export members as well as export content
- This change is made in fixtures and with a migration to ensure both new and existing sites get the update, and it's also applied in tests

