### PR TITLE
Removed inline styles for latest posts and feedback sections

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -535,6 +535,13 @@ figure blockquote p {
     FEEDBACK BUTTONS
 ------------------------------------- */
 
+.feedback-buttons-container {
+    padding: 32px 0 24px;
+    border-bottom: 1px solid #e0e7eb;
+    background-color: #ffffff;
+    text-align: center;
+}
+
 .feedback-buttons {
     /*width: auto !important;*/
     width: 100% !important;
@@ -561,6 +568,11 @@ figure blockquote p {
 /* -------------------------------------
     LATEST POSTS TABLE
 ------------------------------------- */
+
+.latest-posts-container {
+    padding: 24px 0;
+    border-bottom: 1px solid #e0e7eb;
+}
 
 h3.latest-posts-header {
     margin: 0;

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -153,7 +153,7 @@
 
                             {{#if (or feedbackButtons newsletter.showCommentCta) }}
                                 <tr>
-                                    <td dir="ltr" width="100%" style="background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e0e7eb;" align="center">
+                                    <td class="feedback-buttons-container" dir="ltr" width="100%" align="center">
                                         <table class="feedback-buttons" role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
                                                 {{#if feedbackButtons }}
@@ -171,7 +171,7 @@
 
                              {{#if latestPosts.length}}
                                 <tr>
-                                    <td style="padding: 24px 0; border-bottom: 1px solid #e0e7eb;">
+                                    <td class="latest-posts-container">
                                         <h3 class="latest-posts-header">{{t 'Keep reading'}}</h3>
                                         {{> latestPosts}}
                                     </td>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1705

- moving to classes keeps all styling in styles.hbs
- allows for easier overriding of divider color in a future update
