### PR TITLE
Newsletter divider color setting alpha

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
@@ -1,6 +1,7 @@
 import NewsletterPreview from './NewsletterPreview';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
+import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
 import validator from 'validator';
 import {Button, ButtonGroup, ColorPickerField, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, SelectOption, Separator, Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
@@ -66,7 +67,7 @@ const Sidebar: React.FC<{
     errors: ErrorMessages;
     clearError: (field: string) => void;
 }> = ({newsletter, onlyOne, updateNewsletter, validate, errors, clearError}) => {
-    // const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
+    const hasEmailCustomizationAlpha = useFeatureFlag('emailCustomizationAlpha');
 
     const {updateRoute} = useRouting();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
@@ -688,27 +689,29 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
-                    {/* <div className='mb-1'>
-                        <ColorPickerField
-                            direction='rtl'
-                            eyedropper={true}
-                            swatches={[
-                                {
-                                    value: 'light',
-                                    title: 'Light',
-                                    hex: '#e0e7eb'
-                                },
-                                {
-                                    value: 'accent',
-                                    title: 'Accent',
-                                    hex: siteData.accent_color
-                                }
-                            ]}
-                            title='Divider color'
-                            value={newsletter.divider_color || 'light'}
-                            onChange={color => updateNewsletter({divider_color: color})}
-                        />
-                    </div> */}
+                    {hasEmailCustomizationAlpha &&
+                        <div className='mb-1'>
+                            <ColorPickerField
+                                direction='rtl'
+                                eyedropper={true}
+                                swatches={[
+                                    {
+                                        value: 'light',
+                                        title: 'Light',
+                                        hex: '#e0e7eb'
+                                    },
+                                    {
+                                        value: 'accent',
+                                        title: 'Accent',
+                                        hex: siteData.accent_color
+                                    }
+                                ]}
+                                title='Divider color'
+                                value={newsletter.divider_color || 'light'}
+                                onChange={color => updateNewsletter({divider_color: color})}
+                            />
+                        </div>
+                    }
                 </Form>
             </>
         }

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -348,7 +348,11 @@ class EmailRenderer {
         if (labs?.isSet('emailCustomizationAlpha')) {
             renderOptions.design = {
                 ...renderOptions.design,
-                ...betaDesignOptions
+                ...betaDesignOptions,
+                // TODO:
+                // if the other options have default values we should follow the same pattern
+                // as the divider color to avoid duplicating magic values in renderers
+                dividerColor: this.#getDividerColor(newsletter)
             };
         }
 
@@ -1025,6 +1029,24 @@ class EmailRenderer {
         return false;
     }
 
+    #getDividerColor(newsletter) {
+        const labs = this.getLabs();
+
+        if (labs?.isSet('emailCustomizationAlpha')) {
+            const value = newsletter?.get('divider_color');
+            const validHex = /#([0-9a-f]{3}){1,2}$/i;
+
+            if (value === 'accent') {
+                return this.#settingsCache.get('accent_color');
+            } else if (validHex.test(value)) {
+                return value;
+            }
+        }
+
+        // value === 'light'/missing/invalid
+        return '#e0e7eb';
+    }
+
     /**
      * @private
      */
@@ -1054,6 +1076,7 @@ class EmailRenderer {
         const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
         const hasRoundedImageCorners = hasAnyEmailCustomization ? this.#getImageCorners(newsletter) : false;
         const sectionTitleColor = hasAnyEmailCustomization ? this.#getSectionTitleColor(newsletter, accentColor) : null;
+        const dividerColor = this.#getDividerColor(newsletter);
 
         let buttonBorderRadius = '6px';
         if (hasAnyEmailCustomization) {
@@ -1216,6 +1239,7 @@ class EmailRenderer {
             headerImage,
             headerImageWidth,
             showHeaderIcon: newsletter.get('show_header_icon') && this.#settingsCache.get('icon'),
+            dividerColor,
 
             // TODO: consider moving these to newsletter property
             showHeaderTitle: newsletter.get('show_header_title'),

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -86,7 +86,7 @@ hr {
     height: 1px;
     background-color: transparent;
     border: 0;
-    border-top: 1px solid #e0e7eb;
+    border-top: 1px solid {{dividerColor}};
 }
 
 p,
@@ -537,7 +537,7 @@ figure blockquote p {
 
 .feedback-buttons-container {
     padding: 32px 0 24px;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
     background-color: #ffffff;
     text-align: center;
 }
@@ -571,7 +571,7 @@ figure blockquote p {
 
 .latest-posts-container {
     padding: 24px 0;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
 }
 
 h3.latest-posts-header {
@@ -655,7 +655,7 @@ h3.latest-posts-header {
 
 .subscription-box {
     padding: 32px 0;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
     color: #15212A;
 }
 
@@ -702,7 +702,7 @@ h3.latest-posts-header {
     line-height: 1.5em;
     color: #15212A;
     padding-bottom: 20px;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
 }
 
 .post-content-sans-serif {
@@ -711,7 +711,7 @@ h3.latest-posts-header {
     line-height: 1.5em;
     color: #15212A;
     padding-bottom: 20px;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
 }
 
 .post-content-row:first-child > td, .header-image-row + .post-content-row > td {
@@ -1030,11 +1030,11 @@ td.kg-card-spacing {
 }
 
 .kg-cta-card.kg-cta-bg-none:not(.kg-cta-no-dividers) {
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
 }
 
 .kg-cta-bg-none.kg-cta-no-label:not(.kg-cta-no-dividers) {
-    border-top: 1px solid #e0e7eb;
+    border-top: 1px solid {{dividerColor}};
 }
 
 .kg-cta-bg-white {
@@ -1072,7 +1072,7 @@ td.kg-card-spacing {
 
 .kg-cta-sponsor-label {
     padding: 12px 0;
-    border-bottom: 1px solid #e0e7eb;
+    border-bottom: 1px solid {{dividerColor}};
 }
 
 .kg-cta-bg-none .kg-cta-sponsor-label {
@@ -1086,7 +1086,7 @@ td.kg-card-spacing {
 
 .kg-cta-bg-none .kg-cta-sponsor-label,
 .kg-cta-bg-white .kg-cta-sponsor-label {
-    border-color: #e0e7eb;
+    border-color: {{dividerColor}};
 }
 
 .kg-cta-bg-grey .kg-cta-sponsor-label {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2101,7 +2101,8 @@ describe('Email renderer', function () {
                 link_style: 'normal',
                 image_corners: 'rounded',
                 section_title_color: '#BADA55',
-                post_title_color: '#BADA55'
+                post_title_color: '#BADA55',
+                divider_color: 'light' // should return our default hex value
             });
             const segment = null;
             const options = {};
@@ -2141,7 +2142,8 @@ describe('Email renderer', function () {
                     linkStyle: 'normal',
                     imageCorners: 'rounded',
                     sectionTitleColor: '#BADA55',
-                    postTitleColor: '#BADA55'
+                    postTitleColor: '#BADA55',
+                    dividerColor: '#e0e7eb'
                 },
                 labs: {emailCustomizationAlpha: true}
             });
@@ -2307,6 +2309,7 @@ describe('Email renderer', function () {
             });
             assert.equal(data.sectionTitleColor, null);
         });
+
         it('Sets the backgroundIsDark correctly', async function () {
             const tests = [
                 {background_color: '#15212A', expected: true},
@@ -2743,6 +2746,37 @@ describe('Email renderer', function () {
 
         it('passes newsletter link_style through (emailCustomizationAlpha)', async function () {
             await testLinkStyle('normal', 'normal', {labsEnabled: false});
+        });
+
+        function testDividerColor(settingValue, expectedValue) {
+            testDataProperty({
+                divider_color: settingValue
+            }, 'dividerColor', expectedValue, {labsEnabled: true});
+        }
+
+        it('sets dividerColor to correct default (no labs flags)', async function () {
+            await testDividerColor('accent', '#e0e7eb');
+        });
+
+        it('sets dividerColor to correct default value (emailCustomizationAlpha)', async function () {
+            await testDividerColor(null, '#e0e7eb');
+        });
+
+        it('sets dividerColor to correct light value (emailCustomizationAlpha)', async function () {
+            await testDividerColor('light', '#e0e7eb');
+        });
+
+        it('sets dividerColor to correct accent value (emailCustomizationAlpha)', async function () {
+            settings.accent_color = '#aabbcc';
+            await testDividerColor('accent', '#aabbcc');
+        });
+
+        it('sets dividerColor to correct custom value (emailCustomizationAlpha)', async function () {
+            await testDividerColor('#BADA55', '#BADA55');
+        });
+
+        it('sets dividerColor to default value if invalid value is provided (emailCustomizationAlpha)', async function () {
+            await testDividerColor('#nothex', '#e0e7eb');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1705

- enabled divider color setting in newsletter design modal
- added `dividerColor` property to email template data
  - uses site accent color when setting is set to "accent"
  - uses custom color when setting has a valid hex string
  - otherwise defaults to our standard "light" divider color (same when flag is not enabled)
- updated `styles.hbs` to use `{{dividerColor}}` everywhere we previously used the hardcoded "light" hex color for dividers
- CTA card still uses hardcoded hex colors when a different background color is applied