### PR TITLE
Fixed email-renderer unit test for dividerColor with no labs flag set

### DIFF
--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2748,14 +2748,14 @@ describe('Email renderer', function () {
             await testLinkStyle('normal', 'normal', {labsEnabled: false});
         });
 
-        function testDividerColor(settingValue, expectedValue) {
+        function testDividerColor(settingValue, expectedValue, options = {labsEnabled: true}) {
             testDataProperty({
                 divider_color: settingValue
-            }, 'dividerColor', expectedValue, {labsEnabled: true});
+            }, 'dividerColor', expectedValue, options);
         }
 
         it('sets dividerColor to correct default (no labs flags)', async function () {
-            await testDividerColor('accent', '#e0e7eb');
+            await testDividerColor('accent', '#e0e7eb', {labsEnabled: false});
         });
 
         it('sets dividerColor to correct default value (emailCustomizationAlpha)', async function () {


### PR DESCRIPTION
no issue

- fixed hardcoded `labsEnabled: true` in test function so our "no labs flag" test can correctly disable labs flags
