### PR TITLE
Added "View all" to long tables in analytics

### DIFF
--- a/apps/shade/src/components/ui/sheet.tsx
+++ b/apps/shade/src/components/ui/sheet.tsx
@@ -22,7 +22,7 @@ const SheetOverlay = React.forwardRef<
 >(({className, ...props}, ref) => (
     <SheetPrimitive.Overlay
         className={cn(
-            'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'fixed inset-0 z-50 bg-black/10  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
             className
         )}
         {...props}
@@ -59,18 +59,20 @@ const SheetContent = React.forwardRef<
     SheetContentProps
 >(({side = 'right', className, children, ...props}, ref) => (
     <SheetPortal>
-        <SheetOverlay />
-        <SheetPrimitive.Content
-            ref={ref}
-            className={cn(sheetVariants({side}), className)}
-            {...props}
-        >
-            <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-                <X className="h-4 w-4" />
-                <span className="sr-only">Close</span>
-            </SheetPrimitive.Close>
-            {children}
-        </SheetPrimitive.Content>
+        <div className='shade'>
+            <SheetOverlay />
+            <SheetPrimitive.Content
+                ref={ref}
+                className={cn(sheetVariants({side}), className)}
+                {...props}
+            >
+                <SheetPrimitive.Close className="fixed right-4 top-4 z-50 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+                    <X className="size-4" />
+                    <span className="sr-only">Close</span>
+                </SheetPrimitive.Close>
+                {children}
+            </SheetPrimitive.Content>
+        </div>
     </SheetPortal>
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -1,11 +1,11 @@
 import AreaChart from './components/AreaChart';
 import AudienceSelect, {getAudienceQueryParam} from './components/AudienceSelect';
 import DateRangeSelect from './components/DateRangeSelect';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange, isValidDomain} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange, isValidDomain} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {SourceRow} from './Sources';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
@@ -27,6 +27,12 @@ interface TopContentData {
 interface KpiDataItem {
     date: string;
     [key: string]: string | number;
+}
+
+interface SourcesData {
+    source?: string | number;
+    visits: string | number;
+    [key: string]: unknown;
 }
 
 const KPI_METRICS: Record<string, KpiMetric> = {
@@ -56,39 +62,31 @@ const KPI_METRICS: Record<string, KpiMetric> = {
     }
 };
 
-const WebKPIs:React.FC = ({}) => {
-    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
+interface WebKPIsProps {
+    data: KpiDataItem[] | null;
+    isLoading: boolean;
+    range: number;
+}
+
+const WebKPIs: React.FC<WebKPIsProps> = ({data, isLoading, range}) => {
     const [currentTab, setCurrentTab] = useState('visits');
-    const {range, audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
-
-    const params = {
-        site_uuid: statsConfig?.id || '',
-        date_from: formatQueryDate(startDate),
-        date_to: formatQueryDate(endDate),
-        timezone: timezone,
-        member_status: getAudienceQueryParam(audience)
-    };
-
-    const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: getToken(statsConfig),
-        params
-    });
-
-    const isLoading = isConfigLoading || loading;
-
     const currentMetric = KPI_METRICS[currentTab];
 
-    const chartData = sanitizeChartData<KpiDataItem>(data as KpiDataItem[] || [], range, currentMetric.dataKey as keyof KpiDataItem, 'sum')?.map((item: KpiDataItem) => {
-        const value = Number(item[currentMetric.dataKey]);
-        return {
-            date: String(item.date),
-            value,
-            formattedValue: currentMetric.formatter(value),
-            label: currentMetric.label
-        };
-    });
+    const chartData = useMemo(() => {
+        if (!data || isLoading) {
+            return [];
+        }
+
+        return sanitizeChartData<KpiDataItem>(data, range, currentMetric.dataKey as keyof KpiDataItem, 'sum')?.map((item: KpiDataItem) => {
+            const value = Number(item[currentMetric.dataKey]);
+            return {
+                date: String(item.date),
+                value,
+                formattedValue: currentMetric.formatter(value),
+                label: currentMetric.label
+            };
+        });
+    }, [data, range, currentMetric, isLoading]);
 
     // Calculate KPI values
     const getKpiValues = () => {
@@ -96,7 +94,10 @@ const WebKPIs:React.FC = ({}) => {
             return {visits: 0, views: 0, bounceRate: 0, duration: 0};
         }
 
-        // Sum total KPI value from the trend, ponderating using sessions
+        const totalVisits = data.reduce((sum, item) => sum + Number(item.visits), 0);
+        const totalViews = data.reduce((sum, item) => sum + Number(item.pageviews), 0);
+
+        // Ponderated KPIs calculation
         const _ponderatedKPIsTotal = (kpi: keyof typeof data[0]) => {
             return data.reduce((prev, curr) => {
                 const currValue = Number(curr[kpi] ?? 0);
@@ -105,8 +106,6 @@ const WebKPIs:React.FC = ({}) => {
             }, 0);
         };
 
-        const totalVisits = data.reduce((sum, item) => sum + Number(item.visits), 0);
-        const totalViews = data.reduce((sum, item) => sum + Number(item.pageviews), 0);
         const avgBounceRate = _ponderatedKPIsTotal('bounce_rate');
         const avgDuration = _ponderatedKPIsTotal('avg_session_sec');
 
@@ -123,14 +122,10 @@ const WebKPIs:React.FC = ({}) => {
     return (
         <Tabs defaultValue="visits" variant='kpis'>
             <TabsList className="-mx-6 grid grid-cols-2">
-                <KpiTabTrigger value="visits" onClick={() => {
-                    setCurrentTab('visits');
-                }}>
+                <KpiTabTrigger value="visits" onClick={() => setCurrentTab('visits')}>
                     <KpiTabValue color={KPI_METRICS.visits.chartColor} label="Unique visitors" value={kpiValues.visits} />
                 </KpiTabTrigger>
-                <KpiTabTrigger value="views" onClick={() => {
-                    setCurrentTab('views');
-                }}>
+                <KpiTabTrigger value="views" onClick={() => setCurrentTab('views')}>
                     <KpiTabValue color={KPI_METRICS.views.chartColor} label="Total views" value={kpiValues.views} />
                 </KpiTabTrigger>
             </TabsList>
@@ -150,11 +145,123 @@ const WebKPIs:React.FC = ({}) => {
     );
 };
 
-const SourcesTable:React.FC = () => {
-    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
-    const {range, audience} = useGlobalData();
+interface TopContentCardProps {
+    data: TopContentData[] | null;
+    range: number;
+}
+
+const TopContentCard: React.FC<TopContentCardProps> = ({data, range}) => {
+    const navigate = useNavigate();
+    const topContent = data || [];
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Top content</CardTitle>
+                <CardDescription>Your highest viewed posts or pages {getPeriodText(range)}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Separator />
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Content</TableHead>
+                            <TableHead className='text-right'>Visitors</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {topContent?.map((row: TopContentData) => {
+                            return (
+                                <TableRow key={row.pathname}>
+                                    <TableCell className="font-medium">
+                                        <div className='group/link inline-flex items-center gap-2'>
+                                            {row.post_id ?
+                                                <Button className='h-auto whitespace-normal p-0 text-left hover:!underline' title="View post analytics" variant='link' onClick={() => {
+                                                    navigate(`/posts/analytics/beta/${row.post_id}`, {crossApp: true});
+                                                }}>
+                                                    {row.title || row.pathname}
+                                                </Button>
+                                                :
+                                                <>
+                                                    {row.title || row.pathname}
+                                                </>
+                                            }
+                                            <a className='-mx-2 inline-flex min-h-6 items-center gap-1 rounded-sm px-2 opacity-0 hover:underline group-hover/link:opacity-75' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
+                                                <LucideIcon.SquareArrowOutUpRight size={12} strokeWidth={2.5} />
+                                            </a>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
+                                </TableRow>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    );
+};
+
+interface SourcesCardProps {
+    data: SourcesData[] | null;
+    isLoading: boolean;
+    range: number;
+}
+
+const SourcesCard: React.FC<SourcesCardProps> = ({data, isLoading, range}) => {
+    const topSources = data?.slice(0, 10);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Top Sources</CardTitle>
+                <CardDescription>How readers found your site {getPeriodText(range)}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Separator />
+                {isLoading ? '' :
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Source</TableHead>
+                                <TableHead className='text-right'>Visitors</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {topSources?.map((row) => {
+                                return (
+                                    <TableRow key={row.source || 'direct'}>
+                                        <TableCell className="font-medium">
+                                            {row.source && typeof row.source === 'string' && isValidDomain(row.source) ?
+                                                <a className='group flex items-center gap-1' href={`https://${row.source}`} rel="noreferrer" target="_blank">
+                                                    <SourceRow className='group-hover:underline' source={row.source} />
+                                                </a>
+                                                :
+                                                <span className='flex items-center gap-1'>
+                                                    <SourceRow source={row.source} />
+                                                </span>
+                                            }
+                                        </TableCell>
+                                        <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
+                                    </TableRow>
+                                );
+                            })}
+                        </TableBody>
+                    </Table>
+                }
+            </CardContent>
+            <CardFooter>
+                <Button variant='outline'>View all</Button>
+            </CardFooter>
+        </Card>
+    );
+};
+
+const Web: React.FC = () => {
+    const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
+    // Prepare query parameters
     const params = {
         site_uuid: statsConfig?.id || '',
         date_from: formatQueryDate(startDate),
@@ -163,78 +270,37 @@ const SourcesTable:React.FC = () => {
         member_status: getAudienceQueryParam(audience)
     };
 
-    const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
-        token: getToken(statsConfig),
-        params
-    });
-
-    const isLoading = isConfigLoading || loading;
-
-    return (
-        <>
-            {isLoading ? '' :
-                <Table>
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead>Source</TableHead>
-                            <TableHead className='text-right'>Visitors</TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {data?.map((row) => {
-                            return (
-                                <TableRow key={row.source || 'direct'}>
-                                    <TableCell className="font-medium">
-                                        {row.source && typeof row.source === 'string' && isValidDomain(row.source) ?
-                                            <a className='group flex items-center gap-1' href={`https://${row.source}`} rel="noreferrer" target="_blank">
-                                                <SourceRow className='group-hover:underline' source={row.source} />
-                                            </a>
-                                            :
-                                            <span className='flex items-center gap-1'>
-                                                <SourceRow source={row.source} />
-                                            </span>
-                                        }
-                                    </TableCell>
-                                    <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
-                                </TableRow>
-                            );
-                        })}
-                    </TableBody>
-                </Table>
-            }
-        </>
-    );
-};
-
-const Web:React.FC = () => {
-    const {isLoading: isConfigLoading} = useGlobalData();
-    const {range, audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
-    const navigate = useNavigate();
-
-    // Include essential query parameters that change frequently
-    // Server will use defaults for other values
     const queryParams: Record<string, string> = {
         date_from: formatQueryDate(startDate),
         date_to: formatQueryDate(endDate),
         member_status: getAudienceQueryParam(audience)
     };
 
-    // Add timezone only if it differs from default
     if (timezone) {
         queryParams.timezone = timezone;
     }
 
-    // Use the admin-x-framework hook
-    const {data, isLoading: isDataLoading} = useTopContent({
+    // Get KPI data
+    const {data: kpiData, loading: kpiLoading} = useQuery({
+        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
+        token: getToken(statsConfig),
+        params
+    });
+
+    // Get top content data
+    const {data: topContentData, isLoading: topContentLoading} = useTopContent({
         searchParams: queryParams
     });
 
-    const isLoading = isConfigLoading || isDataLoading;
+    // Get top sources data
+    const {data: sourcesData, loading: sourcesLoading} = useQuery({
+        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
+        token: getToken(statsConfig),
+        params
+    });
 
-    // The data structure from the hook is {stats: TopContentData[]}
-    const topContent = data?.stats || [];
+    // Calculate combined loading state
+    const isLoading = isConfigLoading || kpiLoading || topContentLoading || sourcesLoading;
 
     return (
         <StatsLayout>
@@ -242,67 +308,15 @@ const Web:React.FC = () => {
                 <AudienceSelect />
                 <DateRangeSelect />
             </StatsHeader>
-            <StatsView data={topContent} isLoading={isLoading}>
+            <StatsView isLoading={isLoading}>
                 <Card>
                     <CardContent>
-                        <WebKPIs />
+                        <WebKPIs data={kpiData as KpiDataItem[] | null} isLoading={kpiLoading} range={range} />
                     </CardContent>
                 </Card>
                 <div className='grid grid-cols-2 gap-8'>
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>Top content</CardTitle>
-                            <CardDescription>Your highest viewed posts or pages {getPeriodText(range)}</CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <Separator />
-                            <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead>Content</TableHead>
-                                        <TableHead className='text-right'>Visitors</TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {topContent?.map((row: TopContentData) => {
-                                        return (
-                                            <TableRow key={row.pathname}>
-                                                <TableCell className="font-medium">
-                                                    <div className='group/link inline-flex items-center gap-2'>
-                                                        {row.post_id ?
-                                                            <Button className='h-auto whitespace-normal p-0 text-left hover:!underline' title="View post analytics" variant='link' onClick={() => {
-                                                                navigate(`/posts/analytics/beta/${row.post_id}`, {crossApp: true});
-                                                            }}>
-                                                                {row.title || row.pathname}
-                                                            </Button>
-                                                            :
-                                                            <>
-                                                                {row.title || row.pathname}
-                                                            </>
-                                                        }
-                                                        <a className='-mx-2 inline-flex min-h-6 items-center gap-1 rounded-sm px-2 opacity-0 hover:underline group-hover/link:opacity-75' href={`${row.pathname}`} rel="noreferrer" target='_blank'>
-                                                            <LucideIcon.SquareArrowOutUpRight size={12} strokeWidth={2.5} />
-                                                        </a>
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>{formatNumber(Number(row.visits))}</TableCell>
-                                            </TableRow>
-                                        );
-                                    })}
-                                </TableBody>
-                            </Table>
-                        </CardContent>
-                    </Card>
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>Top Sources</CardTitle>
-                            <CardDescription>How readers found your site {getPeriodText(range)}</CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <Separator />
-                            <SourcesTable />
-                        </CardContent>
-                    </Card>
+                    <TopContentCard data={topContentData?.stats || null} range={range} />
+                    <SourcesCard data={sourcesData as SourcesData[] | null} isLoading={sourcesLoading} range={range} />
                 </div>
             </StatsView>
         </StatsLayout>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1849/add-view-all-pattern-to-all-tables

- Some of the tables have had lots of items and needed a way to limit them to the top x and let users view all on request.
