### PR TITLE
🎨 Fixed infinite wait when auth code email fails to send in Direct mode

### DIFF
--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -13,6 +13,10 @@ describe('SessionService', function () {
         getSettingsCache.withArgs('admin_session_secret').returns('secret-key');
     });
 
+    afterEach(function () {
+        sinon.restore();
+    });
+
     it('Returns the user for the id stored on the session', async function () {
         const getSession = async (req) => {
             if (req.session) {
@@ -452,6 +456,139 @@ describe('SessionService', function () {
             .rejectedWith({
                 message: 'Failed to send email. Please check your site configuration and try again.'
             });
+    });
+
+    it('should throw an error after 15 seconds when using direct mode if send has not resolved', async function () {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            shouldAdvanceTime: true
+        });
+        
+        const getSession = async (req) => {
+            if (req.session) {
+                return req.session;
+            }
+            req.session = {
+                user_id: 'user-123',
+                ip: '0.0.0.0',
+                user_agent: 'Fake'
+            };
+            return req.session;
+        };
+
+        const findUserById = sinon.stub().resolves({
+            id: 'user-123',
+            get: sinon.stub().returns('test@example.com')
+        });
+
+        const mailer = {
+            send: sinon.stub().returns(new Promise((resolve) => { setTimeout(() => resolve(), 20000) })),
+            state: {
+                usingDirect: true
+            }
+        };
+
+        const getBlogLogo = sinon.stub().returns('logo.png');
+        const urlUtils = {
+            urlFor: sinon.stub().returns('https://example.com')
+        };
+
+        const t = sinon.stub().callsFake(text => text);
+
+        const sessionService = SessionService({
+            getSession,
+            findUserById,
+            getSettingsCache,
+            getBlogLogo,
+            urlUtils,
+            mailer,
+            t,
+            getOriginOfRequest: sinon.stub(),
+            isStaffDeviceVerificationDisabled: sinon.stub()
+        });
+
+        const req = Object.create(express.request);
+        const res = Object.create(express.response);
+
+        const resultPromise = sessionService.sendAuthCodeToUser(req, res);
+        
+        // Make sure fake timers have had a chance to run
+        await new Promise(setImmediate);
+        
+        // Advance the clock by the expected timeout of 15 seconds
+        clock.tick(15000);
+        
+        // Give our promises a chance to resolve
+        await new Promise(setImmediate);
+        
+        await should(resultPromise).rejectedWith({
+            message: 'Failed to send email. Please check your site configuration and try again.'
+        });
+    });
+
+    it('should wait more than 15 seconds for send to resolve when not using direct mode', async function () {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            shouldAdvanceTime: true
+        });
+        const getSession = async (req) => {
+            if (req.session) {
+                return req.session;
+            }
+            req.session = {
+                user_id: 'user-123',
+                ip: '0.0.0.0',
+                user_agent: 'Fake'
+            };
+            return req.session;
+        };
+
+        const findUserById = sinon.stub().resolves({
+            id: 'user-123',
+            get: sinon.stub().returns('test@example.com')
+        });
+
+        const mailer = {
+            send: sinon.stub().returns(new Promise((resolve) => { setTimeout(() => resolve(), 20000) })),
+            state: {
+                usingDirect: false
+            }
+        };
+
+        const getBlogLogo = sinon.stub().returns('logo.png');
+        const urlUtils = {
+            urlFor: sinon.stub().returns('https://example.com')
+        };
+
+        const t = sinon.stub().callsFake(text => text);
+
+        const sessionService = SessionService({
+            getSession,
+            findUserById,
+            getSettingsCache,
+            getBlogLogo,
+            urlUtils,
+            mailer,
+            t,
+            getOriginOfRequest: sinon.stub(),
+            isStaffDeviceVerificationDisabled: sinon.stub()
+        });
+
+        const req = Object.create(express.request);
+        const res = Object.create(express.response);
+
+        const resultPromise = sessionService.sendAuthCodeToUser(req, res);
+        
+        // Make sure fake timers have had a chance to run
+        await new Promise(setImmediate);
+        
+        // Advance the clock by the expected timeout of 15 seconds
+        clock.tick(20000);
+        
+        // Give our promises a chance to resolve
+        await new Promise(setImmediate);
+        
+        await should(resultPromise).resolved();
     });
 
     it('Can create a verified session for SSO', async function () {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/23050

When email is configured to use Direct mode, it can take over 15 minutes for the email to actually fail to send. When a user attempts to sign in on a new device in this situation, the login screen will appear to be stuck with no feedback.

This is especially problematic because the Docker installation sets up Direct mode for you automatically, and most hosts / ISPs block outbound port 25. This likely means almost any self hoster that has not taken the step of explicitly setting up email will unknowingly be unable to log in to from a new device, and will have difficulty even discovering why.

This change adds a timeout in Direct mode to the sendAuthCodeToUser function. If the email has not been sent after 15 seconds, an error is thrown, which will then surface the 'Failed to send email. Please check your site configuration and try again.', which will will then lead them to either setting up email correctly or disabling the email 2FA.


Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
