### PR TITLE
Added custom link color to email settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
@@ -603,7 +603,7 @@ const Sidebar: React.FC<{
                             }
                         ]} clearBg={false} />
                     </div>
-                    {/* <div className='mb-1'>
+                    <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
                             eyedropper={true}
@@ -623,7 +623,7 @@ const Sidebar: React.FC<{
                             value={newsletter.link_color}
                             onChange={color => updateNewsletter({link_color: color})}
                         />
-                    </div> */}
+                    </div>
                     <div className='flex w-full justify-between'>
                         <div>Link style</div>
                         <ButtonGroup activeKey={newsletter.link_style || 'underline'} buttons={[

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -352,7 +352,8 @@ class EmailRenderer {
                 // TODO:
                 // if the other options have default values we should follow the same pattern
                 // as the divider color to avoid duplicating magic values in renderers
-                dividerColor: this.#getDividerColor(newsletter)
+                dividerColor: this.#getDividerColor(newsletter),
+                linkColor: newsletter.get('link_color')
             };
         }
 
@@ -1047,6 +1048,19 @@ class EmailRenderer {
         return '#e0e7eb';
     }
 
+    #getLinkColor(newsletter, accentColor, backgroundIsDark) {
+        const labs = this.getLabs();
+        if (labs?.isSet('emailCustomizationAlpha')) {
+            const value = newsletter.get('link_color');
+            const validHex = /#([0-9a-f]{3}){1,2}$/i;
+
+            if (validHex.test(value)) {
+                return value;
+            }
+        }
+
+        return backgroundIsDark ? '#ffffff' : accentColor;
+    }
     /**
      * @private
      */
@@ -1073,7 +1087,7 @@ class EmailRenderer {
         const titleStrongWeight = this.#getTitleStrongWeight(titleWeight);
         const textColor = textColorForBackgroundColor(backgroundColor).hex();
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
-        const linkColor = backgroundIsDark ? '#ffffff' : accentColor;
+        const linkColor = this.#getLinkColor(newsletter, accentColor, backgroundIsDark);
         const hasRoundedImageCorners = hasAnyEmailCustomization ? this.#getImageCorners(newsletter) : false;
         const sectionTitleColor = hasAnyEmailCustomization ? this.#getSectionTitleColor(newsletter, accentColor) : null;
         const dividerColor = this.#getDividerColor(newsletter);

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1054,6 +1054,10 @@ class EmailRenderer {
             const value = newsletter.get('link_color');
             const validHex = /#([0-9a-f]{3}){1,2}$/i;
 
+            if (value === 'accent') {
+                return accentColor;
+            }
+
             if (validHex.test(value)) {
                 return value;
             }

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1048,7 +1048,7 @@ class EmailRenderer {
         return '#e0e7eb';
     }
 
-    #getLinkColor(newsletter, accentColor, backgroundIsDark) {
+    #getLinkColor(newsletter, accentColor) {
         const labs = this.getLabs();
         if (labs?.isSet('emailCustomizationAlpha')) {
             const value = newsletter.get('link_color');
@@ -1063,7 +1063,7 @@ class EmailRenderer {
             }
         }
 
-        return backgroundIsDark ? '#ffffff' : accentColor;
+        return accentColor;
     }
     /**
      * @private
@@ -1091,7 +1091,7 @@ class EmailRenderer {
         const titleStrongWeight = this.#getTitleStrongWeight(titleWeight);
         const textColor = textColorForBackgroundColor(backgroundColor).hex();
         const secondaryTextColor = textColorForBackgroundColor(backgroundColor).alpha(0.5).toString();
-        const linkColor = this.#getLinkColor(newsletter, accentColor, backgroundIsDark);
+        const linkColor = hasAnyEmailCustomization ? this.#getLinkColor(newsletter, accentColor) : backgroundIsDark ? '#ffffff' : accentColor;
         const hasRoundedImageCorners = hasAnyEmailCustomization ? this.#getImageCorners(newsletter) : false;
         const sectionTitleColor = hasAnyEmailCustomization ? this.#getSectionTitleColor(newsletter, accentColor) : null;
         const dividerColor = this.#getDividerColor(newsletter);

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -353,7 +353,7 @@ class EmailRenderer {
                 // if the other options have default values we should follow the same pattern
                 // as the divider color to avoid duplicating magic values in renderers
                 dividerColor: this.#getDividerColor(newsletter),
-                linkColor: newsletter.get('link_color')
+                linkColor: newsletter?.get('link_color')
             };
         }
 

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -276,6 +276,12 @@ h6 {
     {{/if}}
 }
 
+{{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
+.post-content-row a {
+    color: {{linkColor}} !important;
+}
+{{/hasFeature}}
+
 h1 strong,
 h2 strong,
 h3 strong,

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -277,7 +277,24 @@ h6 {
 }
 
 {{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
-.post-content-row a {
+/* Links in captions */
+.feature-image-caption a,
+figcaption a {
+    color: {{linkColor}};
+}
+
+/* Links inside toggle card (not in CTA cards which have their own setting) */
+.kg-toggle-card:not(.kg-cta-card) a {
+    color: {{linkColor}};
+}
+
+/* Links inside callout cards (except the accent variant which has white links) */
+.kg-callout-card:not(.kg-callout-card-accent) a {
+    color: {{linkColor}};
+}
+
+/* Manage subscription link */
+.subscription-box .manage-subscription a {
     color: {{linkColor}} !important;
 }
 {{/hasFeature}}
@@ -726,7 +743,11 @@ h3.latest-posts-header {
 
 .post-content a,
 .post-content-sans-serif a {
+    {{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
+    color: {{linkColor}};
+    {{else}}
     color: {{accentColor}};
+    {{/hasFeature}}
     {{#if (eq linkStyle "regular")}}
     text-decoration: none;
     {{else if (eq linkStyle "bold")}}

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -276,24 +276,20 @@ h6 {
     {{/if}}
 }
 
-{{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
+{{#hasFeature "emailCustomizationAlpha"}}
 /* Links in captions */
 .feature-image-caption a,
 figcaption a {
     color: {{linkColor}};
 }
 
-/* Links inside toggle card (not in CTA cards which have their own setting) */
 .kg-toggle-card:not(.kg-cta-card) a {
     color: {{linkColor}};
 }
-
-/* Links inside callout cards (except the accent variant which has white links) */
 .kg-callout-card:not(.kg-callout-card-accent) a {
     color: {{linkColor}};
 }
 
-/* Manage subscription link */
 .subscription-box .manage-subscription a {
     color: {{linkColor}} !important;
 }
@@ -743,7 +739,7 @@ h3.latest-posts-header {
 
 .post-content a,
 .post-content-sans-serif a {
-    {{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
+    {{#hasFeature "emailCustomizationAlpha"}}
     color: {{linkColor}};
     {{else}}
     color: {{accentColor}};

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2102,7 +2102,8 @@ describe('Email renderer', function () {
                 image_corners: 'rounded',
                 section_title_color: '#BADA55',
                 post_title_color: '#BADA55',
-                divider_color: 'light' // should return our default hex value
+                divider_color: 'light', // should return our default hex value
+                link_color: '#BADA55'
             });
             const segment = null;
             const options = {};
@@ -2143,7 +2144,8 @@ describe('Email renderer', function () {
                     imageCorners: 'rounded',
                     sectionTitleColor: '#BADA55',
                     postTitleColor: '#BADA55',
-                    dividerColor: '#e0e7eb'
+                    dividerColor: '#e0e7eb',
+                    linkColor: '#BADA55'
                 },
                 labs: {emailCustomizationAlpha: true}
             });
@@ -2334,6 +2336,24 @@ describe('Email renderer', function () {
             for (const test of tests) {
                 const data = await templateDataWithSettings({
                     background_color: test.background_color
+                });
+                assert.equal(data.linkColor, test.expected);
+            }
+        });
+
+        it('Uses the correct link colour best on settings when emailCustomizationAlpha is enabled', async function () {
+            labsEnabled = true;
+            settings.accent_color = '#A1B2C3';
+            const tests = [
+                {input: '#BADA55', expected: '#BADA55'},
+                {input: 'accent', expected: settings.accent_color},
+                {input: 'Invalid Color', expected: settings.accent_color}, // default to accent color
+                {input: null, expected: settings.accent_color} // default to accent color
+            ];
+
+            for (const test of tests) {
+                const data = await templateDataWithSettings({
+                    link_color: test.input
                 });
                 assert.equal(data.linkColor, test.expected);
             }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1713/implement-link-color-setting

- Apply `{{linkColor}}` to post content, captions, toggle/callout cards, and manage subscription link
- Exclude post titles, header cards, CTA cards, bookmarks, buttons, and footer links
- Use `:not()` selectors to exclude CTA cards (have own colour setting) and accent callout cards (need white links on coloured background)