### PR TITLE
Added no-referrer policy to images in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.47",
+  "version": "0.7.48",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -76,7 +76,7 @@ export function renderFeedAttachment(
         return (
             <div className={`attachment-gallery mt-3 grid ${gridClass} gap-2`}>
                 {attachment.map((item, index) => (
-                    <img key={item.url} alt={item.name || `Image-${index}`} className={`size-full cursor-pointer rounded-md object-cover outline outline-1 -outline-offset-1 outline-black/10 ${attachmentCount === 3 && index === 0 ? 'row-span-2' : ''}`} src={item.url} onClick={onImageClick ? handleImageClick(item.url) : undefined} />
+                    <img key={item.url} alt={item.name || `Image-${index}`} className={`size-full cursor-pointer rounded-md object-cover outline outline-1 -outline-offset-1 outline-black/10 ${attachmentCount === 3 && index === 0 ? 'row-span-2' : ''}`} referrerPolicy='no-referrer' src={item.url} onClick={onImageClick ? handleImageClick(item.url) : undefined} />
                 ))}
             </div>
         );
@@ -87,7 +87,7 @@ export function renderFeedAttachment(
     case 'image/png':
     case 'image/gif':
     case 'image/webp':
-        return <img alt={attachment.name || 'Image'} className={`cursor-pointer ${object.type === 'Article' ? 'w-full rounded-t-md' : 'mt-3 max-h-[420px] rounded-md outline outline-1 -outline-offset-1 outline-black/10'}`} src={attachment.url} onClick={onImageClick ? handleImageClick(attachment.url) : undefined} />;
+        return <img alt={attachment.name || 'Image'} className={`cursor-pointer ${object.type === 'Article' ? 'w-full rounded-t-md' : 'mt-3 max-h-[420px] rounded-md outline outline-1 -outline-offset-1 outline-black/10'}`} referrerPolicy='no-referrer' src={attachment.url} onClick={onImageClick ? handleImageClick(attachment.url) : undefined} />;
     case 'video/mp4':
     case 'video/webm':
         return <div className='relative mb-4 mt-3'>
@@ -117,6 +117,7 @@ export function renderFeedAttachment(
                 <img
                     alt={attachment.name || 'Image'}
                     className={imageClassName}
+                    referrerPolicy='no-referrer'
                     src={imageUrl}
                     onClick={onImageClick ? handleImageClick(imageUrl) : undefined}
                 />
@@ -142,7 +143,7 @@ function renderInboxAttachment(object: ObjectProperties, isLoading: boolean | un
 
     if (Array.isArray(attachment)) {
         return (
-            <img className={imageAttachmentStyles} src={attachment[0].url} />
+            <img className={imageAttachmentStyles} referrerPolicy='no-referrer' src={attachment[0].url} />
         );
     }
 
@@ -151,7 +152,7 @@ function renderInboxAttachment(object: ObjectProperties, isLoading: boolean | un
     case 'image/png':
     case 'image/gif':
         return (
-            <img className={imageAttachmentStyles} src={attachment.url} />
+            <img className={imageAttachmentStyles} referrerPolicy='no-referrer' src={attachment.url} />
         );
     case 'video/mp4':
     case 'video/webm':
@@ -176,7 +177,7 @@ function renderInboxAttachment(object: ObjectProperties, isLoading: boolean | un
         );
     default:
         if (object.image) {
-            return <img className={imageAttachmentStyles} src={typeof object.image === 'string' ? object.image : object.image?.url} />;
+            return <img className={imageAttachmentStyles} referrerPolicy='no-referrer' src={typeof object.image === 'string' ? object.image : object.image?.url} />;
         }
         return null;
     }

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import clsx from 'clsx';
-import getUsername from '../../utils/get-username';
+import getUsername from '@utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {LucideIcon, Skeleton} from '@tryghost/shade';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -89,6 +89,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
             >
                 <img
                     className={imageClass}
+                    referrerPolicy='no-referrer'
                     src={iconUrl}
                     onError={() => setIconUrl(undefined)}
                 />

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -109,6 +109,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                 <img
                                     alt={account?.name}
                                     className='size-full object-cover'
+                                    referrerPolicy='no-referrer'
                                     src={account?.bannerImageUrl}
                                 />
                             </div>


### PR DESCRIPTION
ref PROD-1880

- Set referrerPolicy='no-referrer' on all image elements
- Applied to avatars, cover images, and attachments
- Prevented leaking referrer information when images are loaded
- Improved privacy by not sharing origin information with external image hosts