### PR TITLE
Improved charts in analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -42,7 +42,7 @@ const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
 
     return (
         <ChartContainer
-            className='mx-auto my-8 aspect-square max-h-[250px]'
+            className='mx-auto aspect-square'
             config={config}
         >
             <Recharts.RadialBarChart
@@ -304,8 +304,9 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                 <CardDescription>How did this post perform</CardDescription>
                             </CardHeader>
                             <CardContent className='p-0'>
-                                <div className='grid grid-cols-3 items-stretch'>
+                                <div className='grid grid-cols-3 items-stretch border-b'>
                                     <KpiCard className='relative grow'>
+                                        <FunnelArrow />
                                         <KpiCardLabel>
                                             <div className='size-2.5 rounded-[2px] bg-purple/30'></div>
                                             {/* <LucideIcon.Send strokeWidth={1.5} /> */}
@@ -316,6 +317,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         </KpiCardContent>
                                     </KpiCard>
                                     <KpiCard className='relative grow'>
+                                        <FunnelArrow />
                                         <KpiCardLabel>
                                             <div className='size-2.5 rounded-[2px] bg-blue/30'></div>
                                             {/* <LucideIcon.Eye strokeWidth={1.5} /> */}
@@ -342,26 +344,24 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                         <TabsTrigger value="bar"><LucideIcon.ChartNoAxesColumnDecreasing /></TabsTrigger>
                                     </TabsList> */}
                                     <TabsContent value="radial">
-                                        <div className='mx-auto -mt-8 grid grid-cols-3 items-center justify-center'>
-                                            <div className='relative min-w-[250px] border-r px-6'>
+                                        <div className='mx-auto grid grid-cols-3 items-center justify-center'>
+                                            <div className='border-r px-6'>
                                                 <NewsletterRadialChart
                                                     config={sentChartConfig}
                                                     data={sentChartData}
                                                     percentageLabel='Sent'
                                                     percentageValue={1}
                                                 />
-                                                <FunnelArrow />
                                             </div>
-                                            <div className='relative min-w-[250px] border-r px-6'>
+                                            <div className='border-r px-6'>
                                                 <NewsletterRadialChart
                                                     config={openedChartConfig}
                                                     data={openedChartData}
                                                     percentageLabel='Opened'
                                                     percentageValue={stats.openedRate}
                                                 />
-                                                <FunnelArrow />
                                             </div>
-                                            <div className='min-w-[250px] px-6'>
+                                            <div className='px-6'>
                                                 <NewsletterRadialChart
                                                     config={clickedChartConfig}
                                                     data={clickedChartData}

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, LucideIcon, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber, formatPercentage} from '@tryghost/shade';
 import {useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
 
@@ -28,7 +28,7 @@ const NewsletterOverview:React.FC = () => {
         }
     } satisfies ChartConfig;
 
-    const radialBarChartClassName = 'mx-auto aspect-square w-full min-h-[200px] max-w-[200px] grow';
+    const radialBarChartClassName = cn('mx-auto aspect-square w-full min-h-[200px] max-w-[200px] grow pointer-events-none');
 
     return (
         <div className='grid grid-cols-1 gap-8 xl:grid-cols-2'>
@@ -52,8 +52,10 @@ const NewsletterOverview:React.FC = () => {
                             <BarChartLoadingIndicator />
                         </div>
                         :
-                        <div className='mx-auto flex min-h-[250px] flex-wrap items-center justify-center xl:size-full'>
-                            <div className='flex grow flex-col items-center'>
+                        <div className='mx-auto flex min-h-[250px] flex-wrap items-stretch justify-center xl:size-full'>
+                            <div className='group flex grow flex-col items-center rounded-md p-4 transition-all hover:!cursor-pointer' onClick={() => {
+                                navigate(`/analytics/beta/${postId}/newsletter`);
+                            }}>
                                 <ChartContainer
                                     className={radialBarChartClassName}
                                     config={opensChartConfig}
@@ -109,13 +111,15 @@ const NewsletterOverview:React.FC = () => {
                                         </Recharts.PolarRadiusAxis>
                                     </Recharts.RadialBarChart>
                                 </ChartContainer>
-                                <div className='-mt-2 flex items-center gap-1.5 font-medium text-muted-foreground'>
+                                <div className='-mt-2 flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                     <LucideIcon.MailOpen size={16} strokeWidth={1.5} />
                                 Opened
                                 </div>
                             </div>
 
-                            <div className='flex grow flex-col items-center'>
+                            <div className='group flex grow flex-col items-center rounded-md p-4 transition-all hover:!cursor-pointer' onClick={() => {
+                                navigate(`/analytics/beta/${postId}/newsletter`);
+                            }}>
                                 <ChartContainer
                                     className={radialBarChartClassName}
                                     config={clickschartConfig}
@@ -172,7 +176,7 @@ const NewsletterOverview:React.FC = () => {
                                         </Recharts.PolarRadiusAxis>
                                     </Recharts.RadialBarChart>
                                 </ChartContainer>
-                                <div className='-mt-2 flex items-center gap-1.5 font-medium text-muted-foreground'>
+                                <div className='-mt-2 flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                                     <LucideIcon.MousePointerClick size={16} strokeWidth={1.5} />
                                 Clicked
                                 </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {AlignedAxisTick, BarChartLoadingIndicator, ChartConfig, ChartContainer, ChartTooltip, DateTooltipContent, Recharts, calculateYAxisWidth, formatDisplayDateWithRange, formatNumber, formatQueryDate, getRangeDates, getYRange, sanitizeChartData} from '@tryghost/shade';
+import {BarChartLoadingIndicator, GhAreaChart, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
 import {KPI_METRICS} from '../../Web/components/Kpis';
 import {KpiDataItem} from '@src/utils/kpi-helpers';
 import {STATS_RANGES} from '@src/utils/constants';
@@ -48,12 +48,6 @@ const WebOverview:React.FC = () => {
         params: params
     });
 
-    const chartConfig = {
-        value: {
-            label: currentMetric.label
-        }
-    } satisfies ChartConfig;
-
     const chartData = sanitizeChartData<KpiDataItem>(data as KpiDataItem[] || [], range, currentMetric.dataKey as keyof KpiDataItem, 'sum')?.map((item: KpiDataItem) => {
         const value = Number(item[currentMetric.dataKey]);
         return {
@@ -66,8 +60,6 @@ const WebOverview:React.FC = () => {
 
     const isLoading = isConfigLoading || loading;
 
-    const yRange = [getYRange(chartData).min, getYRange(chartData).max];
-
     return (
         <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
             {isLoading ?
@@ -75,71 +67,15 @@ const WebOverview:React.FC = () => {
                     <BarChartLoadingIndicator />
                 </div>
                 :
-                <ChartContainer className='-mb-3 h-[16vw] max-h-[320px] w-full' config={chartConfig}>
-                    <Recharts.AreaChart
-                        data={chartData}
-                        margin={{
-                            left: 0,
-                            right: 20,
-                            top: 12
-                        }}
-                    >
-                        <Recharts.CartesianGrid horizontal={false} vertical={false} />
-                        <Recharts.XAxis
-                            axisLine={false}
-                            dataKey="date"
-                            interval={0}
-                            tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(value, range)} />}
-                            tickFormatter={(value) => {
-                                return formatDisplayDateWithRange(value, range);
-                            }}
-                            tickLine={false}
-                            tickMargin={8}
-                            ticks={chartData && chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}
-                        />
-                        <Recharts.YAxis
-                            axisLine={false}
-                            domain={yRange}
-                            scale="linear"
-                            tickFormatter={(value) => {
-                                return formatNumber(value);
-                            }}
-                            tickLine={false}
-                            ticks={yRange}
-                            width={calculateYAxisWidth(yRange, currentMetric.formatter)}
-                        />
-                        <ChartTooltip
-                            content={<DateTooltipContent range={range} />}
-                            cursor={true}
-                            isAnimationActive={false}
-                            position={{y: 20}}
-                        />
-                        <defs>
-                            <linearGradient id="fillChart" x1="0" x2="0" y1="0" y2="1">
-                                <stop
-                                    offset="5%"
-                                    stopColor="hsl(var(--chart-blue))"
-                                    stopOpacity={0.8}
-                                />
-                                <stop
-                                    offset="95%"
-                                    stopColor="hsl(var(--chart-blue))"
-                                    stopOpacity={0.1}
-                                />
-                            </linearGradient>
-                        </defs>
-                        <Recharts.Area
-                            dataKey="value"
-                            fill="url(#fillChart)"
-                            fillOpacity={0.2}
-                            isAnimationActive={false}
-                            stackId="a"
-                            stroke="hsl(var(--chart-blue))"
-                            strokeWidth={2}
-                            type="linear"
-                        />
-                    </Recharts.AreaChart>
-                </ChartContainer>
+                <GhAreaChart
+                    className={'-mb-3 h-[16vw] max-h-[320px] w-full'}
+                    color='hsl(var(--chart-blue))'
+                    data={chartData}
+                    id="mrr"
+                    range={range}
+                    showYAxisValues={false}
+                    syncId="overview-charts"
+                />
             }
         </div>
     );

--- a/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
@@ -97,7 +97,6 @@ const Kpis:React.FC<KpisProps> = ({queryParams}) => {
                                             data={chartData}
                                             id={currentMetric.dataKey}
                                             range={range}
-                                            showYAxisValues={false}
                                             syncId="overview-charts"
                                         />
                                     </div>

--- a/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
@@ -1,6 +1,6 @@
 import EmptyStatView from '../../components/EmptyStatView';
 import React, {useState} from 'react';
-import {AlignedAxisTick, Card, CardContent, ChartConfig, ChartContainer, ChartTooltip, DateTooltipContent, KpiTabTrigger, KpiTabValue, Recharts, Tabs, TabsList, calculateYAxisWidth, formatDisplayDateWithRange, formatDuration, formatNumber, formatPercentage, getYRange, sanitizeChartData} from '@tryghost/shade';
+import {Card, CardContent, GhAreaChart, KpiTabTrigger, KpiTabValue, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, sanitizeChartData} from '@tryghost/shade';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
@@ -70,14 +70,6 @@ const Kpis:React.FC<KpisProps> = ({queryParams}) => {
 
     const kpiValues = getWebKpiValues(data as unknown as KpiDataItem[] | null);
 
-    const chartConfig = {
-        value: {
-            label: currentMetric.label
-        }
-    } satisfies ChartConfig;
-
-    const yRange = [getYRange(chartData).min, getYRange(chartData).max];
-
     return (
         <>
             {isLoading ? '' :
@@ -99,79 +91,15 @@ const Kpis:React.FC<KpisProps> = ({queryParams}) => {
                                         </KpiTabTrigger>
                                     </TabsList>
                                     <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-                                        <ChartContainer className='-mb-3 h-[16vw] max-h-[320px] w-full' config={chartConfig}>
-                                            <Recharts.AreaChart
-                                                data={chartData}
-                                                margin={{
-                                                    left: 0,
-                                                    right: 20,
-                                                    top: 12
-                                                }}
-                                            >
-                                                <Recharts.CartesianGrid horizontal={false} vertical={false} />
-                                                <Recharts.XAxis
-                                                    axisLine={false}
-                                                    dataKey="date"
-                                                    interval={0}
-                                                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(value, range)} />}
-                                                    tickFormatter={value => formatDisplayDateWithRange(value, range)}
-                                                    tickLine={false}
-                                                    tickMargin={8}
-                                                    ticks={chartData && chartData.length > 0 ? [chartData[0].date, chartData[chartData.length - 1].date] : []}
-                                                />
-                                                <Recharts.YAxis
-                                                    axisLine={false}
-                                                    domain={yRange}
-                                                    scale="linear"
-                                                    tickFormatter={(value) => {
-                                                        switch (currentTab) {
-                                                        case 'bounce-rate':
-                                                            return formatPercentage(value);
-                                                        case 'duration':
-                                                            return formatDuration(value);
-                                                        case 'visits':
-                                                        case 'views':
-                                                            return formatNumber(value);
-                                                        default:
-                                                            return value.toLocaleString();
-                                                        }
-                                                    }}
-                                                    tickLine={false}
-                                                    ticks={yRange}
-                                                    width={calculateYAxisWidth(yRange, currentMetric.formatter)}
-                                                />
-                                                <ChartTooltip
-                                                    content={<DateTooltipContent color={currentMetric.color} range={range} />}
-                                                    cursor={true}
-                                                    isAnimationActive={false}
-                                                    position={{y: 20}}
-                                                />
-                                                <defs>
-                                                    <linearGradient id="fillChart" x1="0" x2="0" y1="0" y2="1">
-                                                        <stop
-                                                            offset="5%"
-                                                            stopColor={currentMetric.color}
-                                                            stopOpacity={0.8}
-                                                        />
-                                                        <stop
-                                                            offset="95%"
-                                                            stopColor={currentMetric.color}
-                                                            stopOpacity={0.1}
-                                                        />
-                                                    </linearGradient>
-                                                </defs>
-                                                <Recharts.Area
-                                                    dataKey="value"
-                                                    fill="url(#fillChart)"
-                                                    fillOpacity={0.2}
-                                                    isAnimationActive={false}
-                                                    stackId="a"
-                                                    stroke={currentMetric.color}
-                                                    strokeWidth={2}
-                                                    type="linear"
-                                                />
-                                            </Recharts.AreaChart>
-                                        </ChartContainer>
+                                        <GhAreaChart
+                                            className={'-mb-3 h-[16vw] max-h-[320px] w-full'}
+                                            color={currentMetric.color}
+                                            data={chartData}
+                                            id={currentMetric.dataKey}
+                                            range={range}
+                                            showYAxisValues={false}
+                                            syncId="overview-charts"
+                                        />
                                     </div>
                                 </Tabs>
                             </CardContent>

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -30,7 +30,7 @@ const KpiCard: React.FC<React.HTMLAttributes<HTMLButtonElement>> = ({children, c
         <button
             className={
                 cn(
-                    'flex flex-col border-r border-border last:border-none items-start gap-4 px-6 py-5 transition-all',
+                    'flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all',
                     props.onClick ? 'hover:bg-accent' : 'cursor-auto',
                     className
                 )}

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -11,7 +11,7 @@ export const KpiCardContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
 
 export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('[&_svg]:size-4 flex items-center gap-1.5 text-base text-muted-foreground h-[22px] font-medium', className)} {...props}>
+        <div className={cn('[&_svg]:size-4 flex items-center gap-1.5 text-base h-[22px] font-medium transition-all', className)} {...props}>
             {children}
         </div>
     );
@@ -19,7 +19,7 @@ export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
 
 export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('text-[26px] mt-0.5 tracking-tighter leading-none font-semibold', className)} {...props}>
+        <div className={cn('text-[26px] mt-0.5 tracking-tighter leading-none text-foreground font-semibold', className)} {...props}>
             {children}
         </div>
     );
@@ -30,8 +30,8 @@ const KpiCard: React.FC<React.HTMLAttributes<HTMLButtonElement>> = ({children, c
         <button
             className={
                 cn(
-                    'flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all',
-                    props.onClick ? 'hover:bg-accent' : 'cursor-auto',
+                    'group flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all text-muted-foreground',
+                    props.onClick ? 'hover:bg-accent/50 hover:text-foreground' : 'cursor-auto',
                     className
                 )}
             type='button'

--- a/apps/shade/src/components/ui/gh-chart.tsx
+++ b/apps/shade/src/components/ui/gh-chart.tsx
@@ -1,4 +1,4 @@
-import {calculateYAxisWidth, cn, formatDisplayDateWithRange, formatNumber, getYRange, getYRangeWithMinPadding} from '@/lib/utils';
+import {calculateYAxisWidth, cn, formatDisplayDateWithRange, formatNumber, getYRange} from '@/lib/utils';
 import React from 'react';
 import {AlignedAxisTick, ChartConfig, ChartContainer, ChartTooltip} from './chart';
 import {Area, AreaChart, CartesianGrid, XAxis, YAxis} from 'recharts';
@@ -82,6 +82,9 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
         }
     } satisfies ChartConfig;
 
+    // Use yRange as domain and set baseValue to the minimum
+    const baseValue = yRange[0];
+
     return (
         <ChartContainer className={
             cn('w-full', className)
@@ -109,7 +112,7 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                 <YAxis
                     allowDataOverflow={allowDataOverflow}
                     axisLine={false}
-                    domain={allowDataOverflow ? getYRangeWithMinPadding({min: yRange[0], max: yRange[1]}) : yRange}
+                    domain={allowDataOverflow ? undefined : yRange}
                     scale="linear"
                     tickFormatter={(value: number) => {
                         return dataFormatter(value);
@@ -127,23 +130,23 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                 <defs>
                     <linearGradient id={`fillChart-${id}`} x1="0" x2="0" y1="0" y2="1">
                         <stop
-                            offset="5%"
+                            offset='5%'
                             stopColor={color}
                             stopOpacity={0.8}
                         />
                         <stop
-                            offset="95%"
+                            offset='95%'
                             stopColor={color}
                             stopOpacity={0.1}
                         />
                     </linearGradient>
                 </defs>
                 <Area
+                    baseValue={baseValue}
                     dataKey="value"
                     fill={`url(#fillChart-${id})`}
                     fillOpacity={0.2}
                     isAnimationActive={false}
-                    stackId="a"
                     stroke={color}
                     strokeWidth={2}
                     type="linear"

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -184,7 +184,7 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({color, label, value, diffDirec
         diffDirection === 'same' && 'text-gray-700'
     );
     return (
-        <div className='flex w-full flex-col items-start gap-4'>
+        <div className='flex w-full flex-col items-start gap-2'>
             <div className='flex h-[22px] items-center gap-2 text-base font-medium text-muted-foreground'>
                 {color && <div className='ml-1 size-[9px] rounded-[2px] opacity-50' style={{backgroundColor: color}}></div>}
                 {label}

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -86,7 +86,7 @@ const tabsTriggerVariants = cva(
                 underline: 'relative h-[36px] px-0 text-md font-semibold text-gray-700 after:absolute after:inset-x-0 after:bottom-[-1px] after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:after:opacity-10 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:!opacity-100',
                 navbar: 'relative h-[52px] px-px text-md font-semibold text-muted-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:!opacity-100',
                 pill: 'relative h-[30px] rounded-full px-3 text-md font-medium text-gray-800 hover:text-foreground data-[state=active]:bg-muted-foreground/15 data-[state=active]:font-semibold data-[state=active]:text-foreground dark:text-gray-500 dark:data-[state=active]:text-foreground',
-                kpis: 'relative rounded-none border-border bg-transparent px-6 py-5 text-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] first:rounded-tl-md last:rounded-tr-md hover:bg-muted/50 data-[state=active]:bg-transparent data-[state=active]:after:opacity-100 [&:not(:last-child)]:border-r'
+                kpis: 'relative rounded-none border-border bg-transparent px-6 py-5 text-foreground transition-all after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] first:rounded-tl-md last:rounded-tr-md hover:bg-accent/50 data-[state=active]:bg-transparent data-[state=active]:after:opacity-100 [&:not(:last-child)]:border-r'
             }
         },
         defaultVariants: {
@@ -184,8 +184,8 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({color, label, value, diffDirec
         diffDirection === 'same' && 'text-gray-700'
     );
     return (
-        <div className='flex w-full flex-col items-start gap-2'>
-            <div className='flex h-[22px] items-center gap-2 text-base font-medium text-muted-foreground'>
+        <div className='group flex w-full flex-col items-start gap-2'>
+            <div className='flex h-[22px] items-center gap-2 text-base font-medium text-muted-foreground transition-all group-hover:text-foreground'>
                 {color && <div className='ml-1 size-[9px] rounded-[2px] opacity-50' style={{backgroundColor: color}}></div>}
                 {label}
             </div>

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/ui/dialog';
 export * from './components/ui/dropdown-menu';
 export * from './components/ui/flag';
 export * from './components/ui/form';
+export * from './components/ui/gh-chart';
 export * from './components/ui/input';
 export * from './components/ui/label';
 export * from './components/ui/loading-indicator';

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -58,7 +58,7 @@ export {useSimplePagination} from './hooks/use-simple-pagination';
 
 // Utils
 export * from '@/lib/utils';
-export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, getYRangeWithMinPadding, getYRangeWithLargePadding, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars} from '@/lib/utils';
+export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, getYRangeWithMinPadding, getYRangeWithLargePadding, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars, getRangeForStartDate} from '@/lib/utils';
 
 export {default as ShadeApp} from './ShadeApp';
 export type {ShadeAppProps} from './ShadeApp';

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -329,6 +329,17 @@ export const calculateYAxisWidth = (ticks: number[], formatter: (value: number) 
     return width;
 };
 
+// Get range for date
+export const getRangeForStartDate = (startDate: string) => {
+    const publishedDate = new Date(startDate);
+    const today = new Date();
+    const diffInTime = today.getTime() - publishedDate.getTime();
+    const diffInDays = Math.ceil(diffInTime / (1000 * 3600 * 24));
+
+    // Ensure minimum of 1 day to avoid issues with same-day publications
+    return Math.max(diffInDays, 1);
+};
+
 //Return today and startdate for charts
 export const getRangeDates = (range: number) => {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -211,7 +211,7 @@ export const centsToDollars = (value: number) => {
 /* Chart formatters
 /* -------------------------------------------------------------------------- */
 
-// Calculates the Y-axis range with appropriate padding
+// Calculates the Y-axis range with padding
 export const getYRangeWithLargePadding = (data: { value: number }[]): {min: number; max: number} => {
     if (!data.length) {
         return {min: 0, max: 1};
@@ -259,34 +259,19 @@ export const getYRange = (data: { value: number }[]): {min: number; max: number}
     let min = Math.min(...values);
     let max = Math.max(...values);
 
-    // If min and max are the same, create a range around the value
-    // if (min === max) {
-    //     const value = min;
-    //     // Round to nearest 10
-    //     const roundTo = 10;
-    //     min = Math.max(0, Math.floor(value / roundTo) * roundTo);
-    //     max = Math.ceil(value / roundTo) * roundTo;
-    //     // If min and max are still the same, add 10 to max
-    //     if (min === max) {
-    //         max += roundTo;
-    //     }
-    //     return {min, max};
-    // }
-
     if (min === max) {
         const value = min;
         return {min: Math.max(0, value - 1), max: value + 1};
     }
 
-    // Calculate the range
-    const range = max - min;
-
-    // Use a percentage-based padding (5% of the range)
-    const padding = range * 0.05;
+    // Use a percentage-based padding (10% of the range)
+    const padding = 0.02;
 
     // Add padding and ensure min is not negative
-    min = Math.max(0, min - padding);
-    max = max + padding;
+    min = Math.max(0, min - (min * padding));
+    max = max + (max * padding);
+
+    const range = max - min;
 
     // Determine the order of magnitude for rounding based on the range
     const rangeMagnitude = Math.floor(Math.log10(range));
@@ -295,13 +280,17 @@ export const getYRange = (data: { value: number }[]): {min: number; max: number}
     const roundTo = Math.pow(10, rangeMagnitude);
 
     // Round min and max to the appropriate precision
-    min = Math.max(0, Math.floor(min / roundTo) * roundTo);
-    max = Math.ceil(max / roundTo) * roundTo;
+    const roundedMax = Math.round(max / roundTo) * roundTo;
+    max = roundedMax < max ? Math.ceil(max / roundTo) * roundTo : roundedMax;
+
+    const roundedMin = Math.round(min / roundTo) * roundTo;
+    min = roundedMin > min ? Math.floor(min / roundTo) * roundTo : roundedMin;
+    min = Math.max(0, min);
 
     // Ensure we have a visible range even after rounding
     if (min === max) {
         const midPoint = (min + max) / 2;
-        const smallRange = Math.max(Math.abs(midPoint) * 0.01, roundTo);
+        const smallRange = Math.max(Math.abs(midPoint) * padding, roundTo);
         min = Math.max(0, Math.floor(midPoint - smallRange));
         max = Math.ceil(midPoint + smallRange);
     }

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -1,11 +1,10 @@
-import AreaChart, {AreaChartDataItem} from './components/AreaChart';
 import DateRangeSelect from './components/DateRangeSelect';
 import React, {useMemo, useState} from 'react';
 import SortButton from './components/SortButton';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, KpiTabTrigger, KpiTabValue, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, centsToDollars, formatNumber} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, KpiTabTrigger, KpiTabValue, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, centsToDollars, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -81,7 +80,7 @@ const GrowthKPIs: React.FC<{
         sanitizedData = sanitizeChartData(allChartData, range, fieldName, 'exact');
 
         // Then map the sanitized data to the final format
-        let processedData: AreaChartDataItem[] = [];
+        let processedData: GhAreaChartDataItem[] = [];
 
         switch (currentTab) {
         case 'free-members':
@@ -184,7 +183,7 @@ const GrowthKPIs: React.FC<{
                 </KpiTabTrigger>
             </TabsList>
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-                <AreaChart
+                <GhAreaChart
                     allowDataOverflow={true}
                     className='-mb-3 h-[16vw] max-h-[320px] w-full'
                     color={tabConfig[currentTab as keyof typeof tabConfig].color}

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -184,7 +184,6 @@ const GrowthKPIs: React.FC<{
             </TabsList>
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 <GhAreaChart
-                    allowDataOverflow={true}
                     className='-mb-3 h-[16vw] max-h-[320px] w-full'
                     color={tabConfig[currentTab as keyof typeof tabConfig].color}
                     data={chartData}

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -1,5 +1,4 @@
 // import AudienceSelect from './components/AudienceSelect';
-import AreaChart from './components/AreaChart';
 import DateRangeSelect from './components/DateRangeSelect';
 import NewsletterSelect from './components/NewsletterSelect';
 import React, {useMemo, useState} from 'react';
@@ -7,7 +6,7 @@ import SortButton from './components/SortButton';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, ChartContainer, ChartTooltip, GhAreaChart, KpiTabTrigger, KpiTabValue, Recharts, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, calculateYAxisWidth, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -191,7 +190,7 @@ const NewsletterKPIs: React.FC<{
             </TabsList>
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 {(currentTab === 'total-subscribers') &&
-                    <AreaChart
+                    <GhAreaChart
                         allowDataOverflow={true}
                         className='-mb-3 h-[16vw] max-h-[320px] w-full'
                         color={tabConfig['total-subscribers'].color}

--- a/apps/stats/src/views/Stats/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters.tsx
@@ -191,7 +191,6 @@ const NewsletterKPIs: React.FC<{
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 {(currentTab === 'total-subscribers') &&
                     <GhAreaChart
-                        allowDataOverflow={true}
                         className='-mb-3 h-[16vw] max-h-[320px] w-full'
                         color={tabConfig['total-subscribers'].color}
                         data={subscribersData}

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -1,10 +1,9 @@
-import AreaChart, {AreaChartDataItem} from './components/AreaChart';
 import DateRangeSelect from './components/DateRangeSelect';
 import React, {useMemo} from 'react';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, centsToDollars, cn, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, centsToDollars, cn, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
 import {getAudienceQueryParam} from './components/AudienceSelect';
 import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -166,7 +165,7 @@ const Overview: React.FC = () => {
             };
         });
     }, [visitorsData, range]);
-    const visitorsYRange: [number, number] = [0, Math.max(...(visitorsChartData?.map((item: AreaChartDataItem) => item.value) || [0]))];
+    const visitorsYRange: [number, number] = [0, Math.max(...(visitorsChartData?.map((item: GhAreaChartDataItem) => item.value) || [0]))];
 
     /* Get members
     /* ---------------------------------------------------------------------- */
@@ -182,7 +181,7 @@ const Overview: React.FC = () => {
         sanitizedData = sanitizeChartData<GrowthChartDataItem>(growthChartData, range, fieldName, 'exact');
 
         // Then map the sanitized data to the final format
-        const processedData: AreaChartDataItem[] = sanitizedData.map(item => ({
+        const processedData: GhAreaChartDataItem[] = sanitizedData.map(item => ({
             date: item.date,
             value: item.free + item.paid + item.comped,
             formattedValue: formatNumber(item.free + item.paid + item.comped),
@@ -206,7 +205,7 @@ const Overview: React.FC = () => {
         sanitizedData = sanitizeChartData<GrowthChartDataItem>(growthChartData, range, fieldName, 'exact');
 
         // Then map the sanitized data to the final format
-        const processedData: AreaChartDataItem[] = sanitizedData.map(item => ({
+        const processedData: GhAreaChartDataItem[] = sanitizedData.map(item => ({
             date: item.date,
             value: centsToDollars(item.mrr),
             formattedValue: `$${formatNumber(centsToDollars(item.mrr))}`,
@@ -249,7 +248,7 @@ const Overview: React.FC = () => {
                         linkto='/web/'
                         title='Unique visitors'
                     >
-                        <AreaChart
+                        <GhAreaChart
                             className={areaChartClassName}
                             color='hsl(var(--chart-blue))'
                             data={visitorsChartData}
@@ -270,7 +269,7 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='Members'
                     >
-                        <AreaChart
+                        <GhAreaChart
                             allowDataOverflow={true}
                             className={areaChartClassName}
                             color='hsl(var(--chart-green))'
@@ -291,7 +290,7 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='MRR'
                     >
-                        <AreaChart
+                        <GhAreaChart
                             allowDataOverflow={true}
                             className={areaChartClassName}
                             color='hsl(var(--chart-orange))'

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -270,7 +270,6 @@ const Overview: React.FC = () => {
                         title='Members'
                     >
                         <GhAreaChart
-                            allowDataOverflow={true}
                             className={areaChartClassName}
                             color='hsl(var(--chart-green))'
                             data={membersChartData}
@@ -291,7 +290,6 @@ const Overview: React.FC = () => {
                         title='MRR'
                     >
                         <GhAreaChart
-                            allowDataOverflow={true}
                             className={areaChartClassName}
                             color='hsl(var(--chart-orange))'
                             data={mrrChartData}

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -1,11 +1,10 @@
-import AreaChart from './components/AreaChart';
 import AudienceSelect, {getAudienceQueryParam} from './components/AudienceSelect';
 import DateRangeSelect from './components/DateRangeSelect';
 import React, {useMemo, useState} from 'react';
 import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange, isValidDomain} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, GhAreaChart, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange, isValidDomain} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {SourceRow} from './Sources';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
@@ -129,7 +128,7 @@ const WebKPIs: React.FC<WebKPIsProps> = ({data, range}) => {
                 </KpiTabTrigger>
             </TabsList>
             <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-                <AreaChart
+                <GhAreaChart
                     className='-mb-3 h-[16vw] max-h-[320px] w-full'
                     color={currentMetric.chartColor}
                     data={chartData}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1823/qa-newsletteroverview-tab-defaulting-to-all-time-on-overview-has

- Chart ranges with very small change (e.g. 0.5%) gave a false impression of a large change because the Y range was too narrow. A refined version of getting the Y range solves for this issue.
- Unified Ghost style Area Charts in a component in Shade for better reusability.
- Refined range for the web visitors chart on post analytics overview: from now on it will show data from the publish date, not from a fixed date (like 1000 days ago).