### PR TITLE
Added divider color support to email paywall

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/paywall.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/paywall.hbs
@@ -1,36 +1,42 @@
-<div class="align-center" style="text-align: center;">
-    <hr
-        style="position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e0e7eb;">
-    <h3
-        style="margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; text-wrap: pretty;">
-        {{t 'Upgrade to continue reading.'}}</h3>
-    <p style="margin: 0 auto 1.5em auto; line-height: 1.6em; max-width: 440px; text-wrap: pretty;">{{{t 'Become a paid member of {site} to get access to all premium content.' site=site.title}}}</p>
-    {{#hasFeature "emailCustomizationAlpha"}}
-        <table border="0" cellpadding="0" cellspacing="0">
-            <tr>
-                <td>
-                    <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+{{#hasFeature "emailCustomizationAlpha"}}
+    <div class="kg-paywall align-center">
+        <hr>
+        <h3>{{t 'Upgrade to continue reading.'}}</h3>
+        <p>{{{t 'Become a paid member of {site} to get access to all premium content.' site=site.title}}}</p>
+            <table border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+                            <tr>
+                                <td align="center">
+                                    <a href="{{paywall.signupUrl}}">{{t 'Upgrade'}}</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        <p></p>
+    </div>
+{{else}}
+    <div class="align-center" style="text-align: center;">
+        <hr
+            style="position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e0e7eb;">
+        <h3
+            style="margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; text-wrap: pretty;">
+            {{t 'Upgrade to continue reading.'}}</h3>
+        <p style="margin: 0 auto 1.5em auto; line-height: 1.6em; max-width: 440px; text-wrap: pretty;">{{{t 'Become a paid member of {site} to get access to all premium content.' site=site.title}}}</p>
+            <div class="btn btn-accent" style="box-sizing: border-box; width: 100%; display: table;">
+                <table border="0" cellspacing="0" cellpadding="0" align="center" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                    <tbody>
                         <tr>
-                            <td align="center">
-                                <a href="{{paywall.signupUrl}}">{{t 'Upgrade'}}</a>
+                            <td align="center" valign="top" bgcolor="{{accentColor}}" style="vertical-align: top; text-align: center; border-radius: 5px;">
+                                <a href="{{paywall.signupUrl}}" style="overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: {{accentColor}}; border-color: {{accentColor}}; color: #FFFFFF;" target="_blank">{{t 'Upgrade'}}</a>
                             </td>
                         </tr>
-                    </table>
-                </td>
-            </tr>
-        </table>
-    {{else}}
-        <div class="btn btn-accent" style="box-sizing: border-box; width: 100%; display: table;">
-            <table border="0" cellspacing="0" cellpadding="0" align="center" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
-                <tbody>
-                    <tr>
-                        <td align="center" valign="top" bgcolor="{{accentColor}}" style="vertical-align: top; text-align: center; border-radius: 5px;">
-                            <a href="{{paywall.signupUrl}}" style="overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: {{accentColor}}; border-color: {{accentColor}}; color: #FFFFFF;" target="_blank">{{t 'Upgrade'}}</a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    {{/hasFeature}}
-    <p style="margin: 0 0 1.5em 0; line-height: 1.6em;"></p>
-</div>
+                    </tbody>
+                </table>
+            </div>
+        <p style="margin: 0 0 1.5em 0; line-height: 1.6em;"></p>
+    </div>
+{{/hasFeature}}

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1858,6 +1858,22 @@ img.kg-cta-image {
 }
 {{/hasFeature}}
 
+{{#hasFeature "emailCustomizationAlpha"}}
+.kg-paywall {
+    text-align: center;
+}
+
+.kg-paywall h3 {
+    text-wrap: pretty;
+}
+
+.kg-paywall p {
+    max-width: 440px;
+    text-wrap: pretty;
+}
+{{/hasFeature}}
+
+
 /* -------------------------------------
     HEADER, FOOTER, MAIN
 ------------------------------------- */


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1705/implement-divider-color-setting
- The paywall was relying on inline styles, which were overriding the generic hr color styling. The inline styles have been replaced and any specific styling has been moved to the styles.hbs file.