### PR TITLE
Added analytics service route handler to Caddyfile

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -4,6 +4,13 @@
 
 # Run `sudo ./.docker/caddy/trust_caddy_ca.sh` while the caddy container is running to trust the Caddy CA
 (common_ghost_config) {
+    # Proxy analytics requests with any prefix (e.g. /.ghost/analytics/ or /blog/.ghost/analytics/)
+    @analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
+    handle @analytics_paths {
+        rewrite * {re.analytics_match.2}
+        reverse_proxy analytics-service:3000
+    }
+
     handle /ember-cli-live-reload.js {
         reverse_proxy admin:4200
     }


### PR DESCRIPTION
no refs

This commit adds routing logic to the Caddyfile used in Docker Compose to route requests from `/.ghost/analytics` to the `analytics-service`, which needs to be running in a separate terminal window. This is a more production like setup, which is useful when testing Ghost with the analytics service locally.