### PR TITLE
Fixed ghost migrations in docker compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -128,7 +128,7 @@ services:
       context: .
       dockerfile: ./.docker/Dockerfile
       target: development
-    command: ["yarn", "knex-migrator", "migrate"]
+    command: sh -c "yarn knex-migrator init && yarn knex-migrator migrate"
     profiles: [ ghost, split ]
     tty: true
     depends_on:


### PR DESCRIPTION
no refs

The `ghost-migrations` service in Docker Compose only works if the database had already been initialized. This commit adds `yarn knex-migrate init` before `yarn knex-migrate migrate` so it will work for fresh installs that start with an empty database. 