### PR TITLE
Added cache support for loading notes in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.49",
+  "version": "0.7.50",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no issues

- Created new query to load notes from cache when available
- Used cached data for faster initial display of notes
- Maintained existing refetch behavior when cache is empty
- Improved loading speed and reduced unnecessary network requests