### PR TITLE
Added link color and style support to manage subscription link

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -110,8 +110,6 @@ const NewsletterPreviewContent: React.FC<{
     });
     const currentYear = new Date().getFullYear();
 
-    const backgroundColorIsDark = backgroundColor && textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
-
     // Process footer content to add target and rel attributes to links
     const processedFooterContent = footerContent ? footerContent.replace(/<a/g, '<a target="_blank" rel="noopener noreferrer"') : '';
 

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import {GhostOrb, Icon} from '@tryghost/admin-x-design-system';
 import {isManagedEmail} from '@tryghost/admin-x-framework/api/config';
-import {textColorForBackgroundColor} from '@tryghost/color-utils';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 
 const NewsletterPreviewContent: React.FC<{

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -424,7 +424,7 @@ const NewsletterPreviewContent: React.FC<{
                                             <p style={{color: textColor}}>Email: jamie@example.com</p>
                                             <p style={{color: textColor}}>Member since: 17 July 2023</p>
                                         </div>
-                                        <span className={clsx('w-full self-end whitespace-nowrap text-right text-base text-grey-700 underline', backgroundColorIsDark && 'text-white')}>
+                                        <span className={clsx('w-full self-end whitespace-nowrap text-right text-base', linkStyle === 'underline' && 'underline', linkStyle === 'bold' && 'font-bold')} style={{color: linkColor || accentColor}}>
                                             Manage subscription
                                         </span>
                                     </div>

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -703,11 +703,27 @@ h3.latest-posts-header {
 .manage-subscription {
     white-space: nowrap;
     font-size: 15px;
-    font-weight: 600;
+    font-weight: 400;
     text-align: right;
     line-height: 1.45em;
     vertical-align: bottom;
+}
+
+.manage-subscription a {
+    {{#hasFeature "emailCustomization" "emailCustomizationAlpha"}}
+    color: {{linkColor}};
+    {{#if (eq linkStyle "regular")}}
+    text-decoration: none;
+    {{else if (eq linkStyle "bold")}}
+    text-decoration: none;
+    font-weight: 700;
+    {{else}}
+    text-decoration: underline;
+    {{/if}}
+    {{else}}
     color: {{accentColor}};
+    text-decoration: underline;
+    {{/hasFeature}}
 }
 
 /* -------------------------------------

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -193,7 +193,7 @@
                                                     <p>{{t 'Member since'}}: %%{created_at}%%</p>
                                                 </td>
                                                 <td align="right" valign="bottom" class="manage-subscription">
-                                                    <a href="%%{manage_account_url}%%"> {{t 'Manage subscription'}} &rarr;</a>
+                                                    <a href="%%{manage_account_url}%%"> {{t 'Manage subscription'}}</a>
                                                 </td>
                                             </tr>
                                         </table>


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1930/improve-manage-subscription-link
- The current newsletter preview and actual styling of the manage subscription link was not consistent. Now the preview is aligned with the actual styling; accent color and underlined.
- The right arrow has been removed from the manage subscription link.
- The manage subscription link now uses the link color and style settings when the email customization alpha feature flag is enabled.
