### PR TITLE
Update top posts

### DIFF
--- a/apps/stats/src/hooks/useTopPostsViews.ts
+++ b/apps/stats/src/hooks/useTopPostsViews.ts
@@ -5,6 +5,7 @@ interface TopPostViewsStats {
     post_id: string;
     title: string;
     published_at: string;
+    feature_image: string;
     views: number;
     open_rate: number | null;
     members: number;

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -772,9 +772,7 @@ class PostsStatsService {
             }));
 
             // Combine both sets of posts
-            const allPosts = [...postsWithViews, ...additionalPostsWithZeroViews];
-            console.log(`allPosts`, allPosts);
-            return allPosts;
+            return [...postsWithViews, ...additionalPostsWithZeroViews];
         } catch (error) {
             logging.error('Error fetching top posts views:', error);
             return [];

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -16,6 +16,7 @@ const create = ({config, request}) => {
      * @param {string} [options.dateTo] - End date in YYYY-MM-DD format
      * @param {string} [options.timezone] - Timezone for the query
      * @param {string} [options.memberStatus] - Member status filter (defaults to 'all')
+     * @param {string} [options.postType] - Post type filter
      * @param {string} [options.tbVersion] - Tinybird version for API URL
      * @returns {Object} Object with URL and request options
      */
@@ -50,8 +51,10 @@ const create = ({config, request}) => {
         if (options.memberStatus) {
             searchParams.member_status = options.memberStatus;
         }
-        
-        // Add any other options that might be needed (like post_uuid)
+        if (options.postType) {
+            searchParams.post_type = options.postType;
+        }
+        // Add any other options that might be needed
         Object.entries(options).forEach(([key, value]) => {
             if (!['dateFrom', 'dateTo', 'timezone', 'memberStatus'].includes(key)) {
                 searchParams[key] = value;

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -132,12 +132,6 @@ describe('PostsStatsService', function () {
         await _createPaidConversionEvent(conversionPostId, finalMemberId, finalSubscriptionId, mrr, referrerSource);
     }
 
-    async function _verifyDatabaseState() {
-        const posts = await db.select('*').from('posts');
-        const emails = await db.select('*').from('emails');
-        return {posts, emails};
-    }
-
     before(async function () {
         db = knex({
             client: 'sqlite3',
@@ -719,7 +713,7 @@ describe('PostsStatsService', function () {
             assert.deepEqual(result, []);
         });
 
-        it('returns empty array when no views data exists', async function () {
+        it('returns latest posts with zero views when no views data exists', async function () {
             const mockTinybirdClient = {
                 fetch: (endpoint) => {
                     if (endpoint === 'api_top_pages') {
@@ -730,39 +724,7 @@ describe('PostsStatsService', function () {
             };
             service = new PostsStatsService({knex: db, tinybirdClient: mockTinybirdClient});
 
-            const result = await service.getTopPostsViews({
-                date_from: '2025-01-01',
-                date_to: '2025-01-31',
-                timezone: 'UTC'
-            });
-
-            assert.deepEqual(result, []);
-        });
-
-        it('returns empty array when views exist but no matching posts found', async function () {
-            const mockTinybirdClient = {
-                fetch: (endpoint) => {
-                    if (endpoint === 'api_top_pages') {
-                        return Promise.resolve([
-                            {post_uuid: 'unknown_uuid', visits: 100}
-                        ]);
-                    }
-                    return Promise.resolve([]);
-                }
-            };
-            service = new PostsStatsService({knex: db, tinybirdClient: mockTinybirdClient});
-
-            const result = await service.getTopPostsViews({
-                date_from: '2025-01-01',
-                date_to: '2025-01-31',
-                timezone: 'UTC'
-            });
-
-            assert.deepEqual(result, []);
-        });
-
-        it('returns correct stats when views and posts exist', async function () {
-            // Create posts with UUIDs
+            // Create posts with different published dates
             await db('posts').truncate();
             await _createPostWithDetails('post1', 'Post 1', 'published', {
                 uuid: 'uuid1',
@@ -772,10 +734,86 @@ describe('PostsStatsService', function () {
                 uuid: 'uuid2',
                 published_at: new Date('2025-01-16')
             });
+            await _createPostWithDetails('post3', 'Post 3', 'published', {
+                uuid: 'uuid3',
+                published_at: new Date('2025-01-17')
+            });
 
             // Add email stats
             await _createEmailStats('post1', 100, 50);
             await _createEmailStats('post2', 200, 150);
+            await _createEmailStats('post3', 300, 225);
+
+            const result = await service.getTopPostsViews({
+                date_from: '2025-01-01',
+                date_to: '2025-01-31',
+                timezone: 'UTC',
+                limit: 5
+            });
+
+            // Should return the 3 posts ordered by published_at desc with 0 views
+            const expected = [
+                {
+                    post_id: 'post3',
+                    title: 'Post 3',
+                    published_at: new Date('2025-01-17').getTime(),
+                    feature_image: null,
+                    views: 0,
+                    open_rate: 75,
+                    members: 300
+                },
+                {
+                    post_id: 'post2',
+                    title: 'Post 2',
+                    published_at: new Date('2025-01-16').getTime(),
+                    feature_image: null,
+                    views: 0,
+                    open_rate: 75,
+                    members: 200
+                },
+                {
+                    post_id: 'post1',
+                    title: 'Post 1',
+                    published_at: new Date('2025-01-15').getTime(),
+                    feature_image: null,
+                    views: 0,
+                    open_rate: 50,
+                    members: 100
+                }
+            ];
+
+            assert.deepEqual(result, expected);
+        });
+
+        it('backfills with latest posts when not enough views data', async function () {
+            // Create posts with UUIDs
+            await db('posts').truncate();
+            await _createPostWithDetails('post1', 'Post 1', 'published', {
+                uuid: 'uuid1',
+                published_at: new Date('2025-01-15'),
+                feature_image: 'https://example.com/image1.jpg'
+            });
+            await _createPostWithDetails('post2', 'Post 2', 'published', {
+                uuid: 'uuid2',
+                published_at: new Date('2025-01-16'),
+                feature_image: 'https://example.com/image2.jpg'
+            });
+            await _createPostWithDetails('post3', 'Post 3', 'published', {
+                uuid: 'uuid3',
+                published_at: new Date('2025-01-17'),
+                feature_image: 'https://example.com/image3.jpg'
+            });
+            await _createPostWithDetails('post4', 'Post 4', 'published', {
+                uuid: 'uuid4',
+                published_at: new Date('2025-01-18'),
+                feature_image: 'https://example.com/image4.jpg'
+            });
+
+            // Add email stats
+            await _createEmailStats('post1', 100, 50);
+            await _createEmailStats('post2', 200, 150);
+            await _createEmailStats('post3', 300, 225);
+            await _createEmailStats('post4', 400, 300);
 
             const mockTinybirdClient = {
                 fetch: (endpoint) => {
@@ -791,24 +829,20 @@ describe('PostsStatsService', function () {
 
             service = new PostsStatsService({knex: db, tinybirdClient: mockTinybirdClient});
 
-            // Verify database state
-            const dbState = await _verifyDatabaseState();
-            assert.equal(dbState.posts.length, 2, 'Should have 2 posts in database');
-            assert.equal(dbState.emails.length, 2, 'Should have 2 email records in database');
-            assert.equal(dbState.posts[0].uuid, 'uuid1', 'First post should have uuid1');
-            assert.equal(dbState.posts[1].uuid, 'uuid2', 'Second post should have uuid2');
-
             const result = await service.getTopPostsViews({
                 date_from: '2025-01-01',
                 date_to: '2025-01-31',
-                timezone: 'UTC'
+                timezone: 'UTC',
+                limit: 5
             });
 
+            // Should return 2 posts with views and 3 latest posts with 0 views
             const expected = [
                 {
                     post_id: 'post1',
                     title: 'Post 1',
                     published_at: new Date('2025-01-15').getTime(),
+                    feature_image: 'https://example.com/image1.jpg',
                     views: 1000,
                     open_rate: 50,
                     members: 100
@@ -817,32 +851,32 @@ describe('PostsStatsService', function () {
                     post_id: 'post2',
                     title: 'Post 2',
                     published_at: new Date('2025-01-16').getTime(),
+                    feature_image: 'https://example.com/image2.jpg',
                     views: 500,
                     open_rate: 75,
                     members: 200
+                },
+                {
+                    post_id: 'post4',
+                    title: 'Post 4',
+                    published_at: new Date('2025-01-18').getTime(),
+                    feature_image: 'https://example.com/image4.jpg',
+                    views: 0,
+                    open_rate: 75,
+                    members: 400
+                },
+                {
+                    post_id: 'post3',
+                    title: 'Post 3',
+                    published_at: new Date('2025-01-17').getTime(),
+                    feature_image: 'https://example.com/image3.jpg',
+                    views: 0,
+                    open_rate: 75,
+                    members: 300
                 }
             ];
 
-            // Sort both arrays by post_id to ensure consistent ordering
-            const sortedResult = result.sort((a, b) => a.post_id.localeCompare(b.post_id));
-            const sortedExpected = expected.sort((a, b) => a.post_id.localeCompare(b.post_id));
-
-            assert.deepEqual(sortedResult, sortedExpected);
-        });
-
-        it('handles errors gracefully', async function () {
-            const mockTinybirdClient = {
-                fetch: () => Promise.reject(new Error('Tinybird error'))
-            };
-            service = new PostsStatsService({knex: db, tinybirdClient: mockTinybirdClient});
-
-            const result = await service.getTopPostsViews({
-                date_from: '2025-01-01',
-                date_to: '2025-01-31',
-                timezone: 'UTC'
-            });
-
-            assert.deepEqual(result, []);
+            assert.deepEqual(result, expected);
         });
 
         it('passes correct parameters to Tinybird client', async function () {
@@ -866,8 +900,24 @@ describe('PostsStatsService', function () {
                 dateFrom: '2025-01-01',
                 dateTo: '2025-01-31',
                 timezone: 'America/New_York',
+                post_type: 'post',
                 limit: 10
             });
+        });
+
+        it('handles errors gracefully', async function () {
+            const mockTinybirdClient = {
+                fetch: () => Promise.reject(new Error('Tinybird error'))
+            };
+            service = new PostsStatsService({knex: db, tinybirdClient: mockTinybirdClient});
+
+            const result = await service.getTopPostsViews({
+                date_from: '2025-01-01',
+                date_to: '2025-01-31',
+                timezone: 'UTC'
+            });
+
+            assert.deepEqual(result, []);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1896
- updated stats endpoint to use new post_type filter, always return up to 5 entries, provide feature_image
- updated tests

The `/stats/top-posts-views` endpoint should always return up to 5 entries. The sort order is highest web count views, but if we're missing web traffic data (perhaps it just got enabled) we'll fall back to the latest posts (`order by published_at desc`).