### PR TITLE
Fixed divider card Outlook rendering

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -88,6 +88,19 @@ hr {
     border: 0;
     border-top: 1px solid {{dividerColor}};
 }
+.kg-hr-card td {
+    margin: 0;
+    padding-top: 1.5em; /* account for elements above having bottom padding, we want 3em total */
+    padding-bottom: 3em;
+    font-size: 17px;
+}
+.kg-hr td {
+    margin: 0;
+    padding: 0;
+    border-top: 1px solid {{dividerColor}};
+    font-size: 0;
+    line-height: 0;
+}
 
 p,
 ul,
@@ -262,6 +275,38 @@ h6 {
     margin: 2em 0 0.5em 0;
     font-size: 19px;
     line-height: 1.3em;
+}
+
+/*
+  Adjust margins and padding when hr cards surround headings to simulate the
+  margin collapsing that we no longer have when using table+padding for hr cards.
+  Goal is to always have 3em spacing between heading and divider line.
+*/
+h1:has(+ .kg-hr-card),
+h2:has(+ .kg-hr-card),
+h3:has(+ .kg-hr-card),
+h4:has(+ .kg-hr-card),
+h5:has(+ .kg-hr-card),
+h6:has(+ .kg-hr-card) {
+    margin-bottom: 0;
+}
+
+h1 + .kg-hr-card td,
+h2 + .kg-hr-card td,
+h3 + .kg-hr-card td,
+h4 + .kg-hr-card td,
+h5 + .kg-hr-card td,
+h6 + .kg-hr-card td {
+    padding-top: 3em;
+}
+
+.kg-hr-card + h1,
+.kg-hr-card + h2,
+.kg-hr-card + h3,
+.kg-hr-card + h4,
+.kg-hr-card + h5,
+.kg-hr-card + h6 {
+    margin-top: 0;
 }
 
 /* Post content headings */

--- a/ghost/core/core/server/services/koenig/node-renderers/horizontalrule-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/horizontalrule-renderer.js
@@ -1,11 +1,50 @@
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
+const {html} = require('../render-utils/tagged-template-fns');
+
+function horizontalRuleFrontendTemplate() {
+    return html`<hr />`;
+}
+
+function horizontalRuleEmailTemplate() {
+    // Outlook doesn't support HR tags so we need to use a table with colored borders
+    // Outer table sets spacing using padding for Outlook compatibility, inner table houses the colored border.
+
+    // HR is kept for html-to-plaintext conversion but not shown. Must be inside the table so we can use
+    // sibling selectors to adjust spacing between headings and hr cards.
+    return html`
+        <table class="kg-card kg-hr-card" role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0">
+            <tbody>
+                <tr>
+                    <td>
+                        <hr style="display: none;" />
+                        <table class="kg-hr" role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tbody>
+                                <tr>
+                                    <td>&nbsp;</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+}
 
 function renderHorizontalRuleNode(_, options = {}) {
     addCreateDocumentOption(options);
     const document = options.createDocument();
 
-    const element = document.createElement('hr');
-    return {element};
+    let renderedHtml;
+    if (options.feature?.emailCustomizationAlpha && options.target === 'email') {
+        renderedHtml = horizontalRuleEmailTemplate();
+    } else {
+        renderedHtml = horizontalRuleFrontendTemplate();
+    }
+
+    const element = document.createElement('div');
+    element.innerHTML = renderedHtml;
+    return {element, type: 'inner'};
 }
 
 module.exports = renderHorizontalRuleNode;

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -7388,7 +7388,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph inside an HTML card.</p>
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another one, with some <b>bold</b> text.</p>
 <!--kg-card-end: html-->
-<hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #73818c; font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
+<table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #73818c; font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
         <!--[if !mso !vml]-->
             <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%; background: #ffffff;\\">
                 <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; border-radius: 3px; border: 1px solid #e0e7eb; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
@@ -7830,6 +7830,8 @@ And another one, with some bold text.
 
 
 ----------------------------------------
+
+ 
 
 A gallery.
 
@@ -8666,6 +8668,8 @@ And another one, with some bold text.
 
 ----------------------------------------
 
+&#xA0;
+
 A gallery.
 
 
@@ -8674,7 +8678,7 @@ A gallery.
 
 
 Ghost: Independent technology for modern publishing
-Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 40</span>
+Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky,</span>
         <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #fff; width: 100%;\\" bgcolor=\\"#fff\\">
             <!-- Outlook doesn't respect max-width so we need an extra centered table -->
             <!--[if mso]>
@@ -8751,7 +8755,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph inside an HTML card.</p>
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another one, with some <b>bold</b> text.</p>
 <!--kg-card-end: html-->
-<hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #73818c; font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
+<table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #73818c; font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
         <!--[if !mso !vml]-->
             <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%; background: #ffffff;\\">
                 <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; border-radius: 3px; border: 1px solid #e0e7eb; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
@@ -9193,6 +9197,8 @@ And another one, with some bold text.
 
 
 ----------------------------------------
+
+ 
 
 A gallery.
 

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/horizontalrule-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/horizontalrule-renderer.test.js
@@ -39,4 +39,31 @@ describe('services/koenig/node-renderers/horizontalrule-renderer', function () {
             `);
         });
     });
+
+    describe('email (emailCustomizationAlpha)', function () {
+        it('matches snapshot for default test data', function () {
+            const result = renderForEmail(getTestData(), {feature: {emailCustomizationAlpha: true}});
+
+            assert.ok(result.html);
+
+            assertPrettifiesTo(result.html, html`
+                <table class="kg-card kg-hr-card" role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <hr style="display: none;" />
+                                <table class="kg-hr" role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                    <tbody>
+                                        <tr>
+                                            <td>&nbsp;</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1932

- switched to a table-based solution for email so there's full compatibility across email clients
  - Outlook requires spacing to be applied using padding on `<td>`, this requires a nested table for the colored border because padding sits inside of the border box
  - kept `<hr>` but set to not display so that `----------` rendering is kept in the plaintext version of emails
  - added specific css handling for spacing between HR cards and headings now that we can't rely on standard `<hr>` margins and modern client (not Outlook) margin collapsing