### PR TITLE
Fixed feature image urls in top posts component

### DIFF
--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
+const urlUtils = require('../../../shared/url-utils');
 
 /**
  * @typedef {Object} StatsServiceOptions
@@ -658,7 +659,7 @@ class PostsStatsService {
                     id: latestPost.id,
                     title: latestPost.title,
                     slug: latestPost.slug,
-                    feature_image: latestPost.feature_image,
+                    feature_image: latestPost.feature_image ? urlUtils.transformReadyToAbsolute(latestPost.feature_image) : latestPost.feature_image,
                     published_at: latestPost.published_at,
                     recipient_count: latestPost.email_count,
                     opened_count: latestPost.opened_count,
@@ -729,7 +730,7 @@ class PostsStatsService {
                     post_id: post.post_id,
                     title: post.title,
                     published_at: post.published_at,
-                    feature_image: post.feature_image,
+                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
                     views: row.visits,
                     open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
                     members: post.email_count || 0
@@ -765,7 +766,7 @@ class PostsStatsService {
                 post_id: post.post_id,
                 title: post.title,
                 published_at: post.published_at,
-                feature_image: post.feature_image,
+                feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
                 views: 0,
                 open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
                 members: post.email_count || 0


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1748967097990189?thread_ts=1748888558.819159&cid=C07HTEJMR2R

The post `feature_image` url can contain a ghost placeholder like `__GHOST_URL__`. In the Posts model we use `urlUtils` to change this to an absolute path. I've updated the stats endpoint to do the same thing.