### PR TITLE
Updated CTA card renderer to use email-button partial

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -1,3 +1,4 @@
+const {renderEmailButton} = require('../render-partials/email-button');
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {renderWithVisibility} = require('../render-utils/visibility');
 const {getResizedImageDimensions} = require('../render-utils/get-resized-image-dimensions');
@@ -107,6 +108,13 @@ function emailCTATemplate(dataset, options = {}) {
     }
 
     if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
+        const buttonHtml = renderEmailButton({
+            url: dataset.buttonUrl,
+            text: dataset.buttonText,
+            color: dataset.buttonColor,
+            style: options?.design?.buttonStyle
+        });
+
         const renderContent = () => {
             if (dataset.layout === 'minimal') {
                 return `
@@ -131,18 +139,20 @@ function emailCTATemplate(dataset, options = {}) {
                                             ${showButton(dataset) ? `
                                             <tr>
                                                 <td class="kg-cta-button-container">
-                                                    <table border="0" cellpadding="0" cellspacing="0" class="btn">
-                                                        <tr>
-                                                            <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
-                                                                <a href="${dataset.buttonUrl}"
-                                                                   class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
-                                                                   style="${buttonLinkStyle}"
-                                                                >
-                                                                    ${dataset.buttonText}
-                                                                </a>
-                                                            </td>
-                                                        </tr>
-                                                    </table>
+                                                    ${options.feature.emailCustomizationAlpha ? buttonHtml : `
+                                                        <table border="0" cellpadding="0" cellspacing="0" class="btn">
+                                                            <tr>
+                                                                <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
+                                                                    <a href="${dataset.buttonUrl}"
+                                                                    class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
+                                                                    style="${buttonLinkStyle}"
+                                                                    >
+                                                                        ${dataset.buttonText}
+                                                                    </a>
+                                                                </td>
+                                                            </tr>
+                                                        </table>
+                                                    `}
                                                 </td>
                                             </tr>
                                             ` : ''}

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert/strict');
-const {callRenderer, html, assertPrettifiesTo, visibility} = require('../test-utils');
+const {callRenderer, html, assertPrettifiesTo, assertPrettifiedIncludes, visibility} = require('../test-utils');
 
 describe('services/koenig/node-renderers/call-to-action-renderer', function () {
     function getTestData(overrides = {}) {
@@ -245,11 +245,11 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                                                         </tr>
                                                         <tr>
                                                             <td class="kg-cta-button-container">
-                                                                <table border="0" cellpadding="0" cellspacing="0" class="btn">
+                                                                <table class="btn" border="0" cellspacing="0" cellpadding="0">
                                                                     <tbody>
                                                                         <tr>
-                                                                            <td class="" style="background-color: #000000; color: #ffffff;">
-                                                                                <a href="http://blog.com/post1" class="" style="background-color: #000000; color: #ffffff;">
+                                                                            <td align="center" style="background-color: #000000;">
+                                                                                <a href="http://blog.com/post1" style="color: #ffffff !important;">
                                                                                     click me
                                                                                 </a>
                                                                             </td>
@@ -264,6 +264,44 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                                         </tr>
                                     </tbody>
                                 </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('handles accent button color', function () {
+            const data = getTestData({buttonColor: 'accent'});
+            const result = renderForEmail(data, {feature: {emailCustomizationAlpha: true}});
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center">
+                                <a href="http://blog.com/post1">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('handles outline buttons', function () {
+            const data = getTestData();
+            const result = renderForEmail(data, {design: {buttonStyle: 'outline'}, feature: {emailCustomizationAlpha: true}});
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="border: 1px solid #000000; background-color: transparent; color: #000000 !important;">
+                                <a href="http://blog.com/post1" style="color: #000000 !important;">
+                                    click me
+                                </a>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1709

- finishes normalization of email button rendering across our cards by always using the same `renderEmailButton` function to generate the button HTML
