### PR TITLE
Removed alpha flag from routes

### DIFF
--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -4,18 +4,18 @@ import Newsletters from './views/Stats/Newsletters';
 import Overview from './views/Stats/Overview';
 import Web from './views/Stats/Web';
 import {RouteObject} from '@tryghost/admin-x-framework';
-import {withFeatureFlag} from './hooks/withFeatureFlag';
+// import {withFeatureFlag} from './hooks/withFeatureFlag';
 
 export const APP_ROUTE_PREFIX = '/stats';
 
 // Wrap all components with feature flag protection
 //  e.g.
-const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalyticsAlpha', '/', 'Overview');
+// const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalyticsAlpha', '/', 'Overview');
 
 export const routes: RouteObject[] = [
     {
         path: '/overview/',
-        element: <ProtectedOverview />
+        element: <Overview />
     },
     {
         path: '/',


### PR DESCRIPTION
ref 36b1006

The Routes protection was missing from the previous commit.