### PR TITLE
Fixed member counts in top posts component

### DIFF
--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -723,6 +723,7 @@ class PostsStatsService {
                 .select('attribution_id as post_id')
                 .count('id as member_count')
                 .where('attribution_type', 'post')
+                .where('source', 'member')
                 .whereIn('attribution_id', posts.map(p => p.post_id))
                 .groupBy('attribution_id');
 
@@ -779,6 +780,7 @@ class PostsStatsService {
                         .select('attribution_id as post_id')
                         .count('id as member_count')
                         .where('attribution_type', 'post')
+                        .where('source', 'member')
                         .whereIn('attribution_id', additionalPosts.map(p => p.post_id))
                         .groupBy('attribution_id');
                 }


### PR DESCRIPTION
no ref

In doing general QA, we found that the member attribution count for the top posts was quite far off. This was counting the emails instead of the actual members_created_events and was oversight when using small amounts of local data.