### PR TITLE
Updated stats app routes and index

### DIFF
--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -14,10 +14,6 @@ export const APP_ROUTE_PREFIX = '/stats';
 
 export const routes: RouteObject[] = [
     {
-        path: '/overview/',
-        element: <Overview />
-    },
-    {
         path: '/',
         index: true,
         element: <Overview />
@@ -33,8 +29,7 @@ export const routes: RouteObject[] = [
     {
         path: '/growth/',
         element: <Growth />
-    }
-    ,
+    },
     {
         path: '/newsletters/',
         element: <Newsletters />

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -26,13 +26,13 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
             <Navbar className='sticky top-0 z-50 items-center border-none bg-white/70 py-8 backdrop-blur-md dark:bg-black'>
                 <Tabs className="w-full" defaultValue={location.pathname} variant='pill'>
                     <TabsList>
-                        <TabsTrigger value="/overview/" onClick={() => {
-                            navigate('/overview/');
+                        <TabsTrigger value="/" onClick={() => {
+                            navigate('/');
                         }}>
                             Overview
                         </TabsTrigger>
-                        <TabsTrigger value="/" onClick={() => {
-                            navigate('/');
+                        <TabsTrigger value="/web/" onClick={() => {
+                            navigate('/web/');
                         }}>
                         Web traffic
                         </TabsTrigger>


### PR DESCRIPTION
no ref

We've decided to switch the index to Overview, rather than having a distinct route for /overview.