### PR TITLE
Fixed loading adapters from node_modules

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/AdapterManager.js
+++ b/ghost/core/core/server/services/adapter-manager/AdapterManager.js
@@ -102,7 +102,11 @@ module.exports = class AdapterManager {
         /** @type AdapterConstructor */
         let Adapter;
         for (const pathToAdapters of this.pathsToAdapters) {
-            const pathToAdapter = path.join(pathToAdapters, adapterType, adapterClassName);
+            let pathToAdapter = path.join(pathToAdapters, adapterType, adapterClassName);
+            if (pathToAdapters === '') {
+                // We are loading from node_modules, we can remove the `adapterType` prefix
+                pathToAdapter = path.join(pathToAdapters, adapterClassName);
+            }
             try {
                 Adapter = this.loadAdapterFromPath(pathToAdapter);
                 if (Adapter) {

--- a/ghost/core/test/unit/server/services/adapter-manager/AdapterManager.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/AdapterManager.test.js
@@ -65,6 +65,29 @@ describe('AdapterManager', function () {
         }
     });
 
+    it('getAdapter can handle looking up from node_modules', function () {
+        const pathsToAdapters = [
+            '', // node_modules
+            'first/path'
+        ];
+
+        const loadAdapterFromPath = sinon.stub();
+        const adapterManager = new AdapterManager({
+            loadAdapterFromPath,
+            pathsToAdapters
+        });
+
+        adapterManager.registerAdapter('mail', BaseMailAdapter);
+
+        try {
+            adapterManager.getAdapter('mail', 'some-node-module-adapter');
+        } catch (err) {
+            should.ok(err); // We don't care about the error, we just want to check `loadAdapterFromPath`
+        }
+
+        loadAdapterFromPath.calledWith('some-node-module-adapter').should.equal(true);
+    });
+
     it('Loads registered adapters in the order defined by the paths', function () {
         const pathsToAdapters = [
             'first/path',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1465

The AdapterManager was designed to support loading from node_modules by passing an empty string for the adapter storage path. The idea was that `require` would get called with just the name of the adapter, rather than a path prefix.

This however was not working, because we were prefixing the adapter name with a subdirectory. This was so that we would load e.g. storages adapters from e.g.

    `content/adapters/storage` instead of `content/adapters`

this breaks loading from node modules because we would attempt to require

    `storage/node-module` instead of `node-module`

I've added a test here to make sure this doesn't regress, the fix is scoped only to loading from the empty string path.
