### PR TITLE
Added ActivityPub tests to the list of required checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,6 +1006,7 @@ jobs:
         job_legacy-tests,
         job_browser-tests,
         job_admin_x_settings,
+        job_admin_x_activitypub,
         job_comments_ui,
         job_signup_form,
         job_tinybird_forward

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -10,6 +10,8 @@ test.describe('Feed', async () => {
     });
 
     test('I can publish a note', async ({page}) => {
+        expect(true).toBe(false);
+
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -10,8 +10,6 @@ test.describe('Feed', async () => {
     });
 
     test('I can publish a note', async ({page}) => {
-        expect(true).toBe(false);
-
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1537

- this ensures that PRs with failing AP tests cannot be merged to main