### PR TITLE
Fixed member attribution counts for latest post

### DIFF
--- a/apps/stats/src/hooks/useLatestPostStats.ts
+++ b/apps/stats/src/hooks/useLatestPostStats.ts
@@ -10,6 +10,8 @@ interface LatestPostStats {
     opened_count: number | null;
     open_rate: number | null;
     member_delta: number;
+    free_members: number;
+    paid_members: number;
     visitors: number;
 }
 


### PR DESCRIPTION
no ref
- latest post now returns a more accurate count for member signups
- latest post now returns data for both paid and free members separately

Member attribution counts were not including paid members, nor was it deduplicating free+paid signups. This is bringing the logic in line with the latest posts changes.