### PR TITLE
Improved performance for members subscribe events

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.123/2025-06-04-17-48-32-add-members-subscribe-events-performance-indices.js
+++ b/ghost/core/core/server/data/migrations/versions/5.123/2025-06-04-17-48-32-add-members-subscribe-events-performance-indices.js
@@ -1,0 +1,21 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+const {addIndex, dropIndex} = require('../../../schema/commands');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding performance indexes for members_subscribe_events');
+        
+        // Index for newsletter-based queries with date filtering
+        await addIndex('members_subscribe_events', ['newsletter_id', 'created_at'], knex);
+        
+        // Index for member-based filtering (used in newsletter stats)
+        await addIndex('members_subscribe_events', ['member_id', 'newsletter_id'], knex);
+    },
+    async function down(knex) {
+        logging.info('Removing performance indexes from members_subscribe_events');
+        
+        await dropIndex('members_subscribe_events', ['newsletter_id', 'created_at'], knex);
+        await dropIndex('members_subscribe_events', ['member_id', 'newsletter_id'], knex);
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.123/2025-06-04-17-48-47-add-members-email-disabled-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.123/2025-06-04-17-48-47-add-members-email-disabled-index.js
@@ -1,0 +1,3 @@
+const {createAddIndexMigration} = require('../../utils');
+
+module.exports = createAddIndexMigration('members', ['email_disabled']); 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1789/
- Created migration to add performance indexes for members_subscribe_events to optimize queries.
- Added index for email_disabled field in members table to improve filtering efficiency.
- Rebuild `subscriber-stats` endpoint query.

A few MySQL indices were added to improve the performance of querying the `members_subscribe_events` table for the purposes of the `subscriber-stats` endpoint, which could take several seconds for data for particularly large sites. The query was also rebuilt to make better use of the new indices, as well as more efficiently filter, as instead of looking for 'active' members we strip out 'inactive' members, a much smaller subset that is usually a few percentage of total members.