### PR TITLE
Used /replies endpoint for all reply data for reply chain in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref PROD-1934

- Switched to using only `/replies` endpoint when `reply-chain` flag is enabled
- Removed redundant calls to `/threads` endpoint for top-level replies
- Simplified data fetching by using single source for note and all replies