### PR TITLE
Removed migrations sidecar from compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -55,8 +55,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      ghost-migrations:
-        condition: service_completed_successfully
     environment:
       - DEBUG=${DEBUG:-}
       - SSH_AUTH_SOCK=/ssh-agent
@@ -118,21 +116,6 @@ services:
       mysql:
         condition: service_healthy
       redis:
-        condition: service_healthy
-      ghost-migrations:
-        condition: service_completed_successfully
-  ghost-migrations:
-    <<: *service-template
-    image: ghost-monorepo:latest
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile
-      target: development
-    command: sh -c "yarn knex-migrator init && yarn knex-migrator migrate"
-    profiles: [ ghost, split ]
-    tty: true
-    depends_on:
-      mysql:
         condition: service_healthy
 
   mysql:


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C08BZH42QF8/p1749123227586969

The migrations sidecar service is getting stuck with migration lock issues for some people. Ghost will run migrations on boot anyhow, so at least until we figure out what's going wrong with the sidecar, this commit removes it.