### PR TITLE
Fixed favicons for analytics traffic sources

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -8,6 +8,9 @@ export {getStatEndpointUrl, getToken} from './utils/stats-config';
 // Post utilities
 export {hasBeenEmailed} from './utils/post-utils';
 
+// Source utilities
+export {SOURCE_DOMAIN_MAP, extractDomain, isDomainOrSubdomain, getFaviconDomain} from './utils/source-utils';
+
 // Routing
 export type {RouteObject} from 'react-router';
 export type {RouterProviderProps} from './providers/RouterProvider';

--- a/apps/admin-x-framework/src/utils/source-utils.ts
+++ b/apps/admin-x-framework/src/utils/source-utils.ts
@@ -1,0 +1,97 @@
+// Source domain mapping for favicons
+export const SOURCE_DOMAIN_MAP: Record<string, string> = {
+    Reddit: 'reddit.com',
+    Facebook: 'facebook.com',
+    Twitter: 'twitter.com',
+    Bluesky: 'bsky.app',
+    Instagram: 'instagram.com',
+    LinkedIn: 'linkedin.com',
+    Threads: 'threads.net',
+    'Brave Search': 'search.brave.com',
+    Ecosia: 'ecosia.org',
+    Gmail: 'gmail.com',
+    Outlook: 'outlook.com',
+    'Yahoo!': 'yahoo.com',
+    'AOL Mail': 'aol.com',
+    Flipboard: 'flipboard.com',
+    Substack: 'substack.com',
+    Ghost: 'ghost.org',
+    'Ghost Explore': 'ghost.org',
+    Buffer: 'buffer.com',
+    Taboola: 'taboola.com',
+    AppNexus: 'appnexus.com',
+    Wikipedia: 'wikipedia.org',
+    Mastodon: 'mastodon.social',
+    Memeorandum: 'memeorandum.com',
+    'Ground News': 'ground.news',
+    'Apple News': 'apple.com',
+    SmartNews: 'smartnews.com',
+    'Hacker News': 'news.ycombinator.com',
+    // Search engines
+    Google: 'google.com',
+    'Google News': 'news.google.com',
+    Bing: 'bing.com',
+    DuckDuckGo: 'duckduckgo.com',
+    // Email/Newsletter
+    'newsletter-email': 'static.ghost.org',
+    newsletter: 'static.ghost.org'
+};
+
+// Helper function to extract domain from URL
+export const extractDomain = (url: string): string | null => {
+    try {
+        const domain = new URL(url.startsWith('http') ? url : `https://${url}`).hostname;
+        return domain.replace(/^www\./, '');
+    } catch {
+        return null;
+    }
+};
+
+// Helper function to check if a domain is the same or a subdomain
+export const isDomainOrSubdomain = (sourceDomain: string, siteDomain: string): boolean => {
+    // Exact match
+    if (sourceDomain === siteDomain) {
+        return true;
+    }
+    
+    // Subdomain check: source should end with ".siteDomain"
+    return sourceDomain.endsWith(`.${siteDomain}`);
+};
+
+// Helper function to get favicon domain and determine if it's direct traffic
+export const getFaviconDomain = (source: string | number | undefined, siteUrl?: string): {domain: string | null, isDirectTraffic: boolean} => {
+    if (!source || typeof source !== 'string') {
+        return {domain: null, isDirectTraffic: false};
+    }
+    
+    // Extract site domain for comparison
+    const siteDomain = siteUrl ? extractDomain(siteUrl) : null;
+    
+    // Check if source matches site domain or is a subdomain (treat as direct traffic)
+    if (siteDomain) {
+        const sourceDomain = extractDomain(source);
+        if (sourceDomain && isDomainOrSubdomain(sourceDomain, siteDomain)) {
+            return {domain: siteDomain, isDirectTraffic: true};
+        }
+        
+        // Also check the source string directly (in case it's already just a domain)
+        if (isDomainOrSubdomain(source, siteDomain)) {
+            return {domain: siteDomain, isDirectTraffic: true};
+        }
+    }
+    
+    // First check our mapping for known sources
+    const mappedDomain = SOURCE_DOMAIN_MAP[source];
+    if (mappedDomain) {
+        return {domain: mappedDomain, isDirectTraffic: false};
+    }
+    
+    // If not in mapping, check if it's already a domain
+    const isDomain = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(source);
+    if (isDomain) {
+        return {domain: source, isDirectTraffic: false};
+    }
+    
+    // No domain found
+    return {domain: null, isDirectTraffic: false};
+}; 

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -6,6 +6,7 @@ import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, GhAreaChart, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange, isValidDomain} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
+import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
 
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
@@ -32,6 +33,7 @@ const SOURCE_DOMAIN_MAP: Record<string, string> = {
     Flipboard: 'flipboard.com',
     Substack: 'substack.com',
     Ghost: 'ghost.org',
+    'Ghost Explore': 'ghost.org',
     Buffer: 'buffer.com',
     Taboola: 'taboola.com',
     AppNexus: 'appnexus.com',
@@ -40,7 +42,16 @@ const SOURCE_DOMAIN_MAP: Record<string, string> = {
     Memeorandum: 'memeorandum.com',
     'Ground News': 'ground.news',
     'Apple News': 'apple.com',
-    SmartNews: 'smartnews.com'
+    SmartNews: 'smartnews.com',
+    'Hacker News': 'news.ycombinator.com',
+    // Search engines
+    Google: 'google.com',
+    'Google News': 'news.google.com',
+    Bing: 'bing.com',
+    DuckDuckGo: 'duckduckgo.com',
+    // Email/Newsletter
+    'newsletter-email': 'static.ghost.org',
+    newsletter: 'static.ghost.org'
 };
 
 // Helper function to extract domain from URL
@@ -370,7 +381,7 @@ const SourcesTable: React.FC<SourcesTableProps> = ({data, siteUrl}) => {
                                                     className="size-4"
                                                     src={`https://www.faviconextractor.com/favicon/${faviconDomain}?larger=true`}
                                                     onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiByeD0iMiIgZmlsbD0iIzZCNzI4MCIvPgo8L3N2Zz4K';
+                                                        e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
                                                     }} />
                                                 <span className='group-hover/link:underline'>{displayName}</span>
                                             </a>
@@ -378,7 +389,7 @@ const SourcesTable: React.FC<SourcesTableProps> = ({data, siteUrl}) => {
                                             <span className='flex items-center gap-2'>
                                                 <img
                                                     className="size-4"
-                                                    src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiByeD0iMiIgZmlsbD0iIzZCNzI4MCIvPgo8L3N2Zz4K' />
+                                                    src={STATS_DEFAULT_SOURCE_ICON_URL} />
                                                 <span>{displayName}</span>
                                             </span>
                                         }

--- a/apps/stats/test/utils/test-helpers.ts
+++ b/apps/stats/test/utils/test-helpers.ts
@@ -109,6 +109,23 @@ export const applyMocksToModules = (mocks: ReturnType<typeof setupStatsAppMocks>
     }));
 };
 
+// Mock sources data with for testing traffic
+export const createMockSourcesData = () => [
+    {source: 'Reddit', visits: 120},
+    {source: 'Google', visits: 100},
+    {source: 'twitter.com', visits: 80},
+    {source: 'ghost.org', visits: 60},
+    {source: '', visits: 50} // Already direct traffic
+];
+
+// Helper to create mock global data with custom site URL
+export const createMockGlobalData = (siteUrl = 'https://ghost.org') => ({
+    ...defaultMockData.globalData,
+    data: {
+        url: siteUrl
+    }
+});
+
 // Legacy compatibility
 export const setupUniversalMocks = setupStatsAppMocks;
 export const setupDefaultStatsMocks = setupStatsAppMocks; 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1838/
- added domain mappings for common referrers/sources to pick up favicon
- centralized logic for lookup and mappings in admin-x-framework
- updated stats and posts apps to use new utils/mappings

The new groupings are done based on source, not a domain, so we can't easily pick up the favicon. Regardless, grouping by source makes it far, far easier for us to group, and far less requests for icons, creating a much cleaner and clearer view of traffic sources. We can maintain a list of the top few dozen sites which should encompass 90%+ of traffic.