### PR TITLE
Updated TailwindCSS config of Shade for multiple React apps

### DIFF
--- a/apps/posts/tailwind.config.cjs
+++ b/apps/posts/tailwind.config.cjs
@@ -2,5 +2,14 @@ import shadePreset from '@tryghost/shade/tailwind.cjs';
 
 module.exports = {
     presets: [shadePreset('.shade')],
-    content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}']
+    content: [
+        './index.html',
+        './src/**/*.{js,ts,jsx,tsx}',
+        '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
+
+        // We need to scan all apps that use shade to force Tailwind build all used classes
+        '../posts/src/**/*.{js,ts,jsx,tsx}',
+        '../stats/src/**/*.{js,ts,jsx,tsx}',
+        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+    ]
 };

--- a/apps/posts/tailwind.config.cjs
+++ b/apps/posts/tailwind.config.cjs
@@ -1,10 +1,10 @@
 import shadePreset from '@tryghost/shade/tailwind.cjs';
+import sharedContent from '@tryghost/shade/shared-content.cjs';
 
 module.exports = {
     presets: [shadePreset('.shade')],
-    content: [
+    content: sharedContent.getAllContent([
         './index.html',
-        '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
-        ...shadePreset('.shade').appsContent
-    ]
+        './src/**/*.{js,ts,jsx,tsx}'
+    ])
 };

--- a/apps/posts/tailwind.config.cjs
+++ b/apps/posts/tailwind.config.cjs
@@ -4,12 +4,7 @@ module.exports = {
     presets: [shadePreset('.shade')],
     content: [
         './index.html',
-        './src/**/*.{js,ts,jsx,tsx}',
         '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
-
-        // We need to scan all apps that use shade to force Tailwind build all used classes
-        '../posts/src/**/*.{js,ts,jsx,tsx}',
-        '../stats/src/**/*.{js,ts,jsx,tsx}',
-        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+        ...shadePreset('.shade').appsContent
     ]
 };

--- a/apps/shade/shared-content.cjs
+++ b/apps/shade/shared-content.cjs
@@ -1,0 +1,25 @@
+// Shared content configuration for all apps using shade
+// This ensures consistent class availability across micro frontends
+
+module.exports = {
+    // Shade's own components
+    shadeComponents: [
+        '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}'
+    ],
+
+    // All consumer apps - add new apps here when they start using shade
+    consumerApps: [
+        '../posts/src/**/*.{js,ts,jsx,tsx}',
+        '../stats/src/**/*.{js,ts,jsx,tsx}',
+        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+    ],
+
+    // Get all content paths for an app
+    getAllContent: function (appSpecificPaths = []) {
+        return [
+            ...appSpecificPaths,
+            ...this.shadeComponents,
+            ...this.consumerApps
+        ];
+    }
+};

--- a/apps/shade/tailwind.cjs
+++ b/apps/shade/tailwind.cjs
@@ -3,5 +3,12 @@ const config = require('./tailwind.config');
 
 module.exports = selector => ({
     ...config,
+
+    // Add app src content here to force TailwindCSS scan them when building classes
+    appsContent: [
+        '../posts/src/**/*.{js,ts,jsx,tsx}',
+        '../stats/src/**/*.{js,ts,jsx,tsx}',
+        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+    ],
     important: selector
 });

--- a/apps/shade/tailwind.cjs
+++ b/apps/shade/tailwind.cjs
@@ -3,12 +3,5 @@ const config = require('./tailwind.config');
 
 module.exports = selector => ({
     ...config,
-
-    // Add app src content here to force TailwindCSS scan them when building classes
-    appsContent: [
-        '../posts/src/**/*.{js,ts,jsx,tsx}',
-        '../stats/src/**/*.{js,ts,jsx,tsx}',
-        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
-    ],
     important: selector
 });

--- a/apps/stats/tailwind.config.cjs
+++ b/apps/stats/tailwind.config.cjs
@@ -1,4 +1,4 @@
-import shadePreset from '@tryghost/shade/tailwind.cjs';
+const shadePreset = require('@tryghost/shade/tailwind.cjs');
 
 module.exports = {
     presets: [shadePreset('.shade')],

--- a/apps/stats/tailwind.config.cjs
+++ b/apps/stats/tailwind.config.cjs
@@ -1,15 +1,10 @@
-const shadePreset = require('@tryghost/shade/tailwind.cjs');
+import shadePreset from '@tryghost/shade/tailwind.cjs';
 
 module.exports = {
     presets: [shadePreset('.shade')],
     content: [
         './index.html',
-        './src/**/*.{js,ts,jsx,tsx}',
         '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
-
-        // We need to scan all apps that use shade to force Tailwind build all used classes
-        '../posts/src/**/*.{js,ts,jsx,tsx}',
-        '../stats/src/**/*.{js,ts,jsx,tsx}',
-        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+        ...shadePreset('.shade').appsContent
     ]
 };

--- a/apps/stats/tailwind.config.cjs
+++ b/apps/stats/tailwind.config.cjs
@@ -2,5 +2,14 @@ const shadePreset = require('@tryghost/shade/tailwind.cjs');
 
 module.exports = {
     presets: [shadePreset('.shade')],
-    content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}']
+    content: [
+        './index.html',
+        './src/**/*.{js,ts,jsx,tsx}',
+        '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
+
+        // We need to scan all apps that use shade to force Tailwind build all used classes
+        '../posts/src/**/*.{js,ts,jsx,tsx}',
+        '../stats/src/**/*.{js,ts,jsx,tsx}',
+        '../admin-x-activitypub/src/**/*.{js,ts,jsx,tsx}'
+    ]
 };

--- a/apps/stats/tailwind.config.cjs
+++ b/apps/stats/tailwind.config.cjs
@@ -1,10 +1,10 @@
 const shadePreset = require('@tryghost/shade/tailwind.cjs');
+const sharedContent = require('@tryghost/shade/shared-content.cjs');
 
 module.exports = {
     presets: [shadePreset('.shade')],
-    content: [
+    content: sharedContent.getAllContent([
         './index.html',
-        '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}',
-        ...shadePreset('.shade').appsContent
-    ]
+        './src/**/*.{js,ts,jsx,tsx}'
+    ])
 };


### PR DESCRIPTION
no ref

- Currently there are multiple React apps using the same design system in Ghost. Each app builds its own CSS bundle with only the classes it directly uses. When the user navigates between apps, we're switching CSS bundles, so classes used in one app but not another aren't available. To solve this, with this PR we introduced a shared-content concept which ensures all apps scan each other's code so classes are available everywhere.