### PR TITLE
Fixed Stats > Growth tab source icons

### DIFF
--- a/apps/admin-x-framework/src/utils/source-utils.ts
+++ b/apps/admin-x-framework/src/utils/source-utils.ts
@@ -4,6 +4,7 @@ export const SOURCE_DOMAIN_MAP: Record<string, string> = {
     Facebook: 'facebook.com',
     Twitter: 'twitter.com',
     Bluesky: 'bsky.app',
+    'go.bsky.app': 'bsky.app',
     Instagram: 'instagram.com',
     LinkedIn: 'linkedin.com',
     Threads: 'threads.net',

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -126,7 +126,10 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                                                 <span className='flex items-center gap-2'>
                                                                     <img
                                                                         className="size-4"
-                                                                        src={STATS_DEFAULT_SOURCE_ICON_URL} />
+                                                                        src={domain ? `https://www.faviconextractor.com/favicon/${domain}?larger=true` : STATS_DEFAULT_SOURCE_ICON_URL}
+                                                                        onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                                            e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
+                                                                        }} />
                                                                     <span>{displayName}</span>
                                                                 </span>
                                                             }


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1749143634298599?thread_ts=1749131615.870009&cid=C07HTEJMR2R
ref [c18701f](https://github.com/TryGhost/Ghost/commit/c18701fac9018fdf5d3b057b7de28e8841e24490)

These weren't fully wired up to the mappings that were added previously.