### PR TITLE
Added pagination for top-level replies in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.53",
+  "version": "0.7.54",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -136,7 +136,8 @@ const Note = () => {
                 try {
                     await loadMoreChildren();
                 } catch (error) {
-
+                    // eslint-disable-next-line no-console
+                    console.error('Failed to load more top-level replies:', error);
                 } finally {
                     setIsLoadingMoreTopLevelReplies(false);
                 }


### PR DESCRIPTION
ref PROD-1968

- Implemented pagination logic for loading additional top-level replies
- Set up early loading trigger based on scroll position from bottom
- Created buffer zone to fetch next page before user reaches the end