### PR TITLE
Added cursor dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ bower_components
 # node-waf configuration
 .lock-wscript
 
+# Cursor config
+.cursor/
+
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 


### PR DESCRIPTION
no ref

Cursor config such as .mcp shouldn't be included in our repo, but are often configured at a repo level.