### PR TITLE
Refactored Sources handling across stats and posts apps

### DIFF
--- a/apps/admin-x-framework/src/components/Sources/SourcesCard.tsx
+++ b/apps/admin-x-framework/src/components/Sources/SourcesCard.tsx
@@ -101,7 +101,7 @@ const SourcesTable: React.FC<SourcesTableProps> = ({data, mode, defaultSourceIco
                 {data?.map((row) => {
                     return (
                         <DataListRow key={row.source} className='group/row'>
-                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all group-hover/row:opacity-40' style={{
+                            <DataListBar className='from-muted-foreground/40 to-muted-foreground/60 bg-gradient-to-r opacity-20 transition-all group-hover/row:opacity-40' style={{
                                 width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
                             }} />
                             <DataListItemContent className='group-hover/datalist:max-w-[calc(100%-140px)]'>
@@ -308,7 +308,7 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
             <CardContent>
                 <Separator />
                 {topSources.length > 0 ? (
-                    <SourcesTable data={topSources} mode={mode} range={range} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} />
+                    <SourcesTable data={topSources} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} mode={mode} range={range} />
                 ) : (
                     <div className='py-20 text-center text-sm text-gray-700'>
                         {mode === 'growth' 
@@ -330,7 +330,7 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                                 <SheetDescription>{sheetDescription}</SheetDescription>
                             </SheetHeader>
                             <div className='group/datalist'>
-                                <SourcesTable data={extendedData} mode={mode} range={range} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} />
+                                <SourcesTable data={extendedData} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} mode={mode} range={range} />
                             </div>
                         </SheetContent>
                     </Sheet>

--- a/apps/admin-x-framework/src/components/Sources/SourcesCard.tsx
+++ b/apps/admin-x-framework/src/components/Sources/SourcesCard.tsx
@@ -1,0 +1,343 @@
+import React from 'react';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
+import {getFaviconDomain} from '../../utils/source-utils';
+
+// Default source icon URL - apps can override this
+const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
+
+// Base interface for all source data types
+interface BaseSourceData {
+    source?: string | number;
+    visits?: number;
+    free_members?: number;
+    paid_members?: number;
+    mrr?: number;
+    [key: string]: unknown;
+}
+
+// Processed source data with pre-computed display values
+interface ProcessedSourceData {
+    source: string;
+    visits: number;
+    isDirectTraffic: boolean;
+    iconSrc: string;
+    displayName: string;
+    linkUrl?: string;
+    percentage?: number;
+    // Additional fields for growth data
+    free_members?: number;
+    paid_members?: number;
+    mrr?: number;
+}
+
+interface SourcesTableProps {
+    data: ProcessedSourceData[] | null;
+    mode: 'visits' | 'growth';
+    range?: number;
+    defaultSourceIconUrl?: string;
+    getPeriodText?: (range: number) => string;
+}
+
+const SourcesTable: React.FC<SourcesTableProps> = ({data, mode, defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL}) => {
+    if (mode === 'growth') {
+        return (
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Source</TableHead>
+                        <TableHead className='w-[110px] text-right'>Free members</TableHead>
+                        <TableHead className='w-[110px] text-right'>Paid members</TableHead>
+                        <TableHead className='w-[110px] text-right'>MRR impact</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {data?.map((row) => {
+                        const centsToDollars = (value: number) => Math.round(value / 100);
+                        
+                        return (
+                            <TableRow key={row.source}>
+                                <TableCell>
+                                    {row.linkUrl ?
+                                        <a className='group flex items-center gap-2' href={row.linkUrl} rel="noreferrer" target="_blank">
+                                            <img
+                                                className="size-4"
+                                                src={row.iconSrc}
+                                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                    e.currentTarget.src = defaultSourceIconUrl;
+                                                }} />
+                                            <span className='group-hover:underline'>{row.displayName}</span>
+                                        </a>
+                                        :
+                                        <span className='flex items-center gap-2'>
+                                            <img
+                                                className="size-4"
+                                                src={row.iconSrc}
+                                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                    e.currentTarget.src = defaultSourceIconUrl;
+                                                }} />
+                                            <span>{row.displayName}</span>
+                                        </span>
+                                    }
+                                </TableCell>
+                                <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.free_members || 0)}</TableCell>
+                                <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.paid_members || 0)}</TableCell>
+                                <TableCell className='text-right font-mono text-sm'>+${centsToDollars(row.mrr || 0)}</TableCell>
+                            </TableRow>
+                        );
+                    })}
+                </TableBody>
+            </Table>
+        );
+    }
+
+    // Default visits mode using DataList
+    return (
+        <DataList>
+            <DataListHeader>
+                <DataListHead>Source</DataListHead>
+                <DataListHead>Visitors</DataListHead>
+            </DataListHeader>
+            <DataListBody>
+                {data?.map((row) => {
+                    return (
+                        <DataListRow key={row.source} className='group/row'>
+                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all group-hover/row:opacity-40' style={{
+                                width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
+                            }} />
+                            <DataListItemContent className='group-hover/datalist:max-w-[calc(100%-140px)]'>
+                                <div className='flex items-center space-x-4 overflow-hidden'>
+                                    <div className='truncate font-medium'>
+                                        {row.linkUrl ?
+                                            <a className='group/link flex items-center gap-2' href={row.linkUrl} rel="noreferrer" target="_blank">
+                                                <img
+                                                    className="size-4"
+                                                    src={row.iconSrc}
+                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                        e.currentTarget.src = defaultSourceIconUrl;
+                                                    }} />
+                                                <span className='group-hover/link:underline'>{row.displayName}</span>
+                                            </a>
+                                            :
+                                            <span className='flex items-center gap-2'>
+                                                <img
+                                                    className="size-4"
+                                                    src={row.iconSrc}
+                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                                        e.currentTarget.src = defaultSourceIconUrl;
+                                                    }} />
+                                                <span>{row.displayName}</span>
+                                            </span>
+                                        }
+                                    </div>
+                                </div>
+                            </DataListItemContent>
+                            <DataListItemValue>
+                                <DataListItemValueAbs>{formatNumber(row.visits)}</DataListItemValueAbs>
+                                <DataListItemValuePerc>{formatPercentage(row.percentage || 0)}</DataListItemValuePerc>
+                            </DataListItemValue>
+                        </DataListRow>
+                    );
+                })}
+            </DataListBody>
+        </DataList>
+    );
+};
+
+interface SourcesCardProps {
+    title?: string;
+    description?: string;
+    data: BaseSourceData[] | null;
+    mode?: 'visits' | 'growth';
+    range?: number;
+    totalVisitors?: number;
+    siteUrl?: string;
+    siteIcon?: string;
+    defaultSourceIconUrl?: string;
+    getPeriodText?: (range: number) => string;
+}
+
+export const SourcesCard: React.FC<SourcesCardProps> = ({
+    title = 'Top Sources',
+    description,
+    data,
+    mode = 'visits',
+    range = 30,
+    totalVisitors = 0,
+    siteUrl,
+    siteIcon,
+    defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
+    getPeriodText
+}) => {
+    // Process and group sources data with pre-computed icons and display values
+    const processedData = React.useMemo(() => {
+        if (!data) {
+            return [];
+        }
+
+        const sourceMap = new Map<string, ProcessedSourceData>();
+        let directTrafficTotal = mode === 'visits' ? 0 : undefined;
+        const directTrafficData = mode === 'growth' ? {
+            free_members: 0,
+            paid_members: 0,
+            mrr: 0
+        } : undefined;
+
+        // Process each source and group direct traffic
+        data.forEach((item) => {
+            const {domain: faviconDomain, isDirectTraffic} = getFaviconDomain(item.source, siteUrl);
+            const visits = Number(item.visits || 0);
+
+            if (isDirectTraffic || !item.source || item.source === '') {
+                // Accumulate all direct traffic
+                if (mode === 'visits') {
+                    directTrafficTotal! += visits;
+                } else if (mode === 'growth' && directTrafficData) {
+                    directTrafficData.free_members += item.free_members || 0;
+                    directTrafficData.paid_members += item.paid_members || 0;
+                    directTrafficData.mrr += item.mrr || 0;
+                }
+            } else {
+                // Keep other sources as-is
+                const sourceKey = String(item.source);
+                const iconSrc = faviconDomain 
+                    ? `https://www.faviconextractor.com/favicon/${faviconDomain}?larger=true`
+                    : defaultSourceIconUrl;
+                const linkUrl = faviconDomain ? `https://${faviconDomain}` : undefined;
+
+                if (sourceMap.has(sourceKey)) {
+                    const existing = sourceMap.get(sourceKey)!;
+                    existing.visits += visits;
+                    if (mode === 'growth') {
+                        existing.free_members = (existing.free_members || 0) + (item.free_members || 0);
+                        existing.paid_members = (existing.paid_members || 0) + (item.paid_members || 0);
+                        existing.mrr = (existing.mrr || 0) + (item.mrr || 0);
+                    }
+                } else {
+                    const processedItem: ProcessedSourceData = {
+                        source: sourceKey,
+                        visits,
+                        isDirectTraffic: false,
+                        iconSrc,
+                        displayName: sourceKey,
+                        linkUrl
+                    };
+
+                    if (mode === 'growth') {
+                        processedItem.free_members = item.free_members || 0;
+                        processedItem.paid_members = item.paid_members || 0;
+                        processedItem.mrr = item.mrr || 0;
+                    }
+
+                    sourceMap.set(sourceKey, processedItem);
+                }
+            }
+        });
+
+        // Add consolidated direct traffic entry if there's any
+        const hasDirectTraffic = mode === 'visits' 
+            ? directTrafficTotal! > 0
+            : directTrafficData && (directTrafficData.free_members > 0 || directTrafficData.paid_members > 0 || directTrafficData.mrr > 0);
+
+        if (hasDirectTraffic) {
+            const directEntry: ProcessedSourceData = {
+                source: 'Direct',
+                visits: mode === 'visits' ? directTrafficTotal! : 0,
+                isDirectTraffic: true,
+                iconSrc: siteIcon || defaultSourceIconUrl,
+                displayName: 'Direct',
+                linkUrl: undefined
+            };
+
+            if (mode === 'growth' && directTrafficData) {
+                directEntry.free_members = directTrafficData.free_members;
+                directEntry.paid_members = directTrafficData.paid_members;
+                directEntry.mrr = directTrafficData.mrr;
+            }
+
+            sourceMap.set('Direct', directEntry);
+        }
+
+        // Convert back to array and sort
+        const result = Array.from(sourceMap.values());
+        
+        if (mode === 'growth') {
+            // Sort by total impact (prioritizing MRR, then paid members, then free members)
+            return result.sort((a, b) => {
+                const aScore = (a.mrr || 0) * 100 + (a.paid_members || 0) * 10 + (a.free_members || 0);
+                const bScore = (b.mrr || 0) * 100 + (b.paid_members || 0) * 10 + (b.free_members || 0);
+                return bScore - aScore;
+            });
+        } else {
+            // Sort by visits
+            return result.sort((a, b) => b.visits - a.visits);
+        }
+    }, [data, siteUrl, siteIcon, mode, defaultSourceIconUrl]);
+
+    // Extend processed data with percentage values for visits mode
+    const extendedData = React.useMemo(() => {
+        if (mode === 'growth') {
+            return processedData;
+        }
+        
+        return processedData.map(item => ({
+            ...item,
+            percentage: totalVisitors > 0 ? (item.visits / totalVisitors) : 0
+        }));
+    }, [processedData, totalVisitors, mode]);
+
+    const topSources = extendedData.slice(0, 10);
+    
+    // Generate description based on mode and range
+    const cardDescription = description || (
+        mode === 'growth' 
+            ? 'Where did your growth come from?'
+            : `How readers found your ${range ? 'site' : 'post'}${range && getPeriodText ? ` ${getPeriodText(range)}` : ''}`
+    );
+
+    const sheetTitle = mode === 'growth' ? 'Sources' : 'Top sources';
+    const sheetDescription = mode === 'growth' 
+        ? 'Where did your growth come from?'
+        : `How readers found your ${range ? 'site' : 'post'}${range && getPeriodText ? ` ${getPeriodText(range)}` : ''}`;
+
+    return (
+        <Card className='group/datalist'>
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{cardDescription}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Separator />
+                {topSources.length > 0 ? (
+                    <SourcesTable data={topSources} mode={mode} range={range} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} />
+                ) : (
+                    <div className='py-20 text-center text-sm text-gray-700'>
+                        {mode === 'growth' 
+                            ? 'Once someone signs up on this post, sources will show here.'
+                            : 'No sources data available.'
+                        }
+                    </div>
+                )}
+            </CardContent>
+            {extendedData.length > 10 &&
+                <CardFooter>
+                    <Sheet>
+                        <SheetTrigger asChild>
+                            <Button variant='outline'>View all <LucideIcon.TableOfContents /></Button>
+                        </SheetTrigger>
+                        <SheetContent className='overflow-y-auto pt-0 sm:max-w-[600px]'>
+                            <SheetHeader className='sticky top-0 z-40 -mx-6 bg-white/60 p-6 backdrop-blur'>
+                                <SheetTitle>{sheetTitle}</SheetTitle>
+                                <SheetDescription>{sheetDescription}</SheetDescription>
+                            </SheetHeader>
+                            <div className='group/datalist'>
+                                <SourcesTable data={extendedData} mode={mode} range={range} defaultSourceIconUrl={defaultSourceIconUrl} getPeriodText={getPeriodText} />
+                            </div>
+                        </SheetContent>
+                    </Sheet>
+                </CardFooter>
+            }
+        </Card>
+    );
+};
+
+export default SourcesCard; 

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -10,6 +10,7 @@ export {hasBeenEmailed} from './utils/post-utils';
 
 // Source utilities
 export {SOURCE_DOMAIN_MAP, extractDomain, isDomainOrSubdomain, getFaviconDomain} from './utils/source-utils';
+export {SourcesCard} from './components/Sources/SourcesCard';
 
 // Routing
 export type {RouteObject} from 'react-router';

--- a/apps/posts/src/hooks/usePostReferrers.ts
+++ b/apps/posts/src/hooks/usePostReferrers.ts
@@ -2,6 +2,117 @@ import moment from 'moment';
 import {useMemo} from 'react';
 import {usePostGrowthStats as usePostGrowthStatsAPI, usePostReferrers as usePostReferrersAPI} from '@tryghost/admin-x-framework/api/stats';
 
+// Source normalization mapping - matches Tinybird's mv_hits.pipe logic
+const normalizeSource = (source: string): string => {
+    if (!source || source === '') {
+        return '';
+    }
+    
+    // Social Media Consolidation
+    if (['Facebook', 'www.facebook.com', 'l.facebook.com', 'lm.facebook.com', 'm.facebook.com', 'facebook'].includes(source)) {
+        return 'Facebook';
+    }
+    if (['Twitter', 'x.com', 'com.twitter.android'].includes(source)) {
+        return 'Twitter';
+    }
+    if (['go.bsky.app', 'bsky', 'bsky.app'].includes(source)) {
+        return 'Bluesky';
+    }
+    if (['LinkedIn', 'www.linkedin.com', 'linkedin.com'].includes(source)) {
+        return 'LinkedIn';
+    }
+    if (['Instagram', 'www.instagram.com', 'instagram.com'].includes(source)) {
+        return 'Instagram';
+    }
+    if (['YouTube', 'www.youtube.com', 'youtube.com', 'm.youtube.com'].includes(source)) {
+        return 'YouTube';
+    }
+    if (['Threads', 'www.threads.net', 'threads.net'].includes(source)) {
+        return 'Threads';
+    }
+    if (['TikTok', 'www.tiktok.com', 'tiktok.com'].includes(source)) {
+        return 'TikTok';
+    }
+    if (['Pinterest', 'www.pinterest.com', 'pinterest.com'].includes(source)) {
+        return 'Pinterest';
+    }
+    if (['Reddit', 'www.reddit.com', 'reddit.com'].includes(source)) {
+        return 'Reddit';
+    }
+    if (['WhatsApp', 'whatsapp.com', 'www.whatsapp.com'].includes(source)) {
+        return 'WhatsApp';
+    }
+    if (['Telegram', 'telegram.org', 'www.telegram.org', 't.me'].includes(source)) {
+        return 'Telegram';
+    }
+    if (['Hacker News', 'news.ycombinator.com'].includes(source)) {
+        return 'Hacker News';
+    }
+    if (['Substack', 'substack.com', 'www.substack.com'].includes(source)) {
+        return 'Substack';
+    }
+    if (['Medium', 'medium.com', 'www.medium.com'].includes(source)) {
+        return 'Medium';
+    }
+    
+    // Search Engines
+    if (['Google', 'www.google.com', 'google.com'].includes(source)) {
+        return 'Google';
+    }
+    if (['Bing', 'www.bing.com', 'bing.com'].includes(source)) {
+        return 'Bing';
+    }
+    if (['Yahoo', 'www.yahoo.com', 'yahoo.com', 'search.yahoo.com'].includes(source)) {
+        return 'Yahoo';
+    }
+    if (['DuckDuckGo', 'duckduckgo.com', 'www.duckduckgo.com'].includes(source)) {
+        return 'DuckDuckGo';
+    }
+    if (['Brave Search', 'search.brave.com'].includes(source)) {
+        return 'Brave Search';
+    }
+    if (['Yandex', 'yandex.com', 'www.yandex.com'].includes(source)) {
+        return 'Yandex';
+    }
+    if (['Baidu', 'baidu.com', 'www.baidu.com'].includes(source)) {
+        return 'Baidu';
+    }
+    if (['Ecosia', 'www.ecosia.org', 'ecosia.org'].includes(source)) {
+        return 'Ecosia';
+    }
+    
+    // Email Platforms
+    if (['Gmail', 'mail.google.com', 'gmail.com'].includes(source)) {
+        return 'Gmail';
+    }
+    if (['Outlook', 'outlook.live.com', 'outlook.com', 'hotmail.com'].includes(source)) {
+        return 'Outlook';
+    }
+    if (['Yahoo Mail', 'mail.yahoo.com', 'ymail.com'].includes(source)) {
+        return 'Yahoo Mail';
+    }
+    if (['Apple Mail', 'icloud.com', 'me.com', 'mac.com'].includes(source)) {
+        return 'Apple Mail';
+    }
+    
+    // News Aggregators
+    if (['Google News', 'news.google.com'].includes(source)) {
+        return 'Google News';
+    }
+    if (['Apple News', 'apple.news'].includes(source)) {
+        return 'Apple News';
+    }
+    if (['Flipboard', 'flipboard.com', 'www.flipboard.com'].includes(source)) {
+        return 'Flipboard';
+    }
+    if (['SmartNews', 'smartnews.com', 'www.smartnews.com'].includes(source)) {
+        return 'SmartNews';
+    }
+    
+    // If no match found, return original source
+    return source;
+};
+
 // Helper function to convert range to date parameters
 export const getRangeDates = (rangeInDays: number) => {
     // Always use UTC to stay aligned with the backend's date arithmetic
@@ -29,7 +140,14 @@ export const usePostReferrers = (postId: string) => {
     // API doesn't support date_from yet, so we fetch all data and filter on the client for now
     const {data: postGrowthStatsResponse, isLoading: isPostGrowthStatsLoading} = usePostGrowthStatsAPI(postId);
 
-    const stats = useMemo(() => postReferrerResponse?.stats || [], [postReferrerResponse]);
+    const stats = useMemo(() => {
+        const rawStats = postReferrerResponse?.stats || [];
+        // Apply source normalization to match Tinybird data
+        return rawStats.map(stat => ({
+            ...stat,
+            source: normalizeSource(stat.source || '')
+        }));
+    }, [postReferrerResponse]);
     const totals = useMemo(() => {
         if (postGrowthStatsResponse?.stats.length === 0) {
             return {

--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -3,6 +3,7 @@ import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_RANGES} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig} from '@tryghost/admin-x-framework';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
 type PostAnalyticsContextType = {
     data: Config | undefined;
@@ -27,13 +28,14 @@ export const useGlobalData = () => {
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const config = useBrowseConfig();
+    const site = useBrowseSite();
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
     const settings = useBrowseSettings();
 
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
 
-    const requests = [config, settings];
+    const requests = [config, site, settings];
     const error = requests.map(request => request.error).find(Boolean);
     const isLoading = requests.some(request => request.isLoading);
 
@@ -41,8 +43,15 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         throw error;
     }
 
+    // Add url and icon from site data to config data
+    const dataWithUrl = config.data ? {
+        ...config.data,
+        url: site.data?.site.url,
+        icon: site.data?.site.icon
+    } : undefined;
+
     return <PostAnalyticsContext.Provider value={{
-        data: config.data as Config | undefined,
+        data: dataWithUrl as Config | undefined,
         statsConfig: config.data?.config?.stats as StatsConfig | undefined,
         isLoading,
         range,

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -2,28 +2,13 @@ import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import React from 'react';
-import {BarChartLoadingIndicator, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatNumber} from '@tryghost/shade';
-import {SOURCE_DOMAIN_MAP, extractDomain, getFaviconDomain, useParams} from '@tryghost/admin-x-framework';
-import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
+import {BarChartLoadingIndicator, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, formatNumber} from '@tryghost/shade';
+import {SourcesCard, useParams} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 
 export const centsToDollars = (value : number) => {
     return Math.round(value / 100);
-};
-
-// Check if the source has a valid URL that should be linked
-const hasLinkableUrl = (url: string | undefined): boolean => {
-    if (!url) {
-        return false;
-    }
-
-    try {
-        new URL(url);
-        return true;
-    } catch (e) {
-        return false;
-    }
 };
 
 interface postAnalyticsProps {}
@@ -39,93 +24,6 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     // TEMPORARY: For testing levernews.com direct traffic grouping
     // Remove this line when done testing  
     const testingSiteUrl = siteUrl || 'https://levernews.com';
-
-    // Process and group sources data with consolidation
-    const processedReferrers = React.useMemo(() => {
-        if (!postReferrers) {
-            return [];
-        }
-        
-        const sourceMap = new Map<string, {
-            source: string, 
-            free_members: number, 
-            paid_members: number, 
-            mrr: number,
-            isDirectTraffic: boolean,
-            domain?: string,
-            referrer_url?: string
-        }>();
-        const directTrafficData = {
-            free_members: 0,
-            paid_members: 0,
-            mrr: 0
-        };
-        
-        // Process each source and group
-        postReferrers.forEach((item) => {
-            const {domain, isDirectTraffic} = getFaviconDomain(item.source, testingSiteUrl);
-            
-            if (isDirectTraffic || !item.source || item.source === '') {
-                // Accumulate all direct traffic
-                directTrafficData.free_members += item.free_members || 0;
-                directTrafficData.paid_members += item.paid_members || 0;
-                directTrafficData.mrr += item.mrr || 0;
-            } else {
-                // For non-direct sources, try to find a clean display name
-                let displayName = item.source;
-                
-                // Check if we have a mapping for this source
-                const mappedDomain = Object.entries(SOURCE_DOMAIN_MAP).find(([key, value]) => {
-                    return key.toLowerCase() === item.source?.toLowerCase() || 
-                           value === domain ||
-                           item.source?.toLowerCase().includes(key.toLowerCase());
-                });
-                
-                if (mappedDomain) {
-                    displayName = mappedDomain[0];
-                }
-                
-                const sourceKey = displayName;
-                if (sourceMap.has(sourceKey)) {
-                    const existing = sourceMap.get(sourceKey)!;
-                    existing.free_members += item.free_members || 0;
-                    existing.paid_members += item.paid_members || 0;
-                    existing.mrr += item.mrr || 0;
-                } else {
-                    sourceMap.set(sourceKey, {
-                        source: displayName,
-                        free_members: item.free_members || 0,
-                        paid_members: item.paid_members || 0,
-                        mrr: item.mrr || 0,
-                        isDirectTraffic: false,
-                        domain: domain ?? undefined,
-                        referrer_url: item.referrer_url
-                    });
-                }
-            }
-        });
-        
-        // Add consolidated direct traffic entry if there's any
-        if (directTrafficData.free_members > 0 || directTrafficData.paid_members > 0 || directTrafficData.mrr > 0) {
-            const siteDomain = testingSiteUrl ? extractDomain(testingSiteUrl) : null;
-            sourceMap.set('Direct', {
-                source: 'Direct',
-                free_members: directTrafficData.free_members,
-                paid_members: directTrafficData.paid_members,
-                mrr: directTrafficData.mrr,
-                isDirectTraffic: true,
-                domain: siteDomain || undefined
-            });
-        }
-        
-        // Convert back to array and sort by total impact (prioritizing MRR, then paid members, then free members)
-        return Array.from(sourceMap.values())
-            .sort((a, b) => {
-                const aScore = (a.mrr || 0) * 100 + (a.paid_members || 0) * 10 + (a.free_members || 0);
-                const bScore = (b.mrr || 0) * 100 + (b.paid_members || 0) * 10 + (b.free_members || 0);
-                return bScore - aScore;
-            });
-    }, [postReferrers, testingSiteUrl]);
 
     return (
         <>
@@ -174,70 +72,11 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                 </div>
                             </CardContent>
                         </Card>
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>Sources</CardTitle>
-                                <CardDescription>Where did your growth come from?</CardDescription>
-                            </CardHeader>
-                            <CardContent>
-                                <Separator />
-                                {processedReferrers.length > 0
-                                    ?
-                                    <Table>
-                                        <TableHeader>
-                                            <TableRow>
-                                                <TableHead>Source</TableHead>
-                                                <TableHead className='w-[110px] text-right'>Free members</TableHead>
-                                                <TableHead className='w-[110px] text-right'>Paid members</TableHead>
-                                                <TableHead className='w-[110px] text-right'>MRR impact</TableHead>
-                                            </TableRow>
-                                        </TableHeader>
-                                        <TableBody>
-                                            {processedReferrers?.map((row) => {
-                                                const iconSrc = row.domain ? 
-                                                    `https://www.faviconextractor.com/favicon/${row.domain}?larger=true` : 
-                                                    STATS_DEFAULT_SOURCE_ICON_URL;
-                                                
-                                                return (
-                                                    <TableRow key={row.source}>
-                                                        <TableCell>
-                                                            {row.source && row.referrer_url && hasLinkableUrl(row.referrer_url) ?
-                                                                <a className='group flex items-center gap-2' href={row.referrer_url} rel="noreferrer" target="_blank">
-                                                                    <img
-                                                                        className="size-4"
-                                                                        src={iconSrc}
-                                                                        onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                                            e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
-                                                                        }} />
-                                                                    <span className='group-hover:underline'>{row.source}</span>
-                                                                </a>
-                                                                :
-                                                                <span className='flex items-center gap-2'>
-                                                                    <img
-                                                                        className="size-4"
-                                                                        src={iconSrc}
-                                                                        onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                                            e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
-                                                                        }} />
-                                                                    <span>{row.source}</span>
-                                                                </span>
-                                                            }
-                                                        </TableCell>
-                                                        <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.free_members)}</TableCell>
-                                                        <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.paid_members)}</TableCell>
-                                                        <TableCell className='text-right font-mono text-sm'>+${centsToDollars(row.mrr)}</TableCell>
-                                                    </TableRow>
-                                                );
-                                            })}
-                                        </TableBody>
-                                    </Table>
-                                    :
-                                    <div className='py-20 text-center text-sm text-gray-700'>
-                                    Once someone signs up on this post, sources will show here.
-                                    </div>
-                                }
-                            </CardContent>
-                        </Card>
+                        <SourcesCard 
+                            data={postReferrers}
+                            mode="growth"
+                            siteUrl={testingSiteUrl}
+                        />
                     </div>
                 }
             </PostAnalyticsContent>

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -18,8 +18,9 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {postId} = useParams();
     const {stats: postReferrers, totals, isLoading} = usePostReferrers(postId || '');
     
-    // Get site URL from global data
+    // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;
+    const siteIcon = globalData?.icon as string | undefined;
     
     // TEMPORARY: For testing levernews.com direct traffic grouping
     // Remove this line when done testing  
@@ -75,6 +76,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                         <SourcesCard 
                             data={postReferrers}
                             mode="growth"
+                            siteIcon={siteIcon}
                             siteUrl={testingSiteUrl}
                         />
                     </div>

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, formatNumber, formatPercentage} from '@tryghost/shade';
-import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
-import {getFaviconDomain, getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
-import {getPeriodText} from '@src/utils/chart-helpers';
+import {getStatEndpointUrl, getToken, SourcesCard} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -10,76 +7,7 @@ interface SourcesProps {
     queryParams: Record<string, string | number>
 }
 
-interface SourceData {
-    source: string;
-    visits: number;
-}
-
-interface SourceDataWithPercentage extends SourceData {
-    percentage: number;
-}
-
-interface SourcesTableProps {
-    data: SourceDataWithPercentage[] | null;
-    range: number;
-    siteUrl?: string;
-}
-
-const SourcesTable: React.FC<SourcesTableProps> = ({data, siteUrl}) => {
-    return (
-        <DataList>
-            <DataListHeader>
-                <DataListHead>Source</DataListHead>
-                <DataListHead>Visitors</DataListHead>
-            </DataListHeader>
-            <DataListBody>
-                {data?.map((row) => {
-                    const {domain, isDirectTraffic} = getFaviconDomain(row.source, siteUrl);
-                    const displayName = isDirectTraffic ? 'Direct' : (row.source || 'Direct');
-
-                    return (
-                        <DataListRow key={row.source || 'direct'} className='group/row'>
-                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all' style={{
-                                width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
-                                // backgroundColor: 'hsl(var(--chart-blue))'
-                            }} />
-                            <DataListItemContent className='group-hover/datalist:max-w-[calc(100%-140px)]'>
-                                <div className='flex items-center space-x-4 overflow-hidden'>
-                                    <div className={`truncate font-medium`}>
-                                        {domain && !isDirectTraffic ?
-                                            <a className='group/link flex items-center gap-2' href={`https://${domain}`} rel="noreferrer" target="_blank">
-                                                <img
-                                                    className="size-4"
-                                                    src={`https://www.faviconextractor.com/favicon/${domain}?larger=true`}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
-                                                    }} />
-                                                <span className='group-hover/link:underline'>{displayName}</span>
-                                            </a>
-                                            :
-                                            <span className='flex items-center gap-2'>
-                                                <img
-                                                    className="size-4"
-                                                    src={STATS_DEFAULT_SOURCE_ICON_URL} />
-                                                <span>{displayName}</span>
-                                            </span>
-                                        }
-                                    </div>
-                                </div>
-                            </DataListItemContent>
-                            <DataListItemValue>
-                                <DataListItemValueAbs>{formatNumber(Number(row.visits))}</DataListItemValueAbs>
-                                <DataListItemValuePerc>{formatPercentage(row.percentage || 0)}</DataListItemValuePerc>
-                            </DataListItemValue>
-                        </DataListRow>
-                    );
-                })}
-            </DataListBody>
-        </DataList>
-    );
-};
-
-const Sources:React.FC<SourcesProps> = ({queryParams}) => {
+const Sources: React.FC<SourcesProps> = ({queryParams}) => {
     const {statsConfig, data: globalData, isLoading: isConfigLoading, range} = useGlobalData();
 
     // Get site URL from global data
@@ -95,106 +23,31 @@ const Sources:React.FC<SourcesProps> = ({queryParams}) => {
         params: queryParams
     });
 
+    // Calculate total visits for percentage calculation
     const totalVisits = React.useMemo(() => {
-        if (!data) {
-            return 0;
-        }
-        return (data as unknown as SourceData[]).reduce((sum: number, source: SourceData) => sum + Number(source.visits), 0);
+        if (!data) return 0;
+        return data.reduce((sum, source) => sum + Number(source.visits || 0), 0);
     }, [data]);
-
-    // Process and group sources data with direct traffic consolidation
-    const processedData = React.useMemo(() => {
-        if (!data) {
-            return [];
-        }
-
-        const sourceMap = new Map<string, {source: string, visits: number, isDirectTraffic: boolean}>();
-        let directTrafficTotal = 0;
-
-        // Process each source and group direct traffic
-        (data as unknown as SourceData[]).forEach((item) => {
-            const {isDirectTraffic} = getFaviconDomain(item.source, testingSiteUrl);
-            const visits = Number(item.visits);
-
-            if (isDirectTraffic || !item.source || item.source === '') {
-                // Accumulate all direct traffic
-                directTrafficTotal += visits;
-            } else {
-                // Keep other sources as-is
-                const sourceKey = String(item.source);
-                if (sourceMap.has(sourceKey)) {
-                    const existing = sourceMap.get(sourceKey)!;
-                    existing.visits += visits;
-                } else {
-                    sourceMap.set(sourceKey, {
-                        source: sourceKey,
-                        visits,
-                        isDirectTraffic: false
-                    });
-                }
-            }
-        });
-
-        // Add consolidated direct traffic entry if there's any
-        if (directTrafficTotal > 0) {
-            sourceMap.set('Direct', {
-                source: 'Direct',
-                visits: directTrafficTotal,
-                isDirectTraffic: true
-            });
-        }
-
-        // Convert back to array and sort by visits
-        return Array.from(sourceMap.values())
-            .sort((a, b) => b.visits - a.visits);
-    }, [data, testingSiteUrl]);
-
-    const dataWithPercentages = React.useMemo(() => {
-        return processedData.map(item => ({
-            ...item,
-            percentage: totalVisits > 0 ? (item.visits / totalVisits) : 0
-        })) as SourceDataWithPercentage[];
-    }, [processedData, totalVisits]);
 
     const isLoading = isConfigLoading || loading;
 
+    if (isLoading) {
+        return null;
+    }
+
+    if (!data || data.length === 0) {
+        return null;
+    }
+
     return (
-        <>
-            {isLoading ? '' :
-                <>
-                    {dataWithPercentages.length > 0 &&
-                        <Card className='group/datalist'>
-                            <CardHeader>
-                                <CardTitle>Top Sources</CardTitle>
-                                <CardDescription>How readers found your post</CardDescription>
-                            </CardHeader>
-                            <CardContent>
-                                <Separator />
-                                <SourcesTable data={dataWithPercentages} range={range} siteUrl={testingSiteUrl} />
-                            </CardContent>
-                            {dataWithPercentages.length > 10 &&
-                                <CardFooter>
-                                    <Sheet>
-                                        <SheetTrigger asChild>
-                                            <Button variant='outline'>View all <LucideIcon.TableOfContents /></Button>
-                                        </SheetTrigger>
-                                        <SheetContent className='overflow-y-auto pt-0 sm:max-w-[600px]'>
-                                            <SheetHeader className='sticky top-0 z-40 -mx-6 bg-white/60 p-6 backdrop-blur'>
-                                                <SheetTitle>Top sources</SheetTitle>
-                                                <SheetDescription>How readers found this post {getPeriodText(range)}</SheetDescription>
-                                            </SheetHeader>
-                                            <div className='group/datalist'>
-                                                <SourcesTable data={dataWithPercentages} range={range} siteUrl={testingSiteUrl} />
-                                            </div>
-                                        </SheetContent>
-                                    </Sheet>
-                                </CardFooter>
-                            }
-                        </Card>
-                    }
-                </>
-            }
-        </>
+        <SourcesCard 
+            data={data}
+            description="How readers found your post"
+            mode="visits"
+            range={range}
+            siteUrl={testingSiteUrl}
+            totalVisitors={totalVisits}
+        />
     );
 };
 

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {getStatEndpointUrl, getToken, SourcesCard} from '@tryghost/admin-x-framework';
+import {SourcesCard, getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -10,8 +10,9 @@ interface SourcesProps {
 const Sources: React.FC<SourcesProps> = ({queryParams}) => {
     const {statsConfig, data: globalData, isLoading: isConfigLoading, range} = useGlobalData();
 
-    // Get site URL from global data
+    // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;
+    const siteIcon = globalData?.icon as string | undefined;
 
     // TEMPORARY: For testing levernews.com direct traffic grouping
     // Remove this line when done testing
@@ -45,6 +46,7 @@ const Sources: React.FC<SourcesProps> = ({queryParams}) => {
             description="How readers found your post"
             mode="visits"
             range={range}
+            siteIcon={siteIcon}
             siteUrl={testingSiteUrl}
             totalVisitors={totalVisits}
         />

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -26,7 +26,9 @@ const Sources: React.FC<SourcesProps> = ({queryParams}) => {
 
     // Calculate total visits for percentage calculation
     const totalVisits = React.useMemo(() => {
-        if (!data) return 0;
+        if (!data) {
+            return 0;
+        }
         return data.reduce((sum, source) => sum + Number(source.visits || 0), 0);
     }, [data]);
 

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -25,6 +25,7 @@
         "build": "tsc && vite build",
         "lint": "yarn run lint:code && yarn run lint:test",
         "lint:code": "eslint --ext .js,.ts,.cjs,.tsx --cache src",
+        "lint:code:fix": "eslint --ext .js,.ts,.cjs,.tsx --cache --fix src",
         "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx --cache test",
         "preview": "vite preview"
     },

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -3,6 +3,7 @@ import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_DEFAULT_RANGE_KEY, STATS_RANGE_OPTIONS} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig} from '@tryghost/admin-x-framework';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
 interface GlobalData {
     data: Config | undefined;
@@ -29,13 +30,14 @@ export const useGlobalData = () => {
 
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const settings = useBrowseSettings();
+    const site = useBrowseSite();
     const config = useBrowseConfig() as unknown as { data: Config & { config: { stats?: StatsConfig } } | null, isLoading: boolean, error: Error | null };
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
     const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
-    const requests = [config, settings];
+    const requests = [config, settings, site];
     const error = requests.map(request => request.error).find(Boolean);
     const isLoading = requests.some(request => request.isLoading);
 
@@ -43,8 +45,15 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
         throw error;
     }
 
+    // Add url and icon from site data to config data
+    const dataWithUrl = config.data ? {
+        ...config.data,
+        url: site.data?.site.url,
+        icon: site.data?.site.icon
+    } : undefined;
+
     return <GlobalDataContext.Provider value={{
-        data: config.data ?? undefined,
+        data: dataWithUrl as Config | undefined,
         statsConfig: config.data?.config?.stats,
         isLoading,
         range,

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -164,7 +164,7 @@ const TopContentTable: React.FC<TopContentTableProps> = ({data}) => {
                                 navigate(`/posts/analytics/beta/${row.post_id}`, {crossApp: true});
                             }
                         }}>
-                            <DataListBar className='from-muted-foreground/40 to-muted-foreground/60 bg-gradient-to-r opacity-20 transition-all group-hover/row:opacity-40' style={{
+                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all group-hover/row:opacity-40' style={{
                                 width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
                                 // backgroundColor: 'hsl(var(--chart-blue))'
                             }} />

--- a/apps/stats/src/views/Stats/Web.tsx
+++ b/apps/stats/src/views/Stats/Web.tsx
@@ -7,8 +7,7 @@ import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, GhAreaChart, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Tabs, TabsList, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates, getYRange} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
-
-import {extractDomain, getFaviconDomain, getStatEndpointUrl, getToken, useNavigate} from '@tryghost/admin-x-framework';
+import {SourcesCard, getStatEndpointUrl, getToken, useNavigate} from '@tryghost/admin-x-framework';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
@@ -31,7 +30,7 @@ interface KpiDataItem {
 
 interface SourcesData {
     source?: string | number;
-    visits: string | number;
+    visits?: number;
     [key: string]: unknown;
     percentage?: number;
 }
@@ -165,7 +164,7 @@ const TopContentTable: React.FC<TopContentTableProps> = ({data}) => {
                                 navigate(`/posts/analytics/beta/${row.post_id}`, {crossApp: true});
                             }
                         }}>
-                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all group-hover/row:opacity-40' style={{
+                            <DataListBar className='from-muted-foreground/40 to-muted-foreground/60 bg-gradient-to-r opacity-20 transition-all group-hover/row:opacity-40' style={{
                                 width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
                                 // backgroundColor: 'hsl(var(--chart-blue))'
                             }} />
@@ -249,176 +248,13 @@ const TopContentCard: React.FC<TopContentCardProps> = ({totalVisitors, data, ran
     );
 };
 
-interface SourcesTableProps {
-    data: SourcesData[] | null;
-    range: number;
-    siteUrl?: string;
-}
-
-const SourcesTable: React.FC<SourcesTableProps> = ({data, siteUrl}) => {
-    return (
-        <DataList>
-            <DataListHeader>
-                <DataListHead>Source</DataListHead>
-                <DataListHead>Visitors</DataListHead>
-            </DataListHeader>
-            <DataListBody>
-                {data?.map((row) => {
-                    // Use precomputed values if available (from processed data), otherwise compute
-                    const faviconDomain = 'faviconDomain' in row && row.faviconDomain
-                        ? row.faviconDomain
-                        : getFaviconDomain(row.source, siteUrl).domain;
-                    const isDirectTraffic = 'isDirectTraffic' in row
-                        ? row.isDirectTraffic
-                        : getFaviconDomain(row.source, siteUrl).isDirectTraffic;
-                    const displayName = isDirectTraffic ? 'Direct' : (row.source || 'Direct');
-
-                    return (
-                        <DataListRow key={row.source || 'direct'} className='group/row'>
-                            <DataListBar className='bg-gradient-to-r from-muted-foreground/40 to-muted-foreground/60 opacity-20 transition-all group-hover/row:opacity-40' style={{
-                                width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
-                                // backgroundColor: 'hsl(var(--chart-blue))'
-                            }} />
-                            <DataListItemContent className='group-hover/datalist:max-w-[calc(100%-140px)]'>
-                                <div className='flex items-center space-x-4 overflow-hidden'>
-                                    <div className={`truncate font-medium`}>
-                                        {faviconDomain ?
-                                            <a className='group/link flex items-center gap-2' href={`https://${faviconDomain}`} rel="noreferrer" target="_blank">
-                                                <img
-                                                    className="size-4"
-                                                    src={`https://www.faviconextractor.com/favicon/${faviconDomain}?larger=true`}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = STATS_DEFAULT_SOURCE_ICON_URL;
-                                                    }} />
-                                                <span className='group-hover/link:underline'>{displayName}</span>
-                                            </a>
-                                            :
-                                            <span className='flex items-center gap-2'>
-                                                <img
-                                                    className="size-4"
-                                                    src={STATS_DEFAULT_SOURCE_ICON_URL} />
-                                                <span>{displayName}</span>
-                                            </span>
-                                        }
-                                    </div>
-                                </div>
-                            </DataListItemContent>
-                            <DataListItemValue>
-                                <DataListItemValueAbs>{formatNumber(Number(row.visits))}</DataListItemValueAbs>
-                                <DataListItemValuePerc>{formatPercentage(row.percentage || 0)}</DataListItemValuePerc>
-                            </DataListItemValue>
-                        </DataListRow>
-                    );
-                })}
-            </DataListBody>
-        </DataList>
-    );
-};
-
-interface SourcesCardProps {
-    totalVisitors: number;
-    data: SourcesData[] | null;
-    range: number;
-    siteUrl?: string;
-}
-
-const SourcesCard: React.FC<SourcesCardProps> = ({totalVisitors, data, range, siteUrl}) => {
-    // Process and group sources data
-    const processedData = React.useMemo(() => {
-        if (!data) {
-            return [];
-        }
-
-        const sourceMap = new Map<string, {source: string, visits: number, isDirectTraffic: boolean, faviconDomain?: string}>();
-        let directTrafficTotal = 0;
-
-        // Process each source and group direct traffic
-        data.forEach((item) => {
-            const {domain: faviconDomain, isDirectTraffic} = getFaviconDomain(item.source, siteUrl);
-            const visits = Number(item.visits);
-
-            if (isDirectTraffic || !item.source || item.source === '') {
-                // Accumulate all direct traffic
-                directTrafficTotal += visits;
-            } else {
-                // Keep other sources as-is
-                const sourceKey = String(item.source);
-                if (sourceMap.has(sourceKey)) {
-                    const existing = sourceMap.get(sourceKey)!;
-                    existing.visits += visits;
-                } else {
-                    sourceMap.set(sourceKey, {
-                        source: sourceKey,
-                        visits,
-                        isDirectTraffic: false,
-                        faviconDomain: faviconDomain || undefined
-                    });
-                }
-            }
-        });
-
-        // Add consolidated direct traffic entry if there's any
-        if (directTrafficTotal > 0) {
-            const siteDomain = siteUrl ? extractDomain(siteUrl) : null;
-            sourceMap.set('Direct', {
-                source: 'Direct',
-                visits: directTrafficTotal,
-                isDirectTraffic: true,
-                faviconDomain: siteDomain || undefined
-            });
-        }
-
-        // Convert back to array and sort by visits
-        return Array.from(sourceMap.values())
-            .sort((a, b) => b.visits - a.visits);
-    }, [data, siteUrl]);
-
-    // Extend processed data with percentage values
-    const extendedData = processedData.map(item => ({
-        ...item,
-        percentage: totalVisitors > 0 ? (item.visits / totalVisitors) : 0
-    }));
-
-    const topSources = extendedData.slice(0, 10);
-
-    return (
-        <Card className='group/datalist'>
-            <CardHeader>
-                <CardTitle>Top Sources</CardTitle>
-                <CardDescription>How readers found your site {getPeriodText(range)}</CardDescription>
-            </CardHeader>
-            <CardContent>
-                <Separator />
-                <SourcesTable data={topSources || null} range={range} siteUrl={siteUrl} />
-            </CardContent>
-            {extendedData.length > 10 &&
-                <CardFooter>
-                    <Sheet>
-                        <SheetTrigger asChild>
-                            <Button variant='outline'>View all <LucideIcon.TableOfContents /></Button>
-                        </SheetTrigger>
-                        <SheetContent className='overflow-y-auto pt-0 sm:max-w-[600px]'>
-                            <SheetHeader className='sticky top-0 z-40 -mx-6 bg-white/60 p-6 backdrop-blur'>
-                                <SheetTitle>Top sources</SheetTitle>
-                                <SheetDescription>How readers found your site {getPeriodText(range)}</SheetDescription>
-                            </SheetHeader>
-                            <div className='group/datalist'>
-                                <SourcesTable data={extendedData} range={range} siteUrl={siteUrl} />
-                            </div>
-                        </SheetContent>
-                    </Sheet>
-                </CardFooter>
-            }
-        </Card>
-    );
-};
-
 const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
-    // Get site URL for domain comparison
+    // Get site URL and icon for domain comparison and Direct traffic favicon
     const siteUrl = data?.url as string | undefined;
+    const siteIcon = data?.icon as string | undefined;
 
     // Prepare query parameters
     const params = {
@@ -478,7 +314,15 @@ const Web: React.FC = () => {
                 </Card>
                 <div className='grid grid-cols-2 gap-8'>
                     <TopContentCard data={topContentData?.stats || null} range={range} totalVisitors={totalVisitors} />
-                    <SourcesCard data={sourcesData as SourcesData[] | null} range={range} siteUrl={siteUrl} totalVisitors={totalVisitors} />
+                    <SourcesCard 
+                        data={sourcesData as SourcesData[] | null} 
+                        defaultSourceIconUrl={STATS_DEFAULT_SOURCE_ICON_URL}
+                        getPeriodText={getPeriodText}
+                        range={range} 
+                        siteIcon={siteIcon} 
+                        siteUrl={siteUrl} 
+                        totalVisitors={totalVisitors} 
+                    />
                 </div>
             </StatsView>
         </StatsLayout>


### PR DESCRIPTION
no ref
- refactored Growth into its own component within admin-x-framework; this is shared across three views in two apps already
- updated logo handling; will default to site logo for 'Direct' traffic
- updated 'Direct' traffic handling; if the site is its own referrer (which is something we need to look into) we will attempt to group it with 'Direct'
- updated `usePostReferrers` hook to map domains, much like we do for the tinybird top_sources data; this feels redundant but is necessary until we have all data in tinybird...

There was a variety of inconsistencies between the components and display that I tried to resolve with this PR. This is largely handled with a centralized card, `SourcesCard`, which has the flexibility to be used with various data columns.