### PR TITLE
Remove trend values when range is "All time"

### DIFF
--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -176,7 +176,7 @@ const KpiCardHeaderLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({chi
 
 interface KpiCardValueProps {
     value: string | number;
-    diffDirection?: 'up' | 'down' | 'same' | 'empty';
+    diffDirection?: 'up' | 'down' | 'same' | 'empty' | 'hidden';
     diffValue?: string | number;
 }
 
@@ -192,7 +192,7 @@ const KpiCardHeaderValue: React.FC<KpiCardValueProps> = ({value, diffDirection, 
             <div className='text-[2.3rem] font-semibold leading-none tracking-tight xl:text-[2.6rem] xl:tracking-[-0.04em]'>
                 {value}
             </div>
-            {diffDirection &&
+            {diffDirection !== 'hidden' &&
             <>
                 <div className={diffContainerClassName}>
                     {diffDirection === 'up' &&

--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -192,7 +192,7 @@ const KpiCardHeaderValue: React.FC<KpiCardValueProps> = ({value, diffDirection, 
             <div className='text-[2.3rem] font-semibold leading-none tracking-tight xl:text-[2.6rem] xl:tracking-[-0.04em]'>
                 {value}
             </div>
-            {diffDirection !== 'hidden' &&
+            {diffDirection && diffDirection !== 'hidden' &&
             <>
                 <div className={diffContainerClassName}>
                     {diffDirection === 'up' &&

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -174,7 +174,7 @@ interface KpiTabValueProps {
     icon?: keyof typeof LucideIcons;
     label: string;
     value: string | number;
-    diffDirection?: 'up' | 'down' | 'same';
+    diffDirection?: 'up' | 'down' | 'same' | 'hidden';
     diffValue?: string | number;
 }
 
@@ -198,7 +198,7 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({color, icon: iconName, label, 
                 <div className='text-[2.3rem] font-semibold leading-none tracking-tight xl:text-[2.6rem] xl:tracking-[-0.04em]'>
                     {value}
                 </div>
-                {diffValue &&
+                {diffDirection !== 'hidden' &&
                     <>
                         <div className={diffContainerClassName}>
                             {diffDirection === 'up' &&

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -198,7 +198,7 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({color, icon: iconName, label, 
                 <div className='text-[2.3rem] font-semibold leading-none tracking-tight xl:text-[2.6rem] xl:tracking-[-0.04em]'>
                     {value}
                 </div>
-                {diffDirection !== 'hidden' &&
+                {diffDirection && diffDirection !== 'hidden' &&
                     <>
                         <div className={diffContainerClassName}>
                             {diffDirection === 'up' &&

--- a/apps/stats/src/utils/constants.ts
+++ b/apps/stats/src/utils/constants.ts
@@ -1,12 +1,35 @@
-export const STATS_RANGE_OPTIONS = [
-    {name: 'Today', value: 1},
-    {name: 'Last 7 days', value: 7},
-    {name: 'Last 30 days', value: 30 + 1},
-    {name: 'Last 3 months', value: 90 + 1},
-    {name: 'Year to date', value: -1},
-    {name: 'Last 12 months', value: 12 * (30 + 1)},
-    {name: 'All time', value: 1000}
-];
+export const STATS_RANGE_KV = {
+    today: {
+        name: 'Today',
+        value: 1
+    },
+    last7Days: {
+        name: 'Last 7 days',
+        value: 7
+    },
+    last30Days: {
+        name: 'Last 30 days',
+        value: 30 + 1
+    },
+    last3Months: {
+        name: 'Last 3 months',
+        value: 91
+    },
+    yearToDate: {
+        name: 'Year to date',
+        value: -1
+    },
+    last12Months: {
+        name: 'Last 12 months',
+        value: 12 * (30 + 1)
+    },
+    allTime: {
+        name: 'All time',
+        value: 1000
+    }
+};
+
+export const STATS_RANGE_OPTIONS = Object.values(STATS_RANGE_KV);
 
 export const STATS_DEFAULT_RANGE_KEY = 2;
 

--- a/apps/stats/src/utils/constants.ts
+++ b/apps/stats/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const STATS_RANGE_KV = {
+export const STATS_RANGES = {
     today: {
         name: 'Today',
         value: 1
@@ -29,7 +29,7 @@ export const STATS_RANGE_KV = {
     }
 };
 
-export const STATS_RANGE_OPTIONS = Object.values(STATS_RANGE_KV);
+export const STATS_RANGE_OPTIONS = Object.values(STATS_RANGES);
 
 export const STATS_DEFAULT_RANGE_KEY = 2;
 

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -6,6 +6,7 @@ import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, GhAreaChart, GhAreaChartDataItem, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, centsToDollars, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
+import {STATS_RANGE_KV} from '@src/utils/constants';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -14,7 +15,7 @@ import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
 // Define content types
 const CONTENT_TYPES = {
     POSTS: 'posts',
-    PAGES: 'pages', 
+    PAGES: 'pages',
     POSTS_AND_PAGES: 'posts_and_pages'
 } as const;
 
@@ -169,7 +170,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-teal))'
-                        diffDirection={directions.total}
+                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.total}
                         label="Total members"
                         value={formatNumber(totalMembers)}
@@ -180,7 +181,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-blue))'
-                        diffDirection={directions.free}
+                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.free}
                         label="Free members"
                         value={formatNumber(freeMembers)}
@@ -191,7 +192,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-yellow))'
-                        diffDirection={directions.paid}
+                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.paid}
                         label="Paid members"
                         value={formatNumber(paidMembers)}
@@ -202,7 +203,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-purple))'
-                        diffDirection={directions.mrr}
+                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.mrr}
                         label="MRR"
                         value={`$${formatNumber(centsToDollars(mrr))}`}
@@ -260,7 +261,7 @@ const Growth: React.FC = () => {
             } else if (sortBy.includes('mrr') && totalMrr > 0) {
                 percentage = item.mrr / totalMrr;
             }
-            
+
             return {
                 title: item.title,
                 post_id: item.post_id,
@@ -270,7 +271,7 @@ const Growth: React.FC = () => {
                 percentage
             };
         });
-    }, [topPostsData, sortBy, selectedContentType]);
+    }, [topPostsData, sortBy]);
 
     const getContentTypeLabel = () => {
         const option = CONTENT_TYPE_OPTIONS.find(opt => opt.value === selectedContentType);
@@ -328,7 +329,7 @@ const Growth: React.FC = () => {
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent>
                                     {CONTENT_TYPE_OPTIONS.map(option => (
-                                        <DropdownMenuItem 
+                                        <DropdownMenuItem
                                             key={option.value}
                                             onClick={() => setSelectedContentType(option.value)}
                                         >

--- a/apps/stats/src/views/Stats/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth.tsx
@@ -6,7 +6,7 @@ import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, GhAreaChart, GhAreaChartDataItem, KpiTabTrigger, KpiTabValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, centsToDollars, formatNumber} from '@tryghost/shade';
 import {DiffDirection, useGrowthStats} from '@src/hooks/useGrowthStats';
-import {STATS_RANGE_KV} from '@src/utils/constants';
+import {STATS_RANGES} from '@src/utils/constants';
 import {getPeriodText, sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
@@ -170,7 +170,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-teal))'
-                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
+                        diffDirection={range === STATS_RANGES.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.total}
                         label="Total members"
                         value={formatNumber(totalMembers)}
@@ -181,7 +181,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-blue))'
-                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
+                        diffDirection={range === STATS_RANGES.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.free}
                         label="Free members"
                         value={formatNumber(freeMembers)}
@@ -192,7 +192,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-yellow))'
-                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
+                        diffDirection={range === STATS_RANGES.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.paid}
                         label="Paid members"
                         value={formatNumber(paidMembers)}
@@ -203,7 +203,7 @@ const GrowthKPIs: React.FC<{
                 }}>
                     <KpiTabValue
                         color='hsl(var(--chart-purple))'
-                        diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : directions.total}
+                        diffDirection={range === STATS_RANGES.allTime.value ? 'hidden' : directions.total}
                         diffValue={percentChanges.mrr}
                         label="MRR"
                         value={`$${formatNumber(centsToDollars(mrr))}`}

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -5,6 +5,7 @@ import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, centsToDollars, cn, formatDisplayDate, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
+import {STATS_RANGE_KV} from '@src/utils/constants';
 import {getAudienceQueryParam} from './components/AudienceSelect';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken, useNavigate} from '@tryghost/admin-x-framework';
@@ -40,6 +41,7 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
     onClick
 }) => {
     // const navigate = useNavigate();
+    const {range} = useGlobalData();
     const IconComponent = iconName && LucideIcon[iconName] as LucideIcon.LucideIcon;
 
     return (
@@ -55,7 +57,7 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
                     {title}
                 </KpiCardHeaderLabel>
                 <KpiCardHeaderValue
-                    diffDirection={diffDirection}
+                    diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : diffDirection}
                     diffValue={diffValue}
                     value={formattedValue}
                 />

--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -5,7 +5,7 @@ import StatsHeader from './layout/StatsHeader';
 import StatsLayout from './layout/StatsLayout';
 import StatsView from './layout/StatsView';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, centsToDollars, cn, formatDisplayDate, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
-import {STATS_RANGE_KV} from '@src/utils/constants';
+import {STATS_RANGES} from '@src/utils/constants';
 import {getAudienceQueryParam} from './components/AudienceSelect';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {getStatEndpointUrl, getToken, useNavigate} from '@tryghost/admin-x-framework';
@@ -57,7 +57,7 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
                     {title}
                 </KpiCardHeaderLabel>
                 <KpiCardHeaderValue
-                    diffDirection={range === STATS_RANGE_KV.allTime.value ? 'hidden' : diffDirection}
+                    diffDirection={range === STATS_RANGES.allTime.value ? 'hidden' : diffDirection}
                     diffValue={diffValue}
                     value={formattedValue}
                 />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1978/remove-trend-values-when-range-is-all-time

- When viewing "All time" range in post analytics there was nothing to compare the currently visible data to.