### PR TITLE
Added pagination for child replies in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.54",
+  "version": "0.7.55",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/global/ShowRepliesButton.tsx
+++ b/apps/admin-x-activitypub/src/components/global/ShowRepliesButton.tsx
@@ -1,27 +1,50 @@
 import React, {useRef} from 'react';
-import {Button} from '@tryghost/shade';
+import {Button, LoadingIndicator} from '@tryghost/shade';
 
 interface ShowRepliesButtonProps {
-    count: number;
+    count?: number;
     onClick: () => void;
+    variant?: 'default' | 'expand' | 'loadMore';
+    preserveScroll?: boolean;
+    loading?: boolean;
 }
 
-const ShowRepliesButton: React.FC<ShowRepliesButtonProps> = ({count, onClick}) => {
+const ShowRepliesButton: React.FC<ShowRepliesButtonProps> = ({count, onClick, variant = 'default', preserveScroll = true, loading = false}) => {
     const buttonRef = useRef<HTMLDivElement>(null);
 
+    const getButtonText = () => {
+        if (count && count > 0) {
+            return `Show ${count} more ${count === 1 ? 'reply' : 'replies'}`;
+        }
+
+        switch (variant) {
+        case 'expand':
+            return 'Show replies';
+        case 'loadMore':
+            return 'Show more replies';
+        case 'default':
+        default:
+            return 'Show replies';
+        }
+    };
+
     const handleClick = () => {
-        const container = document.querySelector('[data-scrollable-container]') as HTMLElement;
-        const scrollTop = container ? container.scrollTop : window.scrollY;
+        if (preserveScroll) {
+            const container = document.querySelector('[data-scrollable-container]') as HTMLElement;
+            const scrollTop = container ? container.scrollTop : window.scrollY;
 
-        onClick();
+            onClick();
 
-        setTimeout(() => {
-            if (container) {
-                container.scrollTop = scrollTop;
-            } else {
-                window.scrollTo(0, scrollTop);
-            }
-        }, 0);
+            setTimeout(() => {
+                if (container) {
+                    container.scrollTop = scrollTop;
+                } else {
+                    window.scrollTo(0, scrollTop);
+                }
+            }, 0);
+        } else {
+            onClick();
+        }
     };
 
     return (
@@ -41,7 +64,14 @@ const ShowRepliesButton: React.FC<ShowRepliesButtonProps> = ({count, onClick}) =
                     handleClick();
                 }}
             >
-                Show {count} more {count === 1 ? 'reply' : 'replies'}
+                {loading ? (
+                    <div className='flex items-center gap-2'>
+                        <LoadingIndicator size='sm' />
+                        <span>Loading...</span>
+                    </div>
+                ) : (
+                    getButtonText()
+                )}
             </Button>
         </div>
     );

--- a/apps/admin-x-activitypub/src/components/global/ShowRepliesButton.tsx
+++ b/apps/admin-x-activitypub/src/components/global/ShowRepliesButton.tsx
@@ -22,7 +22,6 @@ const ShowRepliesButton: React.FC<ShowRepliesButtonProps> = ({count, onClick, va
             return 'Show replies';
         case 'loadMore':
             return 'Show more replies';
-        case 'default':
         default:
             return 'Show replies';
         }

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -2206,11 +2206,16 @@ export function useReplyChainForUser(handle: string, postApId: string | null) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI(handle, siteUrl);
             const child = replyChain.children[childIndex];
-            const lastReplyInChain = child.chain[child.chain.length - 1];
 
-            const nextPage = await api.getReplies(lastReplyInChain.id);
+            // Use the second-to-last reply as the starting point for pagination
+            // This ensures we get proper continuity without gaps
+            const replyForPagination = child.chain.length > 1
+                ? child.chain[child.chain.length - 2]
+                : child.post;
 
-            const moreReplies = [nextPage.children[0].post, ...nextPage.children[0].chain];
+            const nextPage = await api.getReplies(replyForPagination.id);
+
+            const moreReplies = nextPage.children[0].chain;
 
             setReplyChain((prev) => {
                 if (!prev) {


### PR DESCRIPTION
ref PROD-1968

- Implemented pagination for replies within reply chains
- Limited initial display to first reply with client-side pagination
- Added "Show more replies" expansion that triggers server pagination