### PR TITLE
Updated eslint config for TailwindCSS

### DIFF
--- a/apps/admin-x-settings/.eslintrc.cjs
+++ b/apps/admin-x-settings/.eslintrc.cjs
@@ -1,4 +1,7 @@
 /* eslint-env node */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+
 module.exports = {
     root: true,
     extends: [
@@ -134,12 +137,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}]
     }
 };

--- a/apps/posts/.eslintrc.cjs
+++ b/apps/posts/.eslintrc.cjs
@@ -1,4 +1,7 @@
 /* eslint-env node */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+
 module.exports = {
     root: true,
     extends: [
@@ -45,12 +48,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}]
     }
 };

--- a/apps/stats/.eslintrc.cjs
+++ b/apps/stats/.eslintrc.cjs
@@ -1,4 +1,7 @@
 /* eslint-env node */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+
 module.exports = {
     root: true,
     extends: [
@@ -45,12 +48,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: path.join(__dirname, 'tailwind.config.cjs')}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: path.join(__dirname, 'tailwind.config.cjs')}]
     }
 };


### PR DESCRIPTION
Problem: classname ordering is getting messed up in monorepos using eslint-plugin-tailwindcss. This is especially a problem when you want to update classname ordering automatically on save because the wrong order would be saved which fails tests on CI.

According to this issue (https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/241) using absolute URL for the tailwind config file could help with the issue.