### PR TITLE
Added tab handling to Stats > Growth

### DIFF
--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -270,7 +270,7 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='Members'
                         onClick={() => {
-                            navigate('/growth/');
+                            navigate('/growth/?tab=total-members');
                         }}
                     >
                         <GhAreaChart
@@ -294,7 +294,7 @@ const Overview: React.FC = () => {
                         linkto='/growth/'
                         title='MRR'
                         onClick={() => {
-                            navigate('/growth/');
+                            navigate('/growth/?tab=mrr');
                         }}
                     >
                         <GhAreaChart


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1942/

Now when clicking the MRR stats on Overview, it'll take you directly to the Growth tab with MRR selected. This can be extended to the other components should we have a later need to link directly to free/paid member counts.