### PR TITLE
Updated querying frequency for stats/posts apps

### DIFF
--- a/apps/admin-x-framework/src/providers/FrameworkProvider.tsx
+++ b/apps/admin-x-framework/src/providers/FrameworkProvider.tsx
@@ -1,6 +1,6 @@
 import {ErrorBoundary as SentryErrorBoundary} from '@sentry/react';
-import {QueryClientProvider} from '@tanstack/react-query';
-import {ReactNode, createContext, useContext} from 'react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {ReactNode, createContext, useContext, useMemo} from 'react';
 import queryClient from '../utils/queryClient';
 import {ExternalLink} from './RoutingProvider';
 
@@ -30,6 +30,13 @@ export interface FrameworkProviderProps {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    
+    // Optional QueryClient configuration for apps that need different defaults
+    queryClientOptions?: {
+        staleTime?: number;
+        refetchOnMount?: boolean;
+        refetchOnWindowFocus?: boolean;
+    };
 
     children: ReactNode;
 }
@@ -54,10 +61,30 @@ const FrameworkContext = createContext<FrameworkContextType>({
     onDelete: () => {}
 });
 
-export function FrameworkProvider({children, ...props}: FrameworkProviderProps) {
+export function FrameworkProvider({children, queryClientOptions, ...props}: FrameworkProviderProps) {
+    const client = useMemo(() => {
+        if (!queryClientOptions) {
+            return queryClient;
+        }
+        
+        return new QueryClient({
+            defaultOptions: {
+                queries: {
+                    refetchOnWindowFocus: queryClientOptions.refetchOnWindowFocus ?? false,
+                    staleTime: queryClientOptions.staleTime ?? 5 * (60 * 1000), // 5 mins
+                    refetchOnMount: queryClientOptions.refetchOnMount ?? false,
+                    cacheTime: 10 * (60 * 1000), // 10 mins
+                    // We have custom retry logic for specific errors in fetchApi()
+                    retry: false,
+                    networkMode: 'always'
+                }
+            }
+        });
+    }, [queryClientOptions]);
+
     return (
         <SentryErrorBoundary>
-            <QueryClientProvider client={queryClient}>
+            <QueryClientProvider client={client}>
                 <FrameworkContext.Provider value={props}>
                     {children}
                 </FrameworkContext.Provider>

--- a/apps/posts/src/App.tsx
+++ b/apps/posts/src/App.tsx
@@ -9,7 +9,14 @@ interface AppProps {
 
 const App: React.FC<AppProps> = ({framework, designSystem}) => {
     return (
-        <FrameworkProvider {...framework}>
+        <FrameworkProvider 
+            {...framework}
+            queryClientOptions={{
+                staleTime: 0, // Always consider data stale (matches Ember admin route behavior)
+                refetchOnMount: true, // Always refetch when component mounts (matches Ember route model)
+                refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
+            }}
+        >
             <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                 <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
                     <Outlet />

--- a/apps/stats/src/App.tsx
+++ b/apps/stats/src/App.tsx
@@ -10,7 +10,14 @@ interface AppProps {
 
 const App: React.FC<AppProps> = ({framework, designSystem}) => {
     return (
-        <FrameworkProvider {...framework}>
+        <FrameworkProvider 
+            {...framework}
+            queryClientOptions={{
+                staleTime: 0, // Always consider data stale (matches Ember admin route behavior)
+                refetchOnMount: true, // Always refetch when component mounts (matches Ember route model)
+                refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
+            }}
+        >
             <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                 <GlobalDataProvider>
                     <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>

--- a/apps/stats/src/hooks/useLatestPostStats.ts
+++ b/apps/stats/src/hooks/useLatestPostStats.ts
@@ -28,10 +28,7 @@ export const useLatestPostStats = () => {
                 throw new Error('Failed to fetch latest post stats');
             }
             return response.json();
-        },
-        staleTime: 30 * 1000, // Consider data stale after 30 seconds
-        refetchOnMount: true, // Always refetch when component mounts
-        refetchOnWindowFocus: true // Refetch when window gains focus
+        }
     });
 
     return {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1854/
- refactored the framework provider to allow setting queryClient defaults at the app level
- added app-level defaults to the stats and posts apps to refresh consistently on mount

The current Admin Dashboard view (in Ember) refreshes on every load, so we should replicate that behavior for consistency. If we find this to be too aggressive, considering we're pulling a lot more data now, we may want to add a stale time to the data like ~30s.

This approach makes it so that we can simply use any hooks using react-query and we'll have consistent behavior without extra options, though they can be overridden at the hook level should need be.