### PR TITLE
Cleaned up old references to 'dark' background color

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModalLabs.tsx
@@ -103,9 +103,6 @@ const Sidebar: React.FC<{
     ];
 
     const backgroundColorIsDark = () => {
-        if (newsletter.background_color === 'dark') {
-            return true;
-        }
         if (newsletter.background_color === 'light') {
             return false;
         }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -36,10 +36,6 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
             return value;
         }
 
-        if (value === 'dark') {
-            return '#15212a';
-        }
-
         return '#ffffff';
     };
 

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -943,18 +943,14 @@ class EmailRenderer {
     }
 
     #getBackgroundColor(newsletter) {
-        /** @type {'light' | 'dark' | string | null} */
+        /** @type {'light' | string | null} */
         const value = newsletter.get('background_color');
 
         if (VALID_HEX_REGEX.test(value)) {
             return value;
         }
 
-        if (value === 'dark') {
-            return DEFAULT_ACCENT_COLOR;
-        }
-
-        // value === dark, value === null, value is not valid hex
+        // value === null, value is not valid hex
         return '#ffffff';
     }
 

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2236,7 +2236,7 @@ describe('Email renderer', function () {
             const tests = [
                 {input: 'Invalid Color', expected: '#ffffff'},
                 {input: '#BADA55', expected: '#BADA55'},
-                {input: 'dark', expected: '#15212A'},
+                {input: 'dark', expected: '#ffffff'}, // not a valid hex color, first iteration of email customization had light/dark
                 {input: 'light', expected: '#ffffff'},
                 {input: null, expected: '#ffffff'}
             ];


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1982

- `'dark'` option was a hangover from the first attempt at email customization and is no longer used. Current setting values are `'light'` or a fixed hex code
