### PR TITLE
Fixed like count cache for posts on other profiles in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.56",
+  "version": "0.7.57",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref PROD-1926

- Resolved issue where like counts weren't updating on other users' profiles
- Extended existing cache update logic to work across all profile views
