### PR TITLE
Fixed CTA Visibility on transparent background

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1146,7 +1146,7 @@ class EmailRenderer {
         const hasAnyEmailCustomization = labs.isSet('emailCustomization') || labs.isSet('emailCustomizationAlpha');
 
         const backgroundColor = this.#getBackgroundColor(newsletter);
-        const backgroundIsDark = textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
+        const backgroundIsDark = this.#checkIfBackgroundIsDark(newsletter);
         const postTitleColor = this.#getPostTitleColor(newsletter, accentColor);
         const titleWeight = this.#getTitleWeight(newsletter);
         const titleStrongWeight = this.#getTitleStrongWeight(titleWeight);

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -366,7 +366,8 @@ class EmailRenderer {
             renderOptions.design = {
                 ...renderOptions.design,
                 ...betaDesignOptions,
-                backgroundColor: newsletter?.get('background_color')
+                backgroundColor: newsletter?.get('background_color'),
+                backgroundIsDark: this.#checkIfBackgroundIsDark(newsletter)
             };
         }
 
@@ -1091,6 +1092,11 @@ class EmailRenderer {
     #getButtonTextColor(newsletter, accentColor) {
         const buttonColor = this.#getButtonColor(newsletter, accentColor);
         return textColorForBackgroundColor(buttonColor).hex();
+    }
+
+    #checkIfBackgroundIsDark(newsletter) {
+        const backgroundColor = this.#getBackgroundColor(newsletter);
+        return textColorForBackgroundColor(backgroundColor).hex().toLowerCase() === '#ffffff';
     }
 
     /**

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -945,7 +945,7 @@ class EmailRenderer {
 
     #getBackgroundColor(newsletter) {
         /** @type {'light' | string | null} */
-        const value = newsletter.get('background_color');
+        const value = newsletter?.get('background_color');
 
         if (VALID_HEX_REGEX.test(value)) {
             return value;

--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -87,15 +87,18 @@ function emailCTATemplate(dataset, options = {}) {
         }
     }
 
-    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
+    if (options.feature?.emailCustomizationAlpha) {
         const isTransparentCTA = dataset.backgroundColor === 'none';
-        const isDarkBackground = options.feature?.emailCustomizationAlpha && options.design?.backgroundIsDark;
+        const isDarkBackground = options.design?.backgroundIsDark;
         const isBlackButton = dataset.buttonColor === 'black' || dataset.buttonColor === '#000000' || dataset.buttonColor === '#000';
 
         if (isTransparentCTA && isDarkBackground && isBlackButton) {
             buttonStyle = `color: white;`;
             dataset.buttonColor = 'white';
         }
+    }
+
+    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
         const buttonHtml = renderEmailButton({
             url: dataset.buttonUrl,
             text: dataset.buttonText,

--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -93,7 +93,7 @@ function emailCTATemplate(dataset, options = {}) {
         const isBlackButton = dataset.buttonColor === 'black' || dataset.buttonColor === '#000000' || dataset.buttonColor === '#000';
 
         if (isTransparentCTA && isDarkBackground && isBlackButton) {
-            buttonStyle = `color: white;`;
+            buttonStyle = `color: #000000;`;
             dataset.buttonColor = 'white';
         }
     }

--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -88,6 +88,14 @@ function emailCTATemplate(dataset, options = {}) {
     }
 
     if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
+        const isTransparentCTA = dataset.backgroundColor === 'none';
+        const isDarkBackground = options.feature?.emailCustomizationAlpha && options.design?.backgroundIsDark;
+        const isBlackButton = dataset.buttonColor === 'black' || dataset.buttonColor === '#000000' || dataset.buttonColor === '#000';
+
+        if (isTransparentCTA && isDarkBackground && isBlackButton) {
+            buttonStyle = `color: white;`;
+            dataset.buttonColor = 'white';
+        }
         const buttonHtml = renderEmailButton({
             url: dataset.buttonUrl,
             text: dataset.buttonText,

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2145,7 +2145,8 @@ describe('Email renderer', function () {
                     sectionTitleColor: '#BADA55',
                     postTitleColor: '#BADA55',
                     dividerColor: '#e0e7eb',
-                    linkColor: '#BADA55'
+                    linkColor: '#BADA55',
+                    backgroundIsDark: false
                 },
                 labs: {emailCustomizationAlpha: true}
             });

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
@@ -308,5 +308,130 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                 </table>
             `);
         });
+
+        it('converts black button to white on dark background with transparent CTA', function () {
+            const data = getTestData({
+                backgroundColor: 'none',
+                buttonColor: 'black'
+            });
+            const result = renderForEmail(data, {
+                design: {backgroundIsDark: true},
+                feature: {emailCustomizationAlpha: true}
+            });
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="background-color: white;">
+                                <a href="http://blog.com/post1" style="color: #000000 !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('converts #000000 button to white on dark background with transparent CTA', function () {
+            const data = getTestData({
+                backgroundColor: 'none',
+                buttonColor: '#000000'
+            });
+            const result = renderForEmail(data, {
+                design: {backgroundIsDark: true},
+                feature: {emailCustomizationAlpha: true}
+            });
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="background-color: white;">
+                                <a href="http://blog.com/post1" style="color: #000000 !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('converts #000 button to white on dark background with transparent CTA', function () {
+            const data = getTestData({
+                backgroundColor: 'none',
+                buttonColor: '#000'
+            });
+            const result = renderForEmail(data, {
+                design: {backgroundIsDark: true},
+                feature: {emailCustomizationAlpha: true}
+            });
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="background-color: white;">
+                                <a href="http://blog.com/post1" style="color: #000000 !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('does not convert black button when background is not dark', function () {
+            const data = getTestData({
+                backgroundColor: 'none',
+                buttonColor: 'black'
+            });
+            const result = renderForEmail(data, {
+                design: {backgroundIsDark: false},
+                feature: {emailCustomizationAlpha: true}
+            });
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="background-color: black;">
+                                <a href="http://blog.com/post1" style="color: #ffffff !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
+
+        it('does not convert black button when CTA background is not transparent', function () {
+            const data = getTestData({
+                backgroundColor: 'white',
+                buttonColor: 'black'
+            });
+            const result = renderForEmail(data, {
+                design: {backgroundIsDark: true},
+                feature: {emailCustomizationAlpha: true}
+            });
+
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="background-color: black;">
+                                <a href="http://blog.com/post1" style="color: #ffffff !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1985/cta-buttons-invisible-with-no-bg-color-dark-global-bg-outline-buttons

- Added `backgroundIsDark` check in `EmailRenderer` to detect dark newsletter backgrounds based on `background_color`.
- Updated `call-to-action-renderer` to convert black buttons (`black`, `#000000`, `#000`) to white when CTA background is transparent and newsletter background is dark, ensuring visibility.
- Added tests.
- Implemented colour logic in `call-to-action-renderer` instead of `styles.hbs` to use knowledge about button and card colours, to have better control of the CTA rendering in emails.