### PR TITLE
Bumped ActivityPub to 0.8.0

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.7.58",
+  "version": "0.8.00",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1907
ref https://github.com/TryGhost/Ghost/commit/df54e2788a

The last commit failed to bump the version which we need to release.

