### PR TITLE
Fixed datestring in useTopPosts fetch

### DIFF
--- a/apps/stats/src/views/Stats/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview.tsx
@@ -125,8 +125,8 @@ const Overview: React.FC = () => {
     const navigate = useNavigate();
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
-            date_from: startDate,
-            date_to: endDate,
+            date_from: formatQueryDate(startDate),
+            date_to: formatQueryDate(endDate),
             limit: '5',
             timezone
         }


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1749537976535149

We were passing an ISO date to Tinybird's endpoint instead off a formatted date. I wouldn't mind handling this further up the chain so that we don't need to remember to do this in every hook implementation.