### PR TITLE
Fixed count display on Posts > Overview

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -24,7 +24,6 @@ const Overview: React.FC = () => {
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid,email,status,count,feature_image',
             include: 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions'
         }
     });


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1749549907697619

The fields parameter conflicts with count relations in Ghost's API. When both fields and include are specified, the column restrictions from fields prevent the countRelations method from properly adding computed columns like count__clicks to the query. Count relations require unrestricted column access to function correctly.