### PR TITLE
🐛 Fixed integrations not being visible when count > 11

### DIFF
--- a/apps/admin-x-framework/src/api/integrations.ts
+++ b/apps/admin-x-framework/src/api/integrations.ts
@@ -31,7 +31,7 @@ export const integrationsDataType = dataType;
 export const useBrowseIntegrations = createQuery<IntegrationsResponseType>({
     dataType,
     path: '/integrations/',
-    defaultSearchParams: {include: 'api_keys,webhooks'}
+    defaultSearchParams: {include: 'api_keys,webhooks', limit: '50'}
 });
 
 export const useCreateIntegration = createMutation<IntegrationsResponseType, Partial<Integration>>({

--- a/apps/admin-x-settings/test/acceptance/advanced/integrations/custom.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/integrations/custom.test.ts
@@ -61,7 +61,7 @@ test.describe('Custom integrations', async () => {
                 ...globalDataRequests,
                 browseIntegrations: {
                     method: 'GET',
-                    path: '/integrations/?include=api_keys%2Cwebhooks',
+                    path: '/integrations/?include=api_keys%2Cwebhooks&limit=50',
                     response: {integrations: []} satisfies IntegrationsResponseType
                 },
                 addIntegration: {

--- a/apps/admin-x-settings/test/acceptance/advanced/integrations/zapier.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/integrations/zapier.test.ts
@@ -35,7 +35,7 @@ test.describe('Zapier integration settings', async () => {
                 ...globalDataRequests,
                 browseIntegrations: {
                     method: 'GET',
-                    path: '/integrations/?include=api_keys%2Cwebhooks',
+                    path: '/integrations/?include=api_keys%2Cwebhooks&limit=50',
                     response: ({
                         integrations: [zapierIntegration]
                     } satisfies IntegrationsResponseType)


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1000

- when fetching custom integrations to display in the admin panel we weren't specifying a page size so we were limited to receiving/displaying 15 integrations for a section that doesn't have any pagination UI (4 returned integrations are "built-in" so the custom list was effectively limited to 11)
- increased the fetched page size to 50 to cover situations where many integrations are used
