### PR TITLE
Set header for requests with analytics script

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -363,6 +363,10 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
 
             if (labs.isSet('trafficAnalytics') && config.get('tinybird') && config.get('tinybird:tracker')) {
                 head.push(getTinybirdTrackerScript(dataRoot));
+                // Set a flag in response locals to indicate tracking script is being served
+                if (dataRoot._locals) {
+                    dataRoot._locals.ghostAnalytics = true;
+                }
             }
 
             // Check if if the request is for a site preview, in which case we **always** use the custom font values

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -158,6 +158,19 @@ module.exports = function setupSiteApp(routerConfig) {
 
     debug('General middleware done');
 
+    // Middleware to set analytics indicator header when analytics tracking is included
+    siteApp.use(function ghostAnalyticsHeaderMiddleware(req, res, next) {
+        const originalSend = res.send;
+        // Has to be on res.send otherwise this executes prior to ghost_head
+        res.send = function (data) {
+            if (res.locals && (res.locals.ghostAnalytics)) {
+                res.set('X-Ghost-Analytics', 'true');
+            }
+            return originalSend.call(this, data);
+        };
+        next();
+    });
+
     router = siteRoutes(routerConfig);
     Object.setPrototypeOf(SiteRouter, router);
 


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1749550971586209
- added new middleware to Ghost frontend to set `X-Ghost-Analytics: true` for responses serving the analytics script

Added header to the response to Ghost's frontend when we serve the traffic analytics script. This will let us compare against network logs to see how much traffic is being blocked.