### PR TITLE
Fixed TailwindCSS eslint issue

### DIFF
--- a/apps/admin-x-framework/.eslintrc.cjs
+++ b/apps/admin-x-framework/.eslintrc.cjs
@@ -28,14 +28,6 @@ module.exports = {
         }],
         'react/button-has-type': 'error',
         'react/no-array-index-key': 'error',
-        'react/jsx-key': 'off',
-
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/no-arbitrary-value': 'off',
-        'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'react/jsx-key': 'off'
     }
 };


### PR DESCRIPTION
no ref.

Problem: classname ordering is getting messed up in monorepos using eslint-plugin-tailwindcss. This is especially a problem when you want to update classname ordering automatically on save because the wrong order would be saved which fails tests on CI.

This PR removes TailwindCSS ESlint settings from AdminX Framework because it's irrelevant/non-existant and is messing up ESlint.