### PR TITLE
Improved data fetching performance in Stats > Newsletters

### DIFF
--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -63,7 +63,7 @@ export const newslettersDataType = dataType;
 export const useBrowseNewsletters = createInfiniteQuery<NewslettersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/newsletters/',
-    defaultSearchParams: {include: 'count.active_members,count.posts', limit: '50'},
+    defaultSearchParams: {limit: '50'},
     defaultNextPageParams: (lastPage, otherParams) => ({
         ...otherParams,
         page: (lastPage.meta?.pagination.next || 1).toString()
@@ -86,7 +86,7 @@ export const useAddNewsletter = createMutation<NewslettersResponseType, Partial<
     path: () => '/newsletters/',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     body: ({opt_in_existing: _, ...newsletter}) => ({newsletters: [newsletter]}),
-    searchParams: payload => ({opt_in_existing: payload.opt_in_existing.toString(), include: 'count.active_members,count.posts'}),
+    searchParams: payload => ({opt_in_existing: payload.opt_in_existing.toString()}),
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',
@@ -106,7 +106,7 @@ export const useEditNewsletter = createMutation<NewslettersEditResponseType, New
     method: 'PUT',
     path: newsletter => `/newsletters/${newsletter.id}/`,
     body: newsletter => ({newsletters: [newsletter]}),
-    defaultSearchParams: {include: 'count.active_members,count.posts'},
+    defaultSearchParams: {},
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',
@@ -118,7 +118,7 @@ export const useVerifyNewsletterEmail = createMutation<NewslettersVerifyResponse
     method: 'PUT',
     path: () => '/newsletters/verifications/',
     body: ({token}) => ({token}),
-    defaultSearchParams: {include: 'count.active_members,count.posts'},
+    defaultSearchParams: {},
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',

--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -63,7 +63,7 @@ export const newslettersDataType = dataType;
 export const useBrowseNewsletters = createInfiniteQuery<NewslettersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/newsletters/',
-    defaultSearchParams: {limit: '50'},
+    defaultSearchParams: {include: 'count.active_members,count.posts', limit: '50'},
     defaultNextPageParams: (lastPage, otherParams) => ({
         ...otherParams,
         page: (lastPage.meta?.pagination.next || 1).toString()
@@ -86,7 +86,7 @@ export const useAddNewsletter = createMutation<NewslettersResponseType, Partial<
     path: () => '/newsletters/',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     body: ({opt_in_existing: _, ...newsletter}) => ({newsletters: [newsletter]}),
-    searchParams: payload => ({opt_in_existing: payload.opt_in_existing.toString()}),
+    searchParams: payload => ({opt_in_existing: payload.opt_in_existing.toString(), include: 'count.active_members,count.posts'}),
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',
@@ -106,7 +106,7 @@ export const useEditNewsletter = createMutation<NewslettersEditResponseType, New
     method: 'PUT',
     path: newsletter => `/newsletters/${newsletter.id}/`,
     body: newsletter => ({newsletters: [newsletter]}),
-    defaultSearchParams: {},
+    defaultSearchParams: {include: 'count.active_members,count.posts'},
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',
@@ -118,7 +118,7 @@ export const useVerifyNewsletterEmail = createMutation<NewslettersVerifyResponse
     method: 'PUT',
     path: () => '/newsletters/verifications/',
     body: ({token}) => ({token}),
-    defaultSearchParams: {},
+    defaultSearchParams: {include: 'count.active_members,count.posts'},
     updateQueries: {
         dataType,
         emberUpdateType: 'createOrUpdate',

--- a/apps/stats/src/hooks/useFeatureFlag.tsx
+++ b/apps/stats/src/hooks/useFeatureFlag.tsx
@@ -15,7 +15,14 @@ export const useFeatureFlag = (flagName: string, fallbackPath: string) => {
     
     // Parse labs settings
     const labsJSON = getSettingValue<string>(settings, 'labs') || '{}';
-    const labs = JSON.parse(labsJSON);
+    let labs: Record<string, unknown> = {};
+    
+    try {
+        labs = JSON.parse(labsJSON);
+    } catch (error) {
+        // If JSON parsing fails, fall back to empty object
+        labs = {};
+    }
     
     // Check if the feature flag is enabled
     const isEnabled = labs[flagName] === true;

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -15,8 +15,9 @@ export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate d
  * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
  * @param order - The field and direction to order by (e.g., 'open_rate desc'). Defaults to 'date desc'.
  * @param newsletterId - Optional ID of the specific newsletter to get stats for
+ * @param shouldFetch - Whether to actually fetch data. If false, returns loading state without making API calls.
  */
-export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslettersOrder, newsletterId?: string) => {
+export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslettersOrder, newsletterId?: string, shouldFetch = true) => {
     // Default range and order
     const currentRange = range ?? 30;
     const currentOrder = order ?? 'date desc'; // Default to date descending
@@ -39,8 +40,20 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
         return params;
     }, [dateFrom, endDate, currentOrder, newsletterId]);
 
-    // Call the newsletter stats API
-    return useNewsletterStats({searchParams});
+    // Conditionally call the hook or return empty state
+    const realResult = useNewsletterStats({searchParams, enabled: shouldFetch});
+    
+    if (!shouldFetch) {
+        return {
+            data: undefined,
+            isLoading: false,
+            error: null,
+            isError: false,
+            refetch: realResult.refetch
+        };
+    }
+    
+    return realResult;
 };
 
 /**
@@ -49,8 +62,9 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
  *
  * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
  * @param newsletterId - Optional ID of the specific newsletter to get stats for
+ * @param shouldFetch - Whether to actually fetch data. If false, returns loading state without making API calls.
  */
-export const useSubscriberCountWithRange = (range?: number, newsletterId?: string) => {
+export const useSubscriberCountWithRange = (range?: number, newsletterId?: string, shouldFetch = true) => {
     // Default range
     const currentRange = range ?? 30;
 
@@ -71,8 +85,20 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
         return params;
     }, [dateFrom, endDate, newsletterId]);
 
-    // Call the subscriber count API
-    return useSubscriberCount({searchParams});
+    // Conditionally call the hook or return empty state
+    const realResult = useSubscriberCount({searchParams, enabled: shouldFetch});
+    
+    if (!shouldFetch) {
+        return {
+            data: undefined,
+            isLoading: false,
+            error: null,
+            isError: false,
+            refetch: realResult.refetch
+        };
+    }
+    
+    return realResult;
 };
 
 /**
@@ -81,4 +107,17 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
  */
 export const useNewslettersList = () => {
     return useBrowseNewsletters();
+};
+
+/**
+ * Lightweight hook to fetch newsletters for dropdown only (without expensive member counts)
+ * This should be much faster than the full newsletter list with counts
+ */
+export const useNewslettersListLight = () => {
+    return useBrowseNewsletters({
+        searchParams: {
+            // Remove the expensive count includes - just get basic newsletter data
+            limit: '50'
+        }
+    });
 };

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -108,16 +108,3 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
 export const useNewslettersList = () => {
     return useBrowseNewsletters();
 };
-
-/**
- * Lightweight hook to fetch newsletters for dropdown only (without expensive member counts)
- * This should be much faster than the full newsletter list with counts
- */
-export const useNewslettersListLight = () => {
-    return useBrowseNewsletters({
-        searchParams: {
-            // Remove the expensive count includes - just get basic newsletter data
-            limit: '50'
-        }
-    });
-};

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -268,7 +268,7 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
                 };
             })
             .filter((item) => {
-                return item.free_members > 0 || item.paid_members > 0; // Only show sources with conversions
+                return item.free_members >= 0 && (item.free_members > 0 || item.paid_members > 0); // Skip sources with negative free members, only show sources with conversions
             })
             .sort((a, b) => {
                 return (b.free_members + b.paid_members) - (a.free_members + a.paid_members); // Sort by total conversions

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -2,7 +2,7 @@
 import DateRangeSelect from '../components/DateRangeSelect';
 import NewsletterKPIs from './components/NewslettersKPIs';
 import NewsletterSelect from '../components/NewsletterSelect';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import SortButton from '../components/SortButton';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
@@ -26,23 +26,9 @@ export type AvgsDataItem = {
 };
 
 const Newsletters: React.FC = () => {
-    const instanceId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
-    // eslint-disable-next-line no-console
-    console.log(`🚀 Newsletters component [${instanceId}] mounted at ${Date.now()}`);
-    
     const {range, selectedNewsletterId} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
-
-    // Use useRef for stable timing references
-    const fetchStartTimes = useRef({
-        newsletters: Date.now(),
-        newsletterStats: Date.now(),
-        subscriberStats: Date.now()
-    });
-
-    // eslint-disable-next-line no-console
-    console.log(`📡 [${instanceId}] About to call newsletter hooks at ${Date.now()}`);
 
     // Get newsletters list for dropdown and basic stats
     const {data: newslettersData, isLoading: isNewslettersLoading} = useNewslettersList();
@@ -67,47 +53,6 @@ const Newsletters: React.FC = () => {
         selectedNewsletterId || undefined,
         shouldFetchStats
     );
-
-    // eslint-disable-next-line no-console
-    console.log(`🎯 [${instanceId}] Hooks called, data loading states: newsletters=${isNewslettersLoading}, stats=${isStatsLoading}, subscribers=${isSubscriberStatsLoading}, shouldFetch=${shouldFetchStats}`);
-
-    // Log fetch completion times
-    useEffect(() => {
-        if (!isNewslettersLoading && newslettersData) {
-            const duration = Date.now() - fetchStartTimes.current.newsletters;
-            // eslint-disable-next-line no-console
-            console.log(`📊 Newsletter list fetch completed in ${duration}ms`);
-        }
-    }, [isNewslettersLoading, newslettersData, fetchStartTimes]);
-
-    useEffect(() => {
-        if (!isStatsLoading && newsletterStatsData) {
-            const duration = Date.now() - fetchStartTimes.current.newsletterStats;
-            // eslint-disable-next-line no-console
-            console.log(`📈 Newsletter stats fetch completed in ${duration}ms`);
-        }
-    }, [isStatsLoading, newsletterStatsData, fetchStartTimes]);
-
-    useEffect(() => {
-        if (!isSubscriberStatsLoading && subscriberStatsData) {
-            const duration = Date.now() - fetchStartTimes.current.subscriberStats;
-            // eslint-disable-next-line no-console
-            console.log(`👥 Subscriber stats fetch completed in ${duration}ms`);
-        }
-    }, [isSubscriberStatsLoading, subscriberStatsData, fetchStartTimes]);
-
-    // Log when all fetches are complete
-    useEffect(() => {
-        if (!isNewslettersLoading && !isStatsLoading && !isSubscriberStatsLoading) {
-            const totalDuration = Date.now() - Math.min(
-                fetchStartTimes.current.newsletters,
-                fetchStartTimes.current.newsletterStats,
-                fetchStartTimes.current.subscriberStats
-            );
-            // eslint-disable-next-line no-console
-            console.log(`🎉 All newsletter data loaded in ${totalDuration}ms`);
-        }
-    }, [isNewslettersLoading, isStatsLoading, isSubscriberStatsLoading, fetchStartTimes]);
 
     // Find the selected newsletter to get its active_members count
     const selectedNewsletter = useMemo(() => {

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -34,8 +34,7 @@ const Newsletters: React.FC = () => {
     // Get newsletters list for dropdown (without expensive counts)
     const {data: newslettersData, isLoading: isNewslettersLoading} = useBrowseNewsletters({
         searchParams: {
-            limit: '50',
-            include: '' // Exclude expensive count calculations
+            limit: '50'
         }
     });
 

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -2,7 +2,7 @@
 import DateRangeSelect from '../components/DateRangeSelect';
 import NewsletterKPIs from './components/NewslettersKPIs';
 import NewsletterSelect from '../components/NewsletterSelect';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import SortButton from '../components/SortButton';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
@@ -26,25 +26,88 @@ export type AvgsDataItem = {
 };
 
 const Newsletters: React.FC = () => {
+    const instanceId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+    // eslint-disable-next-line no-console
+    console.log(`🚀 Newsletters component [${instanceId}] mounted at ${Date.now()}`);
+    
     const {range, selectedNewsletterId} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
 
+    // Use useRef for stable timing references
+    const fetchStartTimes = useRef({
+        newsletters: Date.now(),
+        newsletterStats: Date.now(),
+        subscriberStats: Date.now()
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(`📡 [${instanceId}] About to call newsletter hooks at ${Date.now()}`);
+
     // Get newsletters list for dropdown and basic stats
     const {data: newslettersData, isLoading: isNewslettersLoading} = useNewslettersList();
+
+    // Only enable stats queries once newsletters are loaded AND we have a newsletter selected
+    // This prevents both: 
+    // 1. Empty API calls before newsletters load
+    // 2. Unnecessary calls when no newsletter is selected yet
+    const shouldFetchStats = !isNewslettersLoading && newslettersData && newslettersData.newsletters.length > 0 && !!selectedNewsletterId;
 
     // Get newsletter stats (emailed posts with their metrics)
     const {data: newsletterStatsData, isLoading: isStatsLoading} = useNewsletterStatsWithRange(
         range,
         sortBy,
-        selectedNewsletterId || undefined
+        selectedNewsletterId || undefined,
+        shouldFetchStats
     );
 
     // Get subscriber count over time for the selected newsletter
     const {data: subscriberStatsData, isLoading: isSubscriberStatsLoading} = useSubscriberCountWithRange(
         range,
-        selectedNewsletterId || undefined
+        selectedNewsletterId || undefined,
+        shouldFetchStats
     );
+
+    // eslint-disable-next-line no-console
+    console.log(`🎯 [${instanceId}] Hooks called, data loading states: newsletters=${isNewslettersLoading}, stats=${isStatsLoading}, subscribers=${isSubscriberStatsLoading}, shouldFetch=${shouldFetchStats}`);
+
+    // Log fetch completion times
+    useEffect(() => {
+        if (!isNewslettersLoading && newslettersData) {
+            const duration = Date.now() - fetchStartTimes.current.newsletters;
+            // eslint-disable-next-line no-console
+            console.log(`📊 Newsletter list fetch completed in ${duration}ms`);
+        }
+    }, [isNewslettersLoading, newslettersData, fetchStartTimes]);
+
+    useEffect(() => {
+        if (!isStatsLoading && newsletterStatsData) {
+            const duration = Date.now() - fetchStartTimes.current.newsletterStats;
+            // eslint-disable-next-line no-console
+            console.log(`📈 Newsletter stats fetch completed in ${duration}ms`);
+        }
+    }, [isStatsLoading, newsletterStatsData, fetchStartTimes]);
+
+    useEffect(() => {
+        if (!isSubscriberStatsLoading && subscriberStatsData) {
+            const duration = Date.now() - fetchStartTimes.current.subscriberStats;
+            // eslint-disable-next-line no-console
+            console.log(`👥 Subscriber stats fetch completed in ${duration}ms`);
+        }
+    }, [isSubscriberStatsLoading, subscriberStatsData, fetchStartTimes]);
+
+    // Log when all fetches are complete
+    useEffect(() => {
+        if (!isNewslettersLoading && !isStatsLoading && !isSubscriberStatsLoading) {
+            const totalDuration = Date.now() - Math.min(
+                fetchStartTimes.current.newsletters,
+                fetchStartTimes.current.newsletterStats,
+                fetchStartTimes.current.subscriberStats
+            );
+            // eslint-disable-next-line no-console
+            console.log(`🎉 All newsletter data loaded in ${totalDuration}ms`);
+        }
+    }, [isNewslettersLoading, isStatsLoading, isSubscriberStatsLoading, fetchStartTimes]);
 
     // Find the selected newsletter to get its active_members count
     const selectedNewsletter = useMemo(() => {

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -9,9 +9,9 @@ import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Separator, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
-import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useNewsletterStatsWithRange, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -156,7 +156,7 @@ const Newsletters: React.FC = () => {
     return (
         <StatsLayout>
             <StatsHeader>
-                <NewsletterSelect />
+                <NewsletterSelect newsletters={newslettersData?.newsletters} />
                 <DateRangeSelect />
             </StatsHeader>
             <StatsView data={pageData} isLoading={false} loadingComponent={<></>}>

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -11,7 +11,8 @@ import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Separ
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
-import {useNewsletterStatsWithRange, useNewslettersList, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useNewsletterStatsWithRange, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 
 export type AvgsDataItem = {
@@ -30,8 +31,13 @@ const Newsletters: React.FC = () => {
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
 
-    // Get newsletters list for dropdown and basic stats
-    const {data: newslettersData, isLoading: isNewslettersLoading} = useNewslettersList();
+    // Get newsletters list for dropdown (without expensive counts)
+    const {data: newslettersData, isLoading: isNewslettersLoading} = useBrowseNewsletters({
+        searchParams: {
+            limit: '50',
+            include: '' // Exclude expensive count calculations
+        }
+    });
 
     // Only enable stats queries once newsletters are loaded AND we have a newsletter selected
     // This prevents both: 

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -1,16 +1,14 @@
 import React, {useEffect, useMemo} from 'react';
 import {LucideIcon, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue} from '@tryghost/shade';
-import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
-const NewsletterSelect: React.FC = () => {
+interface NewsletterSelectProps {
+    newsletters?: Newsletter[];
+}
+
+const NewsletterSelect: React.FC<NewsletterSelectProps> = ({newsletters}) => {
     const {selectedNewsletterId, setSelectedNewsletterId} = useGlobalData();
-    const {data: {newsletters} = {}} = useBrowseNewsletters({
-        searchParams: {
-            limit: '50'
-            // Omit include parameter to avoid expensive count.active_members,count.posts
-        }
-    });
 
     // Filter only active newsletters
     const activeNewsletters = useMemo(() => {

--- a/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
+++ b/apps/stats/src/views/Stats/components/NewsletterSelect.tsx
@@ -5,7 +5,12 @@ import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
 const NewsletterSelect: React.FC = () => {
     const {selectedNewsletterId, setSelectedNewsletterId} = useGlobalData();
-    const {data: {newsletters} = {}} = useBrowseNewsletters();
+    const {data: {newsletters} = {}} = useBrowseNewsletters({
+        searchParams: {
+            limit: '50'
+            // Omit include parameter to avoid expensive count.active_members,count.posts
+        }
+    });
 
     // Filter only active newsletters
     const activeNewsletters = useMemo(() => {

--- a/apps/stats/test/unit/hooks/useFeatureFlag.test.tsx
+++ b/apps/stats/test/unit/hooks/useFeatureFlag.test.tsx
@@ -72,9 +72,11 @@ describe('useFeatureFlag', () => {
     it('handles invalid JSON gracefully', () => {
         mocks.mockGetSettingValue.mockReturnValue('invalid json');
 
-        expect(() => {
-            renderHook(() => useFeatureFlag('testFlag', '/fallback'));
-        }).toThrow();
+        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'));
+
+        expect(result.current.isEnabled).toBe(false);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.redirect).toBeTruthy();
     });
 
     it('handles null labs setting', () => {

--- a/apps/stats/test/unit/hooks/useNewsletterStatsWithRange.test.tsx
+++ b/apps/stats/test/unit/hooks/useNewsletterStatsWithRange.test.tsx
@@ -139,7 +139,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_from: '2024-01-01',
                     date_to: '2024-01-31',
                     order: 'date desc'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -153,7 +154,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_from: '2024-01-24',
                     date_to: '2024-01-31',
                     order: 'date desc'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -167,7 +169,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_from: '2024-01-17',
                     date_to: '2024-01-31',
                     order: 'date desc'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -181,7 +184,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_from: '2024-01-01',
                     date_to: '2024-01-31',
                     order: 'open_rate desc'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -196,7 +200,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_to: '2024-01-31',
                     order: 'date desc',
                     newsletter_id: 'newsletter-123'
-                }
+                },
+                enabled: true
             });
         });
     });
@@ -211,7 +216,8 @@ describe('Newsletter Stats Hooks', () => {
                 searchParams: {
                     date_from: '2024-01-01',
                     date_to: '2024-01-31'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -224,7 +230,8 @@ describe('Newsletter Stats Hooks', () => {
                 searchParams: {
                     date_from: '2024-01-24',
                     date_to: '2024-01-31'
-                }
+                },
+                enabled: true
             });
         });
 
@@ -238,7 +245,8 @@ describe('Newsletter Stats Hooks', () => {
                     date_from: '2024-01-01',
                     date_to: '2024-01-31',
                     newsletter_id: 'newsletter-123'
-                }
+                },
+                enabled: true
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2019/
- removed unnecessary relations from the initial newsletter fetch
- restructured data fetching to only fetch when we have a newsletter id (reduce unnecessary queries)

The default includes were causing severe performance degradations when fetching all the newsletters from the site. We don't actually need the member counts because we fetch that with a separate query in order to get historic data (we also only need it for the selected newsletter, not all newsletters).