### PR TITLE
Fixed bad date format when querying top posts endpoint

### DIFF
--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -70,8 +70,8 @@ const Overview: React.FC = () => {
     const latestPostStats = latestPostStatsData?.stats?.[0] || null;
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
-            date_from: startDate,
-            date_to: endDate,
+            date_from: formatQueryDate(startDate),
+            date_to: formatQueryDate(endDate),
             limit: '5',
             timezone
         }


### PR DESCRIPTION
no ref

We were not formatting the query date as a simple date string, e.g. YYYY-MM-DD, leading to errors with the database query.