### PR TITLE
Improved Stats > Newsletter performance 

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -230,6 +230,22 @@ export const useNewsletterStats = createQuery<NewsletterStatsResponseType>({
     }
 });
 
+export const useNewsletterBasicStats = createQuery<NewsletterStatsResponseType>({
+    dataType: newsletterStatsDataType,
+    path: '/stats/newsletter-basic-stats/',
+    defaultSearchParams: {
+        // Empty default params, will be filled by the hook
+    }
+});
+
+export const useNewsletterClickStats = createQuery<NewsletterStatsResponseType>({
+    dataType: newsletterStatsDataType,
+    path: '/stats/newsletter-click-stats/',
+    defaultSearchParams: {
+        // Empty default params, will be filled by the hook
+    }
+});
+
 // Hook wrapper to accept a newsletterId parameter
 export const useNewsletterStatsByNewsletterId = (newsletterId?: string, options: Partial<NewsletterStatsSearchParams> = {}) => {
     const searchParams: Record<string, string> = {};

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -1,7 +1,7 @@
 import {getRangeDates} from './useGrowthStats';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useMemo} from 'react';
-import {useNewsletterStats, useSubscriberCount} from '@tryghost/admin-x-framework/api/stats';
+import {useNewsletterBasicStats, useNewsletterClickStats, useNewsletterStats, useSubscriberCount} from '@tryghost/admin-x-framework/api/stats';
 
 /**
  * Represents the possible fields to order top newsletters by.
@@ -107,4 +107,163 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
  */
 export const useNewslettersList = () => {
     return useBrowseNewsletters();
+};
+
+/**
+ * Hook to fetch Newsletter Basic Stats (without click data), handling the conversion from a numeric range
+ * and an optional order parameter to API query parameters.
+ *
+ * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
+ * @param order - The field and direction to order by (e.g., 'open_rate desc'). Defaults to 'date desc'.
+ * @param newsletterId - Optional ID of the specific newsletter to get stats for
+ * @param shouldFetch - Whether to actually fetch data. If false, returns loading state without making API calls.
+ */
+export const useNewsletterBasicStatsWithRange = (range?: number, order?: TopNewslettersOrder, newsletterId?: string, shouldFetch = true) => {
+    // Default range and order
+    const currentRange = range ?? 30;
+    const currentOrder = order ?? 'date desc'; // Default to date descending
+
+    // Calculate date strings using the helper, memoize for stability
+    const {dateFrom, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
+
+    // Build search params
+    const searchParams = useMemo(() => {
+        const params: Record<string, string> = {
+            date_from: dateFrom,
+            date_to: endDate,
+            order: currentOrder
+        };
+
+        if (newsletterId) {
+            params.newsletter_id = newsletterId;
+        }
+
+        return params;
+    }, [dateFrom, endDate, currentOrder, newsletterId]);
+
+    // Conditionally call the hook or return empty state
+    const realResult = useNewsletterBasicStats({searchParams, enabled: shouldFetch});
+    
+    if (!shouldFetch) {
+        return {
+            data: undefined,
+            isLoading: false,
+            error: null,
+            isError: false,
+            refetch: realResult.refetch
+        };
+    }
+    
+    return realResult;
+};
+
+/**
+ * Hook to fetch Newsletter Click Stats for specific posts
+ *
+ * @param newsletterId - ID of the specific newsletter to get click stats for
+ * @param postIds - Array of post IDs to get click data for
+ * @param shouldFetch - Whether to actually fetch data. If false, returns loading state without making API calls.
+ */
+export const useNewsletterClickStatsWithRange = (newsletterId?: string, postIds: string[] = [], shouldFetch = true) => {
+    // Build search params
+    const searchParams = useMemo(() => {
+        const params: Record<string, string> = {};
+
+        if (newsletterId) {
+            params.newsletter_id = newsletterId;
+        }
+
+        if (postIds.length > 0) {
+            params.post_ids = postIds.join(',');
+        }
+
+        return params;
+    }, [newsletterId, postIds]);
+
+    // Conditionally call the hook or return empty state
+    const realResult = useNewsletterClickStats({searchParams, enabled: shouldFetch});
+    
+    if (!shouldFetch) {
+        return {
+            data: undefined,
+            isLoading: false,
+            error: null,
+            isError: false,
+            refetch: realResult.refetch
+        };
+    }
+    
+    return realResult;
+};
+
+/**
+ * Combined hook to fetch Newsletter Stats using split endpoints for better performance
+ * This fetches basic stats immediately and click stats in parallel
+ *
+ * @param range - The number of days for the date range (e.g., 7, 30, 90). Defaults to 30.
+ * @param order - The field and direction to order by (e.g., 'open_rate desc'). Defaults to 'date desc'.
+ * @param newsletterId - Optional ID of the specific newsletter to get stats for
+ * @param shouldFetch - Whether to actually fetch data. If false, returns loading state without making API calls.
+ */
+export const useNewsletterStatsWithRangeSplit = (range?: number, order?: TopNewslettersOrder, newsletterId?: string, shouldFetch = true) => {
+    // Get basic stats first (fast)
+    const basicStatsResult = useNewsletterBasicStatsWithRange(range, order, newsletterId, shouldFetch);
+    
+    // Extract post IDs from basic stats to fetch click data
+    const postIds = useMemo(() => {
+        if (!basicStatsResult.data?.stats) {
+            return [];
+        }
+        return basicStatsResult.data.stats.map(stat => stat.post_id);
+    }, [basicStatsResult.data]);
+
+    // Get click stats for the posts (potentially slower)
+    const clickStatsResult = useNewsletterClickStatsWithRange(
+        newsletterId, 
+        postIds, 
+        shouldFetch && postIds.length > 0
+    );
+
+    // Merge the data
+    const mergedData = useMemo(() => {
+        if (!basicStatsResult.data?.stats) {
+            return undefined;
+        }
+
+        const basicStats = basicStatsResult.data.stats;
+        const clickStats = clickStatsResult.data?.stats || [];
+
+        // Create a map of click data by post_id for fast lookup
+        const clickStatsMap = new Map();
+        clickStats.forEach((clickStat) => {
+            clickStatsMap.set(clickStat.post_id, clickStat);
+        });
+
+        // Merge basic stats with click stats
+        const mergedStats = basicStats.map((basicStat) => {
+            const clickData = clickStatsMap.get(basicStat.post_id);
+            return {
+                ...basicStat,
+                total_clicks: clickData?.total_clicks || 0,
+                click_rate: clickData?.click_rate || 0
+            };
+        });
+
+        return {
+            ...basicStatsResult.data,
+            stats: mergedStats
+        };
+    }, [basicStatsResult.data, clickStatsResult.data]);
+
+    return {
+        data: mergedData,
+        isLoading: basicStatsResult.isLoading,
+        isClicksLoading: clickStatsResult.isLoading,
+        error: basicStatsResult.error || clickStatsResult.error,
+        isError: basicStatsResult.isError || clickStatsResult.isError,
+        refetch: () => {
+            basicStatsResult.refetch();
+            clickStatsResult.refetch();
+        }
+    };
 };

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -12,7 +12,7 @@ import {getPeriodText} from '@src/utils/chart-helpers';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useNavigate} from '@tryghost/admin-x-framework';
-import {useNewsletterStatsWithRange, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
+import {useNewsletterStatsWithRangeSplit, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 
 export type AvgsDataItem = {
@@ -44,8 +44,8 @@ const Newsletters: React.FC = () => {
     // 2. Unnecessary calls when no newsletter is selected yet
     const shouldFetchStats = !isNewslettersLoading && newslettersData && newslettersData.newsletters.length > 0 && !!selectedNewsletterId;
 
-    // Get newsletter stats (emailed posts with their metrics)
-    const {data: newsletterStatsData, isLoading: isStatsLoading} = useNewsletterStatsWithRange(
+    // Get newsletter stats using the split hook for better performance
+    const {data: newsletterStatsData, isLoading: isStatsLoading, isClicksLoading} = useNewsletterStatsWithRangeSplit(
         range,
         sortBy,
         selectedNewsletterId || undefined,
@@ -247,8 +247,14 @@ const Newsletters: React.FC = () => {
                                                 <span className="hidden group-hover:!visible group-hover:!block">{formatNumber(post.total_opens)}</span>
                                             </TableCell>
                                             <TableCell className='text-right font-mono text-sm'>
-                                                <span className="group-hover:hidden">{formatPercentage(post.click_rate)}</span>
-                                                <span className="hidden group-hover:!visible group-hover:!block">{formatNumber(post.total_clicks)}</span>
+                                                {isClicksLoading ? (
+                                                    <span className="inline-block h-4 w-8 animate-pulse rounded bg-gray-200"></span>
+                                                ) : (
+                                                    <>
+                                                        <span className="group-hover:hidden">{formatPercentage(post.click_rate)}</span>
+                                                        <span className="hidden group-hover:!visible group-hover:!block">{formatNumber(post.total_clicks)}</span>
+                                                    </>
+                                                )}
                                             </TableCell>
                                         </TableRow>
                                     ))}

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -70,8 +70,8 @@ const Overview: React.FC = () => {
     const latestPostStats = latestPostStatsData?.stats?.[0] || null;
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
-            date_from: startDate,
-            date_to: endDate,
+            date_from: formatQueryDate(startDate),
+            date_to: formatQueryDate(endDate),
             limit: '5',
             timezone
         }

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -267,6 +267,66 @@ const controller = {
             return await statsService.api.getNewsletterStats(frame.options);
         }
     },
+    newsletterBasicStats: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'order',
+            'limit',
+            'date_from',
+            'date_to',
+            'timezone',
+            'newsletter_id'
+        ],
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'getNewsletterBasicStats',
+                options: {
+                    order: frame.options.order,
+                    limit: frame.options.limit,
+                    date_from: frame.options.date_from,
+                    date_to: frame.options.date_to,
+                    timezone: frame.options.timezone,
+                    newsletter_id: frame.options.newsletter_id
+                }
+            };
+        },
+        async query(frame) {
+            return await statsService.api.getNewsletterBasicStats(frame.options);
+        }
+    },
+    newsletterClickStats: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'newsletter_id',
+            'post_ids'
+        ],
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'getNewsletterClickStats',
+                options: {
+                    newsletter_id: frame.options.newsletter_id,
+                    post_ids: frame.options.post_ids
+                }
+            };
+        },
+        async query(frame) {
+            return await statsService.api.getNewsletterClickStats(frame.options);
+        }
+    },
     subscriberCount: {
         headers: {
             cacheInvalidate: false

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -568,6 +568,134 @@ class PostsStatsService {
     }
 
     /**
+     * Get newsletter basic statistics (without click data) for faster loading
+     *
+     * @param {string} newsletterId - ID of the newsletter to get stats for
+     * @param {Object} options - Query options
+     * @param {string} [options.order] - Sort order (e.g., 'date desc', 'open_rate desc')
+     * @param {number} [options.limit] - Number of results to return (default: 20)
+     * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
+     * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @returns {Promise<{data: Array}>} The newsletter basic stats (without click data)
+     */
+    async getNewsletterBasicStats(newsletterId, options = {}) {
+        try {
+            const order = options.order || 'date desc';
+            const limitRaw = Number.parseInt(String(options.limit ?? 20), 10);
+            const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20;
+
+            // Parse order field and direction
+            let [orderField, orderDirection = 'desc'] = order.split(' ');
+
+            // Map frontend order fields to database fields (simplified for ORDER BY)
+            const orderFieldMap = {
+                date: 'send_date',
+                open_rate: 'open_rate',
+                sent_to: 'sent_to'
+            };
+
+            // Validate order field (excluding click_rate since we don't fetch click data)
+            if (!Object.keys(orderFieldMap).includes(orderField)) {
+                throw new errors.BadRequestError({
+                    message: `Invalid order field: ${orderField}. Must be one of: date, open_rate, sent_to`
+                });
+            }
+
+            // Validate order direction
+            if (!['asc', 'desc'].includes(orderDirection.toLowerCase())) {
+                throw new errors.BadRequestError({
+                    message: `Invalid order direction: ${orderDirection}`
+                });
+            }
+
+            // Build date filters if provided
+            let dateFilter = this.knex.raw('1=1');
+            if (options.date_from) {
+                dateFilter = this.knex.raw(`p.published_at >= ?`, [options.date_from]);
+            }
+            if (options.date_to) {
+                dateFilter = options.date_from
+                    ? this.knex.raw(`p.published_at >= ? AND p.published_at <= ?`, [options.date_from, options.date_to])
+                    : this.knex.raw(`p.published_at <= ?`, [options.date_to]);
+            }
+
+            // Build the query to get newsletter basic stats (without click data)
+            const query = this.knex
+                .select(
+                    'p.id as post_id',
+                    'p.title as post_title',
+                    'p.published_at as send_date',
+                    this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
+                    this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
+                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate')
+                )
+                .from('posts as p')
+                .leftJoin('emails as e', 'p.id', 'e.post_id')
+                .where('p.newsletter_id', newsletterId)
+                .whereIn('p.status', ['sent', 'published'])
+                .whereNotNull('e.id') // Ensure there is an associated email record
+                .whereRaw(dateFilter)
+                .orderBy(orderFieldMap[orderField], orderDirection)
+                .limit(limit);
+
+            const results = await query;
+
+            return {data: results};
+        } catch (error) {
+            logging.error(`Error fetching newsletter basic stats for newsletter ${newsletterId}:`, error);
+            return {data: []};
+        }
+    }
+
+    /**
+     * Get newsletter click statistics for specific posts
+     *
+     * @param {string} newsletterId - ID of the newsletter to get click stats for
+     * @param {Array<string>|string} postIds - Array of post IDs or comma-separated string of post IDs to get click data for
+     * @returns {Promise<{data: Array}>} The newsletter click stats
+     */
+    async getNewsletterClickStats(newsletterId, postIds = []) {
+        try {
+            // Handle postIds as either array or comma-separated string
+            let postIdsArray = [];
+            if (Array.isArray(postIds)) {
+                postIdsArray = postIds;
+            } else if (typeof postIds === 'string' && postIds.length > 0) {
+                postIdsArray = postIds.split(',').map(id => id.trim()).filter(id => id.length > 0);
+            }
+
+            if (postIdsArray.length === 0) {
+                return {data: []};
+            }
+
+            // Subquery to count clicks from members_click_events
+            const clicksQuery = this.knex
+                .select(
+                    'r.post_id',
+                    this.knex.raw('COALESCE(COUNT(DISTINCT mce.member_id), 0) as total_clicks')
+                )
+                .from('redirects as r')
+                .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
+                .leftJoin('posts as p', 'r.post_id', 'p.id')
+                .leftJoin('emails as e', 'p.id', 'e.post_id')
+                .whereIn('r.post_id', postIdsArray)
+                .where('p.newsletter_id', newsletterId)
+                .whereNotNull('r.post_id')
+                .groupBy('r.post_id', 'e.email_count')
+                .select(
+                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(COUNT(DISTINCT mce.member_id), 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate')
+                );
+
+            const results = await clicksQuery;
+
+            return {data: results};
+        } catch (error) {
+            logging.error(`Error fetching newsletter click stats for newsletter ${newsletterId}:`, error);
+            return {data: []};
+        }
+    }
+
+    /**
      * Get newsletter subscriber statistics including total count and daily deltas for a specific newsletter
      *
      * @param {string} newsletterId - ID of the newsletter to get subscriber stats for

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -173,6 +173,51 @@ class StatsService {
     }
 
     /**
+     * Get newsletter basic stats for sent posts (without click data)
+     * @param {Object} options
+     * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
+     * @param {string} [options.order='published_at desc'] - Order field and direction
+     * @param {number} [options.limit=20] - Max number of results to return
+     * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
+     * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
+     * @returns {Promise<{data: Object[]}>}
+     */
+    async getNewsletterBasicStats(options = {}) {
+        // Extract newsletter_id from options
+        const {newsletter_id: newsletterId, ...otherOptions} = options;
+        
+        // If no newsletterId is provided, we can't get specific stats
+        if (!newsletterId) {
+            return {data: []};
+        }
+        
+        // Return newsletter basic stats for the specific newsletter
+        const result = await this.posts.getNewsletterBasicStats(newsletterId, otherOptions);
+        return result;
+    }
+
+    /**
+     * Get newsletter click stats for specific posts
+     * @param {Object} options
+     * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
+     * @param {string} [options.post_ids] - Comma-separated string of post IDs to get click data for
+     * @returns {Promise<{data: Object[]}>}
+     */
+    async getNewsletterClickStats(options = {}) {
+        // Extract newsletter_id and post_ids from options
+        const {newsletter_id: newsletterId, post_ids: postIds} = options;
+        
+        // If no newsletterId is provided, we can't get specific stats
+        if (!newsletterId) {
+            return {data: []};
+        }
+        
+        // Return newsletter click stats for the specific newsletter and posts
+        const result = await this.posts.getNewsletterClickStats(newsletterId, postIds);
+        return result;
+    }
+
+    /**
      * @param {object} deps
      *
      * @returns {StatsService}

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -162,6 +162,8 @@ module.exports = function apiRoutes() {
         router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
         router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
         router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
+        router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
+        router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
         router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
         router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
         router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2019/
- Add newsletter-basic-stats and newsletter-click-stats endpoints
- Create split hooks to fetch basic stats first, clicks in parallel
- Update Newsletter component to show loading states for click data
- Improves perceived performance by avoiding slow click query blocking

I've split the click stats into its own endpoint so that we can both fetch in parallel, and separate the heaviest data into its own query that can populate as it comes in, rather than holding up the display of everything in the view.