### PR TITLE
Added ActivityPub notification count UI to navigation

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import {Button, Dialog, DialogContent, DialogTrigger, LucideIcon} from '@tryghos
 import {useFeatureFlags} from '@src/lib/feature-flags';
 
 const Sidebar: React.FC = () => {
-    const {allFlags, flags} = useFeatureFlags();
+    const {allFlags, flags, isEnabled} = useFeatureFlags();
     const [isSearchOpen, setIsSearchOpen] = React.useState(false);
     const [searchQuery, setSearchQuery] = React.useState('');
 
@@ -36,7 +36,7 @@ const Sidebar: React.FC = () => {
                             <LucideIcon.Hash size={18} strokeWidth={1.5} />
                             Feed
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/notifications'>
+                        <SidebarMenuLink count={isEnabled('notification') ? 5 : undefined} to='/notifications'>
                             <LucideIcon.Bell size={18} strokeWidth={1.5} />
                             Notifications
                         </SidebarMenuLink>

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
@@ -5,10 +5,11 @@ import {Link, resetScrollPosition, useLocation, useNavigationStack} from '@trygh
 interface SidebarButtonProps extends ButtonProps {
     to?: string;
     children: React.ReactNode;
+    count?: number;
 }
 
 const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
-    ({to, children, ...props}, ref) => {
+    ({to, children, count, ...props}, ref) => {
         const location = useLocation();
         const {resetStack} = useNavigationStack();
 
@@ -17,13 +18,24 @@ const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
             (to && location.pathname === to) && 'bg-gray-100 dark:bg-gray-925/70 dark:text-white text-black font-semibold'
         );
 
+        const badge = count && count > 0 ? (
+            <span className={cn(
+                'ml-auto bg-purple-500 text-white text-xs font-semibold p-1 rounded-full min-w-[20px] h-5 flex items-center justify-center'
+            )}>
+                {count}
+            </span>
+        ) : null;
+
         if (to) {
             return (
                 <Button className={linkClass} variant='ghost' asChild>
                     <Link to={to} onClick={() => {
                         resetStack();
                         resetScrollPosition(to);
-                    }}>{children}</Link>
+                    }}>
+                        {children}
+                        {badge}
+                    </Link>
                 </Button>
             );
         }
@@ -37,6 +49,7 @@ const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
                 {...props}
             >
                 {children}
+                {badge}
             </Button>
         );
     }

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = [] as const;
+export const FEATURE_FLAGS = ['notification'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -35,6 +35,10 @@ const features = [{
     title: 'Explore',
     description: 'Enables keeping in touch with the new Explore API',
     flag: 'explore'
+}, {
+    title: 'ActivityPub Notifications',
+    description: 'Enables notification count badge for ActivityPub',
+    flag: 'apNotification'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -54,8 +54,12 @@
             {{else}}
                 <ul class="gh-nav-list gh-nav-main">
                     {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
-                        <li>
-                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "house"}}Home</LinkTo>
+                        <li class="relative gh-nav-list-ap">
+                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "house"}}Home
+                                {{#if (feature "apNotification")}}
+                                    <span class="gh-nav-member-count">5</span>
+                                {{/if}}
+                            </LinkTo>
                         </li>
                     {{/if}}
                     {{#if (gh-user-can-admin this.session.user)}}

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -76,6 +76,7 @@ export default class FeatureService extends Service {
     @feature('trafficAnalyticsAlpha') trafficAnalyticsAlpha;
     @feature('updatedMainNav') updatedMainNav;
     @feature('trafficAnalytics') trafficAnalytics;
+    @feature('apNotification') apNotification;
 
     _user = null;
 

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -551,6 +551,10 @@ body:not(.gh-body-fullscreen) .gh-viewport {
     opacity: 1;
 }
 
+.gh-nav-list a:hover .gh-nav-member-count {
+    background: color-mod(var(--mainmenu-color-active-bg) l(-5%));
+}
+
 /* Icons */
 .gh-nav-list svg {
     margin-right: 11px;
@@ -684,7 +688,7 @@ body:not(.gh-body-fullscreen) .gh-viewport {
     padding: 2px 7px;
     margin: 0;
     right: 10px;
-    top: 5px;
+    top: 7px;
     background: var(--mainmenu-color-active-bg);
     color: var(--middarkgrey);
     border-radius: 999px;
@@ -692,6 +696,10 @@ body:not(.gh-body-fullscreen) .gh-viewport {
     font-size: 1.3rem;
     min-width: 23px;
     text-align: center;
+}
+
+.gh-nav-list-ap .active .gh-nav-member-count {
+    display: none;
 }
 
 .gh-nav-main {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -53,7 +53,8 @@ const PRIVATE_FEATURES = [
     'trafficAnalyticsAlpha',
     'updatedMainNav',
     'contentVisibilityAlpha',
-    'explore'
+    'explore',
+    'apNotification'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -12,6 +12,7 @@ Object {
       "ActivityPub": true,
       "additionalPaymentMethods": true,
       "announcementBar": true,
+      "apNotification": true,
       "audienceFeedback": true,
       "collectionsCard": true,
       "contentVisibility": true,


### PR DESCRIPTION
ref PROD-2014

- Implemented notification counter design in UI (currently showing static "5")
- Added `apNotification` flag to beta settings for main nav integration
- Added ActivityPub-specific `notification` feature flag for inner nav integration