### PR TITLE
🌐 Added i18n support for meta title

### DIFF
--- a/ghost/core/core/frontend/meta/title.js
+++ b/ghost/core/core/frontend/meta/title.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const settingsCache = require('../../shared/settings-cache');
+const {t} = require('../../server/services/i18n');
 
 function optionalString(test, string) {
     if (test) {
@@ -20,7 +21,11 @@ function getTitle(data, root, options = {}) {
     let pageString = '';
 
     if (pagination && pagination.total > 1) {
-        pageString = _.has(options.hash, 'page') ? options.hash.page.replace('%', pagination.page) : ' (Page ' + pagination.page + ')';
+        const paginatingPage = t(`Page {page}`, {
+            page: pagination.page,
+            interpolation: {escapeValue: false}
+        });
+        pageString = _.has(options.hash, 'page') ? options.hash.page.replace('%', pagination.page) : ' (' + paginatingPage + ')';
     }
 
     const dashSiteTitle = optionalString(siteTitle, ' - ' + siteTitle);

--- a/ghost/i18n/locales/af/ghost.json
+++ b/ghost/i18n/locales/af/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Bevestig asseblief u e-posadres met hierdie skakel:",
     "Secure sign in link for {siteTitle}": "Veilige aanmeldskakel vir {siteTitle}",

--- a/ghost/i18n/locales/ar/ghost.json
+++ b/ghost/i18n/locales/ar/ghost.json
@@ -31,6 +31,7 @@
     "Name": "الاسم",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "مدفوع",
     "Please confirm your email address with this link:": "برجاء تأكيد بريدك الاكتروني من خلال الرابط:",
     "Secure sign in link for {siteTitle}": "رابط تسجيل الدخول الامن الى {siteTitle}",

--- a/ghost/i18n/locales/bg/ghost.json
+++ b/ghost/i18n/locales/bg/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Име",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "платен",
     "Please confirm your email address with this link:": "Моля, потвърдете своя имейл адрес чрез този линк:",
     "Secure sign in link for {siteTitle}": "Линк за сигурно влизане в сайта {siteTitle}",

--- a/ghost/i18n/locales/bn/ghost.json
+++ b/ghost/i18n/locales/bn/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "এই লিঙ্ক দিয়ে আপনার ইমেল ঠিকানা নিশ্চিত করুন:",
     "Secure sign in link for {siteTitle}": "{siteTitle} এর জন্য নিরাপদ সাইন ইন লিঙ্ক",

--- a/ghost/i18n/locales/bs/ghost.json
+++ b/ghost/i18n/locales/bs/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Potvrdi svoju email adresu putem slijedećeg linka:",
     "Secure sign in link for {siteTitle}": "Siguran link za prijavu za {siteTitle}",

--- a/ghost/i18n/locales/ca/ghost.json
+++ b/ghost/i18n/locales/ca/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nom",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "de pagament",
     "Please confirm your email address with this link:": "Si us plau, confirma la teva adreça de correu electrònic amb aquest enllaç:",
     "Secure sign in link for {siteTitle}": "Enllaç segur d'inici de sessió per {siteTitle}",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -169,6 +169,7 @@
     "Once resubscribed, if you still don't see emails in your inbox, check your spam folder. Some inbox providers keep a record of previous spam complaints and will continue to flag emails. If this happens, mark the latest newsletter as 'Not spam' to move it back to your primary inbox.": "A paragraph in the email suppression FAQ",
     "One hour ago": "Time a comment was placed",
     "One min ago": "Time since a comment was made",
+    "Page {page}": "",
     "Permanent failure (bounce)": "A section title in the email suppression FAQ",
     "Phone number": "Label for phone number input",
     "Plan": "Label for the default subscription plan",

--- a/ghost/i18n/locales/cs/ghost.json
+++ b/ghost/i18n/locales/cs/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Jméno",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "placený",
     "Please confirm your email address with this link:": "Prosím, potvrďte svou e-mailovou adresu kliknutím na následující odkaz:",
     "Secure sign in link for {siteTitle}": "Bezpečný přihlašovací odkaz pro {siteTitle}",

--- a/ghost/i18n/locales/da/ghost.json
+++ b/ghost/i18n/locales/da/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Navn",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "betalt",
     "Please confirm your email address with this link:": "Bekræft venligst din e-mail med dette link:",
     "Secure sign in link for {siteTitle}": "Sikker log ind link til {siteTitle}",

--- a/ghost/i18n/locales/de-CH/ghost.json
+++ b/ghost/i18n/locales/de-CH/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Name",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "zahlendes",
     "Please confirm your email address with this link:": "Bitte bestätigen Sie Ihre E-Mail-Adresse mit diesem Link:",
     "Secure sign in link for {siteTitle}": "Sicherer Anmeldelink für unsere Seite «{siteTitle}»",

--- a/ghost/i18n/locales/de/ghost.json
+++ b/ghost/i18n/locales/de/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Name",
     "New comment on {postTitle}": "Neuer Kommentar zu {postTitle}",
     "New reply to your comment on {siteTitle}": "Neue Antwort auf dein Kommentar bei {siteTitle}",
+    "Page {page}": "Seite {page}",
     "paid": "zahlendes",
     "Please confirm your email address with this link:": "Bitte bestätige deine E-Mail-Adresse mit diesem Link:",
     "Secure sign in link for {siteTitle}": "Sicherer Anmeldelink für {siteTitle}",

--- a/ghost/i18n/locales/el/ghost.json
+++ b/ghost/i18n/locales/el/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Παρακαλούμε επιβεβαιώστε τη διεύθυνση email σας με αυτόν τον σύνδεσμο:",
     "Secure sign in link for {siteTitle}": "Ασφαλής σύνδεσμος σύνδεσης για το {siteTitle}",

--- a/ghost/i18n/locales/en/ghost.json
+++ b/ghost/i18n/locales/en/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "",
     "Secure sign in link for {siteTitle}": "",

--- a/ghost/i18n/locales/eo/ghost.json
+++ b/ghost/i18n/locales/eo/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Bonvolu konfirmi vian retadreson per ĉi tiu ligilo:",
     "Secure sign in link for {siteTitle}": "Sekura ensaluta ligilo por {siteTitle}",

--- a/ghost/i18n/locales/es/ghost.json
+++ b/ghost/i18n/locales/es/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nombre",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "de pago",
     "Please confirm your email address with this link:": "Por favor, confirma tu dirección de correo electrónico haciendo clic en este enlace:",
     "Secure sign in link for {siteTitle}": "Inicio de sesión seguro para {siteTitle}",

--- a/ghost/i18n/locales/et/ghost.json
+++ b/ghost/i18n/locales/et/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Palun kinnita oma e-posti aadress selle lingiga:",
     "Secure sign in link for {siteTitle}": "Turvaline sisselogimislink {siteTitle} lehele",

--- a/ghost/i18n/locales/fa/ghost.json
+++ b/ghost/i18n/locales/fa/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "خواهشمند است از طریق این پیوند آدرس ایمیل خود را تأیید کنید:",
     "Secure sign in link for {siteTitle}": "پیوند امن ورود به وب\u200cسایت {siteTitle}",

--- a/ghost/i18n/locales/fi/ghost.json
+++ b/ghost/i18n/locales/fi/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Vahvista sähköpostisi tästä linkistä:",
     "Secure sign in link for {siteTitle}": "Turvallinen kirjautumislinkki sivustolle {siteTitle}",

--- a/ghost/i18n/locales/fr/ghost.json
+++ b/ghost/i18n/locales/fr/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nom",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "payé",
     "Please confirm your email address with this link:": "Veuillez confirmez votre adresse e-mail en cliquant ce lien :",
     "Secure sign in link for {siteTitle}": "Lien sécurisé de connexion pour {siteTitle}",

--- a/ghost/i18n/locales/gd/ghost.json
+++ b/ghost/i18n/locales/gd/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Ainm",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "pàighte",
     "Please confirm your email address with this link:": "Dearbhaich am post-d agad leis a' cheangal seo:",
     "Secure sign in link for {siteTitle}": "Ceangal tèarainte airson clàradh a-steach ris an làrach-lìn, {siteTitle}",

--- a/ghost/i18n/locales/he/ghost.json
+++ b/ghost/i18n/locales/he/ghost.json
@@ -31,6 +31,7 @@
     "Name": "שם",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "בתשלום",
     "Please confirm your email address with this link:": "אנא אשרו את כתובת המייל שלכם בעזרת הלינק הבא:",
     "Secure sign in link for {siteTitle}": "לינק הרשמה מאובטח ל{siteTitle}",

--- a/ghost/i18n/locales/hi/ghost.json
+++ b/ghost/i18n/locales/hi/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "कृपया इस लिंक से अपना ईमेल पता पुष्टि करें:",
     "Secure sign in link for {siteTitle}": "{siteTitle} के लिए सुरक्षित साइन इन लिंक",

--- a/ghost/i18n/locales/hr/ghost.json
+++ b/ghost/i18n/locales/hr/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Ime",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "plaćeno",
     "Please confirm your email address with this link:": "Molimo vas da potvrdite adresu e-pošte klikom na ovaj link:",
     "Secure sign in link for {siteTitle}": "Sigurni link za prijavu na {siteTitle}",

--- a/ghost/i18n/locales/hu/ghost.json
+++ b/ghost/i18n/locales/hu/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Név",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "fizetve",
     "Please confirm your email address with this link:": "Kattints az alábbi linkre az e-mail-címed megerősítéséért:",
     "Secure sign in link for {siteTitle}": "{siteTitle} — Biztonságos bejelentkezési link",

--- a/ghost/i18n/locales/id/ghost.json
+++ b/ghost/i18n/locales/id/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Harap konfirmasikan alamat email Anda dengan tautan ini:",
     "Secure sign in link for {siteTitle}": "Tautan masuk yang aman untuk {siteTitle}",

--- a/ghost/i18n/locales/is/ghost.json
+++ b/ghost/i18n/locales/is/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Vinsamlegast staðfestið netfangið með þessum hlekki",
     "Secure sign in link for {siteTitle}": "Innskráningarhlekkur fyrir {siteTitle}",

--- a/ghost/i18n/locales/it/ghost.json
+++ b/ghost/i18n/locales/it/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nome",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "a pagamento",
     "Please confirm your email address with this link:": "Conferma il tuo indirizzo email a questo link:",
     "Secure sign in link for {siteTitle}": "Link per l'accesso sicuro a {siteTitle}",

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "このリンクを使用してメールアドレスを確認してください：",
     "Secure sign in link for {siteTitle}": "{siteTitle}へのログインリンクです",

--- a/ghost/i18n/locales/ko/ghost.json
+++ b/ghost/i18n/locales/ko/ghost.json
@@ -31,6 +31,7 @@
     "Name": "이름",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "유료",
     "Please confirm your email address with this link:": "아래 링크를 사용하여 이메일 주소를 확인해 주세요:",
     "Secure sign in link for {siteTitle}": "{siteTitle}의 안전한 로그인 링크예요.",

--- a/ghost/i18n/locales/kz/ghost.json
+++ b/ghost/i18n/locales/kz/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Email поштаңызды осы сілтеме арқылы растауыңызды сұраймыз:",
     "Secure sign in link for {siteTitle}": "{siteTitle} сайтына қауіпсіз кіруге арналған сілтеме",

--- a/ghost/i18n/locales/lt/ghost.json
+++ b/ghost/i18n/locales/lt/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Patvirtinkite savo el. pašto adresą su šia nuoroda:",
     "Secure sign in link for {siteTitle}": "Saugi prisijungimo nuoroda į {siteTitle}",

--- a/ghost/i18n/locales/lv/ghost.json
+++ b/ghost/i18n/locales/lv/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Vārds",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "samaksāts",
     "Please confirm your email address with this link:": "Lūdzu, apstipriniet savu e-pasta adresi, izmantojot šo saiti:",
     "Secure sign in link for {siteTitle}": "Droša pierakstīšanās saite vietnei {siteTitle}",

--- a/ghost/i18n/locales/mk/ghost.json
+++ b/ghost/i18n/locales/mk/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Потврдете ја вашата email адреса со овој линк:",
     "Secure sign in link for {siteTitle}": "Безбеден линк за најава на {siteTitle}",

--- a/ghost/i18n/locales/mn/ghost.json
+++ b/ghost/i18n/locales/mn/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Нэр",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "төлбөртэй",
     "Please confirm your email address with this link:": "Та өөрийн имэйл хаягаа дараах холбоосоор баталгаажуулна уу:",
     "Secure sign in link for {siteTitle}": "{siteTitle}-д нэвтрэх нууцлал бүхий холбоос",

--- a/ghost/i18n/locales/ms/ghost.json
+++ b/ghost/i18n/locales/ms/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Sila sahkan alamat e-mel anda dengan pautan ini:",
     "Secure sign in link for {siteTitle}": "Pautan log masuk untuk {siteTitle}",

--- a/ghost/i18n/locales/nb/ghost.json
+++ b/ghost/i18n/locales/nb/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Navn",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "betalt",
     "Please confirm your email address with this link:": "Vennligst bekreft e-postadressen din med denne lenken:",
     "Secure sign in link for {siteTitle}": "Sikker påloggingslenke for {siteTitle}",

--- a/ghost/i18n/locales/ne/ghost.json
+++ b/ghost/i18n/locales/ne/ghost.json
@@ -31,6 +31,7 @@
     "Name": "नाम",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "भुक्तान गरिएको",
     "Please confirm your email address with this link:": "कृपया यो लिङ्कसँग तपाईंको इमेल ठेगाना पुष्टि गर्नुहोस्:",
     "Secure sign in link for {siteTitle}": "{siteTitle} को लागि सुरक्षित साइन इन लिङ्क",

--- a/ghost/i18n/locales/nl/ghost.json
+++ b/ghost/i18n/locales/nl/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Naam",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "betaald",
     "Please confirm your email address with this link:": "Bevestig je e-mailadres met deze link:",
     "Secure sign in link for {siteTitle}": "Veilige inloglink voor {siteTitle}",

--- a/ghost/i18n/locales/nn/ghost.json
+++ b/ghost/i18n/locales/nn/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Ver gild og bekreft e-postadressa di med denne lenka:",
     "Secure sign in link for {siteTitle}": "Trygg innlogginslenke for {siteTitle}",

--- a/ghost/i18n/locales/pa/ghost.json
+++ b/ghost/i18n/locales/pa/ghost.json
@@ -31,6 +31,7 @@
     "Name": "ਨਾਮ",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "ਭੁਗਤਾਨ ਕੀਤਾ",
     "Please confirm your email address with this link:": "ਕਿਰਪਾ ਕਰਕੇ ਇਸ ਲਿੰਕ ਨਾਲ ਆਪਣੇ ਈਮੇਲ ਪਤੇ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ:",
     "Secure sign in link for {siteTitle}": "{siteTitle} ਲਈ ਸੁਰੱਖਿਅਤ ਸਾਈਨ-ਇਨ ਲਿੰਕ",

--- a/ghost/i18n/locales/pl/ghost.json
+++ b/ghost/i18n/locales/pl/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Imię",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "płatnym",
     "Please confirm your email address with this link:": "Potwierdź proszę swój adres email, klikając w ten link:",
     "Secure sign in link for {siteTitle}": "Bezpieczny link logowania do {siteTitle}",

--- a/ghost/i18n/locales/pt-BR/ghost.json
+++ b/ghost/i18n/locales/pt-BR/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nome",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "pago",
     "Please confirm your email address with this link:": "Por favor, confirme seu endereço de e-mail usando este link:",
     "Secure sign in link for {siteTitle}": "Link seguro para acesso ao site {siteTitle}",

--- a/ghost/i18n/locales/pt/ghost.json
+++ b/ghost/i18n/locales/pt/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nome",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "paga",
     "Please confirm your email address with this link:": "Por favor, confirme o seu email através deste link:",
     "Secure sign in link for {siteTitle}": "Ligação segura para entrar em {siteTitle}",

--- a/ghost/i18n/locales/ro/ghost.json
+++ b/ghost/i18n/locales/ro/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Nume",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "plătit",
     "Please confirm your email address with this link:": "Te rugăm să confirmi adresa ta de email cu acest link:",
     "Secure sign in link for {siteTitle}": "Link securizat pentru autentificarea la {siteTitle}",

--- a/ghost/i18n/locales/ru/ghost.json
+++ b/ghost/i18n/locales/ru/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Имя",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "платным",
     "Please confirm your email address with this link:": "Пожалуйста, подтвердите свой email адрес, перейдя по этой ссылке:",
     "Secure sign in link for {siteTitle}": "Ссылка для безопасного входа в систему на {siteTitle}",

--- a/ghost/i18n/locales/si/ghost.json
+++ b/ghost/i18n/locales/si/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "ඔබගේ email ලිපිනය තහවුරු කිරීම සඳහා මෙම link එක භාවිතා කරන්න:",
     "Secure sign in link for {siteTitle}": "{siteTitle} වෙත ආරක්ෂිතව sign in වීම සඳහා වන link එක",

--- a/ghost/i18n/locales/sk/ghost.json
+++ b/ghost/i18n/locales/sk/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Meno",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "plateným",
     "Please confirm your email address with this link:": "Prosím potvrďte svoju e-mailovú adresu kliknutím na nasledujúci odkaz",
     "Secure sign in link for {siteTitle}": "Bezpečný prihlasovací odkaz pre {siteTitle}",

--- a/ghost/i18n/locales/sl/ghost.json
+++ b/ghost/i18n/locales/sl/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Ime",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "plačljivi",
     "Please confirm your email address with this link:": "S to povezavo potrdite svoj e-poštni naslov:",
     "Secure sign in link for {siteTitle}": "Varna povezava za prijavo na {siteTitle}",

--- a/ghost/i18n/locales/sq/ghost.json
+++ b/ghost/i18n/locales/sq/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Ju lutem konfirmoni adresen tuaj te emailit me kete link:",
     "Secure sign in link for {siteTitle}": "Lidhja e sigurt e hyrjes për {siteTitle}",

--- a/ghost/i18n/locales/sr-Cyrl/ghost.json
+++ b/ghost/i18n/locales/sr-Cyrl/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Молим Вас да потврдите Вашу мејл адресу путем овог линка:",
     "Secure sign in link for {siteTitle}": "Сигуран линк за пријаву на портал {siteTitle}",

--- a/ghost/i18n/locales/sr/ghost.json
+++ b/ghost/i18n/locales/sr/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Molimo Vas potvrdite Vašu email adresu klikom na ovaj link:",
     "Secure sign in link for {siteTitle}": "Bezbedni link za logovanje na {siteTitle}",

--- a/ghost/i18n/locales/sv/ghost.json
+++ b/ghost/i18n/locales/sv/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Namn",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "betalande",
     "Please confirm your email address with this link:": "Vänligen bekräfta din e-postadress med denna länk:",
     "Secure sign in link for {siteTitle}": "Säker inloggningslänk för {siteTitle}",

--- a/ghost/i18n/locales/sw/ghost.json
+++ b/ghost/i18n/locales/sw/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Tafadhali thibitisha anwani yako ya barua pepe na kiungo hiki:",
     "Secure sign in link for {siteTitle}": "Kiungo salama cha kuingia kwa {siteTitle}",

--- a/ghost/i18n/locales/ta/ghost.json
+++ b/ghost/i18n/locales/ta/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "இந்த இணைப்புடன் உங்கள் மின்னஞ்சல் முகவரியை உறுதிப்படுத்தவும்:",
     "Secure sign in link for {siteTitle}": "{siteTitle} க்கான பாதுகாப்பான உள்நுழைவு இணைப்பு",

--- a/ghost/i18n/locales/th/ghost.json
+++ b/ghost/i18n/locales/th/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "โปรดยืนยันที่อยู่อีเมลของคุณด้วยลิงก์นี้:",
     "Secure sign in link for {siteTitle}": "ลิงก์ลงชื่อเข้าใช้อย่างปลอดภัยสำหรับ {siteTitle}",

--- a/ghost/i18n/locales/tr/ghost.json
+++ b/ghost/i18n/locales/tr/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Ad",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "ücretli",
     "Please confirm your email address with this link:": "Lütfen e-posta adresini bu linke tıklayarak onayla:",
     "Secure sign in link for {siteTitle}": "{siteTitle} için güvenli giriş linki",

--- a/ghost/i18n/locales/uk/ghost.json
+++ b/ghost/i18n/locales/uk/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Будь ласка, підтвердь свою електронну пошту за допомогою цього посилання:",
     "Secure sign in link for {siteTitle}": "Безпечне посилання для входу до {siteTitle}",

--- a/ghost/i18n/locales/ur/ghost.json
+++ b/ghost/i18n/locales/ur/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "براہ کرم اس لنک کے ساتھ آپ کا ای میل پتہ تصدیق کریں:",
     "Secure sign in link for {siteTitle}": "{siteTitle} کے لئے محفوظ سائن ان لنک",

--- a/ghost/i18n/locales/uz/ghost.json
+++ b/ghost/i18n/locales/uz/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "Iltimos, elektron pochta manzilingizni ushbu havola bilan tasdiqlang:",
     "Secure sign in link for {siteTitle}": "{siteTitle} uchun xavfsiz kirish havolasi",

--- a/ghost/i18n/locales/vi/ghost.json
+++ b/ghost/i18n/locales/vi/ghost.json
@@ -31,6 +31,7 @@
     "Name": "Tên",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "trả phí",
     "Please confirm your email address with this link:": "Vui lòng xác nhận địa chỉ email của bạn bằng liên kết này:",
     "Secure sign in link for {siteTitle}": "Liên kết đăng nhập {siteTitle} an toàn",

--- a/ghost/i18n/locales/zh-Hant/ghost.json
+++ b/ghost/i18n/locales/zh-Hant/ghost.json
@@ -31,6 +31,7 @@
     "Name": "名字",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "已付款",
     "Please confirm your email address with this link:": "請透過此連結確認您的 email 地址：",
     "Secure sign in link for {siteTitle}": "為{siteTitle}準備的安全登入連結",

--- a/ghost/i18n/locales/zh/ghost.json
+++ b/ghost/i18n/locales/zh/ghost.json
@@ -31,6 +31,7 @@
     "Name": "",
     "New comment on {postTitle}": "",
     "New reply to your comment on {siteTitle}": "",
+    "Page {page}": "",
     "paid": "",
     "Please confirm your email address with this link:": "请通过此链接确认您的电子邮件地址：",
     "Secure sign in link for {siteTitle}": "为 {siteTitle} 准备的安全登录链接",


### PR DESCRIPTION
Enables missing i18n support for the meta title when pagination information is added.

This is the first i18n in the frontend module, I am not sure if referencing the i18n in the server module is a good way to go but I didn't know how to achieve it otherwise. As there are no tests yet I didn't add any new ones.