### PR TITLE
Wired up APIs for unread notification count and count reset

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -1504,4 +1504,96 @@ describe('ActivityPubAPI', function () {
             await api.updateAccount(data);
         });
     });
+
+    describe('getNotificationsCount', function () {
+        test('It returns the notifications count', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/notifications/unread/count`]: {
+                    response: JSONResponse({
+                        count: 5
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.getNotificationsCount();
+            const expected = {
+                count: 5
+            };
+
+            expect(actual).toEqual(expected);
+        });
+
+        test('It returns zero count when the response is null', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/notifications/unread/count`]: {
+                    response: JSONResponse(null)
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const actual = await api.getNotificationsCount();
+            const expected = {
+                count: 0
+            };
+
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('resetNotificationsCount', function () {
+        test('It resets the notifications count', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/notifications/unread/reset`]: {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('PUT');
+                    },
+                    response: JSONResponse({})
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.resetNotificationsCount();
+            expect(result).toBe(true);
+        });
+    });
 });

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -125,6 +125,10 @@ export interface GetNotificationsResponse {
     next: string | null;
 }
 
+export interface GetNotificationsCountResponse {
+    count: number;
+}
+
 export interface GetBlockedAccountsResponse {
     accounts: Account[];
     next: string | null;
@@ -461,6 +465,30 @@ export class ActivityPubAPI {
             notifications,
             next: nextPage
         };
+    }
+
+    async getNotificationsCount(): Promise<GetNotificationsCountResponse> {
+        const url = new URL('.ghost/activitypub/notifications/unread/count', this.apiUrl);
+
+        const json = await this.fetchJSON(url);
+
+        if (json === null) {
+            return {
+                count: 0
+            };
+        }
+
+        return {
+            count: (json as {count: number}).count
+        };
+    }
+
+    async resetNotificationsCount() {
+        const url = new URL('.ghost/activitypub/notifications/unread/reset', this.apiUrl);
+
+        await this.fetchJSON(url, 'PUT');
+
+        return true;
     }
 
     async getBlockedAccounts(next?: string): Promise<GetBlockedAccountsResponse> {

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -478,9 +478,11 @@ export class ActivityPubAPI {
             };
         }
 
-        return {
-            count: (json as {count: number}).count
-        };
+        const count = typeof (json as Record<string, unknown>).count === 'number'
+            ? (json as {count: number}).count
+            : 0;
+
+        return {count};
     }
 
     async resetNotificationsCount() {

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -6,12 +6,32 @@ import Search from '@src/components/modals/Search';
 import SearchInput from '../Header/SearchInput';
 import SidebarMenuLink from './SidebarMenuLink';
 import {Button, Dialog, DialogContent, DialogTrigger, LucideIcon} from '@tryghost/shade';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
 import {useFeatureFlags} from '@src/lib/feature-flags';
+import {useLocation} from '@tryghost/admin-x-framework';
+import {useNotificationsCountForUser, useResetNotificationsCountForUser} from '@src/hooks/use-activity-pub-queries';
 
 const Sidebar: React.FC = () => {
     const {allFlags, flags, isEnabled} = useFeatureFlags();
     const [isSearchOpen, setIsSearchOpen] = React.useState(false);
     const [searchQuery, setSearchQuery] = React.useState('');
+    const {data: currentUser} = useCurrentUser();
+    const location = useLocation();
+    const {data: notificationsCount} = useNotificationsCountForUser(currentUser?.slug || '');
+    const resetNotificationsCount = useResetNotificationsCountForUser(currentUser?.slug || '');
+
+    // Reset count when on notifications page
+    React.useEffect(() => {
+        if (location.pathname === '/notifications' && notificationsCount && notificationsCount > 0) {
+            resetNotificationsCount.mutate();
+        }
+    }, [location.pathname, notificationsCount, resetNotificationsCount]);
+
+    const handleNotificationsClick = React.useCallback(() => {
+        if (notificationsCount && notificationsCount > 0) {
+            resetNotificationsCount.mutate();
+        }
+    }, [notificationsCount, resetNotificationsCount]);
 
     return (
         <div className='sticky top-0 flex min-h-screen w-[320px] flex-col border-l border-gray-200 pr-8 dark:border-gray-950'>
@@ -36,7 +56,11 @@ const Sidebar: React.FC = () => {
                             <LucideIcon.Hash size={18} strokeWidth={1.5} />
                             Feed
                         </SidebarMenuLink>
-                        <SidebarMenuLink count={isEnabled('notification') ? 5 : undefined} to='/notifications'>
+                        <SidebarMenuLink 
+                            count={isEnabled('notification') && location.pathname !== '/notifications' ? notificationsCount : undefined} 
+                            to='/notifications'
+                            onClick={handleNotificationsClick}
+                        >
                             <LucideIcon.Bell size={18} strokeWidth={1.5} />
                             Notifications
                         </SidebarMenuLink>

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -56,8 +56,10 @@
                     {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
                         <li class="relative gh-nav-list-ap">
                             <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "house"}}Home
-                                {{#if (feature "apNotification")}}
-                                    <span class="gh-nav-member-count">5</span>
+                                {{#if (and (feature "apNotification") (not this.notificationsCount.isLoading))}}
+                                    {{#if (gt this.notificationsCount.count 0)}}
+                                        <span class="gh-nav-member-count">{{format-number this.notificationsCount.count}}</span>
+                                    {{/if}}
                                 {{/if}}
                             </LinkTo>
                         </li>

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -27,12 +27,14 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     @service settings;
     @service explore;
     @service notifications;
+    @service notificationsCount;
 
     @inject config;
 
     iconStyle = '';
     iconClass = '';
     shortcuts = null;
+    previousRoute = null;
 
     @match('router.currentRouteName', /^settings\.integration/)
         isIntegrationRoute;
@@ -59,6 +61,28 @@ export default class Main extends Component.extend(ShortcutsMixin) {
         shortcuts[`${ctrlOrCmd}+k`] = {action: 'openSearchModal'};
         shortcuts[`${ctrlOrCmd}+,`] = {action: 'openSettings'};
         this.shortcuts = shortcuts;
+
+        // Set initial previous route
+        this.previousRoute = this.router.currentRouteName;
+
+        const currentRoute = this.router.currentRouteName || '';
+        // Fetch notifications count if not on activitypub-x route
+        if (!currentRoute.startsWith('activitypub-x')) {
+            this.notificationsCount.fetchCount();
+        }
+
+        this._routeChangeHandler = () => {
+            const current = this.router.currentRouteName || '';
+            const prev = this.previousRoute || '';
+        
+            if (prev.startsWith('activitypub-x') && !current.startsWith('activitypub-x')) {
+                this.notificationsCount.fetchCount();
+            }
+        
+            this.previousRoute = current;
+        };
+        
+        this.router.on('routeDidChange', this._routeChangeHandler);
     }
 
     // the menu has a rendering issue (#8307) when the the world is reloaded
@@ -78,6 +102,9 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     willDestroyElement() {
         this.removeShortcuts();
         super.willDestroyElement(...arguments);
+        if (this._routeChangeHandler) {
+            this.router.off('routeDidChange', this._routeChangeHandler);
+        }
     }
 
     @action

--- a/ghost/admin/app/services/notifications-count.js
+++ b/ghost/admin/app/services/notifications-count.js
@@ -1,0 +1,43 @@
+import Service from '@ember/service';
+import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
+
+export default class NotificationsCountService extends Service {
+    @service ajax;
+    @service session;
+    @tracked count = 0;
+    @tracked isLoading = false;
+
+    async fetchCount() {
+        try {
+            this.count = 0;
+            this.isLoading = true;
+            
+            const identityResponse = await this.ajax.request('/ghost/api/admin/identities/');
+            const token = identityResponse?.identities?.[0]?.token;
+
+            if (!token) {
+                this.count = 0;
+                return 0;
+            }
+
+            const response = await this.ajax.request('/.ghost/activitypub/notifications/unread/count', {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: 'application/activity+json'
+                }
+            });
+            this.count = response.count || 0;
+            return this.count;
+        } catch (error) {
+            this.count = 0;
+            return 0;
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    updateCount(newCount) {
+        this.count = newCount;
+    }
+} 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2032/

- We want to show badges on AP UI to indicate when there's new notifications
- The notification count should reset once the user clicks on "Notifications" tab