### PR TITLE
Fixed incorrect post title color in newsletter design preview

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -98,7 +98,10 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
             return siteData.accent_color;
         }
 
-        return textColorForBackgroundColor(headerBackgroundColor() || backgroundColor()).hex();
+        const headerBgColor = headerBackgroundColor();
+        const bgColor = headerBgColor === 'transparent' ? backgroundColor() : headerBgColor;
+
+        return textColorForBackgroundColor(bgColor).hex();
     };
 
     const sectionTitleColor = () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2010/

- `header_background_color` uses `transparent` rather than `null` which meant the fallback logic from header to body background color was incorrect when calculating the appropriate text color
