### PR TITLE
Fixed newsletter product card title color

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -2035,11 +2035,13 @@ img.kg-cta-image {
 
 .kg-product-card h4 {
     {{#if sectionTitleColor}}
-    color: {{sectionTitleColor}};
+        color: {{sectionTitleColor}} !important;
     {{else}}
-    {{#hasFeature "emailCustomization"}}
-    color: #15212A !important;
-    {{/hasFeature}}
+        {{#if backgroundIsDark}}
+            color: #ffffff !important;
+        {{else}}
+            color: #15212A !important;
+        {{/if}}
     {{/if}}
 }
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2046/

- if a custom section title color wasn't set then we were always using the light-bg text color for product cards which wasn't correct since we've adjusted the card's background color to better match the newsletter background color
- adjusted to correctly swap between dark/light depending on background color
