### PR TITLE
Updated top content endpoint to treat index as Homepage

### DIFF
--- a/ghost/core/core/server/services/stats/ContentStatsService.js
+++ b/ghost/core/core/server/services/stats/ContentStatsService.js
@@ -198,7 +198,7 @@ class ContentStatsService {
             }
 
             // Otherwise fallback to pathname (removing leading/trailing slashes)
-            const formattedPath = item.pathname.replace(/^\/|\/$/g, '') || 'Home';
+            const formattedPath = item.pathname.replace(/^\/|\/$/g, '') || 'Homepage';
             return {
                 ...item,
                 title: formattedPath,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1814/

Homepage is what we use in member attribution, so we should be consistent in our display by changing Home to Homepage.