### PR TITLE
Fixed newsletter design preview button text color

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -69,6 +69,17 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         return siteData.accent_color;
     };
 
+    const buttonTextColor = () => {
+        const buttonStyle = newsletter.button_style;
+        const calcButtonColor = buttonColor();
+
+        if (calcButtonColor && buttonStyle === 'fill') {
+            return textColorForBackgroundColor(calcButtonColor).hex();
+        }
+
+        return undefined;
+    };
+
     const linkColor = () => {
         const value = newsletter.link_color === undefined ? 'accent' : newsletter.link_color;
 
@@ -148,6 +159,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         postTitleColor?: string;
         sectionTitleColor?: string;
         buttonColor?: string;
+        buttonTextColor?: string;
         linkColor?: string;
         dividerColor?: string;
         textColor?: string;
@@ -164,6 +176,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
             postTitleColor: postTitleColor() || undefined,
             sectionTitleColor: sectionTitleColor() || undefined,
             buttonColor: buttonColor() || undefined,
+            buttonTextColor: buttonTextColor() || undefined,
             linkColor: linkColor() || undefined,
             dividerColor: dividerColor() || undefined,
             textColor,

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreviewContent.tsx
@@ -49,6 +49,7 @@ const NewsletterPreviewContent: React.FC<{
     sectionTitleColor?: string;
     dividerColor?: string;
     buttonColor?: string;
+    buttonTextColor?: string;
     linkColor?: string;
     buttonStyle?: string;
     buttonCorners?: string;
@@ -92,6 +93,7 @@ const NewsletterPreviewContent: React.FC<{
     sectionTitleColor,
     dividerColor,
     buttonColor,
+    buttonTextColor,
     linkColor,
     buttonCorners,
     buttonStyle,
@@ -278,7 +280,8 @@ const NewsletterPreviewContent: React.FC<{
                                                         color: buttonColor || accentColor
                                                     }
                                                     : {
-                                                        backgroundColor: buttonColor || accentColor
+                                                        backgroundColor: buttonColor || accentColor,
+                                                        color: buttonTextColor
                                                     }
                                             }
                                             type="button"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2037/

- the text color for the button shown in the preview was not updating between black/white depending on the button fill color
- added new `buttonTextColor` property to the colors passed into/used by the preview content that returns an appropriate fixed black/white color when the button is filled
