### PR TITLE
Matched feature image caption links to header text color

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -424,13 +424,15 @@ h6 + .kg-paywall .kg-paywall-hr td {
 {{#hasFeature "emailCustomization"}}
 /* Links in captions */
 .feature-image-caption a,
-figcaption a {
-    color: {{linkColor}};
-}
-
 .kg-toggle-card:not(.kg-cta-card) a {
     color: {{linkColor}};
 }
+
+.feature-image-caption a {
+    color: {{#if headerBackgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
+    text-decoration: underline;
+}
+
 .kg-callout-card:not(.kg-callout-card-accent) a {
     color: {{linkColor}};
 }


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2043

- certain header background color settings in combination with link color settings would result in difficult-to-read links in feature image captions
- resolved by always using the header text color for feature caption links and underlining to make it obvious it's a link
