### PR TITLE
Refactored link processing logic in post analytics

### DIFF
--- a/apps/posts/src/hooks/usePostNewsletterStats.ts
+++ b/apps/posts/src/hooks/usePostNewsletterStats.ts
@@ -1,6 +1,6 @@
-import {type CleanedLink, cleanTrackedUrl} from '@src/utils/link-helpers';
 import {type NewsletterStatItem, useNewsletterBasicStats, useNewsletterClickStats} from '@tryghost/admin-x-framework/api/stats';
 import {type Post, getPost} from '@tryghost/admin-x-framework/api/posts';
+import {processAndGroupTopLinks} from '@src/utils/link-helpers';
 import {useMemo} from 'react';
 import {useTopLinks} from '@tryghost/admin-x-framework/api/links';
 
@@ -85,7 +85,7 @@ export const usePostNewsletterStats = (postId: string) => {
         return basicStatsResponse.stats.map(stat => stat.post_id);
     }, [basicStatsResponse]);
 
-    // 2. Click stats (potentially slower) - fetch separately 
+    // 2. Click stats (potentially slower) - fetch separately
     const {data: clickStatsResponse, isLoading: isClickStatsLoading} = useNewsletterClickStats({
         searchParams: newsletterId && postIds.length > 0 ? {
             newsletter_id: newsletterId,
@@ -134,13 +134,6 @@ export const usePostNewsletterStats = (postId: string) => {
         }
     });
 
-    const links = useMemo(() => {
-        return clicksResponse?.links.map(link => ({
-            link: link.link,
-            count: link.count?.clicks || 0
-        })) || [];
-    }, [clicksResponse]);
-
     // Calculate average open and click rates across newsletters
     const averages = useMemo(() => {
         if (!newsletterStatsResponse || !newsletterStatsResponse.stats) {
@@ -168,36 +161,8 @@ export const usePostNewsletterStats = (postId: string) => {
     }, [newsletterStatsResponse]);
 
     const topLinks = useMemo(() => {
-        const cleanedLinks = links.map((link) => {
-            return {
-                ...link,
-                link: {
-                    ...link.link,
-                    originalTo: link.link.to,
-                    to: cleanTrackedUrl(link.link.to, false),
-                    title: cleanTrackedUrl(link.link.to, true)
-                }
-            };
-        });
-
-        const linksByTitle = cleanedLinks.reduce((acc: Record<string, CleanedLink>, link: CleanedLink) => {
-            if (!acc[link.link.title]) {
-                acc[link.link.title] = link;
-            } else {
-                if (!acc[link.link.title].count) {
-                    acc[link.link.title].count = 0;
-                }
-                acc[link.link.title].count += (link.count ?? 0);
-            }
-            return acc;
-        }, {});
-
-        return Object.values(linksByTitle).sort((a, b) => {
-            const aClicks = a.count || 0;
-            const bClicks = b.count || 0;
-            return bClicks - aClicks;
-        });
-    }, [links]);
+        return processAndGroupTopLinks(clicksResponse);
+    }, [clicksResponse]);
 
     const averageStats = useMemo(() => {
         return {

--- a/apps/posts/src/utils/link-helpers.ts
+++ b/apps/posts/src/utils/link-helpers.ts
@@ -1,3 +1,5 @@
+import {type LinkResponseType} from '@tryghost/admin-x-framework/api/links';
+
 export type CleanedLink = {
     count: number;
     link: {
@@ -33,4 +35,42 @@ export const cleanTrackedUrl = (url: string, display = false): string => {
 
 export const getLinkById = (links: CleanedLink[], linkId: string) => {
     return links.find(link => link.link.link_id === linkId);
+};
+
+export const processAndGroupTopLinks = (clicksResponse: LinkResponseType | undefined): CleanedLink[] => {
+    // Convert clicksResponse to links format
+    const links = clicksResponse?.links.map(link => ({
+        link: link.link,
+        count: link.count?.clicks || 0
+    })) || [];
+
+    const cleanedLinks = links.map((link) => {
+        return {
+            ...link,
+            link: {
+                ...link.link,
+                originalTo: link.link.to,
+                to: cleanTrackedUrl(link.link.to, false),
+                title: cleanTrackedUrl(link.link.to, true)
+            }
+        };
+    });
+
+    const linksByTitle = cleanedLinks.reduce((acc: Record<string, CleanedLink>, link: CleanedLink) => {
+        if (!acc[link.link.title]) {
+            acc[link.link.title] = link;
+        } else {
+            if (!acc[link.link.title].count) {
+                acc[link.link.title].count = 0;
+            }
+            acc[link.link.title].count += (link.count ?? 0);
+        }
+        return acc;
+    }, {});
+
+    return Object.values(linksByTitle).sort((a, b) => {
+        const aClicks = a.count || 0;
+        const bClicks = b.count || 0;
+        return bClicks - aClicks;
+    });
 };

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, ChartConfig, HTable, LucideIcon, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from '../../Newsletter/components/NewsLetterRadialChart';
 import {Post} from '@tryghost/admin-x-framework/api/posts';
-import {cleanTrackedUrl} from '@src/utils/link-helpers';
+import {cleanTrackedUrl, processAndGroupTopLinks} from '@src/utils/link-helpers';
 import {useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {useTopLinks} from '@tryghost/admin-x-framework/api/links';
 
@@ -38,7 +38,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
     });
 
     const topLinks = useMemo(() => {
-        return linksResponse?.links || [];
+        return processAndGroupTopLinks(linksResponse);
     }, [linksResponse]);
 
     // "Clicked" Chart
@@ -138,7 +138,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                                         {cleanTrackedUrl(link.link.to, true)}
                                                     </a>
                                                 </TableCell>
-                                                <TableCell className='w-[10%] py-2.5 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count?.clicks || 0)}</TableCell>
+                                                <TableCell className='w-[10%] py-2.5 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count || 0)}</TableCell>
                                             </TableRow>
                                         );
                                     })}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2055/same-link-appears-multiple-times-in-link-list

- Links were grouped only on the Newsletter tab of post analytics, but not on the overview which resulted in similar links appearing multiple times. This PR factored out the link processing and grouping logic to link utilities so it's reusable at both places.