### PR TITLE
Updated order of filter options on Growth tab

### DIFF
--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -159,9 +159,9 @@ const Growth: React.FC = () => {
                                                 setSelectedContentType(value as ContentType);
                                             }}>
                                                 <TabsList>
-                                                    <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
+                                                    <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.SOURCES}>Sources</TabsTrigger>
                                                 </TabsList>
                                             </Tabs>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2061/growth-tab-order-of-filter-options

https://github.com/TryGhost/Ghost/commit/165400d35033713e1ceea699d8844021af418d82

- After switching to "Posts" as the default option the order of options had to be adjusted