### PR TITLE
Attempted to fix flakey portal signup test (again)

### DIFF
--- a/apps/portal/src/tests/SignupFlow.test.js
+++ b/apps/portal/src/tests/SignupFlow.test.js
@@ -359,7 +359,12 @@ describe('Signup', () => {
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
 
             fireEvent.click(monthlyPlanContainer.parentNode);
-            await within(popupIframeDocument).findByText(benefitText);
+            // Wait for the benefit to appear in the UI - it may appear multiple times, so use findAllByText
+            await waitFor(() => {
+                expect(
+                    within(popupIframeDocument).queryAllByText(benefitText).length
+                ).toBeGreaterThan(0);
+            });
             expect(emailInput).toHaveValue('jamie@example.com');
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(submitButton);
@@ -400,7 +405,12 @@ describe('Signup', () => {
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
 
             fireEvent.click(yearlyPlanContainer.parentNode);
-            await within(popupIframeDocument).findByText(benefitText);
+            // Wait for the benefit to appear in the UI - it may appear multiple times, so use findAllByText
+            await waitFor(() => {
+                expect(
+                    within(popupIframeDocument).queryAllByText(benefitText).length
+                ).toBeGreaterThan(0);
+            });
             expect(emailInput).toHaveValue('jamie@example.com');
             expect(nameInput).toHaveValue('Jamie Larsen');
             fireEvent.click(submitButton);
@@ -440,7 +450,12 @@ describe('Signup', () => {
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});
 
             fireEvent.click(monthlyPlanContainer);
-            await within(popupIframeDocument).findByText(benefitText);
+            // Wait for the benefit to appear in the UI - it may appear multiple times, so use findAllByText
+            await waitFor(() => {
+                expect(
+                    within(popupIframeDocument).queryAllByText(benefitText).length
+                ).toBeGreaterThan(0);
+            });
 
             expect(emailInput).toHaveValue('jamie@example.com');
             fireEvent.click(submitButton);

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -290,16 +290,16 @@ export function getFreeProduct({
 }
 
 export function getBenefits({numOfBenefits}) {
-    const timestamp = Date.now();
-    const random = Math.floor(Math.random() * 100);
+    // Generate a unique suffix for benefit names to avoid clashes across test runs
+    const uniqueId = objectId();
 
-    const beenfits = [
-        getBenefitData({name: `Limited early adopter pricing #${random}-${timestamp}`}),
-        getBenefitData({name: `Latest gear reviews #${random}-${timestamp}`}),
-        getBenefitData({name: `Weekly email newsletter #${random}-${timestamp}`}),
-        getBenefitData({name: `Listen to my podcast #$${random}-${timestamp}`})
+    const benefits = [
+        getBenefitData({name: `Limited early adopter pricing #${uniqueId.substring(0, 6)}`}),
+        getBenefitData({name: `Latest gear reviews #${uniqueId.substring(6, 12)}`}),
+        getBenefitData({name: `Weekly email newsletter #${uniqueId.substring(12, 18)}`}),
+        getBenefitData({name: `Listen to my podcast #${uniqueId.substring(18)}`})
     ];
-    return beenfits.slice(0, numOfBenefits);
+    return benefits.slice(0, numOfBenefits);
 }
 
 export function getBenefitData({


### PR DESCRIPTION
- We keep seeing a flakey failure in the portal tests: FAIL src/tests/SignupFlow.test.js > Signup > as paid member on single tier site > with default settings on monthly plan

[2726](https://github.com/TryGhost/Ghost/actions/runs/15649953622/job/44093261730#step:7:2744) TestingLibraryElementError: Found multiple elements with the text: Limited early adopter pricing #7-1749888016395

- This is yet another attempt to fix it:

- Eliminates Race Conditions: Using objectId() instead of Date.now() + Math.random() ensures each fixture gets a truly unique identifier
- Handles Expected UI Behavior: The test now correctly handles the fact that benefits legitimately appear in multiple places in the UI
- More Robust Assertions: Using queryAllByText + waitFor makes the test more resilient to timing issues
- Maintains Test Intent: The test still verifies that the benefit text appears in the UI, just more flexibly

