### PR TITLE
Fixed flaky history test in admin-x-settings

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
@@ -45,6 +45,11 @@ test.describe('History', async () => {
         await popoverContent.getByLabel('Deleted').click();
         await expect(popoverContent.getByLabel('Deleted')).toHaveAttribute('data-state', 'unchecked');
 
+        // Wait for the API request with the expected filter
+        await page.waitForRequest(request => request.url().includes('event%3A-%5Bdeleted%5D') &&
+            request.url().includes('resource_type%3A-%5Blabel%2Cpost%5D')
+        );
+
         expect(lastApiRequests.browseActionsFiltered?.url).toEqual('http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=event%3A-%5Bdeleted%5D%2Bresource_type%3A-%5Blabel%2Cpost%5D');
     });
 });


### PR DESCRIPTION
- The test was checking the API request URL immediately after clicking the Deleted filter, causing a race condition between React state updates and the subsequent API request
- Added waitForRequest to ensure the filtered API request completes before asserting the URL, preventing intermittent failures
- Considered using waitForTimeout but that would make tests slower and less reliable than waiting for the specific request
- Alternative of mocking React Query's timing was too complex and would reduce test realism

- Resolves the following flaky failure:

1) [chromium] › test/acceptance/advanced/history.test.ts:6:9 › History › Browsing history ────────
    Error: expect(received).toEqual(expected) // deep equality
    Expected: "http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=event%3A-%5Bdeleted%5D%2Bresource_type%3A-%5Blabel%2Cpost%5D"
    Received: "http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=resource_type%3A-%5Blabel%2Cpost%5D"

