### PR TITLE
Fixed flaky history filter test in admin-x-settings

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
@@ -8,7 +8,7 @@ test.describe('History', async () => {
             ...globalDataRequests,
             browseActionsFiltered: {
                 method: 'GET',
-                path: /\/actions\/.+post/,
+                path: /\/actions\/.*filter=.*(?:post|event)/,
                 response: {
                     ...responseFixtures.actions,
                     actions: responseFixtures.actions.actions.filter(action => action.resource_type !== 'post')
@@ -44,6 +44,10 @@ test.describe('History', async () => {
 
         await popoverContent.getByLabel('Deleted').click();
         await expect(popoverContent.getByLabel('Deleted')).toHaveAttribute('data-state', 'unchecked');
+
+        await page.waitForResponse(response => response.url().includes('/ghost/api/admin/actions/')
+            && response.url().includes('event%3A-%5Bdeleted%5D')
+        );
 
         expect(lastApiRequests.browseActionsFiltered?.url).toEqual('http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=event%3A-%5Bdeleted%5D%2Bresource_type%3A-%5Blabel%2Cpost%5D');
     });


### PR DESCRIPTION

• The mock regex patterns weren't correctly distinguishing between initial and filtered requests, causing the wrong mock to handle API calls

• Updated browseActionsFiltered regex to match requests containing 'post' or 'event' in filter params

• Added waitForResponse to ensure the API request completes after clicking Deleted filter before asserting the URL

• This prevents race conditions between React state updates and API requests

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [ ] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [ ] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
