### PR TITLE
Disabled renovate for ember packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,22 +55,22 @@
         "ghost/admin/lib/koenig-editor/package.json"
     ],
     "packageRules": [
-        // Special package rules for ember / admin
+
+        // Ignore all ember-related packages in admin
+        // Our ember codebase is being replaced with react and
+        // Most of the dependencies have breaking changes and it's too hard to update
+        // Therefore, we'll leave these as-is for now
         {
-            "groupName": "ember-basic-dropdown addons",
+            "groupName": "Disable ember updates",
+            "matchFileNames": [
+                "ghost/admin/package.json"
+            ],
             "matchPackageNames": [
-                "/^ember-basic/",
-                "/^ember-power/"
-            ]
+                "/ember/"
+            ],
+            "enabled": false
         },
-        {
-            "groupName": "ember core",
-            "matchPackageNames": [
-                "ember-source",
-                "ember-cli",
-                "ember-data"
-            ]
-        },
+
         // Don't allow css preprocessor updates in admin
         {
             "groupName": "disable css",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,7 +66,12 @@
                 "ghost/admin/package.json"
             ],
             "matchPackageNames": [
-                "/ember/"
+                // `ember-foo` style packages
+                "/^ember(-|$)/",
+                // scoped `@ember/*` packages
+                "/^@ember\\//",
+                // foo/ember-something style packages
+                "/\\/ember(-|$)/"
             ],
             "enabled": false
         },


### PR DESCRIPTION
- Our ember codebase is being replaced with react
- Most ember dependencies are too far out of date and have far too many complex breaking changes to make
- We've gotten to a point where it's too time-consuming to untangle
- And likely we'll finish the replacement before we could ever get Ember updated to latest
- Ignoring them in renovate for now, to make it easier to focus on all the _other_ out of date dependencies

