### PR TITLE
Fixed incorrect paywall text color with opposing header/body bg darkness

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -2447,7 +2447,7 @@ img.kg-cta-image {
     margin: 0 auto 1.5em auto;
     text-wrap: pretty;
     {{#hasFeature "emailCustomization"}}
-    color: {{#if headerBackgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
+    color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
     {{/hasFeature}}
 }
 {{/hasFeature}}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2045/

- paywall text color was set to the contrasting color for the header background rather than the body background meaning it could display light-on-light or dark-on-dark when header/bg color had opposing lightness levels
- corrected to use the main body background text contrast color
