### PR TITLE
Removed unnecessary tb script commands

### DIFF
--- a/ghost/core/core/server/data/tinybird/readme.md
+++ b/ghost/core/core/server/data/tinybird/readme.md
@@ -2,14 +2,9 @@
 This is the web analytics implementation using [Tinybird Forward](https://www.tinybird.co/docs/forward).
 
 ### Usage
-*Only for the first time: run `yarn tbf:install` from `/ghost/`*.
+*Only for the first time: run `yarn tb:install` from `/ghost/`*.
 
-Run `yarn tbf` from `/ghost/`. This will start/install the TB Local Docker container, change the path, and start `tb dev`.
-
-### Local
-Run `yarn tb:local` from `/ghost/` to spin up a Docker container running Tinybird local.
-
-In order to use `tb local` with Ghost, the config local blocks should be updated with your tokens: `tb token ls`.
+Run `yarn tb` from `/ghost/`. This will start/install the TB Local Docker container, change the path, and start `tb dev`. `tb dev` automatically starts Tinybird Local - in order to use this with Ghost, the config local blocks should be updated with your tokens: `tb token ls`.
 
 Simply disable local to use the cloud version by switching `local: false` - this is switchable both via tracker script (ideally not used with the cloud data except with a unique id) and stats page.
 
@@ -44,4 +39,4 @@ Sample config:
 ```
 
 ### Testing
-Tests are executed using `tb test run`.
+Tests are executed using `test run` when running `tb dev`.

--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main\"",
     "prepare": "husky install .github/hooks",
     "tb": "tb local start && cd ghost/core/core/server/data/tinybird && tb dev",
-    "tb:update": "docker pull tinybirdco/tinybird-cli-docker",
-    "tb:local": "tb local start",
-    "tb:local:stop": "docker stop tinybird-local && docker rm tinybird-local",
     "tb:install": "curl https://tinybird.co | sh",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
no ref

We do not need these extra Tinybird CLI commands.

yarn tb will start local in the correct directory, and exiting that will kill the docker container. It seems unnecessary to keep a command around to remove the container altogether.