### PR TITLE
Removed usage of adjustedAccentColor

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -326,10 +326,12 @@ class EmailRenderer {
 
         const labs = this.getLabs();
         const accentColor = this.#getAccentColor();
+        const accentContrastColor = this.#getAccentContrastColor();
 
         if (labs?.isSet('emailCustomization')) {
             renderOptions.design = {
                 accentColor,
+                accentContrastColor,
                 backgroundColor: newsletter?.get('background_color'),
                 backgroundIsDark: this.#checkIfBackgroundIsDark(newsletter),
                 headerBackgroundColor: this.#getHeaderBackgroundColor(newsletter, accentColor),
@@ -937,6 +939,11 @@ class EmailRenderer {
         return accentColor;
     }
 
+    #getAccentContrastColor() {
+        const accentColor = this.#getAccentColor();
+        return textColorForBackgroundColor(accentColor).hex();
+    }
+
     #getBackgroundColor(newsletter) {
         /** @type {'light' | string | null} */
         const value = newsletter?.get('background_color');
@@ -1117,8 +1124,10 @@ class EmailRenderer {
     async getTemplateData({post, newsletter, html, addPaywall, segment}) {
         const labs = this.getLabs();
 
-        let accentColor = this.#getAccentColor();
+        const accentColor = this.#getAccentColor();
+        const accentContrastColor = this.#getAccentContrastColor();
 
+        // TODO: remove adjusted accent colors when emailCustomization flag is cleaned up
         let adjustedAccentColor;
         let adjustedAccentContrastColor;
         try {
@@ -1300,6 +1309,7 @@ class EmailRenderer {
 
             //CSS
             accentColor: accentColor, // default to #15212A
+            accentContrastColor,
             adjustedAccentColor: adjustedAccentColor || '#3498db', // default to #3498db
             adjustedAccentContrastColor: adjustedAccentContrastColor || '#ffffff', // default to #ffffff
             showBadge: newsletter.get('show_badge'),

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1698,8 +1698,8 @@ img.kg-cta-image {
 .kg-cta-minimal table.btn td.kg-style-accent {
     {{#if hasOutlineButtons}}
     background-color: transparent !important;
-    color: {{adjustedAccentColor}} !important;
-    border: 1px solid {{adjustedAccentColor}} !important;
+    color: {{accentColor}} !important;
+    border: 1px solid {{accentColor}} !important;
     {{else}}
     background-color: {{accentColor}} !important;
     {{/if}}
@@ -1708,8 +1708,8 @@ img.kg-cta-image {
 .kg-cta-immersive table.btn td.kg-style-accent {
     {{#if hasOutlineButtons}}
     background-color: transparent !important;
-    color: {{adjustedAccentColor}} !important;
-    border: 1px solid {{adjustedAccentColor}} !important;
+    color: {{accentColor}} !important;
+    border: 1px solid {{accentColor}} !important;
     {{else}}
     background-color: {{accentColor}} !important;
     color: #fff !important;
@@ -1719,7 +1719,7 @@ img.kg-cta-image {
 .kg-cta-card .btn a.kg-style-accent {
     {{#if hasOutlineButtons}}
     background-color: transparent !important;
-    color: {{adjustedAccentColor}} !important;
+    color: {{accentColor}} !important;
     {{else}}
     background-color: {{accentColor}} !important;
     color: #fff !important;
@@ -2603,22 +2603,22 @@ table.btn a {
 
 table.btn-accent td {
     {{#if hasOutlineButtons}}
-    border: 1px solid {{adjustedAccentColor}};
+    border: 1px solid {{accentColor}};
     background-color: transparent;
     {{else}}
-    background-color: {{adjustedAccentColor}};
+    background-color: {{accentColor}};
     {{/if}}
 }
 
 table.btn-accent a {
     {{#if hasOutlineButtons}}
     background-color: transparent;
-    border-color: {{adjustedAccentColor}};
-    color: {{adjustedAccentColor}};
+    border-color: {{accentColor}};
+    color: {{accentColor}};
     {{else}}
-    background-color: {{adjustedAccentColor}};
-    border-color: {{adjustedAccentColor}};
-    color: {{adjustedAccentContrastColor}};
+    background-color: {{accentColor}};
+    border-color: {{accentColor}};
+    color: {{accentContrastColor}};
     {{/if}}
 }
 {{else}}

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2127,6 +2127,7 @@ describe('Email renderer', function () {
             await testLexicalRenderDesignOptions({
                 expectedObject: {
                     accentColor: '#ffffff',
+                    accentContrastColor: '#000000',
                     backgroundColor: '#000000',
                     backgroundIsDark: true,
                     headerBackgroundColor: '#000044',
@@ -2226,6 +2227,13 @@ describe('Email renderer', function () {
             const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
             return data;
         }
+
+        it('Includes accent and accent contrast colors', async function () {
+            settings.accent_color = '#15212A';
+            const data = await templateDataWithSettings({});
+            assert.equal(data.accentColor, '#15212A');
+            assert.equal(data.accentContrastColor, '#FFFFFF');
+        });
 
         it('Uses the correct background colors based on settings', async function () {
             const tests = [


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1958/

- "adjusted" accent color was a hangover from previous email customization work and was only used for buttons
- removed usage that had crept into the new email customization work so that we're consistently using the base accent color everywhere
- added `accentContrastColor` for use in place of `adjustedAccentContrastColor` and ensured that it gets passed through to card renderers for consistency if they need to use it
