### PR TITLE
Added `x-site-uuid` header to traffic analytics requests

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -86,7 +86,7 @@ export class GhostStats {
             const headers = {
                 'Content-Type': 'application/json',
             };
-            if (config.globalAttributes.site_uuid) {
+            if (config.globalAttributes?.site_uuid) {
                 headers['x-site-uuid'] = config.globalAttributes.site_uuid;
             }
 

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -60,7 +60,6 @@ export class GhostStats {
     }
 
     async trackEvent(name, payload) {
-        console.log(config);
         try {
             // Check if we have required configuration
             if (!config.host || !config.token) {
@@ -84,12 +83,16 @@ export class GhostStats {
             const controller = new AbortController();
             const timeoutId = this.browser.setTimeout(() => controller.abort(), 5000); // 5 second timeout
 
+            const headers = {
+                'Content-Type': 'application/json',
+            };
+            if (config.globalAttributes.site_uuid) {
+                headers['x-site-uuid'] = config.globalAttributes.site_uuid;
+            }
+
             const response = await this.browser.fetch(url, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'x-site-uuid': config.globalAttributes.site_uuid
-                },
+                headers,
                 body: JSON.stringify(data),
                 signal: controller.signal
             });

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -60,6 +60,7 @@ export class GhostStats {
     }
 
     async trackEvent(name, payload) {
+        console.log(config);
         try {
             // Check if we have required configuration
             if (!config.host || !config.token) {
@@ -86,7 +87,8 @@ export class GhostStats {
             const response = await this.browser.fetch(url, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'x-site-uuid': config.globalAttributes.site_uuid
                 },
                 body: JSON.stringify(data),
                 signal: controller.signal

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -183,7 +183,17 @@ describe('ghost-stats.js', function () {
         beforeEach(function () {
             mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
             mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            mockDocument.currentScript.attributes = [
+                {name: 'tb_site_uuid', value: 'test-site-uuid'}
+            ];
             ghostStats.initConfig();
+        });
+
+        it('should set the x-site-uuid header', async function () {
+            await ghostStats.trackEvent('test_event', {data: 'test'});
+
+            expect(mockFetch.calledOnce).to.be.true;
+            expect(mockFetch.firstCall.args[1].headers['x-site-uuid']).to.equal('test-site-uuid');
         });
 
         it('should track custom events with correct data', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2073/send-site-uuid-to-analytics-service-with-a-header-instead-of-in

Currently the `ghost-stats.js` script sends the `site_uuid` in each tracking request's payload. However, since we're using the `site_uuid` for validation in our API Gateway, we'd prefer to set this value in a header, so the API Gateway doesn't need to parse the full request body. 

This commit sets the `x-site-uuid` header on all the tracking requests, so the API Gateway can validate the request just by looking at the headers, which is much less resource intensive than parsing the full request body.