### PR TITLE
Fixed scroll jump when interacting with threaded notes in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -47,6 +47,7 @@ const Note = () => {
     const object = currentPost?.object;
 
     const [replyCount, setReplyCount] = useState(object?.replyCount ?? 0);
+    const [hasScrolledToPost, setHasScrolledToPost] = useState(false);
 
     useEffect(() => {
         if (object?.replyCount !== undefined) {
@@ -55,13 +56,14 @@ const Note = () => {
     }, [object?.replyCount]);
 
     useEffect(() => {
-        if (postRef.current && threadParents.length > 0) {
+        if (postRef.current && threadParents.length > 0 && !hasScrolledToPost) {
             postRef.current.scrollIntoView({
                 behavior: 'instant',
                 block: 'start'
             });
+            setHasScrolledToPost(true);
         }
-    }, [threadParents]);
+    }, [threadParents, hasScrolledToPost]);
 
     useEffect(() => {
         if (observerRef.current) {


### PR DESCRIPTION
ref PROD-1999

- Resolved issue where liking or reposting a note caused page to jump
- Fixed problem specifically affecting notes displayed with parent replies