### PR TITLE
Updated tinybird config to use `site_uuid` setting

### DIFF
--- a/ghost/core/core/server/data/tinybird/readme.md
+++ b/ghost/core/core/server/data/tinybird/readme.md
@@ -15,7 +15,6 @@ Sample config:
         "tracker": {
             "endpoint": "https://e.ghost.org/tb/web_analytics",
             "token": "xxxxx",
-            "id": "local-ghost",
             "datasource": "analytics_events",
             "local": {
                 "enabled": true,
@@ -27,7 +26,6 @@ Sample config:
         "stats": {
             "endpoint": "https://api.tinybird.co",
             "token": "xxxxx",
-            "id": "local-ghost",
             "local": {
                 "enabled": true,
                 "token": "xxxxx",

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -28,10 +28,11 @@ module.exports = function getConfigProperties() {
     // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now
     if (config.get('tinybird') && config.get('tinybird:stats')) {
         const statsConfig = config.get('tinybird:stats');
-        if (!statsConfig.id) {
-            statsConfig.id = settingsCache.get('site_uuid');
-        }
-        configProperties.stats = statsConfig;
+        const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
+        configProperties.stats = {
+            ...statsConfig,
+            id: siteUuid
+        };
     }
 
     return configProperties;

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -1,5 +1,6 @@
 const {isPlainObject} = require('lodash');
 const config = require('../../../shared/config');
+const settingsCache = require('../../../shared/settings-cache');
 const labs = require('../../../shared/labs');
 const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
@@ -26,7 +27,11 @@ module.exports = function getConfigProperties() {
 
     // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now
     if (config.get('tinybird') && config.get('tinybird:stats')) {
-        configProperties.stats = config.get('tinybird:stats');
+        const statsConfig = config.get('tinybird:stats');
+        if (!statsConfig.id) {
+            statsConfig.id = settingsCache.get('site_uuid');
+        }
+        configProperties.stats = statsConfig;
     }
 
     return configProperties;

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -227,12 +227,14 @@ class StatsService {
         let tinybirdClient = null;
         const config = deps.config || require('../../../shared/config');
         const request = deps.request || require('../../lib/request-external');
+        const settingsCache = deps.settingsCache || require('../../../shared/settings-cache');
 
         // Only create the client if Tinybird is configured
         if (config.get('tinybird') && config.get('tinybird:stats')) {
             tinybirdClient = tinybird.create({
                 config,
-                request
+                request,
+                settingsCache
             });
         }
 

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -5,9 +5,10 @@ const logging = require('@tryghost/logging');
  * @param {object} deps - Configuration and request dependencies
  * @param {object} deps.config - Ghost configuration
  * @param {object} deps.request - HTTP request client
+ * @param {object} deps.settingsCache - Settings cache client
  * @returns {Object} Tinybird client with methods
  */
-const create = ({config, request}) => {
+const create = ({config, request, settingsCache}) => {
     /**
      * Builds a Tinybird API request
      * @param {string} pipeName - The name of the Tinybird pipe to query
@@ -22,6 +23,10 @@ const create = ({config, request}) => {
      */
     const buildRequest = (pipeName, options = {}) => {
         const statsConfig = config.get('tinybird:stats');
+        // TEMP HACK: allow override of site_uuid via config
+        if (!statsConfig.id) {
+            statsConfig.id = settingsCache.get('site_uuid');
+        }
         const localEnabled = statsConfig?.local?.enabled ?? false;
         const endpoint = localEnabled ? statsConfig.local.endpoint : statsConfig.endpoint;
         const token = localEnabled ? statsConfig.local.token : statsConfig.token;

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -26,9 +26,7 @@ const create = ({config, request, settingsCache}) => {
         // Use tinybird:stats:id if provided, otherwise use site_uuid from settings cache
         // Allows overriding site_uuid via config
         // This is temporary until we have a proper way to use mock data locally
-        if (!statsConfig.id) {
-            statsConfig.id = settingsCache.get('site_uuid');
-        }
+        const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
         const localEnabled = statsConfig?.local?.enabled ?? false;
         const endpoint = localEnabled ? statsConfig.local.endpoint : statsConfig.endpoint;
         const token = localEnabled ? statsConfig.local.token : statsConfig.token;
@@ -42,7 +40,7 @@ const create = ({config, request, settingsCache}) => {
 
         // Use snake_case for query parameters as expected by Tinybird API
         const searchParams = {
-            site_uuid: statsConfig.id
+            site_uuid: siteUuid
         };
 
         // todo: refactor all uses to simply pass options through

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -23,7 +23,9 @@ const create = ({config, request, settingsCache}) => {
      */
     const buildRequest = (pipeName, options = {}) => {
         const statsConfig = config.get('tinybird:stats');
-        // TEMP HACK: allow override of site_uuid via config
+        // Use tinybird:stats:id if provided, otherwise use site_uuid from settings cache
+        // Allows overriding site_uuid via config
+        // This is temporary until we have a proper way to use mock data locally
         if (!statsConfig.id) {
             statsConfig.id = settingsCache.get('site_uuid');
         }

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -1,6 +1,8 @@
 const assert = require('assert/strict');
 const configUtils = require('../../../../utils/configUtils');
+const settingsCache = require('../../../../../core/shared/settings-cache');
 const getConfigProperties = require('../../../../../core/server/services/public-config/config');
+const sinon = require('sinon');
 
 // List of allowed keys to be returned by the public-config service
 // This is kind of a duplicate of the keys in the config.js output serializer in the api-framework
@@ -27,8 +29,12 @@ const allowedKeys = [
 
 describe('Public-config Service', function () {
     describe('Config Properties', function () {
+        beforeEach(async function () {
+            sinon.stub(settingsCache, 'get').returns('931ade9e-a4f1-4217-8625-34bd34250c16');
+        });
         afterEach(async function () {
             await configUtils.restore();
+            sinon.restore();
         });
 
         it('should return the correct default config properties', function () {
@@ -84,7 +90,19 @@ describe('Public-config Service', function () {
 
             let configProperties = getConfigProperties();
 
-            assert.deepEqual(configProperties.stats, {endpoint: 'xxx'});
+            assert.deepEqual(configProperties.stats, {endpoint: 'xxx', id: '931ade9e-a4f1-4217-8625-34bd34250c16'});
+        });
+
+        it('should return stats id when tinybird config is set with the id key', function () {
+            configUtils.set('tinybird', {
+                stats: {
+                    id: '1234567890'
+                }
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.deepEqual(configProperties.stats.id, '1234567890');
         });
 
         it('should NOT return stats when tinybird config is set without the stats key', function () {

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -30,7 +30,9 @@ const allowedKeys = [
 describe('Public-config Service', function () {
     describe('Config Properties', function () {
         beforeEach(async function () {
-            sinon.stub(settingsCache, 'get').returns('931ade9e-a4f1-4217-8625-34bd34250c16');
+            sinon.stub(settingsCache, 'get')
+                .withArgs('site_uuid')
+                .returns('931ade9e-a4f1-4217-8625-34bd34250c16');
         });
         afterEach(async function () {
             await configUtils.restore();

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -6,6 +6,7 @@ describe('Tinybird Client', function () {
     let tinybirdClient;
     let mockConfig;
     let mockRequest;
+    let mockSettingsCache;
     
     beforeEach(function () {
         // Set up mocks
@@ -17,18 +18,23 @@ describe('Tinybird Client', function () {
             get: sinon.stub()
         };
 
+        mockSettingsCache = {
+            get: sinon.stub()
+        };
+
         // Configure mocks
         mockConfig.get.withArgs('timezone').returns('UTC');
         mockConfig.get.withArgs('tinybird:stats').returns({
-            id: 'site-id',
             endpoint: 'https://api.tinybird.co',
             token: 'tb-token'
         });
+        mockSettingsCache.get.withArgs('site_uuid').returns('931ade9e-a4f1-4217-8625-34bd34250c16');
 
         // Create tinybird client with mocked dependencies
         tinybirdClient = tinybird.create({
             config: mockConfig,
-            request: mockRequest
+            request: mockRequest,
+            settingsCache: mockSettingsCache
         });
     });
 
@@ -45,7 +51,7 @@ describe('Tinybird Client', function () {
 
             should.exist(url);
             url.should.startWith('https://api.tinybird.co/v0/pipes/test_pipe.json?');
-            url.should.containEql('site_uuid=site-id');
+            url.should.containEql('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16');
             url.should.containEql('date_from=2023-01-01');
             url.should.containEql('date_to=2023-01-31');
             // url.should.containEql('timezone=UTC');
@@ -74,7 +80,7 @@ describe('Tinybird Client', function () {
                 memberStatus: 'paid'
             });
 
-            url.should.containEql('site_uuid=site-id');
+            url.should.containEql('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16');
             url.should.containEql('timezone=America%2FNew_York');
             url.should.containEql('member_status=paid');
         });
@@ -82,7 +88,6 @@ describe('Tinybird Client', function () {
         it('uses local endpoint and token when local is enabled', function () {
             // Update config mock to return local config
             mockConfig.get.withArgs('tinybird:stats').returns({
-                id: 'site-id',
                 endpoint: 'https://api.tinybird.co',
                 token: 'tb-token',
                 local: {
@@ -101,7 +106,6 @@ describe('Tinybird Client', function () {
         it('ignores tbVersion when local is enabled', function () {
             // Update config mock to return local config
             mockConfig.get.withArgs('tinybird:stats').returns({
-                id: 'site-id',
                 endpoint: 'https://api.tinybird.co',
                 token: 'tb-token',
                 local: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-197/ghost-site-uuid-implementation

Currently traffic analytics uses the configured value from `tinybird:stats:id` for the `site_uuid` when querying Tinybird. Now that we have a `site_uuid` settings key persisted in the database, we should switch to using this value as the source of truth, rather than passing it via config. This change switches to using the `site_uuid` setting if the value isn't provided via config, which allows us to override the `site_uuid` to e.g. that of a staging site with real data for local testing. 

Once we make it easier to generate fake data for local development, we should remove this logic, and strictly use the `site_uuid` in the settings table. Until then, this allows us to switch over to using the `site_uuid` in production, while still allowing overrides for local development. 