### PR TITLE
Fixed email product card rating always using dark images

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/product-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/product-renderer.js
@@ -11,9 +11,11 @@ function renderProductNode(node, options = {}) {
         return renderEmptyContainer(document);
     }
 
+    const dataset = node.getDataset();
+
     let buttonBorderRadius = '5px';
 
-    // we're switching to 6px by default as part of settings being added
+    // we're switching to 6px by default as part of emailCustomization project
     // TODO: remove 'rounded' check and switch default above to 6px
     if (options.design?.buttonCorners === 'rounded') {
         buttonBorderRadius = '6px';
@@ -23,10 +25,16 @@ function renderProductNode(node, options = {}) {
         buttonBorderRadius = '9999px';
     }
 
+    const ratingImage = options.design?.backgroundIsDark
+        ? `https://static.ghost.org/v4.0.0/images/star-rating-darkmode-${dataset.productStarRating}.png`
+        : `https://static.ghost.org/v4.0.0/images/star-rating-${dataset.productStarRating}.png`;
+
     const templateData = {
-        ...node.getDataset(),
+        ...dataset,
         starIcon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg>`,
-        buttonBorderRadius
+        ratingImage,
+        buttonBorderRadius,
+        productRatingEnabled: dataset.productRatingEnabled && dataset.productStarRating !== undefined
     };
 
     const starActiveClasses = 'kg-product-card-rating-active';
@@ -118,7 +126,7 @@ function emailCardTemplate({data, feature}) {
                             ${data.productRatingEnabled ? `
                                 <tr class="kg-product-rating">
                                     <td valign="top">
-                                        <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.productStarRating}.png`}" border="0" />
+                                        <img src="${data.ratingImage}" border="0" />
                                     </td>
                                 </tr>
                             ` : ''}

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/product-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/product-renderer.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert/strict');
-const {callRenderer, html, assertPrettifiesTo} = require('../test-utils');
+const {callRenderer, html, assertPrettifiesTo, assertPrettifiedIncludes} = require('../test-utils');
 
 describe('services/koenig/node-renderers/product-renderer', function () {
     function getTestData(overrides = {}) {
@@ -13,6 +13,7 @@ describe('services/koenig/node-renderers/product-renderer', function () {
             productButtonEnabled: true,
             productButton: 'Button text',
             productUrl: 'https://google.com/',
+            productStarRating: 3,
             ...overrides
         };
     }
@@ -39,17 +40,17 @@ describe('services/koenig/node-renderers/product-renderer', function () {
                             <h4 class="kg-product-card-title">This is a <b>title</b></h4>
                         </div>
                         <div class="kg-product-card-rating">
-                            <span class=" kg-product-card-rating-star">
+                            <span class="kg-product-card-rating-active kg-product-card-rating-star">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                     <path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path>
                                 </svg>
                             </span>
-                            <span class=" kg-product-card-rating-star">
+                            <span class="kg-product-card-rating-active kg-product-card-rating-star">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                     <path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path>
                                 </svg>
                             </span>
-                            <span class=" kg-product-card-rating-star">
+                            <span class="kg-product-card-rating-active kg-product-card-rating-star">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                     <path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path>
                                 </svg>
@@ -102,7 +103,7 @@ describe('services/koenig/node-renderers/product-renderer', function () {
                         </tr>
                         <tr style="padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;">
                             <td valign="top">
-                                <img src="https://static.ghost.org/v4.0.0/images/star-rating-undefined.png" style="border: none; width: 96px" border="0" />
+                                <img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" style="border: none; width: 96px" border="0" />
                             </td>
                         </tr>
                         <tr>
@@ -160,7 +161,7 @@ describe('services/koenig/node-renderers/product-renderer', function () {
                                         <tr class="kg-product-rating">
                                             <td valign="top">
                                                 <img
-                                                    src="https://static.ghost.org/v4.0.0/images/star-rating-undefined.png"
+                                                    src="https://static.ghost.org/v4.0.0/images/star-rating-3.png"
                                                     border="0" />
                                             </td>
                                         </tr>
@@ -198,6 +199,22 @@ describe('services/koenig/node-renderers/product-renderer', function () {
         it('renders nothing with a missing data', function () {
             const result = renderForEmail(getTestData({isEmpty: () => true}), {feature: {emailCustomization: true}});
             assert.equal(result.html, '');
+        });
+
+        it('renders dark mode rating image when background is dark', function () {
+            const result = renderForEmail(getTestData(), {feature: {emailCustomization: true}, design: {backgroundIsDark: true}});
+            assert.ok(result.html);
+            assertPrettifiedIncludes(result.html, html`
+                <img src="https://static.ghost.org/v4.0.0/images/star-rating-darkmode-3.png" border="0" />
+            `);
+        });
+
+        it('renders light mode rating image when background is light', function () {
+            const result = renderForEmail(getTestData(), {feature: {emailCustomization: true}, design: {backgroundIsDark: false}});
+            assert.ok(result.html);
+            assertPrettifiedIncludes(result.html, html`
+                <img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" border="0" />
+            `);
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2048/

- enabled switch to the existing darkmode images when the email background is dark
- ensures we're showing a white rating alongside white text on dark backgrounds and dark rating alongside dark text on light backgrounds
