### PR TITLE
Fixed "Auto" button color always using accent color

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -957,8 +957,8 @@ class EmailRenderer {
     }
 
     #getPostTitleColor(newsletter, accentColor) {
-        /** @type {'accent' | 'auto' | string | null} */
-        const value = newsletter.get('post_title_color');
+        /** @type {'accent' | string | null} */
+        const value = newsletter?.get('post_title_color');
 
         if (VALID_HEX_REGEX.test(value)) {
             return value;
@@ -968,7 +968,7 @@ class EmailRenderer {
             return accentColor;
         }
 
-        // value === 'auto', value === null, value is not valid hex
+        // value === null, value is not valid hex
         const backgroundColor = this.#getHeaderBackgroundColor(newsletter, accentColor) || this.#getBackgroundColor(newsletter);
         return textColorForBackgroundColor(backgroundColor).hex();
     }
@@ -979,7 +979,7 @@ class EmailRenderer {
             return null;
         }
 
-        /** @type {'accent' | 'auto' | string | null} */
+        /** @type {'accent' | string | null} */
         const value = newsletter.get('section_title_color');
 
         if (VALID_HEX_REGEX.test(value)) {
@@ -1069,14 +1069,14 @@ class EmailRenderer {
     }
 
     #getButtonColor(newsletter, accentColor) {
-        /** @type {'accent' | 'auto' | string | null} */
-        const buttonColor = newsletter?.get('button_color') || 'accent';
+        /** @type {'accent' | string | null} */
+        const buttonColor = newsletter?.get('button_color');
 
         if (buttonColor === 'accent') {
             return accentColor;
         }
 
-        if (buttonColor === 'auto') {
+        if (buttonColor === null) {
             const backgroundColor = this.#getBackgroundColor(newsletter);
             return textColorForBackgroundColor(backgroundColor).hex();
         }

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2833,10 +2833,9 @@ describe('Email renderer', function () {
 
         [
             // button_color, expectedButtonColor, expectedButtonTextColor, otherSettings
-            [null, '#15212A', '#FFFFFF'],
+            [null, '#000000', '#FFFFFF', {background_color: '#dddddd'}], // light bg
+            [null, '#FFFFFF', '#000000', {background_color: '#222222'}], // dark bg
             ['accent', '#15212A', '#FFFFFF'],
-            ['auto', '#000000', '#FFFFFF', {background_color: '#dddddd'}], // light bg
-            ['auto', '#FFFFFF', '#000000', {background_color: '#222222'}], // dark bg
             ['#BADA55', '#BADA55', '#000000'],
             ['#nothex', '#15212A', '#FFFFFF']
         ].forEach(([settingValue, expectedValue, expectedTextValue, otherSettings]) => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2037/

- our code to determine button color mistakenly used `'auto'` in place of `null` in it's conditionals meaning we always defaulted to accent color when `newsletter.button_color` was set to `null`
- fixed conditionals in `#getButtonColor()`
- removed incorrect references to `'auto'` in various types and comments, "auto" is always represented as `null` in our color fields
