### PR TITLE
Improved behaviour of outline buttons in darkmode inversions

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -2571,7 +2571,9 @@ table.btn {
 table.btn td {
     padding: 8px 20px 9px;
     {{#if hasOutlineButtons}}
+    color: {{buttonColor}};
     border: 1px solid {{buttonColor}};
+    border-color: currentColor; {{!-- match text color in dark mode inversions --}}
     background-color: transparent;
     {{else}}
     background-color: {{buttonColor}};
@@ -2598,7 +2600,9 @@ table.btn a {
 
 table.btn-accent td {
     {{#if hasOutlineButtons}}
+    color: {{accentColor}};
     border: 1px solid {{accentColor}};
+    border-color: currentColor; {{!-- match text color in dark mode inversions --}}
     background-color: transparent;
     {{else}}
     background-color: {{accentColor}};
@@ -2607,12 +2611,8 @@ table.btn-accent td {
 
 table.btn-accent a {
     {{#if hasOutlineButtons}}
-    background-color: transparent;
-    border-color: {{accentColor}};
     color: {{accentColor}};
     {{else}}
-    background-color: {{accentColor}};
-    border-color: {{accentColor}};
     color: {{accentContrastColor}};
     {{/if}}
 }

--- a/ghost/core/core/server/services/koenig/render-partials/email-button.js
+++ b/ghost/core/core/server/services/koenig/render-partials/email-button.js
@@ -111,9 +111,10 @@ function _getButtonStyle({color, style}) {
             backgroundColor: color
         },
         _isColoredOutline({color, style}) && {
+            color: `${color} !important`,
             border: `1px solid ${color}`,
-            backgroundColor: 'transparent',
-            color: `${color} !important`
+            borderColor: 'currentColor', // match text color in dark mode inversions
+            backgroundColor: 'transparent'
         }
     );
 }

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
@@ -231,7 +231,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                 <table class="btn" border="0" cellspacing="0" cellpadding="0">
                     <tbody>
                         <tr>
-                            <td align="center" style="border: 1px solid #000000; background-color: transparent; color: #000000 !important;">
+                            <td align="center" style="color: #000000 !important; border: 1px solid #000000; border-color: currentColor; background-color: transparent;">
                                 <a href="http://blog.com/post1" style="color: #000000 !important;">
                                     click me
                                 </a>

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
@@ -194,7 +194,7 @@ describe('services/koenig/node-renderers/header-v2-renderer', function () {
             const result = renderForEmail(getTestData(), {design: {buttonStyle: 'outline'}, feature: {emailCustomization: true}});
 
             assertPrettifiedIncludes(result.html, html`
-                <td align="center" style="border: 1px solid #ffffff; background-color: transparent; color: #ffffff !important">
+                <td align="center" style="color: #ffffff !important; border: 1px solid #ffffff; border-color: currentColor; background-color: transparent;">
                     <a href="https://example.com/" style="color: #ffffff !important">The button</a>
                 </td>
             `);

--- a/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
@@ -79,7 +79,7 @@ describe('koenig/services/render-partials/email-button', function () {
         });
         it('returns expected style for outline custom color button', function () {
             const result = emailButton._getButtonStyle({color: '#222222', style: 'outline'});
-            assert.equal(result, 'border: 1px solid #222222; background-color: transparent; color: #222222 !important;');
+            assert.equal(result, 'color: #222222 !important; border: 1px solid #222222; border-color: currentColor; background-color: transparent;');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2054/

- when outline button colors get inverted by email clients in dark mode we want the outline border to match the text color but this wasn't always happening due to email clients have varied/inconsistent handling of border color changes
- added `border-color: currentColor` in addition to the standard border color (kept as a fallback) plus an explicit `color: #xxx` value on the button table so that when email clients adjust the text color our border color automatically adjusts to match
