### PR TITLE
Reduced likelihood of subscription box triggering gmail auto-resizing

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1016,7 +1016,6 @@ h3.latest-posts-header {
     text-decoration: none;
 }
 .manage-subscription {
-    white-space: nowrap;
     font-size: 15px;
     font-weight: 400;
     text-align: right;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2016/

- having the unwrappable link TD next to the subscription details TD was causing gmail to break card layouts when it tried/failed to automatically resize it to fit
