### PR TITLE
Fixed Outlook always having blue links in header cards

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -1814,20 +1814,6 @@ img.kg-cta-image {
     text-align: left;
 }
 
-.kg-header-card.kg-style-dark {
-    background: #15171a;
-    color: #ffffff;
-}
-
-.kg-header-card.kg-style-light {
-    background-color: #F9F9FA;
-}
-
-.kg-header-card.kg-style-accent {
-    background: {{accentColor}};
-    color: #ffffff;
-}
-
 .kg-header-card.kg-style-image {
     background-color: #e7e7eb;
     background-size: cover;
@@ -1901,6 +1887,14 @@ img.kg-cta-image {
 .kg-header-card.kg-v2 .kg-header-card-subheading a {
     color: inherit;
     text-decoration: underline;
+}
+
+.kg-header-card.kg-header-card-dark-bg a {
+    color: #ffffff !important;
+}
+
+.kg-header-card.kg-header-card-light-bg a {
+    color: #000000 !important;
 }
 
 {{else}}

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -86,10 +86,12 @@ function emailTemplate(nodeData, options) {
         style: options?.design?.buttonStyle
     });
 
+    const hasDarkBg = nodeData.textColor?.toLowerCase() === '#ffffff';
+
     if (options?.feature?.emailCustomization) {
         return (
             `
-            <div class="kg-header-card kg-v2" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+            <div class="kg-header-card kg-v2${hasDarkBg ? ' kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                         <tr>

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -5005,7 +5005,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                         </tbody></table>
                     </td>
                 </tr>
-            </tbody></table><div class=\\"kg-header-card kg-v2\\" style=\\"margin: 0 0 1.5em 0; padding: 0; color: #FFFFFF; text-align: center; background-color: #000000;\\">
+            </tbody></table><div class=\\"kg-header-card kg-v2 kg-header-card-dark-bg\\" style=\\"margin: 0 0 1.5em 0; padding: 0; color: #FFFFFF; text-align: center; background-color: #000000;\\">
                 
                 <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                     <tbody><tr>
@@ -6419,7 +6419,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                         </tbody></table>
                     </td>
                 </tr>
-            </tbody></table><div class=\\"kg-header-card kg-v2\\" style=\\"margin: 0 0 1.5em 0; padding: 0; color: #FFFFFF; text-align: center; background-color: #000000;\\">
+            </tbody></table><div class=\\"kg-header-card kg-v2 kg-header-card-dark-bg\\" style=\\"margin: 0 0 1.5em 0; padding: 0; color: #FFFFFF; text-align: center; background-color: #000000;\\">
                 
                 <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                     <tbody><tr>

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
@@ -121,7 +121,7 @@ describe('services/koenig/node-renderers/header-v2-renderer', function () {
 
             assertPrettifiesTo(result.html, html`
                 <div
-                    class="kg-header-card kg-v2"
+                    class="kg-header-card kg-v2 kg-header-card-dark-bg"
                     style="
                         color: #ffffff;
                         text-align: center;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1827/

- added `kg-header-card-dark-bg` and `kg-header-card-light-bg` classes to the card output so we can specifically target the `a` elements in the user-provided HTML content
- Outlook requires an explicit `color` style on `a` elements in order to override it's default blue color for links, using the new class allowed us to target those with the correct white/black text color so they match the surrounding text
