### PR TITLE
Removed zero comment count on feed items in activitypub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemStats.tsx
@@ -121,7 +121,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
                     onClick={handleCommentClick}
                 >
                     <LucideIcon.MessageCircle className='-mr-px' />
-                    {layout !== 'inbox' && formatNumber(commentCount)}
+                    {(layout !== 'inbox' && commentCount > 0) && formatNumber(commentCount)}
                 </Button>
                 <Button
                     className={`${buttonClass} ${isReposted && 'text-green-500 hover:text-green-500'}`}


### PR DESCRIPTION
no ref

Removed zero comment count on feed items in activitypub to be consistent with other feed item stats