### PR TITLE
Added labs flag to enable traffic analytics tracking separately

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -12,7 +12,6 @@ const {cardAssets} = require('../services/assets-minification');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('ghost_head');
-const crypto = require('crypto');
 const templateStyles = require('./tpl/styles');
 const {getFrontendAppConfig, getDataAttributes} = require('../utils/frontend-apps');
 
@@ -167,15 +166,12 @@ function getTinybirdTrackerScript(dataRoot) {
     const token = localEnabled ? localConfig.token : statsConfig.token;
     const datasource = localEnabled ? localConfig.datasource : statsConfig.datasource;
 
-    const isTrackingOnly = labs.isSet('trafficAnalyticsTracking') && !labs.isSet('trafficAnalytics');
-    const siteUuid = isTrackingOnly ? 'anon_' + crypto.createHash('sha256').update(settingsCache.get('site_uuid')).digest('hex').substring(0, 16) : settingsCache.get('site_uuid');
-    
     const tbParams = _.map({
-        site_uuid: siteUuid,
-        post_uuid: isTrackingOnly ? undefined : dataRoot.post?.uuid,
+        site_uuid: settingsCache.get('site_uuid'),
+        post_uuid: dataRoot.post?.uuid,
         post_type: dataRoot.context.includes('post') ? 'post' : dataRoot.context.includes('page') ? 'page' : null,
-        member_uuid: isTrackingOnly ? undefined : dataRoot.member?.uuid,
-        member_status: isTrackingOnly ? undefined : dataRoot.member?.status
+        member_uuid: dataRoot.member?.uuid,
+        member_status: dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');
 
     return `<script defer src="${src}" data-stringify-payload="false" ${datasource ? `data-datasource="${datasource}"` : ''} data-storage="localStorage" data-host="${endpoint}" data-token="${token}" ${tbParams}></script>`;

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -360,8 +360,9 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
             if (!_.isEmpty(tagCodeInjection)) {
                 head.push(tagCodeInjection);
             }
-
-            if ((labs.isSet('trafficAnalytics') || labs.isSet('trafficAnalyticsTracking')) && config.get('tinybird') && config.get('tinybird:tracker')) {
+            const isTbTrackingEnabled = labs.isSet('trafficAnalytics') || labs.isSet('trafficAnalyticsTracking');
+            const hasTbConfig = config.get('tinybird') && config.get('tinybird:tracker');
+            if (isTbTrackingEnabled && hasTbConfig) {
                 head.push(getTinybirdTrackerScript(dataRoot));
                 // Set a flag in response locals to indicate tracking script is being served
                 if (dataRoot._locals) {

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -12,6 +12,7 @@ const {cardAssets} = require('../services/assets-minification');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('ghost_head');
+const crypto = require('crypto');
 const templateStyles = require('./tpl/styles');
 const {getFrontendAppConfig, getDataAttributes} = require('../utils/frontend-apps');
 
@@ -166,12 +167,15 @@ function getTinybirdTrackerScript(dataRoot) {
     const token = localEnabled ? localConfig.token : statsConfig.token;
     const datasource = localEnabled ? localConfig.datasource : statsConfig.datasource;
 
+    const isTrackingOnly = labs.isSet('trafficAnalyticsTracking') && !labs.isSet('trafficAnalytics');
+    const siteUuid = isTrackingOnly ? 'anon_' + crypto.createHash('sha256').update(settingsCache.get('site_uuid')).digest('hex').substring(0, 16) : settingsCache.get('site_uuid');
+    
     const tbParams = _.map({
-        site_uuid: settingsCache.get('site_uuid'),
-        post_uuid: dataRoot.post?.uuid,
+        site_uuid: siteUuid,
+        post_uuid: isTrackingOnly ? undefined : dataRoot.post?.uuid,
         post_type: dataRoot.context.includes('post') ? 'post' : dataRoot.context.includes('page') ? 'page' : null,
-        member_uuid: dataRoot.member?.uuid,
-        member_status: dataRoot.member?.status
+        member_uuid: isTrackingOnly ? undefined : dataRoot.member?.uuid,
+        member_status: isTrackingOnly ? undefined : dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');
 
     return `<script defer src="${src}" data-stringify-payload="false" ${datasource ? `data-datasource="${datasource}"` : ''} data-storage="localStorage" data-host="${endpoint}" data-token="${token}" ${tbParams}></script>`;

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -361,7 +361,7 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
                 head.push(tagCodeInjection);
             }
 
-            if (labs.isSet('trafficAnalytics') && config.get('tinybird') && config.get('tinybird:tracker')) {
+            if ((labs.isSet('trafficAnalytics') || labs.isSet('trafficAnalyticsTracking')) && config.get('tinybird') && config.get('tinybird:tracker')) {
                 head.push(getTinybirdTrackerScript(dataRoot));
                 // Set a flag in response locals to indicate tracking script is being served
                 if (dataRoot._locals) {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -43,6 +43,7 @@ const PRIVATE_FEATURES = [
     'stripeAutomaticTax',
     'webmentions',
     'trafficAnalytics',
+    'trafficAnalyticsTracking',
     'importMemberTier',
     'urlCache',
     'emailCustomization',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,6 +30,7 @@ Object {
       "themeErrorsNotification": true,
       "trafficAnalytics": true,
       "trafficAnalyticsAlpha": true,
+      "trafficAnalyticsTracking": true,
       "updatedMainNav": true,
       "urlCache": true,
       "webmentions": true,

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -1733,6 +1733,57 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when preview is set 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
@@ -1915,6 +1966,110 @@ Object {
 `;
 
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script when both trafficAnalytics and trafficAnalyticsTracking are set 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script when trafficAnalyticsTracking is set 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -1733,6 +1733,58 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set anonymizes site_uuid when trafficAnalyticsTracking is enabled but trafficAnalytics is not 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -1965,6 +2017,58 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes member data when both trafficAnalytics and trafficAnalyticsTracking are enabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\"></script>",
+}
+`;
+
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -2117,7 +2221,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
@@ -2170,6 +2274,76 @@ Object {
     
     <link href=\\"http://localhost:2388/blog/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/blog/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set omits member and post data when trafficAnalyticsTracking is enabled but trafficAnalytics is not 1 1`] = `
+Object {
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Testing stats\\">
+    <meta property=\\"og:description\\" content=\\"Creating stats for the site\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Testing stats\\">
+    <meta name=\\"twitter:description\\" content=\\"Creating stats for the site\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"Article\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"author\\": {
+        \\"@type\\": \\"Person\\",
+        \\"name\\": \\"Author name\\",
+        \\"image\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/content/images/test-author-image.png\\"
+        },
+        \\"url\\": \\"https://mysite.com/fakeauthor/\\",
+        \\"sameAs\\": [
+            \\"http://authorwebsite.com\\",
+            \\"https://www.facebook.com/testuser\\",
+            \\"https://x.com/testuser\\"
+        ]
+    },
+    \\"headline\\": \\"Testing stats\\",
+    \\"url\\": \\"http://127.0.0.1:2369/post/\\",
+    \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"description\\": \\"Creating stats for the site\\",
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/post/\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"post\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -1733,58 +1733,6 @@ Object {
 }
 `;
 
-exports[`{{ghost_head}} helper includes tinybird tracker script when config is set anonymizes site_uuid when trafficAnalyticsTracking is enabled but trafficAnalytics is not 1 1`] = `
-Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
-    <meta property=\\"og:type\\" content=\\"website\\">
-    <meta property=\\"og:title\\" content=\\"Ghost\\">
-    <meta property=\\"og:description\\" content=\\"site description\\">
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
-    <meta name=\\"twitter:description\\" content=\\"site description\\">
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    
-    <script type=\\"application/ld+json\\">
-{
-    \\"@context\\": \\"https://schema.org\\",
-    \\"@type\\": \\"WebSite\\",
-    \\"publisher\\": {
-        \\"@type\\": \\"Organization\\",
-        \\"name\\": \\"Ghost\\",
-        \\"url\\": \\"http://127.0.0.1:2369/\\",
-        \\"logo\\": {
-            \\"@type\\": \\"ImageObject\\",
-            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
-        }
-    },
-    \\"url\\": \\"http://127.0.0.1:2369/\\",
-    \\"name\\": \\"Ghost\\",
-    \\"image\\": {
-        \\"@type\\": \\"ImageObject\\",
-        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
-    },
-    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
-    \\"description\\": \\"site description\\"
-}
-    </script>
-
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
-    
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
-}
-`;
-
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -2017,58 +1965,6 @@ Object {
 }
 `;
 
-exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes member data when both trafficAnalytics and trafficAnalyticsTracking are enabled 1 1`] = `
-Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
-    <meta property=\\"og:type\\" content=\\"website\\">
-    <meta property=\\"og:title\\" content=\\"Ghost\\">
-    <meta property=\\"og:description\\" content=\\"site description\\">
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
-    <meta name=\\"twitter:description\\" content=\\"site description\\">
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    
-    <script type=\\"application/ld+json\\">
-{
-    \\"@context\\": \\"https://schema.org\\",
-    \\"@type\\": \\"WebSite\\",
-    \\"publisher\\": {
-        \\"@type\\": \\"Organization\\",
-        \\"name\\": \\"Ghost\\",
-        \\"url\\": \\"http://127.0.0.1:2369/\\",
-        \\"logo\\": {
-            \\"@type\\": \\"ImageObject\\",
-            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
-        }
-    },
-    \\"url\\": \\"http://127.0.0.1:2369/\\",
-    \\"name\\": \\"Ghost\\",
-    \\"image\\": {
-        \\"@type\\": \\"ImageObject\\",
-        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
-    },
-    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
-    \\"description\\": \\"site description\\"
-}
-    </script>
-
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
-    
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\"></script>",
-}
-`;
-
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -2221,7 +2117,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
@@ -2274,76 +2170,6 @@ Object {
     
     <link href=\\"http://localhost:2388/blog/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/blog/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
-}
-`;
-
-exports[`{{ghost_head}} helper includes tinybird tracker script when config is set omits member and post data when trafficAnalyticsTracking is enabled but trafficAnalytics is not 1 1`] = `
-Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\">
-    
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
-    <meta property=\\"og:type\\" content=\\"article\\">
-    <meta property=\\"og:title\\" content=\\"Testing stats\\">
-    <meta property=\\"og:description\\" content=\\"Creating stats for the site\\">
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
-    <meta name=\\"twitter:title\\" content=\\"Testing stats\\">
-    <meta name=\\"twitter:description\\" content=\\"Creating stats for the site\\">
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
-    
-    <script type=\\"application/ld+json\\">
-{
-    \\"@context\\": \\"https://schema.org\\",
-    \\"@type\\": \\"Article\\",
-    \\"publisher\\": {
-        \\"@type\\": \\"Organization\\",
-        \\"name\\": \\"Ghost\\",
-        \\"url\\": \\"http://127.0.0.1:2369/\\",
-        \\"logo\\": {
-            \\"@type\\": \\"ImageObject\\",
-            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
-        }
-    },
-    \\"author\\": {
-        \\"@type\\": \\"Person\\",
-        \\"name\\": \\"Author name\\",
-        \\"image\\": {
-            \\"@type\\": \\"ImageObject\\",
-            \\"url\\": \\"http://127.0.0.1:2369/content/images/test-author-image.png\\"
-        },
-        \\"url\\": \\"https://mysite.com/fakeauthor/\\",
-        \\"sameAs\\": [
-            \\"http://authorwebsite.com\\",
-            \\"https://www.facebook.com/testuser\\",
-            \\"https://x.com/testuser\\"
-        ]
-    },
-    \\"headline\\": \\"Testing stats\\",
-    \\"url\\": \\"http://127.0.0.1:2369/post/\\",
-    \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
-    \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
-    \\"description\\": \\"Creating stats for the site\\",
-    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/post/\\"
-}
-    </script>
-
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
-    
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"anon_b0a7b3c03de9f004\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"post\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1409,6 +1409,10 @@ describe('{{ghost_head}} helper', function () {
 
     describe('includes tinybird tracker script when config is set', function () {
         let labsStub;
+        function setAnalyticsFlags({analytics = false, tracking = false} = {}) {
+            labsStub.withArgs('trafficAnalytics').returns(analytics);
+            labsStub.withArgs('trafficAnalyticsTracking').returns(tracking);
+        }
         beforeEach(function () {
             configUtils.set({
                 tinybird: {
@@ -1426,7 +1430,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             });
             labsStub = sinon.stub(labs, 'isSet');
-            labsStub.withArgs('trafficAnalytics').returns(true);
+            setAnalyticsFlags({analytics: true, tracking: false});
             labsStub.withArgs('i18n').returns(true);
         });
 
@@ -1443,7 +1447,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('does not include tracker script when trafficAnalytics is not set', async function () {
-            labsStub.withArgs('trafficAnalytics').returns(false);
+            setAnalyticsFlags({analytics: false, tracking: false});
 
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
@@ -1457,8 +1461,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('includes tracker script when trafficAnalyticsTracking is set', async function () {
-            labsStub.withArgs('trafficAnalytics').returns(false);
-            labsStub.withArgs('trafficAnalyticsTracking').returns(true);
+            setAnalyticsFlags({analytics: false, tracking: true});
 
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
@@ -1472,8 +1475,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('includes tracker script when both trafficAnalytics and trafficAnalyticsTracking are set', async function () {
-            labsStub.withArgs('trafficAnalytics').returns(true);
-            labsStub.withArgs('trafficAnalyticsTracking').returns(true);
+            setAnalyticsFlags({analytics: true, tracking: true});
 
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
@@ -1487,8 +1489,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set', async function () {
-            labsStub.withArgs('trafficAnalytics').returns(false);
-            labsStub.withArgs('trafficAnalyticsTracking').returns(false);
+            setAnalyticsFlags({analytics: false, tracking: false});
 
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1456,6 +1456,51 @@ describe('{{ghost_head}} helper', function () {
             rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
         });
 
+        it('includes tracker script when trafficAnalyticsTracking is set', async function () {
+            labsStub.withArgs('trafficAnalytics').returns(false);
+            labsStub.withArgs('trafficAnalyticsTracking').returns(true);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+        });
+
+        it('includes tracker script when both trafficAnalytics and trafficAnalyticsTracking are set', async function () {
+            labsStub.withArgs('trafficAnalytics').returns(true);
+            labsStub.withArgs('trafficAnalyticsTracking').returns(true);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+        });
+
+        it('does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set', async function () {
+            labsStub.withArgs('trafficAnalytics').returns(false);
+            labsStub.withArgs('trafficAnalyticsTracking').returns(false);
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+        });
+
         it('includes tracker script with subdir', async function () {
             configUtils.set('url', 'http://localhost:2388/blog/');
 

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1578,69 +1578,6 @@ describe('{{ghost_head}} helper', function () {
             }));
         });
 
-        it('anonymizes site_uuid when trafficAnalyticsTracking is enabled but trafficAnalytics is not', async function () {
-            setAnalyticsFlags({analytics: false, tracking: true});
-
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                locals: {
-                    relativeUrl: '/',
-                    context: ['home', 'index'],
-                    safeVersion: '4.3'
-                }
-            }));
-
-            rendered.should.match(/tb_site_uuid="anon_[a-f0-9]{16}"/);
-            rendered.should.not.match(/tb_site_uuid="site_uuid"/);
-        });
-
-        it('omits member and post data when trafficAnalyticsTracking is enabled but trafficAnalytics is not', async function () {
-            setAnalyticsFlags({analytics: false, tracking: true});
-
-            const renderObject = {
-                member: {
-                    uuid: 'member_uuid',
-                    status: 'paid'
-                },
-                post: posts[10]
-            };
-
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                renderObject: renderObject,
-                locals: {
-                    relativeUrl: '/post/',
-                    context: ['post'],
-                    safeVersion: '4.3'
-                }
-            }));
-
-            rendered.should.match(/tb_member_uuid="undefined"/);
-            rendered.should.match(/tb_member_status="undefined"/);
-            rendered.should.match(/tb_post_uuid="undefined"/);
-        });
-
-        it('includes member data when both trafficAnalytics and trafficAnalyticsTracking are enabled', async function () {
-            setAnalyticsFlags({analytics: true, tracking: true});
-
-            const renderObject = {
-                member: {
-                    uuid: 'member_uuid',
-                    status: 'paid'
-                }
-            };
-
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                renderObject: renderObject,
-                locals: {
-                    relativeUrl: '/',
-                    context: ['home', 'index'],
-                    safeVersion: '4.3'
-                }
-            }));
-
-            rendered.should.match(/tb_member_uuid="member_uuid"/);
-            rendered.should.match(/tb_member_status="paid"/);
-        });
-
         it('includes datasource when set', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1578,6 +1578,69 @@ describe('{{ghost_head}} helper', function () {
             }));
         });
 
+        it('anonymizes site_uuid when trafficAnalyticsTracking is enabled but trafficAnalytics is not', async function () {
+            setAnalyticsFlags({analytics: false, tracking: true});
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.match(/tb_site_uuid="anon_[a-f0-9]{16}"/);
+            rendered.should.not.match(/tb_site_uuid="site_uuid"/);
+        });
+
+        it('omits member and post data when trafficAnalyticsTracking is enabled but trafficAnalytics is not', async function () {
+            setAnalyticsFlags({analytics: false, tracking: true});
+
+            const renderObject = {
+                member: {
+                    uuid: 'member_uuid',
+                    status: 'paid'
+                },
+                post: posts[10]
+            };
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                renderObject: renderObject,
+                locals: {
+                    relativeUrl: '/post/',
+                    context: ['post'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.match(/tb_member_uuid="undefined"/);
+            rendered.should.match(/tb_member_status="undefined"/);
+            rendered.should.match(/tb_post_uuid="undefined"/);
+        });
+
+        it('includes member data when both trafficAnalytics and trafficAnalyticsTracking are enabled', async function () {
+            setAnalyticsFlags({analytics: true, tracking: true});
+
+            const renderObject = {
+                member: {
+                    uuid: 'member_uuid',
+                    status: 'paid'
+                }
+            };
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                renderObject: renderObject,
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+
+            rendered.should.match(/tb_member_uuid="member_uuid"/);
+            rendered.should.match(/tb_member_status="paid"/);
+        });
+
         it('includes datasource when set', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2075/add-flag-to-enable-tracking-only

For testing purposes, it can be useful to enable the tracking for traffic analytics without enabling the whole suite of features in the Admin UI. This commit adds a `trafficAnalyticsTracking` flag, which can be enabled independently from the main `trafficAnalytics` flag.