### PR TITLE
Added retry and fallback if github actions cache restore fails

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -15,11 +15,9 @@ runs:
         path: ${{ env.CACHED_DEPENDENCY_PATHS }}
         key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
-    - name: Check if caches are restored
-      id: check-cache
-      uses: actions/github-script@v6
+    - name: Install dependencies on cache miss
       if: steps.dep-cache.outputs.cache-hit != 'true'
-      with:
-        script: |
-          core.warning('Dependency cache could not be restored - proceeding with cold cache.');
-          core.setOutput('cache-miss', 'true');
+      shell: bash
+      run: |
+        echo "::warning::Dependency cache could not be restored - installing dependencies from scratch"
+        yarn install --prefer-offline --frozen-lockfile

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -37,3 +37,13 @@ runs:
       run: |
         echo "::warning::Dependency cache could not be restored after retry - installing dependencies from scratch"
         yarn install --prefer-offline --frozen-lockfile
+
+    - name: Set cache miss output
+      id: check-cache
+      shell: bash
+      run: |
+        if [ "${{ steps.dep-cache.outputs.cache-hit }}" = "true" ] || [ "${{ steps.dep-cache-retry-attempt.outputs.cache-hit }}" = "true" ]; then
+          echo "cache-miss=false" >> $GITHUB_OUTPUT
+        else
+          echo "cache-miss=true" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -1,5 +1,9 @@
 name: "Restore dependency cache"
 description: "Restore the dependency cache."
+outputs:
+  cache-miss:
+    description: "Whether the cache was missed"
+    value: ${{ steps.check-cache.outputs.cache-miss }}
 
 runs:
   using: "composite"
@@ -12,7 +16,10 @@ runs:
         key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
     - name: Check if caches are restored
+      id: check-cache
       uses: actions/github-script@v6
       if: steps.dep-cache.outputs.cache-hit != 'true'
       with:
-        script: core.setFailed('Dependency cache could not be restored - please re-run ALL jobs.')
+        script: |
+          core.warning('Dependency cache could not be restored - proceeding with cold cache.');
+          core.setOutput('cache-miss', 'true');

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -15,9 +15,25 @@ runs:
         path: ${{ env.CACHED_DEPENDENCY_PATHS }}
         key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
-    - name: Install dependencies on cache miss
+    - name: Retry cache restore on miss
+      id: dep-cache-retry
       if: steps.dep-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo "::warning::Dependency cache could not be restored - installing dependencies from scratch"
+        echo "::warning::Cache miss detected, waiting 10 seconds and retrying..."
+        sleep 10
+      
+    - name: Check dependency cache (retry)
+      id: dep-cache-retry-attempt
+      if: steps.dep-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+        key: ${{ env.DEPENDENCY_CACHE_KEY }}
+
+    - name: Install dependencies on cache miss
+      if: steps.dep-cache.outputs.cache-hit != 'true' && steps.dep-cache-retry-attempt.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "::warning::Dependency cache could not be restored after retry - installing dependencies from scratch"
         yarn install --prefer-offline --frozen-lockfile


### PR DESCRIPTION
Github had an outage earlier today, and while mostly everything is back, the cache restoration doesn't seem to be fully back online — it's pretty flaky right now, failing on a handful of jobs in each run of our CI workflow. Our workflow is designed to _require_ the cache, without any fallback behavior if there is a cache miss or if the cache fails to restore for any reason. This means that all PRs are currently blocked from merging if the GHA cache is acting up.

This commit adds two new steps to our `restore-cache` action:
1. It will first wait 10 seconds then retry
2. If the retry fails as well, it will re-install dependencies with `yarn install` and continue on its way

This makes our CI significantly slower when there are lots of cache misses, but it at least unblocks PRs from merging.