### PR TITLE
Enabled analytics tracking script in playwright for synthetic monitoring

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/browser-service.js
+++ b/ghost/core/core/frontend/src/ghost-stats/browser-service.js
@@ -3,6 +3,7 @@
  * @property {any} [__nightmare]
  * @property {any} [Cypress]
  * @property {any} [Tinybird]
+ * @property {boolean} [__GHOST_SYNTHETIC_MONITORING__]
  */
 
 /**

--- a/ghost/core/core/frontend/src/ghost-stats/browser-service.js
+++ b/ghost/core/core/frontend/src/ghost-stats/browser-service.js
@@ -82,6 +82,11 @@ export class BrowserService {
     }
 
     isTestEnvironment() {
+        // Allow synthetic monitoring to bypass test environment detection
+        if (this.window?.__GHOST_SYNTHETIC_MONITORING__ === true) {
+            return false;
+        }
+        
         return !!(
             this.window && (
                 this.window.__nightmare ||

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -120,6 +120,26 @@ describe('ghost-stats.js', function () {
             expect(browserService.isTestEnvironment()).to.be.true;
         });
 
+        it('should allow synthetic monitoring to bypass test environment detection', function () {
+            // Set up webdriver environment (normally would be detected as test)
+            Object.defineProperty(mockWindow.navigator, 'webdriver', {
+                value: true,
+                configurable: true
+            });
+            expect(browserService.isTestEnvironment()).to.be.true;
+
+            // Enable synthetic monitoring flag - should bypass test detection
+            Object.defineProperty(mockWindow, '__GHOST_SYNTHETIC_MONITORING__', {
+                value: true,
+                configurable: true
+            });
+            expect(browserService.isTestEnvironment()).to.be.false;
+
+            // Clean up
+            delete mockWindow.__GHOST_SYNTHETIC_MONITORING__;
+            delete mockWindow.navigator.webdriver;
+        });
+
         it('should handle browser APIs safely', function () {
             expect(browserService.getNavigator()).to.equal(mockWindow.navigator);
             expect(browserService.getLocation()).to.equal(mockWindow.location);


### PR DESCRIPTION
Currently the `ghost-stats.js` script doesn't send analytics events if it's running in the context of playwright, cypress, or other browser automation tools, so we don't send a bunch of junk events when running tests. 

However, sometimes we specifically want to test the tracking script in playwright, which isn't possible with this setup. This commit carves out an exception, which allows a playwright test suite to effectively force-enable the page view events.