### PR TITLE
Updated post analytics overview UI structure

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -3,7 +3,7 @@ import NewsletterOverview from './components/NewsletterOverview';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import WebOverview from './components/WebOverview';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
+import {Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
 import {KPI_METRICS} from '../Web/components/Kpis';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
@@ -126,28 +126,12 @@ const Overview: React.FC = () => {
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
                 <div className='grid grid-cols-2 gap-8'>
-                    <Card className='group/card'>
-                        <div className='flex items-center justify-between gap-6'>
-                            <CardHeader>
-                                <CardTitle>Web performance</CardTitle>
-                                <CardDescription>Unique visitors since you published this post</CardDescription>
-                            </CardHeader>
-                            <Button className='mr-6 opacity-0 transition-all group-hover/card:opacity-100' variant='outline' onClick={() => {
-                                navigate(`/analytics/beta/${postId}/web`);
-                            }}>
-                                View more
-                                <LucideIcon.ArrowRight />
-                            </Button>
-                        </div>
-                        <CardContent>
-                            <Separator />
-                            <WebOverview
-                                chartData={processedChartData}
-                                isLoading={chartIsLoading}
-                                range={chartRange}
-                            />
-                        </CardContent>
-                    </Card>
+                    <WebOverview
+                        chartData={processedChartData}
+                        isLoading={chartIsLoading || kpiIsLoading}
+                        range={chartRange}
+                        visitors={kpiValues.visits}
+                    />
                     {showNewsletterSection && (
                         <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={typedPost} />
                     )}
@@ -156,7 +140,7 @@ const Overview: React.FC = () => {
                     <CardHeader className='hidden'>
                         <CardTitle>Post performance</CardTitle>
                     </CardHeader>
-                    <CardContent className='grid grid-cols-4 items-stretch p-0'>
+                    <CardContent className='grid grid-cols-2 items-stretch p-0'>
                         {kpiIsLoading ?
                             Array.from({length: 4}, (_, i) => (
                                 <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
@@ -166,28 +150,6 @@ const Overview: React.FC = () => {
                             ))
                             :
                             <>
-                                <KpiCard className='grow' onClick={() => {
-                                    navigate(`/analytics/beta/${postId}/web`);
-                                }}>
-                                    <KpiCardLabel>
-                                        <LucideIcon.MousePointer size={16} strokeWidth={1.5} />
-                                    Unique visitors
-                                    </KpiCardLabel>
-                                    <KpiCardContent>
-                                        <KpiCardValue>{kpiValues.visits}</KpiCardValue>
-                                    </KpiCardContent>
-                                </KpiCard>
-                                <KpiCard className='grow' onClick={() => {
-                                    navigate(`/analytics/beta/${postId}/web/?tab=views`);
-                                }}>
-                                    <KpiCardLabel>
-                                        <LucideIcon.Eye size={16} strokeWidth={1.5} />
-                                    Pageviews
-                                    </KpiCardLabel>
-                                    <KpiCardContent>
-                                        <KpiCardValue>{kpiValues.views}</KpiCardValue>
-                                    </KpiCardContent>
-                                </KpiCard>
                                 <KpiCard className='grow' onClick={() => {
                                     navigate(`/analytics/beta/${postId}/growth`);
                                 }}>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -145,13 +145,21 @@ const Overview: React.FC = () => {
                         <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={typedPost} />
                     )}
                 </div>
-                <Card className='overflow-hidden p-0'>
-                    <CardHeader className='hidden'>
-                        <CardTitle>Post performance</CardTitle>
-                    </CardHeader>
-                    <CardContent className='grid grid-cols-2 items-stretch p-0'>
+                <Card className='group overflow-hidden p-0'>
+                    <div className='relative flex items-center justify-between gap-6'>
+                        <CardHeader>
+                            <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                <LucideIcon.Sprout size={16} strokeWidth={1.5} />
+                                Growth
+                            </CardTitle>
+                        </CardHeader>
+                        <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                            navigate(`/analytics/beta/${postId}/growth`);
+                        }}>View more</Button>
+                    </div>
+                    <CardContent className='grid grid-cols-3 items-stretch px-0'>
                         {kpiIsLoading ?
-                            Array.from({length: 4}, (_, i) => (
+                            Array.from({length: 3}, (_, i) => (
                                 <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
                                     <Skeleton className='w-2/3' />
                                     <Skeleton className='h-7 w-12' />
@@ -159,26 +167,28 @@ const Overview: React.FC = () => {
                             ))
                             :
                             <>
-                                <KpiCard className='grow' onClick={() => {
-                                    navigate(`/analytics/beta/${postId}/growth`);
-                                }}>
+                                <KpiCard className='grow py-0'>
                                     <KpiCardLabel>
-                                        <LucideIcon.UserPlus size={16} strokeWidth={1.5} />
-                                    Conversions
+                                        Free members
                                     </KpiCardLabel>
                                     <KpiCardContent>
-                                        <KpiCardValue>{formatNumber((totals?.free_members || 0) + (totals?.paid_members || 0))}</KpiCardValue>
+                                        <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
                                     </KpiCardContent>
                                 </KpiCard>
-                                <KpiCard className='grow' onClick={() => {
-                                    navigate(`/analytics/beta/${postId}/growth`);
-                                }}>
+                                <KpiCard className='grow py-0'>
                                     <KpiCardLabel>
-                                        <LucideIcon.DollarSign size={16} strokeWidth={1.5} />
-                                    MRR impact
+                                        Paid members
                                     </KpiCardLabel>
                                     <KpiCardContent>
-                                        <KpiCardValue>{currencySymbol}{centsToDollars(totals?.mrr || 0)}</KpiCardValue>
+                                        <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.paid_members || 0))}</KpiCardValue>
+                                    </KpiCardContent>
+                                </KpiCard>
+                                <KpiCard className='grow py-0'>
+                                    <KpiCardLabel>
+                                        MRR impact
+                                    </KpiCardLabel>
+                                    <KpiCardContent>
+                                        <KpiCardValue className='text-[2.2rem]'>{currencySymbol}{centsToDollars(totals?.mrr || 0)}</KpiCardValue>
                                     </KpiCardContent>
                                 </KpiCard>
                             </>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -106,6 +106,13 @@ const Overview: React.FC = () => {
         };
     });
 
+    // Get sources data
+    const {data: sourcesData, loading: isSourcesLoading} = useQuery({
+        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
+        token: getToken(statsConfig),
+        params: params
+    });
+
     const kpiIsLoading = isConfigLoading || isTotalsLoading || isPostLoading || tbLoading;
     const chartIsLoading = isPostLoading || isConfigLoading || chartLoading;
     const typedPost = post as Post;
@@ -125,11 +132,13 @@ const Overview: React.FC = () => {
                 </div>
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
-                <div className='grid grid-cols-2 gap-8'>
+                <div className={showNewsletterSection ? 'grid grid-cols-2 gap-8' : ''}>
                     <WebOverview
                         chartData={processedChartData}
-                        isLoading={chartIsLoading || kpiIsLoading}
+                        fullWidth={!showNewsletterSection}
+                        isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
                         range={chartRange}
+                        sourcesData={sourcesData}
                         visitors={kpiValues.visits}
                     />
                     {showNewsletterSection && (

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -116,10 +116,10 @@ const Overview: React.FC = () => {
     return (
         <>
             <PostAnalyticsHeader currentTab='Overview'>
-                <div className='flex items-center gap-1 text-nowrap rounded-full bg-green/10 px-3 py-px pr-4 text-xs text-green-600'>
+                <div className='flex items-center gap-1 text-nowrap rounded-md bg-purple/10 px-2 py-px pr-3 text-xs text-purple-600'>
                     <LucideIcon.FlaskConical size={16} strokeWidth={1.5} />
                     Viewing Analytics (beta)
-                    <Button className='pl-1 pr-0 text-green-600 !underline' size='sm' variant='link' onClick={() => {
+                    <Button className='pl-1 pr-0 text-purple-600 !underline' size='sm' variant='link' onClick={() => {
                         navigate(`/posts/analytics/${postId}`, {crossApp: true});
                     }}>Switch back</Button>
                 </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -125,6 +125,33 @@ const Overview: React.FC = () => {
                 </div>
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
+                <div className='grid grid-cols-2 gap-8'>
+                    <Card className='group/card'>
+                        <div className='flex items-center justify-between gap-6'>
+                            <CardHeader>
+                                <CardTitle>Web performance</CardTitle>
+                                <CardDescription>Unique visitors since you published this post</CardDescription>
+                            </CardHeader>
+                            <Button className='mr-6 opacity-0 transition-all group-hover/card:opacity-100' variant='outline' onClick={() => {
+                                navigate(`/analytics/beta/${postId}/web`);
+                            }}>
+                                View more
+                                <LucideIcon.ArrowRight />
+                            </Button>
+                        </div>
+                        <CardContent>
+                            <Separator />
+                            <WebOverview
+                                chartData={processedChartData}
+                                isLoading={chartIsLoading}
+                                range={chartRange}
+                            />
+                        </CardContent>
+                    </Card>
+                    {showNewsletterSection && (
+                        <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={typedPost} />
+                    )}
+                </div>
                 <Card className='overflow-hidden p-0'>
                     <CardHeader className='hidden'>
                         <CardTitle>Post performance</CardTitle>
@@ -185,31 +212,6 @@ const Overview: React.FC = () => {
                                 </KpiCard>
                             </>
                         }
-                    </CardContent>
-                </Card>
-                {showNewsletterSection && (
-                    <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={typedPost} />
-                )}
-                <Card className='group/card'>
-                    <div className='flex items-center justify-between gap-6'>
-                        <CardHeader>
-                            <CardTitle>Web performance</CardTitle>
-                            <CardDescription>Unique visitors since you published this post</CardDescription>
-                        </CardHeader>
-                        <Button className='mr-6 opacity-0 transition-all group-hover/card:opacity-100' variant='outline' onClick={() => {
-                            navigate(`/analytics/beta/${postId}/web`);
-                        }}>
-                                View more
-                            <LucideIcon.ArrowRight />
-                        </Button>
-                    </div>
-                    <CardContent>
-                        <Separator />
-                        <WebOverview
-                            chartData={processedChartData}
-                            isLoading={chartIsLoading}
-                            range={chartRange}
-                        />
                     </CardContent>
                 </Card>
             </PostAnalyticsContent>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, ChartConfig, HTable, LucideIcon, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from '../../Newsletter/components/NewsLetterRadialChart';
 import {Post} from '@tryghost/admin-x-framework/api/posts';
 import {cleanTrackedUrl, processAndGroupTopLinks} from '@src/utils/link-helpers';
@@ -60,66 +60,67 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
     } satisfies ChartConfig;
 
     return (
-        <div className='grid grid-cols-1 gap-8 xl:grid-cols-2'>
-            <Card className='group/card hover:cursor-pointer' onClick={() => {
-                navigate(`/analytics/beta/${postId}/newsletter`);
-            }}>
-                <div className='flex items-center justify-between gap-6'>
-                    <CardHeader>
-                        <CardTitle>Newsletter performance</CardTitle>
-                        <CardDescription>How members interacted with this email</CardDescription>
-                    </CardHeader>
-                </div>
-                {isNewsletterStatsLoading ?
-                    <CardContent>
-                        <div className='mx-auto flex min-h-[250px] items-center justify-center xl:size-full'>
-                            <BarChartLoadingIndicator />
-                        </div>
-                    </CardContent>
-                    :
-                    <CardContent>
-                        <Separator />
-                        <div className='mx-auto mt-4 h-[240px]'>
-                            <NewsletterRadialChart
-                                className='pointer-events-none h-[240px]'
-                                config={commonChartConfig}
-                                data={commonChartData}
-                                percentageLabel='Sent'
-                                percentageValue={formatNumber(stats.sent)}
-                                tooltip={false}
-                            />
-                        </div>
-                        <div className='mt-2 flex items-center justify-center gap-8'>
-                            <div className='flex gap-1.5 text-sm text-muted-foreground'>
-                                <div className='flex items-center gap-1.5'>
-                                    <div className='size-2 rounded-full bg-chart-blue/50'></div>
-                                    <span className='font-medium'>Opened</span>
-                                </div>
-                                <span className='text-lg font-semibold tracking-tighter text-foreground'>{formatPercentage(stats.openedRate)}</span>
-                            </div>
-                            <div className='flex gap-1.5 text-sm text-muted-foreground'>
-                                <div className='flex items-center gap-1.5'>
-                                    <div className='size-2 rounded-full bg-chart-teal/50'></div>
-                                    <span className='font-medium'>Clicked</span>
-                                </div>
-                                <span className='text-lg font-semibold tracking-tighter text-foreground'>{formatPercentage(stats.clickedRate)}</span>
-                            </div>
-                        </div>
-                    </CardContent>
-                }
-
-            </Card>
-            <Card className='group/card'>
-                <div className='flex items-center justify-between gap-6 p-6'>
-                    <CardHeader className='p-0'>
-                        <CardTitle>Top links</CardTitle>
-                        <CardDescription>Links in your newsletter people clicked on the most</CardDescription>
-                    </CardHeader>
-                    <HTable className='mr-2 text-right'>No. of members</HTable>
-                </div>
+        <Card className='group/card'>
+            <div className='relative flex items-center justify-between gap-6'>
+                <CardHeader>
+                    <CardTitle>Newsletter performance</CardTitle>
+                </CardHeader>
+                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover/card:translate-x-0 group-hover/card:opacity-100' size='sm' variant='outline' onClick={() => {
+                    navigate(`/analytics/beta/${postId}/newsletter`);
+                }}>View more</Button>
+            </div>
+            {isNewsletterStatsLoading ?
                 <CardContent>
+                    <div className='mx-auto flex min-h-[250px] items-center justify-center xl:size-full'>
+                        <BarChartLoadingIndicator />
+                    </div>
+                </CardContent>
+                :
+                <CardContent>
+                    <div className='grid grid-cols-2 gap-6'>
+                        <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                            <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                                <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
+                                    Open rate
+                                </KpiCardHeaderLabel>
+                                <KpiCardHeaderValue
+                                    // diffDirection={'up'}
+                                    // diffTooltip={'Better than the average'}
+                                    // diffValue={1.45}
+                                    value={formatPercentage(stats.openedRate)}
+                                />
+                            </div>
+                        </KpiCardHeader>
+                        <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                            <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                                <KpiCardHeaderLabel color='hsl(var(--chart-teal))'>
+                                    Click rate
+                                </KpiCardHeaderLabel>
+                                <KpiCardHeaderValue
+                                    // diffDirection={'up'}
+                                    // diffTooltip={'Better than the average'}
+                                    // diffValue={1.45}
+                                    value={formatPercentage(stats.clickedRate)}
+                                />
+                            </div>
+
+                        </KpiCardHeader>
+                    </div>
+                    <Separator />
+                    <div className='mx-auto my-6 h-[240px]'>
+                        <NewsletterRadialChart
+                            className='pointer-events-none h-[240px]'
+                            config={commonChartConfig}
+                            data={commonChartData}
+                            tooltip={false}
+                        />
+                    </div>
                     <Separator />
                     <div className='pt-3'>
+                        <div className='flex items-center justify-between gap-3 py-3'>
+                            <span className='font-medium'>Top clicked links in this email</span>
+                            <HTable>Members</HTable>
+                        </div>
                         <Table>
                             {topLinks.length > 0
                                 ?
@@ -127,9 +128,9 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                     {topLinks.slice(0, 5).map((link) => {
                                         return (
                                             <TableRow key={link.link.link_id} className='border-none'>
-                                                <TableCell className='max-w-0 py-2.5 group-hover:!bg-transparent'>
+                                                <TableCell className='max-w-0 px-0 group-hover:!bg-transparent'>
                                                     <a
-                                                        className='block truncate font-medium hover:underline'
+                                                        className='block truncate hover:underline'
                                                         href={link.link.to}
                                                         rel="noreferrer"
                                                         target='_blank'
@@ -138,7 +139,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                                         {cleanTrackedUrl(link.link.to, true)}
                                                     </a>
                                                 </TableCell>
-                                                <TableCell className='w-[10%] py-2.5 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count || 0)}</TableCell>
+                                                <TableCell className='w-[10%] pl-3 pr-0 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count || 0)}</TableCell>
                                             </TableRow>
                                         );
                                     })}
@@ -156,19 +157,15 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                             }
                         </Table>
                     </div>
-                </CardContent>
-                {topLinks.length > 0 &&
-                <CardFooter>
-                    <Button variant='outline' onClick={() => {
+                    {/* <Button variant='outline' onClick={() => {
                         navigate(`/analytics/beta/${postId}/newsletter`);
                     }}>
                         View all
                         <LucideIcon.ArrowRight />
-                    </Button>
-                </CardFooter>
-                }
-            </Card>
-        </div>
+                    </Button> */}
+                </CardContent>
+            }
+        </Card>
     );
 };
 

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, ChartConfig, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, ChartConfig, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from '../../Newsletter/components/NewsLetterRadialChart';
 import {Post} from '@tryghost/admin-x-framework/api/posts';
 import {cleanTrackedUrl, processAndGroupTopLinks} from '@src/utils/link-helpers';

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, ChartConfig, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, ChartConfig, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, Table, TableBody, TableCell, TableRow, formatNumber, formatPercentage} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from '../../Newsletter/components/NewsLetterRadialChart';
 import {Post} from '@tryghost/admin-x-framework/api/posts';
 import {cleanTrackedUrl, processAndGroupTopLinks} from '@src/utils/link-helpers';
@@ -63,7 +63,10 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         <Card className='group/card'>
             <div className='relative flex items-center justify-between gap-6'>
                 <CardHeader>
-                    <CardTitle>Newsletter performance</CardTitle>
+                    <CardTitle className='flex items-center gap-1.5 text-lg'>
+                        <LucideIcon.Mail size={16} strokeWidth={1.5} />
+                        Newsletter performance
+                    </CardTitle>
                 </CardHeader>
                 <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover/card:translate-x-0 group-hover/card:opacity-100' size='sm' variant='outline' onClick={() => {
                     navigate(`/analytics/beta/${postId}/newsletter`);
@@ -118,7 +121,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     <Separator />
                     <div className='pt-3'>
                         <div className='flex items-center justify-between gap-3 py-3'>
-                            <span className='font-semibold'>Top clicked links in this email</span>
+                            <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
                             <HTable>Members</HTable>
                         </div>
                         <Table>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -109,7 +109,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     <Separator />
                     <div className='mx-auto my-6 h-[240px]'>
                         <NewsletterRadialChart
-                            className='pointer-events-none h-[240px]'
+                            className='pointer-events-none aspect-square h-[240px]'
                             config={commonChartConfig}
                             data={commonChartData}
                             tooltip={false}
@@ -118,7 +118,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     <Separator />
                     <div className='pt-3'>
                         <div className='flex items-center justify-between gap-3 py-3'>
-                            <span className='font-medium'>Top clicked links in this email</span>
+                            <span className='font-semibold'>Top clicked links in this email</span>
                             <HTable>Members</HTable>
                         </div>
                         <Table>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -125,7 +125,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                             {topLinks.length > 0
                                 ?
                                 <TableBody>
-                                    {topLinks.slice(0, 5).map((link) => {
+                                    {topLinks.slice(0, 3).map((link) => {
                                         return (
                                             <TableRow key={link.link.link_id} className='border-none'>
                                                 <TableCell className='max-w-0 px-0 group-hover:!bg-transparent'>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -1,30 +1,69 @@
 import React from 'react';
-import {BarChartLoadingIndicator, GhAreaChart, GhAreaChartDataItem} from '@tryghost/shade';
+// import Sources from '../../Web/components/Sources';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, Separator, formatNumber} from '@tryghost/shade';
+import {ProcessedSourceData, useNavigate, useParams} from '@tryghost/admin-x-framework';
 
 interface WebOverviewProps {
+    sourcesData?: ProcessedSourceData[] | null;
     chartData?: GhAreaChartDataItem[];
     range: number;
     isLoading: boolean;
+    visitors: number;
 }
 
-const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading}) => {
+const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors}) => {
+    const {postId} = useParams();
+    const navigate = useNavigate();
+
     return (
-        <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-            {isLoading ?
-                <div className='flex h-[16vw] min-h-[320px] items-center justify-center'>
-                    <BarChartLoadingIndicator />
+        <>
+            <Card className='group/card'>
+                <div className='relative flex items-center justify-between gap-6'>
+                    <CardHeader>
+                        <CardTitle>Web performance</CardTitle>
+                    </CardHeader>
+                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover/card:translate-x-0 group-hover/card:opacity-100' size='sm' variant='outline' onClick={() => {
+                        navigate(`/analytics/beta/${postId}/web`);
+                    }}>View more</Button>
                 </div>
-                :
-                <GhAreaChart
-                    className={'-mb-3 h-[16vw] max-h-[320px] w-full'}
-                    color='hsl(var(--chart-blue))'
-                    data={chartData || []}
-                    id="visitors"
-                    range={range}
-                    syncId="overview-charts"
-                />
-            }
-        </div>
+                <CardContent>
+                    <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                        <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                            <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
+                            Unique visitors
+                            </KpiCardHeaderLabel>
+                            <KpiCardHeaderValue
+                                value={formatNumber(visitors)}
+                            />
+                        </div>
+                    </KpiCardHeader>
+                    <Separator />
+                    <div className='max-h-[288px] py-6 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+                        {isLoading ?
+                            <div className='flex h-[16vw] min-h-[240px] items-center justify-center'>
+                                <BarChartLoadingIndicator />
+                            </div>
+                            :
+                            <GhAreaChart
+                                className={'h-[240px] w-full'}
+                                color='hsl(var(--chart-blue))'
+                                data={chartData || []}
+                                id="visitors"
+                                range={range}
+                                syncId="overview-charts"
+                            />
+                        }
+                    </div>
+                    <Separator />
+                    <div className='pt-3'>
+                        <div className='flex items-center justify-between gap-3 py-3'>
+                            <span className='font-semibold'>How people found your site</span>
+                            <HTable>Visitors</HTable>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </>
     );
 };
 

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -1,66 +1,104 @@
-import React from 'react';
-// import Sources from '../../Web/components/Sources';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, Separator, formatNumber} from '@tryghost/shade';
-import {ProcessedSourceData, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import React, {useMemo} from 'react';
+import Sources from '../../Web/components/Sources';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, formatNumber} from '@tryghost/shade';
+import {BaseSourceData, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
 interface WebOverviewProps {
-    sourcesData?: ProcessedSourceData[] | null;
+    sourcesData: BaseSourceData[] | null;
     chartData?: GhAreaChartDataItem[];
     range: number;
     isLoading: boolean;
     visitors: number;
+    fullWidth?: boolean;
 }
 
-const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors}) => {
+const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors, sourcesData, fullWidth = false}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
 
+    // Get global data for site info
+    const {data: globalData} = useGlobalData();
+    const siteUrl = globalData?.url as string | undefined;
+    const siteIcon = globalData?.icon as string | undefined;
+
+    // Calculate total visits for sources percentage calculation
+    const totalSourcesVisits = useMemo(() => {
+        if (!sourcesData) {
+            return 0;
+        }
+        return sourcesData.reduce((sum, source) => sum + Number(source.visits || 0), 0);
+    }, [sourcesData]);
+
     return (
         <>
-            <Card className='group/card'>
+            <Card className='group/datalist'>
                 <div className='relative flex items-center justify-between gap-6'>
                     <CardHeader>
-                        <CardTitle>Web performance</CardTitle>
+                        <CardTitle className='flex items-center gap-1.5 text-lg'>
+                            <LucideIcon.Globe size={16} strokeWidth={1.5} />
+                            Web performance
+                        </CardTitle>
                     </CardHeader>
-                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover/card:translate-x-0 group-hover/card:opacity-100' size='sm' variant='outline' onClick={() => {
+                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
                         navigate(`/analytics/beta/${postId}/web`);
                     }}>View more</Button>
                 </div>
                 <CardContent>
-                    <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
-                        <div className='flex grow flex-col gap-1.5 border-none pb-0'>
-                            <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
+                    <div>
+                        <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                            <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                                <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
                             Unique visitors
-                            </KpiCardHeaderLabel>
-                            <KpiCardHeaderValue
-                                value={formatNumber(visitors)}
-                            />
-                        </div>
-                    </KpiCardHeader>
-                    <Separator />
-                    <div className='max-h-[288px] py-6 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
-                        {isLoading ?
-                            <div className='flex h-[16vw] min-h-[240px] items-center justify-center'>
-                                <BarChartLoadingIndicator />
+                                </KpiCardHeaderLabel>
+                                <KpiCardHeaderValue
+                                    value={formatNumber(visitors)}
+                                />
                             </div>
-                            :
-                            <GhAreaChart
-                                className={'h-[240px] w-full'}
-                                color='hsl(var(--chart-blue))'
-                                data={chartData || []}
-                                id="visitors"
-                                range={range}
-                                syncId="overview-charts"
-                            />
-                        }
-                    </div>
-                    <Separator />
-                    <div className='pt-3'>
-                        <div className='flex items-center justify-between gap-3 py-3'>
-                            <span className='font-semibold'>How people found your site</span>
-                            <HTable>Visitors</HTable>
+                        </KpiCardHeader>
+                        <Separator />
+                        <div className='max-h-[288px] py-6 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+                            {isLoading ?
+                                <div className='flex h-[16vw] min-h-[240px] items-center justify-center'>
+                                    <BarChartLoadingIndicator />
+                                </div>
+                                :
+                                <GhAreaChart
+                                    className={'h-[240px] w-full'}
+                                    color='hsl(var(--chart-blue))'
+                                    data={chartData || []}
+                                    id="visitors"
+                                    range={range}
+                                    syncId="overview-charts"
+                                />
+                            }
                         </div>
                     </div>
+                    {!fullWidth &&
+                        <div className={fullWidth ? '-mt-3' : 'border-t pt-3'}>
+                            <div>
+                                <div className='flex items-center justify-between gap-3 py-3'>
+                                    <span className='font-medium text-muted-foreground'>How readers found this post</span>
+                                    <HTable>Visitors</HTable>
+                                </div>
+                            </div>
+                            {sourcesData && sourcesData.length > 0 ?
+                                <Sources
+                                    data={sourcesData as BaseSourceData[] | null}
+                                    range={range}
+                                    siteIcon={siteIcon}
+                                    siteUrl={siteUrl}
+                                    tableOnly={true}
+                                    topSourcesLimit={3}
+                                    totalVisitors={totalSourcesVisits}
+                                />
+                                :
+                                <div className='py-10 text-center text-sm text-muted-foreground'>
+                                    No data available.
+                                </div>
+                            }
+                        </div>
+                    }
                 </CardContent>
             </Card>
         </>

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -13,7 +13,7 @@ interface SourcesTableProps {
     dataTableHeader: boolean;
 }
 
-const SourcesTable: React.FC<SourcesTableProps> = ({dataTableHeader, data, defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL}) => {
+export const SourcesTable: React.FC<SourcesTableProps> = ({dataTableHeader, data, defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL}) => {
     return (
         <DataList>
             {dataTableHeader &&
@@ -78,6 +78,7 @@ interface SourcesCardProps {
     siteIcon?: string;
     defaultSourceIconUrl?: string;
     getPeriodText?: (range: number) => string;
+    tableOnly?: boolean;
 }
 
 export const Sources: React.FC<SourcesCardProps> = ({
@@ -86,7 +87,8 @@ export const Sources: React.FC<SourcesCardProps> = ({
     totalVisitors = 0,
     siteUrl,
     siteIcon,
-    defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL
+    defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
+    tableOnly = false
 }) => {
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
@@ -112,6 +114,17 @@ export const Sources: React.FC<SourcesCardProps> = ({
 
     // Generate description based on mode and range
     const cardDescription = `How readers found your ${range ? 'site' : 'post'}${range && ` ${getPeriodText(range)}`}`;
+
+    if (tableOnly) {
+        return (
+            <SourcesTable
+                data={extendedData}
+                dataTableHeader={true}
+                defaultSourceIconUrl={defaultSourceIconUrl}
+                range={range}
+            />
+        );
+    }
 
     return (
         <Card className='group/datalist'>

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -79,6 +79,7 @@ interface SourcesCardProps {
     defaultSourceIconUrl?: string;
     getPeriodText?: (range: number) => string;
     tableOnly?: boolean;
+    topSourcesLimit?:number;
 }
 
 export const Sources: React.FC<SourcesCardProps> = ({
@@ -88,7 +89,8 @@ export const Sources: React.FC<SourcesCardProps> = ({
     siteUrl,
     siteIcon,
     defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
-    tableOnly = false
+    tableOnly = false,
+    topSourcesLimit = 10
 }) => {
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
@@ -110,16 +112,16 @@ export const Sources: React.FC<SourcesCardProps> = ({
         });
     }, [processedData, totalVisitors]);
 
-    const topSources = extendedData.slice(0, 10);
+    const topSources = extendedData.slice(0, topSourcesLimit);
 
     // Generate description based on mode and range
-    const cardDescription = `How readers found your ${range ? 'site' : 'post'}${range && ` ${getPeriodText(range)}`}`;
+    const cardDescription = `How readers found this post ${range && ` ${getPeriodText(range)}`}`;
 
     if (tableOnly) {
         return (
             <SourcesTable
                 data={extendedData}
-                dataTableHeader={true}
+                dataTableHeader={false}
                 defaultSourceIconUrl={defaultSourceIconUrl}
                 range={range}
             />

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -151,7 +151,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         {!isPostLoading &&
                         <div className='flex items-center gap-6'>
                             {post?.feature_image &&
-                                <div className='h-[82px] w-[132px] rounded-md bg-cover' style={{
+                                <div className='h-[82px] w-[132px] rounded-md bg-cover bg-center' style={{
                                     backgroundImage: `url(${post.feature_image})`
                                 }}></div>
                             }

--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -166,9 +166,10 @@ const KpiCardHeader: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children
     );
 };
 
-const KpiCardHeaderLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
+const KpiCardHeaderLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, color, ...props}) => {
     return (
         <div className={cn('[&_svg]:size-4 flex items-center gap-1.5 text-base text-muted-foreground h-[22px] font-medium', className)} {...props}>
+            {color && <div className='ml-1 size-2 rounded-full opacity-50' style={{backgroundColor: color}}></div>}
             {children}
         </div>
     );

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -126,7 +126,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         <LucideIcon.Eye size={16} strokeWidth={1.25} />
                                         Visitors
                                     </div>
-                                    <span className='text-[2.3rem] font-semibold leading-none tracking-tighter'>
+                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
                                         {formatNumber(latestPostStats.visitors)}
                                     </span>
                                 </div>
@@ -137,7 +137,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         <LucideIcon.UserPlus size={16} strokeWidth={1.25} />
                                         Members
                                     </div>
-                                    <span className='text-[2.3rem] font-semibold leading-none tracking-tighter'>
+                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
                                         {latestPostStats.member_delta ?
                                             <>
                                                 +{formatNumber(latestPostStats.member_delta)}
@@ -155,7 +155,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                                 <LucideIcon.MailOpen size={16} strokeWidth={1.25} />
                                                 Open rate
                                             </div>
-                                            <span className='text-[2.3rem] font-semibold leading-none tracking-tighter'>
+                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
                                                 {formatPercentage(latestPostStats.open_rate / 100)}
                                             </span>
                                         </div>
@@ -166,7 +166,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                                 <LucideIcon.MousePointerClick size={16} strokeWidth={1.25} />
                                                 Click rate
                                             </div>
-                                            <span className='text-[2.3rem] font-semibold leading-none tracking-tighter'>
+                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
                                                 {formatPercentage((latestPostStats.click_rate || 0) / 100)}
                                             </span>
                                         </div>

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -117,8 +117,8 @@ const LatestPost: React.FC<LatestPostProps> = ({
                             </div>
                         </div>
 
-                        <div className='flex h-full flex-col items-stretch gap-2 pr-6 text-sm'>
-                            <div className='grid h-full grid-cols-2 gap-x-6 border-l pl-6'>
+                        <div className='-ml-4 flex h-full flex-col items-stretch gap-2 pr-6 text-sm'>
+                            <div className='grid h-full grid-cols-2 gap-x-6 border-l pl-10'>
                                 <div className='group mr-2 flex flex-col gap-1.5 hover:cursor-pointer' onClick={() => {
                                     navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
                                 }}>

--- a/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
@@ -51,10 +51,18 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
             .replace(/^\(|\)$/g, ''); // Remove parentheses for "(all time)"
 
         if (diffDirection === 'same') {
-            return `You're trending at the same level as ${formattedValue} compared to the ${timeRangeText}`;
+            return (
+                <span>
+                    You&apos;re trending at the same level as <span className='font-semibold'>{formattedValue}</span> compared to the <span className='font-semibold'>{timeRangeText}</span>
+                </span>
+            );
         }
 
-        return `You're trending ${directionText} ${diffValue} from ${trendingFromValue} compared to the ${timeRangeText}`;
+        return (
+            <span>
+                You&apos;re trending <span className='font-semibold'>{directionText} {diffValue}</span> from <span className='font-semibold'>{trendingFromValue}</span> compared to the {timeRangeText}
+            </span>
+        );
     }, [diffDirection, diffValue, trendingFromValue, formattedValue, range]);
 
     return (
@@ -186,7 +194,7 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                 iconName='Coins'
                 linkto='/growth/'
                 title='MRR'
-                trendingFromValue={`${formatNumber(mrrChartData[0].value)}`}
+                trendingFromValue={`${currencySymbol}${formatNumber(mrrChartData[0].value)}`}
                 onClick={() => {
                     navigate('/growth/?tab=mrr');
                 }}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1757/what-happens-when-paid-members-are-turned-off

- The current structure of post analytics overview wasn't flexible and focused enough to work well with various states of Ghost (e.g. what if paid members are turned off)