### PR TITLE
Added analytics metrics to posts index

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -162,9 +162,9 @@
                 </span>
             </LinkTo>
         {{else}}
-            <LinkTo @route={{this.editorRoute}} @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data">
-                {{!-- Empty on purpose --}}
-            </LinkTo>
+            <div class="permalink gh-list-data gh-post-list-metrics">
+                {{!-- Empty column to maintain spacing --}}
+            </div>
         {{/if}}
 
         {{!-- Clicked / Conversions column --}}
@@ -196,9 +196,9 @@
                     </span>
                 </LinkTo>
             {{else}}
-                <LinkTo @route={{this.editorRoute}} @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data">
-                    {{!-- Empty on purpose --}}
-                </LinkTo>
+                <div class="permalink gh-list-data gh-post-list-metrics">
+                    {{!-- Empty column to maintain spacing --}}
+                </div>
             {{/if}}
         {{/if}}
 

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -230,6 +230,39 @@
                 </div>
             {{/if}}
         {{/if}}
+
+        {{!-- Member conversions column (only show for published posts when traffic analytics is enabled) --}}
+        {{#if (feature "trafficAnalytics")}}
+            {{#if @post.isPublished}}
+                {{#if this.hasMemberData}}
+                    <div class="permalink gh-list-data gh-post-list-metrics">
+                        <span class="gh-content-email-stats-value">
+                            {{#if this.isHovered}}
+                                +{{format-number this.memberCounts.free}} free, +{{format-number this.memberCounts.paid}} paid
+                            {{else}}
+                                +{{format-number this.totalMemberConversions}}
+                            {{/if}}
+                        </span>
+                        <span class="gh-content-email-stats">
+                            members
+                        </span>
+                    </div>
+                {{else}}
+                    <div class="permalink gh-list-data gh-post-list-metrics">
+                        <span class="gh-content-email-stats-value">
+                            —
+                        </span>
+                        <span class="gh-content-email-stats">
+                            members
+                        </span>
+                    </div>
+                {{/if}}
+            {{else}}
+                <div class="permalink gh-list-data">
+                    {{!-- Empty column for non-published posts --}}
+                </div>
+            {{/if}}
+        {{/if}}
     </div>
 
     {{!-- Button column --}}

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -202,31 +202,33 @@
             {{/if}}
         {{/if}}
 
-        {{!-- Visitor count column (only show for published posts) --}}
-        {{#if @post.isPublished}}
-            {{#if this.hasVisitorData}}
-                <div class="permalink gh-list-data gh-post-list-metrics">
-                    <span class="gh-content-email-stats-value">
-                        {{format-number this.visitorCount}}
-                    </span>
-                    <span class="gh-content-email-stats">
-                        visitors
-                    </span>
-                </div>
+        {{!-- Visitor count column (only show for published posts when traffic analytics is enabled) --}}
+        {{#if (feature "trafficAnalytics")}}
+            {{#if @post.isPublished}}
+                {{#if this.hasVisitorData}}
+                    <div class="permalink gh-list-data gh-post-list-metrics">
+                        <span class="gh-content-email-stats-value">
+                            {{format-number this.visitorCount}}
+                        </span>
+                        <span class="gh-content-email-stats">
+                            visitors
+                        </span>
+                    </div>
+                {{else}}
+                    <div class="permalink gh-list-data gh-post-list-metrics">
+                        <span class="gh-content-email-stats-value">
+                            —
+                        </span>
+                        <span class="gh-content-email-stats">
+                            visitors
+                        </span>
+                    </div>
+                {{/if}}
             {{else}}
-                <div class="permalink gh-list-data gh-post-list-metrics">
-                    <span class="gh-content-email-stats-value">
-                        —
-                    </span>
-                    <span class="gh-content-email-stats">
-                        visitors
-                    </span>
+                <div class="permalink gh-list-data">
+                    {{!-- Empty column for non-published posts --}}
                 </div>
             {{/if}}
-        {{else}}
-            <div class="permalink gh-list-data">
-                {{!-- Empty column for non-published posts --}}
-            </div>
         {{/if}}
     </div>
 

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -203,7 +203,7 @@
         {{/if}}
 
         {{!-- Visitor count column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalytics")}}
+        {{#if (feature "trafficAnalyticsAlpha")}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -232,7 +232,7 @@
         {{/if}}
 
         {{!-- Member conversions column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalytics")}}
+        {{#if (feature "trafficAnalyticsAlpha")}}
             {{#if @post.isPublished}}
                 {{#if this.hasMemberData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -267,7 +267,7 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
+        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalyticsAlpha"))}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics Beta"}}

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -201,6 +201,33 @@
                 </LinkTo>
             {{/if}}
         {{/if}}
+
+        {{!-- Visitor count column (only show for published posts) --}}
+        {{#if @post.isPublished}}
+            {{#if this.hasVisitorData}}
+                <div class="permalink gh-list-data gh-post-list-metrics">
+                    <span class="gh-content-email-stats-value">
+                        {{format-number this.visitorCount}}
+                    </span>
+                    <span class="gh-content-email-stats">
+                        visitors
+                    </span>
+                </div>
+            {{else}}
+                <div class="permalink gh-list-data gh-post-list-metrics">
+                    <span class="gh-content-email-stats-value">
+                        —
+                    </span>
+                    <span class="gh-content-email-stats">
+                        visitors
+                    </span>
+                </div>
+            {{/if}}
+        {{else}}
+            <div class="permalink gh-list-data">
+                {{!-- Empty column for non-published posts --}}
+            </div>
+        {{/if}}
     </div>
 
     {{!-- Button column --}}

--- a/ghost/admin/app/components/posts-list/list-item.js
+++ b/ghost/admin/app/components/posts-list/list-item.js
@@ -46,6 +46,21 @@ export default class PostsListItemClicks extends Component {
         return this.visitorCount !== null;
     }
 
+    get memberCounts() {
+        return this.postAnalytics.getMemberCounts(this.post.uuid);
+    }
+
+    get hasMemberData() {
+        return this.memberCounts !== null;
+    }
+
+    get totalMemberConversions() {
+        if (!this.memberCounts) {
+            return 0;
+        }
+        return this.memberCounts.free + this.memberCounts.paid;
+    }
+
     @action
     mouseOver() {
         this.isHovered = true;

--- a/ghost/admin/app/components/posts-list/list-item.js
+++ b/ghost/admin/app/components/posts-list/list-item.js
@@ -9,6 +9,7 @@ export default class PostsListItemClicks extends Component {
     @service feature;
     @service session;
     @service settings;
+    @service postAnalytics;
 
     @tracked isHovered = false;
 
@@ -35,6 +36,14 @@ export default class PostsListItemClicks extends Component {
         text.push(formattedTime);
 
         return text.join(' ');
+    }
+
+    get visitorCount() {
+        return this.postAnalytics.getVisitorCount(this.post.uuid);
+    }
+
+    get hasVisitorData() {
+        return this.visitorCount !== null;
     }
 
     @action

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -1,4 +1,4 @@
-import AdminRoute from 'ghost-admin/routes/admin';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import InfinityModel from 'ember-infinity/lib/infinity-model';
 import RSVP from 'rsvp';
 import classic from 'ember-classic-decorator';
@@ -30,10 +30,9 @@ class PostsWithAnalytics extends InfinityModel {
     }
 }
 
-export default class PostsRoute extends AdminRoute {
+export default class PostsRoute extends AuthenticatedRoute {
     @service infinity;
     @service router;
-    @service session;
     @service feature;
     @service postAnalytics;
 

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -1,11 +1,13 @@
 import AdminRoute from 'ghost-admin/routes/admin';
 import InfinityModel from 'ember-infinity/lib/infinity-model';
 import RSVP from 'rsvp';
+import classic from 'ember-classic-decorator';
 import {action} from '@ember/object';
 import {assign} from '@ember/polyfills';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
+@classic
 class PostsWithAnalytics extends InfinityModel {
     @service postAnalytics;
 

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -69,10 +69,9 @@ export default class PostAnalyticsService extends Service {
         try {
             const statsUrl = this.ghostPaths.url.api('stats/posts-visitor-counts');
             const result = yield this.ajax.request(statsUrl, {
-                method: 'GET',
-                data: {
-                    postUuids: postUuids.join(',')
-                }
+                method: 'POST',
+                data: JSON.stringify({postUuids}),
+                contentType: 'application/json'
             });
             // Parse the nested response structure
             const statsData = result.stats?.[0]?.data?.visitor_counts || {};

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -41,7 +41,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha) {
             return Promise.resolve();
         }
         
@@ -78,7 +78,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha) {
             return Promise.resolve();
         }
         

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -12,13 +12,13 @@ export default class PostAnalyticsService extends Service {
      * @type {?Object} Post visitor counts by UUID
      */
     @tracked
-        visitorCounts = null;
+        visitorCounts = {};
 
     /**
      * @type {?Object} Post member conversion counts by UUID
      */
     @tracked
-        memberCounts = null;
+        memberCounts = {};
 
     /**
      * @type {Set} UUIDs of posts we've already fetched analytics for
@@ -132,8 +132,10 @@ export default class PostAnalyticsService extends Service {
                 ...statsData
             };
         } catch (error) {
+            // Rollback: remove failed UUIDs from fetched set to allow retry
+            postUuids.forEach(uuid => this._fetchedUuids.delete(uuid));
             // Silent failure - visitor counts are not critical
-            this.visitorCounts = {};
+            this.visitorCounts = this.visitorCounts || {};
         }
     }
 
@@ -169,8 +171,10 @@ export default class PostAnalyticsService extends Service {
                 ...memberCountsByUuid
             };
         } catch (error) {
+            // Rollback: remove failed post IDs from fetched set to allow retry
+            posts.forEach(post => this._fetchedMemberIds.delete(post.id));
             // Silent failure - member counts are not critical
-            this.memberCounts = {};
+            this.memberCounts = this.memberCounts || {};
         }
     }
 } 

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -108,8 +108,8 @@ export default class PostAnalyticsService extends Service {
      * Reset the analytics cache - call this when filters change or on route transitions
      */
     reset() {
-        this.visitorCounts = null;
-        this.memberCounts = null;
+        this.visitorCounts = {};
+        this.memberCounts = {};
         this._fetchedUuids.clear();
         this._fetchedMemberIds.clear();
     }

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -1,0 +1,62 @@
+import Service from '@ember/service';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
+
+export default class PostAnalyticsService extends Service {
+    @service ajax;
+    @service ghostPaths;
+    @service feature;
+
+    /**
+     * @type {?Object} Post visitor counts by UUID
+     */
+    @tracked
+        visitorCounts = null;
+
+    /**
+     * Load visitor counts for the given post UUIDs
+     * @param {string[]} postUuids - Array of post UUIDs
+     * @returns {Promise}
+     */
+    loadVisitorCounts(postUuids) {
+        if (!postUuids || postUuids.length === 0) {
+            return Promise.resolve();
+        }
+        
+        // Check if traffic analytics is enabled
+        if (!this.feature.trafficAnalytics) {
+            return Promise.resolve();
+        }
+        
+        return this._loadVisitorCounts.perform(postUuids);
+    }
+
+    /**
+     * Get visitor count for a specific post UUID
+     * @param {string} postUuid - Post UUID
+     * @returns {number|null} Visitor count or null if not available
+     */
+    getVisitorCount(postUuid) {
+        return this.visitorCounts && this.visitorCounts[postUuid] ? this.visitorCounts[postUuid] : null;
+    }
+
+    @task
+    *_loadVisitorCounts(postUuids) {
+        try {
+            const statsUrl = this.ghostPaths.url.api('stats/posts-visitor-counts');
+            const result = yield this.ajax.request(statsUrl, {
+                method: 'GET',
+                data: {
+                    postUuids: postUuids.join(',')
+                }
+            });
+            // Parse the nested response structure
+            const statsData = result.stats?.[0]?.data?.visitor_counts || {};
+            this.visitorCounts = statsData;
+        } catch (error) {
+            // Silent failure - visitor counts are not critical
+            this.visitorCounts = {};
+        }
+    }
+} 

--- a/ghost/admin/mirage/config/stats.js
+++ b/ghost/admin/mirage/config/stats.js
@@ -70,4 +70,41 @@ export default function mockStats(server) {
             meta: {}
         };
     });
+
+    server.post('/stats/posts-visitor-counts/', function (schema, request) {
+        const requestBody = JSON.parse(request.requestBody);
+        const postUuids = requestBody.postUuids || [];
+        
+        // Return mock visitor counts for the requested post UUIDs
+        const visitorCounts = {};
+        postUuids.forEach((uuid) => {
+            visitorCounts[uuid] = Math.floor(Math.random() * 1000) + 100; // Random count between 100-1100
+        });
+        
+        return {
+            stats: [{
+                data: {
+                    visitor_counts: visitorCounts
+                }
+            }]
+        };
+    });
+
+    server.post('/stats/posts-member-counts/', function (schema, request) {
+        const requestBody = JSON.parse(request.requestBody);
+        const postIds = requestBody.postIds || [];
+        
+        // Return mock member counts for the requested post IDs
+        const memberCounts = {};
+        postIds.forEach((id) => {
+            memberCounts[id] = {
+                free_members: Math.floor(Math.random() * 50) + 5, // Random count between 5-55
+                paid_members: Math.floor(Math.random() * 20) + 1 // Random count between 1-21
+            };
+        });
+        
+        return {
+            stats: [memberCounts]
+        };
+    });
 }

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -1,0 +1,246 @@
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {settled} from '@ember/test-helpers';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Service: post-analytics', function () {
+    setupTest();
+
+    let service;
+    let ajaxStub;
+    let ghostPathsStub;
+    let featureStub;
+
+    beforeEach(function () {
+        service = this.owner.lookup('service:post-analytics');
+        
+        // Stub dependencies
+        ajaxStub = sinon.stub();
+        ghostPathsStub = {
+            url: {
+                api: sinon.stub()
+            }
+        };
+        featureStub = {
+            trafficAnalyticsAlpha: true
+        };
+
+        service.ajax = {request: ajaxStub};
+        service.ghostPaths = ghostPathsStub;
+        service.feature = featureStub;
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('loadVisitorCounts', function () {
+        it('returns early if no post UUIDs provided', async function () {
+            const result = await service.loadVisitorCounts([]);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('returns early if feature flag is disabled', async function () {
+            featureStub.trafficAnalyticsAlpha = false;
+            const result = await service.loadVisitorCounts(['uuid1']);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('does not fetch already fetched UUIDs', async function () {
+            service._fetchedUuids.add('uuid1');
+            const result = await service.loadVisitorCounts(['uuid1']);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('fetches visitor counts for new UUIDs', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-visitor-counts');
+            ajaxStub.resolves({
+                stats: [{
+                    data: {
+                        visitor_counts: {
+                            uuid1: 100,
+                            uuid2: 200
+                        }
+                    }
+                }]
+            });
+
+            await service.loadVisitorCounts(['uuid1', 'uuid2']);
+            await settled();
+
+            expect(ajaxStub.calledOnce).to.be.true;
+            expect(ajaxStub.firstCall.args[1].method).to.equal('POST');
+            expect(ajaxStub.firstCall.args[1].data).to.equal(JSON.stringify({postUuids: ['uuid1', 'uuid2']}));
+            expect(service.visitorCounts).to.deep.equal({
+                uuid1: 100,
+                uuid2: 200
+            });
+        });
+
+        it('handles API errors gracefully', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-visitor-counts');
+            ajaxStub.rejects(new Error('API Error'));
+
+            await service.loadVisitorCounts(['uuid1']);
+            await settled();
+
+            expect(service.visitorCounts).to.deep.equal({});
+            expect(service._fetchedUuids.has('uuid1')).to.be.false; // Should be removed on error
+        });
+
+        it('merges with existing visitor counts', async function () {
+            service.visitorCounts = {existing: 50};
+            ghostPathsStub.url.api.returns('/stats/posts-visitor-counts');
+            ajaxStub.resolves({
+                stats: [{
+                    data: {
+                        visitor_counts: {
+                            uuid1: 100
+                        }
+                    }
+                }]
+            });
+
+            await service.loadVisitorCounts(['uuid1']);
+            await settled();
+
+            expect(service.visitorCounts).to.deep.equal({
+                existing: 50,
+                uuid1: 100
+            });
+        });
+    });
+
+    describe('getVisitorCount', function () {
+        it('returns visitor count for UUID', function () {
+            service.visitorCounts = {uuid1: 100};
+            expect(service.getVisitorCount('uuid1')).to.equal(100);
+        });
+
+        it('returns null for unknown UUID', function () {
+            service.visitorCounts = {uuid1: 100};
+            expect(service.getVisitorCount('uuid2')).to.be.null;
+        });
+
+        it('returns null when visitorCounts is null', function () {
+            service.visitorCounts = null;
+            expect(service.getVisitorCount('uuid1')).to.be.null;
+        });
+    });
+
+    describe('loadMemberCounts', function () {
+        it('returns early if no posts provided', async function () {
+            const result = await service.loadMemberCounts([]);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('returns early if feature flag is disabled', async function () {
+            featureStub.trafficAnalyticsAlpha = false;
+            const result = await service.loadMemberCounts([{id: '1', uuid: 'uuid1'}]);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('does not fetch already fetched post IDs', async function () {
+            service._fetchedMemberIds.add('1');
+            const result = await service.loadMemberCounts([{id: '1', uuid: 'uuid1'}]);
+            expect(result).to.be.undefined;
+            expect(ajaxStub.called).to.be.false;
+        });
+
+        it('fetches member counts for new posts', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-member-counts');
+            ajaxStub.resolves({
+                stats: [{
+                    1: {free_members: 10, paid_members: 5},
+                    2: {free_members: 20, paid_members: 15}
+                }]
+            });
+
+            const posts = [
+                {id: '1', uuid: 'uuid1'},
+                {id: '2', uuid: 'uuid2'}
+            ];
+
+            await service.loadMemberCounts(posts);
+            await settled();
+
+            expect(ajaxStub.calledOnce).to.be.true;
+            expect(ajaxStub.firstCall.args[1].method).to.equal('POST');
+            expect(ajaxStub.firstCall.args[1].data).to.equal(JSON.stringify({postIds: ['1', '2']}));
+            expect(service.memberCounts).to.deep.equal({
+                uuid1: {free: 10, paid: 5},
+                uuid2: {free: 20, paid: 15}
+            });
+        });
+
+        it('handles API errors gracefully', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-member-counts');
+            ajaxStub.rejects(new Error('API Error'));
+
+            const posts = [{id: '1', uuid: 'uuid1'}];
+            await service.loadMemberCounts(posts);
+            await settled();
+
+            expect(service.memberCounts).to.deep.equal({});
+            expect(service._fetchedMemberIds.has('1')).to.be.false; // Should be removed on error
+        });
+
+        it('merges with existing member counts', async function () {
+            service.memberCounts = {existing: {free: 5, paid: 2}};
+            ghostPathsStub.url.api.returns('/stats/posts-member-counts');
+            ajaxStub.resolves({
+                stats: [{
+                    1: {free_members: 10, paid_members: 5}
+                }]
+            });
+
+            const posts = [{id: '1', uuid: 'uuid1'}];
+            await service.loadMemberCounts(posts);
+            await settled();
+
+            expect(service.memberCounts).to.deep.equal({
+                existing: {free: 5, paid: 2},
+                uuid1: {free: 10, paid: 5}
+            });
+        });
+    });
+
+    describe('getMemberCounts', function () {
+        it('returns member counts for UUID', function () {
+            service.memberCounts = {uuid1: {free: 10, paid: 5}};
+            expect(service.getMemberCounts('uuid1')).to.deep.equal({free: 10, paid: 5});
+        });
+
+        it('returns null for unknown UUID', function () {
+            service.memberCounts = {uuid1: {free: 10, paid: 5}};
+            expect(service.getMemberCounts('uuid2')).to.be.null;
+        });
+
+        it('returns null when memberCounts is null', function () {
+            service.memberCounts = null;
+            expect(service.getMemberCounts('uuid1')).to.be.null;
+        });
+    });
+
+    describe('reset', function () {
+        it('clears all cached data', function () {
+            service.visitorCounts = {uuid1: 100};
+            service.memberCounts = {uuid1: {free: 10, paid: 5}};
+            service._fetchedUuids.add('uuid1');
+            service._fetchedMemberIds.add('1');
+
+            service.reset();
+
+            expect(service.visitorCounts).to.deep.equal({});
+            expect(service.memberCounts).to.deep.equal({});
+            expect(service._fetchedUuids.size).to.equal(0);
+            expect(service._fetchedMemberIds.size).to.equal(0);
+        });
+    });
+}); 

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -454,6 +454,7 @@ const controller = {
         validation: {
             data: {
                 postUuids: {
+                    type: 'array',
                     required: true
                 }
             }
@@ -490,6 +491,7 @@ const controller = {
         validation: {
             data: {
                 postIds: {
+                    type: 'array',
                     required: true
                 }
             }

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -448,11 +448,11 @@ const controller = {
         headers: {
             cacheInvalidate: false
         },
-        data: [
+        options: [
             'postUuids'
         ],
         validation: {
-            data: {
+            options: {
                 postUuids: {
                     required: true
                 }
@@ -466,13 +466,23 @@ const controller = {
         generateCacheKeyData(frame) {
             return {
                 method: 'getPostsVisitorCounts',
-                data: {
-                    postUuids: frame.data.postUuids
+                options: {
+                    postUuids: frame.options.postUuids
                 }
             };
         },
         async query(frame) {
-            return await statsService.api.getPostsVisitorCounts(frame.data.postUuids);
+            // Parse comma-separated postUuids from query parameter
+            const postUuids = typeof frame.options.postUuids === 'string' 
+                ? frame.options.postUuids.split(',') 
+                : frame.options.postUuids;
+            
+            const visitorCounts = await statsService.api.getPostsVisitorCounts(postUuids);
+            
+            // Return in format expected by serializer
+            return {
+                data: [visitorCounts]
+            };
         }
     }
 };

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -448,11 +448,11 @@ const controller = {
         headers: {
             cacheInvalidate: false
         },
-        options: [
+        data: [
             'postUuids'
         ],
         validation: {
-            options: {
+            data: {
                 postUuids: {
                     required: true
                 }
@@ -466,18 +466,13 @@ const controller = {
         generateCacheKeyData(frame) {
             return {
                 method: 'getPostsVisitorCounts',
-                options: {
-                    postUuids: frame.options.postUuids
+                data: {
+                    postUuids: frame.data.postUuids
                 }
             };
         },
         async query(frame) {
-            // Parse comma-separated postUuids from query parameter
-            const postUuids = typeof frame.options.postUuids === 'string' 
-                ? frame.options.postUuids.split(',') 
-                : frame.options.postUuids;
-            
-            const visitorCounts = await statsService.api.getPostsVisitorCounts(postUuids);
+            const visitorCounts = await statsService.api.getPostsVisitorCounts(frame.data.postUuids);
             
             // Return in format expected by serializer
             return {

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -479,6 +479,42 @@ const controller = {
                 data: [visitorCounts]
             };
         }
+    },
+    postsMemberCounts: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'postIds'
+        ],
+        validation: {
+            data: {
+                postIds: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'getPostsMemberCounts',
+                data: {
+                    postIds: frame.data.postIds
+                }
+            };
+        },
+        async query(frame) {
+            const memberCounts = await statsService.api.getPostsMemberCounts(frame.data.postIds);
+            
+            // Return in format expected by serializer
+            return {
+                data: [memberCounts]
+            };
+        }
     }
 };
 

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -443,6 +443,37 @@ const controller = {
         async query() {
             return await statsService.api.getLatestPostStats();
         }
+    },
+    postsVisitorCounts: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'postUuids'
+        ],
+        validation: {
+            data: {
+                postUuids: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'getPostsVisitorCounts',
+                data: {
+                    postUuids: frame.data.postUuids
+                }
+            };
+        },
+        async query(frame) {
+            return await statsService.api.getPostsVisitorCounts(frame.data.postUuids);
+        }
     }
 };
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
@@ -1,0 +1,18 @@
+TOKEN "stats_page" READ
+
+NODE _post_visitor_counts_0
+SQL >
+%
+    select
+        post_uuid,
+        uniqExact(session_id) as visits
+    from _mv_hits h
+    -- inner join filtered_sessions fs
+    --     on fs.session_id = h.session_id
+    where
+        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Site UUID", required=True)}}
+        and post_uuid IN {{ Array(post_uuids, description="Array of post UUIDs to get visitor counts for", required=True) }}
+    group by post_uuid
+    order by visits desc
+
+TYPE ENDPOINT

--- a/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
@@ -6,9 +6,7 @@ SQL >
     select
         post_uuid,
         uniqExact(session_id) as visits
-    from _mv_hits h
-    -- inner join filtered_sessions fs
-    --     on fs.session_id = h.session_id
+    from _mv_hits
     where
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Site UUID", required=True)}}
         and post_uuid IN {{ Array(post_uuids, description="Array of post UUIDs to get visitor counts for", required=True) }}

--- a/ghost/core/core/server/data/tinybird/tests/api_post_visitor_counts.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_post_visitor_counts.yaml
@@ -1,0 +1,19 @@
+
+- name: post_visitor_counts_single_post
+  description: Test visitor counts for a single post UUID
+  parameters: site_uuid=mock_site_uuid&post_uuids=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc
+  expected_result: |
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","visits":8}
+
+- name: null
+  description: Test visitor counts for multiple post UUIDs
+  parameters: site_uuid=mock_site_uuid&post_uuids=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc,6b8635fb-292f-4422-9fe4-d76cfab2ba31,06b1b0c9-fb53-4a15-a060-3db3fde7b1dd
+  expected_result: |
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","visits":9}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","visits":8}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","visits":1}
+
+- name: null
+  description: Test visitor counts for a single post with no data
+  parameters: site_uuid=mock_site_uuid&post_uuids=abcd-efgh-ijkl-mnop
+  expected_result: ''

--- a/ghost/core/core/server/data/tinybird/tests/api_post_visitor_counts.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_post_visitor_counts.yaml
@@ -5,7 +5,7 @@
   expected_result: |
     {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","visits":8}
 
-- name: null
+- name: post_visitor_counts_multiple_posts
   description: Test visitor counts for multiple post UUIDs
   parameters: site_uuid=mock_site_uuid&post_uuids=06b1b0c9-fb53-4a15-a060-3db3fde7b1fc,6b8635fb-292f-4422-9fe4-d76cfab2ba31,06b1b0c9-fb53-4a15-a060-3db3fde7b1dd
   expected_result: |
@@ -13,7 +13,7 @@
     {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","visits":8}
     {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","visits":1}
 
-- name: null
+- name: post_visitor_counts_no_data
   description: Test visitor counts for a single post with no data
   parameters: site_uuid=mock_site_uuid&post_uuids=abcd-efgh-ijkl-mnop
   expected_result: ''

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -1070,6 +1070,32 @@ class PostsStatsService {
     }
 
     /**
+     * Get member attribution counts for multiple posts
+     * @param {string[]} postIds - Array of post IDs
+     * @param {Object} options - Date filter options
+     * @returns {Promise<Object>} Map of post ID to member counts
+     */
+    async getPostsMemberCounts(postIds, options = {}) {
+        try {
+            const attributionCounts = await this._getMemberAttributionCounts(postIds, options);
+            
+            // Convert array to object mapping post_id -> counts
+            const memberCounts = {};
+            attributionCounts.forEach((count) => {
+                memberCounts[count.post_id] = {
+                    free_members: count.free_members,
+                    paid_members: count.paid_members
+                };
+            });
+            
+            return memberCounts;
+        } catch (error) {
+            logging.error('Error fetching member counts:', error);
+            return {};
+        }
+    }
+
+    /**
      * Get visitor counts for multiple posts from Tinybird
      * @param {string[]} postUuids - Array of post UUIDs
      * @returns {Promise<Object>} Map of post UUID to visitor count

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -1068,6 +1068,44 @@ class PostsStatsService {
             }));
         }
     }
+
+    /**
+     * Get visitor counts for multiple posts from Tinybird
+     * @param {string[]} postUuids - Array of post UUIDs
+     * @returns {Promise<Object>} Map of post UUID to visitor count
+     */
+    async getPostsVisitorCounts(postUuids) {
+        try {
+            if (!postUuids || !Array.isArray(postUuids) || postUuids.length === 0) {
+                return {};
+            }
+
+            if (!this.tinybirdClient) {
+                // Return empty object if Tinybird is not configured
+                return {};
+            }
+
+            // Fetch visitor counts from Tinybird for all posts
+            const visitorData = await this.tinybirdClient.fetch('api_post_visitor_counts', {
+                post_uuids: postUuids
+            });
+
+            // Convert the response to a simple UUID -> count mapping
+            const visitorCounts = {};
+            if (visitorData && Array.isArray(visitorData)) {
+                visitorData.forEach((row) => {
+                    if (row.post_uuid && row.visits !== undefined) {
+                        visitorCounts[row.post_uuid] = row.visits;
+                    }
+                });
+            }
+
+            return visitorCounts;
+        } catch (error) {
+            logging.error('Error fetching visitor counts from Tinybird:', error);
+            return {};
+        }
+    }
 }
 
 module.exports = PostsStatsService;

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -173,6 +173,20 @@ class StatsService {
     }
 
     /**
+     * Get visitor counts for multiple posts
+     * @param {string[]} postUuids - Array of post UUIDs
+     * @returns {Promise<{data: Object}>} Visitor counts mapped by post UUID
+     */
+    async getPostsVisitorCounts(postUuids) {
+        const visitorCounts = await this.posts.getPostsVisitorCounts(postUuids);
+        return {
+            data: {
+                visitor_counts: visitorCounts
+            }
+        };
+    }
+
+    /**
      * Get newsletter basic stats for sent posts (without click data)
      * @param {Object} options
      * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -119,6 +119,13 @@ class StatsService {
     }
 
     /**
+     * @param {string[]} postIds
+     */
+    async getPostsMemberCounts(postIds) {
+        return await this.posts.getPostsMemberCounts(postIds);
+    }
+
+    /**
      * Get newsletter stats for sent posts
      * @param {Object} options
      * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -61,8 +61,13 @@ const create = ({config, request, settingsCache}) => {
         }
         // Add any other options that might be needed
         Object.entries(options).forEach(([key, value]) => {
-            if (!['dateFrom', 'dateTo', 'timezone', 'memberStatus'].includes(key)) {
-                searchParams[key] = value;
+            if (!['dateFrom', 'dateTo', 'timezone', 'memberStatus', 'postType', 'tbVersion'].includes(key)) {
+                // Handle arrays by converting them to comma-separated strings for Tinybird
+                if (Array.isArray(value)) {
+                    searchParams[key] = value.join(',');
+                } else {
+                    searchParams[key] = value;
+                }
             }
         });
         

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -168,6 +168,7 @@ module.exports = function apiRoutes() {
         router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
         router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
         router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
+        router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
     }
 
     // ## Labels

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -167,6 +167,7 @@ module.exports = function apiRoutes() {
         router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
         router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
         router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
+        router.get('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
     }
 
     // ## Labels

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -167,7 +167,7 @@ module.exports = function apiRoutes() {
         router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
         router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
         router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
-        router.get('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
+        router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
     }
 
     // ## Labels

--- a/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -147,6 +147,46 @@ Object {
 }
 `;
 
+exports[`Stats API Posts Member Counts Returns empty results when postIds is not an array 1: [body] 1`] = `
+Object {
+  "stats": Array [
+    Object {},
+  ],
+}
+`;
+
+exports[`Stats API Posts Member Counts Returns empty results when postIds parameter is missing 1: [body] 1`] = `
+Object {
+  "stats": Array [
+    Object {},
+  ],
+}
+`;
+
+exports[`Stats API Posts Visitor Counts Returns empty results when postUuids is not an array 1: [body] 1`] = `
+Object {
+  "stats": Array [
+    Object {
+      "data": Object {
+        "visitor_counts": Object {},
+      },
+    },
+  ],
+}
+`;
+
+exports[`Stats API Posts Visitor Counts Returns empty results when postUuids parameter is missing 1: [body] 1`] = `
+Object {
+  "stats": Array [
+    Object {
+      "data": Object {
+        "visitor_counts": Object {},
+      },
+    },
+  ],
+}
+`;
+
 exports[`Stats API Referrer source history stats Can fetch attribution stats 1: [body] 1`] = `
 Object {
   "meta": Object {},

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -274,4 +274,127 @@ describe('Stats API', function () {
                 });
         });
     });
+
+    describe('Posts Visitor Counts', function () {
+        it('Can fetch visitor counts for multiple posts', async function () {
+            const post1 = fixtureManager.get('posts', 0);
+            const post2 = fixtureManager.get('posts', 1);
+            
+            await agent
+                .post('/stats/posts-visitor-counts')
+                .body({
+                    postUuids: [post1.uuid, post2.uuid]
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.ok(body.stats, 'Response should contain a stats property');
+                    assert.ok(Array.isArray(body.stats), 'body.stats should be an array');
+                    assert.equal(body.stats.length, 1, 'Should return one stats object');
+                    assert.ok(body.stats[0].data, 'Stats should contain data');
+                    assert.ok(body.stats[0].data.visitor_counts, 'Data should contain visitor_counts');
+                });
+        });
+
+        it('Returns empty visitor counts for invalid UUIDs', async function () {
+            await agent
+                .post('/stats/posts-visitor-counts')
+                .body({
+                    postUuids: ['invalid-uuid-1', 'invalid-uuid-2']
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.ok(body.stats, 'Response should contain a stats property');
+                    assert.ok(Array.isArray(body.stats), 'body.stats should be an array');
+                    assert.equal(body.stats.length, 1, 'Should return one stats object');
+                    assert.ok(body.stats[0].data, 'Stats should contain data');
+                    assert.ok(body.stats[0].data.visitor_counts, 'Data should contain visitor_counts');
+                });
+        });
+
+        it('Validates postUuids parameter', async function () {
+            await agent
+                .post('/stats/posts-visitor-counts')
+                .body({})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyObjectId
+                    }]
+                });
+        });
+
+        it('Validates postUuids is an array', async function () {
+            await agent
+                .post('/stats/posts-visitor-counts')
+                .body({
+                    postUuids: 'not-an-array'
+                })
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyObjectId
+                    }]
+                });
+        });
+    });
+
+    describe('Posts Member Counts', function () {
+        it('Can fetch member counts for multiple posts', async function () {
+            const post1 = fixtureManager.get('posts', 0);
+            const post2 = fixtureManager.get('posts', 1);
+            
+            await agent
+                .post('/stats/posts-member-counts')
+                .body({
+                    postIds: [post1.id, post2.id]
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.ok(body.stats, 'Response should contain a stats property');
+                    assert.ok(Array.isArray(body.stats), 'body.stats should be an array');
+                    assert.equal(body.stats.length, 1, 'Should return one stats object');
+                    // Member counts might be empty if no attribution data exists
+                });
+        });
+
+        it('Returns empty member counts for invalid IDs', async function () {
+            await agent
+                .post('/stats/posts-member-counts')
+                .body({
+                    postIds: ['invalid-id-1', 'invalid-id-2']
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.ok(body.stats, 'Response should contain a stats property');
+                    assert.ok(Array.isArray(body.stats), 'body.stats should be an array');
+                    assert.equal(body.stats.length, 1, 'Should return one stats object');
+                });
+        });
+
+        it('Validates postIds parameter', async function () {
+            await agent
+                .post('/stats/posts-member-counts')
+                .body({})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyObjectId
+                    }]
+                });
+        });
+
+        it('Validates postIds is an array', async function () {
+            await agent
+                .post('/stats/posts-member-counts')
+                .body({
+                    postIds: 'not-an-array'
+                })
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyObjectId
+                    }]
+                });
+        });
+    });
 });

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -311,28 +311,32 @@ describe('Stats API', function () {
                 });
         });
 
-        it('Validates postUuids parameter', async function () {
+        it('Returns empty results when postUuids parameter is missing', async function () {
             await agent
                 .post('/stats/posts-visitor-counts')
                 .body({})
-                .expectStatus(422)
+                .expectStatus(200)
                 .matchBodySnapshot({
-                    errors: [{
-                        id: anyObjectId
+                    stats: [{
+                        data: {
+                            visitor_counts: {}
+                        }
                     }]
                 });
         });
 
-        it('Validates postUuids is an array', async function () {
+        it('Returns empty results when postUuids is not an array', async function () {
             await agent
                 .post('/stats/posts-visitor-counts')
                 .body({
                     postUuids: 'not-an-array'
                 })
-                .expectStatus(422)
+                .expectStatus(200)
                 .matchBodySnapshot({
-                    errors: [{
-                        id: anyObjectId
+                    stats: [{
+                        data: {
+                            visitor_counts: {}
+                        }
                     }]
                 });
         });
@@ -371,29 +375,25 @@ describe('Stats API', function () {
                 });
         });
 
-        it('Validates postIds parameter', async function () {
+        it('Returns empty results when postIds parameter is missing', async function () {
             await agent
                 .post('/stats/posts-member-counts')
                 .body({})
-                .expectStatus(422)
+                .expectStatus(200)
                 .matchBodySnapshot({
-                    errors: [{
-                        id: anyObjectId
-                    }]
+                    stats: [{}]
                 });
         });
 
-        it('Validates postIds is an array', async function () {
+        it('Returns empty results when postIds is not an array', async function () {
             await agent
                 .post('/stats/posts-member-counts')
                 .body({
                     postIds: 'not-an-array'
                 })
-                .expectStatus(422)
+                .expectStatus(200)
                 .matchBodySnapshot({
-                    errors: [{
-                        id: anyObjectId
-                    }]
+                    stats: [{}]
                 });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1860
- added new tb endpoint `api_post_visitor_counts` to fetch visitor counts for multiple posts, unfiltered, for all time
- added display of visitor counts and member attribution to posts in the posts list behind the traffic analytics alpha flag
- created new post analytics service for use in the Ember app(s)

I've put this behind the alpha flag because we're going to need design changes here to accommodate the extra pieces of data. The current display gets very full and doesn't look particularly good once you start getting that many numbers in there.