### PR TITLE
Added React app setting params to Posts and Stats

### DIFF
--- a/apps/posts/src/App.tsx
+++ b/apps/posts/src/App.tsx
@@ -11,12 +11,12 @@ interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: ShadeAppProps;
     fromAnalytics?: boolean;
-    appSettings: AppSettingsType;
+    appSettings?: AppSettingsType;
 }
 
 interface AppContextType {
     fromAnalytics: boolean;
-    appSettings: AppSettingsType;
+    appSettings?: AppSettingsType;
     externalNavigate: (url: string) => void;
 }
 

--- a/apps/posts/src/App.tsx
+++ b/apps/posts/src/App.tsx
@@ -3,14 +3,20 @@ import {APP_ROUTE_PREFIX, routes} from '@src/routes';
 import {FrameworkProvider, Outlet, RouterProvider, TopLevelFrameworkProps} from '@tryghost/admin-x-framework';
 import {ShadeApp, ShadeAppProps} from '@tryghost/shade';
 
+type AppSettingsType = {
+    paidMembersEnabled: boolean;
+}
+
 interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: ShadeAppProps;
     fromAnalytics?: boolean;
+    appSettings: AppSettingsType;
 }
 
 interface AppContextType {
     fromAnalytics: boolean;
+    appSettings: AppSettingsType;
     externalNavigate: (url: string) => void;
 }
 
@@ -24,9 +30,10 @@ export const useAppContext = () => {
     return context;
 };
 
-const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false}) => {
+const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false, appSettings}) => {
     const appContextValue: AppContextType = {
         fromAnalytics,
+        appSettings,
         externalNavigate: (url: string) => {
             window.location.href = url;
         }

--- a/apps/stats/src/App.tsx
+++ b/apps/stats/src/App.tsx
@@ -11,11 +11,11 @@ type AppSettingsType = {
 interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: ShadeAppProps;
-    appSettings: AppSettingsType;
+    appSettings?: AppSettingsType;
 }
 
 interface AppContextType {
-    appSettings: AppSettingsType;
+    appSettings?: AppSettingsType;
     externalNavigate: (url: string) => void;
 }
 

--- a/apps/stats/src/App.tsx
+++ b/apps/stats/src/App.tsx
@@ -2,15 +2,43 @@ import GlobalDataProvider from './providers/GlobalDataProvider';
 import {APP_ROUTE_PREFIX, routes} from '@src/routes';
 import {FrameworkProvider, Outlet, RouterProvider, TopLevelFrameworkProps} from '@tryghost/admin-x-framework';
 import {ShadeApp, ShadeAppProps} from '@tryghost/shade';
+import {createContext, useContext} from 'react';
+
+type AppSettingsType = {
+    paidMembersEnabled: boolean;
+}
 
 interface AppProps {
     framework: TopLevelFrameworkProps;
     designSystem: ShadeAppProps;
+    appSettings: AppSettingsType;
 }
 
-const App: React.FC<AppProps> = ({framework, designSystem}) => {
+interface AppContextType {
+    appSettings: AppSettingsType;
+    externalNavigate: (url: string) => void;
+}
+
+const AppContext = createContext<AppContextType | undefined>(undefined);
+
+export const useAppContext = () => {
+    const context = useContext(AppContext);
+    if (context === undefined) {
+        throw new Error('useAppContext must be used within an AppProvider');
+    }
+    return context;
+};
+
+const App: React.FC<AppProps> = ({framework, designSystem, appSettings}) => {
+    const appContextValue: AppContextType = {
+        appSettings,
+        externalNavigate: (url: string) => {
+            window.location.href = url;
+        }
+    };
+
     return (
-        <FrameworkProvider 
+        <FrameworkProvider
             {...framework}
             queryClientOptions={{
                 staleTime: 0, // Always consider data stale (matches Ember admin route behavior)
@@ -18,13 +46,15 @@ const App: React.FC<AppProps> = ({framework, designSystem}) => {
                 refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
             }}
         >
-            <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
-                <GlobalDataProvider>
-                    <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
-                        <Outlet />
-                    </ShadeApp>
-                </GlobalDataProvider>
-            </RouterProvider>
+            <AppContext.Provider value={appContextValue}>
+                <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
+                    <GlobalDataProvider>
+                        <ShadeApp darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
+                            <Outlet />
+                        </ShadeApp>
+                    </GlobalDataProvider>
+                </RouterProvider>
+            </AppContext.Provider>
         </FrameworkProvider>
     );
 };

--- a/ghost/admin/app/components/admin-x/posts.js
+++ b/ghost/admin/app/components/admin-x/posts.js
@@ -14,7 +14,10 @@ export default class Posts extends AdminXComponent {
         const fromAnalytics = controller?.fromAnalytics ?? this.args.fromAnalytics ?? false;
 
         return {
-            fromAnalytics: fromAnalytics
+            fromAnalytics: fromAnalytics,
+            appSettings: {
+                paidMembersEnabled: true
+            }
         };
     };
 

--- a/ghost/admin/app/components/admin-x/stats.js
+++ b/ghost/admin/app/components/admin-x/stats.js
@@ -4,5 +4,13 @@ import {inject as service} from '@ember/service';
 export default class Stats extends AdminXComponent {
     @service upgradeStatus;
 
+    additionalProps = () => {
+        return {
+            appSettings: {
+                paidMembersEnabled: true
+            }
+        };
+    };
+
     static packageName = '@tryghost/stats';
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2036/state-combinations

- Added a custom app settings object to both Posts and Stats app to control various states of the app (e.g. paid memberships are off). With this change we keep all settings in Ember instead of handling this logic inside each individual React app.