### PR TITLE
Added migration for web_analytics setting

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -52,6 +52,7 @@ const EDITABLE_SETTINGS = [
     'email_track_opens',
     'email_track_clicks',
     'members_track_sources',
+    'web_analytics',
     'amp',
     'amp_gtag_id',
     'slack_url',

--- a/ghost/core/core/server/data/migrations/versions/5.127/2025-06-19-13-41-54-add-web-analytics-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.127/2025-06-19-13-41-54-add-web-analytics-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'web_analytics',
+    value: 'true',
+    type: 'boolean',
+    group: 'analytics'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -551,6 +551,14 @@
                 "isIn": [["true", "false"]]
             },
             "type": "boolean"
+        },
+        "web_analytics": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
         }
     },
     "pintura": {

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 91;
+            const allowedKeysLength = 92;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99566c8c6b729dd1c516bba432a6e1a2';
     const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
-    const currentSettingsHash = 'f56c96f35c3654a74a9414fa0d10d1ba';
+    const currentSettingsHash = 'de95b390395d682d4868bf30567de0cb';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-53/

Added analytics setting for `web_analytics`. We will use this to control whether or not we display/utilize/record 'web traffic' data (page hits).