### PR TITLE
Refactored Posts app global data use

### DIFF
--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -1,9 +1,37 @@
 import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_RANGES} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+import {useParams} from '@tryghost/admin-x-framework';
+
+// Comprehensive Post type with all the includes we fetch in PostAnalytics
+export interface Post extends PostBase {
+    published_at?: string;
+    excerpt?: string;
+    authors?: {
+        name: string;
+    }[];
+    email?: {
+        opened_count: number;
+        email_count: number;
+        status?: string;
+    };
+    newsletter?: {
+        feedback_enabled?: boolean;
+    };
+    count?: {
+        positive_feedback?: number;
+        negative_feedback?: number;
+        clicks?: number;
+        signups?: number;
+        paid_conversions?: number;
+    };
+    tags?: object[];
+    tiers?: object[];
+}
 
 type PostAnalyticsContextType = {
     data: Config | undefined;
@@ -19,6 +47,9 @@ type PostAnalyticsContextType = {
     setAudience: (value: number) => void;
     setRange: (value: number) => void;
     settings: Setting[];
+    postId: string;
+    post: Post | undefined;
+    isPostLoading: boolean;
 }
 
 const PostAnalyticsContext = createContext<PostAnalyticsContextType | undefined>(undefined);
@@ -32,6 +63,7 @@ export const useGlobalData = () => {
 };
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
+    const {postId} = useParams();
     const config = useBrowseConfig();
     const site = useBrowseSite();
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
@@ -39,6 +71,14 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
 
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
+
+    // Fetch post data with all required includes
+    const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
+        searchParams: {
+            filter: `id:${postId}`,
+            include: 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions,count.positive_feedback,count.negative_feedback,newsletter'
+        }
+    });
 
     const requests = [config, site, settings];
     const error = requests.map(request => request.error).find(Boolean);
@@ -63,7 +103,10 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         setRange,
         audience,
         setAudience,
-        settings: settings.data?.settings || []
+        settings: settings.data?.settings || [],
+        postId: postId as string,
+        post: post as Post,
+        isPostLoading
     }}>
         {children}
     </PostAnalyticsContext.Provider>;

--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -64,6 +64,12 @@ export const useGlobalData = () => {
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const {postId} = useParams();
+    
+    // Validate that postId exists - the app cannot function without it
+    if (!postId) {
+        throw new Error('Post ID is required for PostAnalyticsProvider');
+    }
+    
     const config = useBrowseConfig();
     const site = useBrowseSite();
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
@@ -104,8 +110,8 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         audience,
         setAudience,
         settings: settings.data?.settings || [],
-        postId: postId as string,
-        post: post as Post,
+        postId: postId, 
+        post: post as Post | undefined, 
         isPostLoading
     }}>
         {children}

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -5,9 +5,9 @@ import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, ChartConfig, HTable, Input, LucideIcon, Separator, SimplePagination, SimplePaginationNavigation, SimplePaginationNextButton, SimplePaginationPreviousButton, SkeletonTable, formatNumber, formatPercentage, useSimplePagination} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from './components/NewsLetterRadialChart';
-import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
+import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {getLinkById} from '@src/utils/link-helpers';
-import {hasBeenEmailed, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {hasBeenEmailed, useNavigate} from '@tryghost/admin-x-framework';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';
@@ -62,7 +62,6 @@ const BlockTooltip:React.FC<BlockTooltipProps> = ({
 };
 
 const Newsletter: React.FC<postAnalyticsProps> = () => {
-    const {postId} = useParams();
     const navigate = useNavigate();
     const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
     const [editedUrl, setEditedUrl] = useState('');
@@ -70,13 +69,8 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     const containerRef = useRef<HTMLDivElement>(null);
     const ITEMS_PER_PAGE = 5;
 
-    const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
-        searchParams: {
-            filter: `id:${postId}`,
-            include: 'email,count.positive_feedback,count.negative_feedback'
-        }
-    });
-
+    // Use shared post data from context
+    const {post, isPostLoading, postId} = useGlobalData();
     const typedPost = post as Post;
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(typedPost);
@@ -88,7 +82,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         }
     }, [navigate, postId, isPostLoading, showNewsletterSection]);
 
-    const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading, refetchTopLinks} = usePostNewsletterStats(postId || '');
+    const {stats, averageStats, topLinks, isLoading: isNewsletterStatsLoading, refetchTopLinks} = usePostNewsletterStats(postId);
     const {editLinks} = useEditLinks();
 
     // Calculate feedback stats from the post data
@@ -110,6 +104,11 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
             negativeFeedback,
             totalFeedback
         };
+    }, [typedPost]);
+
+    // Check if feedback is enabled for the newsletter
+    const isFeedbackEnabled = useMemo(() => {
+        return typedPost?.newsletter?.feedback_enabled === true;
     }, [typedPost]);
 
     const handleEdit = (linkId: string) => {
@@ -137,7 +136,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
         editLinks({
             originalUrl: link.link.originalTo,
             editedUrl: editedUrl,
-            postId: postId || ''
+            postId: postId
         }, {
             onSuccess: () => {
                 setEditingLinkId(null);
@@ -334,7 +333,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                             </CardContent>
                         }
                     </Card>
-                    <Feedback feedbackStats={feedbackStats} />
+                    {isFeedbackEnabled && <Feedback feedbackStats={feedbackStats} />}
                     <Card>
                         <div className='flex items-center justify-between p-6'>
                             <CardHeader className='p-0'>

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -240,8 +240,8 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
             <PostAnalyticsHeader currentTab='Newsletter' />
             <PostAnalyticsContent>
 
-                <div className='grid grid-cols-2 gap-8'>
-                    <Card className='col-span-2'>
+                <div className={`grid gap-8 ${isFeedbackEnabled ? 'grid-cols-2' : 'grid-cols-1'}`}>
+                    <Card className={isFeedbackEnabled ? 'col-span-2' : 'col-span-1'}>
                         <CardHeader className='hidden'>
                             <CardTitle>Newsletters</CardTitle>
                             <CardDescription>How did this post perform</CardDescription>
@@ -334,7 +334,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                         }
                     </Card>
                     {isFeedbackEnabled && <Feedback feedbackStats={feedbackStats} />}
-                    <Card>
+                    <Card className={isFeedbackEnabled ? '' : 'col-span-1'}>
                         <div className='flex items-center justify-between p-6'>
                             <CardHeader className='p-0'>
                                 <CardTitle>Newsletter clicks</CardTitle>

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -6,30 +6,21 @@ import WebOverview from './components/WebOverview';
 import {Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
 import {KPI_METRICS} from '../Web/components/Kpis';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
-import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
+import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {STATS_RANGES} from '@src/utils/constants';
 import {centsToDollars} from '../Growth/Growth';
-import {getStatEndpointUrl, getToken, hasBeenEmailed, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {getStatEndpointUrl, getToken, hasBeenEmailed, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/App';
-import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 import {useQuery} from '@tinybirdco/charts';
 
 const Overview: React.FC = () => {
-    const {postId} = useParams();
     const navigate = useNavigate();
-    const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
-    const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId || '');
+    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId} = useGlobalData();
+    const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {startDate, endDate, timezone} = getRangeDates(STATS_RANGES.ALL_TIME.value);
     const {appSettings} = useAppContext();
-
-    const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
-        searchParams: {
-            filter: `id:${postId}`,
-            include: 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions'
-        }
-    });
 
     // Calculate chart range based on days between today and post publication date
     const chartRange = useMemo(() => {

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -9,10 +9,10 @@ import Sources from './components/Sources';
 import {BarChartLoadingIndicator, Card, CardContent, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {BaseSourceData, getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
-import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
+
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useMemo} from 'react';
-import {useParams} from '@tryghost/admin-x-framework';
+
 import {useQuery} from '@tinybirdco/charts';
 
 // Array of values that represent unknown locations
@@ -30,18 +30,12 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
-    const {postId} = useParams();
 
     // Get global data for site info
     const {data: globalData} = useGlobalData();
 
-    // Get post data
-    const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
-        searchParams: {
-            filter: `id:${postId}`,
-            fields: 'title,slug,published_at,uuid'
-        }
-    });
+    // Get post data from context
+    const {post, isPostLoading} = useGlobalData();
 
     // Get params
     const params = useMemo(() => {

--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -1,45 +1,13 @@
 import React from 'react';
 import {LucideIcon, RightSidebarMenu, RightSidebarMenuLink} from '@tryghost/shade';
-// import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
-// import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {Post, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
-import {useLocation, useNavigate, useParams} from '@tryghost/admin-x-framework';
-
-// Extended Email type to include status field
-interface ExtendedEmail {
-    opened_count: number;
-    email_count: number;
-    status?: string;
-}
-
-// Extended Post type with the ExtendedEmail and additional fields
-interface PostWithEmail extends Post {
-    email?: ExtendedEmail;
-    newsletter_id?: string;
-    newsletter?: object;
-    status?: string;
-    email_only?: boolean;
-    email_segment?: string;
-    email_recipient_filter?: string;
-    send_email_when_published?: boolean;
-    email_stats?: object;
-}
+import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
+import {useLocation, useNavigate} from '@tryghost/admin-x-framework';
 
 const Sidebar:React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {postId} = useParams();
-    // const {settings} = useGlobalData();
-    // const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
-
-    const {data: {posts: [post]} = {posts: []}} = useBrowsePosts({
-        searchParams: {
-            filter: `id:${postId}`,
-            fields: 'email,status,email_only,email_segment,newsletter,newsletter_id'
-        }
-    });
-
-    const typedPost = post as PostWithEmail;
+    const {post, postId} = useGlobalData();
+    const typedPost = post as Post;
     
     // In the Ember app, a post has been emailed if:
     // 1. It has an email object with non-failed status, or

--- a/apps/posts/test/unit/hooks/useEditLinks.test.tsx
+++ b/apps/posts/test/unit/hooks/useEditLinks.test.tsx
@@ -2,9 +2,18 @@ import GlobalDataProvider from '@src/providers/PostAnalyticsContext';
 import React, {act} from 'react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {createErrorHandler, setupMswServer} from '@tryghost/admin-x-framework/test/msw-utils';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {renderHook, waitFor} from '@testing-library/react';
 import {useEditLinks} from '@src/hooks/useEditLinks';
+
+// Mock useParams to provide postId
+vi.mock('@tryghost/admin-x-framework', async () => {
+    const actual = await vi.importActual('@tryghost/admin-x-framework');
+    return {
+        ...actual,
+        useParams: () => ({postId: 'test-post-id'})
+    };
+});
 
 // Set up MSW server with common Ghost API handlers
 const server = setupMswServer();

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -93,7 +93,34 @@ export const defaultMockData = {
         range: 30,
         audience: 7,
         setAudience: vi.fn(),
-        setRange: vi.fn()
+        setRange: vi.fn(),
+        postId: 'test-post-id',
+        post: {
+            id: '64d623b64676110001e897d9',
+            url: 'https://example.com/post',
+            slug: 'test-post',
+            title: 'Test Post',
+            uuid: 'test-uuid',
+            newsletter: {feedback_enabled: true},
+            email: {
+                email_count: 1000,
+                opened_count: 300,
+                status: 'submitted'
+            },
+            count: {
+                clicks: 50,
+                positive_feedback: 10,
+                negative_feedback: 2,
+                signups: 15,
+                paid_conversions: 3
+            },
+            authors: [{name: 'Test Author'}],
+            published_at: '2024-01-01T00:00:00.000Z',
+            excerpt: 'Test excerpt',
+            tags: [],
+            tiers: []
+        },
+        isPostLoading: false
     }
 };
 

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -268,13 +268,14 @@ const Locations:React.FC = () => {
                                                                 <div className='flex items-center space-x-3 overflow-hidden'>
                                                                     <Flag
                                                                         countryCode={`${normalizeCountryCode(row.location as string)}`}
+                                                                        data-testid='country-flag'
                                                                         fallback={
                                                                             <span className='flex h-[14px] w-[22px] items-center justify-center rounded-[2px] bg-black text-white'>
                                                                                 <Icon.SkullAndBones className='size-3' />
                                                                             </span>
                                                                         }
                                                                     />
-                                                                    <div className='truncate font-medium'>{countryName}</div>
+                                                                    <div className='truncate font-medium' data-testid='country-name'>{countryName}</div>
                                                                 </div>
                                                             </DataListItemContent>
                                                             <DataListItemValue>

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -268,14 +268,13 @@ const Locations:React.FC = () => {
                                                                 <div className='flex items-center space-x-3 overflow-hidden'>
                                                                     <Flag
                                                                         countryCode={`${normalizeCountryCode(row.location as string)}`}
-                                                                        data-testid='country-flag'
                                                                         fallback={
                                                                             <span className='flex h-[14px] w-[22px] items-center justify-center rounded-[2px] bg-black text-white'>
                                                                                 <Icon.SkullAndBones className='size-3' />
                                                                             </span>
                                                                         }
                                                                     />
-                                                                    <div className='truncate font-medium' data-testid='country-name'>{countryName}</div>
+                                                                    <div className='truncate font-medium'>{countryName}</div>
                                                                 </div>
                                                             </DataListItemContent>
                                                             <DataListItemValue>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2023
- Hid Feedback table in Posts > Newsletter if disabled for the newsletter
- Updated PostAnalyticsProvider to fetch post data using useBrowsePosts and provide it through context
- Unified to one Post type across the app for more consistency/less boilerplate
- Refactored components in PostAnalytics to consume post data from context to cut down on duplicative fetching
- Adjusted Newsletter and Overview components to utilize shared post data and loading states from context

This is a fairly substantial refactor. The initial intent was to change the handling of Newsletter > Clicks, but it became clear we were fetching post data all over the place, and our extended post types were getting to be unwieldy. Instead, now we fetch once for the app and share that data across the whole app, as we should've from the start.

I've also updated `postId` to be passed via `useGlobalData` to cut down on the use of `useParams`. Instead of using `post.id` this can be helpful as the `postId` is always available via the url, whereas we have to fetch the post data on first load.