### PR TITLE
Updated Stats app to handle tab changes with URL updates

### DIFF
--- a/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
@@ -5,6 +5,7 @@ import {STATS_RANGES} from '@src/utils/constants';
 import {sanitizeChartData} from '@src/utils/chart-helpers';
 import {useAppContext} from '@src/App';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 
 type ChartDataItem = {
     date: string;
@@ -46,11 +47,21 @@ const GrowthKPIs: React.FC<{
     const [currentTab, setCurrentTab] = useState(initialTab);
     const {range} = useGlobalData();
     const {appSettings} = useAppContext();
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
 
     // Update current tab if initialTab changes
     useEffect(() => {
         setCurrentTab(initialTab);
     }, [initialTab]);
+
+    // Function to update tab and URL
+    const handleTabChange = (tabValue: string) => {
+        setCurrentTab(tabValue);
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('tab', tabValue);
+        navigate(`?${newSearchParams.toString()}`, {replace: true});
+    };
 
     const {totalMembers, freeMembers, paidMembers, mrr, percentChanges, directions} = totals;
 
@@ -171,7 +182,7 @@ const GrowthKPIs: React.FC<{
             <TabsList className="-mx-6 grid grid-cols-4">
                 <KpiTabTrigger className={!appSettings?.paidMembersEnabled ? 'cursor-auto after:hidden' : ''} value="total-members" onClick={() => {
                     if (appSettings?.paidMembersEnabled) {
-                        setCurrentTab('total-members');
+                        handleTabChange('total-members');
                     }
                 }}>
                     <KpiTabValue
@@ -186,7 +197,7 @@ const GrowthKPIs: React.FC<{
                 <>
 
                     <KpiTabTrigger value="free-members" onClick={() => {
-                        setCurrentTab('free-members');
+                        handleTabChange('free-members');
                     }}>
                         <KpiTabValue
                             color='hsl(var(--chart-blue))'
@@ -197,7 +208,7 @@ const GrowthKPIs: React.FC<{
                         />
                     </KpiTabTrigger>
                     <KpiTabTrigger value="paid-members" onClick={() => {
-                        setCurrentTab('paid-members');
+                        handleTabChange('paid-members');
                     }}>
                         <KpiTabValue
                             color='hsl(var(--chart-purple))'
@@ -208,7 +219,7 @@ const GrowthKPIs: React.FC<{
                         />
                     </KpiTabTrigger>
                     <KpiTabTrigger value="mrr" onClick={() => {
-                        setCurrentTab('mrr');
+                        handleTabChange('mrr');
                     }}>
                         <KpiTabValue
                             color='hsl(var(--chart-teal))'

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -11,7 +11,7 @@ import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Skele
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import {useNewsletterStatsWithRangeSplit, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 
@@ -30,6 +30,10 @@ const Newsletters: React.FC = () => {
     const {range, selectedNewsletterId} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+
+    // Get the initial tab from URL search parameters
+    const initialTab = searchParams.get('tab') || 'total-subscribers';
 
     // Get newsletters list for dropdown (without expensive counts)
     const {data: newslettersData, isLoading: isNewslettersLoading} = useBrowseNewsletters({
@@ -164,6 +168,7 @@ const Newsletters: React.FC = () => {
                     <CardContent>
                         <NewsletterKPIs
                             avgsData={avgsData}
+                            initialTab={initialTab}
                             isAvgsLoading={isStatsLoading}
                             isLoading={isKPIsLoading}
                             subscribersData={subscribersData}

--- a/apps/stats/src/views/Stats/Newsletters/components/NewslettersKPIs.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/components/NewslettersKPIs.tsx
@@ -1,9 +1,9 @@
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {AvgsDataItem} from '../Newsletters';
 import {BarChartLoadingIndicator, ChartConfig, ChartContainer, ChartTooltip, GhAreaChart, KpiTabTrigger, KpiTabValue, Recharts, Tabs, TabsList, calculateYAxisWidth, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 import {sanitizeChartData} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 
 interface BarTooltipPayload {
     value: number;
@@ -73,19 +73,35 @@ const NewsletterKPIs: React.FC<{
     totals: Totals;
     isLoading: boolean;
     isAvgsLoading: boolean;
+    initialTab?: string;
 }> = ({
     subscribersData: allSubscribersData,
     avgsData,
     totals,
     isLoading,
-    isAvgsLoading
+    isAvgsLoading,
+    initialTab = 'total-subscribers'
 }) => {
-    const [currentTab, setCurrentTab] = useState('total-subscribers');
+    const [currentTab, setCurrentTab] = useState(initialTab);
     const [isHoveringClickable, setIsHoveringClickable] = useState(false);
     const {range} = useGlobalData();
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
 
     const {totalSubscribers, avgOpenRate, avgClickRate} = totals;
+
+    // Update current tab if initialTab changes
+    useEffect(() => {
+        setCurrentTab(initialTab);
+    }, [initialTab]);
+
+    // Function to update tab and URL
+    const handleTabChange = (tabValue: string) => {
+        setCurrentTab(tabValue);
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('tab', tabValue);
+        navigate(`?${newSearchParams.toString()}`, {replace: true});
+    };
 
     // Sanitize subscribers data and convert deltas to cumulative values
     const subscribersData = useMemo(() => {
@@ -151,10 +167,10 @@ const NewsletterKPIs: React.FC<{
     }
 
     return (
-        <Tabs defaultValue="total-subscribers" variant='kpis'>
+        <Tabs defaultValue={initialTab} variant='kpis'>
             <TabsList className="-mx-6 grid grid-cols-3">
                 <KpiTabTrigger value="total-subscribers" onClick={() => {
-                    setCurrentTab('total-subscribers');
+                    handleTabChange('total-subscribers');
                 }}>
                     <KpiTabValue
                         color={tabConfig['total-subscribers'].color}
@@ -163,7 +179,7 @@ const NewsletterKPIs: React.FC<{
                     />
                 </KpiTabTrigger>
                 <KpiTabTrigger value="avg-open-rate" onClick={() => {
-                    setCurrentTab('avg-open-rate');
+                    handleTabChange('avg-open-rate');
                 }}>
                     <KpiTabValue
                         className={isAvgsLoading ? 'opacity-50' : ''}
@@ -173,7 +189,7 @@ const NewsletterKPIs: React.FC<{
                     />
                 </KpiTabTrigger>
                 <KpiTabTrigger value="avg-click-rate" onClick={() => {
-                    setCurrentTab('avg-click-rate');
+                    handleTabChange('avg-click-rate');
                 }}>
                     <KpiTabValue
                         className={isAvgsLoading ? 'opacity-50' : ''}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2062
- Added `useSearchParams` to manage URL search parameters in GrowthKPIs and Newsletters components
- Introduced `handleTabChange` function to update the current tab and synchronize it with the URL
- Updated tab click handlers to utilize the new function for better state management and navigation

We were already accepting query params on loading, but we weren't setting it when switching tabs in the app.