### PR TITLE
Fixed top posts endpoint returning empty data

### DIFF
--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -244,9 +244,11 @@ const Growth: React.FC = () => {
                                                             </svg>
                                                         </div>
                                                         <div className='space-y-1'>
-                                                            <h3 className='text-sm font-medium text-foreground'>No {selectedContentType === CONTENT_TYPES.PAGES ? 'pages' : selectedContentType === CONTENT_TYPES.POSTS_AND_PAGES ? 'content' : 'posts'} found</h3>
+                                                            <h3 className='text-sm font-medium text-foreground'>
+                                                                No conversions {selectedContentType === CONTENT_TYPES.PAGES ? 'on pages' : selectedContentType === CONTENT_TYPES.POSTS ? 'on posts' : ''} {getPeriodText(range).toLowerCase()}
+                                                            </h3>
                                                             <p className='text-sm text-muted-foreground'>
-                                                                No {selectedContentType === CONTENT_TYPES.PAGES ? 'pages' : selectedContentType === CONTENT_TYPES.POSTS_AND_PAGES ? 'posts or pages' : 'posts'} with member activity were published {getPeriodText(range).toLowerCase()}
+                                                                Try adjusting your date range to see more data.
                                                             </p>
                                                         </div>
                                                     </div>

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -201,38 +201,58 @@ const Growth: React.FC = () => {
                                     />
                                     :
                                     <TableBody>
-                                        {transformedTopPosts.map(post => (
-                                            <TableRow key={post.post_id} className='last:border-none'>
-                                                <TableCell className="font-medium">
-                                                    <div className='group/link inline-flex items-center gap-2'>
-                                                        {post.post_id ?
-                                                            <Button className='h-auto whitespace-normal p-0 text-left hover:!underline' title="View post analytics" variant='link' onClick={() => {
-                                                                navigate(`/posts/analytics/beta/${post.post_id}`, {crossApp: true});
-                                                            }}>
-                                                                {post.title}
-                                                            </Button>
-                                                            :
-                                                            <>
-                                                                {post.title}
-                                                            </>
-                                                        }
+                                        {transformedTopPosts.length > 0 ? (
+                                            transformedTopPosts.map(post => (
+                                                <TableRow key={post.post_id} className='last:border-none'>
+                                                    <TableCell className="font-medium">
+                                                        <div className='group/link inline-flex items-center gap-2'>
+                                                            {post.post_id ?
+                                                                <Button className='h-auto whitespace-normal p-0 text-left hover:!underline' title="View post analytics" variant='link' onClick={() => {
+                                                                    navigate(`/posts/analytics/beta/${post.post_id}`, {crossApp: true});
+                                                                }}>
+                                                                    {post.title}
+                                                                </Button>
+                                                                :
+                                                                <>
+                                                                    {post.title}
+                                                                </>
+                                                            }
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell className='text-right font-mono text-sm'>
+                                                        {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
+                                                    </TableCell>
+                                                    {appSettings?.paidMembersEnabled &&
+                                                    <>
+                                                        <TableCell className='text-right font-mono text-sm'>
+                                                            {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
+                                                        </TableCell>
+                                                        <TableCell className='text-right font-mono text-sm'>
+                                                            {(post.mrr > 0 && '+')}{currencySymbol}{centsToDollars(post.mrr).toFixed(0)}
+                                                        </TableCell>
+                                                    </>
+                                                    }
+                                                </TableRow>
+                                            ))
+                                        ) : (
+                                            <TableRow>
+                                                <TableCell className='py-12' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
+                                                    <div className='flex flex-col items-center justify-center space-y-3 text-center'>
+                                                        <div className='flex size-12 items-center justify-center rounded-full bg-muted'>
+                                                            <svg className='size-6 text-muted-foreground' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                                                                <path d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} />
+                                                            </svg>
+                                                        </div>
+                                                        <div className='space-y-1'>
+                                                            <h3 className='text-sm font-medium text-foreground'>No {selectedContentType === CONTENT_TYPES.PAGES ? 'pages' : selectedContentType === CONTENT_TYPES.POSTS_AND_PAGES ? 'content' : 'posts'} found</h3>
+                                                            <p className='text-sm text-muted-foreground'>
+                                                                No {selectedContentType === CONTENT_TYPES.PAGES ? 'pages' : selectedContentType === CONTENT_TYPES.POSTS_AND_PAGES ? 'posts or pages' : 'posts'} with member activity were published {getPeriodText(range).toLowerCase()}
+                                                            </p>
+                                                        </div>
                                                     </div>
                                                 </TableCell>
-                                                <TableCell className='text-right font-mono text-sm'>
-                                                    {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
-                                                </TableCell>
-                                                {appSettings?.paidMembersEnabled &&
-                                                <>
-                                                    <TableCell className='text-right font-mono text-sm'>
-                                                        {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
-                                                    </TableCell>
-                                                    <TableCell className='text-right font-mono text-sm'>
-                                                        {(post.mrr > 0 && '+')}{currencySymbol}{centsToDollars(post.mrr).toFixed(0)}
-                                                    </TableCell>
-                                                </>
-                                                }
                                             </TableRow>
-                                        ))}
+                                        )}
                                     </TableBody>
                                 }
                             </Table>

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -325,9 +325,27 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
                     sortBy={sortBy}
                 />
             ) : (
-                <div className='py-20 text-center text-sm text-gray-700'>
-                    Once someone signs up, sources will show here.
-                </div>
+                <TableBody>
+                    <TableRow>
+                        <TableCell className='py-12' colSpan={4}>
+                            <div className='flex flex-col items-center justify-center space-y-3 text-center'>
+                                <div className='flex size-12 items-center justify-center rounded-full bg-muted'>
+                                    <svg className='size-6 text-muted-foreground' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                                        <path d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} />
+                                    </svg>
+                                </div>
+                                <div className='space-y-1'>
+                                    <h3 className='text-sm font-medium text-foreground'>
+                                        No conversions {getPeriodText(range).toLowerCase()}
+                                    </h3>
+                                    <p className='text-sm text-muted-foreground'>
+                                        Try adjusting your date range to see more data.
+                                    </p>
+                                </div>
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                </TableBody>
             )}
             {showViewAll && processedData.length > limit &&
                 <TableFooter className='border-none bg-transparent hover:!bg-transparent'>

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -109,9 +109,6 @@ class PostsStatsService {
                 query = query.where('p.type', options.post_type);
             }
 
-            // Apply date filters to posts' published_at date
-            this._applyDateFilter(query, options, 'p.published_at');
-
             const results = await query
                 .orderBy(orderField, orderDirection)
                 .limit(limit);
@@ -119,7 +116,7 @@ class PostsStatsService {
             // Filter out posts with zero attribution across all metrics
             const filteredResults = results.filter(post => post.free_members > 0 || post.paid_members > 0 || post.mrr > 0
             ).slice(0, limit);
-
+            
             return {data: filteredResults};
         } catch (error) {
             logging.error('Error fetching top posts by attribution:', error);

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -109,11 +109,18 @@ class PostsStatsService {
                 query = query.where('p.type', options.post_type);
             }
 
+            // Apply date filters to posts' published_at date
+            this._applyDateFilter(query, options, 'p.published_at');
+
             const results = await query
                 .orderBy(orderField, orderDirection)
                 .limit(limit);
 
-            return {data: results};
+            // Filter out posts with zero attribution across all metrics
+            const filteredResults = results.filter(post => post.free_members > 0 || post.paid_members > 0 || post.mrr > 0
+            ).slice(0, limit);
+
+            return {data: filteredResults};
         } catch (error) {
             logging.error('Error fetching top posts by attribution:', error);
             return {data: []};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1894
- added empty state
- filtered posts with no results (no free/paid/mrr activity)

When we weren't finding data in the lookback period, top posts was returning results that incidentally from the start of the posts table (oldest data).