### PR TITLE
Fixed post type filter not returning the homepage in api_top_pages

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -47,7 +47,13 @@ SQL >
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
         {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
-        {% if defined(post_type) %} and post_type = {{ String(post_type, description="Post type to filter on", required=False) }} {% end %}
+        {% if defined(post_type) %}
+            {% if post_type == 'post' %}
+                and post_type = 'post'
+            {% else %}
+                and (post_type != 'post' or post_type is null)
+            {% end %}
+        {% end %}
     group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
@@ -103,3 +103,10 @@
   expected_result: |
     {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":9}
     {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
+
+- name: Test with post_type - page
+  description: Test with post_type - page
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&post_type=page
+  expected_result: |
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
+    {"post_uuid":"","pathname":"\/","visits":7}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2102

The homepage is unique in that it doesn't have a post_type set at all. Pages have the type of 'page', while posts have a type of 'post'. When wanted to search pages, we really want to see anything that's not a post, so that's what I've updated the filter to do.