### PR TITLE
Hid web components for email only posts

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -16,7 +16,7 @@ interface postAnalyticsProps {}
 
 const FunnelArrow: React.FC = () => {
     return (
-        <div className='absolute -right-4 top-1/2 flex size-8 -translate-y-1/2 items-center justify-center rounded-full border bg-background text-muted-foreground'>
+        <div className='absolute -right-4 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full border bg-background text-muted-foreground'>
             <LucideIcon.ChevronRight className='ml-0.5' size={16} strokeWidth={1.5}/>
         </div>
     );

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -125,54 +125,51 @@ const Overview: React.FC = () => {
                 </div>
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
-                {(showWebSection || showNewsletterSection) && (
-                    <div className={showWebSection && showNewsletterSection ? 'grid grid-cols-2 gap-8' : ''}>
-                        {showWebSection && (
-                            <WebOverview
-                                chartData={processedChartData}
-                                fullWidth={!showNewsletterSection}
-                                isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
-                                range={chartRange}
-                                sourcesData={sourcesData}
-                                visitors={kpiValues.visits}
-                            />
-                        )}
-                        {showNewsletterSection && (
-                            <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={post as Post} />
-                        )}
-                    </div>
-                )}
-                <Card className='group overflow-hidden p-0'>
-                    <div className='relative flex items-center justify-between gap-6'>
-                        <CardHeader>
-                            <CardTitle className='flex items-center gap-1.5 text-lg'>
-                                <LucideIcon.Sprout size={16} strokeWidth={1.5} />
+                <div className='grid grid-cols-2 gap-8'>
+                    {showWebSection && (
+                        <WebOverview
+                            chartData={processedChartData}
+                            fullWidth={!showNewsletterSection}
+                            isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
+                            range={chartRange}
+                            sourcesData={sourcesData}
+                            visitors={kpiValues.visits}
+                        />
+                    )}
+                    {showNewsletterSection && (
+                        <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={post as Post} />
+                    )}
+                    <Card className='group col-span-2 overflow-hidden p-0'>
+                        <div className='relative flex items-center justify-between gap-6'>
+                            <CardHeader>
+                                <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                    <LucideIcon.Sprout size={16} strokeWidth={1.5} />
                                 Growth
-                            </CardTitle>
-                        </CardHeader>
-                        <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                            navigate(`/analytics/beta/${postId}/growth`);
-                        }}>View more</Button>
-                    </div>
-                    <CardContent className='grid grid-cols-3 items-stretch px-0'>
-                        {kpiIsLoading ?
-                            Array.from({length: 3}, (_, i) => (
-                                <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
-                                    <Skeleton className='w-2/3' />
-                                    <Skeleton className='h-7 w-12' />
-                                </div>
-                            ))
-                            :
-                            <>
-                                <KpiCard className='grow gap-1 py-0'>
-                                    <KpiCardLabel>
+                                </CardTitle>
+                            </CardHeader>
+                            <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                navigate(`/analytics/beta/${postId}/growth`);
+                            }}>View more</Button>
+                        </div>
+                        <CardContent className='grid grid-cols-3 items-stretch px-0'>
+                            {kpiIsLoading ?
+                                Array.from({length: 3}, (_, i) => (
+                                    <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
+                                        <Skeleton className='w-2/3' />
+                                        <Skeleton className='h-7 w-12' />
+                                    </div>
+                                ))
+                                :
+                                <>
+                                    <KpiCard className='grow gap-1 py-0'>
+                                        <KpiCardLabel>
                                         Free members
-                                    </KpiCardLabel>
-                                    <KpiCardContent>
-                                        <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
-                                    </KpiCardContent>
-                                </KpiCard>
-                                {appSettings?.paidMembersEnabled &&
+                                        </KpiCardLabel>
+                                        <KpiCardContent>
+                                            <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
+                                        </KpiCardContent>
+                                    </KpiCard>
+                                    {appSettings?.paidMembersEnabled &&
                                 <>
                                     <KpiCard className='grow gap-1 py-0'>
                                         <KpiCardLabel>
@@ -191,11 +188,12 @@ const Overview: React.FC = () => {
                                         </KpiCardContent>
                                     </KpiCard>
                                 </>
-                                }
-                            </>
-                        }
-                    </CardContent>
-                </Card>
+                                    }
+                                </>
+                            }
+                        </CardContent>
+                    </Card>
+                </div>
             </PostAnalyticsContent>
         </>
     );

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -108,10 +108,10 @@ const Overview: React.FC = () => {
 
     const kpiIsLoading = isConfigLoading || isTotalsLoading || isPostLoading || tbLoading;
     const chartIsLoading = isPostLoading || isConfigLoading || chartLoading;
-    const typedPost = post as Post;
 
     // Use the utility function from admin-x-framework
-    const showNewsletterSection = hasBeenEmailed(typedPost);
+    const showNewsletterSection = hasBeenEmailed(post as Post);
+    const showWebSection = !post?.email_only;
 
     return (
         <>
@@ -125,19 +125,23 @@ const Overview: React.FC = () => {
                 </div>
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
-                <div className={showNewsletterSection ? 'grid grid-cols-2 gap-8' : ''}>
-                    <WebOverview
-                        chartData={processedChartData}
-                        fullWidth={!showNewsletterSection}
-                        isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
-                        range={chartRange}
-                        sourcesData={sourcesData}
-                        visitors={kpiValues.visits}
-                    />
-                    {showNewsletterSection && (
-                        <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={typedPost} />
-                    )}
-                </div>
+                {(showWebSection || showNewsletterSection) && (
+                    <div className={showWebSection && showNewsletterSection ? 'grid grid-cols-2 gap-8' : ''}>
+                        {showWebSection && (
+                            <WebOverview
+                                chartData={processedChartData}
+                                fullWidth={!showNewsletterSection}
+                                isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
+                                range={chartRange}
+                                sourcesData={sourcesData}
+                                visitors={kpiValues.visits}
+                            />
+                        )}
+                        {showNewsletterSection && (
+                            <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={post as Post} />
+                        )}
+                    </div>
+                )}
                 <Card className='group overflow-hidden p-0'>
                     <div className='relative flex items-center justify-between gap-6'>
                         <CardHeader>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -60,7 +60,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
     } satisfies ChartConfig;
 
     return (
-        <Card className='group/card'>
+        <Card className={`group/card ${post.email_only && 'col-span-2'}`}>
             <div className='relative flex items-center justify-between gap-6'>
                 <CardHeader>
                     <CardTitle className='flex items-center gap-1.5 text-lg'>
@@ -79,86 +79,91 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     </div>
                 </CardContent>
                 :
-                <CardContent>
-                    <div className='grid grid-cols-2 gap-6'>
-                        <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
-                            <div className='flex grow flex-col gap-1.5 border-none pb-0'>
-                                <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
+                <CardContent className={`${post.email_only && 'grid grid-cols-2'}`}>
+                    <div className={`${post.email_only && 'border-r pr-6'}`}>
+                        <div className='grid grid-cols-2 gap-6'>
+                            <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                                <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                                    <KpiCardHeaderLabel color='hsl(var(--chart-blue))'>
                                     Open rate
-                                </KpiCardHeaderLabel>
-                                <KpiCardHeaderValue
+                                    </KpiCardHeaderLabel>
+                                    <KpiCardHeaderValue
                                     // diffDirection={'up'}
                                     // diffTooltip={'Better than the average'}
                                     // diffValue={1.45}
-                                    value={formatPercentage(stats.openedRate)}
-                                />
-                            </div>
-                        </KpiCardHeader>
-                        <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
-                            <div className='flex grow flex-col gap-1.5 border-none pb-0'>
-                                <KpiCardHeaderLabel color='hsl(var(--chart-teal))'>
+                                        value={formatPercentage(stats.openedRate)}
+                                    />
+                                </div>
+                            </KpiCardHeader>
+                            <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
+                                <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                                    <KpiCardHeaderLabel color='hsl(var(--chart-teal))'>
                                     Click rate
-                                </KpiCardHeaderLabel>
-                                <KpiCardHeaderValue
+                                    </KpiCardHeaderLabel>
+                                    <KpiCardHeaderValue
                                     // diffDirection={'up'}
                                     // diffTooltip={'Better than the average'}
                                     // diffValue={1.45}
-                                    value={formatPercentage(stats.clickedRate)}
-                                />
-                            </div>
+                                        value={formatPercentage(stats.clickedRate)}
+                                    />
+                                </div>
 
-                        </KpiCardHeader>
-                    </div>
-                    <Separator />
-                    <div className='mx-auto my-6 h-[240px]'>
-                        <NewsletterRadialChart
-                            className='pointer-events-none aspect-square h-[240px]'
-                            config={commonChartConfig}
-                            data={commonChartData}
-                            tooltip={false}
-                        />
-                    </div>
-                    <Separator />
-                    <div className='pt-3'>
-                        <div className='flex items-center justify-between gap-3 py-3'>
-                            <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
-                            <HTable>Members</HTable>
+                            </KpiCardHeader>
                         </div>
-                        <Table>
-                            {topLinks.length > 0
-                                ?
-                                <TableBody>
-                                    {topLinks.slice(0, 3).map((link) => {
-                                        return (
-                                            <TableRow key={link.link.link_id} className='border-none'>
-                                                <TableCell className='max-w-0 px-0 group-hover:!bg-transparent'>
-                                                    <a
-                                                        className='block truncate hover:underline'
-                                                        href={link.link.to}
-                                                        rel="noreferrer"
-                                                        target='_blank'
-                                                        title={link.link.to}
-                                                    >
-                                                        {cleanTrackedUrl(link.link.to, true)}
-                                                    </a>
-                                                </TableCell>
-                                                <TableCell className='w-[10%] pl-3 pr-0 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count || 0)}</TableCell>
-                                            </TableRow>
-                                        );
-                                    })}
-                                </TableBody>
-                                :
-                                <TableBody>
-                                    <TableRow>
-                                        <TableCell colSpan={2}>
-                                            <div className='py-20 text-center text-sm text-gray-700'>
+                        {!post.email_only && <Separator />}
+                        <div className='mx-auto my-6 h-[240px]'>
+                            <NewsletterRadialChart
+                                className='pointer-events-none aspect-square h-[240px]'
+                                config={commonChartConfig}
+                                data={commonChartData}
+                                tooltip={false}
+                            />
+                        </div>
+                    </div>
+
+                    <div className={`${post.email_only && 'pl-6'}`}>
+                        {!post.email_only && <Separator />}
+                        <div className={post.email_only ? '' : 'pt-3'}>
+                            <div className={`flex items-center justify-between gap-3 ${post.email_only ? 'pb-3' : 'py-3'}`}>
+                                <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
+                                <HTable>Members</HTable>
+                            </div>
+                            <Table>
+                                {topLinks.length > 0
+                                    ?
+                                    <TableBody>
+                                        {topLinks.slice(0, (post.email_only ? 6 : 3)).map((link) => {
+                                            return (
+                                                <TableRow key={link.link.link_id} className='border-none'>
+                                                    <TableCell className='max-w-0 px-0 group-hover:!bg-transparent'>
+                                                        <a
+                                                            className='block truncate hover:underline'
+                                                            href={link.link.to}
+                                                            rel="noreferrer"
+                                                            target='_blank'
+                                                            title={link.link.to}
+                                                        >
+                                                            {cleanTrackedUrl(link.link.to, true)}
+                                                        </a>
+                                                    </TableCell>
+                                                    <TableCell className='w-[10%] pl-3 pr-0 text-right font-mono text-sm group-hover:!bg-transparent'>{formatNumber(link.count || 0)}</TableCell>
+                                                </TableRow>
+                                            );
+                                        })}
+                                    </TableBody>
+                                    :
+                                    <TableBody>
+                                        <TableRow>
+                                            <TableCell colSpan={2}>
+                                                <div className='py-20 text-center text-sm text-gray-700'>
                                                 You have no links in your post.
-                                            </div>
-                                        </TableCell>
-                                    </TableRow>
-                                </TableBody>
-                            }
-                        </Table>
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    </TableBody>
+                                }
+                            </Table>
+                        </div>
                     </div>
                     {/* <Button variant='outline' onClick={() => {
                         navigate(`/analytics/beta/${postId}/newsletter`);

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -32,7 +32,7 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
 
     return (
         <>
-            <Card className='group/datalist'>
+            <Card className={`group/datalist ${fullWidth && 'col-span-2'}`}>
                 <div className='relative flex items-center justify-between gap-6'>
                     <CardHeader>
                         <CardTitle className='flex items-center gap-1.5 text-lg'>

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -7,11 +7,11 @@ import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import Sources from './components/Sources';
 import {BarChartLoadingIndicator, Card, CardContent, formatQueryDate, getRangeDates} from '@tryghost/shade';
-import {BaseSourceData, getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
+import {BaseSourceData, getStatEndpointUrl, getToken, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 
+import {useEffect, useMemo} from 'react';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
-import {useMemo} from 'react';
 
 import {useQuery} from '@tinybirdco/charts';
 
@@ -27,6 +27,8 @@ interface ProcessedLocationData {
 interface postAnalyticsProps {}
 
 const Web: React.FC<postAnalyticsProps> = () => {
+    const navigate = useNavigate();
+    const {postId} = useParams();
     const {statsConfig, isLoading: isConfigLoading} = useGlobalData();
     const {range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
@@ -36,6 +38,13 @@ const Web: React.FC<postAnalyticsProps> = () => {
 
     // Get post data from context
     const {post, isPostLoading} = useGlobalData();
+
+    // Redirect to Overview if this is an email-only post
+    useEffect(() => {
+        if (!isPostLoading && post?.email_only) {
+            navigate(`/analytics/beta/${postId}`);
+        }
+    }, [isPostLoading, post?.email_only, navigate, postId]);
 
     // Get params
     const params = useMemo(() => {

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -26,9 +26,8 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
 
     // Use shared post data from context
     const {post, isPostLoading, postId} = useGlobalData();
-    const typedPost = post as Post;
     // Use the utility function from admin-x-framework
-    const showNewsletterTab = hasBeenEmailed(typedPost);
+    const showNewsletterTab = hasBeenEmailed(post as Post);
 
     const handleDeletePost = () => {
         if (!post) {
@@ -84,16 +83,16 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 {/* <Button variant='outline'><LucideIcon.Share /></Button> */}
                                 {!isPostLoading &&
                                 <>
-                                    {!typedPost.email_only && (
+                                    {!post?.email_only && (
                                         <PostShareModal
-                                            author={typedPost.authors?.[0]?.name || ''}
+                                            author={post?.authors?.[0]?.name || ''}
                                             description=''
                                             faviconURL={site?.icon || ''}
-                                            featureImageURL={typedPost.feature_image}
+                                            featureImageURL={post?.feature_image}
                                             open={isShareOpen}
-                                            postExcerpt={typedPost.excerpt || ''}
-                                            postTitle={typedPost.title}
-                                            postURL={typedPost.url}
+                                            postExcerpt={post?.excerpt || ''}
+                                            postTitle={post?.title}
+                                            postURL={post?.url}
                                             siteTitle={site?.title || ''}
                                             onClose={() => setIsShareOpen(false)}
                                             onOpenChange={setIsShareOpen}
@@ -148,9 +147,9 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 <H1 className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]'>
                                     {post?.title}
                                 </H1>
-                                {typedPost && typedPost.published_at && (
+                                {post?.published_at && (
                                     <div className='mt-0.5 flex items-center justify-start text-sm leading-[1.65em] text-muted-foreground'>
-                            Published on your site on {moment.utc(typedPost.published_at).format('D MMM YYYY')} at {moment.utc(typedPost.published_at).format('HH:mm')}
+                            Published on your site on {moment.utc(post.published_at).format('D MMM YYYY')} at {moment.utc(post.published_at).format('HH:mm')}
                                     </div>
                                 )}
                             </div>
@@ -167,11 +166,13 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         }}>
                             Overview
                         </TabsTrigger>
-                        <TabsTrigger value="Web" onClick={() => {
-                            navigate(`/analytics/beta/${postId}/web`);
-                        }}>
-                            Web traffic
-                        </TabsTrigger>
+                        {!post?.email_only && (
+                            <TabsTrigger value="Web" onClick={() => {
+                                navigate(`/analytics/beta/${postId}/web`);
+                            }}>
+                                Web traffic
+                            </TabsTrigger>
+                        )}
                         {showNewsletterTab && (
                             <TabsTrigger value="Newsletter" onClick={() => {
                                 navigate(`/analytics/beta/${postId}/newsletter`);

--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import {LucideIcon, RightSidebarMenu, RightSidebarMenuLink} from '@tryghost/shade';
-import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
+import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useLocation, useNavigate} from '@tryghost/admin-x-framework';
 
 const Sidebar:React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const {post, postId} = useGlobalData();
-    const typedPost = post as Post;
     
     // In the Ember app, a post has been emailed if:
     // 1. It has an email object with non-failed status, or
     // 2. It has email_only flag set
     const hasBeenEmailed = Boolean(
-        (typedPost?.email && typedPost.email.status !== 'failed') || 
-        typedPost?.email_only
+        (post?.email && post.email.status !== 'failed') || 
+        post?.email_only
     );
 
     return (
@@ -26,12 +25,14 @@ const Sidebar:React.FC = () => {
                     <LucideIcon.LayoutTemplate size={16} strokeWidth={1.25} />
                     Overview
                 </RightSidebarMenuLink>
-                <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/web`} onClick={() => {
-                    navigate(`/analytics/beta/${postId}/web`);
-                }}>
-                    <LucideIcon.MousePointer size={16} strokeWidth={1.25} />
-                    Web
-                </RightSidebarMenuLink>
+                {!post?.email_only && (
+                    <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/web`} onClick={() => {
+                        navigate(`/analytics/beta/${postId}/web`);
+                    }}>
+                        <LucideIcon.MousePointer size={16} strokeWidth={1.25} />
+                        Web
+                    </RightSidebarMenuLink>
+                )}
 
                 {hasBeenEmailed && (
                     <RightSidebarMenuLink active={location.pathname === `/analytics/beta/${postId}/newsletter`} onClick={() => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1539
- Updated components to directly use post data from context instead of casting.
- Introduced conditional rendering for web and newsletter sections based on post properties.
- Added navigation logic to redirect email-only posts to the Overview page.
- Improved loading state management across components.