### PR TITLE
Added status handling for no web analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -111,7 +111,7 @@ const Overview: React.FC = () => {
 
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(post as Post);
-    const showWebSection = !post?.email_only;
+    const showWebSection = !post?.email_only && appSettings?.analytics.webAnalytics;
 
     return (
         <>
@@ -129,15 +129,19 @@ const Overview: React.FC = () => {
                     {showWebSection && (
                         <WebOverview
                             chartData={processedChartData}
-                            fullWidth={!showNewsletterSection}
                             isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
+                            isNewsletterShown={showNewsletterSection}
                             range={chartRange}
                             sourcesData={sourcesData}
                             visitors={kpiValues.visits}
                         />
                     )}
                     {showNewsletterSection && (
-                        <NewsletterOverview isNewsletterStatsLoading={isPostLoading} post={post as Post} />
+                        <NewsletterOverview
+                            isNewsletterStatsLoading={isPostLoading}
+                            isWebShown={showWebSection}
+                            post={post as Post}
+                        />
                     )}
                     <Card className='group col-span-2 overflow-hidden p-0'>
                         <div className='relative flex items-center justify-between gap-6'>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -9,9 +9,10 @@ import {useTopLinks} from '@tryghost/admin-x-framework/api/links';
 interface NewsletterOverviewProps {
     post: Post;
     isNewsletterStatsLoading: boolean;
+    isWebShown?: boolean;
 }
 
-const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewsletterStatsLoading}) => {
+const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewsletterStatsLoading, isWebShown}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
 
@@ -59,8 +60,10 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         }
     } satisfies ChartConfig;
 
+    const fullWidth = post.email_only || !isWebShown;
+
     return (
-        <Card className={`group/card ${post.email_only && 'col-span-2'}`}>
+        <Card className={`group/card ${fullWidth && 'col-span-2'}`}>
             <div className='relative flex items-center justify-between gap-6'>
                 <CardHeader>
                     <CardTitle className='flex items-center gap-1.5 text-lg'>
@@ -79,8 +82,8 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     </div>
                 </CardContent>
                 :
-                <CardContent className={`${post.email_only && 'grid grid-cols-2'}`}>
-                    <div className={`${post.email_only && 'border-r pr-6'}`}>
+                <CardContent className={`${fullWidth && 'grid grid-cols-2'}`}>
+                    <div className={`${fullWidth && 'border-r pr-6'}`}>
                         <div className='grid grid-cols-2 gap-6'>
                             <KpiCardHeader className='group relative flex grow flex-row items-start justify-between gap-5 border-none px-0 pt-0'>
                                 <div className='flex grow flex-col gap-1.5 border-none pb-0'>
@@ -110,7 +113,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
 
                             </KpiCardHeader>
                         </div>
-                        {!post.email_only && <Separator />}
+                        {!fullWidth && <Separator />}
                         <div className='mx-auto my-6 h-[240px]'>
                             <NewsletterRadialChart
                                 className='pointer-events-none aspect-square h-[240px]'
@@ -121,10 +124,10 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                         </div>
                     </div>
 
-                    <div className={`${post.email_only && 'pl-6'}`}>
-                        {!post.email_only && <Separator />}
-                        <div className={post.email_only ? '' : 'pt-3'}>
-                            <div className={`flex items-center justify-between gap-3 ${post.email_only ? 'pb-3' : 'py-3'}`}>
+                    <div className={`${fullWidth && 'pl-6'}`}>
+                        {!fullWidth && <Separator />}
+                        <div className={fullWidth ? '' : 'pt-3'}>
+                            <div className={`flex items-center justify-between gap-3 ${fullWidth ? 'pb-3' : 'py-3'}`}>
                                 <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
                                 <HTable>Members</HTable>
                             </div>
@@ -132,7 +135,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                 {topLinks.length > 0
                                     ?
                                     <TableBody>
-                                        {topLinks.slice(0, (post.email_only ? 6 : 3)).map((link) => {
+                                        {topLinks.slice(0, (fullWidth ? 6 : 3)).map((link) => {
                                             return (
                                                 <TableRow key={link.link.link_id} className='border-none'>
                                                     <TableCell className='max-w-0 px-0 group-hover:!bg-transparent'>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -10,10 +10,10 @@ interface WebOverviewProps {
     range: number;
     isLoading: boolean;
     visitors: number;
-    fullWidth?: boolean;
+    isNewsletterShown?: boolean;
 }
 
-const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors, sourcesData, fullWidth = false}) => {
+const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors, sourcesData, isNewsletterShown = true}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
 
@@ -32,7 +32,7 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
 
     return (
         <>
-            <Card className={`group/datalist ${fullWidth && 'col-span-2'}`}>
+            <Card className={`group/datalist ${!isNewsletterShown && 'col-span-2'}`}>
                 <div className='relative flex items-center justify-between gap-6'>
                     <CardHeader>
                         <CardTitle className='flex items-center gap-1.5 text-lg'>
@@ -74,8 +74,8 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
                             }
                         </div>
                     </div>
-                    {!fullWidth &&
-                        <div className={fullWidth ? '-mt-3' : 'border-t pt-3'}>
+                    {isNewsletterShown &&
+                        <div className={!isNewsletterShown ? '-mt-3' : 'border-t pt-3'}>
                             <div>
                                 <div className='flex items-center justify-between gap-3 py-3'>
                                     <span className='font-medium text-muted-foreground'>How readers found this post</span>

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -17,7 +17,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     children
 }) => {
     const navigate = useNavigate();
-    const {fromAnalytics} = useAppContext();
+    const {fromAnalytics, appSettings} = useAppContext();
     const {mutateAsync: deletePost} = useDeletePost();
     const handleError = useHandleError();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -166,7 +166,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         }}>
                             Overview
                         </TabsTrigger>
-                        {!post?.email_only && (
+                        {!post?.email_only || !appSettings?.analytics.webAnalytics && (
                             <TabsTrigger value="Web" onClick={() => {
                                 navigate(`/analytics/beta/${postId}/web`);
                             }}>

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -42,7 +42,7 @@ type TopPostsOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc';
 const Growth: React.FC = () => {
     const {range} = useGlobalData();
     const [sortBy, setSortBy] = useState<TopPostsOrder>('free_members desc');
-    const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS);
+    const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const {appSettings} = useAppContext();
@@ -163,9 +163,9 @@ const Growth: React.FC = () => {
                                                 setSelectedContentType(value as ContentType);
                                             }}>
                                                 <TabsList>
+                                                    <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
-                                                    <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
                                                     <TabsTrigger value={CONTENT_TYPES.SOURCES}>Sources</TabsTrigger>
                                                 </TabsList>
                                             </Tabs>

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -8,10 +8,10 @@ import World from '@svg-maps/world';
 import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, Flag, Icon, SimplePagination, SimplePaginationNavigation, SimplePaginationNextButton, SimplePaginationPages, SimplePaginationPreviousButton, SkeletonTable, cn, formatNumber, formatPercentage, formatQueryDate, getRangeDates, useSimplePagination} from '@tryghost/shade';
+import {Navigate, getStatEndpointUrl, getToken, useAppContext} from '@tryghost/admin-x-framework';
 import {STATS_LABEL_MAPPINGS} from '@src/utils/constants';
 import {SVGMap} from 'react-svg-map';
 import {getPeriodText} from '@src/utils/chart-helpers';
-import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -61,6 +61,7 @@ const Locations:React.FC = () => {
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
     const ITEMS_PER_PAGE = 10;
+    const {appSettings} = useAppContext();
 
     const params = {
         site_uuid: statsConfig?.id || '',
@@ -197,6 +198,12 @@ const Locations:React.FC = () => {
     };
 
     const isLoading = isConfigLoading || loading;
+
+    if (!appSettings?.analytics.webAnalytics) {
+        return (
+            <Navigate to='/' />
+        );
+    }
 
     return (
         <StatsLayout>

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, PostShareModal, Skeleton, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, PostShareModal, Skeleton, cn, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 
+import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate} from '@tryghost/admin-x-framework';
 
 // Import the interface from the hook
 import {LatestPostWithStats} from '@src/hooks/useLatestPostStats';
@@ -19,9 +19,12 @@ const LatestPost: React.FC<LatestPostProps> = ({
     const navigate = useNavigate();
     const [isShareOpen, setIsShareOpen] = useState(false);
     const {site, settings} = useGlobalData();
+    const {appSettings} = useAppContext();
 
     // Get site title from settings or site data
     const siteTitle = site.title || String(settings.find(setting => setting.key === 'title')?.value || 'Ghost Site');
+
+    const metricClassName = 'group mr-2 flex flex-col gap-1.5 hover:cursor-pointer';
 
     return (
         <Card className='group/card bg-gradient-to-tr from-muted/40 to-muted/0 to-50%'>
@@ -118,19 +121,26 @@ const LatestPost: React.FC<LatestPostProps> = ({
                         </div>
 
                         <div className='-ml-4 flex h-full flex-col items-stretch gap-2 pr-6 text-sm'>
-                            <div className='grid h-full grid-cols-2 gap-x-6 border-l pl-10'>
-                                <div className='group mr-2 flex flex-col gap-1.5 hover:cursor-pointer' onClick={() => {
-                                    navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
-                                }}>
-                                    <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                        <LucideIcon.Eye size={16} strokeWidth={1.25} />
-                                        Visitors
+                            <div className='grid h-full grid-cols-2 gap-6 border-l pl-10'>
+                                {appSettings?.analytics.webAnalytics &&
+                                    <div className={metricClassName} onClick={() => {
+                                        navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
+                                    }}>
+                                        <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                            <LucideIcon.Eye size={16} strokeWidth={1.25} />
+                                            Visitors
+                                        </div>
+                                        <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                            {formatNumber(latestPostStats.visitors)}
+                                        </span>
                                     </div>
-                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                        {formatNumber(latestPostStats.visitors)}
-                                    </span>
-                                </div>
-                                <div className='group mr-2 flex flex-col gap-1.5 hover:cursor-pointer' onClick={() => {
+                                }
+                                <div className={
+                                    cn(
+                                        metricClassName,
+                                        !appSettings?.analytics.webAnalytics && 'row-[2/3] col-[1/2]'
+                                    )
+                                } onClick={() => {
                                     navigate(`/posts/analytics/beta/${latestPostStats.id}/growth`, {crossApp: true});
                                 }}>
                                     <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
@@ -148,7 +158,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 </div>
                                 {latestPostStats.open_rate ?
                                     <>
-                                        <div className='group mr-2 flex flex-col gap-1.5 pt-6 hover:cursor-pointer' onClick={() => {
+                                        <div className={metricClassName} onClick={() => {
                                             navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
                                         }}>
                                             <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
@@ -159,7 +169,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                                 {formatPercentage(latestPostStats.open_rate / 100)}
                                             </span>
                                         </div>
-                                        <div className='group mr-2 flex flex-col gap-1.5 pt-6 hover:cursor-pointer' onClick={() => {
+                                        <div className={metricClassName} onClick={() => {
                                             navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
                                         }}>
                                             <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>

--- a/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
@@ -137,38 +137,45 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
         );
     }
 
-    let containerClass = '';
-    if (appSettings?.paidMembersEnabled) {
-        containerClass = 'grid grid-cols-3 gap-8';
-    } else {
-        containerClass = 'grid grid-cols-2 gap-8';
+    let cols = 'grid-cols-3';
+    if ((appSettings?.analytics.webAnalytics && !appSettings?.paidMembersEnabled) ||
+        (!appSettings?.analytics.webAnalytics && appSettings?.paidMembersEnabled)) {
+        cols = 'grid-cols-2';
     }
+
+    if (!appSettings?.analytics.webAnalytics && !appSettings?.paidMembersEnabled) {
+        cols = 'grid-cols-1';
+    }
+
+    const containerClass = `grid ${cols} gap-8`;
 
     return (
         <div className={containerClass}>
-            <OverviewKPICard
-                description='Number of individual people who visited your website'
-                diffDirection='empty'
-                formattedValue={kpiValues.visits}
-                iconName='Eye'
-                linkto='/web/'
-                title='Unique visitors'
-                onClick={() => {
-                    navigate('/web/');
-                }}
-            >
-                <GhAreaChart
-                    className={areaChartClassName}
-                    color='hsl(var(--chart-blue))'
-                    data={visitorsChartData}
-                    id="visitors"
-                    range={range}
-                    showHorizontalLines={true}
-                    showYAxisValues={false}
-                    syncId="overview-charts"
-                    yAxisRange={visitorsYRange}
-                />
-            </OverviewKPICard>
+            {appSettings?.analytics.webAnalytics === true &&
+                <OverviewKPICard
+                    description='Number of individual people who visited your website'
+                    diffDirection='empty'
+                    formattedValue={kpiValues.visits}
+                    iconName='Eye'
+                    linkto='/web/'
+                    title='Unique visitors'
+                    onClick={() => {
+                        navigate('/web/');
+                    }}
+                >
+                    <GhAreaChart
+                        className={areaChartClassName}
+                        color='hsl(var(--chart-blue))'
+                        data={visitorsChartData}
+                        id="visitors"
+                        range={range}
+                        showHorizontalLines={true}
+                        showYAxisValues={false}
+                        syncId="overview-charts"
+                        yAxisRange={visitorsYRange}
+                    />
+                </OverviewKPICard>
+            }
 
             <OverviewKPICard
                 description='How number of members of your publication changed over time'

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {TopPostViewsStats} from '@tryghost/admin-x-framework/api/stats';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate} from '@tryghost/admin-x-framework';
 
 interface TopPostsData {
     stats?: TopPostViewsStats[];
@@ -21,6 +21,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
 }) => {
     const navigate = useNavigate();
     const {range} = useGlobalData();
+    const {appSettings} = useAppContext();
 
     return (
         <Card className='group/card lg:col-span-2'>
@@ -36,7 +37,9 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                     <CardDescription className='hidden'>Most viewed posts in this period</CardDescription>
                                 </CardHeader>
                             </TableHead>
-                            <TableHead className='w-[12%] text-right'>Visitors</TableHead>
+                            {appSettings?.analytics.webAnalytics &&
+                                <TableHead className='w-[12%] text-right'>Visitors</TableHead>
+                            }
                             <TableHead className='w-[12%] whitespace-nowrap text-right'>Open rate</TableHead>
                             <TableHead className='w-[12%] text-right'>Members</TableHead>
                         </TableRow>
@@ -53,7 +56,9 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                         </div>
                                     </div>
                                 </TableCell>
-                                <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
+                                {appSettings?.analytics.webAnalytics &&
+                                    <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
+                                }
                                 <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
                                 <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
                             </TableRow>
@@ -82,9 +87,11 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             </div>
                                         </div>
                                     </TableCell>
-                                    <TableCell className='text-right font-mono'>
-                                        {formatNumber(post.views)}
-                                    </TableCell>
+                                    {appSettings?.analytics.webAnalytics &&
+                                        <TableCell className='text-right font-mono'>
+                                            {formatNumber(post.views)}
+                                        </TableCell>
+                                    }
                                     <TableCell className='text-right font-mono'>
                                         {post.open_rate ? `${Math.round(post.open_rate)}%` : <>&mdash;</>}
                                     </TableCell>

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -9,8 +9,8 @@ import TopContent from './components/TopContent';
 import WebKPIs, {KpiDataItem} from './components/WebKPIs';
 import {Card, CardContent, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
+import {Navigate, getStatEndpointUrl, getToken, useAppContext} from '@tryghost/admin-x-framework';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
-import {getStatEndpointUrl, getToken} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -51,6 +51,7 @@ export const KPI_METRICS: Record<string, KpiMetric> = {
 const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
+    const {appSettings} = useAppContext();
 
     // Get site URL and icon for domain comparison and Direct traffic favicon
     const siteUrl = data?.url as string | undefined;
@@ -94,6 +95,12 @@ const Web: React.FC = () => {
 
     // Calculate combined loading state
     const isPageLoading = isConfigLoading;
+
+    if (!appSettings?.analytics.webAnalytics) {
+        return (
+            <Navigate to='/' />
+        );
+    }
 
     return (
         <StatsLayout>

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {H1, Navbar, NavbarActions, Tabs, TabsList, TabsTrigger} from '@tryghost/shade';
 // import {useFeatureFlag} from '@src/hooks/useFeatureFlag';
-import {useLocation, useNavigate} from '@tryghost/admin-x-framework';
+import {useAppContext, useLocation, useNavigate} from '@tryghost/admin-x-framework';
 
 interface StatsHeaderProps {
     children?: React.ReactNode;
@@ -12,6 +12,7 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
+    const {appSettings} = useAppContext();
     // const alphaFlag = useFeatureFlag('trafficAnalyticsAlpha', '/');
 
     return (
@@ -31,11 +32,15 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         }}>
                             Overview
                         </TabsTrigger>
-                        <TabsTrigger value="/web/" onClick={() => {
-                            navigate('/web/');
-                        }}>
-                        Web traffic
-                        </TabsTrigger>
+
+                        {appSettings?.analytics.webAnalytics &&
+                            <TabsTrigger value="/web/" onClick={() => {
+                                navigate('/web/');
+                            }}>
+                            Web traffic
+                            </TabsTrigger>
+                        }
+
                         <TabsTrigger value="/newsletters/" onClick={() => {
                             navigate('/newsletters/');
                         }}>
@@ -46,11 +51,13 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         }}>
                         Growth
                         </TabsTrigger>
-                        <TabsTrigger value="/locations/" onClick={() => {
-                            navigate('/locations/');
-                        }}>
-                        Locations
-                        </TabsTrigger>
+                        {appSettings?.analytics.webAnalytics &&
+                            <TabsTrigger value="/locations/" onClick={() => {
+                                navigate('/locations/');
+                            }}>
+                            Locations
+                            </TabsTrigger>
+                        }
                     </TabsList>
                 </Tabs>
                 <NavbarActions>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1758/what-happens-when-traffic-analytics-is-turned-off

When web analytics is turned off, related parts of Admin should be hidden:
- Visitors chart from analytics overview
- Visitor count from latest post
- Visitor column from top posts
- Web traffic tab from site-wide analytics
- Locations tab from site-wide analytics
- Web block from post analytics overview
- Web tab from post analytics