### PR TITLE
🔥 Removed Node.js v18 support

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -6,14 +6,6 @@ const debug = require('debug')('ghost:dev');
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
-// check we're running on Node 18 and above
-debug('checking node version');
-const nodeVersion = parseInt(process.versions.node.split('.')[0]);
-if (nodeVersion < 18) {
-    console.error('`yarn dev` requires Node v18 or above. Please upgrade your version of Node.');
-    process.exit(1);
-}
-debug('node version check passed');
 
 debug('loading config');
 const config = require('../../ghost/core/core/shared/config/loader').loadNconf({
@@ -86,7 +78,6 @@ let commands = [];
 
 const COMMAND_GHOST = {
     name: 'ghost',
-    // Note: if this isn't working for you, please use Node 18 and above
     command: 'nx run ghost:dev',
     prefixColor: 'blue',
     env: {

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:js && yarn lint:hbs"
   },
   "engines": {
-    "node": "^18.12.1 || ^20.11.1 || ^22.13.1"
+    "node": "^20.11.1 || ^22.13.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.27.5",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -58,7 +58,7 @@
     "prepack": "node monobundle.js"
   },
   "engines": {
-    "node": "^18.12.1 || ^20.11.1 || ^22.13.1",
+    "node": "^20.11.1 || ^22.13.1",
     "cli": "^1.27.0"
   },
   "dependencies": {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/23924
closes https://linear.app/ghost/issue/PROD-1763/breaking-change-drop-support-for-node-18

- Node.js v18 was EOL on April 30, 2025
- This officially removes support for Node.js v18 in Ghost 6.0
- I've also removed some caveats from the dev tooling which applied to versions less than 18 and so is really not relevant anymore

