### PR TITLE
Add web traffic tab analytics initial test

### DIFF
--- a/apps/stats/test/acceptance/location.test.ts
+++ b/apps/stats/test/acceptance/location.test.ts
@@ -1,5 +1,4 @@
-import 'dotenv/config';
-import LocationsPage from './pages/LocationsPage.ts';
+import LocationsTab from './pages/LocationsTab.ts';
 import {addAnalyticsEvent, statsConfig} from '../utils/tinybird-helpers.ts';
 import {expect, test} from '@playwright/test';
 import {faker} from '@faker-js/faker';
@@ -32,7 +31,7 @@ test.describe('Stats App - Locations', () => {
 
         await addAnalyticsEvent({siteUuid: siteUuid, locale: 'en-GB', location: 'GB'});
 
-        const locationsPage = new LocationsPage(page);
+        const locationsPage = new LocationsTab(page);
         await locationsPage.visit();
 
         await expect(locationsPage.body).toContainText('United Kingdom');
@@ -58,7 +57,7 @@ test.describe('Stats App - Locations', () => {
             }
         });
 
-        const locationsPage = new LocationsPage(page);
+        const locationsPage = new LocationsTab(page);
         await locationsPage.visit();
 
         await expect(locationsPage.body).toContainText('No stats available');

--- a/apps/stats/test/acceptance/pages/GrowthTab.ts
+++ b/apps/stats/test/acceptance/pages/GrowthTab.ts
@@ -1,0 +1,11 @@
+import AnalyticsPage from './AnalyticsPage.ts';
+import {Page} from '@playwright/test';
+
+class GrowthTab extends AnalyticsPage {
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/analytics/growth';
+    }
+}
+
+export default GrowthTab;

--- a/apps/stats/test/acceptance/pages/LocationsTab.ts
+++ b/apps/stats/test/acceptance/pages/LocationsTab.ts
@@ -1,7 +1,7 @@
 import AnalyticsPage from './AnalyticsPage.ts';
 import {Page} from '@playwright/test';
 
-class LocationsPage extends AnalyticsPage {
+class LocationsTab extends AnalyticsPage {
     constructor(page: Page) {
         super(page);
 
@@ -9,4 +9,4 @@ class LocationsPage extends AnalyticsPage {
     }
 }
 
-export default LocationsPage;
+export default LocationsTab;

--- a/apps/stats/test/acceptance/pages/OverviewTab.ts
+++ b/apps/stats/test/acceptance/pages/OverviewTab.ts
@@ -1,14 +1,15 @@
 import AnalyticsPage from './AnalyticsPage.ts';
 import {Locator, Page} from '@playwright/test';
 
-class OverviewPage extends AnalyticsPage {
+class OverviewTab extends AnalyticsPage {
     public readonly header: Locator;
 
     constructor(page: Page) {
         super(page);
 
+        this.pageUrl = '/ghost/#/analytics';
         this.header = page.getByRole('heading', {name: 'Analytics'});
     }
 }
 
-export default OverviewPage;
+export default OverviewTab;

--- a/apps/stats/test/acceptance/pages/WebTrafficTab.ts
+++ b/apps/stats/test/acceptance/pages/WebTrafficTab.ts
@@ -1,0 +1,11 @@
+import AnalyticsPage from './AnalyticsPage.ts';
+import {Page} from '@playwright/test';
+
+class WebTrafficTab extends AnalyticsPage {
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/analytics/web';
+    }
+}
+
+export default WebTrafficTab;

--- a/apps/stats/test/acceptance/stats.test.ts
+++ b/apps/stats/test/acceptance/stats.test.ts
@@ -1,4 +1,4 @@
-import OverviewPage from './pages/OverviewPage.ts';
+import OverviewTab from './pages/OverviewTab.ts';
 import {
     createMockRequests,
     mockApi
@@ -10,14 +10,14 @@ test.describe('Stats App', () => {
         // Use the default mock requests - includes all common endpoints
         await mockApi({page, requests: createMockRequests()});
 
-        const overviewPage = new OverviewPage(page);
+        const overviewPage = new OverviewTab(page);
         await overviewPage.visit();
 
         await expect(overviewPage.header).toBeVisible();
     });
 
     test('shows an error without mocked data', async ({page}) => {
-        const overviewPage = new OverviewPage(page);
+        const overviewPage = new OverviewTab(page);
         await overviewPage.visit();
 
         await expect(overviewPage.body).toContainText(/Unexpected Application Error/);
@@ -39,7 +39,7 @@ test.describe('Stats App', () => {
             }
         })});
 
-        const overviewPage = new OverviewPage(page);
+        const overviewPage = new OverviewTab(page);
         await overviewPage.visit();
 
         await expect(overviewPage.body).toContainText('155');

--- a/apps/stats/test/acceptance/web-traffic.test.ts
+++ b/apps/stats/test/acceptance/web-traffic.test.ts
@@ -1,0 +1,40 @@
+import WebTrafficTab from './pages/WebTrafficTab.ts';
+import {addAnalyticsEvent, statsConfig} from '../utils/tinybird-helpers.ts';
+import {expect, test} from '@playwright/test';
+import {faker} from '@faker-js/faker';
+import {
+    globalDataRequests,
+    mockApi,
+    responseFixtures
+} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('Stats App - Web Traffic', () => {
+    test('loads tab with correct top sources', async ({page}) => {
+        const siteUuid = faker.string.uuid();
+
+        await mockApi({
+            page, requests: {
+                ...globalDataRequests,
+                browseConfig: {
+                    method: 'GET', path: '/config/', response: {
+                        config: {
+                            ...responseFixtures.config.config,
+                            stats: {
+                                ...statsConfig,
+                                id: siteUuid
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        const domain = 'example.com';
+        await addAnalyticsEvent({siteUuid: siteUuid, referrer: faker.internet.url(), referrerSource: domain});
+
+        const webTrafficPage = new WebTrafficTab(page);
+        await webTrafficPage.visit();
+
+        await expect(webTrafficPage.body).toContainText(domain);
+    });
+});

--- a/apps/stats/test/utils/test-helpers.ts
+++ b/apps/stats/test/utils/test-helpers.ts
@@ -23,12 +23,12 @@ export const createTestWrapper = () => {
             mutations: {retry: false}
         }
     });
-    
+
     const Wrapper = ({children}: {children: React.ReactNode}) => (
         React.createElement(QueryClientProvider, {client: queryClient}, children)
     );
     Wrapper.displayName = 'TestWrapper';
-    
+
     return Wrapper;
 };
 
@@ -128,4 +128,4 @@ export const createMockGlobalData = (siteUrl = 'https://ghost.org') => ({
 
 // Legacy compatibility
 export const setupUniversalMocks = setupStatsAppMocks;
-export const setupDefaultStatsMocks = setupStatsAppMocks; 
+export const setupDefaultStatsMocks = setupStatsAppMocks;

--- a/apps/stats/test/utils/tinybird-helpers.ts
+++ b/apps/stats/test/utils/tinybird-helpers.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {faker} from '@faker-js/faker';
 
 export const statsConfig = {
@@ -12,11 +13,13 @@ export const statsConfig = {
     }
 };
 
-export interface AnalyticsEventProps {
+interface AnalyticsEventProps {
     siteUuid: string;
     timestamp?: Date;
-    location: string;
-    locale: string;
+    location?: string;
+    locale?: string;
+    referrer?: string;
+    referrerSource?: string;
 }
 
 const formatDate = (date: Date): string => {
@@ -38,7 +41,7 @@ function getFormattedDate(daysAgo: number) {
 }
 
 export async function addAnalyticsEvent(eventProps: AnalyticsEventProps) {
-    const {siteUuid, locale, location} = eventProps;
+    const {siteUuid, locale, location, referrer, referrerSource} = eventProps;
 
     const {local} = statsConfig;
     const eventsUrl = `${local.endpoint}/v0/events?name=${local.datasource}`;
@@ -61,13 +64,13 @@ export async function addAnalyticsEvent(eventProps: AnalyticsEventProps) {
                 post_uuid: faker.string.uuid(),
                 post_type: 'post',
                 'user-agent': faker.internet.userAgent(),
-                locale: locale,
-                location: location,
-                referrer: 'https://example.com',
+                locale: locale || 'en-GB',
+                location: location || 'GB',
+                referrer: referrer || 'https://example.com',
                 pathname: '/hello-world/',
                 href: 'https://my-ghost-site.com/hello-world/',
                 meta: {
-                    referrerSource: 'https://example.com'
+                    referrerSource: referrerSource || 'https://example.com'
                 }
             }
         })


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1796/testing-add-acceptance-test-suite-for-stats-and-posts-app

* added web tab initial analytics test to make sure data is loading from TinyBird is verified
* cleaned up a bit existing tests
* added more page objects to support traversing through analytics tabs
* update will help further test web traffic analytics details

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
