### PR TITLE
Updated flag for post analytics button in posts index

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -259,7 +259,7 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalyticsAlpha"))}}
+        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics Beta"}}


### PR DESCRIPTION
no ref

We should be using the beta and not the alpha flag.