### PR TITLE
Hid live reader display for email only posts in analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -84,7 +84,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 </BreadcrumbList>
                             </Breadcrumb>
                             <div className='flex items-center gap-2'>
-                                {appSettings?.analytics.webAnalytics && (
+                                {appSettings?.analytics.webAnalytics && !post?.email_only && (
                                     <div className='mr-3 flex items-center gap-2 text-sm'>
                                         <div className='flex items-center gap-2 text-sm text-muted-foreground' title='Active readers in the last 5 minutes · Updates every 60 seconds'>
                                             <span className='text-sm'>


### PR DESCRIPTION
no ref

With no page to nav to it doesn't make sense to show a count, as it will always be zero.