### PR TITLE
Update HomePage.ts with getByRole selector

### DIFF
--- a/e2e/src/pages/HomePage.ts
+++ b/e2e/src/pages/HomePage.ts
@@ -8,7 +8,7 @@ export class HomePage {
 
     constructor(page: Page) {
         this.page = page;
-        this.title = page.locator('h1, .site-title');
+        this.title = page.getByRole('heading', { level: 1 });
         this.navigation = page.locator('.site-nav');
         this.posts = page.locator('.post-card');
     }

--- a/e2e/src/pages/HomePage.ts
+++ b/e2e/src/pages/HomePage.ts
@@ -8,7 +8,7 @@ export class HomePage {
 
     constructor(page: Page) {
         this.page = page;
-        this.title = page.getByRole('heading', { level: 1 });
+        this.title = page.getByRole('heading',{level:1});
         this.navigation = page.locator('.site-nav');
         this.posts = page.locator('.post-card');
     }

--- a/e2e/src/pages/HomePage.ts
+++ b/e2e/src/pages/HomePage.ts
@@ -8,7 +8,7 @@ export class HomePage {
 
     constructor(page: Page) {
         this.page = page;
-        this.title = page.getByRole('heading',{level:1});
+        this.title = page.getByRole('heading', {level:1});
         this.navigation = page.locator('.site-nav');
         this.posts = page.locator('.post-card');
     }

--- a/e2e/src/pages/HomePage.ts
+++ b/e2e/src/pages/HomePage.ts
@@ -8,7 +8,7 @@ export class HomePage {
 
     constructor(page: Page) {
         this.page = page;
-        this.title = page.getByRole('heading', {level:1});
+        this.title = page.getByRole('heading', {level: 1});
         this.navigation = page.locator('.site-nav');
         this.posts = page.locator('.post-card');
     }


### PR DESCRIPTION
Consider adopting Playwright's [recommended Locators](https://playwright.dev/docs/locators#quick-guide), which encourage some accessibility coverage.

For example, `getByRole` will fail in the unlikely event the `<h1>` is marked `aria-hidden`. But more practically, `getByRole("button")` prevents div-buttons without roles, for example.

---

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
