### PR TITLE
Fixed logic for hiding web traffic tab

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -181,7 +181,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                         }}>
                             Overview
                         </TabsTrigger>
-                        {!post?.email_only || !appSettings?.analytics.webAnalytics && (
+                        {!post?.email_only && appSettings?.analytics.webAnalytics && (
                             <TabsTrigger value="Web" onClick={() => {
                                 navigate(`/analytics/beta/${postId}/web`);
                             }}>


### PR DESCRIPTION
no ref

Fixed up the logic. We should just be checking BOTH ARE TRUE:
- Post is not email only
- Web analytics is enabled