### PR TITLE
Removed unsupported codecov option from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1028,7 +1028,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: admin-tests
-          move_coverage_to_trash: true
 
       - name: Restore E2E coverage
         if: contains(needs.job_acceptance-tests.result, 'success')
@@ -1046,7 +1045,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: e2e-tests
-          move_coverage_to_trash: true
 
   job_required_tests:
     name: All required tests passed or skipped


### PR DESCRIPTION
- Not sure where this option came from, maybe an older version
- I can only find reference to it in the nx fork, which we don't use
- https://github.com/joinrepublic/codecov-action-nx
- Removing cos AI gets really annoyed about this when trying to make any other change!

