### PR TITLE
More CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           echo "GITHUB_EVENT_NAME: ${{ github.event_name }}"
           echo "GITHUB_CONTEXT: ${{ toJson(github.event) }}"
 
-
       - name: Get metadata (push)
         if: github.event_name == 'push'
         run: |
@@ -134,11 +133,6 @@ jobs:
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
               - '!**/*.md'
-
-      - name: 'Checkout current commit'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD_COMMIT }}
 
       - name: Compute lockfile hash
         run: echo "hash=lockfile-${{ hashFiles('yarn.lock') }}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,9 +534,6 @@ jobs:
         with:
           timezoneLinux: "America/New_York"
 
-      - name: Record start time
-        run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
-
       - name: Set env vars (SQLite)
         if: contains(matrix.env.DB, 'sqlite')
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
@@ -553,13 +550,6 @@ jobs:
         working-directory: ghost/core
         run: yarn test:ci:integration
 
-      # Get runtime in seconds for test suite
-      - name: Record test duration
-        run: |
-          startTime="$(cat ${{ runner.temp }}/startTime)"
-          endTime="$(date +%s)"
-          echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v4
         if: matrix.node == env.NODE_VERSION && contains(matrix.env.DB, 'mysql')
         with:
@@ -567,41 +557,6 @@ jobs:
           path: |
             ghost/*/coverage-e2e/cobertura-coverage.xml
             ghost/*/coverage-integration/cobertura-coverage.xml
-
-      # Continue on error if TailScale service is down
-      - name: Tailscale Action
-        timeout-minutes: 2
-        continue-on-error: true
-        if: (github.event_name == 'push' && github.repository_owner == 'TryGhost') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'TryGhost/'))
-        uses: tailscale/github-action@v1
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
-      # Report time taken to metrics service
-      # Continue on error if previous TailScale step fails
-      - name: Store test duration
-        uses: tryghost/actions/actions/trigger-metric@main
-        timeout-minutes: 1
-        continue-on-error: true
-        if: (github.event_name == 'push' && github.repository_owner == 'TryGhost') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'TryGhost/'))
-        with:
-          metricName: 'test-time'
-          metricValue: ${{ env.test_time }}
-          configuration: |
-            {
-              "metrics": {
-                "transports": ["elasticsearch"],
-                "metadata": {
-                  "database": "${{ matrix.env.DB }}",
-                  "node": "${{ matrix.node }}"
-                }
-              },
-              "elasticsearch": {
-                "host": "${{ secrets.ELASTICSEARCH_HOST }}",
-                "username": "${{ secrets.ELASTICSEARCH_USERNAME }}",
-                "password": "${{ secrets.ELASTICSEARCH_PASSWORD }}"
-              }
-            }
 
       - uses: tryghost/actions/actions/slack-build@main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
[Removed duplicate checkout step from ci.yml](https://github.com/TryGhost/Ghost/commit/e1f646dc8e20e816163c8f0c7f8b4907dfdd6f22) 

- Not sure how this got here!
- There are duplicate checkout steps which seems unnecessary
- Cleaning up the ci.yml file to make it easier to work with
- 

[Removed tailscale and metrics from ci](https://github.com/TryGhost/Ghost/commit/96f23efdb2d4787be55a5efc88064e532680d062) 

- We have this complex block for tracking test-time
- However, it's been broken for a month and noone noticed
- Therefore I don't think this is used
- Also note that boot time is tracked in a different way
- There are lots of ways to get job time statistics from GHA
- So if we do want this, there's probably an easier way