### PR TITLE
Added Tinybird staging workspace for tests and deployments

### DIFF
--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -10,7 +10,6 @@ inputs:
   workspace:
     description: 'Workspace name (for logging purposes)'
     required: true
-    default: 'default'
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -27,3 +27,28 @@ runs:
       shell: bash
       run: tb --cloud --host ${{ inputs.host }} --token ${{ inputs.token }} deployment create --wait
       working-directory: ghost/core/core/server/data/tinybird
+
+    - name: Send slack notification
+      uses: slackapi/slack-github-action@v2.1.0
+      if: always() && steps.conclusion != 'skipped'
+      with:
+        webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: "Tinybird Deployment: ${{ inputs.workspace }}"
+          blocks:
+            - type: "section"
+              text:
+                type: "mrkdwn"
+                text: "${{ job.status == 'success' && ':rocket: *Tinybird Deployment*' || ':x: *Tinybird Deployment*' }}"
+            - type: "section"
+              fields:
+                - type: "mrkdwn"
+                  text: "*Workspace:*\n:bird: ${{ inputs.workspace }}"
+                - type: "mrkdwn"
+                  text: "*Status:*\n${{ job.status == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
+                - type: "mrkdwn"
+                  text: "*Workflow:*\n:link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+          attachments:
+            - color: "${{ job.status == 'success' && 'good' || 'danger' }}"
+              fallback: "Tinybird Deployment: ${{ job.status }}"

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -1,0 +1,29 @@
+name: 'Deploy Tinybird'
+description: 'Deploy Tinybird configuration to a workspace'
+inputs:
+  host:
+    description: 'Tinybird host URL'
+    required: true
+  token:
+    description: 'Tinybird authentication token'
+    required: true
+  workspace:
+    description: 'Workspace name (for logging purposes)'
+    required: true
+    default: 'default'
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Tinybird CLI
+      shell: bash
+      run: curl -fsSL https://tinybird.co/install.sh | sh
+    - name: Check the deployment
+      shell: bash
+      run: tb --cloud --host ${{ inputs.host }} --token ${{ inputs.token }} deployment create --check
+      working-directory: ghost/core/core/server/data/tinybird
+    - name: Create a ${{ inputs.workspace }} deployment
+      shell: bash
+      run: tb --cloud --host ${{ inputs.host }} --token ${{ inputs.token }} deployment create --wait
+      working-directory: ghost/core/core/server/data/tinybird

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Send slack notification
       uses: slackapi/slack-github-action@v2.1.0
-      if: always() && steps.conclusion != 'skipped'
+      if: always()
       with:
         webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,13 +844,22 @@ jobs:
           retention-days: 30
 
   job_tinybird_forward:
-    name: Tinybird Tests (Forward)
+    name: Tinybird Tests (Forward) - ${{ matrix.workspace }}
     runs-on: ubuntu-latest
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
+    strategy:
+      matrix:
+        include:
+          - workspace: staging
+            host_secret: TINYBIRD_HOST_STAGING
+            token_secret: TINYBIRD_TOKEN_STAGING
+          - workspace: production
+            host_secret: TINYBIRD_HOST
+            token_secret: TINYBIRD_TOKEN
     env:
-      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST_STAGING }}
-      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
+      TINYBIRD_HOST: ${{ secrets[matrix.host_secret] }}
+      TINYBIRD_TOKEN: ${{ secrets[matrix.token_secret] }}
     defaults:
         run:
           working-directory: ghost/core/core/server/data/tinybird
@@ -867,7 +876,7 @@ jobs:
         run: tb build
       - name: Test project
         run: tb test run
-      - name: Deployment check
+      - name: Deployment check - ${{ matrix.workspace }}
         run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
 
   job_ghost-cli:
@@ -1180,31 +1189,35 @@ jobs:
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
 
-  deploy_tinybird_forward:
-    name: Deploy Tinybird (Forward) - ${{ matrix.workspace }}
+  deploy_tinybird_forward_staging:
+    name: Deploy Tinybird (Forward) - Staging
     runs-on: ubuntu-latest
     needs: [
       job_setup,
       job_tinybird_forward
     ]
     if: always() && needs.job_setup.outputs.changed_tinybird_forward == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird_forward.result == 'success' && needs.job_setup.outputs.is_main == 'true'
-    strategy:
-      matrix:
-        include:
-          - workspace: production
-          - workspace: staging
-    env:
-      TINYBIRD_HOST: ${{ matrix.workspace == 'production' && secrets.TINYBIRD_HOST || secrets.TINYBIRD_HOST_STAGING }}
-      TINYBIRD_TOKEN: ${{ matrix.workspace == 'production' && secrets.TINYBIRD_TOKEN || secrets.TINYBIRD_TOKEN_STAGING }}
-    defaults:
-      run:
-        working-directory: ghost/core/core/server/data/tinybird
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Tinybird CLI
-        run: curl -fsSL https://tinybird.co/install.sh | sh
-      - name: Check the deployment
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deployment create --check
-      - name: Create a ${{ matrix.workspace }} deployment
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deployment create --wait
+      - name: Deploy to Staging
+        uses: ./.github/actions/deploy-tinybird
+        with:
+          host: ${{ secrets.TINYBIRD_HOST_STAGING }}
+          token: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
+          workspace: 'staging'
+
+  deploy_tinybird_forward_production:
+    name: Deploy Tinybird (Forward) - Production
+    runs-on: ubuntu-latest
+    needs: [
+      job_setup,
+      job_tinybird_forward,
+      deploy_tinybird_forward_staging
+    ]
+    if: always() && needs.job_setup.outputs.changed_tinybird_forward == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird_forward.result == 'success' && needs.deploy_tinybird_forward_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    steps:
+      - name: Deploy to Production
+        uses: ./.github/actions/deploy-tinybird
+        with:
+          host: ${{ secrets.TINYBIRD_HOST }}
+          token: ${{ secrets.TINYBIRD_TOKEN }}
+          workspace: 'production'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,7 +844,7 @@ jobs:
           retention-days: 30
 
   job_tinybird-tests:
-    name: Tinybird Tests - ${{ matrix.workspace }}
+    name: Tinybird Tests
     runs-on: ubuntu-latest
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_tinybird == 'true'
@@ -1040,7 +1040,7 @@ jobs:
   canary:
     needs: [
       job_setup,
-      job_required-tests
+      job_required_tests
     ]
     name: Canary
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             sodo-search:
               - *shared
               - 'apps/sodo-search/**'
-            tinybird-forward:
+            tinybird:
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
             any-code:
@@ -194,7 +194,7 @@ jobs:
       changed_portal: ${{ steps.changed.outputs.portal }}
       changed_signup_form: ${{ steps.changed.outputs.signup-form }}
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
-      changed_tinybird_forward: ${{ steps.changed.outputs.tinybird-forward }}
+      changed_tinybird: ${{ steps.changed.outputs.tinybird }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
@@ -843,23 +843,11 @@ jobs:
           path: e2e/test-results
           retention-days: 30
 
-  job_tinybird_forward:
-    name: Tinybird Tests (Forward) - ${{ matrix.workspace }}
+  job_tinybird-tests:
+    name: Tinybird Tests - ${{ matrix.workspace }}
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
-    strategy:
-      matrix:
-        include:
-          - workspace: staging
-            host_secret: TINYBIRD_HOST_STAGING
-            token_secret: TINYBIRD_TOKEN_STAGING
-          - workspace: production
-            host_secret: TINYBIRD_HOST
-            token_secret: TINYBIRD_TOKEN
-    env:
-      TINYBIRD_HOST: ${{ secrets[matrix.host_secret] }}
-      TINYBIRD_TOKEN: ${{ secrets[matrix.token_secret] }}
+    if: needs.job_setup.outputs.changed_tinybird == 'true'
     defaults:
         run:
           working-directory: ghost/core/core/server/data/tinybird
@@ -868,6 +856,11 @@ jobs:
         image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
+    env:
+      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
+      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+      TINYBIRD_HOST_STAGING: ${{ secrets.TINYBIRD_HOST_STAGING }}
+      TINYBIRD_TOKEN_STAGING: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Tinybird CLI
@@ -876,7 +869,9 @@ jobs:
         run: tb build
       - name: Test project
         run: tb test run
-      - name: Deployment check - ${{ matrix.workspace }}
+      - name: Deployment check - Staging
+        run: tb --cloud --host ${{ env.TINYBIRD_HOST_STAGING }} --token ${{ env.TINYBIRD_TOKEN_STAGING }} deploy --check
+      - name: Deployment check - Production
         run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
 
   job_ghost-cli:
@@ -1029,7 +1024,7 @@ jobs:
         job_comments_ui,
         job_signup_form,
         job_e2e-tests,
-        job_tinybird_forward
+        job_tinybird-tests
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -1045,7 +1040,7 @@ jobs:
   canary:
     needs: [
       job_setup,
-      job_required_tests
+      job_required-tests
     ]
     name: Canary
     runs-on: ubuntu-latest
@@ -1189,14 +1184,14 @@ jobs:
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
 
-  deploy_tinybird_forward_staging:
-    name: Deploy Tinybird (Forward) - Staging
+  deploy_tinybird_staging:
+    name: Deploy Tinybird - Staging
     runs-on: ubuntu-latest
     needs: [
       job_setup,
-      job_tinybird_forward
+      job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird_forward == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird_forward.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Deploy to Staging
         uses: ./.github/actions/deploy-tinybird
@@ -1205,15 +1200,15 @@ jobs:
           token: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
           workspace: 'staging'
 
-  deploy_tinybird_forward_production:
-    name: Deploy Tinybird (Forward) - Production
+  deploy_tinybird_production:
+    name: Deploy Tinybird - Production
     runs-on: ubuntu-latest
     needs: [
       job_setup,
-      job_tinybird_forward,
-      deploy_tinybird_forward_staging
+      job_tinybird-tests,
+      deploy_tinybird_staging
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird_forward == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird_forward.result == 'success' && needs.deploy_tinybird_forward_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.deploy_tinybird_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Deploy to Production
         uses: ./.github/actions/deploy-tinybird

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,8 +849,8 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_tinybird_forward == 'true'
     env:
-      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST_STAGING }}
+      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
     defaults:
         run:
           working-directory: ghost/core/core/server/data/tinybird
@@ -1181,16 +1181,21 @@ jobs:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}
 
   deploy_tinybird_forward:
-    name: Deploy Tinybird (Forward)
+    name: Deploy Tinybird (Forward) - ${{ matrix.workspace }}
     runs-on: ubuntu-latest
     needs: [
       job_setup,
       job_tinybird_forward
     ]
     if: always() && needs.job_setup.outputs.changed_tinybird_forward == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird_forward.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    strategy:
+      matrix:
+        include:
+          - workspace: production
+          - workspace: staging
     env:
-      TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-      TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+      TINYBIRD_HOST: ${{ matrix.workspace == 'production' && secrets.TINYBIRD_HOST || secrets.TINYBIRD_HOST_STAGING }}
+      TINYBIRD_TOKEN: ${{ matrix.workspace == 'production' && secrets.TINYBIRD_TOKEN || secrets.TINYBIRD_TOKEN_STAGING }}
     defaults:
       run:
         working-directory: ghost/core/core/server/data/tinybird
@@ -1201,5 +1206,5 @@ jobs:
         run: curl -fsSL https://tinybird.co/install.sh | sh
       - name: Check the deployment
         run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deployment create --check
-      - name: Create a staging deployment
+      - name: Create a ${{ matrix.workspace }} deployment
         run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deployment create --wait

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -1,0 +1,14 @@
+TOKEN "tracker" APPEND
+
+
+SCHEMA >
+    `timestamp` DateTime `json:$.timestamp`,
+    `session_id` String `json:$.session_id`,
+    `action` LowCardinality(String) `json:$.action`,
+    `version` LowCardinality(String) `json:$.version`,
+    `payload` JSON(max_dynamic_types=4, max_dynamic_paths=32) `json:$.payload`,
+    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "site_uuid, timestamp"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -1,3 +1,6 @@
+# This is a test datasource with the same schema as analytics_events.datasource
+# A place to send data for testing and monitoring purposes
+
 TOKEN "tracker" APPEND
 
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1943/separate-stagingproduction-tinybird-workspaces

We currently only have one Tinybird workspace, and all commits deploy straight to it. This commit adds a new staging workspace, which all our staging sites will point to. Changes to our Tinybird files will be deployed to staging first before moving on to production.