### PR TITLE
Fixed broken Tinybird deployment workflow

### DIFF
--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -41,11 +41,9 @@ runs:
             - type: "section"
               text:
                 type: "mrkdwn"
-                text: "${{ steps.deploy.outcome == 'success' && ':rocket: *Tinybird Deployment*' || ':x: *Tinybird Deployment*' }}"
+                text: "${{ steps.deploy.outcome == 'success' && ':white_check_mark: *Tinybird ${{ inputs.workspace }} Deployment*' || ':x: *Tinybird ${{ inputs.workspace }} Deployment*' }}"
             - type: "section"
               fields:
-                - type: "mrkdwn"
-                  text: "*Workspace:*\n:bird: ${{ inputs.workspace }}"
                 - type: "mrkdwn"
                   text: "*Status:*\n${{ steps.deploy.outcome == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
                 - type: "mrkdwn"

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -38,16 +38,17 @@ runs:
         payload: |
           text: "Tinybird Deployment: ${{ inputs.workspace }}"
           blocks:
-            - type: "section"
+            - type: "header"
               text:
-                type: "mrkdwn"
-                text: "${{ steps.deploy.outcome == 'success' && ':white_check_mark: *Tinybird ${{ inputs.workspace }} Deployment*' || ':x: *Tinybird ${{ inputs.workspace }} Deployment*' }}"
+                type: "plain_text"
+                text: "${{ steps.deploy.outcome == 'success' && ':white_check_mark: *Tinybird ' + inputs.workspace + ' Deployment*' || ':x: *Tinybird ' + inputs.workspace + ' Deployment*' }}"                
             - type: "section"
               fields:
                 - type: "mrkdwn"
                   text: "*Status:*\n${{ steps.deploy.outcome == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
                 - type: "mrkdwn"
                   text: "*Workflow:*\n:link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            - type: "divider"
           attachments:
             - color: "${{ steps.deploy.outcome == 'success' && 'good' || 'danger' }}"
               fallback: "Tinybird Deployment: ${{ steps.deploy.outcome }}"

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -10,11 +10,12 @@ inputs:
   workspace:
     description: 'Workspace name (for logging purposes)'
     required: true
+  slack-webhook:
+    description: 'Slack webhook URL for notifications'
+    required: true
 runs:
   using: 'composite'
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
     - name: Install Tinybird CLI
       shell: bash
       run: curl -fsSL https://tinybird.co/install.sh | sh
@@ -23,6 +24,7 @@ runs:
       run: tb --cloud --host ${{ inputs.host }} --token ${{ inputs.token }} deployment create --check
       working-directory: ghost/core/core/server/data/tinybird
     - name: Create a ${{ inputs.workspace }} deployment
+      id: deploy
       shell: bash
       run: tb --cloud --host ${{ inputs.host }} --token ${{ inputs.token }} deployment create --wait
       working-directory: ghost/core/core/server/data/tinybird
@@ -31,7 +33,7 @@ runs:
       uses: slackapi/slack-github-action@v2.1.0
       if: always()
       with:
-        webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
+        webhook: ${{ inputs.slack-webhook }}
         webhook-type: incoming-webhook
         payload: |
           text: "Tinybird Deployment: ${{ inputs.workspace }}"
@@ -39,15 +41,15 @@ runs:
             - type: "section"
               text:
                 type: "mrkdwn"
-                text: "${{ job.status == 'success' && ':rocket: *Tinybird Deployment*' || ':x: *Tinybird Deployment*' }}"
+                text: "${{ steps.deploy.outcome == 'success' && ':rocket: *Tinybird Deployment*' || ':x: *Tinybird Deployment*' }}"
             - type: "section"
               fields:
                 - type: "mrkdwn"
                   text: "*Workspace:*\n:bird: ${{ inputs.workspace }}"
                 - type: "mrkdwn"
-                  text: "*Status:*\n${{ job.status == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
+                  text: "*Status:*\n${{ steps.deploy.outcome == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
                 - type: "mrkdwn"
                   text: "*Workflow:*\n:link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
           attachments:
-            - color: "${{ job.status == 'success' && 'good' || 'danger' }}"
-              fallback: "Tinybird Deployment: ${{ job.status }}"
+            - color: "${{ steps.deploy.outcome == 'success' && 'good' || 'danger' }}"
+              fallback: "Tinybird Deployment: ${{ steps.deploy.outcome }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,7 +1191,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1193,6 +1193,8 @@ jobs:
     ]
     if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Deploy to Staging
         uses: ./.github/actions/deploy-tinybird
         with:
@@ -1210,6 +1212,8 @@ jobs:
     ]
     if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.deploy_tinybird_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Deploy to Production
         uses: ./.github/actions/deploy-tinybird
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1200,7 +1200,7 @@ jobs:
         with:
           host: ${{ secrets.TINYBIRD_HOST_STAGING }}
           token: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
-          workspace: 'staging'
+          workspace: 'Staging'
           slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
 
   deploy_tinybird_production:
@@ -1220,5 +1220,5 @@ jobs:
         with:
           host: ${{ secrets.TINYBIRD_HOST }}
           token: ${{ secrets.TINYBIRD_TOKEN }}
-          workspace: 'production'
+          workspace: 'Production'
           slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,7 +1191,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1201,6 +1201,7 @@ jobs:
           host: ${{ secrets.TINYBIRD_HOST_STAGING }}
           token: ${{ secrets.TINYBIRD_TOKEN_STAGING }}
           workspace: 'staging'
+          slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
 
   deploy_tinybird_production:
     name: Deploy Tinybird - Production
@@ -1220,3 +1221,4 @@ jobs:
           host: ${{ secrets.TINYBIRD_HOST }}
           token: ${{ secrets.TINYBIRD_TOKEN }}
           workspace: 'production'
+          slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -1,5 +1,6 @@
 # This is a test datasource with the same schema as analytics_events.datasource
 # A place to send data for testing and monitoring purposes
+# Not for production use
 
 TOKEN "tracker" APPEND
 

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -4,7 +4,6 @@
 
 TOKEN "tracker" APPEND
 
-
 SCHEMA >
     `timestamp` DateTime `json:$.timestamp`,
     `session_id` String `json:$.session_id`,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1943/separate-stagingproduction-tinybird-workspaces

The Tinybird Deploy steps were failing because they didn't include a checkout step, and they are trying to run a local action. This adds the checkout step so they should run successfully.