### PR TITLE
Fixed tinybird deployment workflow syntax

### DIFF
--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -38,9 +38,9 @@ runs:
         payload: |
           text: "Tinybird Deployment: ${{ inputs.workspace }}"
           blocks:
-            - type: "header"
+            - type: "section"
               text:
-                type: "plain_text"
+                type: "mrkdwn"
                 text: "${{ steps.deploy.outcome == 'success' && format(':white_check_mark: *Tinybird {0} Deployment*', inputs.workspace) || format(':x: *Tinybird {0} Deployment*', inputs.workspace) }}"                
             - type: "section"
               fields:

--- a/.github/actions/deploy-tinybird/action.yml
+++ b/.github/actions/deploy-tinybird/action.yml
@@ -41,7 +41,7 @@ runs:
             - type: "header"
               text:
                 type: "plain_text"
-                text: "${{ steps.deploy.outcome == 'success' && ':white_check_mark: *Tinybird ' + inputs.workspace + ' Deployment*' || ':x: *Tinybird ' + inputs.workspace + ' Deployment*' }}"                
+                text: "${{ steps.deploy.outcome == 'success' && format(':white_check_mark: *Tinybird {0} Deployment*', inputs.workspace) || format(':x: *Tinybird {0} Deployment*', inputs.workspace) }}"                
             - type: "section"
               fields:
                 - type: "mrkdwn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,7 +1191,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,7 +1191,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -1,6 +1,5 @@
 # This is a test datasource with the same schema as analytics_events.datasource
 # A place to send data for testing and monitoring purposes
-# Not for production use
 
 TOKEN "tracker" APPEND
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1943/separate-stagingproduction-tinybird-workspaces

Fixes a syntax error in the deploy-tinybird action, which was preventing the job from running. Changes a comment in a test datasource to trigger the job.