### PR TITLE
Upgraded Docker to use Node.js v22

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20.15.1
+ARG NODE_VERSION=22.13.1
 
 # --------------------
 # Base Image
@@ -73,6 +73,9 @@ COPY ghost/admin/lib/ember-power-calendar-utils/package.json ghost/admin/lib/emb
 COPY ghost/admin/package.json ghost/admin/package.json
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
+
+# Copy patches directory so patch-package can apply patches during yarn install
+COPY patches patches
 
 RUN yarn install --frozen-lockfile --prefer-offline
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/23703

- We're using Node v22 for native local development and CI
- This changes our docker development tooling to use v22
- This applies the same patch as PR 23703 to workaround ESM not building on v22
