### PR TITLE
🔥 Removed Node.js v20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Define Node test matrix
         id: node_matrix
         run: |
-          echo 'matrix=["20.11.1", "22.13.1"]' >> $GITHUB_OUTPUT
+          echo 'matrix=["22.13.1"]' >> $GITHUB_OUTPUT
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:js && yarn lint:hbs"
   },
   "engines": {
-    "node": "^20.11.1 || ^22.13.1"
+    "node": "^22.13.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.27.5",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -58,7 +58,7 @@
     "prepack": "node monobundle.js"
   },
   "engines": {
-    "node": "^20.11.1 || ^22.13.1",
+    "node": "^22.13.1",
     "cli": "^1.27.0"
   },
   "dependencies": {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/23924 ref https://linear.app/ghost/issue/PROD-1598/breaking-change-drop-support-for-node-v20

- Dropping support for Node.js v20 early as a breaking change
- Node.js v22 has a couple of new features we want to use:
  - support for typescript syntax: https://nodejs.org/en/learn/typescript/run-natively
  - support for loading esm modules https://nodejs.org/en/learn/modules/publishing-a-package
- These will allow us to ugprade tooling and move faster
- Although we usually support all LTS versions of Node.js, there are significant benefits to being Node v22+
- Therefore we feel dropping Node.js v20 early is a reasonable course of action for a major release

