### PR TITLE
Updated final content API tests to latest framework

### DIFF
--- a/ghost/core/test/e2e-api/content/__snapshots__/authors.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/authors.test.js.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authors Content API Can request author by id including post count 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": 4,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+}
+`;
+
+exports[`Authors Content API Can request author by id including post count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "436",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request authors 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "You can delete this user to remove all the welcome posts",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": "ghost",
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "The Internet",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Ghost",
+      "profile_image": "https://static.ghost.org/v4.0.0/images/ghost-user.png",
+      "slug": "ghost",
+      "threads": null,
+      "tiktok": null,
+      "twitter": "ghost",
+      "url": "http://127.0.0.1:2369/author/ghost/",
+      "website": "https://ghost.org",
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": null,
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": null,
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Slimer McEctoplasm",
+      "profile_image": null,
+      "slug": "slimer-mcectoplasm",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/404/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 8,
+    },
+  },
+}
+`;
+
+exports[`Authors Content API Can request authors 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1406",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request authors including post count 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": 1,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Slimer McEctoplasm",
+      "profile_image": null,
+      "slug": "slimer-mcectoplasm",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/404/",
+      "website": null,
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": 4,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+    Object {
+      "bio": "You can delete this user to remove all the welcome posts",
+      "bluesky": null,
+      "count": Object {
+        "posts": 7,
+      },
+      "cover_image": null,
+      "facebook": "ghost",
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "The Internet",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Ghost",
+      "profile_image": "https://static.ghost.org/v4.0.0/images/ghost-user.png",
+      "slug": "ghost",
+      "threads": null,
+      "tiktok": null,
+      "twitter": "ghost",
+      "url": "http://127.0.0.1:2369/author/ghost/",
+      "website": "https://ghost.org",
+      "youtube": null,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 8,
+    },
+  },
+}
+`;
+
+exports[`Authors Content API Can request authors including post count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1466",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request single author 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "You can delete this user to remove all the welcome posts",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": "ghost",
+      "id": Any<String>,
+      "instagram": null,
+      "linkedin": null,
+      "location": "The Internet",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Ghost",
+      "profile_image": "https://static.ghost.org/v4.0.0/images/ghost-user.png",
+      "slug": "ghost",
+      "threads": null,
+      "tiktok": null,
+      "twitter": "ghost",
+      "url": "http://127.0.0.1:2369/author/ghost/",
+      "website": "https://ghost.org",
+      "youtube": null,
+    },
+  ],
+}
+`;
+
+exports[`Authors Content API Can request single author 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "520",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/content/__snapshots__/key_authentication.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/key_authentication.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Content API key authentication Authenticated Can access with with valid key 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "36545",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Content API key authentication Host Settings: custom integration limits Blocks the request when host limit is in place for custom integrations 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": Object {
+        "name": "customIntegrations",
+      },
+      "ghostErrorCode": null,
+      "help": "https://ghost.org/help/",
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Custom limit error message",
+      "property": null,
+      "type": "HostLimitError",
+    },
+  ],
+}
+`;
+
+exports[`Content API key authentication Host Settings: custom integration limits Blocks the request when host limit is in place for custom integrations 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "259",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Content API key authentication Host Settings: custom integration limits Blocks the request when host limit is in place for custom integrations 3: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Content API key authentication Host Settings: custom integration limits Blocks the request when host limit is in place for custom integrations 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "204",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Content API key authentication Unauthenticated Can not access without key 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Unable to determine the authenticated member or integration. Check the supplied Content API Key and ensure cookies are being passed through if member auth is failing.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Authorization failed",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Content API key authentication Unauthenticated Can not access without key 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "374",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/content/__snapshots__/tags.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/tags.test.js.snap
@@ -1,0 +1,536 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tags Content API Can include post count 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": 2,
+      "page": 1,
+      "pages": 4,
+      "prev": null,
+      "total": 56,
+    },
+  },
+  "tags": Array [
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "count": Object {
+        "posts": 7,
+      },
+      "description": null,
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Getting Started",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "getting-started",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "count": Object {
+        "posts": 2,
+      },
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "bacon",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "bacon",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "count": Object {
+        "posts": 1,
+      },
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "chorizo",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "chorizo",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "count": Object {
+        "posts": 2,
+      },
+      "description": "description",
+      "feature_image": "https://example.com/super_photo.jpg",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "kitchen sink",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "kitchen-sink",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/kitchen-sink/",
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can include post count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1993",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tags Content API Can limit tags to receive 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 3,
+      "next": 2,
+      "page": 1,
+      "pages": 19,
+      "prev": null,
+      "total": 56,
+    },
+  },
+  "tags": Array [
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": null,
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Getting Started",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "getting-started",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "bacon",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "bacon",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "chorizo",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "chorizo",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can limit tags to receive 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1425",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tags Content API Can request tags 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": 2,
+      "page": 1,
+      "pages": 4,
+      "prev": null,
+      "total": 56,
+    },
+  },
+  "tags": Array [
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": null,
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Getting Started",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "getting-started",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "bacon",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "bacon",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "chorizo",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "chorizo",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": "https://example.com/super_photo.jpg",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "kitchen sink",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "kitchen-sink",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/kitchen-sink/",
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can request tags 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1913",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tags Content API Can request tags with limit=all 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": "all",
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 4,
+    },
+  },
+  "tags": Array [
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": null,
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Getting Started",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "getting-started",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "bacon",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "bacon",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "chorizo",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "chorizo",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+      "visibility": "public",
+    },
+    Object {
+      "accent_color": null,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "description": "description",
+      "feature_image": "https://example.com/super_photo.jpg",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "kitchen sink",
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "slug": "kitchen-sink",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "url": "http://127.0.0.1:2369/tag/kitchen-sink/",
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can request tags with limit=all 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1918",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tags Content API Can use multiple fields and have valid url fields 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": 2,
+      "page": 1,
+      "pages": 4,
+      "prev": null,
+      "total": 56,
+    },
+  },
+  "tags": Array [
+    Object {
+      "name": "Getting Started",
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+    },
+    Object {
+      "name": "bacon",
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+    },
+    Object {
+      "name": "chorizo",
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+    },
+    Object {
+      "name": "kitchen sink",
+      "url": "http://127.0.0.1:2369/tag/kitchen-sink/",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can use multiple fields and have valid url fields 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "366",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tags Content API Can use single url field and have valid url fields 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": 2,
+      "page": 1,
+      "pages": 4,
+      "prev": null,
+      "total": 56,
+    },
+  },
+  "tags": Array [
+    Object {
+      "url": "http://127.0.0.1:2369/tag/getting-started/",
+    },
+    Object {
+      "url": "http://127.0.0.1:2369/tag/bacon/",
+    },
+    Object {
+      "url": "http://127.0.0.1:2369/tag/chorizo/",
+    },
+    Object {
+      "url": "http://127.0.0.1:2369/tag/kitchen-sink/",
+    },
+  ],
+}
+`;
+
+exports[`Tags Content API Can use single url field and have valid url fields 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "287",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -1,118 +1,92 @@
-const should = require('should');
-const supertest = require('supertest');
-const _ = require('lodash');
-const url = require('url');
-const configUtils = require('../../utils/configUtils');
-const config = require('../../../core/shared/config');
-const models = require('../../../core/server/models');
-const testUtils = require('../../utils');
-const localUtils = require('./utils');
+const assert = require('assert/strict');
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyEtag, anyString} = matchers;
+
+const matchAuthor = {
+    id: anyString
+};
 
 describe('Authors Content API', function () {
-    let request;
+    let agent;
 
     before(async function () {
-        await localUtils.startGhost();
-        request = supertest.agent(config.get('url'));
-        await testUtils.initFixtures('owner:post', 'users', 'user:inactive', 'posts', 'api_keys');
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('owner:post', 'users', 'user:inactive', 'posts', 'api_keys');
+        agent.authenticate();
     });
-
-    afterEach(async function () {
-        await configUtils.restore();
-    });
-
-    const validKey = localUtils.getValidKey();
 
     it('Can request authors', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
+        await agent
+            .get('authors/')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(3).fill(matchAuthor)
+            })
+            .expect((res) => {
+                const {authors} = res.body;
 
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-        should.exist(jsonResponse.authors);
-        localUtils.API.checkResponse(jsonResponse, 'authors');
-        jsonResponse.authors.should.have.length(3);
-
-        // We don't expose the email address, status and other attrs.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['url'], null, null);
-
-        // Default order 'name asc' check
-        jsonResponse.authors[0].name.should.eql('Ghost');
-        jsonResponse.authors[2].name.should.eql('Slimer McEctoplasm');
-
-        should.exist(res.body.authors[0].url);
-        should.exist(url.parse(res.body.authors[0].url).protocol);
-        should.exist(url.parse(res.body.authors[0].url).host);
-
-        // Public api returns all authors, but no status! Locked/Inactive authors can still have written articles.
-        const response = await models.Author.findPage(Object.assign({status: 'all'}, testUtils.context.internal));
-        _.map(response.data, model => model.toJSON()).length.should.eql(3);
+                // Default order 'name asc' check
+                assert.equal(authors[0].name, 'Ghost');
+                assert.equal(authors[2].name, 'Slimer McEctoplasm');
+            });
     });
 
     it('Can request authors including post count', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}&include=count.posts&order=count.posts ASC`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
+        await agent
+            .get('authors/?include=count.posts&order=count.posts ASC')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(3).fill(matchAuthor)
+            })
+            .expect((res) => {
+                const {authors} = res.body;
 
-        const jsonResponse = res.body;
+                // Each user should have the correct count
+                const joeBloggs = authors.find(a => a.slug === 'joe-bloggs');
+                const slimer = authors.find(a => a.slug === 'slimer-mcectoplasm');
+                const ghost = authors.find(a => a.slug === 'ghost');
 
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(3);
+                assert.equal(joeBloggs.count.posts, 4);
+                assert.equal(slimer.count.posts, 1);
+                assert.equal(ghost.count.posts, 7);
 
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['count', 'url'], null, null);
-
-        // Each user should have the correct count and be more than 0
-        _.find(jsonResponse.authors, {slug: 'joe-bloggs'}).count.posts.should.eql(4);
-        _.find(jsonResponse.authors, {slug: 'slimer-mcectoplasm'}).count.posts.should.eql(1);
-        _.find(jsonResponse.authors, {slug: 'ghost'}).count.posts.should.eql(7);
-
-        const ids = jsonResponse.authors
-            .filter(author => (author.slug !== 'ghost'))
-            .map(user => user.id);
-
-        ids.should.eql([
-            testUtils.DataGenerator.Content.users[3].id,
-            testUtils.DataGenerator.Content.users[0].id
-        ]);
+                // Check ordering by count.posts ASC
+                assert.equal(authors[0].slug, 'slimer-mcectoplasm');
+                assert.equal(authors[2].slug, 'ghost');
+            });
     });
 
     it('Can request single author', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/slug/ghost/?key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(1);
-
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['url'], null, null);
+        await agent
+            .get('authors/slug/ghost/')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: [matchAuthor]
+            });
     });
 
     it('Can request author by id including post count', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/1/?key=${validKey}&include=count.posts`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(1);
-
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['count', 'url'], null, null);
+        await agent
+            .get('authors/1/?include=count.posts')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: [matchAuthor]
+            });
     });
 });

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -1,146 +1,115 @@
 const assert = require('assert/strict');
-const should = require('should');
-const supertest = require('supertest');
-const _ = require('lodash');
-const url = require('url');
-const configUtils = require('../../utils/configUtils');
-const config = require('../../../core/shared/config');
-const testUtils = require('../../utils');
-const dbUtils = require('../../utils/db-utils');
-const localUtils = require('./utils');
+const {agentProvider, fixtureManager, matchers, dbUtils} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyEtag, anyObjectId} = matchers;
+
+const matchTag = {
+    id: anyObjectId
+};
 
 describe('Tags Content API', function () {
-    let request;
+    let agent;
 
     before(async function () {
-        await localUtils.startGhost();
-        request = supertest.agent(config.get('url'));
-        await testUtils.initFixtures('users', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('users', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+        agent.authenticate();
     });
-
-    afterEach(async function () {
-        await configUtils.restore();
-    });
-
-    const validKey = localUtils.getValidKey();
 
     it('Can request tags', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
+        await agent
+            .get('tags/')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                tags: new Array(4).fill(matchTag)
+            })
+            .expect((res) => {
+                const {tags} = res.body;
 
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
-        localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(4);
-        localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
-        localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-        // Default order 'name asc' check
-        // the ordering difference is described in https://github.com/TryGhost/Ghost/issues/6104
-        // this condition should be removed once issue mentioned above ^ is resolved
-        if (dbUtils.isMySQL()) {
-            jsonResponse.tags[0].name.should.eql('bacon');
-            jsonResponse.tags[3].name.should.eql('kitchen sink');
-        } else {
-            jsonResponse.tags[0].name.should.eql('Getting Started');
-            jsonResponse.tags[3].name.should.eql('kitchen sink');
-        }
-
-        should.exist(res.body.tags[0].url);
-        should.exist(url.parse(res.body.tags[0].url).protocol);
-        should.exist(url.parse(res.body.tags[0].url).host);
+                // Default order 'name asc' check
+                // the ordering difference is described in https://github.com/TryGhost/Ghost/issues/6104
+                if (dbUtils.isMySQL()) {
+                    assert.equal(tags[0].name, 'bacon');
+                    assert.equal(tags[3].name, 'kitchen sink');
+                } else {
+                    assert.equal(tags[0].name, 'Getting Started');
+                    assert.equal(tags[3].name, 'kitchen sink');
+                }
+            });
     });
 
     it('Can request tags with limit=all', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=all&key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
-        localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(4);
-        localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
-        localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+        await agent
+            .get('tags/?limit=all')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                tags: new Array(4).fill(matchTag)
+            });
     });
 
     it('Can limit tags to receive', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=3&key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
-        localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(3);
-        localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
-        localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+        await agent
+            .get('tags/?limit=3')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                tags: new Array(3).fill(matchTag)
+            });
     });
 
     it('Can include post count', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&include=count.posts`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
+        await agent
+            .get('tags/?include=count.posts')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                tags: new Array(4).fill(matchTag)
+            })
+            .expect((res) => {
+                const {tags} = res.body;
 
-        const jsonResponse = res.body;
+                // Each tag should have the correct count
+                const getTagByName = name => tags.find(t => t.name === name);
 
-        should.exist(jsonResponse.tags);
-        jsonResponse.tags.should.be.an.Array().with.lengthOf(4);
-
-        // Each tag should have the correct count
-        _.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts.should.eql(7);
-        _.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts.should.eql(2);
-        _.find(jsonResponse.tags, {name: 'bacon'}).count.posts.should.eql(2);
-        _.find(jsonResponse.tags, {name: 'chorizo'}).count.posts.should.eql(1);
+                assert.equal(getTagByName('Getting Started').count.posts, 7);
+                assert.equal(getTagByName('kitchen sink').count.posts, 2);
+                assert.equal(getTagByName('bacon').count.posts, 2);
+                assert.equal(getTagByName('chorizo').count.posts, 1);
+            });
     });
 
     it('Can use multiple fields and have valid url fields', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&fields=url,name`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        const jsonResponse = res.body;
-
-        assert(jsonResponse.tags);
-
-        const getTag = name => jsonResponse.tags.find(tag => tag.name === name);
-
-        assert(getTag('Getting Started').url.endsWith('/tag/getting-started/'));
-        assert(getTag('kitchen sink').url.endsWith('/tag/kitchen-sink/'));
-        assert(getTag('bacon').url.endsWith('/tag/bacon/'));
-        assert(getTag('chorizo').url.endsWith('/tag/chorizo/'));
+        await agent
+            .get('tags/?fields=url,name')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot();
     });
 
     it('Can use single url field and have valid url fields', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&fields=url`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        const jsonResponse = res.body;
-
-        assert(jsonResponse.tags);
-
-        const getTag = path => jsonResponse.tags.find(tag => tag.url.endsWith(path));
-
-        assert(getTag('/tag/getting-started/'));
-        assert(getTag('/tag/kitchen-sink/'));
-        assert(getTag('/tag/bacon/'));
-        assert(getTag('/tag/chorizo/'));
+        await agent
+            .get('tags/?fields=url')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot();
     });
 });


### PR DESCRIPTION
ref https://www.notion.so/ghost/End-to-end-Testing-6a2ef073b1754b18aff42e24a632a007

- Author and Tag tests were still using the old framework for some reason
- Uses more minimal assertions in favour of snapshots but keeps custom assertions for important logic
- This should make it easier to migrate in the legacy author and tag tests
- Slowly consolidating all our API testing

