### PR TITLE
Added unfollow option to feed item menu in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.14",
+  "version": "0.8.13",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -165,13 +165,13 @@ export interface Post {
         name: string;
         url: string;
     }[];
-    author: Pick<Account, 'id' | 'handle' | 'avatarUrl' | 'name' | 'url'>;
+    author: Pick<Account, 'id' | 'handle' | 'avatarUrl' | 'name' | 'url' | 'followedByMe'>;
     authoredByMe: boolean;
     repostCount: number;
     repostedByMe: boolean;
     repostedBy: Pick<
         Account,
-        'id' | 'handle' | 'avatarUrl' | 'name' | 'url'
+        'id' | 'handle' | 'avatarUrl' | 'name' | 'url' | 'followedByMe'
     > | null;
     metadata?: {
         ghostAuthors?: Array<{

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -244,20 +244,20 @@ const FeedItem: React.FC<FeedItemProps> = ({
     const followMutation = useFollowMutationForUser(
         'index',
         () => {
-            toast.success('Following');
+            toast.success('User followed');
         },
         () => {
-            toast.error('Failed to follow');
+            toast.error('Failed to follow user');
         }
     );
 
     const unfollowMutation = useUnfollowMutationForUser(
         'index',
         () => {
-            toast.success('Unfollowed');
+            toast.success('User unfollowed');
         },
         () => {
-            toast.error('Failed to unfollow');
+            toast.error('Failed to unfollow user');
         }
     );
 

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -339,7 +339,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
         : (actor?.followedByMe || false);
 
     const isAuthorCurrentUser = type === 'Announce'
-        ? object.reposted
+        ? (typeof object.attributedTo === 'object' && object.attributedTo && !Array.isArray(object.attributedTo) && 'authored' in object.attributedTo ? object.attributedTo.authored : false)
         : object.authored;
 
     const handleFollow = () => {

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -14,7 +14,7 @@ import getUsername from '../../utils/get-username';
 import {handleProfileClick} from '../../utils/handle-profile-click';
 import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {renderTimestamp} from '../../utils/render-timestamp';
-import {useDeleteMutationForUser} from '../../hooks/use-activity-pub-queries';
+import {useDeleteMutationForUser, useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export function getAttachment(object: ObjectProperties) {
@@ -241,6 +241,26 @@ const FeedItem: React.FC<FeedItemProps> = ({
     const deleteMutation = useDeleteMutationForUser('index');
     const navigate = useNavigate();
 
+    const followMutation = useFollowMutationForUser(
+        'index',
+        () => {
+            toast.success('Following');
+        },
+        () => {
+            toast.error('Failed to follow');
+        }
+    );
+
+    const unfollowMutation = useUnfollowMutationForUser(
+        'index',
+        () => {
+            toast.success('Unfollowed');
+        },
+        () => {
+            toast.error('Failed to unfollow');
+        }
+    );
+
     useEffect(() => {
         const element = contentRef.current;
         if (element) {
@@ -310,6 +330,30 @@ const FeedItem: React.FC<FeedItemProps> = ({
         author = typeof object.attributedTo === 'object' ? object.attributedTo as ActorProperties : actor;
     }
 
+    const authorHandle = type === 'Announce'
+        ? (author ? getUsername(author) : null)
+        : (actor ? getUsername(actor) : null);
+
+    const followedByMe = type === 'Announce'
+        ? (typeof object.attributedTo === 'object' && object.attributedTo && !Array.isArray(object.attributedTo) && 'followedByMe' in object.attributedTo ? object.attributedTo.followedByMe : false)
+        : (actor?.followedByMe || false);
+
+    const isAuthorCurrentUser = type === 'Announce'
+        ? object.reposted
+        : object.authored;
+
+    const handleFollow = () => {
+        if (authorHandle) {
+            followMutation.mutate(authorHandle);
+        }
+    };
+
+    const handleUnfollow = () => {
+        if (authorHandle) {
+            unfollowMutation.mutate(authorHandle);
+        }
+    };
+
     const UserMenuTrigger = (
         <Button className={`relative z-10 size-[34px] rounded-md ${layout === 'inbox' || layout === 'modal' ? 'text-gray-900 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-600' : 'text-gray-500 hover:text-gray-500'} dark:bg-black dark:hover:bg-gray-950 [&_svg]:size-5`} data-testid="menu-button" variant='ghost'>
             <LucideIcon.Ellipsis />
@@ -361,11 +405,15 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </div>
                                 <FeedItemMenu
                                     allowDelete={allowDelete}
+                                    authoredByMe={isAuthorCurrentUser}
                                     disabled={isPending}
+                                    followedByMe={followedByMe}
                                     layout='feed'
                                     trigger={UserMenuTrigger}
                                     onCopyLink={handleCopyLink}
                                     onDelete={handleDelete}
+                                    onFollow={handleFollow}
+                                    onUnfollow={handleUnfollow}
                                 />
                             </div>
                             <div className='relative col-start-2 col-end-3 w-full gap-4 pl-[52px]'>
@@ -525,11 +573,15 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     </div>
                                     {!isCompact && <FeedItemMenu
                                         allowDelete={allowDelete}
+                                        authoredByMe={isAuthorCurrentUser}
                                         disabled={isPending}
+                                        followedByMe={followedByMe}
                                         layout='reply'
                                         trigger={UserMenuTrigger}
                                         onCopyLink={handleCopyLink}
                                         onDelete={handleDelete}
+                                        onFollow={handleFollow}
+                                        onUnfollow={handleUnfollow}
                                     />}
                                 </div>
                                 <div className={`relative z-10 col-start-2 col-end-3 w-full gap-4`}>
@@ -632,10 +684,14 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     />}
                                     <FeedItemMenu
                                         allowDelete={allowDelete}
+                                        authoredByMe={isAuthorCurrentUser}
+                                        followedByMe={followedByMe}
                                         layout='inbox'
                                         trigger={UserMenuTrigger}
                                         onCopyLink={handleCopyLink}
                                         onDelete={handleDelete}
+                                        onFollow={handleFollow}
+                                        onUnfollow={handleUnfollow}
                                     />
                                 </div>
                             </div>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -9,6 +9,7 @@ import {
     AlertDialogTitle,
     AlertDialogTrigger,
     Button,
+    LucideIcon,
     Popover,
     PopoverClose,
     PopoverContent,
@@ -71,6 +72,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                         {(!allowDelete || layout === 'inbox') &&
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleCopyLinkClick}>
+                                    <LucideIcon.Link />
                                     Copy link
                                 </Button>
                             </PopoverClose>
@@ -78,6 +80,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                         {!authoredByMe &&
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleFollowClick}>
+                                    {followedByMe ? <LucideIcon.UserRoundMinus /> : <LucideIcon.UserRoundPlus />}
                                     {followedByMe ? 'Unfollow' : 'Follow'}
                                 </Button>
                             </PopoverClose>
@@ -90,6 +93,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                                         variant='ghost'
                                         onClick={e => e.stopPropagation()}
                                     >
+                                        <LucideIcon.Trash2 />
                                         Delete
                                     </Button>
                                 </PopoverClose>

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -16,6 +16,7 @@ import {
     PopoverTrigger,
     buttonVariants
 } from '@tryghost/shade';
+import {useFeatureFlags} from '../../lib/feature-flags';
 
 interface FeedItemMenuProps {
     trigger: React.ReactNode;
@@ -42,6 +43,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
     onFollow = () => {},
     onUnfollow = () => {}
 }) => {
+    const {isEnabled} = useFeatureFlags();
     const handleCopyLinkClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         onCopyLink();
@@ -77,7 +79,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                                 </Button>
                             </PopoverClose>
                         }
-                        {!authoredByMe &&
+                        {!authoredByMe && isEnabled('unfollow') &&
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleFollowClick}>
                                     {followedByMe ? <LucideIcon.UserRoundMinus /> : <LucideIcon.UserRoundPlus />}

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -23,6 +23,10 @@ interface FeedItemMenuProps {
     allowDelete: boolean;
     disabled?: boolean;
     layout?: string;
+    followedByMe?: boolean;
+    authoredByMe?: boolean;
+    onFollow?: () => void;
+    onUnfollow?: () => void;
 }
 
 const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
@@ -31,7 +35,11 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
     onDelete,
     allowDelete = false,
     disabled = false,
-    layout
+    layout,
+    followedByMe = false,
+    authoredByMe = false,
+    onFollow = () => {},
+    onUnfollow = () => {}
 }) => {
     const handleCopyLinkClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
@@ -41,6 +49,15 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
     const handleDeleteClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         onDelete();
+    };
+
+    const handleFollowClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+        if (followedByMe) {
+            onUnfollow();
+        } else {
+            onFollow();
+        }
     };
 
     return (
@@ -55,6 +72,13 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleCopyLinkClick}>
                                     Copy link
+                                </Button>
+                            </PopoverClose>
+                        }
+                        {!authoredByMe &&
+                            <PopoverClose asChild>
+                                <Button className='justify-start' variant='ghost' onClick={handleFollowClick}>
+                                    {followedByMe ? 'Unfollow' : 'Follow'}
                                 </Button>
                             </PopoverClose>
                         }

--- a/apps/admin-x-activitypub/src/components/global/FollowButton.tsx
+++ b/apps/admin-x-activitypub/src/components/global/FollowButton.tsx
@@ -26,18 +26,20 @@ const FollowButton: React.FC<FollowButtonProps> = ({
     const [isFollowing, setIsFollowing] = useState(following);
 
     const unfollowMutation = useUnfollowMutationForUser('index',
-        noop,
         () => {
-            setIsFollowing(false);
             onUnfollow();
+        },
+        () => {
+            setIsFollowing(true);
         }
     );
 
     const followMutation = useFollowMutationForUser('index',
-        noop,
+        () => {
+            onFollow();
+        },
         () => {
             setIsFollowing(false);
-            onUnfollow();
         }
     );
 

--- a/apps/admin-x-activitypub/src/components/global/FollowButton.tsx
+++ b/apps/admin-x-activitypub/src/components/global/FollowButton.tsx
@@ -27,7 +27,7 @@ const FollowButton: React.FC<FollowButtonProps> = ({
 
     const unfollowMutation = useUnfollowMutationForUser('index',
         () => {
-            onUnfollow();
+            // Success handled by cache updates
         },
         () => {
             setIsFollowing(true);
@@ -36,7 +36,7 @@ const FollowButton: React.FC<FollowButtonProps> = ({
 
     const followMutation = useFollowMutationForUser('index',
         () => {
-            onFollow();
+            // Success handled by cache updates
         },
         () => {
             setIsFollowing(false);

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -152,6 +152,71 @@ function updateLikeCache(queryClient: QueryClient, handle: string, id: string, l
     }
 }
 
+function updateFollowCache(queryClient: QueryClient, handle: string, authorHandle: string, followedByMe: boolean) {
+    const queryKeys = [
+        QUERY_KEYS.feed,
+        QUERY_KEYS.inbox,
+        QUERY_KEYS.profilePosts('index')
+    ];
+
+    // Add handle-specific profile posts if different from index
+    if (handle !== 'index') {
+        queryKeys.push(QUERY_KEYS.profilePosts(handle));
+    }
+
+    const preferredUsername = authorHandle.split('@')[1];
+
+    for (const queryKey of queryKeys) {
+        queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+            if (current === undefined) {
+                return current;
+            }
+
+            return {
+                ...current,
+                pages: current.pages.map((page: {posts: Activity[]}) => {
+                    return {
+                        ...page,
+                        posts: page.posts.map((item: Activity) => {
+                            // Update regular posts by this author
+                            if (item.type !== 'Announce' && item.actor?.preferredUsername === preferredUsername) {
+                                return {
+                                    ...item,
+                                    actor: {
+                                        ...item.actor,
+                                        followedByMe: followedByMe
+                                    }
+                                };
+                            }
+
+                            // Update reposts where the original author is being followed/unfollowed
+                            if (item.type === 'Announce' &&
+                                typeof item.object.attributedTo === 'object' &&
+                                item.object.attributedTo &&
+                                !Array.isArray(item.object.attributedTo) &&
+                                'preferredUsername' in item.object.attributedTo &&
+                                item.object.attributedTo.preferredUsername === preferredUsername) {
+                                return {
+                                    ...item,
+                                    object: {
+                                        ...item.object,
+                                        attributedTo: {
+                                            ...item.object.attributedTo,
+                                            followedByMe: followedByMe
+                                        }
+                                    }
+                                };
+                            }
+
+                            return item;
+                        })
+                    };
+                })
+            };
+        });
+    }
+}
+
 // Update non-paginated caches (should only be called once per mutation)
 function updateLikeCacheOnce(queryClient: QueryClient, id: string, liked: boolean) {
     // Handle reply chain cache (used by Note.tsx and Reader.tsx)
@@ -906,6 +971,8 @@ export function useUnfollowMutationForUser(handle: string, onSuccess: () => void
                 });
             });
 
+            updateFollowCache(queryClient, handle, fullHandle, false);
+
             onSuccess();
         },
         onError
@@ -1066,6 +1133,8 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
                     }, ...oldData.pages.slice(1)]
                 };
             });
+
+            updateFollowCache(queryClient, handle, fullHandle, true);
 
             onSuccess();
         },

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -215,6 +215,41 @@ function updateFollowCache(queryClient: QueryClient, handle: string, authorHandl
             };
         });
     }
+
+    // Handle reply chain cache (used by Note.tsx and Reader.tsx)
+    const replyChainQueryKey = QUERY_KEYS.replyChain(null);
+    queryClient.setQueriesData(replyChainQueryKey, (current?: ReplyChainResponse) => {
+        if (!current) {
+            return current;
+        }
+
+        const updatePost = (post: Post) => {
+            if (post.author.handle === authorHandle) {
+                return {
+                    ...post,
+                    author: {
+                        ...post.author,
+                        followedByMe: followedByMe
+                    }
+                };
+            }
+            return post;
+        };
+
+        return {
+            ...current,
+            post: updatePost(current.post),
+            ancestors: {
+                ...current.ancestors,
+                chain: current.ancestors.chain.map(updatePost)
+            },
+            children: current.children.map(child => ({
+                ...child,
+                post: updatePost(child.post),
+                chain: child.chain.map(updatePost)
+            }))
+        };
+    });
 }
 
 // Update non-paginated caches (should only be called once per mutation)

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = [] as const;
+export const FEATURE_FLAGS = ['unfollow'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/utils/posts.ts
+++ b/apps/admin-x-activitypub/src/utils/posts.ts
@@ -24,6 +24,7 @@ export function mapPostToActivity(post: Post): Activity {
         },
         name: post.author.name,
         preferredUsername: post.author.handle.split('@')[1],
+        followedByMe: post.author.followedByMe,
         // These are not used but needed to comply with the ActorProperties type
         '@context': '',
         discoverable: false,
@@ -55,6 +56,7 @@ export function mapPostToActivity(post: Post): Activity {
             },
             name: post.repostedBy.name,
             preferredUsername: post.repostedBy.handle.split('@')[1],
+            followedByMe: post.repostedBy.followedByMe,
             // These are not used but needed to comply with the ActorProperties type
             '@context': '',
             discoverable: false,

--- a/apps/admin-x-activitypub/test/unit/utils/posts.test.ts
+++ b/apps/admin-x-activitypub/test/unit/utils/posts.test.ts
@@ -38,7 +38,8 @@ describe('mapPostToActivity', function () {
                 handle: '@testuser@example.com',
                 avatarUrl: 'https://example.com/users/123/avatar.jpg',
                 name: 'Test User',
-                url: 'https://example.com/users/123'
+                url: 'https://example.com/users/123',
+                followedByMe: false
             },
             authoredByMe: true,
             repostCount: 5,
@@ -60,7 +61,8 @@ describe('mapPostToActivity', function () {
                     handle: '@testuser2@example.com',
                     avatarUrl: 'https://example.com/users/456/avatar.jpg',
                     name: 'Test User 2',
-                    url: 'https://example.com/users/456'
+                    url: 'https://example.com/users/456',
+                    followedByMe: true
                 }
             }).type
         ).toBe('Announce');
@@ -82,7 +84,8 @@ describe('mapPostToActivity', function () {
                 handle: '@testuser2@example.com',
                 avatarUrl: 'https://example.com/users/456/avatar.jpg',
                 name: 'Test User 2',
-                url: 'https://example.com/users/456'
+                url: 'https://example.com/users/456',
+                followedByMe: false
             }
         }).actor;
 
@@ -146,5 +149,61 @@ describe('mapPostToActivity', function () {
             name: 'test1.jpg',
             url: 'https://example.com/test1.jpg'
         });
+    });
+
+    test('it maps followedByMe property correctly', function () {
+        // Test for regular posts (non-reposts)
+        const activity = mapPostToActivity({
+            ...post,
+            author: {
+                ...post.author,
+                followedByMe: true
+            }
+        });
+
+        expect(activity.actor.followedByMe).toBe(true);
+
+        // Test for reposts
+        const repostActivity = mapPostToActivity({
+            ...post,
+            repostedBy: {
+                id: 'https://example.com/users/456',
+                handle: '@testuser2@example.com',
+                avatarUrl: 'https://example.com/users/456/avatar.jpg',
+                name: 'Test User 2',
+                url: 'https://example.com/users/456',
+                followedByMe: true
+            }
+        });
+
+        expect(repostActivity.actor.followedByMe).toBe(true);
+        expect(repostActivity.object.attributedTo.followedByMe).toBe(false); // Original author from post.author
+    });
+
+
+    test('it maps reposted property correctly', function () {
+        // Test for regular posts
+        const activity = mapPostToActivity({
+            ...post,
+            repostedByMe: true
+        });
+
+        expect(activity.object.reposted).toBe(true);
+
+        // Test for reposts
+        const repostActivity = mapPostToActivity({
+            ...post,
+            repostedByMe: false,
+            repostedBy: {
+                id: 'https://example.com/users/456',
+                handle: '@testuser2@example.com',
+                avatarUrl: 'https://example.com/users/456/avatar.jpg',
+                name: 'Test User 2',
+                url: 'https://example.com/users/456',
+                followedByMe: true
+            }
+        });
+
+        expect(repostActivity.object.reposted).toBe(false);
     });
 });

--- a/apps/admin-x-activitypub/test/unit/utils/posts.test.ts
+++ b/apps/admin-x-activitypub/test/unit/utils/posts.test.ts
@@ -180,7 +180,6 @@ describe('mapPostToActivity', function () {
         expect(repostActivity.object.attributedTo.followedByMe).toBe(false); // Original author from post.author
     });
 
-
     test('it maps reposted property correctly', function () {
         // Test for regular posts
         const activity = mapPostToActivity({


### PR DESCRIPTION
ref PROD-2065

- Implemented direct follow/unfollow action in feed item menu options
- Enabled users to manage follows without visiting profile pages