### PR TITLE
Added UI logic to handle email disabled state

### DIFF
--- a/apps/admin-x-framework/src/providers/AppProvider.tsx
+++ b/apps/admin-x-framework/src/providers/AppProvider.tsx
@@ -5,6 +5,7 @@ import {TopLevelFrameworkProps} from './FrameworkProvider';
 // Shared app settings type for all Ghost Admin apps
 export interface AppSettings {
     paidMembersEnabled: boolean;
+    newslettersEnabled: boolean;
     analytics: {
         emailTrackOpens: boolean;
         emailTrackClicks: boolean;

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -8,10 +8,10 @@ import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Navigate, useAppContext, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import {useNewsletterStatsWithRangeSplit, useSubscriberCountWithRange} from '@src/hooks/useNewsletterStatsWithRange';
 import type {TopNewslettersOrder} from '@src/hooks/useNewsletterStatsWithRange';
 
@@ -31,6 +31,7 @@ const Newsletters: React.FC = () => {
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
+    const {appSettings} = useAppContext();
 
     // Get the initial tab from URL search parameters
     const initialTab = searchParams.get('tab') || 'total-subscribers';
@@ -156,6 +157,12 @@ const Newsletters: React.FC = () => {
     const isTableLoading = isStatsLoading || !newsletterStatsData;
 
     const pageData = isKPIsLoading ? undefined : (selectedNewsletterId && subscribersData.length > 1 && newsletterStats.length > 1 ? ['data exists'] : []);
+
+    if (!appSettings?.newslettersEnabled) {
+        return (
+            <Navigate to='/' />
+        );
+    }
 
     return (
         <StatsLayout>

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -156,7 +156,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                             0}
                                     </span>
                                 </div>
-                                {latestPostStats.open_rate ?
+                                {appSettings?.newslettersEnabled && latestPostStats.open_rate ?
                                     <>
                                         <div className={metricClassName} onClick={() => {
                                             navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -40,7 +40,9 @@ const TopPosts: React.FC<TopPostsProps> = ({
                             {appSettings?.analytics.webAnalytics &&
                                 <TableHead className='w-[12%] text-right'>Visitors</TableHead>
                             }
-                            <TableHead className='w-[12%] whitespace-nowrap text-right'>Open rate</TableHead>
+                            {appSettings?.newslettersEnabled &&
+                                <TableHead className='w-[12%] whitespace-nowrap text-right'>Open rate</TableHead>
+                            }
                             <TableHead className='w-[12%] text-right'>Members</TableHead>
                         </TableRow>
                     </TableHeader>
@@ -59,7 +61,9 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                 {appSettings?.analytics.webAnalytics &&
                                     <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
                                 }
-                                <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
+                                {appSettings?.newslettersEnabled &&
+                                    <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
+                                }
                                 <TableCell className='w-[12%] group-hover:bg-transparent'><Skeleton /></TableCell>
                             </TableRow>
                         ))
@@ -92,9 +96,11 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             {formatNumber(post.views)}
                                         </TableCell>
                                     }
-                                    <TableCell className='text-right font-mono'>
-                                        {post.open_rate ? `${Math.round(post.open_rate)}%` : <>&mdash;</>}
-                                    </TableCell>
+                                    {appSettings?.newslettersEnabled &&
+                                        <TableCell className='text-right font-mono'>
+                                            {post.open_rate ? `${Math.round(post.open_rate)}%` : <>&mdash;</>}
+                                        </TableCell>
+                                    }
                                     <TableCell className='text-right font-mono'>
                                         {post.members > 0 ? `+${formatNumber(post.members)}` : '0'}
                                     </TableCell>

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -74,15 +74,18 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                             </TabsTrigger>
                         }
 
-                        <TabsTrigger value="/newsletters/" onClick={() => {
-                            navigate('/newsletters/');
-                        }}>
-                        Newsletters
-                        </TabsTrigger>
+                        {appSettings?.newslettersEnabled &&
+                            <TabsTrigger value="/newsletters/" onClick={() => {
+                                navigate('/newsletters/');
+                            }}>
+                                Newsletters
+                            </TabsTrigger>
+                        }
+
                         <TabsTrigger value="/growth/" onClick={() => {
                             navigate('/growth/');
                         }}>
-                        Growth
+                            Growth
                         </TabsTrigger>
                         {appSettings?.analytics.webAnalytics &&
                             <TabsTrigger value="/locations/" onClick={() => {

--- a/ghost/admin/app/components/admin-x/posts.js
+++ b/ghost/admin/app/components/admin-x/posts.js
@@ -17,6 +17,7 @@ export default class Posts extends AdminXComponent {
             fromAnalytics: fromAnalytics,
             appSettings: {
                 paidMembersEnabled: this.settings.paidMembersEnabled,
+                newslettersEnabled: this.settings.editorDefaultEmailRecipients !== 'disabled',
                 analytics: {
                     emailTrackOpens: this.settings.emailTrackOpens,
                     emailTrackClicks: this.settings.emailTrackClicks,

--- a/ghost/admin/app/components/admin-x/stats.js
+++ b/ghost/admin/app/components/admin-x/stats.js
@@ -8,6 +8,7 @@ export default class Stats extends AdminXComponent {
         return {
             appSettings: {
                 paidMembersEnabled: this.settings.paidMembersEnabled,
+                newslettersEnabled: this.settings.editorDefaultEmailRecipients !== 'disabled',
                 analytics: {
                     emailTrackOpens: this.settings.emailTrackOpens,
                     emailTrackClicks: this.settings.emailTrackClicks,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2035/what-happens-when-newsletter-sending-is-turned-off

- Some of the UI components and data in Analytics is irrelevant when newsletters is turned off in Ghost. We hide these parts in this PR.