### PR TITLE
Added migration to drop nullable on members UUID

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.0/2025-06-23-09-49-25-add-missing-member-uuids.js
+++ b/ghost/core/core/server/data/migrations/versions/6.0/2025-06-23-09-49-25-add-missing-member-uuids.js
@@ -1,0 +1,22 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const logging = require('@tryghost/logging');
+const uuid = require('uuid');
+
+// For DML - data changes
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const membersWithoutUUID = await knex.select('id').from('members').whereNull('uuid');
+
+        logging.info(`Adding uuid field value to ${membersWithoutUUID.length} members.`);
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const member of membersWithoutUUID) {
+            await knex('members').update('uuid', uuid.v4()).where('id', member.id);
+        }
+    },
+    // down is a no-op
+    async function down() {}
+);

--- a/ghost/core/core/server/data/migrations/versions/6.0/2025-06-23-10-03-26-members-nullable-uuid.js
+++ b/ghost/core/core/server/data/migrations/versions/6.0/2025-06-23-10-03-26-members-nullable-uuid.js
@@ -1,0 +1,5 @@
+const {createDropNullableMigration} = require('../../utils');
+
+// Running drop nullable migration without foreign key checks disabled
+// This is because uuid isn't used as a foreign key anywhere in the schema
+module.exports = createDropNullableMigration('members', 'uuid');

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -441,7 +441,7 @@ module.exports = {
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        uuid: {type: 'string', maxlength: 36, nullable: true, unique: true, validations: {isUUID: true}},
+        uuid: {type: 'string', maxlength: 36, nullable: false, unique: true, validations: {isUUID: true}},
         transient_id: {type: 'string', maxlength: 191, nullable: false, unique: true},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
         status: {

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '99566c8c6b729dd1c516bba432a6e1a2';
+    const currentSchemaHash = 'cb7832270e18cf9c8861f658b9645731';
     const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
     const currentSettingsHash = 'de95b390395d682d4868bf30567de0cb';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/22077
closes https://linear.app/ghost/issue/PROD-1611/breaking-change-schema-oss-issue-membersuuid-is-marked-as-nullable-in 
ref https://github.com/TryGhost/Ghost/pull/11341/commits/4095178243638636d19eb1ef0a42738098f99d29
ref https://github.com/TryGhost/Ghost/commit/12f569ebf9aa864deac18b57eb7c77eaccce8dc7

- The migration to add a UUID was originally added in Ghost 3.1
- Therefore, we're going to rerun it first, although we expect this to be a no-op in everything other than absolute edge cases
- Verified that there are no instances of null member uuids anywhere on Pro
- This then sets nullable to false in the DB after
- The net result of this change is that the schema matches the requirements / expectations about the world

