### PR TITLE
Fixed latest post metric display

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -18,7 +18,9 @@ export {getSymbol} from './utils/currency';
 export {getStatEndpointUrl, getToken} from './utils/stats-config';
 
 // Post utilities
+export type {Post} from './api/posts';
 export {hasBeenEmailed} from './utils/post-utils';
+export {isEmailOnly, isPublishedOnly, isPublishedAndEmailed, getPostMetricsToDisplay} from './utils/post-helpers';
 
 // Source utilities
 export type {BaseSourceData, ProcessedSourceData, ExtendSourcesOptions} from './utils/source-utils';

--- a/apps/admin-x-framework/src/utils/post-helpers.ts
+++ b/apps/admin-x-framework/src/utils/post-helpers.ts
@@ -1,0 +1,79 @@
+import {Post} from '../api/posts';
+
+/**
+ * Determines if a post is email-only (newsletter only, not published to the web)
+ */
+export function isEmailOnly(post: Post): boolean {
+    return Boolean(post.email_only) && post.status === 'sent';
+}
+
+/**
+ * Determines if a post is published-only (web only, no email sent)
+ */
+export function isPublishedOnly(post: Post): boolean {
+    return post.status === 'published' && !hasBeenEmailed(post);
+}
+
+/**
+ * Determines if a post is both published and emailed
+ */
+export function isPublishedAndEmailed(post: Post): boolean {
+    return post.status === 'published' && hasBeenEmailed(post);
+}
+
+/**
+ * Determines if a post has been sent as an email
+ * Based on the logic from admin-x-framework/src/utils/post-utils.ts
+ */
+function hasBeenEmailed(post: Post): boolean {
+    const isPublished = post.status === 'published';
+    const isSent = post.status === 'sent';
+    const hasEmail = Boolean(post.email);
+    const validEmailStatus = post.email?.status !== 'failed';
+    const hasEmailCount = typeof post.email?.email_count === 'number' && post.email.email_count > 0;
+    
+    return (isSent || isPublished)
+        && hasEmail 
+        && (validEmailStatus || hasEmailCount);
+}
+
+/**
+ * Gets the appropriate metrics to display based on post type
+ */
+export function getPostMetricsToDisplay(post: Post) {
+    if (isEmailOnly(post)) {
+        return {
+            showEmailMetrics: true,
+            showWebMetrics: false,
+            showMemberGrowth: true
+        };
+    }
+    
+    if (isPublishedOnly(post)) {
+        return {
+            showEmailMetrics: false,
+            showWebMetrics: true,
+            showMemberGrowth: true
+        };
+    }
+    
+    if (isPublishedAndEmailed(post)) {
+        return {
+            showEmailMetrics: true,
+            showWebMetrics: true,
+            showMemberGrowth: true
+        };
+    }
+    
+    // Default fallback
+    return {
+        showEmailMetrics: false,
+        showWebMetrics: true,
+        showMemberGrowth: true
+    };
+}
+
+/**
+ * Post type information with computed properties
+ */
+ 

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -120,7 +120,17 @@ export const defaultMockData = {
             tags: [],
             tiers: []
         },
-        isPostLoading: false
+        isPostLoading: false,
+        postType: {
+            isEmailOnly: false,
+            isPublishedOnly: false,
+            isPublishedAndEmailed: true,
+            metricsToDisplay: {
+                showEmailMetrics: true,
+                showWebMetrics: true,
+                showMemberGrowth: true
+            }
+        }
     }
 };
 

--- a/apps/stats/src/hooks/useLatestPostStats.ts
+++ b/apps/stats/src/hooks/useLatestPostStats.ts
@@ -8,11 +8,11 @@ interface ExtendedPost extends Post {
         name: string;
     }[];
     excerpt?: string;
-    email_only?: boolean;
 }
 
 export interface LatestPostWithStats {
     id: string;
+    uuid: string;
     title: string;
     slug: string;
     feature_image?: string | null;
@@ -20,6 +20,12 @@ export interface LatestPostWithStats {
     url?: string;
     excerpt?: string;
     email_only?: boolean;
+    status?: string;
+    email?: {
+        opened_count: number;
+        email_count: number;
+        status?: string;
+    } | null;
     authors?: {
         name: string;
     }[];
@@ -41,7 +47,7 @@ export const useLatestPostStats = () => {
             filter: 'status:[published,sent]',
             order: 'published_at DESC',
             limit: '1',
-            include: 'authors'
+            include: 'authors,email'
         }
     });
 
@@ -76,6 +82,7 @@ export const useLatestPostStats = () => {
         return {
             // Post content from Posts API
             id: extendedPost.id,
+            uuid: extendedPost.uuid,
             title: extendedPost.title || '',
             slug: extendedPost.slug || '',
             feature_image: extendedPost.feature_image || null,
@@ -83,6 +90,8 @@ export const useLatestPostStats = () => {
             url: extendedPost.url || '',
             excerpt: extendedPost.excerpt || '',
             email_only: extendedPost.email_only || false,
+            status: extendedPost.status,
+            email: extendedPost.email,
             authors: extendedPost.authors || [],
             // Analytics data from Stats API
             recipient_count: statsData.recipient_count,

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, PostShareModal, Skeleton, cn, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 
+import {Post, getPostMetricsToDisplay} from '@tryghost/admin-x-framework';
 import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
@@ -122,68 +123,87 @@ const LatestPost: React.FC<LatestPostProps> = ({
 
                         <div className='-ml-4 flex h-full flex-col items-stretch gap-2 pr-6 text-sm'>
                             <div className='grid h-full grid-cols-2 gap-6 border-l pl-10'>
-                                {appSettings?.analytics.webAnalytics &&
-                                    <div className={metricClassName} onClick={() => {
-                                        navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
-                                    }}>
-                                        <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                            <LucideIcon.Eye size={16} strokeWidth={1.25} />
-                                            Visitors
-                                        </div>
-                                        <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                            {formatNumber(latestPostStats.visitors)}
-                                        </span>
-                                    </div>
-                                }
-                                <div className={
-                                    cn(
-                                        metricClassName,
-                                        !appSettings?.analytics.webAnalytics && 'row-[2/3] col-[1/2]'
-                                    )
-                                } onClick={() => {
-                                    navigate(`/posts/analytics/beta/${latestPostStats.id}/growth`, {crossApp: true});
-                                }}>
-                                    <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                        <LucideIcon.UserPlus size={16} strokeWidth={1.25} />
-                                        Members
-                                    </div>
-                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                        {latestPostStats.member_delta ?
-                                            <>
-                                                +{formatNumber(latestPostStats.member_delta)}
-                                            </>
-                                            :
-                                            0}
-                                    </span>
-                                </div>
-                                {appSettings?.newslettersEnabled && latestPostStats.open_rate ?
-                                    <>
-                                        <div className={metricClassName} onClick={() => {
-                                            navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
-                                        }}>
-                                            <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                                <LucideIcon.MailOpen size={16} strokeWidth={1.25} />
-                                                Open rate
-                                            </div>
-                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                                {formatPercentage(latestPostStats.open_rate / 100)}
-                                            </span>
-                                        </div>
-                                        <div className={metricClassName} onClick={() => {
-                                            navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
-                                        }}>
-                                            <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                                <LucideIcon.MousePointerClick size={16} strokeWidth={1.25} />
-                                                Click rate
-                                            </div>
-                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                                {formatPercentage((latestPostStats.click_rate || 0) / 100)}
-                                            </span>
-                                        </div>
-                                    </>
-                                    :
-                                    <></>
-                                }
+                                {(() => {
+                                    const metricsToShow = getPostMetricsToDisplay(latestPostStats as Post);
+                                    
+                                    return (
+                                        <>
+                                            {/* Web metrics - only for published posts */}
+                                            {metricsToShow.showWebMetrics && appSettings?.analytics.webAnalytics &&
+                                                <div className={metricClassName} onClick={() => {
+                                                    navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
+                                                }}>
+                                                    <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                                        <LucideIcon.Eye size={16} strokeWidth={1.25} />
+                                                        Visitors
+                                                    </div>
+                                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                                        {formatNumber(latestPostStats.visitors)}
+                                                    </span>
+                                                </div>
+                                            }
+                                            
+                                            {/* Member growth - always show if available */}
+                                            {metricsToShow.showMemberGrowth &&
+                                                <div className={
+                                                    cn(
+                                                        metricClassName,
+                                                        (!metricsToShow.showWebMetrics || !appSettings?.analytics.webAnalytics) && 'row-[2/3] col-[1/2]'
+                                                    )
+                                                } onClick={() => {
+                                                    navigate(`/posts/analytics/beta/${latestPostStats.id}/growth`, {crossApp: true});
+                                                }}>
+                                                    <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                                        <LucideIcon.UserPlus size={16} strokeWidth={1.25} />
+                                                        Members
+                                                    </div>
+                                                    <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                                        {latestPostStats.member_delta ?
+                                                            <>
+                                                                +{formatNumber(latestPostStats.member_delta)}
+                                                            </>
+                                                            :
+                                                            0}
+                                                    </span>
+                                                </div>
+                                            }
+                                            
+                                            {/* Email metrics - show for email posts */}
+                                            {metricsToShow.showEmailMetrics && appSettings?.newslettersEnabled && latestPostStats.email && (
+                                                <>
+                                                    {/* Show sent count from email data */}
+                                                    <div className={metricClassName} onClick={() => {
+                                                        navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
+                                                    }}>
+                                                        <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                                            <LucideIcon.Mail size={16} strokeWidth={1.25} />
+                                            Sent
+                                                        </div>
+                                                        <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                                            {formatNumber(latestPostStats.email.email_count || 0)}
+                                                        </span>
+                                                    </div>
+                                    
+                                                    {/* Show open rate - always display if email exists */}
+                                                    <div className={metricClassName} onClick={() => {
+                                                        navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
+                                                    }}>
+                                                        <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                                            <LucideIcon.MailOpen size={16} strokeWidth={1.25} />
+                                            Open rate
+                                                        </div>
+                                                        <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                                            {latestPostStats.email.email_count ? 
+                                                                formatPercentage((latestPostStats.email.opened_count || 0) / latestPostStats.email.email_count) 
+                                                                : '0%'
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                </>
+                                            )}
+                                        </>
+                                    );
+                                })()}
                             </div>
                         </div>
                     </>)


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2114
- Added utility functions in post-helpers for determining post types and metrics to display.
- Updated LatestPost component to conditionally render metrics based on post type using the new utilities.
- Introduced a new Post type in the test helpers to support the updated structure.

I've added a few centralized utils here so that we can centralize the logic for how we consider posts, as Ghost's logic around what is published vs sent vs both is ... not very clean.