### PR TITLE
Cleaned up use of limit=all for fetching counts in Admin

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
@@ -147,7 +147,7 @@ const Connected: React.FC<{onClose?: () => void}> = ({onClose}) => {
     const [stripeConnectAccountName, stripeConnectLivemode] = getSettingValues(settings, ['stripe_connect_display_name', 'stripe_connect_livemode']);
 
     const {refetch: fetchMembers, isFetching: isFetchingMembers} = useBrowseMembers({
-        searchParams: {filter: 'status:paid', limit: '0'},
+        searchParams: {filter: 'status:paid', limit: 1},
         enabled: false
     });
 
@@ -159,7 +159,7 @@ const Connected: React.FC<{onClose?: () => void}> = ({onClose}) => {
         const hasActiveStripeSubscriptions = Boolean(data?.meta?.pagination.total);
 
         // const hasActiveStripeSubscriptions = false; //...
-        // this.ghostPaths.url.api('/members/') + '?filter=status:paid&limit=0';
+        // this.ghostPaths.url.api('/members/') + '?filter=status:paid&limit=1';
         NiceModal.show(ConfirmationModal, {
             title: 'Disconnect Stripe',
             prompt: (hasActiveStripeSubscriptions ? 'Cannot disconnect while there are members with active Stripe subscriptions.' : <>You&lsquo;re about to disconnect your Stripe account {stripeConnectAccountName} from this site. This will automatically turn off paid memberships on this site.</>),

--- a/ghost/admin/app/services/limit.js
+++ b/ghost/admin/app/services/limit.js
@@ -98,7 +98,7 @@ export default class LimitsService extends Service {
     }
 
     async getNewslettersCount() {
-        const activeNewsletters = await this.store.query('newsletter', {filter: 'status:active', limit: 'all'});
-        return activeNewsletters.length;
+        const activeNewsletters = await this.store.query('newsletter', {filter: 'status:active', limit: 1});
+        return activeNewsletters.metadata.pagination.total;
     }
 }

--- a/ghost/admin/app/services/members-count-cache.js
+++ b/ghost/admin/app/services/members-count-cache.js
@@ -34,10 +34,9 @@ export default class MembersCountCacheService extends Service {
     @action
     async countString(filter = '', {knownCount, newsletter} = {}) {
         // Determine if we need to show the name of the newsletter or not
-        // TODO: replace this with a service or a settings boolean if we ever add a shortcut for this
         if (this.hasMultipleNewsletters === null) {
-            const allNewsletters = await this.store.query('newsletter', {status: 'active', limit: 'all'});
-            this.hasMultipleNewsletters = allNewsletters.length > 1;
+            const result = await this.store.query('newsletter', {status: 'active', limit: 1});
+            this.hasMultipleNewsletters = result.meta.pagination.total > 1;
         }
 
         const user = this.session.user;

--- a/ghost/core/core/server/api/endpoints/settings.js
+++ b/ghost/core/core/server/api/endpoints/settings.js
@@ -87,7 +87,7 @@ const controller = {
             method: 'edit'
         },
         async query(frame) {
-            const paidMembers = await membersService.api.memberBREADService.browse({limit: 0, filter: 'status:paid'});
+            const paidMembers = await membersService.api.memberBREADService.browse({limit: 1, filter: 'status:paid'});
             if (_.get(paidMembers, 'meta.pagination.total') !== 0) {
                 throw new BadRequestError({
                     message: 'Cannot disconnect Stripe whilst you have active subscriptions.'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- in a couple of places we were using `limit=all` to fetch every record in order to do a `.length` on the result
- our standard practice is to rely on the server-provided pagination metadata instead and do a `limit=1` to minimise data loading and transfer
- also updated a non-standard use of `limit=0`
