### PR TITLE
Automatically paginated `limit: 'all'` queries in Admin

### DIFF
--- a/ghost/admin/app/adapters/embedded-relation-adapter.js
+++ b/ghost/admin/app/adapters/embedded-relation-adapter.js
@@ -1,7 +1,8 @@
 import BaseAdapter from 'ghost-admin/adapters/base';
+import {decamelize, underscore} from '@ember/string';
 import {get} from '@ember/object';
 import {isNone} from '@ember/utils';
-import {underscore} from '@ember/string';
+import {pluralize} from 'ember-inflector';
 
 // EmbeddedRelationAdapter will augment the query object in calls made to
 // DS.Store#findRecord, findAll, query, and queryRecord with the correct "includes"
@@ -34,8 +35,83 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
         return this.ajax(url, 'GET', {data: query});
     }
 
-    query(store, type, query) {
-        return super.query(store, type, this.buildQuery(store, type.modelName, query));
+    // Our API used to support ?limit=all but it was deprecated
+    // and updated in 6.0 to always return at most 100 results.
+    // However, our own code still makes use of it so when it's used
+    // we handle it automatically by paginating through all results.
+    async query(store, type, query) {
+        if (query.limit !== 'all') {
+            return super.query(store, type, this.buildQuery(store, type.modelName, query));
+        }
+
+        // Handle limit: 'all' by paginating through all results
+        let allData = [];
+        let page = 1;
+        let lastMeta = null;
+        const pageSize = 100;
+
+        // Generate the data key using the same logic as the serializer
+        const root = decamelize(type.modelName);
+        const dataKey = pluralize(root);
+
+        let hasMorePages = true;
+        while (hasMorePages) {
+            // Create a fresh query object for each iteration,
+            // overriding the limit and page parameters
+            const paginatedQuery = {
+                ...query,
+                limit: pageSize,
+                page: page
+            };
+
+            // Use super.query to get raw API responses
+            const result = await super.query(store, type, this.buildQuery(store, type.modelName, paginatedQuery));
+
+            // Handle the raw API response format
+            const pageData = result[dataKey] || [];
+
+            // Accumulate raw data from this page
+            if (pageData.length > 0) {
+                allData = allData.concat(pageData);
+            }
+
+            // Store metadata from this request (will use the last one)
+            lastMeta = result.meta;
+
+            // Check if we should continue paginating
+            // Stop if this page returned fewer results than requested
+            if (pageData.length < pageSize) {
+                hasMorePages = false;
+            }
+
+            // Also stop if we have pagination info indicating we're done
+            if (hasMorePages && lastMeta?.pagination) {
+                const {page: currentPage, pages} = lastMeta.pagination;
+                if (currentPage && pages && currentPage >= pages) {
+                    hasMorePages = false;
+                }
+            }
+
+            page = page + 1;
+        }
+
+        // Return the same raw response format as super.query()
+        // Build our own metadata to show this as a single page with all results
+        const combinedMeta = {
+            pagination: {
+                page: 1,
+                limit: allData.length,
+                pages: 1,
+                total: allData.length,
+                next: null,
+                prev: null
+            }
+        };
+
+        return {
+            [dataKey]: allData,
+            meta: combinedMeta
+        };
     }
 
     queryRecord(store, type, query) {

--- a/ghost/admin/tests/unit/adapters/embedded-relation-adapter-test.js
+++ b/ghost/admin/tests/unit/adapters/embedded-relation-adapter-test.js
@@ -1,0 +1,259 @@
+import EmbeddedRelationAdapter from 'ghost-admin/adapters/embedded-relation-adapter';
+import sinon from 'sinon';
+import {beforeEach, describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit | Adapter | embedded-relation-adapter', function () {
+    setupTest();
+
+    let adapter, store, type, sandbox;
+
+    beforeEach(function () {
+        adapter = this.owner.lookup('adapter:application');
+        store = this.owner.lookup('service:store');
+        type = {modelName: 'post'};
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    // Constants for common test values
+    const PAGE_SIZE = 100;
+    const MODEL_TYPE = 'post';
+    const DATA_KEY = 'posts';
+
+    // Helper functions
+    function expectSuperCalled(query, buildQueryResult) {
+        const superQueryStub = sandbox.stub(EmbeddedRelationAdapter.prototype.__proto__, 'query');
+        sandbox.stub(adapter, 'buildQuery').returns(buildQueryResult);
+
+        adapter.query(store, type, query);
+        expect(superQueryStub).to.have.been.calledOnceWith(store, type, buildQueryResult);
+    }
+
+    function createMockStubs() {
+        return {
+            superQueryStub: sandbox.stub(EmbeddedRelationAdapter.prototype.__proto__, 'query'),
+            buildQueryStub: sandbox.stub(adapter, 'buildQuery')
+        };
+    }
+
+    function createMockPosts(count, startId = 1) {
+        return new Array(count).fill(null).map((_, i) => ({
+            id: startId + i,
+            title: `Post ${startId + i}`
+        }));
+    }
+
+    function createPaginationMeta(page, pages, total) {
+        return {pagination: {page, pages, total}};
+    }
+
+    function createExpectedFinalMeta(total) {
+        return {
+            pagination: {
+                page: 1,
+                limit: total,
+                pages: 1,
+                total: total,
+                next: null,
+                prev: null
+            }
+        };
+    }
+
+    function setupPageMock(stubs, pageNum, query, posts, meta) {
+        const paginatedQuery = {...query, limit: PAGE_SIZE, page: pageNum};
+        const buildQueryResult = {...paginatedQuery, include: 'tags'};
+
+        stubs.buildQueryStub.withArgs(store, MODEL_TYPE, paginatedQuery)
+            .returns(buildQueryResult);
+        stubs.superQueryStub.withArgs(store, type, buildQueryResult)
+            .resolves({[DATA_KEY]: posts, meta});
+    }
+
+    describe('#query', function () {
+        describe('without limit=all', function () {
+            it('calls super.query when query.limit is not "all"', function () {
+                expectSuperCalled(
+                    {limit: 10, filter: 'status:published'},
+                    {limit: 10, filter: 'status:published', include: 'tags'}
+                );
+            });
+
+            it('calls super.query when query.limit is 0', function () {
+                expectSuperCalled(
+                    {limit: 0},
+                    {limit: 0, include: 'tags'}
+                );
+            });
+
+            it('calls super.query when query.limit is undefined', function () {
+                expectSuperCalled(
+                    {filter: 'featured:true'},
+                    {filter: 'featured:true', include: 'tags'}
+                );
+            });
+
+            it('calls super.query with empty query object', function () {
+                expectSuperCalled(
+                    {},
+                    {include: 'tags'}
+                );
+            });
+
+            it('passes through buildQuery result correctly to super.query', function () {
+                // Arrange
+                const query = {limit: 5, page: 2};
+                const buildQueryResult = {
+                    limit: 5,
+                    page: 2,
+                    include: 'authors,tags,count.posts'
+                };
+                const superQueryResult = Promise.resolve({
+                    posts: [{id: 1, title: 'Test Post'}],
+                    meta: {pagination: {total: 100}}
+                });
+
+                const superQueryStub = sandbox.stub(EmbeddedRelationAdapter.prototype.__proto__, 'query')
+                    .returns(superQueryResult);
+                const buildQueryStub = sandbox.stub(adapter, 'buildQuery')
+                    .returns(buildQueryResult);
+
+                // Act
+                adapter.query(store, type, query);
+
+                // Assert
+                expect(buildQueryStub).to.have.been.calledOnceWith(store, 'post', query);
+                expect(superQueryStub).to.have.been.calledOnceWith(store, type, buildQueryResult);
+            });
+        });
+
+        describe('with limit=all', function () {
+            it('fetches all pages when query.limit is "all"', async function () {
+                const stubs = createMockStubs();
+                const query = {filter: 'status:published'};
+
+                // Set up three pages of mock responses
+                setupPageMock(stubs, 1, query, createMockPosts(100, 1), createPaginationMeta(1, 3, 250));
+                setupPageMock(stubs, 2, query, createMockPosts(100, 101), createPaginationMeta(2, 3, 250));
+                setupPageMock(stubs, 3, query, createMockPosts(50, 201), createPaginationMeta(3, 3, 250));
+
+                const result = await adapter.query(store, type, {limit: 'all', ...query});
+
+                // Verify pagination calls
+                expect(stubs.superQueryStub).to.have.been.calledThrice;
+                expect(stubs.buildQueryStub).to.have.been.calledThrice;
+
+                // Verify combined results
+                expect(result[DATA_KEY]).to.have.lengthOf(250);
+                expect(result[DATA_KEY][0]).to.deep.equal({id: 1, title: 'Post 1'});
+                expect(result[DATA_KEY][99]).to.deep.equal({id: 100, title: 'Post 100'});
+                expect(result[DATA_KEY][100]).to.deep.equal({id: 101, title: 'Post 101'});
+                expect(result[DATA_KEY][249]).to.deep.equal({id: 250, title: 'Post 250'});
+
+                // Verify final metadata
+                expect(result.meta).to.deep.equal(createExpectedFinalMeta(250));
+            });
+
+            it('handles single page result when query.limit is "all"', async function () {
+                const stubs = createMockStubs();
+                const query = {filter: 'featured:true'};
+                const posts = [{id: 1, title: 'Featured Post 1'}, {id: 2, title: 'Featured Post 2'}];
+
+                setupPageMock(stubs, 1, query, posts, createPaginationMeta(1, 1, 2));
+
+                const result = await adapter.query(store, type, {limit: 'all', ...query});
+
+                expect(stubs.superQueryStub).to.have.been.calledOnce;
+                expect(result[DATA_KEY]).to.have.lengthOf(2);
+                expect(result[DATA_KEY][0]).to.deep.equal({id: 1, title: 'Featured Post 1'});
+                expect(result[DATA_KEY][1]).to.deep.equal({id: 2, title: 'Featured Post 2'});
+                expect(result.meta).to.deep.equal(createExpectedFinalMeta(2));
+            });
+
+            it('handles empty result when query.limit is "all"', async function () {
+                const stubs = createMockStubs();
+                const query = {filter: 'status:nonexistent'};
+
+                setupPageMock(stubs, 1, query, [], createPaginationMeta(1, 0, 0));
+
+                const result = await adapter.query(store, type, {limit: 'all', ...query});
+
+                expect(stubs.superQueryStub).to.have.been.calledOnce;
+                expect(result[DATA_KEY]).to.have.lengthOf(0);
+                expect(result.meta).to.deep.equal(createExpectedFinalMeta(0));
+            });
+
+            it('preserves other query parameters when paginating', async function () {
+                const superQueryStub = sandbox.stub(EmbeddedRelationAdapter.prototype.__proto__, 'query');
+                const buildQueryStub = sandbox.stub(adapter, 'buildQuery');
+
+                // Set up buildQuery to return the query with includes added
+                buildQueryStub.callsFake((_store, modelName, query) => {
+                    return {...query, include: 'tags'};
+                });
+
+                // Mock super.query responses based on the processed query
+                superQueryStub.callsFake((_store, _type, processedQuery) => {
+                    const pageNum = processedQuery.page;
+                    const dataSize = pageNum === 1 ? 100 : 50;
+                    return Promise.resolve({
+                        posts: new Array(dataSize).fill(null).map((_, i) => ({id: i + (pageNum - 1) * 100 + 1})),
+                        meta: {pagination: {page: pageNum, pages: 2, total: 150}}
+                    });
+                });
+
+                const result = await adapter.query(store, type, {
+                    limit: 'all',
+                    filter: 'status:published',
+                    order: 'published_at desc'
+                });
+
+                expect(result.posts).to.have.lengthOf(150);
+                expect(superQueryStub).to.have.been.calledTwice;
+
+                // Verify metadata shows this as a single page with all results
+                expect(result.meta).to.deep.equal({
+                    pagination: {
+                        page: 1,
+                        limit: 150,
+                        pages: 1,
+                        total: 150,
+                        next: null,
+                        prev: null
+                    }
+                });
+
+                // Verify that both calls preserved the original query parameters
+                expect(buildQueryStub).to.have.been.calledTwice;
+
+                const allCalls = buildQueryStub.getCalls();
+                const callQueries = allCalls.map(call => call.args[2]);
+
+                // Check that we made calls for page 1 and page 2
+                const page1Query = callQueries.find(q => q && q.page === 1);
+                const page2Query = callQueries.find(q => q && q.page === 2);
+
+                // Ensure both queries were found
+                expect(page1Query, 'Should find page 1 query').to.exist;
+                expect(page2Query, 'Should find page 2 query').to.exist;
+
+                expect(page1Query).to.include({
+                    limit: 100,
+                    filter: 'status:published',
+                    order: 'published_at desc'
+                });
+
+                expect(page2Query).to.include({
+                    limit: 100,
+                    filter: 'status:published',
+                    order: 'published_at desc'
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- our API used to support `?limit=all` but it's being deprecated and updated in 6.0 to always return at most 100 results. However, our own code still makes use of it in a number of places. Rather than updating every instance to add looped fetching, or implementing paginated UI which isn't always feasible, we'll be intercepting the store queries and changing to looped `?limit=100` requests.