### PR TITLE
Fixed Stats > Growth > Top pages listing to show dynamic pages

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -39,6 +39,8 @@ export type MemberCountHistoryResponseType = {
 export type TopPostStatItem = {
     post_id: string;
     attribution_url: string;
+    attribution_type: string;
+    attribution_id: string;
     title: string;
     free_members: number;
     paid_members: number;

--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -38,6 +38,7 @@ export type MemberCountHistoryResponseType = {
 
 export type TopPostStatItem = {
     post_id: string;
+    attribution_url: string;
     title: string;
     free_members: number;
     paid_members: number;

--- a/apps/stats/README.md
+++ b/apps/stats/README.md
@@ -1,25 +1,28 @@
-# Ghost Stats
+# Ghost Stats App
 
-A React application for displaying Stats in Ghost Admin.
+The Ghost Stats App provides analytics and insights for Ghost sites.
 
 ## Features
 
-The Ghost Stats app provides sitewide insights through several key views:
+### Top Content Analytics
+- **Growth Tab**: Shows which posts and pages drove the most member conversions
+- **Web Tab**: Shows which posts and pages received the most visitors
 
-- **Web Analytics**: Track page views, traffic patterns, and user engagement
-- **Growth Analytics**: Monitor member growth and conversion metrics
-- **Newsletter Analytics**: Analyze newsletter performance and engagement
-- **Location Data**: View geographical distribution of visitors and members
-- **Traffic Sources**: Track where your visitors are coming from
+### URL Linking
+All content in the analytics tables is now clickable:
+- **Posts**: Click to view detailed post analytics
+- **Pages**: Click to view the page on the frontend site
+- **System Pages**: Click to view homepage, tag pages, author pages, etc. on the frontend site
 
-## Tech Stack
+The app automatically determines the appropriate action:
+- Posts with analytics data → Navigate to post analytics page
+- Pages and system pages → Open frontend URL in new tab
 
-- **Framework**: React 18
-- **Build Tool**: Vite
-- **Language**: TypeScript
-- **Styling**: Tailwind
-- **Testing**: Vitest with React Testing Library
-- **Visualization**: Recharts, SVG Maps for geographical data, Tinybird charts
+### Supported System Pages
+- Homepage (`/`)
+- Tag pages (`/tag/slug/`, `/tags/slug/`)
+- Author pages (`/author/slug/`, `/authors/slug/`)
+- Custom pages and other frontend URLs
 
 ## Development
 
@@ -82,3 +85,11 @@ yarn lint:test
 ## License
 
 MIT - See LICENSE file for details.
+
+## URL Utilities
+
+The app includes URL helper utilities in `src/utils/url-helpers.ts`:
+
+- `getFrontendUrl()`: Generate full frontend URLs from attribution paths
+- `shouldMakeClickable()`: Determine if content should be clickable
+- `getClickHandler()`: Get appropriate click handler for content type

--- a/apps/stats/src/utils/content-helpers.ts
+++ b/apps/stats/src/utils/content-helpers.ts
@@ -1,0 +1,53 @@
+// Shared content type definitions
+export const CONTENT_TYPES = {
+    POSTS: 'posts',
+    PAGES: 'pages',
+    POSTS_AND_PAGES: 'posts_and_pages',
+    SOURCES: 'sources'
+} as const;
+
+export type ContentType = typeof CONTENT_TYPES[keyof typeof CONTENT_TYPES];
+
+// Helper functions for content titles and descriptions
+export const getContentTitle = (selectedContentType: ContentType) => {
+    switch (selectedContentType) {
+    case CONTENT_TYPES.POSTS:
+        return 'Top posts';
+    case CONTENT_TYPES.PAGES:
+        return 'Top pages';
+    case CONTENT_TYPES.SOURCES:
+        return 'Top sources';
+    default:
+        return 'Top content';
+    }
+};
+
+export const getContentDescription = (selectedContentType: ContentType, rangeValue: number, getPeriodText: (range: number) => string) => {
+    switch (selectedContentType) {
+    case CONTENT_TYPES.POSTS:
+        return `Your highest viewed posts ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.PAGES:
+        return `Your highest viewed pages ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.POSTS_AND_PAGES:
+        return `Your highest viewed posts or pages ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.SOURCES:
+        return `How readers found your site ${getPeriodText(rangeValue)}`;
+    default:
+        return `Your highest viewed posts or pages ${getPeriodText(rangeValue)}`;
+    }
+};
+
+export const getGrowthContentDescription = (selectedContentType: ContentType, rangeValue: number, getPeriodText: (range: number) => string) => {
+    switch (selectedContentType) {
+    case CONTENT_TYPES.POSTS:
+        return `Which posts drove the most growth ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.PAGES:
+        return `Which pages drove the most growth ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.POSTS_AND_PAGES:
+        return `Which posts or pages drove the most growth ${getPeriodText(rangeValue)}`;
+    case CONTENT_TYPES.SOURCES:
+        return `How readers found your site ${getPeriodText(rangeValue)}`;
+    default:
+        return `Which posts drove the most growth ${getPeriodText(rangeValue)}`;
+    }
+}; 

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -25,6 +25,38 @@ export function getFrontendUrl(attributionUrl: string, siteUrl: string): string 
 }
 
 /**
+ * Generate a human-readable title from a URL path
+ * This matches the backend _generateTitleFromPath logic for consistency
+ * @param path - The URL path (e.g., '/', '/tag/slug/', '/author/slug/')
+ * @returns A formatted title
+ */
+export function generateTitleFromPath(path: string): string {
+    if (!path) {
+        return 'Unknown';
+    }
+    
+    // Handle common Ghost paths
+    if (path === '/') {
+        return 'Homepage';
+    }
+    if (path.startsWith('/tag/')) {
+        return `Tag: ${path.split('/')[2]}`;
+    }
+    if (path.startsWith('/tags/')) {
+        return `Tag: ${path.split('/')[2]}`;
+    }
+    if (path.startsWith('/author/')) {
+        return `Author: ${path.split('/')[2]}`;
+    }  
+    if (path.startsWith('/authors/')) {
+        return `Author: ${path.split('/')[2]}`;
+    }
+    
+    // For other paths, just return the path itself
+    return path;
+}
+
+/**
  * Check if a URL should be clickable (i.e., it's a valid frontend URL)
  * @param attributionUrl - The attribution URL path
  * @returns Whether the URL should be clickable
@@ -41,28 +73,21 @@ export function shouldMakeClickable(attributionUrl: string): boolean {
  * @param postId - The post ID (if available)
  * @param siteUrl - The site's base URL
  * @param navigate - The navigation function for analytics routes
+ * @param attributionType - The attribution type ('post', 'page', 'url', 'tag', 'author')
  * @returns The appropriate click handler
  */
 export function getClickHandler(
     attributionUrl: string,
     postId: string | null | undefined,
     siteUrl: string,
-    navigate: (path: string, options?: {crossApp?: boolean}) => void
+    navigate: (path: string, options?: {crossApp?: boolean}) => void,
+    attributionType?: string
 ) {
     return () => {
         // For posts with analytics, go to analytics page
-        if (postId && attributionUrl) {
-            // Check if this is a post by seeing if it's not a system page
-            const isSystemPage = attributionUrl === '/' || 
-                                 attributionUrl.startsWith('/tag/') || 
-                                 attributionUrl.startsWith('/tags/') ||
-                                 attributionUrl.startsWith('/author/') ||
-                                 attributionUrl.startsWith('/authors/');
-            
-            if (!isSystemPage) {
-                navigate(`/posts/analytics/beta/${postId}`, {crossApp: true});
-                return;
-            }
+        if (postId && attributionUrl && attributionType === 'post') {
+            navigate(`/posts/analytics/beta/${postId}`, {crossApp: true});
+            return;
         }
         
         // For all other cases (pages, system pages), open frontend URL in new tab

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -40,16 +40,16 @@ export function generateTitleFromPath(path: string): string {
         return 'Homepage';
     }
     if (path.startsWith('/tag/')) {
-        return `Tag: ${path.split('/')[2]}`;
+        return `tag/${path.split('/')[2]}`;
     }
     if (path.startsWith('/tags/')) {
-        return `Tag: ${path.split('/')[2]}`;
+        return `tag/${path.split('/')[2]}`;
     }
     if (path.startsWith('/author/')) {
-        return `Author: ${path.split('/')[2]}`;
+        return `author/${path.split('/')[2]}`;
     }  
     if (path.startsWith('/authors/')) {
-        return `Author: ${path.split('/')[2]}`;
+        return `author/${path.split('/')[2]}`;
     }
     
     // For other paths, just return the path itself

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * Generate a frontend URL from an attribution path and site URL
+ * @param attributionUrl - The path from attribution data (e.g., '/', '/tag/slug/', '/author/slug/')
+ * @param siteUrl - The site's base URL (e.g., 'https://example.com')
+ * @returns The full frontend URL
+ */
+export function getFrontendUrl(attributionUrl: string, siteUrl: string): string {
+    if (!attributionUrl || !siteUrl) {
+        return '';
+    }
+
+    try {
+        const baseUrl = new URL(siteUrl);
+        const subdir = baseUrl.pathname.endsWith('/') ? baseUrl.pathname : `${baseUrl.pathname}/`;
+        
+        // Remove leading slash from attribution URL to avoid double slashes
+        const cleanPath = attributionUrl.replace(/^\//, '');
+        const fullPath = `${subdir}${cleanPath}`;
+
+        return `${baseUrl.origin}${fullPath}`;
+    } catch (error) {
+        // Silently handle URL construction errors
+        return '';
+    }
+}
+
+/**
+ * Check if a URL should be clickable (i.e., it's a valid frontend URL)
+ * @param attributionUrl - The attribution URL path
+ * @returns Whether the URL should be clickable
+ */
+export function shouldMakeClickable(attributionUrl: string): boolean {
+    // Always make clickable if we have an attribution URL
+    // This includes posts, pages, system pages like homepage, tag pages, author pages
+    return Boolean(attributionUrl);
+}
+
+/**
+ * Get the click handler for a content item
+ * @param attributionUrl - The attribution URL path
+ * @param postId - The post ID (if available)
+ * @param siteUrl - The site's base URL
+ * @param navigate - The navigation function for analytics routes
+ * @returns The appropriate click handler
+ */
+export function getClickHandler(
+    attributionUrl: string,
+    postId: string | null | undefined,
+    siteUrl: string,
+    navigate: (path: string, options?: {crossApp?: boolean}) => void
+) {
+    return () => {
+        // For posts with analytics, go to analytics page
+        if (postId && attributionUrl) {
+            // Check if this is a post by seeing if it's not a system page
+            const isSystemPage = attributionUrl === '/' || 
+                                 attributionUrl.startsWith('/tag/') || 
+                                 attributionUrl.startsWith('/tags/') ||
+                                 attributionUrl.startsWith('/author/') ||
+                                 attributionUrl.startsWith('/authors/');
+            
+            if (!isSystemPage) {
+                navigate(`/posts/analytics/beta/${postId}`, {crossApp: true});
+                return;
+            }
+        }
+        
+        // For all other cases (pages, system pages), open frontend URL in new tab
+        if (attributionUrl && siteUrl) {
+            const frontendUrl = getFrontendUrl(attributionUrl, siteUrl);
+            if (frontendUrl) {
+                window.open(frontendUrl, '_blank', 'noopener,noreferrer');
+            }
+        }
+    };
+} 

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -40,16 +40,20 @@ export function generateTitleFromPath(path: string): string {
         return 'Homepage';
     }
     if (path.startsWith('/tag/')) {
-        return `tag/${path.split('/')[2]}`;
+        const segments = path.split('/');
+        return segments.length > 2 && segments[2] ? `tag/${segments[2]}` : 'tag/unknown';
     }
     if (path.startsWith('/tags/')) {
-        return `tag/${path.split('/')[2]}`;
+        const segments = path.split('/');
+        return segments.length > 2 && segments[2] ? `tag/${segments[2]}` : 'tag/unknown';
     }
     if (path.startsWith('/author/')) {
-        return `author/${path.split('/')[2]}`;
+        const segments = path.split('/');
+        return segments.length > 2 && segments[2] ? `author/${segments[2]}` : 'author/unknown';
     }  
     if (path.startsWith('/authors/')) {
-        return `author/${path.split('/')[2]}`;
+        const segments = path.split('/');
+        return segments.length > 2 && segments[2] ? `author/${segments[2]}` : 'author/unknown';
     }
     
     // For other paths, just return the path itself

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -7,7 +7,7 @@ import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber} from '@tryghost/shade';
-import {getClickHandler, shouldMakeClickable} from '@src/utils/url-helpers';
+import {generateTitleFromPath, getClickHandler, shouldMakeClickable} from '@src/utils/url-helpers';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useAppContext} from '@src/App';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -30,6 +30,8 @@ type ContentType = typeof CONTENT_TYPES[keyof typeof CONTENT_TYPES];
 interface UnifiedGrowthContentData {
     pathname?: string;
     attribution_url: string;
+    attribution_type: string;
+    attribution_id: string;
     title: string;
     post_id?: string;
     post_uuid?: string;
@@ -106,9 +108,11 @@ const Growth: React.FC = () => {
             }
 
             return {
-                title: item.title,
+                title: item.title || generateTitleFromPath(item.attribution_url),
                 post_id: item.post_id,
                 attribution_url: item.attribution_url,
+                attribution_type: item.attribution_type,
+                attribution_id: item.attribution_id,
                 free_members: item.free_members,
                 paid_members: item.paid_members,
                 mrr: item.mrr,
@@ -242,7 +246,7 @@ const Growth: React.FC = () => {
                                                                     className='h-auto whitespace-normal p-0 text-left font-medium leading-tight hover:!underline' 
                                                                     title={post.post_id ? 'View post analytics' : 'View page'} 
                                                                     variant='link' 
-                                                                    onClick={getClickHandler(post.attribution_url, post.post_id, site.url || '', navigate)}
+                                                                    onClick={getClickHandler(post.attribution_url, post.post_id, site.url || '', navigate, post.attribution_type)}
                                                                 >
                                                                     {post.title}
                                                                 </Button>

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -66,7 +66,11 @@ const Growth: React.FC = () => {
         
         // First deduplicate by post_id/title to handle backend duplicates
         const uniqueData = growthData.reduce((acc: Map<string, TopPostStatItem>, item: TopPostStatItem) => {
-            const key = item.post_id || item.title;
+            const key = item.post_id || (item.title && item.title.trim() !== '' ? item.title : item.attribution_url);
+            if (!key) {
+                // Skip items that have no valid key - this should not happen with proper backend data
+                return acc;
+            }
             if (!acc.has(key)) {
                 acc.set(key, item);
             } else {

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -1,5 +1,6 @@
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Tabs, TabsList, TabsTrigger, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {getAudienceQueryParam} from '../../components/AudienceSelect';
+import {getClickHandler, shouldMakeClickable} from '@src/utils/url-helpers';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useMemo, useState} from 'react';
@@ -35,6 +36,7 @@ interface TopContentTableProps {
 
 const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, data, contentType}) => {
     const navigate = useNavigate();
+    const {site} = useGlobalData();
 
     const getTableHeader = () => {
         switch (contentType) {
@@ -57,19 +59,15 @@ const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, d
             }
             <DataListBody>
                 {data?.map((row: UnifiedContentData) => {
-                    // Only make posts clickable (not pages), since there's no analytics route for pages
-                    const isClickable = row.post_id && row.post_type === 'post';
-                    const handleClick = () => {
-                        if (isClickable) {
-                            navigate(`/posts/analytics/beta/${row.post_id}`, {crossApp: true});
-                        }
-                    };
+                    // Make all content with a pathname clickable
+                    const isClickable = shouldMakeClickable(row.pathname);
+                    const handleClick = getClickHandler(row.pathname, row.post_id, site.url || '', navigate);
 
                     return (
                         <DataListRow
                             key={row.pathname}
                             className={`group/row ${isClickable && 'hover:cursor-pointer'}`}
-                            onClick={handleClick}
+                            onClick={isClickable ? handleClick : undefined}
                         >
                             <DataListBar style={{
                                 width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -1,6 +1,6 @@
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Tabs, TabsList, TabsTrigger, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, formatNumber, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {generateTitleFromPath, getClickHandler, shouldMakeClickable} from '@src/utils/url-helpers';
 import {getAudienceQueryParam} from '../../components/AudienceSelect';
-import {getClickHandler, shouldMakeClickable} from '@src/utils/url-helpers';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useMemo, useState} from 'react';
@@ -27,78 +27,15 @@ const CONTENT_TYPES = {
 
 type ContentType = typeof CONTENT_TYPES[keyof typeof CONTENT_TYPES];
 
-interface TopContentTableProps {
-    data: UnifiedContentData[] | null;
-    range: number;
-    contentType: ContentType;
-    tableHeader: boolean;
-}
-
-const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, data, contentType}) => {
-    const navigate = useNavigate();
-    const {site} = useGlobalData();
-
-    const getTableHeader = () => {
-        switch (contentType) {
-        case CONTENT_TYPES.POSTS:
-            return 'Post';
-        case CONTENT_TYPES.PAGES:
-            return 'Page';
-        default:
-            return 'Post';
-        }
-    };
-
-    return (
-        <DataList>
-            {tableHeader &&
-                <DataListHeader>
-                    <DataListHead>{getTableHeader()}</DataListHead>
-                    <DataListHead>Visitors</DataListHead>
-                </DataListHeader>
-            }
-            <DataListBody>
-                {data?.map((row: UnifiedContentData) => {
-                    // Make all content with a pathname clickable
-                    const isClickable = shouldMakeClickable(row.pathname);
-                    const handleClick = getClickHandler(row.pathname, row.post_id, site.url || '', navigate);
-
-                    return (
-                        <DataListRow
-                            key={row.pathname}
-                            className={`group/row ${isClickable && 'hover:cursor-pointer'}`}
-                            onClick={isClickable ? handleClick : undefined}
-                        >
-                            <DataListBar style={{
-                                width: `${row.percentage ? Math.round(row.percentage * 100) : 0}%`
-                            }} />
-                            <DataListItemContent className='group-hover/datalist:max-w-[calc(100%-140px)]'>
-                                <div className='flex items-center space-x-4 overflow-hidden'>
-                                    <div className={`truncate font-medium ${isClickable && 'group-hover/row:underline'}`}>
-                                        {row.title}
-                                    </div>
-                                </div>
-                            </DataListItemContent>
-                            <DataListItemValue>
-                                <DataListItemValueAbs>{formatNumber(Number(row.visits))}</DataListItemValueAbs>
-                                <DataListItemValuePerc>{formatPercentage(row.percentage || 0)}</DataListItemValuePerc>
-                            </DataListItemValue>
-                        </DataListRow>
-                    );
-                })}
-            </DataListBody>
-        </DataList>
-    );
-};
-
 interface TopContentProps {
     range: number;
 }
 
 const TopContent: React.FC<TopContentProps> = ({range}) => {
-    const {audience} = useGlobalData();
+    const {audience, site} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
+    const navigate = useNavigate();
 
     // Prepare query parameters based on selected content type
     const queryParams = useMemo(() => {
@@ -140,7 +77,7 @@ const TopContent: React.FC<TopContentProps> = ({range}) => {
 
         return data.map(item => ({
             pathname: item.pathname,
-            title: item.title || item.pathname,
+            title: item.title || generateTitleFromPath(item.pathname),
             visits: item.visits,
             percentage: filteredTotalVisits > 0 ? (Number(item.visits) / filteredTotalVisits) : 0,
             post_uuid: item.post_uuid,
@@ -179,30 +116,81 @@ const TopContent: React.FC<TopContentProps> = ({range}) => {
                 <CardTitle>{getContentTitle()}</CardTitle>
                 <CardDescription>{getContentDescription()}</CardDescription>
             </CardHeader>
-            <div className='flex items-center justify-between px-6 pb-2 pt-0'>
-                <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
-                    setSelectedContentType(value as ContentType);
-                }}>
-                    <TabsList>
-                        <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
-                        <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
-                        <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
-                    </TabsList>
-                </Tabs>
-                <HTable className='mr-2'>Visitors</HTable>
-            </div>
-            <CardContent className='overflow-hidden'>
-                <Separator />
-                {isLoading ?
-                    <SkeletonTable className='mt-3' / >
-                    :
-                    <TopContentTable
-                        contentType={selectedContentType}
-                        data={topContent}
-                        range={range}
-                        tableHeader={false}
-                    />
-                }
+            <CardContent>
+                <Table>
+                    <TableHeader>
+                        <TableRow className='[&>th]:h-auto [&>th]:pb-2 [&>th]:pt-0'>
+                            <TableHead className='pl-0'>
+                                <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
+                                    setSelectedContentType(value as ContentType);
+                                }}>
+                                    <TabsList>
+                                        <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
+                                        <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
+                                        <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
+                                    </TabsList>
+                                </Tabs>
+                            </TableHead>
+                            <TableHead className='w-[140px] text-right'>Visitors</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    {isLoading ?
+                        <TableBody>
+                            <TableRow>
+                                <TableCell colSpan={2}>
+                                    <SkeletonTable lines={5} />
+                                </TableCell>
+                            </TableRow>
+                        </TableBody>
+                        :
+                        <TableBody>
+                            {topContent.length > 0 ? (
+                                topContent.map((row: UnifiedContentData) => {
+                                    const isClickable = shouldMakeClickable(row.pathname);
+
+                                    return (
+                                        <TableRow key={row.pathname} className='last:border-none'>
+                                            <TableCell>
+                                                <div className='group/link inline-flex flex-col items-start gap-px'>
+                                                    {isClickable ?
+                                                        <Button 
+                                                            className='h-auto whitespace-normal p-0 text-left font-medium leading-tight hover:!underline' 
+                                                            title={row.post_id ? 'View post analytics' : 'View page'} 
+                                                            variant='link' 
+                                                            onClick={getClickHandler(row.pathname, row.post_id, site.url || '', navigate, row.post_type)}
+                                                        >
+                                                            {row.title}
+                                                        </Button>
+                                                        :
+                                                        <span className='font-medium'>
+                                                            {row.title}
+                                                        </span>
+                                                    }
+                                                </div>
+                                            </TableCell>
+                                            <TableCell className='text-right font-mono text-sm'>
+                                                {formatNumber(Number(row.visits))}
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })
+                            ) : (
+                                <TableRow>
+                                    <TableCell className='py-12 group-hover:!bg-transparent' colSpan={2}>
+                                        <div className='flex flex-col items-center justify-center space-y-3 text-center'>
+                                            <div className='flex size-12 items-center justify-center rounded-full bg-muted'>
+                                                <svg className='size-6 text-muted-foreground' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                                                    <path d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} />
+                                                </svg>
+                                            </div>
+                                            <div className='text-sm text-muted-foreground'>No content found</div>
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    }
+                </Table>
             </CardContent>
             {transformedData && transformedData.length > 10 &&
                 <CardFooter>
@@ -215,14 +203,47 @@ const TopContent: React.FC<TopContentProps> = ({range}) => {
                                 <SheetTitle>Top content</SheetTitle>
                                 <SheetDescription>{getContentDescription()}</SheetDescription>
                             </SheetHeader>
-                            <div className='group/datalist'>
-                                <TopContentTable
-                                    contentType={selectedContentType}
-                                    data={transformedData}
-                                    range={range}
-                                    tableHeader={true}
-                                />
-                            </div>
+                            <Table>
+                                <TableHeader>
+                                    <TableRow className='[&>th]:h-auto [&>th]:pb-2 [&>th]:pt-0'>
+                                        <TableHead className='pl-0'>
+                                            {selectedContentType === CONTENT_TYPES.POSTS ? 'Post' : selectedContentType === CONTENT_TYPES.PAGES ? 'Page' : 'Content'}
+                                        </TableHead>
+                                        <TableHead className='w-[140px] text-right'>Visitors</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {transformedData.map((row: UnifiedContentData) => {
+                                        const isClickable = shouldMakeClickable(row.pathname);
+
+                                        return (
+                                            <TableRow key={row.pathname} className='last:border-none'>
+                                                <TableCell>
+                                                    <div className='group/link inline-flex flex-col items-start gap-px'>
+                                                        {isClickable ?
+                                                            <Button 
+                                                                className='h-auto whitespace-normal p-0 text-left font-medium leading-tight hover:!underline' 
+                                                                title={row.post_id ? 'View post analytics' : 'View page'} 
+                                                                variant='link' 
+                                                                onClick={getClickHandler(row.pathname, row.post_id, site.url || '', navigate, row.post_type)}
+                                                            >
+                                                                {row.title}
+                                                            </Button>
+                                                            :
+                                                            <span className='font-medium'>
+                                                                {row.title}
+                                                            </span>
+                                                        }
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell className='text-right font-mono text-sm'>
+                                                    {formatNumber(Number(row.visits))}
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
                         </SheetContent>
                     </Sheet>
                 </CardFooter>

--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -541,6 +541,7 @@ const controller = {
             );
         }
     }
+
 };
 
 module.exports = controller;

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -210,16 +210,16 @@ class PostsStatsService {
             return 'Homepage';
         }
         if (path.startsWith('/tag/')) {
-            return `Tag: ${path.split('/')[2]}`;
+            return `tag/${path.split('/')[2]}`;
         }
         if (path.startsWith('/tags/')) {
-            return `Tag: ${path.split('/')[2]}`;
+            return `tag/${path.split('/')[2]}`;
         }
         if (path.startsWith('/author/')) {
-            return `Author: ${path.split('/')[2]}`;
+            return `author/${path.split('/')[2]}`;
         }  
         if (path.startsWith('/authors/')) {
-            return `Author: ${path.split('/')[2]}`;
+            return `author/${path.split('/')[2]}`;
         }
         
         // For other paths, just return the path itself

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -16,6 +16,29 @@ const {normalizeSource} = require('./ReferrersStatsService');
  */
 
 /**
+ * @typedef {Object} TopPostsOptions
+ * @property {string} [order='free_members desc'] - Sort order (e.g., 'free_members desc', 'paid_members desc', 'mrr desc')
+ * @property {number} [limit=20] - Maximum number of results to return
+ * @property {string} [date_from] - Start date filter in YYYY-MM-DD format
+ * @property {string} [date_to] - End date filter in YYYY-MM-DD format
+ * @property {string} [post_type] - Filter by post type ('post', 'page')
+ */
+
+/**
+ * @typedef {Object} AttributionResult
+ * @property {string} [post_id] - Post ID if this is a post/page
+ * @property {string} attribution_url - The URL that drove the conversion
+ * @property {string} attribution_type - Type of attribution ('post', 'page', 'url', 'tag', 'author')
+ * @property {string} attribution_id - ID of the attributed resource
+ * @property {string} title - Display title for the content
+ * @property {string} [published_at] - Publication date
+ * @property {number} free_members - Number of free member conversions
+ * @property {number} paid_members - Number of paid member conversions
+ * @property {number} mrr - Monthly recurring revenue impact
+ * @property {string} [post_type] - Post type if applicable
+ */
+
+/**
  * @typedef {Object} TopPostResult
  * @property {string} post_id - The ID of the post
  * @property {string} title - The title of the post
@@ -65,8 +88,8 @@ class PostsStatsService {
     /**
      * Get top posts by attribution metrics (free_members, paid_members, or mrr)
      *
-     * @param {StatsServiceOptions} options
-     * @returns {Promise<{data: TopPostResult[]}>} The top posts based on the requested attribution metric
+     * @param {TopPostsOptions} options
+     * @returns {Promise<{data: AttributionResult[]}>} The top posts based on the requested attribution metric
      */
     async getTopPosts(options) {
         try {
@@ -117,7 +140,6 @@ class PostsStatsService {
                             const subquery1 = this.select('attribution_url', 'attribution_type', 'attribution_id')
                                 .from('members_created_events')
                                 .whereNotNull('attribution_url');
-                            // Apply date filter using the helper method
                             if (options.date_from || options.date_to) {
                                 if (options.date_from) {
                                     subquery1.where('created_at', '>=', options.date_from);
@@ -131,7 +153,6 @@ class PostsStatsService {
                                 const subquery2 = this.select('attribution_url', 'attribution_type', 'attribution_id')
                                     .from('members_subscription_created_events')
                                     .whereNotNull('attribution_url');
-                                // Apply date filter using the helper method
                                 if (options.date_from || options.date_to) {
                                     if (options.date_from) {
                                         subquery2.where('created_at', '>=', options.date_from);
@@ -228,16 +249,20 @@ class PostsStatsService {
             return 'Homepage';
         }
         if (path.startsWith('/tag/')) {
-            return `tag/${path.split('/')[2]}`;
+            const segments = path.split('/');
+            return segments.length > 2 && segments[2] ? `tag/${segments[2]}` : 'tag/unknown';
         }
         if (path.startsWith('/tags/')) {
-            return `tag/${path.split('/')[2]}`;
+            const segments = path.split('/');
+            return segments.length > 2 && segments[2] ? `tag/${segments[2]}` : 'tag/unknown';
         }
         if (path.startsWith('/author/')) {
-            return `author/${path.split('/')[2]}`;
+            const segments = path.split('/');
+            return segments.length > 2 && segments[2] ? `author/${segments[2]}` : 'author/unknown';
         }  
         if (path.startsWith('/authors/')) {
-            return `author/${path.split('/')[2]}`;
+            const segments = path.split('/');
+            return segments.length > 2 && segments[2] ? `author/${segments[2]}` : 'author/unknown';
         }
         
         // For other paths, just return the path itself

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -1,6 +1,5 @@
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const urlUtils = require('../../../shared/url-utils');
 
 // Import source normalization from ReferrersStatsService
 const {normalizeSource} = require('./ReferrersStatsService');
@@ -71,7 +70,7 @@ class PostsStatsService {
     async getTopPosts(options) {
         try {
             const order = options.order || 'free_members desc';
-            const limitRaw = Number.parseInt(String(options.limit ?? 20), 10); // Ensure options.limit is a string for parseInt
+            const limitRaw = Number.parseInt(String(options.limit ?? 20), 10);
             const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20;
             const [orderField, orderDirection = 'desc'] = order.split(' ');
 
@@ -86,47 +85,144 @@ class PostsStatsService {
                 });
             }
 
-            // Build the main query using CTEs for clarity with the new logic
-            const freeMembersCTE = this._buildFreeMembersSubquery(options);
-            const paidMembersCTE = this._buildPaidMembersSubquery(options);
-            const mrrCTE = this._buildMrrSubquery(options);
+            // Start from attribution events and aggregate by URL to include ALL paths that drove conversions
+            const freeMembersCTE = this._buildFreeMembersSubquery(options, true);
+            const paidMembersCTE = this._buildPaidMembersSubquery(options, true);
+            const mrrCTE = this._buildMrrSubquery(options, true);
 
-            let query = this.knex
-                .with('free', freeMembersCTE)
-                .with('paid', paidMembersCTE)
-                .with('mrr', mrrCTE)
-                .select(
+            // Store knex reference for use in callbacks
+            const knex = this.knex;
+
+            const results = await this.knex
+                .with('free_attr', freeMembersCTE)
+                .with('paid_attr', paidMembersCTE)
+                .with('mrr_attr', mrrCTE)
+                .with('all_urls', function () {
+                    this.select('attribution_url')
+                        .from('free_attr')
+                        .union(function () {
+                            this.select('attribution_url').from('paid_attr');
+                        })
+                        .union(function () {
+                            this.select('attribution_url').from('mrr_attr');
+                        });
+                })
+                .with('url_metadata', function () {
+                    // Get the first occurrence of each URL with its metadata
+                    this.select('attribution_url')
+                        .select(knex.raw('MIN(attribution_type) as attribution_type'))
+                        .select(knex.raw('MIN(attribution_id) as attribution_id'))
+                        .from(function () {
+                            this.select('attribution_url', 'attribution_type', 'attribution_id')
+                                .from('members_created_events')
+                                .whereNotNull('attribution_url')
+                                .whereBetween('created_at', [options.date_from, options.date_to])
+                                .union(function () {
+                                    this.select('attribution_url', 'attribution_type', 'attribution_id')
+                                        .from('members_subscription_created_events')
+                                        .whereNotNull('attribution_url')
+                                        .whereBetween('created_at', [options.date_from, options.date_to]);
+                                })
+                                .as('combined');
+                        })
+                        .groupBy('attribution_url');
+                })
+                .select([
+                    'all_urls.attribution_url',
+                    'url_metadata.attribution_type',
+                    'url_metadata.attribution_id',
                     'p.id as post_id',
                     'p.title',
                     'p.published_at',
-                    this.knex.raw('COALESCE(free.free_members, 0) as free_members'),
-                    this.knex.raw('COALESCE(paid.paid_members, 0) as paid_members'),
-                    this.knex.raw('COALESCE(mrr.mrr, 0) as mrr')
-                )
-                .from('posts as p')
-                .leftJoin('free', 'p.id', 'free.post_id')
-                .leftJoin('paid', 'p.id', 'paid.post_id')
-                .leftJoin('mrr', 'p.id', 'mrr.post_id')
-                .where('p.status', 'published');
-
-            // Add post_type filter if specified
-            if (options.post_type && ['post', 'page'].includes(options.post_type)) {
-                query = query.where('p.type', options.post_type);
-            }
-
-            const results = await query
+                    knex.raw('COALESCE(free_attr.free_members, 0) as free_members'),
+                    knex.raw('COALESCE(paid_attr.paid_members, 0) as paid_members'),
+                    knex.raw('COALESCE(mrr_attr.mrr, 0) as mrr')
+                ])
+                .from('all_urls')
+                .leftJoin('free_attr', 'all_urls.attribution_url', 'free_attr.attribution_url')
+                .leftJoin('paid_attr', 'all_urls.attribution_url', 'paid_attr.attribution_url')
+                .leftJoin('mrr_attr', 'all_urls.attribution_url', 'mrr_attr.attribution_url')
+                .leftJoin('url_metadata', 'all_urls.attribution_url', 'url_metadata.attribution_url')
+                .leftJoin('posts as p', function () {
+                    this.on('url_metadata.attribution_id', 'p.id')
+                        .andOnIn('url_metadata.attribution_type', ['post', 'page']);
+                })
+                .whereRaw('(COALESCE(free_attr.free_members, 0) > 0 OR COALESCE(paid_attr.paid_members, 0) > 0 OR COALESCE(mrr_attr.mrr, 0) > 0)')
                 .orderBy(orderField, orderDirection)
                 .limit(limit);
 
-            // Filter out posts with zero attribution across all metrics
-            const filteredResults = results.filter(post => post.free_members > 0 || post.paid_members > 0 || post.mrr > 0
-            ).slice(0, limit);
-            
-            return {data: filteredResults};
+            // Apply post_type filter after getting results if specified
+            let filteredResults = results;
+            if (options.post_type && ['post', 'page'].includes(options.post_type)) {
+                filteredResults = results.filter((row) => {
+                    if (options.post_type === 'post') {
+                        // Posts tab: Only posts (attribution_type = 'post' && has post_id)
+                        return row.attribution_type === 'post' && row.post_id !== null;
+                    } else if (options.post_type === 'page') {
+                        // Pages tab: Everything except posts
+                        return !(row.attribution_type === 'post' && row.post_id !== null);
+                    }
+                    return false;
+                });
+            }
+
+            // Transform results to include titles using urlService for path resolution
+            const transformedResults = await this._enrichWithTitles(filteredResults);
+
+            return {data: transformedResults.slice(0, limit)};
         } catch (error) {
             logging.error('Error fetching top posts by attribution:', error);
             return {data: []};
         }
+    }
+
+    async _enrichWithTitles(results) {
+        if (!results || !results.length) {
+            return [];
+        }
+
+        // Transform results and enrich with titles
+        return results.map((row) => {
+            const title = row.title || this._generateTitleFromPath(row.attribution_url);
+
+            return {
+                post_id: row.post_id,
+                attribution_url: row.attribution_url,
+                attribution_type: row.attribution_type,
+                attribution_id: row.attribution_id,
+                title,
+                published_at: row.published_at,
+                free_members: row.free_members,
+                paid_members: row.paid_members,
+                mrr: row.mrr
+            };
+        });
+    }
+
+    _generateTitleFromPath(path) {
+        if (!path) {
+            return 'Unknown';
+        }
+        
+        // Handle common Ghost paths
+        if (path === '/') {
+            return 'Homepage';
+        }
+        if (path.startsWith('/tag/')) {
+            return `Tag: ${path.split('/')[2]}`;
+        }
+        if (path.startsWith('/tags/')) {
+            return `Tag: ${path.split('/')[2]}`;
+        }
+        if (path.startsWith('/author/')) {
+            return `Author: ${path.split('/')[2]}`;
+        }  
+        if (path.startsWith('/authors/')) {
+            return `Author: ${path.split('/')[2]}`;
+        }
+        
+        // For other paths, just return the path itself
+        return path;
     }
 
     /**
@@ -296,14 +392,18 @@ class PostsStatsService {
      * @param {StatsServiceOptions} options
      * @returns {import('knex').Knex.QueryBuilder}
      */
-    _buildFreeMembersSubquery(options) {
+    _buildFreeMembersSubquery(options, groupByUrl = false) {
         const knex = this.knex;
+        const selectField = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id as post_id';
+        const groupByField = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id';
+        const joinCondition = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id';
+        
         let subquery = knex('members_created_events as mce')
-            .select('mce.attribution_id as post_id')
+            .select(selectField)
             .countDistinct('mce.member_id as free_members')
             .leftJoin('members_subscription_created_events as msce', function () {
                 this.on('mce.member_id', '=', 'msce.member_id')
-                    .andOn('mce.attribution_id', '=', 'msce.attribution_id');
+                    .andOn(joinCondition, '=', groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id');
                 // Add attribution_type condition based on post_type filter
                 if (options.post_type === 'page') {
                     this.andOnVal('msce.attribution_type', '=', 'page');
@@ -318,16 +418,28 @@ class PostsStatsService {
                 }
             })
             .whereNull('msce.id')
-            .groupBy('mce.attribution_id');
+            .groupBy(groupByField);
 
-        // Filter attribution_type based on post_type
-        if (options.post_type === 'page') {
-            subquery = subquery.where('mce.attribution_type', 'page');
-        } else if (options.post_type === 'post') {
-            subquery = subquery.where('mce.attribution_type', 'post');
+        // Filter attribution_type based on post_type - only when grouping by post_id
+        if (!groupByUrl) {
+            if (options.post_type === 'page') {
+                subquery = subquery.where('mce.attribution_type', 'page');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('mce.attribution_type', 'post');
+            } else {
+                // If no post_type specified, include both
+                subquery = subquery.whereIn('mce.attribution_type', ['post', 'page']);
+            }
         } else {
-            // If no post_type specified, include both
-            subquery = subquery.whereIn('mce.attribution_type', ['post', 'page']);
+            // When groupByUrl=true, include posts, pages, and system pages (url, tag, author)
+            if (options.post_type === 'page') {
+                subquery = subquery.where('mce.attribution_type', '!=', 'post');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('mce.attribution_type', 'post');
+            } else {
+                // Include all types that can drive conversions
+                subquery = subquery.whereIn('mce.attribution_type', ['post', 'page', 'url', 'tag', 'author']);
+            }
         }
 
         this._applyDateFilter(subquery, options, 'mce.created_at');
@@ -341,21 +453,36 @@ class PostsStatsService {
      * @param {StatsServiceOptions} options
      * @returns {import('knex').Knex.QueryBuilder}
      */
-    _buildPaidMembersSubquery(options) {
+    _buildPaidMembersSubquery(options, groupByUrl = false) {
         const knex = this.knex;
+        const selectField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id as post_id';
+        const groupByField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id';
+        
         let subquery = knex('members_subscription_created_events as msce')
-            .select('msce.attribution_id as post_id')
+            .select(selectField)
             .countDistinct('msce.member_id as paid_members')
-            .groupBy('msce.attribution_id');
+            .groupBy(groupByField);
 
-        // Filter attribution_type based on post_type
-        if (options.post_type === 'page') {
-            subquery = subquery.where('msce.attribution_type', 'page');
-        } else if (options.post_type === 'post') {
-            subquery = subquery.where('msce.attribution_type', 'post');
+        // Filter attribution_type based on post_type - only when grouping by post_id
+        if (!groupByUrl) {
+            if (options.post_type === 'page') {
+                subquery = subquery.where('msce.attribution_type', 'page');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('msce.attribution_type', 'post');
+            } else {
+                // If no post_type specified, include both
+                subquery = subquery.whereIn('msce.attribution_type', ['post', 'page']);
+            }
         } else {
-            // If no post_type specified, include both
-            subquery = subquery.whereIn('msce.attribution_type', ['post', 'page']);
+            // When groupByUrl=true, include posts, pages, and system pages (url, tag, author)
+            if (options.post_type === 'page') {
+                subquery = subquery.where('msce.attribution_type', '!=', 'post');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('msce.attribution_type', 'post');
+            } else {
+                // Include all types that can drive conversions
+                subquery = subquery.whereIn('msce.attribution_type', ['post', 'page', 'url', 'tag', 'author']);
+            }
         }
 
         this._applyDateFilter(subquery, options, 'msce.created_at');
@@ -369,24 +496,40 @@ class PostsStatsService {
      * @param {StatsServiceOptions} options
      * @returns {import('knex').Knex.QueryBuilder}
      */
-    _buildMrrSubquery(options) {
+    _buildMrrSubquery(options, groupByUrl = false) {
+        const selectField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id as post_id';
+        const groupByField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id';
+        
         let subquery = this.knex('members_subscription_created_events as msce')
-            .select('msce.attribution_id as post_id')
+            .select(selectField)
             .sum('mpse.mrr_delta as mrr')
             .join('members_paid_subscription_events as mpse', function () {
                 this.on('mpse.subscription_id', '=', 'msce.subscription_id');
                 this.andOn('mpse.member_id', '=', 'msce.member_id');
             })
-            .groupBy('msce.attribution_id');
+            .groupBy(groupByField);
 
-        // Filter attribution_type based on post_type
-        if (options.post_type === 'page') {
-            subquery = subquery.where('msce.attribution_type', 'page');
-        } else if (options.post_type === 'post') {
-            subquery = subquery.where('msce.attribution_type', 'post');
+        // Filter attribution_type based on post_type - only when grouping by post_id
+        if (!groupByUrl) {
+            if (options.post_type === 'page') {
+                subquery = subquery.where('msce.attribution_type', 'page');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('msce.attribution_type', 'post');
+            } else {
+                // If no post_type specified, include both
+                subquery = subquery.whereIn('msce.attribution_type', ['post', 'page']);
+            }
         } else {
-            // If no post_type specified, include both
-            subquery = subquery.whereIn('msce.attribution_type', ['post', 'page']);
+            // When groupByUrl=true, include posts, pages, and system pages (url, tag, author)
+            if (options.post_type === 'page') {
+                // Pages tab: Include actual pages AND system pages (everything except posts)
+                subquery = subquery.where('msce.attribution_type', '!=', 'post');
+            } else if (options.post_type === 'post') {
+                subquery = subquery.where('msce.attribution_type', 'post');
+            } else {
+                // Include all types that can drive conversions
+                subquery = subquery.whereIn('msce.attribution_type', ['post', 'page', 'url', 'tag', 'author']);
+            }
         }
 
         this._applyDateFilter(subquery, options, 'msce.created_at');
@@ -659,549 +802,44 @@ class PostsStatsService {
                     : this.knex.raw(`p.published_at <= ?`, [options.date_to]);
             }
 
-            let query;
+            // Subquery to count clicks from members_click_events
+            const clicksSubquery = this.knex
+                .select('r.post_id')
+                .countDistinct('mce.member_id as click_count')
+                .from('redirects as r')
+                .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
+                .whereNotNull('r.post_id')
+                .groupBy('r.post_id')
+                .as('clicks');
 
-            // If ordering by click_rate, we need to include click data
-            if (orderField === 'click_rate') {
-                // Subquery to count clicks from members_click_events
-                const clicksSubquery = this.knex
-                    .select('r.post_id')
-                    .countDistinct('mce.member_id as click_count')
-                    .from('redirects as r')
-                    .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
-                    .whereNotNull('r.post_id')
-                    .groupBy('r.post_id')
-                    .as('clicks');
-
-                // Build the query with click data
-                query = this.knex
-                    .select(
-                        'p.id as post_id',
-                        'p.title as post_title',
-                        'p.published_at as send_date',
-                        this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
-                        this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
-                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate'),
-                        this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
-                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate')
-                    )
-                    .from('posts as p')
-                    .leftJoin('emails as e', 'p.id', 'e.post_id')
-                    .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
-                    .where('p.newsletter_id', newsletterId)
-                    .whereIn('p.status', ['sent', 'published'])
-                    .whereNotNull('e.id') // Ensure there is an associated email record
-                    .whereRaw(dateFilter)
-                    .orderBy(orderFieldMap[orderField], orderDirection)
-                    .limit(limit);
-            } else {
-                // Build the query without click data for better performance
-                query = this.knex
-                    .select(
-                        'p.id as post_id',
-                        'p.title as post_title',
-                        'p.published_at as send_date',
-                        this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
-                        this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
-                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate')
-                    )
-                    .from('posts as p')
-                    .leftJoin('emails as e', 'p.id', 'e.post_id')
-                    .where('p.newsletter_id', newsletterId)
-                    .whereIn('p.status', ['sent', 'published'])
-                    .whereNotNull('e.id') // Ensure there is an associated email record
-                    .whereRaw(dateFilter)
-                    .orderBy(orderFieldMap[orderField], orderDirection)
-                    .limit(limit);
-            }
+            // Build the query to get newsletter stats
+            const query = this.knex
+                .select(
+                    'p.id as post_id',
+                    'p.title as post_title',
+                    'p.published_at as send_date',
+                    this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
+                    this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
+                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate'),
+                    this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
+                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate')
+                )
+                .from('posts as p')
+                .leftJoin('emails as e', 'p.id', 'e.post_id')
+                .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
+                .where('p.newsletter_id', newsletterId)
+                .whereIn('p.status', ['sent', 'published'])
+                .whereNotNull('e.id') // Ensure there is an associated email record
+                .whereRaw(dateFilter)
+                .orderBy(orderFieldMap[orderField], orderDirection)
+                .limit(limit);
 
             const results = await query;
 
             return {data: results};
         } catch (error) {
-            logging.error(`Error fetching newsletter basic stats for newsletter ${newsletterId}:`, error);
+            logging.error(`Error fetching newsletter stats for newsletter ${newsletterId}:`, error);
             return {data: []};
-        }
-    }
-
-    /**
-     * Get newsletter click statistics for specific posts
-     *
-     * @param {string} newsletterId - ID of the newsletter to get click stats for
-     * @param {Array<string>|string} postIds - Array of post IDs or comma-separated string of post IDs to get click data for
-     * @returns {Promise<{data: Array}>} The newsletter click stats
-     */
-    async getNewsletterClickStats(newsletterId, postIds = []) {
-        try {
-            // Handle postIds as either array or comma-separated string
-            let postIdsArray = [];
-            if (Array.isArray(postIds)) {
-                postIdsArray = postIds;
-            } else if (typeof postIds === 'string' && postIds.length > 0) {
-                postIdsArray = postIds.split(',').map(id => id.trim()).filter(id => id.length > 0);
-            }
-
-            if (postIdsArray.length === 0) {
-                return {data: []};
-            }
-
-            // Subquery to count clicks from members_click_events
-            const clicksQuery = this.knex
-                .select(
-                    'r.post_id',
-                    this.knex.raw('COALESCE(COUNT(DISTINCT mce.member_id), 0) as total_clicks'),
-                    this.knex.raw('MAX(COALESCE(e.email_count, 0)) as email_count')
-                )
-                .from('redirects as r')
-                .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
-                .leftJoin('posts as p', 'r.post_id', 'p.id')
-                .leftJoin('emails as e', 'p.id', 'e.post_id')
-                .whereIn('r.post_id', postIdsArray)
-                .where('p.newsletter_id', newsletterId)
-                .whereNotNull('r.post_id')
-                .groupBy('r.post_id')
-                .select(
-                    this.knex.raw('CASE WHEN MAX(COALESCE(e.email_count, 0)) > 0 THEN COALESCE(COUNT(DISTINCT mce.member_id), 0) / MAX(COALESCE(e.email_count, 0)) ELSE 0 END as click_rate')
-                );
-
-            const results = await clicksQuery;
-
-            return {data: results};
-        } catch (error) {
-            logging.error(`Error fetching newsletter click stats for newsletter ${newsletterId}:`, error);
-            return {data: []};
-        }
-    }
-
-    /**
-     * Get newsletter subscriber statistics including total count and daily deltas for a specific newsletter
-     *
-     * @param {string} newsletterId - ID of the newsletter to get subscriber stats for
-     * @param {Object} options - Query options
-     * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
-     * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
-     * @returns {Promise<{data: Array<{total: number, deltas: Array<{date: string, value: number}>}>}>} The newsletter subscriber stats
-     */
-    async getNewsletterSubscriberStats(newsletterId, options = {}) {
-        try {
-            // Run both queries in parallel for better performance
-            const [totalResult, rawDeltas] = await Promise.all([
-                // Get total subscriber count (optimized query - avoid JOIN)
-                this.knex('members_newsletters as mn')
-                    .countDistinct('mn.member_id as total')
-                    .where('mn.newsletter_id', newsletterId)
-                    .whereNotExists(function () {
-                        this.select('*')
-                            .from('members as m')
-                            .whereRaw('m.id = mn.member_id')
-                            .where('m.email_disabled', 1);
-                    }),
-                
-                // Get daily deltas (optimized query)
-                this._getNewsletterSubscriberDeltas(newsletterId, options)
-            ]);
-
-            const totalValue = totalResult[0] ? totalResult[0].total : 0;
-            const total = parseInt(String(totalValue), 10);
-
-            // Transform raw database results to properly typed objects
-            const deltas = [];
-            for (const row of rawDeltas) {
-                if (row) {
-                    // @ts-ignore
-                    const dateValue = row.date || '';
-                    // @ts-ignore
-                    const deltaValue = row.value || 0;
-                    deltas.push({
-                        date: String(dateValue),
-                        value: parseInt(String(deltaValue), 10)
-                    });
-                }
-            }
-
-            return {
-                data: [{
-                    total,
-                    deltas
-                }]
-            };
-        } catch (error) {
-            logging.error(`Error fetching subscriber stats for newsletter ${newsletterId}:`, error);
-            return {
-                data: [{
-                    total: 0,
-                    deltas: []
-                }]
-            };
-        }
-    }
-
-    /**
-     * Optimized query to get newsletter subscriber deltas
-     * @private
-     */
-    async _getNewsletterSubscriberDeltas(newsletterId, options = {}) {
-        // Build optimized deltas query - avoid expensive JOIN
-        let deltasQuery = this.knex('members_subscribe_events as mse')
-            .select(
-                this.knex.raw(`DATE(mse.created_at) as date`),
-                this.knex.raw(`SUM(CASE WHEN mse.subscribed = 1 THEN 1 ELSE -1 END) as value`)
-            )
-            .where('mse.newsletter_id', newsletterId)
-            .whereNotExists(function () {
-                this.select('*')
-                    .from('members as m')
-                    .whereRaw('m.id = mse.member_id')
-                    .where('m.email_disabled', 1);
-            })
-            .groupByRaw('DATE(mse.created_at)')
-            .orderBy('date', 'asc');
-
-        // Apply date filters early to reduce dataset
-        if (options.date_from) {
-            deltasQuery.where('mse.created_at', '>=', options.date_from);
-        }
-        if (options.date_to) {
-            deltasQuery.where('mse.created_at', '<=', `${options.date_to} 23:59:59`);
-        }
-
-        return await deltasQuery;
-    }
-
-    /**
-     * Get stats for a specific post by ID (analytics only, no post content)
-     * @param {string} postId - The post ID to get stats for
-     * @returns {Promise<{data: Array<{id: string, recipient_count: number|null, opened_count: number|null, open_rate: number|null, member_delta: number, free_members: number, paid_members: number, visitors: number}>}>}
-     */
-    async getPostStats(postId) {
-        try {
-            // Validate postId parameter
-            if (!postId || postId.trim() === '') {
-                return {data: []};
-            }
-            
-            // Get basic post info for stats calculations
-            const postData = await this.knex('posts')
-                .select('posts.id', 'posts.uuid', 'posts.published_at', 'e.email_count', 'e.opened_count')
-                .leftJoin('emails as e', 'posts.id', 'e.post_id')
-                .where('posts.id', postId)
-                .where('posts.status', 'published')
-                .first();
-                
-            if (!postData) {
-                return {data: []};
-            }
-
-            // Get member attribution counts
-            const memberAttributionCounts = await this._getMemberAttributionCounts([postData.id]);
-            const attributionCount = memberAttributionCounts.find(ac => ac.post_id === postData.id);
-            
-            const freeMembers = attributionCount ? attributionCount.free_members : 0;
-            const paidMembers = attributionCount ? attributionCount.paid_members : 0;
-            const totalMembers = freeMembers + paidMembers;
-
-            // Calculate open rate
-            const openRate = postData.email_count ? 
-                (postData.opened_count / postData.email_count) * 100 : 
-                null;
-
-            // Get visitor count from Tinybird
-            let visitors = 0;
-            if (this.tinybirdClient && postData.uuid) {
-                try {
-                    const dateFrom = new Date(postData.published_at).toISOString().split('T')[0];
-                    const visitorData = await this.tinybirdClient.fetch('api_top_pages', {
-                        post_uuid: postData.uuid,
-                        dateFrom: dateFrom
-                    });
-
-                    visitors = visitorData?.[0]?.visits || 0;
-                } catch (error) {
-                    logging.error('Error fetching visitor data from Tinybird:', error);
-                }
-            }
-
-            return {
-                data: [{
-                    id: postData.id,
-                    recipient_count: postData.email_count || null,
-                    opened_count: postData.opened_count || null,
-                    open_rate: openRate,
-                    member_delta: totalMembers,
-                    free_members: freeMembers,
-                    paid_members: paidMembers,
-                    visitors: visitors
-                }]
-            };
-        } catch (error) {
-            logging.error(`Error fetching post stats for post ${postId}:`, error);
-            return {data: []};
-        }
-    }
-
-    /**
-     * Get top posts by views for a given date range
-     * @param {Object} options
-     * @param {string} options.date_from - Start date in YYYY-MM-DD format
-     * @param {string} options.date_to - End date in YYYY-MM-DD format
-     * @param {string} [options.timezone] - Timezone to use for date interpretation (default: 'UTC')
-     * @param {number} [options.limit] - Maximum number of posts to return (default: 5)
-     * @returns {Promise<Object>} Top posts with view counts and additional Ghost data
-     */
-    async getTopPostsViews(options) {
-        try {
-            const limit = options.limit || 5;
-            const timezone = options.timezone || 'UTC';
-            let viewsData = [];
-
-            if (this.tinybirdClient) {
-                const tinybirdOptions = {
-                    dateFrom: options.date_from,
-                    dateTo: options.date_to,
-                    timezone: timezone,
-                    post_type: 'post',
-                    limit: limit
-                };
-
-                viewsData = await this.tinybirdClient.fetch('api_top_pages', tinybirdOptions) || [];
-            }
-
-            // Filter out any rows without post_uuid and get unique UUIDs
-            const postUuids = [...new Set(viewsData.filter(row => row.post_uuid).map(row => row.post_uuid))];
-            
-            // Get posts data from Ghost DB for the posts we have views for
-            const posts = await this.knex('posts as p')
-                .select(
-                    'p.id as post_id',
-                    'p.uuid as post_uuid',
-                    'p.title',
-                    'p.published_at',
-                    'p.feature_image',
-                    'emails.email_count',
-                    'emails.opened_count'
-                )
-                .leftJoin('emails', 'emails.post_id', 'p.id')
-                .whereIn('p.uuid', postUuids);
-
-            // Get member attribution counts for these posts (model after GrowthStats logic)
-            const memberAttributionCounts = await this._getMemberAttributionCounts(posts.map(p => p.post_id), options);
-
-            // Process posts with views
-            const postsWithViews = viewsData.map((row) => {
-                const post = posts.find(p => p.post_uuid === row.post_uuid);
-
-                if (!post) {
-                    return null;
-                }
-
-                // Find the member attribution count for this post
-                const attributionCount = memberAttributionCounts.find(ac => ac.post_id === post.post_id);
-                const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
-
-                return {
-                    post_id: post.post_id,
-                    title: post.title,
-                    published_at: post.published_at,
-                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
-                    views: row.visits,
-                    open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
-                    members: memberCount
-                };
-            }).filter(Boolean);
-
-            // Calculate how many more posts we need - we want to always return 5 posts
-            const remainingCount = limit - postsWithViews.length;
-
-            // If we need more posts, get the latest ones excluding the ones we already have
-            let additionalPosts = [];
-            let additionalMemberAttributionCounts = [];
-            if (remainingCount > 0) {
-                // Get post IDs that we already have to exclude them
-                const existingPostIds = postsWithViews.map(p => p.post_id);
-                
-                additionalPosts = await this.knex('posts as p')
-                    .select(
-                        'p.id as post_id',
-                        'p.uuid as post_uuid',
-                        'p.title',
-                        'p.published_at',
-                        'p.feature_image',
-                        'emails.email_count',
-                        'emails.opened_count'
-                    )
-                    .leftJoin('emails', 'emails.post_id', 'p.id')
-                    .whereNotIn('p.uuid', postUuids)
-                    .whereNotIn('p.id', existingPostIds)
-                    .where('p.status', 'published')
-                    .whereNotNull('p.published_at')
-                    .orderBy('p.published_at', 'desc')
-                    .limit(remainingCount);
-
-                // Get member attribution counts for additional posts
-                if (additionalPosts.length > 0) {
-                    additionalMemberAttributionCounts = await this._getMemberAttributionCounts(additionalPosts.map(p => p.post_id), options);
-                }
-            }
-
-            // Process additional posts with 0 views
-            const additionalPostsWithZeroViews = additionalPosts.map((post) => {
-                // Find the member attribution count for this post
-                const attributionCount = additionalMemberAttributionCounts.find(ac => ac.post_id === post.post_id);
-                const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
-
-                return {
-                    post_id: post.post_id,
-                    title: post.title,
-                    published_at: post.published_at,
-                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
-                    views: 0,
-                    open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
-                    members: memberCount
-                };
-            });
-
-            // Combine both sets of posts
-            return {data: [...postsWithViews, ...additionalPostsWithZeroViews]};
-        } catch (error) {
-            logging.error('Error fetching top posts views:', error);
-            return {data: []};
-        }
-    }
-
-    /**
-     * Get member attribution counts for a set of post IDs, modeling after GrowthStats logic
-     * Properly handles both free and paid members with deduplication
-     * @private
-     * @param {string[]} postIds - Array of post IDs to get attribution counts for
-     * @param {Object} options - Date filter options
-     * @returns {Promise<Array<{post_id: string, free_members: number, paid_members: number}>>}
-     */
-    async _getMemberAttributionCounts(postIds, options = {}) {
-        if (!postIds.length) {
-            return [];
-        }
-
-        try {
-            // Build free members query (modeled after _buildFreeMembersSubquery)
-            // Members who signed up on post but paid elsewhere/never
-            let freeMembersQuery = this.knex('members_created_events as mce')
-                .select('mce.attribution_id as post_id')
-                .countDistinct('mce.member_id as free_members')
-                .leftJoin('members_subscription_created_events as msce', function () {
-                    this.on('mce.member_id', '=', 'msce.member_id')
-                        .andOn('mce.attribution_id', '=', 'msce.attribution_id')
-                        .andOnVal('msce.attribution_type', '=', 'post');
-                })
-                .where('mce.attribution_type', 'post')
-                .whereIn('mce.attribution_id', postIds)
-                .whereNull('msce.id')
-                .groupBy('mce.attribution_id');
-
-            // Apply date filter to free members query
-            this._applyDateFilter(freeMembersQuery, options, 'mce.created_at');
-
-            // Build paid members query (modeled after _buildPaidMembersSubquery)
-            // Members whose paid conversion was attributed to this post
-            let paidMembersQuery = this.knex('members_subscription_created_events as msce')
-                .select('msce.attribution_id as post_id')
-                .countDistinct('msce.member_id as paid_members')
-                .where('msce.attribution_type', 'post')
-                .whereIn('msce.attribution_id', postIds)
-                .groupBy('msce.attribution_id');
-
-            // Apply date filter to paid members query
-            this._applyDateFilter(paidMembersQuery, options, 'msce.created_at');
-
-            // Execute both queries
-            const [freeResults, paidResults] = await Promise.all([
-                freeMembersQuery,
-                paidMembersQuery
-            ]);
-
-            // Combine results for each post
-            const combinedResults = postIds.map((postId) => {
-                const freeResult = freeResults.find(r => r.post_id === postId);
-                const paidResult = paidResults.find(r => r.post_id === postId);
-
-                return {
-                    post_id: postId,
-                    free_members: freeResult ? freeResult.free_members : 0,
-                    paid_members: paidResult ? paidResult.paid_members : 0
-                };
-            });
-
-            return combinedResults;
-        } catch (error) {
-            logging.error('Error fetching member attribution counts:', error);
-            return postIds.map(postId => ({
-                post_id: postId,
-                free_members: 0,
-                paid_members: 0
-            }));
-        }
-    }
-
-    /**
-     * Get member attribution counts for multiple posts
-     * @param {string[]} postIds - Array of post IDs
-     * @param {Object} options - Date filter options
-     * @returns {Promise<Object>} Map of post ID to member counts
-     */
-    async getPostsMemberCounts(postIds, options = {}) {
-        try {
-            const attributionCounts = await this._getMemberAttributionCounts(postIds, options);
-            
-            // Convert array to object mapping post_id -> counts
-            const memberCounts = {};
-            attributionCounts.forEach((count) => {
-                memberCounts[count.post_id] = {
-                    free_members: count.free_members,
-                    paid_members: count.paid_members
-                };
-            });
-            
-            return memberCounts;
-        } catch (error) {
-            logging.error('Error fetching member counts:', error);
-            return {};
-        }
-    }
-
-    /**
-     * Get visitor counts for multiple posts from Tinybird
-     * @param {string[]} postUuids - Array of post UUIDs
-     * @returns {Promise<Object>} Map of post UUID to visitor count
-     */
-    async getPostsVisitorCounts(postUuids) {
-        try {
-            if (!postUuids || !Array.isArray(postUuids) || postUuids.length === 0) {
-                return {};
-            }
-
-            if (!this.tinybirdClient) {
-                // Return empty object if Tinybird is not configured
-                return {};
-            }
-
-            // Fetch visitor counts from Tinybird for all posts
-            const visitorData = await this.tinybirdClient.fetch('api_post_visitor_counts', {
-                post_uuids: postUuids
-            });
-
-            // Convert the response to a simple UUID -> count mapping
-            const visitorCounts = {};
-            if (visitorData && Array.isArray(visitorData)) {
-                visitorData.forEach((row) => {
-                    if (row.post_uuid && row.visits !== undefined) {
-                        visitorCounts[row.post_uuid] = row.visits;
-                    }
-                });
-            }
-
-            return visitorCounts;
-        } catch (error) {
-            logging.error('Error fetching visitor counts from Tinybird:', error);
-            return {};
         }
     }
 }

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
+const urlUtils = require('../../../shared/url-utils');
 
 // Import source normalization from ReferrersStatsService
 const {normalizeSource} = require('./ReferrersStatsService');
@@ -390,6 +391,7 @@ class PostsStatsService {
      * (Signed up on Post, Paid Elsewhere/Never)
      * @private
      * @param {StatsServiceOptions} options
+     * @param {boolean} groupByUrl - Whether to group by attribution_url instead of attribution_id
      * @returns {import('knex').Knex.QueryBuilder}
      */
     _buildFreeMembersSubquery(options, groupByUrl = false) {
@@ -451,6 +453,7 @@ class PostsStatsService {
      * (Paid conversion attributed to this post)
      * @private
      * @param {StatsServiceOptions} options
+     * @param {boolean} groupByUrl - Whether to group by attribution_url instead of attribution_id
      * @returns {import('knex').Knex.QueryBuilder}
      */
     _buildPaidMembersSubquery(options, groupByUrl = false) {
@@ -494,6 +497,7 @@ class PostsStatsService {
      * (Paid Conversions Attributed to Post)
      * @private
      * @param {StatsServiceOptions} options
+     * @param {boolean} groupByUrl - Whether to group by attribution_url instead of attribution_id
      * @returns {import('knex').Knex.QueryBuilder}
      */
     _buildMrrSubquery(options, groupByUrl = false) {
@@ -802,44 +806,549 @@ class PostsStatsService {
                     : this.knex.raw(`p.published_at <= ?`, [options.date_to]);
             }
 
-            // Subquery to count clicks from members_click_events
-            const clicksSubquery = this.knex
-                .select('r.post_id')
-                .countDistinct('mce.member_id as click_count')
-                .from('redirects as r')
-                .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
-                .whereNotNull('r.post_id')
-                .groupBy('r.post_id')
-                .as('clicks');
+            let query;
 
-            // Build the query to get newsletter stats
-            const query = this.knex
-                .select(
-                    'p.id as post_id',
-                    'p.title as post_title',
-                    'p.published_at as send_date',
-                    this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
-                    this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
-                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate'),
-                    this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
-                    this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate')
-                )
-                .from('posts as p')
-                .leftJoin('emails as e', 'p.id', 'e.post_id')
-                .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
-                .where('p.newsletter_id', newsletterId)
-                .whereIn('p.status', ['sent', 'published'])
-                .whereNotNull('e.id') // Ensure there is an associated email record
-                .whereRaw(dateFilter)
-                .orderBy(orderFieldMap[orderField], orderDirection)
-                .limit(limit);
+            // If ordering by click_rate, we need to include click data
+            if (orderField === 'click_rate') {
+                // Subquery to count clicks from members_click_events
+                const clicksSubquery = this.knex
+                    .select('r.post_id')
+                    .countDistinct('mce.member_id as click_count')
+                    .from('redirects as r')
+                    .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
+                    .whereNotNull('r.post_id')
+                    .groupBy('r.post_id')
+                    .as('clicks');
+
+                // Build the query with click data
+                query = this.knex
+                    .select(
+                        'p.id as post_id',
+                        'p.title as post_title',
+                        'p.published_at as send_date',
+                        this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
+                        this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
+                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate'),
+                        this.knex.raw('COALESCE(clicks.click_count, 0) as total_clicks'),
+                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(clicks.click_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as click_rate')
+                    )
+                    .from('posts as p')
+                    .leftJoin('emails as e', 'p.id', 'e.post_id')
+                    .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
+                    .where('p.newsletter_id', newsletterId)
+                    .whereIn('p.status', ['sent', 'published'])
+                    .whereNotNull('e.id') // Ensure there is an associated email record
+                    .whereRaw(dateFilter)
+                    .orderBy(orderFieldMap[orderField], orderDirection)
+                    .limit(limit);
+            } else {
+                // Build the query without click data for better performance
+                query = this.knex
+                    .select(
+                        'p.id as post_id',
+                        'p.title as post_title',
+                        'p.published_at as send_date',
+                        this.knex.raw('COALESCE(e.email_count, 0) as sent_to'),
+                        this.knex.raw('COALESCE(e.opened_count, 0) as total_opens'),
+                        this.knex.raw('CASE WHEN COALESCE(e.email_count, 0) > 0 THEN COALESCE(e.opened_count, 0) / COALESCE(e.email_count, 0) ELSE 0 END as open_rate')
+                    )
+                    .from('posts as p')
+                    .leftJoin('emails as e', 'p.id', 'e.post_id')
+                    .where('p.newsletter_id', newsletterId)
+                    .whereIn('p.status', ['sent', 'published'])
+                    .whereNotNull('e.id') // Ensure there is an associated email record
+                    .whereRaw(dateFilter)
+                    .orderBy(orderFieldMap[orderField], orderDirection)
+                    .limit(limit);
+            }
 
             const results = await query;
 
             return {data: results};
         } catch (error) {
-            logging.error(`Error fetching newsletter stats for newsletter ${newsletterId}:`, error);
+            logging.error(`Error fetching newsletter basic stats for newsletter ${newsletterId}:`, error);
             return {data: []};
+        }
+    }
+
+    /**
+     * Get newsletter click statistics for specific posts
+     *
+     * @param {string} newsletterId - ID of the newsletter to get click stats for
+     * @param {Array<string>|string} postIds - Array of post IDs or comma-separated string of post IDs to get click data for
+     * @returns {Promise<{data: Array}>} The newsletter click stats
+     */
+    async getNewsletterClickStats(newsletterId, postIds = []) {
+        try {
+            // Handle postIds as either array or comma-separated string
+            let postIdsArray = [];
+            if (Array.isArray(postIds)) {
+                postIdsArray = postIds;
+            } else if (typeof postIds === 'string' && postIds.length > 0) {
+                postIdsArray = postIds.split(',').map(id => id.trim()).filter(id => id.length > 0);
+            }
+
+            if (postIdsArray.length === 0) {
+                return {data: []};
+            }
+
+            // Subquery to count clicks from members_click_events
+            const clicksQuery = this.knex
+                .select(
+                    'r.post_id',
+                    this.knex.raw('COALESCE(COUNT(DISTINCT mce.member_id), 0) as total_clicks'),
+                    this.knex.raw('MAX(COALESCE(e.email_count, 0)) as email_count')
+                )
+                .from('redirects as r')
+                .leftJoin('members_click_events as mce', 'r.id', 'mce.redirect_id')
+                .leftJoin('posts as p', 'r.post_id', 'p.id')
+                .leftJoin('emails as e', 'p.id', 'e.post_id')
+                .whereIn('r.post_id', postIdsArray)
+                .where('p.newsletter_id', newsletterId)
+                .whereNotNull('r.post_id')
+                .groupBy('r.post_id')
+                .select(
+                    this.knex.raw('CASE WHEN MAX(COALESCE(e.email_count, 0)) > 0 THEN COALESCE(COUNT(DISTINCT mce.member_id), 0) / MAX(COALESCE(e.email_count, 0)) ELSE 0 END as click_rate')
+                );
+
+            const results = await clicksQuery;
+
+            return {data: results};
+        } catch (error) {
+            logging.error(`Error fetching newsletter click stats for newsletter ${newsletterId}:`, error);
+            return {data: []};
+        }
+    }
+
+    /**
+     * Get newsletter subscriber statistics including total count and daily deltas for a specific newsletter
+     *
+     * @param {string} newsletterId - ID of the newsletter to get subscriber stats for
+     * @param {Object} options - Query options
+     * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
+     * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @returns {Promise<{data: Array<{total: number, deltas: Array<{date: string, value: number}>}>}>} The newsletter subscriber stats
+     */
+    async getNewsletterSubscriberStats(newsletterId, options = {}) {
+        try {
+            // Run both queries in parallel for better performance
+            const [totalResult, rawDeltas] = await Promise.all([
+                // Get total subscriber count (optimized query - avoid JOIN)
+                this.knex('members_newsletters as mn')
+                    .countDistinct('mn.member_id as total')
+                    .where('mn.newsletter_id', newsletterId)
+                    .whereNotExists(function () {
+                        this.select('*')
+                            .from('members as m')
+                            .whereRaw('m.id = mn.member_id')
+                            .where('m.email_disabled', 1);
+                    }),
+                
+                // Get daily deltas (optimized query)
+                this._getNewsletterSubscriberDeltas(newsletterId, options)
+            ]);
+
+            const totalValue = totalResult[0] ? totalResult[0].total : 0;
+            const total = parseInt(String(totalValue), 10);
+
+            // Transform raw database results to properly typed objects
+            const deltas = [];
+            for (const row of rawDeltas) {
+                if (row) {
+                    // @ts-ignore
+                    const dateValue = row.date || '';
+                    // @ts-ignore
+                    const deltaValue = row.value || 0;
+                    deltas.push({
+                        date: String(dateValue),
+                        value: parseInt(String(deltaValue), 10)
+                    });
+                }
+            }
+
+            return {
+                data: [{
+                    total,
+                    deltas
+                }]
+            };
+        } catch (error) {
+            logging.error(`Error fetching subscriber stats for newsletter ${newsletterId}:`, error);
+            return {
+                data: [{
+                    total: 0,
+                    deltas: []
+                }]
+            };
+        }
+    }
+
+    /**
+     * Optimized query to get newsletter subscriber deltas
+     * @private
+     */
+    async _getNewsletterSubscriberDeltas(newsletterId, options = {}) {
+        // Build optimized deltas query - avoid expensive JOIN
+        let deltasQuery = this.knex('members_subscribe_events as mse')
+            .select(
+                this.knex.raw(`DATE(mse.created_at) as date`),
+                this.knex.raw(`SUM(CASE WHEN mse.subscribed = 1 THEN 1 ELSE -1 END) as value`)
+            )
+            .where('mse.newsletter_id', newsletterId)
+            .whereNotExists(function () {
+                this.select('*')
+                    .from('members as m')
+                    .whereRaw('m.id = mse.member_id')
+                    .where('m.email_disabled', 1);
+            })
+            .groupByRaw('DATE(mse.created_at)')
+            .orderBy('date', 'asc');
+
+        // Apply date filters early to reduce dataset
+        if (options.date_from) {
+            deltasQuery.where('mse.created_at', '>=', options.date_from);
+        }
+        if (options.date_to) {
+            deltasQuery.where('mse.created_at', '<=', `${options.date_to} 23:59:59`);
+        }
+
+        return await deltasQuery;
+    }
+
+    /**
+     * Get stats for a specific post by ID (analytics only, no post content)
+     * @param {string} postId - The post ID to get stats for
+     * @returns {Promise<{data: Array<{id: string, recipient_count: number|null, opened_count: number|null, open_rate: number|null, member_delta: number, free_members: number, paid_members: number, visitors: number}>}>}
+     */
+    async getPostStats(postId) {
+        try {
+            // Validate postId parameter
+            if (!postId || postId.trim() === '') {
+                return {data: []};
+            }
+            
+            // Get basic post info for stats calculations
+            const postData = await this.knex('posts')
+                .select('posts.id', 'posts.uuid', 'posts.published_at', 'e.email_count', 'e.opened_count')
+                .leftJoin('emails as e', 'posts.id', 'e.post_id')
+                .where('posts.id', postId)
+                .where('posts.status', 'published')
+                .first();
+                
+            if (!postData) {
+                return {data: []};
+            }
+
+            // Get member attribution counts
+            const memberAttributionCounts = await this._getMemberAttributionCounts([postData.id]);
+            const attributionCount = memberAttributionCounts.find(ac => ac.post_id === postData.id);
+            
+            const freeMembers = attributionCount ? attributionCount.free_members : 0;
+            const paidMembers = attributionCount ? attributionCount.paid_members : 0;
+            const totalMembers = freeMembers + paidMembers;
+
+            // Calculate open rate
+            const openRate = postData.email_count ? 
+                (postData.opened_count / postData.email_count) * 100 : 
+                null;
+
+            // Get visitor count from Tinybird
+            let visitors = 0;
+            if (this.tinybirdClient && postData.uuid) {
+                try {
+                    const dateFrom = new Date(postData.published_at).toISOString().split('T')[0];
+                    const visitorData = await this.tinybirdClient.fetch('api_top_pages', {
+                        post_uuid: postData.uuid,
+                        dateFrom: dateFrom
+                    });
+
+                    visitors = visitorData?.[0]?.visits || 0;
+                } catch (error) {
+                    logging.error('Error fetching visitor data from Tinybird:', error);
+                }
+            }
+
+            return {
+                data: [{
+                    id: postData.id,
+                    recipient_count: postData.email_count || null,
+                    opened_count: postData.opened_count || null,
+                    open_rate: openRate,
+                    member_delta: totalMembers,
+                    free_members: freeMembers,
+                    paid_members: paidMembers,
+                    visitors: visitors
+                }]
+            };
+        } catch (error) {
+            logging.error(`Error fetching post stats for post ${postId}:`, error);
+            return {data: []};
+        }
+    }
+
+    /**
+     * Get top posts by views for a given date range
+     * @param {Object} options
+     * @param {string} options.date_from - Start date in YYYY-MM-DD format
+     * @param {string} options.date_to - End date in YYYY-MM-DD format
+     * @param {string} [options.timezone] - Timezone to use for date interpretation (default: 'UTC')
+     * @param {number} [options.limit] - Maximum number of posts to return (default: 5)
+     * @returns {Promise<Object>} Top posts with view counts and additional Ghost data
+     */
+    async getTopPostsViews(options) {
+        try {
+            const limit = options.limit || 5;
+            const timezone = options.timezone || 'UTC';
+            let viewsData = [];
+
+            if (this.tinybirdClient) {
+                const tinybirdOptions = {
+                    dateFrom: options.date_from,
+                    dateTo: options.date_to,
+                    timezone: timezone,
+                    post_type: 'post',
+                    limit: limit
+                };
+
+                viewsData = await this.tinybirdClient.fetch('api_top_pages', tinybirdOptions) || [];
+            }
+
+            // Filter out any rows without post_uuid and get unique UUIDs
+            const postUuids = [...new Set(viewsData.filter(row => row.post_uuid).map(row => row.post_uuid))];
+            
+            // Get posts data from Ghost DB for the posts we have views for
+            const posts = await this.knex('posts as p')
+                .select(
+                    'p.id as post_id',
+                    'p.uuid as post_uuid',
+                    'p.title',
+                    'p.published_at',
+                    'p.feature_image',
+                    'emails.email_count',
+                    'emails.opened_count'
+                )
+                .leftJoin('emails', 'emails.post_id', 'p.id')
+                .whereIn('p.uuid', postUuids);
+
+            // Get member attribution counts for these posts (model after GrowthStats logic)
+            const memberAttributionCounts = await this._getMemberAttributionCounts(posts.map(p => p.post_id), options);
+
+            // Process posts with views
+            const postsWithViews = viewsData.map((row) => {
+                const post = posts.find(p => p.post_uuid === row.post_uuid);
+
+                if (!post) {
+                    return null;
+                }
+
+                // Find the member attribution count for this post
+                const attributionCount = memberAttributionCounts.find(ac => ac.post_id === post.post_id);
+                const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
+
+                return {
+                    post_id: post.post_id,
+                    title: post.title,
+                    published_at: post.published_at,
+                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
+                    views: row.visits,
+                    open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
+                    members: memberCount
+                };
+            }).filter(Boolean);
+
+            // Calculate how many more posts we need - we want to always return 5 posts
+            const remainingCount = limit - postsWithViews.length;
+
+            // If we need more posts, get the latest ones excluding the ones we already have
+            let additionalPosts = [];
+            let additionalMemberAttributionCounts = [];
+            if (remainingCount > 0) {
+                // Get post IDs that we already have to exclude them
+                const existingPostIds = postsWithViews.map(p => p.post_id);
+                
+                additionalPosts = await this.knex('posts as p')
+                    .select(
+                        'p.id as post_id',
+                        'p.uuid as post_uuid',
+                        'p.title',
+                        'p.published_at',
+                        'p.feature_image',
+                        'emails.email_count',
+                        'emails.opened_count'
+                    )
+                    .leftJoin('emails', 'emails.post_id', 'p.id')
+                    .whereNotIn('p.uuid', postUuids)
+                    .whereNotIn('p.id', existingPostIds)
+                    .where('p.status', 'published')
+                    .whereNotNull('p.published_at')
+                    .orderBy('p.published_at', 'desc')
+                    .limit(remainingCount);
+
+                // Get member attribution counts for additional posts
+                if (additionalPosts.length > 0) {
+                    additionalMemberAttributionCounts = await this._getMemberAttributionCounts(additionalPosts.map(p => p.post_id), options);
+                }
+            }
+
+            // Process additional posts with 0 views
+            const additionalPostsWithZeroViews = additionalPosts.map((post) => {
+                // Find the member attribution count for this post
+                const attributionCount = additionalMemberAttributionCounts.find(ac => ac.post_id === post.post_id);
+                const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
+
+                return {
+                    post_id: post.post_id,
+                    title: post.title,
+                    published_at: post.published_at,
+                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
+                    views: 0,
+                    open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
+                    members: memberCount
+                };
+            });
+
+            // Combine both sets of posts
+            return {data: [...postsWithViews, ...additionalPostsWithZeroViews]};
+        } catch (error) {
+            logging.error('Error fetching top posts views:', error);
+            return {data: []};
+        }
+    }
+
+    /**
+     * Get member attribution counts for a set of post IDs, modeling after GrowthStats logic
+     * Properly handles both free and paid members with deduplication
+     * @private
+     * @param {string[]} postIds - Array of post IDs to get attribution counts for
+     * @param {Object} options - Date filter options
+     * @returns {Promise<Array<{post_id: string, free_members: number, paid_members: number}>>}
+     */
+    async _getMemberAttributionCounts(postIds, options = {}) {
+        if (!postIds.length) {
+            return [];
+        }
+
+        try {
+            // Build free members query (modeled after _buildFreeMembersSubquery)
+            // Members who signed up on post but paid elsewhere/never
+            let freeMembersQuery = this.knex('members_created_events as mce')
+                .select('mce.attribution_id as post_id')
+                .countDistinct('mce.member_id as free_members')
+                .leftJoin('members_subscription_created_events as msce', function () {
+                    this.on('mce.member_id', '=', 'msce.member_id')
+                        .andOn('mce.attribution_id', '=', 'msce.attribution_id')
+                        .andOnVal('msce.attribution_type', '=', 'post');
+                })
+                .where('mce.attribution_type', 'post')
+                .whereIn('mce.attribution_id', postIds)
+                .whereNull('msce.id')
+                .groupBy('mce.attribution_id');
+
+            // Apply date filter to free members query
+            this._applyDateFilter(freeMembersQuery, options, 'mce.created_at');
+
+            // Build paid members query (modeled after _buildPaidMembersSubquery)
+            // Members whose paid conversion was attributed to this post
+            let paidMembersQuery = this.knex('members_subscription_created_events as msce')
+                .select('msce.attribution_id as post_id')
+                .countDistinct('msce.member_id as paid_members')
+                .where('msce.attribution_type', 'post')
+                .whereIn('msce.attribution_id', postIds)
+                .groupBy('msce.attribution_id');
+
+            // Apply date filter to paid members query
+            this._applyDateFilter(paidMembersQuery, options, 'msce.created_at');
+
+            // Execute both queries
+            const [freeResults, paidResults] = await Promise.all([
+                freeMembersQuery,
+                paidMembersQuery
+            ]);
+
+            // Combine results for each post
+            const combinedResults = postIds.map((postId) => {
+                const freeResult = freeResults.find(r => r.post_id === postId);
+                const paidResult = paidResults.find(r => r.post_id === postId);
+
+                return {
+                    post_id: postId,
+                    free_members: freeResult ? freeResult.free_members : 0,
+                    paid_members: paidResult ? paidResult.paid_members : 0
+                };
+            });
+
+            return combinedResults;
+        } catch (error) {
+            logging.error('Error fetching member attribution counts:', error);
+            return postIds.map(postId => ({
+                post_id: postId,
+                free_members: 0,
+                paid_members: 0
+            }));
+        }
+    }
+
+    /**
+     * Get member attribution counts for multiple posts
+     * @param {string[]} postIds - Array of post IDs
+     * @param {Object} options - Date filter options
+     * @returns {Promise<Object>} Map of post ID to member counts
+     */
+    async getPostsMemberCounts(postIds, options = {}) {
+        try {
+            const attributionCounts = await this._getMemberAttributionCounts(postIds, options);
+            
+            // Convert array to object mapping post_id -> counts
+            const memberCounts = {};
+            attributionCounts.forEach((count) => {
+                memberCounts[count.post_id] = {
+                    free_members: count.free_members,
+                    paid_members: count.paid_members
+                };
+            });
+            
+            return memberCounts;
+        } catch (error) {
+            logging.error('Error fetching member counts:', error);
+            return {};
+        }
+    }
+
+    /**
+     * Get visitor counts for multiple posts from Tinybird
+     * @param {string[]} postUuids - Array of post UUIDs
+     * @returns {Promise<Object>} Map of post UUID to visitor count
+     */
+    async getPostsVisitorCounts(postUuids) {
+        try {
+            if (!postUuids || !Array.isArray(postUuids) || postUuids.length === 0) {
+                return {};
+            }
+
+            if (!this.tinybirdClient) {
+                // Return empty object if Tinybird is not configured
+                return {};
+            }
+
+            // Fetch visitor counts from Tinybird for all posts
+            const visitorData = await this.tinybirdClient.fetch('api_post_visitor_counts', {
+                post_uuids: postUuids
+            });
+
+            // Convert the response to a simple UUID -> count mapping
+            const visitorCounts = {};
+            if (visitorData && Array.isArray(visitorData)) {
+                visitorData.forEach((row) => {
+                    if (row.post_uuid && row.visits !== undefined) {
+                        visitorCounts[row.post_uuid] = row.visits;
+                    }
+                });
+            }
+
+            return visitorCounts;
+        } catch (error) {
+            logging.error('Error fetching visitor counts from Tinybird:', error);
+            return {};
         }
     }
 }

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -80,8 +80,8 @@ class StatsService {
 
     /**
      * Get top posts by attribution metrics (includes all content that drove conversions)
-     * @param {Object} options
-     * @returns {Promise<{data: Object[]}>}
+     * @param {import('./PostsStatsService').TopPostsOptions} options
+     * @returns {Promise<{data: import('./PostsStatsService').AttributionResult[]}>}
      */
     async getTopPosts(options = {}) {
         // Return the original { data: results } structure
@@ -125,7 +125,7 @@ class StatsService {
      * @param {number} [options.limit=20] - Max number of results to return
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
-     * @returns {Promise<{data: Object[]}>}
+     * @returns {Promise<{data: import('./PostsStatsService').NewsletterStatResult[]}>}
      */
     async getNewsletterStats(options = {}) {
         // Extract newsletter_id from options
@@ -148,7 +148,7 @@ class StatsService {
      * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
-     * @returns {Promise<{data: Object}>}
+     * @returns {Promise<{data: import('./PostsStatsService').NewsletterSubscriberStats[]}>}
      */
     async getNewsletterSubscriberStats(options = {}) {
         // Extract newsletter_id from options
@@ -194,7 +194,7 @@ class StatsService {
      * @param {number} [options.limit=20] - Max number of results to return
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
-     * @returns {Promise<{data: Object[]}>}
+     * @returns {Promise<{data: import('./PostsStatsService').NewsletterStatResult[]}>}
      */
     async getNewsletterBasicStats(options = {}) {
         // Extract newsletter_id from options

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -79,9 +79,9 @@ class StatsService {
     }
 
     /**
-     * Get top posts by attribution metrics
-     * @param {import('./PostsStatsService').TopPostsOptions} options
-     * @returns {Promise<{data: import('./PostsStatsService').TopPostResult[]}>}
+     * Get top posts by attribution metrics (includes all content that drove conversions)
+     * @param {Object} options
+     * @returns {Promise<{data: Object[]}>}
      */
     async getTopPosts(options = {}) {
         // Return the original { data: results } structure

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -77,6 +77,7 @@ describe('PostsStatsService', function () {
             member_id: memberId,
             attribution_id: postId,
             attribution_type: 'post',
+            attribution_url: `/${postId.replace('post', 'post-')}/`,
             referrer_source: referrerSource,
             referrer_url: referrerSource ? `https://${referrerSource}` : null,
             created_at: createdAt,
@@ -95,6 +96,7 @@ describe('PostsStatsService', function () {
             subscription_id: subscriptionId,
             attribution_id: postId,
             attribution_type: 'post',
+            attribution_url: `/${postId.replace('post', 'post-')}/`,
             referrer_source: referrerSource,
             referrer_url: referrerSource ? `https://${referrerSource}` : null,
             created_at: createdAt
@@ -158,6 +160,7 @@ describe('PostsStatsService', function () {
             table.string('member_id');
             table.string('attribution_id').index();
             table.string('attribution_type');
+            table.string('attribution_url');
             table.dateTime('created_at');
             table.string('referrer_source');
             table.string('referrer_url');
@@ -170,6 +173,7 @@ describe('PostsStatsService', function () {
             table.string('subscription_id');
             table.string('attribution_id').index();
             table.string('attribution_type');
+            table.string('attribution_url');
             table.dateTime('created_at');
             table.string('referrer_source');
             table.string('referrer_url');
@@ -258,9 +262,9 @@ describe('PostsStatsService', function () {
 
             // The test expects timestamps (numbers) as returned by SQLite, not Date objects
             const expectedResults = [
-                {post_id: 'post1', title: 'Post 1', free_members: 2, paid_members: 1, mrr: 500, published_at: result.data[0].published_at},
-                {post_id: 'post2', title: 'Post 2', free_members: 1, paid_members: 1, mrr: 500, published_at: result.data[1].published_at},
-                {post_id: 'post3', title: 'Post 3', free_members: 0, paid_members: 1, mrr: 1000, published_at: result.data[2].published_at}
+                {attribution_url: '/post-1/', title: 'Post 1', free_members: 2, paid_members: 1, mrr: 500, post_id: 'post1', attribution_type: 'post', attribution_id: 'post1', published_at: result.data[0].published_at, post_type: 'post'},
+                {attribution_url: '/post-2/', title: 'Post 2', free_members: 1, paid_members: 1, mrr: 500, post_id: 'post2', attribution_type: 'post', attribution_id: 'post2', published_at: result.data[1].published_at, post_type: 'post'},
+                {attribution_url: '/post-3/', title: 'Post 3', free_members: 0, paid_members: 1, mrr: 1000, post_id: 'post3', attribution_type: 'post', attribution_id: 'post3', published_at: result.data[2].published_at, post_type: 'post'}
             ];
 
             assert.deepEqual(result.data, expectedResults, 'Results should match expected order and counts for free_members desc');
@@ -279,10 +283,10 @@ describe('PostsStatsService', function () {
 
             // The test expects timestamps (numbers) as returned by SQLite, not Date objects
             const expectedResults = [
-                {post_id: 'post2', title: 'Post 2', free_members: 0, paid_members: 2, mrr: 1200, published_at: result.data.find(p => p.post_id === 'post2').published_at},
-                {post_id: 'post1', title: 'Post 1', free_members: 1, paid_members: 1, mrr: 600, published_at: result.data.find(p => p.post_id === 'post1').published_at},
-                {post_id: 'post3', title: 'Post 3', free_members: 1, paid_members: 0, mrr: 0, published_at: result.data.find(p => p.post_id === 'post3').published_at},
-                {post_id: 'post4', title: 'Post 4', free_members: 1, paid_members: 0, mrr: 0, published_at: result.data.find(p => p.post_id === 'post4').published_at}
+                {attribution_url: '/post-2/', title: 'Post 2', free_members: 0, paid_members: 2, mrr: 1200, post_id: 'post2', attribution_type: 'post', attribution_id: 'post2', published_at: result.data.find(p => p.post_id === 'post2').published_at, post_type: 'post'},
+                {attribution_url: '/post-1/', title: 'Post 1', free_members: 1, paid_members: 1, mrr: 600, post_id: 'post1', attribution_type: 'post', attribution_id: 'post1', published_at: result.data.find(p => p.post_id === 'post1').published_at, post_type: 'post'},
+                {attribution_url: '/post-3/', title: 'Post 3', free_members: 1, paid_members: 0, mrr: 0, post_id: 'post3', attribution_type: 'post', attribution_id: 'post3', published_at: result.data.find(p => p.post_id === 'post3').published_at, post_type: 'post'},
+                {attribution_url: '/post-4/', title: 'Post 4', free_members: 1, paid_members: 0, mrr: 0, post_id: 'post4', attribution_type: 'post', attribution_id: 'post4', published_at: result.data.find(p => p.post_id === 'post4').published_at, post_type: 'post'}
             ];
 
             const sortedResults = result.data.sort((a, b) => {
@@ -308,10 +312,10 @@ describe('PostsStatsService', function () {
 
             // The test expects timestamps (numbers) as returned by SQLite, not Date objects
             const expectedResults = [
-                {post_id: 'post2', title: 'Post 2', free_members: 0, paid_members: 2, mrr: 1200, published_at: result.data.find(p => p.post_id === 'post2').published_at},
-                {post_id: 'post1', title: 'Post 1', free_members: 1, paid_members: 1, mrr: 600, published_at: result.data.find(p => p.post_id === 'post1').published_at},
-                {post_id: 'post3', title: 'Post 3', free_members: 1, paid_members: 0, mrr: 0, published_at: result.data.find(p => p.post_id === 'post3').published_at},
-                {post_id: 'post4', title: 'Post 4', free_members: 1, paid_members: 0, mrr: 0, published_at: result.data.find(p => p.post_id === 'post4').published_at}
+                {attribution_url: '/post-2/', title: 'Post 2', free_members: 0, paid_members: 2, mrr: 1200, post_id: 'post2', attribution_type: 'post', attribution_id: 'post2', published_at: result.data.find(p => p.post_id === 'post2').published_at, post_type: 'post'},
+                {attribution_url: '/post-1/', title: 'Post 1', free_members: 1, paid_members: 1, mrr: 600, post_id: 'post1', attribution_type: 'post', attribution_id: 'post1', published_at: result.data.find(p => p.post_id === 'post1').published_at, post_type: 'post'},
+                {attribution_url: '/post-3/', title: 'Post 3', free_members: 1, paid_members: 0, mrr: 0, post_id: 'post3', attribution_type: 'post', attribution_id: 'post3', published_at: result.data.find(p => p.post_id === 'post3').published_at, post_type: 'post'},
+                {attribution_url: '/post-4/', title: 'Post 4', free_members: 1, paid_members: 0, mrr: 0, post_id: 'post4', attribution_type: 'post', attribution_id: 'post4', published_at: result.data.find(p => p.post_id === 'post4').published_at, post_type: 'post'}
             ];
 
             const sortedResults = result.data.sort((a, b) => {
@@ -374,7 +378,7 @@ describe('PostsStatsService', function () {
 
             // Verify that only the top 2 posts by free_members are returned
             assert.equal(result.data[0].post_id, 'post1');
-            assert.equal(result.data[1].post_id, 'post2');
+            assert.ok(result.data[1].post_id === 'post2' || result.data[1].post_id === 'post3');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2102/
- updated top pages endpoint to be able to pick up dynamic urls with no `page` (post) record (like authors, tags, homepage)
- added url helpers
- refactored stats service to differently handle attribution for urls

The problem with the Pages is that we were pulling from `posts` as our primary data source. However, we don't have a row for dynamic pages from the frontend like `authors/{authorSlug}`, or namely, the homepage (`/`). 

Instead we now query for the attribution rows and then work back to finding the post_ids. This is a bit less efficient on the initial posts call, so we could opt to change the queries altogether when the post_id is set, going back to the old logic, in order to speed up the initial load (which defaults to Top Posts).