### PR TITLE
Added inline follow button next to user avatars in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -339,7 +339,11 @@ const FeedItem: React.FC<FeedItemProps> = ({
         : (actor?.followedByMe || false);
 
     const isAuthorCurrentUser = type === 'Announce'
-        ? (typeof object.attributedTo === 'object' && object.attributedTo && !Array.isArray(object.attributedTo) && 'authored' in object.attributedTo ? object.attributedTo.authored : false)
+        ? (typeof object.attributedTo === 'object' && object.attributedTo && !Array.isArray(object.attributedTo) && 'authored' in object.attributedTo
+            ? (object.attributedTo as {authored: boolean}).authored
+            : (typeof object.attributedTo === 'object' && object.attributedTo && !Array.isArray(object.attributedTo) &&
+               typeof actor === 'object' && actor &&
+               (object.attributedTo as {id: string}).id === actor.id))
         : object.authored;
 
     const handleFollow = () => {

--- a/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItem.tsx
@@ -244,20 +244,20 @@ const FeedItem: React.FC<FeedItemProps> = ({
     const followMutation = useFollowMutationForUser(
         'index',
         () => {
-            toast.success('User followed');
+            toast.success('Followed');
         },
         () => {
-            toast.error('Failed to follow user');
+            toast.error('Failed to follow');
         }
     );
 
     const unfollowMutation = useUnfollowMutationForUser(
         'index',
         () => {
-            toast.success('User unfollowed');
+            toast.success('Unfollowed');
         },
         () => {
-            toast.error('Failed to unfollow user');
+            toast.error('Failed to unfollow');
         }
     );
 
@@ -383,22 +383,22 @@ const FeedItem: React.FC<FeedItemProps> = ({
                         </div>}
                         <div className={`border-1 flex flex-col gap-2.5`} data-test-activity>
                             <div className='flex min-w-0 items-center gap-3'>
-                                <APAvatar author={author} disabled={isPending} />
-                                <div className='flex min-w-0 grow flex-col gap-0.5' onClick={(e) => {
+                                <APAvatar author={author} disabled={isPending} showFollowButton={!isAuthorCurrentUser && !followedByMe} />
+                                <div className='flex min-w-0 grow flex-col' onClick={(e) => {
                                     if (!isPending) {
                                         handleProfileClick(author, navigate, e);
                                     }
                                 }}>
-                                    <span className={`min-w-0 truncate font-semibold leading-[normal] break-anywhere ${isCompact ? 'text-lg' : 'text-md'} ${!isPending ? 'hover-underline' : ''} dark:text-white`}
+                                    <span className={`min-w-0 truncate font-semibold break-anywhere ${isCompact ? 'text-lg' : 'text-md'} ${!isPending ? 'hover-underline' : ''} dark:text-white`}
                                         data-test-activity-heading
                                     >
                                         {!isLoading ? author.name : <Skeleton className='w-24' />}
                                     </span>
                                     <div className={`flex w-full ${isCompact ? 'text-md' : 'text-sm'} text-gray-700 dark:text-gray-600`}>
-                                        <span className={`truncate leading-tight ${!isPending ? 'hover-underline' : ''}`}>
+                                        <span className={`truncate ${!isPending ? 'hover-underline' : ''}`}>
                                             {!isLoading ? getUsername(author) : <Skeleton className='w-56' />}
                                         </span>
-                                        <div className={`ml-1 leading-tight before:mr-1 ${!isLoading && 'before:content-["·"]'}`} title={`${timestamp}`}>
+                                        <div className={`ml-1 before:mr-1 ${!isLoading && 'before:content-["·"]'}`} title={`${timestamp}`}>
                                             {!isLoading ? renderTimestamp(object, (isPending === false && !object.authored)) : <Skeleton className='w-4' />}
                                         </div>
                                     </div>
@@ -497,7 +497,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 </div>}
                                 {(showHeader) && <>
                                     <div className='relative z-10 pt-[3px]'>
-                                        <APAvatar author={author}/>
+                                        <APAvatar author={author} showFollowButton={!isAuthorCurrentUser && !followedByMe} />
                                     </div>
                                     <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={(e) => {
                                         if (!isPending) {
@@ -554,7 +554,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                     <div className={`group/article relative ${isCompact ? 'pb-6' : isChainContinuation ? 'pb-5' : 'py-5'} ${!isPending ? 'cursor-pointer' : 'pointer-events-none'}`} data-layout='reply' data-object-id={object.id} onClick={onClick}>
                         <div className={`border-1 z-10 flex items-start gap-3 border-b-gray-200`} data-test-activity>
                             <div className='relative z-10 pt-[3px]'>
-                                <APAvatar author={author} disabled={isPending} />
+                                <APAvatar author={author} disabled={isPending} showFollowButton={!isAuthorCurrentUser && !followedByMe} />
                             </div>
                             <div className='flex w-full min-w-0 flex-col gap-2'>
                                 <div className='flex w-full items-center justify-between'>

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -15,18 +15,11 @@ interface FollowButtonProps {
     onUnfollow: (e: React.MouseEvent) => void;
     authorHandle: string;
     followedByMe: boolean;
+    isLoading?: boolean;
 }
 
 // Global state to track which user was clicked via avatar button
 let avatarClickedUser: string | null = null;
-
-interface FollowButtonProps {
-    onFollow: (e: React.MouseEvent) => void;
-    onUnfollow: (e: React.MouseEvent) => void;
-    authorHandle: string;
-    followedByMe: boolean;
-    isLoading?: boolean;
-}
 
 const FollowButton: React.FC<FollowButtonProps> = ({onFollow, onUnfollow, authorHandle, followedByMe, isLoading = false}) => {
     const [, forceUpdate] = React.useReducer(x => x + 1, 0);

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -2,10 +2,68 @@ import React, {useEffect, useState} from 'react';
 import clsx from 'clsx';
 import getUsername from '@utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
-import {LucideIcon, Skeleton} from '@tryghost/shade';
+import {Button, LucideIcon, Skeleton} from '@tryghost/shade';
+import {toast} from 'sonner';
+import {useFeatureFlags} from '../../lib/feature-flags';
+import {useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 type AvatarSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'notification';
+
+interface FollowButtonProps {
+    onFollow: (e: React.MouseEvent) => void;
+    onUnfollow: (e: React.MouseEvent) => void;
+    authorHandle: string;
+    followedByMe: boolean;
+}
+
+// Global state to track which user was clicked via avatar button
+let avatarClickedUser: string | null = null;
+
+interface FollowButtonProps {
+    onFollow: (e: React.MouseEvent) => void;
+    onUnfollow: (e: React.MouseEvent) => void;
+    authorHandle: string;
+    followedByMe: boolean;
+    isLoading?: boolean;
+}
+
+const FollowButton: React.FC<FollowButtonProps> = ({onFollow, onUnfollow, authorHandle, followedByMe, isLoading = false}) => {
+    const [, forceUpdate] = React.useReducer(x => x + 1, 0);
+    const isClickedUser = avatarClickedUser === authorHandle;
+    const showCheckmark = isClickedUser && !followedByMe;
+
+    const handleClick = (e: React.MouseEvent) => {
+        if (showCheckmark) {
+            onUnfollow(e);
+            setTimeout(() => {
+                avatarClickedUser = null;
+                forceUpdate();
+            }, 0);
+        } else {
+            avatarClickedUser = authorHandle;
+            forceUpdate();
+            onFollow(e);
+        }
+    };
+
+    return (
+        <Button
+            className='absolute -right-1.5 bottom-px z-10 flex size-4 items-center justify-center rounded-full p-0 outline outline-2 outline-white transition-colors disabled:opacity-100 dark:outline-black'
+            disabled={isLoading}
+            title={isLoading ? 'Loading...' : (showCheckmark ? 'Unfollow' : 'Follow')}
+            onClick={handleClick}
+        >
+            {isLoading ? (
+                <LucideIcon.Loader2 className='!size-3 animate-spin !stroke-2' />
+            ) : showCheckmark ? (
+                <LucideIcon.Check className='!size-3 !stroke-[2.4]' />
+            ) : (
+                <LucideIcon.Plus className='!size-[14px] !stroke-2' />
+            )}
+        </Button>
+    );
+};
 
 interface APAvatarProps {
     author: {
@@ -20,14 +78,36 @@ interface APAvatarProps {
     onClick?: () => void;
     disabled?: boolean;
     className?: string;
+    showFollowButton?: boolean;
 }
 
-const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, disabled = false, className = ''}) => {
+const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, disabled = false, className = '', showFollowButton = false}) => {
     let iconSize = 20;
-    let containerClass = `shrink-0 items-center justify-center rounded-full overflow-hidden relative z-10 flex bg-black/5 dark:bg-gray-900 ${size === 'lg' || disabled ? '' : 'cursor-pointer'} ${className}`;
-    let imageClass = 'z-10 object-cover';
+    let containerClass = `shrink-0 items-center justify-center rounded-full relative z-10 flex bg-black/5 dark:bg-gray-900 ${size === 'lg' || disabled ? '' : 'cursor-pointer'} ${className}`;
+    let imageClass = 'z-10 object-cover rounded-full';
     const [iconUrl, setIconUrl] = useState(author?.icon?.url);
     const navigate = useNavigate();
+    const {isEnabled} = useFeatureFlags();
+
+    const followMutation = useFollowMutationForUser(
+        'index',
+        () => {
+            toast.success('Followed');
+        },
+        () => {
+            toast.error('Failed to follow');
+        }
+    );
+
+    const unfollowMutation = useUnfollowMutationForUser(
+        'index',
+        () => {
+            toast.success('Unfollowed');
+        },
+        () => {
+            toast.error('Failed to unfollow');
+        }
+    );
 
     useEffect(() => {
         setIconUrl(author?.icon?.url);
@@ -78,7 +158,20 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
         navigate(`/profile/${handle}`);
     };
 
+    const handleFollowClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        followMutation.mutate(handle);
+    };
+
+    const handleUnfollowClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        unfollowMutation.mutate(handle);
+    };
+
     const title = `${author?.name} ${handle}`;
+    const isClickedUser = avatarClickedUser === handle;
+    const displayFollowButton = isEnabled('unfollow') && (showFollowButton || isClickedUser);
+    const isFollowLoading = followMutation.isLoading || unfollowMutation.isLoading;
 
     if (iconUrl) {
         return (
@@ -93,6 +186,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
                     src={iconUrl}
                     onError={() => setIconUrl(undefined)}
                 />
+                {displayFollowButton && <FollowButton authorHandle={handle} followedByMe={false} isLoading={isFollowLoading} onFollow={handleFollowClick} onUnfollow={handleUnfollowClick} />}
             </div>
         );
     }
@@ -104,6 +198,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
             onClick={disabled ? undefined : handleClick}
         >
             <LucideIcon.UserRound className='text-gray-600' size={iconSize} strokeWidth={1.5} />
+            {displayFollowButton && <FollowButton authorHandle={handle} followedByMe={false} isLoading={isFollowLoading} onFollow={handleFollowClick} onUnfollow={handleUnfollowClick} />}
         </div>
     );
 };

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -54,15 +54,16 @@ const Recommendations: React.FC = () => {
                                         handleProfileClick(profile, navigate);
                                     }
                                 }}>
-                                    {!isLoadingSuggested ? <APAvatar author={
-                                        {
+                                    {!isLoadingSuggested ? <APAvatar 
+                                        author={{
                                             icon: {
                                                 url: actorAvatarUrl
                                             },
                                             name: actorName,
                                             handle: actorHandle
-                                        }
-                                    } /> : <Skeleton className='z-10 size-10' />}
+                                        }}
+                                        showFollowButton={true}
+                                    /> : <Skeleton className='z-10 size-10' />}
                                     <div className='flex min-w-0  flex-col'>
                                         <span className='block max-w-[190px] truncate font-semibold text-black dark:text-white'>{!isLoadingSuggested ? actorName : <Skeleton className='w-24' />}</span>
                                         <span className='block max-w-[190px] truncate text-sm text-gray-600'>{!isLoadingSuggested ? actorHandle : <Skeleton className='w-40' />}</span>

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -203,7 +203,7 @@ const Note = () => {
                             {!threadParents.length &&
                             <div className={`col-[2/3] mx-auto flex w-full items-center gap-3 ${canGoBack ? 'pt-10' : 'pt-5'}`}>
                                 <div className='relative z-10 pt-[3px]'>
-                                    <APAvatar author={currentPost.actor}/>
+                                    <APAvatar author={currentPost.actor} showFollowButton={!currentPost.actor.authored && !currentPost.actor.followedByMe}/>
                                 </div>
                                 <div className='relative z-10 flex w-full min-w-0 cursor-pointer flex-col overflow-visible text-[1.5rem]' onClick={(e) => {
                                     handleProfileClick(currentPost.actor, navigate, e);


### PR DESCRIPTION
ref PROD-1947

- Implemented direct follow button beside avatars for non-followed users
- Enabled one-click following directly from the feed
- Put it behind a feature flag `unfollow` as it uses the same api flag