### PR TITLE
Removed global `MIGRATION_USER` constant

### DIFF
--- a/ghost/core/core/server/data/migrations/utils/constants.js
+++ b/ghost/core/core/server/data/migrations/utils/constants.js
@@ -1,3 +1,0 @@
-module.exports = {
-    MIGRATION_USER: 1
-};

--- a/ghost/core/core/server/data/migrations/utils/index.js
+++ b/ghost/core/core/server/data/migrations/utils/index.js
@@ -3,8 +3,5 @@ module.exports = {
     ...require('./permissions'),
     ...require('./schema'),
     ...require('./settings'),
-    ...require('./tables'),
-    meta: {
-        MIGRATION_USER: require('./constants').MIGRATION_USER
-    }
+    ...require('./tables')
 };

--- a/ghost/core/core/server/data/migrations/utils/permissions.js
+++ b/ghost/core/core/server/data/migrations/utils/permissions.js
@@ -4,7 +4,7 @@ const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const {createTransactionalMigration, combineTransactionalMigrations} = require('./migrations');
-const {MIGRATION_USER} = require('./constants');
+const MIGRATION_USER = 1;
 
 const messages = {
     permissionRoleActionError: 'Cannot {action} permission({permission}) with role({role}) - {resource} does not exist'

--- a/ghost/core/core/server/data/migrations/utils/settings.js
+++ b/ghost/core/core/server/data/migrations/utils/settings.js
@@ -2,7 +2,7 @@ const ObjectId = require('bson-objectid').default;
 const logging = require('@tryghost/logging');
 
 const {createTransactionalMigration} = require('./migrations');
-const {MIGRATION_USER} = require('./constants');
+const MIGRATION_USER = 1;
 
 /**
  * Creates a migration which will insert a new setting in settings table

--- a/ghost/core/core/server/data/migrations/versions/5.100/2024-11-06-04-45-15-add-activitypub-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.100/2024-11-06-04-45-15-add-activitypub-integration.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
 const ObjectID = require('bson-objectid').default;
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -25,7 +27,7 @@ module.exports = createTransactionalMigration(
                 name: 'Ghost ActivityPub',
                 description: 'Internal Integration for ActivityPub',
                 created_at: knex.raw('current_timestamp'),
-                created_by: meta.MIGRATION_USER
+                created_by: MIGRATION_USER
             })
             .into('integrations');
     },

--- a/ghost/core/core/server/data/migrations/versions/5.113/2025-03-07-12-24-00-add-super-editor.js
+++ b/ghost/core/core/server/data/migrations/versions/5.113/2025-03-07-12-24-00-add-super-editor.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -18,7 +20,7 @@ module.exports = createTransactionalMigration(
             id: (new ObjectID()).toHexString(),
             name: 'Super Editor',
             description: 'Editor plus member management',
-            created_by: meta.MIGRATION_USER,
+            created_by: MIGRATION_USER,
             created_at: knex.raw('current_timestamp')
         });
     },

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-07-58-add-ghost-explore-integration-role.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-07-58-add-ghost-explore-integration-role.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -18,7 +20,7 @@ module.exports = createTransactionalMigration(
             id: (new ObjectID()).toHexString(),
             name: 'Ghost Explore Integration',
             description: 'Internal Integration for the Ghost Explore directory',
-            created_by: meta.MIGRATION_USER,
+            created_by: MIGRATION_USER,
             created_at: knex.raw('current_timestamp')
         });
     },

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -22,7 +24,7 @@ module.exports = createTransactionalMigration(
             description: 'Internal Integration for the Ghost Explore directory',
             slug: 'ghost-explore',
             created_at: knex.raw('current_timestamp'),
-            created_by: meta.MIGRATION_USER
+            created_by: MIGRATION_USER
         });
     },
     async function down(knex) {

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
@@ -2,7 +2,9 @@ const {InternalServerError} = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const security = require('@tryghost/security');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -46,7 +48,7 @@ module.exports = createTransactionalMigration(
             role_id: role.id,
             integration_id: integration.id,
             created_at: knex.raw('current_timestamp'),
-            created_by: meta.MIGRATION_USER
+            created_by: MIGRATION_USER
         });
     },
     async function down(knex) {

--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-42-add-self-serve-integration-role.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-42-add-self-serve-integration-role.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -18,7 +20,7 @@ module.exports = createTransactionalMigration(
             id: (new ObjectID()).toHexString(),
             name: 'Self-Serve Migration Integration',
             description: 'Core Integration for the Ghost Explore directory',
-            created_by: meta.MIGRATION_USER,
+            created_by: MIGRATION_USER,
             created_at: knex.raw('current_timestamp')
         });
     },

--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-52-add-self-serve-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-52-add-self-serve-integration.js
@@ -1,6 +1,8 @@
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -22,7 +24,7 @@ module.exports = createTransactionalMigration(
             description: 'Core Integration for the Self-Serve migration tool',
             slug: 'self-serve-migration',
             created_at: knex.raw('current_timestamp'),
-            created_by: meta.MIGRATION_USER
+            created_by: MIGRATION_USER
         });
     },
     async function down(knex) {

--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
@@ -2,7 +2,9 @@ const {InternalServerError} = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const security = require('@tryghost/security');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -46,7 +48,7 @@ module.exports = createTransactionalMigration(
             role_id: role.id,
             integration_id: integration.id,
             created_at: knex.raw('current_timestamp'),
-            created_by: meta.MIGRATION_USER
+            created_by: MIGRATION_USER
         });
     },
     async function down(knex) {

--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-03-10-add-ghost-core-content-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-03-10-add-ghost-core-content-integration.js
@@ -2,7 +2,9 @@
 
 const logging = require('@tryghost/logging');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 const coreContentIntegration = {
     slug: 'ghost-core-content',
@@ -26,7 +28,7 @@ const addIntegration = async (knex, integration) => {
     const now = knex.raw('CURRENT_TIMESTAMP');
     integration.id = (new ObjectID()).toHexString();
     integration.created_at = now;
-    integration.created_by = meta.MIGRATION_USER;
+    integration.created_by = MIGRATION_USER;
 
     await knex('integrations').insert(integration);
 };

--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
@@ -4,7 +4,9 @@ const {InternalServerError} = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const security = require('@tryghost/security');
 const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration, meta} = require('../../utils');
+const {createTransactionalMigration} = require('../../utils');
+
+const MIGRATION_USER = 1;
 
 const coreContentIntegration = {
     slug: 'ghost-core-content',
@@ -45,7 +47,7 @@ const addIntegrationContentKey = async (knex, integration) => {
         role_id: null,
         integration_id: existingIntegration.id,
         created_at: knex.raw('current_timestamp'),
-        created_by: meta.MIGRATION_USER
+        created_by: MIGRATION_USER
     });
 };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2113

Removed the global `MIGRATION_USER` constant to prevent further usage. It's usage has been inlined, mainly in existing migrations, and replaced with a local constant, which was already a pattern being used in some migrations. We do not want to change any existing logic within the migration files as they are already in use