### PR TITLE
Fixed email button partial erroring on invalid hex colors

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -86,7 +86,7 @@ function emailCTATemplate(dataset, options = {}) {
     const isBlackButton = dataset.buttonColor === 'black' || dataset.buttonColor === '#000000' || dataset.buttonColor === '#000';
 
     if (isTransparentCTA && isDarkBackground && isBlackButton) {
-        dataset.buttonColor = 'white';
+        dataset.buttonColor = '#ffffff';
     }
 
     const buttonHtml = renderEmailButton({

--- a/ghost/core/core/server/services/koenig/render-partials/email-button.js
+++ b/ghost/core/core/server/services/koenig/render-partials/email-button.js
@@ -78,12 +78,16 @@ function _isColoredOutline({color, style}) {
     return color && color !== 'accent' && style === 'outline';
 }
 
+function _isValidHexColor(color) {
+    return /^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/.test(color);
+}
+
 /**
  * @param {EmailButtonOptions} options
  * @returns {string}
  */
 function _getTextColor({color, style}) {
-    if (_isColoredFill({color, style})) {
+    if (_isColoredFill({color, style}) && _isValidHexColor(color)) {
         return textColorForBackgroundColor(color).hex();
     }
 

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/call-to-action-renderer.test.js
@@ -239,7 +239,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                 <table class="btn" border="0" cellspacing="0" cellpadding="0">
                     <tbody>
                         <tr>
-                            <td align="center" style="background-color: white;">
+                            <td align="center" style="background-color: #ffffff;">
                                 <a href="http://blog.com/post1" style="color: #000000 !important;">
                                     click me
                                 </a>
@@ -303,7 +303,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
         it('does not convert black button when background is not dark', function () {
             const data = getTestData({
                 backgroundColor: 'none',
-                buttonColor: 'black'
+                buttonColor: '#000000'
             });
             const result = renderForEmail(data, {
                 design: {backgroundIsDark: false},
@@ -314,7 +314,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                 <table class="btn" border="0" cellspacing="0" cellpadding="0">
                     <tbody>
                         <tr>
-                            <td align="center" style="background-color: black;">
+                            <td align="center" style="background-color: #000000;">
                                 <a href="http://blog.com/post1" style="color: #ffffff !important;">
                                     click me
                                 </a>
@@ -328,7 +328,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
         it('does not convert black button when CTA background is not transparent or white', function () {
             const data = getTestData({
                 backgroundColor: 'blue',
-                buttonColor: 'black'
+                buttonColor: '#000000'
             });
             const result = renderForEmail(data, {
                 design: {backgroundIsDark: true},
@@ -339,7 +339,7 @@ describe('services/koenig/node-renderers/call-to-action-renderer', function () {
                 <table class="btn" border="0" cellspacing="0" cellpadding="0">
                     <tbody>
                         <tr>
-                            <td align="center" style="background-color: black;">
+                            <td align="center" style="background-color: #000000;">
                                 <a href="http://blog.com/post1" style="color: #ffffff !important;">
                                     click me
                                 </a>

--- a/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-partials/email-button.test.js
@@ -51,6 +51,10 @@ describe('koenig/services/render-partials/email-button', function () {
             const result = emailButton._getTextColor({color: '#222222', style: 'fill'});
             assert.equal(result, '#FFFFFF');
         });
+        it('handles invalid hex colors', function () {
+            const result = emailButton._getTextColor({color: 'invalid', style: 'fill'});
+            assert.equal(result, '');
+        });
     });
 
     describe('_getButtonClasses', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2149/

- we can't control exactly what is stored in the editor content for button colors so we shouldn't assume that we have valid hex codes
- adds guard for valid hex before calling `textColorForBackgroundColor()`
- fixed incorrect implementation in `call-to-action-renderer` what was passing `white` as a button color for a node property that only stores hex values
