### PR TITLE
Added audit and action to history keywords

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
@@ -13,7 +13,7 @@ export const searchKeywords = {
     migrationtools: ['import', 'export', 'migrate', 'substack', 'substack', 'migration', 'medium', 'wordpress', 'wp', 'squarespace'],
     codeInjection: ['advanced', 'code injection', 'head', 'footer'],
     labs: ['advanced', 'labs', 'alpha', 'private', 'beta', 'flag', 'routes', 'redirect', 'translation', 'editor', 'portal'],
-    history: ['advanced', 'history', 'log', 'events', 'user events', 'staff'],
+    history: ['advanced', 'history', 'log', 'events', 'user events', 'staff', 'audit', 'action'],
     dangerzone: ['danger', 'danger zone', 'delete', 'content', 'delete all content', 'delete site'],
     spamFilters: ['membership', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email']
 };


### PR DESCRIPTION
- I keep searching for these two keywords when looking for the history view
- Audit is the one I use most often cos it's what I think of the feature as being for
- Action because that's the name of the table/model
- 3rd I usually try log or history, which are both there!

