### PR TITLE
Added site_uuid to content API settings endpoint

### DIFF
--- a/ghost/core/core/shared/settings-cache/public.js
+++ b/ghost/core/core/shared/settings-cache/public.js
@@ -49,5 +49,6 @@ module.exports = {
     default_email_address: 'default_email_address',
     support_email_address: 'support_email_address',
     editor_default_email_recipients: 'editor_default_email_recipients',
-    labs: 'labs'
+    labs: 'labs',
+    site_uuid: 'site_uuid'
 };

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -80,6 +80,7 @@ Object {
         "url": "/contribute/",
       },
     ],
+    "site_uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
     "support_email_address": "noreply@127.0.0.1",
     "timezone": "Etc/UTC",
     "title": "Ghost",

--- a/ghost/core/test/e2e-api/content/settings.test.js
+++ b/ghost/core/test/e2e-api/content/settings.test.js
@@ -1,9 +1,10 @@
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
-const {anyEtag, anyContentLength, anyContentVersion} = matchers;
+const {anyEtag, anyContentLength, anyContentVersion, anyUuid, anyString, anyObject} = matchers;
 
 const settingsMatcher = {
-    version: matchers.anyString,
-    labs: matchers.anyObject
+    version: anyString,
+    labs: anyObject,
+    site_uuid: anyUuid
 };
 
 describe('Settings Content API', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-197/ghost-site-uuid-implementation

- site_uuid is a public, read-only setting
- it should be included in the "public" api/content/settings endpoint as well as the api/admin/site endpoint
- this makes it available everywhere the getPublic() method is used
- the main reason for making this change is to make this available in the explore ping service

