### PR TITLE
Removed usage of `?limit=all` in Admin-X

### DIFF
--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -45,7 +45,9 @@ const dataType = 'OffersResponseType';
 
 export const useBrowseOffers = createQuery<OffersResponseType>({
     dataType,
-    path: '/offers/'
+    path: '/offers/',
+    // offers endpoint doesn't support limit or pagination so we exclude the default ?limit=20
+    defaultSearchParams: {}
 });
 
 export const useBrowseOffersById = createQueryWithId<OffersResponseType>({

--- a/apps/admin-x-framework/src/api/roles.ts
+++ b/apps/admin-x-framework/src/api/roles.ts
@@ -20,5 +20,6 @@ const dataType = 'RolesResponseType';
 export const useBrowseRoles = createQuery<RolesResponseType>({
     dataType,
     path: '/roles/',
-    defaultSearchParams: {limit: 'all'}
+    // Ghost has a fixed-by-core number of roles so we know it's less than 100
+    defaultSearchParams: {limit: '100'}
 });

--- a/apps/admin-x-framework/src/hooks/useFilterableApi.ts
+++ b/apps/admin-x-framework/src/hooks/useFilterableApi.ts
@@ -50,7 +50,7 @@ const useFilterableApi = <
         if (missingValues.length) {
             const additionalData = await fetchApi<{meta?: Meta} & {[k in ResponseKey]: Data[]}>(apiUrl(path, {
                 filter: `${key}:[${missingValues.join(',')}]`,
-                limit: 'all'
+                limit: '100'
             }));
 
             data.push(...additionalData[responseKey]);

--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -154,7 +154,7 @@ export const settingsWithStripe = updatedSettingsResponse([
 export const limitRequests = {
     browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
     browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
-    browseRoles: {method: 'GET', path: '/roles/?limit=all', response: responseFixtures.roles},
+    browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters}
 };
 

--- a/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/InviteUserModal.tsx
@@ -17,7 +17,7 @@ const InviteUserModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
     const rolesQuery = useBrowseRoles();
     const assignableRolesQuery = useBrowseRoles({
-        searchParams: {limit: 'all', permissions: 'assign'}
+        searchParams: {limit: '100', permissions: 'assign'}
     });
     const limiter = useLimiter();
 
@@ -175,7 +175,7 @@ const InviteUserModal = NiceModal.create(() => {
             value: 'administrator'
         }
     ];
-  
+
     // If the editor beta is enabled, replace the editor role option with super editor options.
     // This gets a little weird, because we aren't changing what is actually assigned based on the toggle.
     // So, a site could have the editor beta enabled, but that doesn't automatically convert their editors.

--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -102,11 +102,7 @@ export const EmptyState: React.FC<{title?: string, description: string, buttonAc
 export const OffersIndexModal = () => {
     const modal = useModal();
     const {updateRoute} = useRouting();
-    const {data: {offers: allOffers = []} = {}, isFetching: isFetchingOffers} = useBrowseOffers({
-        searchParams: {
-            limit: 'all'
-        }
-    });
+    const {data: {offers: allOffers = []} = {}, isFetching: isFetchingOffers} = useBrowseOffers();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     const activeOffers = allOffers.filter((offer) => {
         const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);

--- a/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
@@ -11,8 +11,8 @@ test.describe('User invitations', async () => {
             ...globalDataRequests,
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
-            browseRoles: {method: 'GET', path: '/roles/?limit=all', response: responseFixtures.roles},
-            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=all&permissions=assign', response: responseFixtures.roles},
+            browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
+            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
             addInvite: {method: 'POST', path: '/invites/', response: {
                 invites: [
                     {
@@ -147,7 +147,7 @@ test.describe('User invitations', async () => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             ...limitRequests,
-            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=all&permissions=assign', response: responseFixtures.roles},
+            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
             browseConfig: {
                 ...globalDataRequests.browseConfig,
                 response: {

--- a/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
@@ -44,8 +44,8 @@ test.describe('User roles', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
-            browseRoles: {method: 'GET', path: '/roles/?limit=all', response: responseFixtures.roles},
-            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=all&permissions=assign', response: responseFixtures.roles},
+            browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
+            browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
                     ...userToEdit,

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -178,7 +178,7 @@ test.describe('Offers Modal', () => {
             browseOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             ...globalDataRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
-            browseAllOffers: {method: 'GET', path: '/offers/?limit=all', response: responseFixtures.offers},
+            browseAllOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers}
         }});
 
@@ -199,7 +199,7 @@ test.describe('Offers Modal', () => {
             browseOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             ...globalDataRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
-            browseAllOffers: {method: 'GET', path: '/offers/?limit=all', response: responseFixtures.offers},
+            browseAllOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers}
         }});
 
@@ -217,7 +217,7 @@ test.describe('Offers Modal', () => {
             browseOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             ...globalDataRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
-            browseAllOffers: {method: 'GET', path: '/offers/?limit=all', response: responseFixtures.offers},
+            browseAllOffers: {method: 'GET', path: '/offers/?', response: responseFixtures.offers},
             browseOffersById: {method: 'GET', path: `/offers/${responseFixtures.offers.offers![0].id}/`, response: responseFixtures.offers},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers},
             editOffer: {method: 'PUT', path: `/offers/${responseFixtures.offers.offers![0].id}/`, response: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- removed `?limit` parameter from `/offers/` requests because that endpoint doesn't support pagination
- changed requests to `/roles/` to use a fixed `?limit=100` because this endpoint has a relatively fixed number of entries that are hardcoded by Ghost's fixtures
- updated `loadInitialValues()` to use a fixed `?limit=100` on requests as it's only use-case is requesting specific records identified by id/slug to populate chosen entries in the default recipients list
