### PR TITLE
Removed trafficAnalytics flag from stats endpoints

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -3,7 +3,6 @@ const api = require('../../../../api').endpoints;
 const {http} = require('@tryghost/api-framework');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
-const labs = require('../../../../../shared/labs');
 
 const shared = require('../../../shared');
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -155,21 +155,19 @@ module.exports = function apiRoutes() {
     router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
     router.get('/stats/referrers/posts/:id', mw.authAdminApi, http(api.stats.postReferrers));
     router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
-    if (labs.isSet('trafficAnalytics')) {
-        router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
-        router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
-        router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
-        router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
-        router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
-        router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
-        router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
-        router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
-        router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
-        router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
-        router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
-        router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
-        router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
-    }
+    router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
+    router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
+    router.get('/stats/top-posts-views', mw.authAdminApi, http(api.stats.topPostsViews));
+    router.get('/stats/top-content', mw.authAdminApi, http(api.stats.topContent));
+    router.get('/stats/newsletter-stats', mw.authAdminApi, http(api.stats.newsletterStats));
+    router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
+    router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
+    router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
+    router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
+    router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
+    router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
+    router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
+    router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));


### PR DESCRIPTION
no ref

The traffic analytics is about to be removed, and we found that this generally caused an issue where we would not mount the routes on boot based on the flag, which could be set to true while running.