### PR TITLE
🎨 Enabled the has helper to be used inline

### DIFF
--- a/ghost/core/core/frontend/helpers/has.js
+++ b/ghost/core/core/frontend/helpers/has.js
@@ -4,6 +4,8 @@
 //
 // Checks if a post has a particular property
 
+const {SafeString} = require('../services/handlebars');
+
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const _ = require('lodash');
@@ -122,6 +124,7 @@ module.exports = function has(options) {
     options = options || {};
     options.hash = options.hash || {};
     options.data = options.data || {};
+    const isBlock = _.has(options, 'fn');
 
     const self = this;
     const attrs = _.pick(options.hash, validAttrs);
@@ -168,9 +171,15 @@ module.exports = function has(options) {
         return checks[attr]();
     });
 
-    if (result) {
-        return options.fn(this);
+    // If we're in block mode, return the outcome from the fn/inverse functions
+    if (isBlock) {
+        if (result) {
+            return options.fn(this);
+        }
+
+        return options.inverse(this);
     }
 
-    return options.inverse(this);
+    // Else return the result as a SafeString Eg.{string: false} || {string: true}
+    return new SafeString(result);    
 };

--- a/ghost/core/test/unit/frontend/helpers/has.test.js
+++ b/ghost/core/test/unit/frontend/helpers/has.test.js
@@ -1,5 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
+const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 
 // Stuff we are testing
 const has = require('../../../../core/frontend/helpers/has');
@@ -840,6 +841,24 @@ describe('{{#has}} helper', function () {
 
             fn.called.should.be.false();
             inverse.called.should.be.true();
+        });
+    });
+    
+    describe('inline mode', function () {  
+        before(function () {
+            registerHelper('has');
+        });
+
+        it('should return "true" if a match was found', function () {
+            let hash = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+    
+            shouldCompileToExpected('{{has tag="invalid, bar, wat"}}', hash, 'true');
+        });
+    
+        it('should return "false" if no match was found', function () {
+            let hash = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+    
+            shouldCompileToExpected('{{has tag="much, such, wow"}}', hash, 'false');
         });
     });
 });


### PR DESCRIPTION
This PR allows the `has` helper to run inline. We can now use it in subexpressions, particularly useful when passing arguments to reusable partials. This also makes it consistent with how the `match` helper works, returning 'true' or 'false' SafeString.

Example usage:
```hbs
{{!-- reusable partial post-content.hbs --}}
<div>
    {{#match hasRelated "true"}}
        {{#get "posts" limit="6" filter="id:-{{id}}"}}
            {{!-- ... --}}
        {{/get}}
    {{/match}}
</div>


{{!-- post type 1: related posts always disable --}}
{{> post-content }}

{{!-- post type 2: enable/disable related posts using a tag --}}
{{> post-content hasRelated=(has tag="#related") }}

{{!-- in another "special" post type: 
      we want to force load the related posts without introducing any tags --}}
{{> post-content hasRelated="true" }}
```


- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

