### PR TITLE
Wired up click rate to latest posts

### DIFF
--- a/apps/stats/src/hooks/useLatestPostStats.ts
+++ b/apps/stats/src/hooks/useLatestPostStats.ts
@@ -8,6 +8,9 @@ interface ExtendedPost extends Post {
         name: string;
     }[];
     excerpt?: string;
+    count?: {
+        clicks?: number;
+    };
 }
 
 export interface LatestPostWithStats {
@@ -25,6 +28,9 @@ export interface LatestPostWithStats {
         opened_count: number;
         email_count: number;
         status?: string;
+    } | null;
+    count?: {
+        clicks?: number;
     } | null;
     authors?: {
         name: string;
@@ -47,7 +53,7 @@ export const useLatestPostStats = () => {
             filter: 'status:[published,sent]',
             order: 'published_at DESC',
             limit: '1',
-            include: 'authors,email'
+            include: 'authors,email,count.clicks'
         }
     });
 
@@ -92,6 +98,7 @@ export const useLatestPostStats = () => {
             email_only: extendedPost.email_only || false,
             status: extendedPost.status,
             email: extendedPost.email,
+            count: extendedPost.count,
             authors: extendedPost.authors || [],
             // Analytics data from Stats API
             recipient_count: statsData.recipient_count,

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -173,19 +173,6 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 {/* Email metrics - show for email posts */}
                                 {metricsToShow.showEmailMetrics && appSettings?.newslettersEnabled && latestPostStats.email && (
                                     <>
-                                        {/* Show sent count from email data */}
-                                        <div className={metricClassName} onClick={() => {
-                                            navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
-                                        }}>
-                                            <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
-                                                <LucideIcon.Mail size={16} strokeWidth={1.25} />
-                                                <span className='hidden md:!visible md:!block'>Sent</span>
-                                            </div>
-                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
-                                                {formatNumber(latestPostStats.email.email_count || 0)}
-                                            </span>
-                                        </div>
-
                                         {/* Show open rate - always display if email exists */}
                                         <div className={metricClassName} onClick={() => {
                                             navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
@@ -197,6 +184,22 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                             <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
                                                 {latestPostStats.email.email_count ?
                                                     formatPercentage((latestPostStats.email.opened_count || 0) / latestPostStats.email.email_count)
+                                                    : '0%'
+                                                }
+                                            </span>
+                                        </div>
+
+                                        {/* Show click rate - display if email exists and has clicks data */}
+                                        <div className={metricClassName} onClick={() => {
+                                            navigate(`/posts/analytics/beta/${latestPostStats.id}/newsletter`, {crossApp: true});
+                                        }}>
+                                            <div className='flex items-center gap-1.5 font-medium text-muted-foreground transition-all group-hover:text-foreground'>
+                                                <LucideIcon.MousePointerClick size={16} strokeWidth={1.25} />
+                                                <span className='hidden whitespace-nowrap md:!visible md:!block'>Click rate</span>
+                                            </div>
+                                            <span className='text-[2.2rem] font-semibold leading-none tracking-tighter'>
+                                                {latestPostStats.email.email_count && latestPostStats.count?.clicks ?
+                                                    formatPercentage((latestPostStats.count.clicks || 0) / latestPostStats.email.email_count)
                                                     : '0%'
                                                 }
                                             </span>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2160/
- Added `count` property to `ExtendedPost` and `LatestPostWithStats` interfaces to track clicks.
- Updated API request to include `count.clicks` in the response.
- Modified the LatestPost component to display click rate based on the new data structure.