### PR TITLE
Added inline follow suggestions to feed in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -79,7 +79,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                                 </Button>
                             </PopoverClose>
                         }
-                        {!authoredByMe && isEnabled('unfollow') &&
+                        {!authoredByMe && isEnabled('follow') &&
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleFollowClick}>
                                     {followedByMe ? <LucideIcon.UserRoundMinus /> : <LucideIcon.UserRoundPlus />}

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -159,7 +159,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
 
     const title = `${author?.name} ${handle}`;
     const isClickedUser = avatarClickedUser === handle;
-    const displayFollowButton = isEnabled('unfollow') && (showFollowButton || isClickedUser);
+    const displayFollowButton = isEnabled('follow') && (showFollowButton || isClickedUser);
 
     if (iconUrl) {
         return (

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -15,6 +15,10 @@ const Recommendations: React.FC = () => {
 
     const hideClassName = '[@media(max-height:740px)]:hidden';
 
+    if (!isLoadingSuggested && (!suggestedData || suggestedData.length === 0)) {
+        return null;
+    }
+
     return (
         <div className={`border-t border-gray-200 px-3 pt-6 dark:border-gray-950 ${hideClassName}`}>
             <div className='mb-3 flex flex-col gap-0.5'>

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -54,7 +54,7 @@ const Recommendations: React.FC = () => {
                                         handleProfileClick(profile, navigate);
                                     }
                                 }}>
-                                    {!isLoadingSuggested ? <APAvatar 
+                                    {!isLoadingSuggested ? <APAvatar
                                         author={{
                                             icon: {
                                                 url: actorAvatarUrl
@@ -74,7 +74,7 @@ const Recommendations: React.FC = () => {
                     );
                 })}
             </ul>
-            <Button className='p-0 font-medium text-purple' variant='link' onClick={() => {
+            <Button className='p-0 font-medium text-purple hover:text-black dark:hover:text-white' variant='link' onClick={() => {
                 resetStack();
                 navigate('/explore');
             }}>Find more &rarr;</Button>

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -56,8 +56,8 @@ const Sidebar: React.FC = () => {
                             <LucideIcon.Hash size={18} strokeWidth={1.5} />
                             Feed
                         </SidebarMenuLink>
-                        <SidebarMenuLink 
-                            count={location.pathname !== '/notifications' ? notificationsCount : undefined} 
+                        <SidebarMenuLink
+                            count={location.pathname !== '/notifications' ? notificationsCount : undefined}
                             to='/notifications'
                             onClick={handleNotificationsClick}
                         >
@@ -78,7 +78,7 @@ const Sidebar: React.FC = () => {
                         </SidebarMenuLink>
                     </div>
                     <NewNoteModal>
-                        <Button className='h-9 rounded-full bg-purple-500 px-3 text-md text-white dark:hover:bg-purple-500'>
+                        <Button className='h-9 rounded-full bg-purple-500 px-3 text-md text-white hover:bg-purple-600 dark:hover:bg-purple-600'>
                             <LucideIcon.FilePen />
                             New note
                         </Button>

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -2164,19 +2164,19 @@ function useFilteredAccountsFromJSON() {
         if (hasNextPage && !isLoadingFollowing) {
             fetchNextPage();
         }
-    }, [hasNextPage, fetchNextPage, isLoadingFollowing]);
+    }, [hasNextPage, fetchNextPage, isLoadingFollowing, followingData?.pages]);
 
     useEffect(() => {
         if (hasNextBlockedAccounts && !isLoadingBlockedAccounts) {
             fetchNextBlockedAccounts();
         }
-    }, [hasNextBlockedAccounts, fetchNextBlockedAccounts, isLoadingBlockedAccounts]);
+    }, [hasNextBlockedAccounts, fetchNextBlockedAccounts, isLoadingBlockedAccounts, blockedAccountsData?.pages]);
 
     useEffect(() => {
         if (hasNextBlockedDomains && !isLoadingBlockedDomains) {
             fetchNextBlockedDomains();
         }
-    }, [hasNextBlockedDomains, fetchNextBlockedDomains, isLoadingBlockedDomains]);
+    }, [hasNextBlockedDomains, fetchNextBlockedDomains, isLoadingBlockedDomains, blockedDomainsData?.pages]);
 
     const followingIds = useMemo(() => {
         const ids = new Set<string>();

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -2155,7 +2155,12 @@ export function useResetNotificationsCountForUser(handle: string) {
     });
 }
 
-function useFilteredAccountsFromJSON() {
+function useFilteredAccountsFromJSON(options: {
+    excludeFollowing?: boolean;
+} = {}) {
+    const {
+        excludeFollowing = true
+    } = options;
     const {data: followingData, hasNextPage, fetchNextPage, isLoading: isLoadingFollowing} = useAccountFollowsForUser('me', 'following');
     const {data: blockedAccountsData, hasNextPage: hasNextBlockedAccounts, fetchNextPage: fetchNextBlockedAccounts, isLoading: isLoadingBlockedAccounts} = useBlockedAccountsForUser('me');
     const {data: blockedDomainsData, hasNextPage: hasNextBlockedDomains, fetchNextPage: fetchNextBlockedDomains, isLoading: isLoadingBlockedDomains} = useBlockedDomainsForUser('me');
@@ -2234,6 +2239,10 @@ function useFilteredAccountsFromJSON() {
             const accounts = data.accounts as Account[];
 
             const filteredAccounts = accounts.filter((account) => {
+                if (excludeFollowing && followingIds.has(account.id)) {
+                    return false;
+                }
+
                 if (blockedAccountIds.has(account.id)) {
                     return false;
                 }
@@ -2258,7 +2267,7 @@ function useFilteredAccountsFromJSON() {
         } catch (error) {
             return [];
         }
-    }, [followingIds, blockedAccountIds, blockedDomains]);
+    }, [followingIds, blockedAccountIds, blockedDomains, excludeFollowing]);
 
     const isLoading = isLoadingFollowing || isLoadingBlockedAccounts || isLoadingBlockedDomains;
 
@@ -2271,7 +2280,9 @@ function useFilteredAccountsFromJSON() {
 export function useExploreProfilesForUser(handle: string) {
     const queryClient = useQueryClient();
     const queryKey = QUERY_KEYS.exploreProfiles(handle);
-    const {fetchAndFilterAccounts, isLoading} = useFilteredAccountsFromJSON();
+    const {fetchAndFilterAccounts, isLoading} = useFilteredAccountsFromJSON({
+        excludeFollowing: false
+    });
 
     const fetchExploreProfilesFromJSON = useCallback(async () => {
         const accounts = await fetchAndFilterAccounts();
@@ -2342,7 +2353,9 @@ export function useExploreProfilesForUser(handle: string) {
 export function useSuggestedProfilesForUser(handle: string, limit = 3) {
     const queryClient = useQueryClient();
     const queryKey = QUERY_KEYS.suggestedProfiles(handle, limit);
-    const {fetchAndFilterAccounts, isLoading} = useFilteredAccountsFromJSON();
+    const {fetchAndFilterAccounts, isLoading} = useFilteredAccountsFromJSON({
+        excludeFollowing: true
+    });
 
     const suggestedProfilesQuery = useQuery({
         queryKey,
@@ -2353,7 +2366,7 @@ export function useSuggestedProfilesForUser(handle: string, limit = 3) {
                 .sort(() => Math.random() - 0.5)
                 .slice(0, limit);
 
-            return randomAccounts;
+            return randomAccounts.length > 0 ? randomAccounts : null;
         },
         retry: false,
         staleTime: 60 * 60 * 1000,

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['unfollow'] as const;
+export const FEATURE_FLAGS = ['follow'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -2,12 +2,14 @@ import FeedInput from './FeedInput';
 import FeedItem from '@src/components/feed/FeedItem';
 import Layout from '@src/components/layout';
 import NewNoteModal from '@src/components/modals/NewNoteModal';
+import SuggestedProfiles from './SuggestedProfiles';
 import {Activity} from '@src/api/activitypub';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LoadingIndicator, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef} from 'react';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export type FeedListProps = {
@@ -28,6 +30,7 @@ const FeedList:React.FC<FeedListProps> = ({
     isFetchingNextPage
 }) => {
     const navigate = useNavigate();
+    const {isEnabled} = useFeatureFlags();
 
     const observerRef = useRef<IntersectionObserver | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -96,6 +99,12 @@ const FeedList:React.FC<FeedListProps> = ({
                                                     />
                                                     {index < activities.length - 1 && (
                                                         <Separator />
+                                                    )}
+                                                    {index === 3 && isEnabled('follow') && (
+                                                        <>
+                                                            <SuggestedProfiles />
+                                                            <Separator />
+                                                        </>
                                                     )}
                                                     {index === loadMoreIndex && (
                                                         <div ref={loadMoreRef} className='h-1'></div>

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -101,10 +101,7 @@ const FeedList:React.FC<FeedListProps> = ({
                                                         <Separator />
                                                     )}
                                                     {index === 3 && isEnabled('follow') && (
-                                                        <>
-                                                            <SuggestedProfiles />
-                                                            <Separator />
-                                                        </>
+                                                        <SuggestedProfiles />
                                                     )}
                                                     {index === loadMoreIndex && (
                                                         <div ref={loadMoreRef} className='h-1'></div>

--- a/apps/admin-x-activitypub/src/views/Feed/components/SuggestedProfiles.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/SuggestedProfiles.tsx
@@ -1,0 +1,122 @@
+import APAvatar from '@src/components/global/APAvatar';
+import FollowButton from '@src/components/global/FollowButton';
+import {Account} from '@src/api/activitypub';
+import {Button, H4, LucideIcon, Skeleton} from '@tryghost/shade';
+import {useNavigate} from '@tryghost/admin-x-framework';
+import {useRef} from 'react';
+import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
+
+const SuggestedProfiles: React.FC = () => {
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const navigate = useNavigate();
+
+    const {suggestedProfilesQuery, updateSuggestedProfile} = useSuggestedProfilesForUser('index', 10);
+    const {data: suggestedProfilesData = [], isLoading: isLoadingSuggestedProfiles} = suggestedProfilesQuery;
+
+    const handleDismiss = (profileId: string) => {
+        // TODO: Implement dismiss functionality
+        void profileId;
+    };
+
+    const handleFollow = (profile: Account) => {
+        updateSuggestedProfile(profile.id, {
+            followedByMe: true,
+            followerCount: profile.followerCount + 1
+        });
+    };
+
+    const handleUnfollow = (profile: Account) => {
+        updateSuggestedProfile(profile.id, {
+            followedByMe: false,
+            followerCount: profile.followerCount - 1
+        });
+    };
+
+    return (
+        <div className='pb-6 pt-5'>
+            <div className='mb-3 flex items-center justify-between'>
+                <H4 className='text-lg font-semibold text-black dark:text-white'>More people to follow</H4>
+                <Button className='px-0 font-medium text-gray-700 hover:text-black dark:text-gray-600 dark:hover:text-white' variant='link' onClick={() => navigate('/explore')}>
+                    Find more &rarr;
+                </Button>
+            </div>
+
+            <div
+                ref={scrollContainerRef}
+                className='scrollbar-hide flex gap-4 overflow-x-auto pb-2'
+                style={{
+                    scrollbarWidth: 'none',
+                    msOverflowStyle: 'none',
+                    scrollSnapType: 'x mandatory'
+                }}
+            >
+                {(isLoadingSuggestedProfiles ? Array(10).fill(null) : suggestedProfilesData).map((profile, index) => (
+                    <div
+                        key={profile?.id || `loading-${index}`}
+                        className='relative w-40 shrink-0 rounded-lg bg-gray-75 p-4 dark:bg-gray-925/30'
+                        style={{scrollSnapAlign: 'start'}}
+                        onClick={!isLoadingSuggestedProfiles && profile ? () => navigate(`/profile/${profile.handle}`) : undefined}
+                    >
+                        <Button
+                            className='absolute right-2 top-1 hidden p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
+                            variant='link'
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleDismiss(profile?.id || '');
+                            }}
+                        >
+                            <LucideIcon.X className='size-4' />
+                        </Button>
+
+                        <div className='flex flex-col items-center text-center'>
+                            <div className='mb-3'>
+                                {isLoadingSuggestedProfiles ? (
+                                    <Skeleton className='size-16 rounded-full' />
+                                ) : (
+                                    <APAvatar
+                                        author={{
+                                            icon: {url: profile?.avatarUrl || ''},
+                                            name: profile?.name || '',
+                                            handle: profile?.handle || ''
+                                        }}
+                                        size='md'
+                                    />
+                                )}
+                            </div>
+
+                            <span className='w-full truncate font-semibold text-black dark:text-white'>
+                                {isLoadingSuggestedProfiles ? (
+                                    <Skeleton className='h-5 w-32' />
+                                ) : (
+                                    profile?.name || ''
+                                )}
+                            </span>
+
+                            <span className='mb-4 truncate text-sm text-gray-700 dark:text-gray-600'>
+                                {isLoadingSuggestedProfiles ? (
+                                    <Skeleton className='h-4 w-20' />
+                                ) : (
+                                    `${profile?.followerCount || 0} ${(profile?.followerCount || 0) === 1 ? 'follower' : 'followers'}`
+                                )}
+                            </span>
+
+                            {isLoadingSuggestedProfiles ? (
+                                <Skeleton className='h-8 w-16' />
+                            ) : (
+                                <FollowButton
+                                    following={profile?.followedByMe || false}
+                                    handle={profile?.handle || ''}
+                                    type='primary'
+                                    onFollow={() => profile && handleFollow(profile)}
+                                    onUnfollow={() => profile && handleUnfollow(profile)}
+                                />
+                            )}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default SuggestedProfiles;

--- a/apps/admin-x-activitypub/src/views/Feed/components/SuggestedProfiles.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/SuggestedProfiles.tsx
@@ -1,7 +1,7 @@
 import APAvatar from '@src/components/global/APAvatar';
 import FollowButton from '@src/components/global/FollowButton';
 import {Account} from '@src/api/activitypub';
-import {Button, H4, LucideIcon, Skeleton} from '@tryghost/shade';
+import {Button, H4, LucideIcon, Separator, Skeleton} from '@tryghost/shade';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useRef} from 'react';
 import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
@@ -12,6 +12,10 @@ const SuggestedProfiles: React.FC = () => {
 
     const {suggestedProfilesQuery, updateSuggestedProfile} = useSuggestedProfilesForUser('index', 10);
     const {data: suggestedProfilesData = [], isLoading: isLoadingSuggestedProfiles} = suggestedProfilesQuery;
+
+    if (!isLoadingSuggestedProfiles && (!suggestedProfilesData || suggestedProfilesData.length < 4)) {
+        return null;
+    }
 
     const handleDismiss = (profileId: string) => {
         // TODO: Implement dismiss functionality
@@ -33,89 +37,92 @@ const SuggestedProfiles: React.FC = () => {
     };
 
     return (
-        <div className='pb-6 pt-5'>
-            <div className='mb-3 flex items-center justify-between'>
-                <H4 className='text-lg font-semibold text-black dark:text-white'>More people to follow</H4>
-                <Button className='px-0 font-medium text-gray-700 hover:text-black dark:text-gray-600 dark:hover:text-white' variant='link' onClick={() => navigate('/explore')}>
+        <>
+            <div className='pb-7 pt-4'>
+                <div className='mb-3 flex items-center justify-between'>
+                    <H4 className='text-lg font-semibold text-black dark:text-white'>More people to follow</H4>
+                    <Button className='px-0 font-medium text-gray-700 hover:text-black dark:text-gray-600 dark:hover:text-white' variant='link' onClick={() => navigate('/explore')}>
                     Find more &rarr;
-                </Button>
-            </div>
+                    </Button>
+                </div>
 
-            <div
-                ref={scrollContainerRef}
-                className='scrollbar-hide flex gap-4 overflow-x-auto pb-2'
-                style={{
-                    scrollbarWidth: 'none',
-                    msOverflowStyle: 'none',
-                    scrollSnapType: 'x mandatory'
-                }}
-            >
-                {(isLoadingSuggestedProfiles ? Array(10).fill(null) : suggestedProfilesData).map((profile, index) => (
-                    <div
-                        key={profile?.id || `loading-${index}`}
-                        className='relative w-40 shrink-0 rounded-lg bg-gray-75 p-4 dark:bg-gray-925/30'
-                        style={{scrollSnapAlign: 'start'}}
-                        onClick={!isLoadingSuggestedProfiles && profile ? () => navigate(`/profile/${profile.handle}`) : undefined}
-                    >
-                        <Button
-                            className='absolute right-2 top-1 hidden p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
-                            variant='link'
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                handleDismiss(profile?.id || '');
-                            }}
+                <div
+                    ref={scrollContainerRef}
+                    className='scrollbar-hide flex gap-4 overflow-x-auto'
+                    style={{
+                        scrollbarWidth: 'none',
+                        msOverflowStyle: 'none',
+                        scrollSnapType: 'x mandatory'
+                    }}
+                >
+                    {(isLoadingSuggestedProfiles ? Array(10).fill(null) : (suggestedProfilesData || [])).map((profile, index) => (
+                        <div
+                            key={profile?.id || `loading-${index}`}
+                            className='relative w-40 shrink-0 rounded-lg bg-gray-75 p-4 dark:bg-gray-925/30'
+                            style={{scrollSnapAlign: 'start'}}
+                            onClick={!isLoadingSuggestedProfiles && profile ? () => navigate(`/profile/${profile.handle}`) : undefined}
                         >
-                            <LucideIcon.X className='size-4' />
-                        </Button>
+                            <Button
+                                className='absolute right-2 top-1 hidden p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
+                                variant='link'
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleDismiss(profile?.id || '');
+                                }}
+                            >
+                                <LucideIcon.X className='size-4' />
+                            </Button>
 
-                        <div className='flex flex-col items-center text-center'>
-                            <div className='mb-3'>
+                            <div className='flex flex-col items-center text-center'>
+                                <div className='mb-3'>
+                                    {isLoadingSuggestedProfiles ? (
+                                        <Skeleton className='size-16 rounded-full' />
+                                    ) : (
+                                        <APAvatar
+                                            author={{
+                                                icon: {url: profile?.avatarUrl || ''},
+                                                name: profile?.name || '',
+                                                handle: profile?.handle || ''
+                                            }}
+                                            size='md'
+                                        />
+                                    )}
+                                </div>
+
+                                <span className='w-full truncate font-semibold text-black dark:text-white'>
+                                    {isLoadingSuggestedProfiles ? (
+                                        <Skeleton className='h-5 w-32' />
+                                    ) : (
+                                        profile?.name || ''
+                                    )}
+                                </span>
+
+                                <span className='mb-4 truncate text-sm text-gray-700 dark:text-gray-600'>
+                                    {isLoadingSuggestedProfiles ? (
+                                        <Skeleton className='h-4 w-20' />
+                                    ) : (
+                                        `${profile?.followerCount || 0} ${(profile?.followerCount || 0) === 1 ? 'follower' : 'followers'}`
+                                    )}
+                                </span>
+
                                 {isLoadingSuggestedProfiles ? (
-                                    <Skeleton className='size-16 rounded-full' />
+                                    <Skeleton className='h-8 w-16' />
                                 ) : (
-                                    <APAvatar
-                                        author={{
-                                            icon: {url: profile?.avatarUrl || ''},
-                                            name: profile?.name || '',
-                                            handle: profile?.handle || ''
-                                        }}
-                                        size='md'
+                                    <FollowButton
+                                        following={profile?.followedByMe || false}
+                                        handle={profile?.handle || ''}
+                                        type='primary'
+                                        onFollow={() => profile && handleFollow(profile)}
+                                        onUnfollow={() => profile && handleUnfollow(profile)}
                                     />
                                 )}
                             </div>
-
-                            <span className='w-full truncate font-semibold text-black dark:text-white'>
-                                {isLoadingSuggestedProfiles ? (
-                                    <Skeleton className='h-5 w-32' />
-                                ) : (
-                                    profile?.name || ''
-                                )}
-                            </span>
-
-                            <span className='mb-4 truncate text-sm text-gray-700 dark:text-gray-600'>
-                                {isLoadingSuggestedProfiles ? (
-                                    <Skeleton className='h-4 w-20' />
-                                ) : (
-                                    `${profile?.followerCount || 0} ${(profile?.followerCount || 0) === 1 ? 'follower' : 'followers'}`
-                                )}
-                            </span>
-
-                            {isLoadingSuggestedProfiles ? (
-                                <Skeleton className='h-8 w-16' />
-                            ) : (
-                                <FollowButton
-                                    following={profile?.followedByMe || false}
-                                    handle={profile?.handle || ''}
-                                    type='primary'
-                                    onFollow={() => profile && handleFollow(profile)}
-                                    onUnfollow={() => profile && handleUnfollow(profile)}
-                                />
-                            )}
                         </div>
-                    </div>
-                ))}
+                    ))}
+                </div>
             </div>
-        </div>
+            <Separator />
+        </>
     );
 };
 


### PR DESCRIPTION
ref PROD-1957

- Implemented suggested accounts to follow directly within the feed
- Enhanced user discovery without requiring navigation to separate sections
- Put it behind a feature flag `follow`
