### PR TITLE
Removed traffic analytics alpha flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -12,10 +12,6 @@ const features = [{
     description: 'Enables traffic analytics',
     flag: 'trafficAnalytics'
 }, {
-    title: 'Traffic Analytics (alpha)',
-    description: 'Enables alpha stage analytics features',
-    flag: 'trafficAnalyticsAlpha'
-}, {
     title: 'Email customization (internal beta)',
     description: 'Newsletter customization settings that have been released to Ghost\'s own production sites',
     flag: 'emailCustomization'

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -12,7 +12,7 @@ export const APP_ROUTE_PREFIX = '/posts';
 
 // Wrap components with feature flag protection where needed
 //  e.g.
-// const ProtectedNewsletter = withFeatureFlag(Newsletter, 'trafficAnalyticsAlpha', '/analytics/', 'Newsletter');
+// const ProtectedNewsletter = withFeatureFlag(Newsletter, 'trafficAnalytics', '/analytics/', 'Newsletter');
 
 export const routes: RouteObject[] = [
     {

--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -10,7 +10,7 @@ export const APP_ROUTE_PREFIX = '/analytics';
 
 // Wrap all components with feature flag protection
 //  e.g.
-// const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalyticsAlpha', '/', 'Overview');
+// const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalytics', '/', 'Overview');
 
 export const routes: RouteObject[] = [
     {

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -203,7 +203,7 @@
         {{/if}}
 
         {{!-- Visitor count column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalyticsAlpha")}}
+        {{#if (feature "trafficAnalytics")}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -228,7 +228,7 @@
         {{/if}}
 
         {{!-- Member conversions column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalyticsAlpha")}}
+        {{#if (feature "trafficAnalytics")}}
             {{#if @post.isPublished}}
                 {{#if this.hasMemberData}}
                     <div class="permalink gh-list-data gh-post-list-metrics" data-tooltip={{if this.totalMemberConversions (concat (format-number this.memberCounts.free) " free " (format-number this.memberCounts.paid) " paid ")}}>

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -14,7 +14,7 @@ class PostsWithAnalytics extends InfinityModel {
 
     async afterInfinityModel(posts) {
         // Only fetch analytics for published/sent posts when feature is enabled
-        if (!this.feature.trafficAnalyticsAlpha) {
+        if (!this.feature.trafficAnalytics) {
             return posts;
         }
         
@@ -66,7 +66,7 @@ export default class PostsRoute extends AuthenticatedRoute {
 
     model(params) {
         // Reset analytics cache every time we load the posts index to ensure fresh data
-        if (this.feature.trafficAnalyticsAlpha) {
+        if (this.feature.trafficAnalytics) {
             this.postAnalytics.reset();
         }
         
@@ -155,7 +155,7 @@ export default class PostsRoute extends AuthenticatedRoute {
      */
     async _fetchAnalyticsForPosts(model) {
         // Only fetch analytics when feature is enabled
-        if (!this.feature.trafficAnalyticsAlpha) {
+        if (!this.feature.trafficAnalytics) {
             return;
         }
         

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -72,7 +72,6 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
-    @feature('trafficAnalyticsAlpha') trafficAnalyticsAlpha;
     @feature('updatedMainNav') updatedMainNav;
     @feature('trafficAnalytics') trafficAnalytics;
 

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -41,7 +41,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalyticsAlpha) {
+        if (!this.feature.trafficAnalytics) {
             return Promise.resolve();
         }
         
@@ -78,7 +78,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalyticsAlpha) {
+        if (!this.feature.trafficAnalytics) {
             return Promise.resolve();
         }
         

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -23,7 +23,7 @@ describe('Unit: Service: post-analytics', function () {
             }
         };
         featureStub = {
-            trafficAnalyticsAlpha: true
+            trafficAnalytics: true
         };
 
         service.ajax = {request: ajaxStub};
@@ -43,7 +43,7 @@ describe('Unit: Service: post-analytics', function () {
         });
 
         it('returns early if feature flag is disabled', async function () {
-            featureStub.trafficAnalyticsAlpha = false;
+            featureStub.trafficAnalytics = false;
             const result = await service.loadVisitorCounts(['uuid1']);
             expect(result).to.be.undefined;
             expect(ajaxStub.called).to.be.false;
@@ -140,7 +140,7 @@ describe('Unit: Service: post-analytics', function () {
         });
 
         it('returns early if feature flag is disabled', async function () {
-            featureStub.trafficAnalyticsAlpha = false;
+            featureStub.trafficAnalytics = false;
             const result = await service.loadMemberCounts([{id: '1', uuid: 'uuid1'}]);
             expect(result).to.be.undefined;
             expect(ajaxStub.called).to.be.false;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -48,7 +48,6 @@ const PRIVATE_FEATURES = [
     'urlCache',
     'mailEvents',
     'lexicalIndicators',
-    'trafficAnalyticsAlpha',
     'updatedMainNav',
     'contentVisibilityAlpha',
     'explore',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,7 +28,6 @@ Object {
       "superEditors": true,
       "themeErrorsNotification": true,
       "trafficAnalytics": true,
-      "trafficAnalyticsAlpha": true,
       "trafficAnalyticsTracking": true,
       "updatedMainNav": true,
       "urlCache": true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2162/

Removed alpha flag and changed any existing use to the beta flag, which will be subsequently removed. This consolidation makes switching from flag > setting a bit easier.