### PR TITLE
Removed usage of limit=all in Comments-UI

### DIFF
--- a/apps/comments-ui/src/utils/adminApi.ts
+++ b/apps/comments-ui/src/utils/adminApi.ts
@@ -94,17 +94,15 @@ export function setupAdminAPI({adminUrl}: {adminUrl: string}) {
 
             return response;
         },
-        async replies({commentId, afterReplyId, limit, memberUuid}: {commentId: string; afterReplyId: string; limit?: number | 'all', memberUuid?: string}) {
-            const filter = `id:>'${afterReplyId}'`;
-
+        async replies({commentId, afterReplyId, limit, memberUuid}: {commentId: string; afterReplyId?: string; limit?: number, memberUuid?: string}) {
             const params = new URLSearchParams();
 
             if (limit) {
                 params.set('limit', limit.toString());
             }
 
-            if (filter) {
-                params.set('filter', filter);
+            if (afterReplyId) {
+                params.set('filter', `id:>'${afterReplyId}'`);
             }
 
             if (memberUuid) {
@@ -122,7 +120,7 @@ export function setupAdminAPI({adminUrl}: {adminUrl: string}) {
             if (memberUuid) {
                 params.set('impersonate_member_uuid', memberUuid);
             }
-        
+
             return await callApi('readComment', {
                 commentId,
                 ...(params.toString() && {params: params.toString()})

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -165,10 +165,15 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
 
                 return response;
             },
-            async replies({commentId, afterReplyId, limit}: {commentId: string; afterReplyId: string; limit?: number | 'all'}) {
-                const filter = encodeURIComponent(`id:>'${afterReplyId}'`);
+            async replies({commentId, afterReplyId, limit}: {commentId: string; afterReplyId?: string; limit?: number | 'all'}) {
+                const params = new URLSearchParams();
+                params.set('limit', (limit ?? 5).toString());
 
-                const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?limit=${limit ?? 5}&filter=${filter}`});
+                if (afterReplyId) {
+                    params.set('filter', `id:>'${afterReplyId}'`);
+                }
+
+                const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?${params.toString()}`});
                 const res = await makeRequest({
                     url,
                     method: 'GET',

--- a/apps/comments-ui/test/e2e/actions.test.ts
+++ b/apps/comments-ui/test/e2e/actions.test.ts
@@ -181,6 +181,100 @@ test.describe('Actions', async () => {
         expect(memberLikeSpy.called).toBe(true);
     });
 
+    test('loads all replies with multiple API calls when replying to comment with >100 replies', async ({page}) => {
+        // Create a comment with 150 replies to test pagination
+        const replies = Array.from({length: 150}, (_, i) => buildReply({
+            id: `reply-${String(i + 1).padStart(3, '0')}`,
+            html: `<p>This is reply ${i + 1}</p>`
+        }));
+
+        mockedApi.addComment({
+            id: 'comment-1',
+            html: '<p>Comment with many replies</p>',
+            replies
+        });
+
+        // Spy on the API calls to verify pagination
+        const getRepliesSpy = sinon.spy(mockedApi.requestHandlers, 'getReplies');
+
+        const {frame} = await initializeTest(page);
+
+        // Click reply on the main comment to trigger loadMoreReplies with limit: 'all'
+        // Use nth(0) to get the first reply button which belongs to the main comment
+        const replyButton = frame.getByTestId('reply-button').nth(0);
+        await replyButton.click();
+
+        // Wait for the reply form to appear - use a more specific selector
+        await frame.getByTestId('reply-form').waitFor();
+
+        // Verify multiple API calls were made for pagination
+        expect(getRepliesSpy.callCount).toBeGreaterThan(1);
+
+        // Verify the calls used different afterReplyId values indicating pagination
+        const calls = getRepliesSpy.getCalls();
+        const firstCallUrl = new URL(calls[0].args[0].request().url());
+        const secondCallUrl = new URL(calls[1].args[0].request().url());
+
+        // First call should start after the 3rd initially loaded reply
+        const firstFilter = firstCallUrl.searchParams.get('filter');
+        expect(firstFilter).toContain('reply-003');
+
+        // Second call should start after the 100th reply from first batch
+        const secondFilter = secondCallUrl.searchParams.get('filter');
+        expect(secondFilter).toContain('reply-103');
+
+        // Both calls should use limit=100
+        expect(firstCallUrl.searchParams.get('limit')).toBe('100');
+        expect(secondCallUrl.searchParams.get('limit')).toBe('100');
+    });
+
+    test('loads all replies with multiple API calls when replying to a reply with >100 replies', async ({page}) => {
+        // Create a comment with 150 replies to test pagination when replying to a reply
+        const replies = Array.from({length: 150}, (_, i) => buildReply({
+            id: `reply-${String(i + 1).padStart(3, '0')}`,
+            html: `<p>This is reply ${i + 1}</p>`
+        }));
+
+        mockedApi.addComment({
+            id: 'comment-1',
+            html: '<p>Comment with many replies</p>',
+            replies
+        });
+
+        // Spy on the API calls to verify pagination
+        const getRepliesSpy = sinon.spy(mockedApi.requestHandlers, 'getReplies');
+
+        const {frame} = await initializeTest(page);
+
+        // Click reply on one of the reply comments to trigger loadMoreReplies with limit: 'all' and isReply: true
+        const replyComment = frame.locator('#reply-002'); // Target a specific reply
+        const replyButton = replyComment.getByTestId('reply-button');
+        await replyButton.click();
+
+        // Wait for the reply form to appear - use a more specific selector
+        await frame.getByTestId('reply-form').waitFor();
+
+        // Verify multiple API calls were made for pagination
+        expect(getRepliesSpy.callCount).toBeGreaterThan(1);
+
+        // Verify the calls used different afterReplyId values indicating pagination
+        const calls = getRepliesSpy.getCalls();
+        const firstCallUrl = new URL(calls[0].args[0].request().url());
+        const secondCallUrl = new URL(calls[1].args[0].request().url());
+
+        // First call should start after the 3rd initially loaded reply (only 3 are shown initially)
+        const firstFilter = firstCallUrl.searchParams.get('filter');
+        expect(firstFilter).toContain('reply-003');
+
+        // Second call should start after the 100th reply from first batch
+        const secondFilter = secondCallUrl.searchParams.get('filter');
+        expect(secondFilter).toContain('reply-103');
+
+        // Both calls should use limit=100
+        expect(firstCallUrl.searchParams.get('limit')).toBe('100');
+        expect(secondCallUrl.searchParams.get('limit')).toBe('100');
+    });
+
     test('like button UI updates instantly when unliking a comment and can like again after button is enabled', async ({page}) => {
         mockedApi.addComment({
             html: '<p>This is comment 1</p>',

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -177,6 +177,7 @@ test.describe('Admin moderation', async () => {
         const comments = await frame.getByTestId('comment-component');
         const comment = comments.nth(0);
         await comment.getByTestId('reply-pagination-button').click();
+        await expect(frame.getByTestId('comment-component')).toHaveCount(7);
         const lastCall = adminBrowseSpy.lastCall.args[0];
         const url = new URL(lastCall.request().url());
         expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');

--- a/apps/comments-ui/test/utils/MockedApi.ts
+++ b/apps/comments-ui/test/utils/MockedApi.ts
@@ -234,7 +234,7 @@ export class MockedApi {
             };
         }
 
-        let replies: any[] = comment.replies;
+        const replies: any[] = comment.replies;
 
         // Sort replies on created at + id
         replies.sort((a, b) => {
@@ -248,24 +248,28 @@ export class MockedApi {
             return aDate > bDate ? 1 : -1;
         });
 
-        // Parse NQL filter
+        // Parse NQL filter and apply pagination
+        let filteredReplies = replies;
         if (filter) {
             const parsed = nql(filter);
-            replies = replies.filter((reply) => {
+            filteredReplies = replies.filter((reply) => {
                 return parsed.queryJSON(reply);
             });
         }
 
-        const limitedReplies = replies.slice(0, limit);
+        const limitedReplies = filteredReplies.slice(0, limit);
+        const hasMore = filteredReplies.length > limit;
 
         return {
             comments: limitedReplies,
             meta: {
                 pagination: {
-                    pages: Math.ceil(replies.length / limit),
-                    total: replies.length,
                     page: 1,
-                    limit
+                    pages: Math.ceil(filteredReplies.length / limit),
+                    total: filteredReplies.length,
+                    limit,
+                    next: hasMore ? 2 : null,
+                    prev: null
                 }
             }
         };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/
closes https://linear.app/ghost/issue/PROD-2124/

- previously we used `limit=all` to populate the replies list when adding a comment but Ghost's API will be removing support for `limit=all` and instead allowing a max of `limit=100`
- updated the `fetchReplies()` action to use `limit=100` and loop through all pages
- updated `MockedApi` to correctly return pagination metadata to allow for testing
- fixed invalid `id:>'undefined'` filter params being generated
- modified api method types so `replies()` doesn't accept `'all'` for it's `limit` param
