### PR TITLE
Added cursor rule for better agent handling of e2e tests

### DIFF
--- a/apps/comments-ui/.cursor/rules/playwright-e2e.mdc
+++ b/apps/comments-ui/.cursor/rules/playwright-e2e.mdc
@@ -1,0 +1,11 @@
+---
+description: Playwright E2E testing configuration for AI agents
+globs:
+alwaysApply: true
+---
+
+When running Playwright e2e tests as an AI agent, use the list reporter for better parsing:
+
+Set PLAYWRIGHT_REPORTER=list environment variable before running tests.
+
+Example: `PLAYWRIGHT_REPORTER=list yarn test:e2e`

--- a/apps/comments-ui/playwright.config.ts
+++ b/apps/comments-ui/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     /* Hardcode to use all cores in CI */
     workers: process.env.CI ? '100%' : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: 'html',
+    reporter: process.env.PLAYWRIGHT_REPORTER ?? 'html',
     timeout: process.env.PLAYWRIGHT_SLOWMO ? 100000 : 20000,
     expect: {
         timeout: process.env.PLAYWRIGHT_SLOWMO ? 100000 : 5000


### PR DESCRIPTION
no issue

- our comments-ui e2e test suite was using the `html` reporter which meant on any test run failure the command would halt and open a browser window which AI agents have no visibility on
- added support for `PLAYWRIGHT_REPORTER` env var for overriding the default reporter
- added cursor rule to instruct agents to use `PLAYWRIGHT_REPORTER=list` when running tests so they can parse the output without getting stuck
