### PR TITLE
Truncated post excerpt on publish modal in Posts app

### DIFF
--- a/apps/posts/src/hooks/usePostSuccessModal.ts
+++ b/apps/posts/src/hooks/usePostSuccessModal.ts
@@ -144,7 +144,7 @@ export const usePostSuccessModal = () => {
             featureImageURL: post.feature_image || '',
             postTitle: post.title || '',
             postExcerpt: truncateText(post.excerpt || '', 100),
-            faviconURL: '', // Could add favicon URL if available
+            faviconURL: site?.icon || '',
             siteTitle: site?.title || '',
             author: getAuthorsText(post.authors),
             onClose: handleClose

--- a/apps/posts/src/hooks/usePostSuccessModal.ts
+++ b/apps/posts/src/hooks/usePostSuccessModal.ts
@@ -62,6 +62,13 @@ export const usePostSuccessModal = () => {
         return authors?.map(author => author.name).join(', ') || '';
     };
 
+    const truncateText = (text: string, maxLength: number) => {
+        if (text.length <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength).trim() + '…';
+    };
+
     // Memoized modal props
     const modalProps = useMemo(() => {
         if (!post) {
@@ -136,7 +143,7 @@ export const usePostSuccessModal = () => {
             description: getDescription(),
             featureImageURL: post.feature_image || '',
             postTitle: post.title || '',
-            postExcerpt: post.excerpt || '',
+            postExcerpt: truncateText(post.excerpt || '', 100),
             faviconURL: '', // Could add favicon URL if available
             siteTitle: site?.title || '',
             author: getAuthorsText(post.authors),


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2152/

In alignment with the Ember implementation, the post share modal excerpt has been truncated to 100 characters.

Added favicon for publish modal. It was only in the share modal and needed to be included in the hook.