### PR TITLE
Updated logic for shown/hidden data with newsletter sending setting

### DIFF
--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -171,7 +171,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 }
 
                                 {/* Email metrics - show for email posts */}
-                                {metricsToShow.showEmailMetrics && appSettings?.newslettersEnabled && latestPostStats.email && (
+                                {metricsToShow.showEmailMetrics && latestPostStats.email && (
                                     <>
                                         {/* Show open rate - always display if email exists */}
                                         <div className={metricClassName} onClick={() => {

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -69,9 +69,11 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         }}>Web traffic</PageMenuItem>
                     }
 
-                    <PageMenuItem value="/newsletters/" onClick={() => {
-                        navigate('/newsletters/');
-                    }}>Newsletters</PageMenuItem>
+                    {appSettings?.newslettersEnabled &&
+                        <PageMenuItem value="/newsletters/" onClick={() => {
+                            navigate('/newsletters/');
+                        }}>Newsletters</PageMenuItem>
+                    }
 
                     <PageMenuItem value="/growth/" onClick={() => {
                         navigate('/growth/');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2155/
- updated logic to always show click & open data if we have it for latest post; ie don't look to newsletter settings
- hid newsletter tab in header if newsletter sending is disabled