### PR TITLE
Released @tryghost/portal v2.51.2

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.51.1",
+  "version": "2.51.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changelog for v2.51.1 -> 2.51.2:
  - Removed usage of `?limit=all` in API queries (https://github.com/TryGhost/Ghost/commit/ff814291a5)
