### PR TITLE
Improved handling for web_analytics setting

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -9,9 +9,9 @@ import {KpiDataItem} from '@src/utils/kpi-helpers';
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {STATS_RANGES} from '@src/utils/constants';
 import {centsToDollars} from '../Growth/Growth';
-import {getStatEndpointUrl, getToken, hasBeenEmailed, useNavigate} from '@tryghost/admin-x-framework';
+import {getStatEndpointUrl, getToken, hasBeenEmailed, isPublishedOnly, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/App';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 import {useQuery} from '@tinybirdco/charts';
 
@@ -121,6 +121,13 @@ const Overview: React.FC = () => {
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(post as Post);
     const showWebSection = !post?.email_only && appSettings?.analytics.webAnalytics;
+
+    // Redirect to Growth tab if this is a published-only post with web analytics disabled
+    useEffect(() => {
+        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics) {
+            navigate(`/analytics/beta/${postId}/growth`);
+        }
+    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId]);
 
     return (
         <>

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -259,7 +259,7 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
+        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics Beta"}}

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -202,8 +202,8 @@
             {{/if}}
         {{/if}}
 
-        {{!-- Visitor count column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalytics")}}
+        {{!-- Visitor count column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
+        {{#if (and (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -227,8 +227,8 @@
             {{/if}}
         {{/if}}
 
-        {{!-- Member conversions column (only show for published posts when traffic analytics is enabled) --}}
-        {{#if (feature "trafficAnalytics")}}
+        {{!-- Member conversions column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
+        {{#if (and (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
             {{#if @post.isPublished}}
                 {{#if this.hasMemberData}}
                     <div class="permalink gh-list-data gh-post-list-metrics" data-tooltip={{if this.totalMemberConversions (concat (format-number this.memberCounts.free) " free " (format-number this.memberCounts.paid) " paid ")}}>
@@ -259,7 +259,7 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
+        {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics Beta"}}

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -11,10 +11,11 @@ import {inject as service} from '@ember/service';
 class PostsWithAnalytics extends InfinityModel {
     @service postAnalytics;
     @service feature;
+    @service settings;
 
     async afterInfinityModel(posts) {
-        // Only fetch analytics for published/sent posts when feature is enabled
-        if (!this.feature.trafficAnalytics) {
+        // Only fetch analytics for published/sent posts when feature is enabled AND web analytics is enabled
+        if (!this.feature.trafficAnalytics || !this.settings.webAnalytics) {
             return posts;
         }
         
@@ -35,6 +36,7 @@ export default class PostsRoute extends AuthenticatedRoute {
     @service router;
     @service feature;
     @service postAnalytics;
+    @service settings;
 
     queryParams = {
         type: {refreshModel: true},
@@ -66,7 +68,7 @@ export default class PostsRoute extends AuthenticatedRoute {
 
     model(params) {
         // Reset analytics cache every time we load the posts index to ensure fresh data
-        if (this.feature.trafficAnalytics) {
+        if (this.feature.trafficAnalytics && this.settings.webAnalytics) {
             this.postAnalytics.reset();
         }
         
@@ -154,8 +156,8 @@ export default class PostsRoute extends AuthenticatedRoute {
      * @param {Object} model - The posts model containing infinity models
      */
     async _fetchAnalyticsForPosts(model) {
-        // Only fetch analytics when feature is enabled
-        if (!this.feature.trafficAnalytics) {
+        // Only fetch analytics when feature is enabled AND web analytics is enabled
+        if (!this.feature.trafficAnalytics || !this.settings.webAnalytics) {
             return;
         }
         


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2157/
- published only posts will only display the Growth tab in posts analytics when web analytics is disabled
- posts index will hide the visitor + attribution data when web analytics is disabled (attribution will be behind the member sources flag later on)

This is one of several incremental changes to how we handle state between flags, config, and settings.