### PR TITLE
🐛 Add missing pagination for staff invitations in admin settings

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -153,7 +153,7 @@ export const settingsWithStripe = updatedSettingsResponse([
 
 export const limitRequests = {
     browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
-    browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
+    browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: responseFixtures.invites},
     browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters}
 };

--- a/apps/admin-x-framework/src/test/responses/invites.json
+++ b/apps/admin-x-framework/src/test/responses/invites.json
@@ -13,7 +13,7 @@
     "meta": {
         "pagination": {
             "page": 1,
-            "limit": 15,
+            "limit": 100,
             "pages": 1,
             "total": 1,
             "next": null,

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -205,6 +205,7 @@ const InvitesUserList: React.FC<InviteListProps> = ({users}) => {
 const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords, highlight = true}) => {
     const {
         totalUsers,
+        totalInvites,
         users,
         ownerUser,
         adminUsers,
@@ -213,7 +214,9 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         contributorUsers,
         invites,
         hasNextPage,
-        fetchNextPage
+        fetchNextPage,
+        invitesHasNextPage,
+        fetchNextInvitePage
     } = useStaffUsers();
     const {updateRoute} = useRouting();
     const {settings, config, currentUser} = useGlobalData();
@@ -272,7 +275,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
             id: 'invited',
             title: 'Invited',
             contents: (<InvitesUserList users={invites} />),
-            counter: invites.length ? invites.length : undefined
+            counter: totalInvites ? totalInvites : undefined
         }
     ];
 
@@ -291,10 +294,16 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         >
             <Owner user={ownerUser} />
             {(users.length > 1 || invites.length > 0) && <TabView selectedTab={selectedTab} tabs={tabs} testId='user-tabview' onTabChange={updateSelectedTab} />}
-            {hasNextPage && <Button
+            
+            {hasNextPage && selectedTab !== 'invited' && <Button
                 label={`Load more (showing ${users.length}/${totalUsers} users)`}
                 link
                 onClick={() => fetchNextPage()}
+            />}
+            {invitesHasNextPage && selectedTab === 'invited' && <Button
+                label={`Load more (showing ${invites.length}/${totalInvites} invites)`}
+                link
+                onClick={() => fetchNextInvitePage()}
             />}
 
             {config?.security?.staffDeviceVerification && hasAdminAccess(currentUser) && (

--- a/apps/admin-x-settings/src/hooks/useStaffUsers.tsx
+++ b/apps/admin-x-settings/src/hooks/useStaffUsers.tsx
@@ -6,6 +6,7 @@ import {useMemo} from 'react';
 
 export type UsersHook = {
     totalUsers: number;
+    totalInvites: number;
     users: User[];
     invites: UserInvite[];
     ownerUser: User;
@@ -16,7 +17,9 @@ export type UsersHook = {
     currentUser: User|null;
     isLoading: boolean;
     hasNextPage?: boolean;
+    invitesHasNextPage?: boolean;
     fetchNextPage: () => void;
+    fetchNextInvitePage: () => void;
 };
 
 function getUsersByRole(users: User[], role: string): User[] {
@@ -42,7 +45,11 @@ function getOwnerUser(users: User[]): User {
 const useStaffUsers = (): UsersHook => {
     const {currentUser} = useGlobalData();
     const {data: {users, meta, isEnd} = {users: []}, isLoading: usersLoading, fetchNextPage} = useBrowseUsers();
-    const {data: {invites} = {invites: []}, isLoading: invitesLoading} = useBrowseInvites();
+    const {
+        data: {invites, meta: invitesMeta, isEnd: invitesIsEnd} = {invites: []}, 
+        isLoading: invitesLoading, 
+        fetchNextPage: fetchNextInvitePage
+    } = useBrowseInvites();
     const {data: {roles} = {}, isLoading: rolesLoading} = useBrowseRoles();
 
     const ownerUser = useMemo(() => getOwnerUser(users), [users]);
@@ -62,6 +69,7 @@ const useStaffUsers = (): UsersHook => {
 
     return {
         totalUsers: meta?.pagination.total || 0,
+        totalInvites: invitesMeta?.pagination.total || 0,
         users,
         ownerUser,
         adminUsers,
@@ -72,7 +80,9 @@ const useStaffUsers = (): UsersHook => {
         invites: mappedInvites,
         isLoading: usersLoading || invitesLoading || rolesLoading,
         hasNextPage: isEnd === false,
-        fetchNextPage
+        invitesHasNextPage: invitesIsEnd === false,
+        fetchNextPage,
+        fetchNextInvitePage
     };
 };
 

--- a/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/invite.test.ts
@@ -9,7 +9,7 @@ test.describe('User invitations', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
-            browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
+            browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: responseFixtures.invites},
             browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
             browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
             addInvite: {method: 'POST', path: '/invites/', response: {
@@ -23,7 +23,17 @@ test.describe('User invitations', async () => {
                         created_at: new Date().toISOString(),
                         updated_at: new Date().toISOString()
                     }
-                ]
+                ],
+                meta: {
+                    pagination: {
+                        page: 1,
+                        limit: 100,
+                        pages: 1,
+                        total: 1,
+                        next: null,
+                        prev: null
+                    }
+                }
             }}
         }});
 
@@ -87,7 +97,7 @@ test.describe('User invitations', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
-            browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
+            browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: responseFixtures.invites},
             deleteInvite: {method: 'DELETE', path: `/invites/${responseFixtures.invites.invites[0].id}/`, response: {}},
             addInvite: {method: 'POST', path: '/invites/', response: responseFixtures.invites}
         }});
@@ -123,7 +133,7 @@ test.describe('User invitations', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
-            browseInvites: {method: 'GET', path: '/invites/', response: responseFixtures.invites},
+            browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: responseFixtures.invites},
             deleteInvite: {method: 'DELETE', path: `/invites/${responseFixtures.invites.invites[0].id}/`, response: {}}
         }});
 
@@ -140,6 +150,101 @@ test.describe('User invitations', async () => {
         await expect(page.getByTestId('toast-success')).toHaveText(/Invitation revoked/);
 
         expect(lastApiRequests.deleteInvite?.url).toMatch(new RegExp(`/invites/${responseFixtures.invites.invites[0].id}`));
+    });
+
+    test('Supports load more functionality for invites', async ({page}) => {
+        // Create a paginated response with multiple pages
+        const firstPageInvites = {
+            invites: [
+                {
+                    id: 'invite-1',
+                    role_id: '645453f3d254799990dd0e18',
+                    status: 'sent',
+                    email: 'invitee1@test.com',
+                    expires: 1687655172000,
+                    created_at: '2023-06-23T00:30:21.000Z',
+                    updated_at: '2023-06-23T00:30:21.000Z'
+                },
+                {
+                    id: 'invite-2',
+                    role_id: '645453f3d254799990dd0e18',
+                    status: 'sent',
+                    email: 'invitee2@test.com',
+                    expires: 1687655172000,
+                    created_at: '2023-06-23T00:30:21.000Z',
+                    updated_at: '2023-06-23T00:30:21.000Z'
+                }
+            ],
+            meta: {
+                pagination: {
+                    page: 1,
+                    limit: 2,
+                    pages: 2,
+                    total: 3,
+                    next: 2,
+                    prev: null
+                }
+            }
+        };
+
+        const secondPageInvites = {
+            invites: [
+                {
+                    id: 'invite-3',
+                    role_id: '645453f3d254799990dd0e18',
+                    status: 'sent',
+                    email: 'invitee3@test.com',
+                    expires: 1687655172000,
+                    created_at: '2023-06-23T00:30:21.000Z',
+                    updated_at: '2023-06-23T00:30:21.000Z'
+                }
+            ],
+            meta: {
+                pagination: {
+                    page: 2,
+                    limit: 2,
+                    pages: 2,
+                    total: 3,
+                    next: null,
+                    prev: 1
+                }
+            }
+        };
+
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
+            browseInvites: {method: 'GET', path: '/invites/?limit=100&include=roles', response: firstPageInvites},
+            browseInvitesPage2: {method: 'GET', path: '/invites/?limit=100&include=roles&page=2', response: secondPageInvites},
+            browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        await section.getByRole('tab', {name: 'Invited'}).click();
+
+        // Initially should show 2 invites and load more button
+        await expect(section.getByTestId('user-invite')).toHaveCount(2);
+        await expect(section.getByText('invitee1@test.com')).toBeVisible();
+        await expect(section.getByText('invitee2@test.com')).toBeVisible();
+
+        // Verify the tab count shows the total (3) even though only 2 are loaded
+        await expect(section.getByRole('tab', {name: 'Invited'})).toContainText('Invited3');
+        
+        const loadMoreButton = section.getByRole('button', {name: /Load more \(showing 2\/3 invites\)/});
+        await expect(loadMoreButton).toBeVisible();
+
+        // Click load more button
+        await loadMoreButton.click();
+
+        // Should now show all 3 invites and button should be hidden
+        await expect(section.getByTestId('user-invite')).toHaveCount(3);
+        await expect(section.getByText('invitee3@test.com')).toBeVisible();
+        await expect(loadMoreButton).not.toBeVisible();
+
+        // Verify the API request was made for the second page
+        expect(lastApiRequests.browseInvitesPage2?.url).toMatch(/\/invites\/\?limit=100&include=roles&page=2/);
     });
 
     test('Limits inviting too many staff users', async ({page}) => {
@@ -180,5 +285,5 @@ test.describe('User invitations', async () => {
         await modal.locator('button[value=contributor]').click();
 
         await expect(modal).not.toHaveText(/Your plan does not support more staff/);
-    });
+    });    
 });


### PR DESCRIPTION
The existing admin UI only handled pagination for users but not invites. 

This PR updates the `useBrowseInvites` hook to mirror the pagination handling in `useBrowseUsers`, enabling the same behaviour for invites. The staff user list component was also updated to accommodate these changes.

### Motivation 

My first naive attempt at solving this was to just bump the page size to 100. In many ways that would probably be enough, but it would still leave the bug in place. On the off chance that some large media conglomerate wants to set up Ghost and invite the entire org fixing things properly seemed like the better way to go. 

Since `limit=all` seems to be going away in Ghost 6 I opted for just doing things in the same way for invites as for the other users. To me this seemed like the better trade-off compared to removing or ignoring the limit parameter on the backend which would make things less consistent across endpoints. 

### Testing
I have added a Playwright test that verifies that the pagination works and updated the moved backend responses.

Fixes https://github.com/TryGhost/Ghost/issues/23946

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works