### PR TITLE
Fixed comments-ui applying limit=all to /settings/ requests

### DIFF
--- a/apps/comments-ui/src/utils/api.test.ts
+++ b/apps/comments-ui/src/utils/api.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 import setupGhostApi from './api';
+import {vi} from 'vitest';
 
 test('should call counts endpoint', () => {
     const spy = vi.spyOn(window, 'fetch');
@@ -42,6 +43,37 @@ test('should call counts endpoint with postId query param', () => {
             method: 'GET',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
+            body: undefined
+        })
+    );
+});
+
+test('should call settings endpoint without limit=all parameter', () => {
+    const spy = vi.spyOn(window, 'fetch');
+    spy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({success: true})
+    } as any);
+
+    const api = setupGhostApi({siteUrl: 'http://localhost:3000', apiUrl: 'http://localhost:3000', apiKey: 'test-api-key'});
+
+    api.site.settings();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Get the actual URL that was called
+    const actualUrl = spy.mock.calls[0][0] as string;
+
+    // Verify the URL structure and that limit=all is NOT present
+    expect(actualUrl).toBe('http://localhost:3000/settings/?key=test-api-key');
+    expect(actualUrl).not.toContain('limit=all');
+
+    expect(spy).toHaveBeenCalledWith(
+        'http://localhost:3000/settings/?key=test-api-key',
+        expect.objectContaining({
+            method: 'GET',
+            headers: {'Content-Type': 'application/json'},
+            credentials: undefined,
             body: undefined
         })
     );

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -10,9 +10,13 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
         return '';
     }
 
-    function contentEndpointFor({resource, params = ''}: {resource: string, params?: string}) {
+    function contentEndpointFor({resource, params = {}}: {resource: string, params?: Record<string, string | number>}) {
         if (apiUrl && apiKey) {
-            return `${apiUrl.replace(/\/$/, '')}/${resource}/?key=${apiKey}&limit=all${params}`;
+            const searchParams = new URLSearchParams({
+                ...params,
+                key: apiKey
+            });
+            return `${apiUrl.replace(/\/$/, '')}/${resource}/?${searchParams.toString()}`;
         }
         return '';
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- we still had one request to `/settings/` which used `?limit=all` due to it being applied by default to all Content API requests
- updated `contentEndpointFor()` to match the same pattern used in Portal and removed the default `limit=all`
- `api.site.settings()` that calls `contentEndpointFor` didn't need changing because `/settings/` does not support a limit parameter
