### PR TITLE
🔥 Removed amp and amp_gtag_id from settings

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -53,8 +53,6 @@ const EDITABLE_SETTINGS = [
     'email_track_clicks',
     'members_track_sources',
     'web_analytics',
-    'amp',
-    'amp_gtag_id',
     'slack_url',
     'slack_username',
     'unsplash',

--- a/ghost/core/core/server/data/migrations/versions/6.0/2025-06-25-15-03-29-remove-amp-from-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/6.0/2025-06-25-15-03-29-remove-amp-from-settings.js
@@ -1,0 +1,6 @@
+const {combineTransactionalMigrations, removeSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    removeSetting('amp'),
+    removeSetting('amp_gtag_id')
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -427,19 +427,6 @@
             "flags": "RO"
         }
     },
-    "amp": {
-        "amp": {
-            "defaultValue": "false",
-            "validations": {
-                "isIn": [["true", "false"]]
-            },
-            "type": "boolean"
-        },
-        "amp_gtag_id": {
-            "defaultValue": null,
-            "type": "string"
-        }
-    },
     "firstpromoter": {
         "firstpromoter": {
             "defaultValue": "false",

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -229,7 +229,6 @@ module.exports = {
             defaultTo: 'core',
             validations: {
                 isIn: [[
-                    'amp',
                     'core',
                     'email',
                     'labs',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -233,14 +233,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -667,14 +659,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -1034,14 +1018,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -1414,14 +1390,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -1789,14 +1757,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -2167,14 +2127,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -2631,14 +2583,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -3009,14 +2953,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -3385,14 +3321,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -3769,14 +3697,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -4144,14 +4064,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -4528,14 +4440,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -4905,14 +4809,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -5272,14 +5168,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -5650,14 +5538,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -6031,14 +5911,6 @@ Object {
       "value": false,
     },
     Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
-    },
-    Object {
       "key": "firstpromoter",
       "value": false,
     },
@@ -6408,14 +6280,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",
@@ -6849,14 +6713,6 @@ Object {
     Object {
       "key": "email_verification_required",
       "value": false,
-    },
-    Object {
-      "key": "amp",
-      "value": false,
-    },
-    Object {
-      "key": "amp_gtag_id",
-      "value": null,
     },
     Object {
       "key": "firstpromoter",

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -8,7 +8,7 @@ const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = 
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 89;
+const CURRENT_SETTINGS_COUNT = 87;
 
 const settingsMatcher = {};
 
@@ -31,10 +31,10 @@ const matchSettingsArray = (length) => {
         settingsArray[26] = publicHashSettingMatcher;
     }
 
-    if (length > 61) {
+    if (length > 59) {
         // Added a setting that is alphabetically before 'labs'? then you need to increment this counter.
         // Item at index x is the lab settings, which changes as we add and remove features
-        settingsArray[61] = labsSettingMatcher;
+        settingsArray[59] = labsSettingMatcher;
     }
 
     return settingsArray;

--- a/ghost/core/test/legacy/models/model_settings.test.js
+++ b/ghost/core/test/legacy/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 95;
+const SETTINGS_LENGTH = 93;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 93;
+            const allowedKeysLength = 91;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'd615cc0cac11d66e6fea41336bbfa751';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
-    const currentSettingsHash = 'eaaa5c08731c598ed6eb452c9ccd0470';
+    const currentSettingsHash = 'f6c250fb2daf5d0047052e368f9faee9';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings-browser.json
+++ b/ghost/core/test/utils/fixtures/default-settings-browser.json
@@ -411,19 +411,6 @@
             "flags": "RO"
         }
     },
-    "amp": {
-        "amp": {
-            "defaultValue": "false",
-            "validations": {
-                "isIn": [["true", "false"]]
-            },
-            "type": "boolean"
-        },
-        "amp_gtag_id": {
-            "defaultValue": null,
-            "type": "string"
-        }
-    },
     "firstpromoter": {
         "firstpromoter": {
             "defaultValue": "false",

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -423,19 +423,6 @@
             "flags": "RO"
         }
     },
-    "amp": {
-        "amp": {
-            "defaultValue": "false",
-            "validations": {
-                "isIn": [["true", "false"]]
-            },
-            "type": "boolean"
-        },
-        "amp_gtag_id": {
-            "defaultValue": null,
-            "type": "string"
-        }
-    },
     "firstpromoter": {
         "firstpromoter": {
             "defaultValue": "false",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/23924
closes https://linear.app/ghost/issue/PROD-2118/run-a-migration-to-remove-amp-from-the-settings-table

- removes `amp` and `amp_gtag_id` from settings table