### PR TITLE
Added `event_id` column to `analytics_events_test` Tinybird datasource

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -10,7 +10,7 @@ SCHEMA >
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
     `payload` JSON(max_dynamic_types=4, max_dynamic_paths=32) `json:$.payload`,
-    `site_uuid` String `json:$.payload.site_uuid`
+    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -5,6 +5,7 @@ TOKEN "tracker" APPEND
 
 SCHEMA >
     `timestamp` DateTime `json:$.timestamp`,
+    `event_id` UUID `json:$.event_id`,
     `session_id` String `json:$.session_id`,
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
@@ -14,3 +15,6 @@ SCHEMA >
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
+
+FORWARD_QUERY >
+    SELECT timestamp, generateUUIDv4() AS event_id, session_id, action, version, payload, site_uuid

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -10,7 +10,7 @@ SCHEMA >
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
     `payload` JSON(max_dynamic_types=4, max_dynamic_paths=32) `json:$.payload`,
-    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
+    `site_uuid` String `json:$.payload.site_uuid`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -5,7 +5,7 @@ TOKEN "tracker" APPEND
 
 SCHEMA >
     `timestamp` DateTime `json:$.timestamp`,
-    `event_id` UUID `json:$.event_id`,
+    `event_id` UUID `json:$.event_id` DEFAULT generateUUIDv4(),
     `session_id` String `json:$.session_id`,
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,


### PR DESCRIPTION
We currently don't have an `event_id` stored in Tinybird for each event. This would be useful to have for debugging if nothing else, and will already be useful to validate that events sent through our batching process are identical to the events sent through our proxying process in the analytics service.