### PR TITLE
Added 'social_web' setting to enable/disable ActivityPub once in GA

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -77,7 +77,8 @@ const EDITABLE_SETTINGS = [
     'body_font',
     'heading_font',
     'blocked_email_domains',
-    'require_email_mfa'
+    'require_email_mfa',
+    'social_web'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/migrations/versions/5.128/2025-06-26-09-36-41-add-social-web-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.128/2025-06-26-09-36-41-add-social-web-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'social_web',
+    value: 'true',
+    type: 'boolean',
+    group: 'social_web'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -614,5 +614,19 @@
             "defaultValue": false,
             "type": "boolean"
         }
+    },
+    "social_web": {
+        "social_web": {
+            "defaultValue": "true",
+            "validations": {
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean"
+        }
     }
 }

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 92;
+            const allowedKeysLength = 93;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99566c8c6b729dd1c516bba432a6e1a2';
     const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
-    const currentSettingsHash = 'de95b390395d682d4868bf30567de0cb';
+    const currentSettingsHash = 'eaaa5c08731c598ed6eb452c9ccd0470';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2172

- ActivityPub is going to be enabled by default in Ghost 6.0
- Publishers can disable it via a setting in Admin
- this commits adds the database migration, and a follow-up commit will add the UI