### PR TITLE
🐛 Fixed infinite `/offers/` fetch loop for sites with >100 offers

### DIFF
--- a/ghost/admin/app/adapters/embedded-relation-adapter.js
+++ b/ghost/admin/app/adapters/embedded-relation-adapter.js
@@ -55,6 +55,7 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
         const dataKey = pluralize(root);
 
         let hasMorePages = true;
+        let firstRequestMade = false;
         while (hasMorePages) {
             // Create a fresh query object for each iteration,
             // overriding the limit and page parameters
@@ -77,6 +78,16 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
 
             // Store metadata from this request (will use the last one)
             lastMeta = result.meta;
+
+            // Guard: if this is the first request and there's no meta key,
+            // assume the endpoint doesn't support pagination and return the data from this request
+            if (!firstRequestMade) {
+                firstRequestMade = true;
+                if (!result.meta) {
+                    hasMorePages = false;
+                    break;
+                }
+            }
 
             // Check if we should continue paginating
             // Stop if this page returned fewer results than requested

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -133,7 +133,7 @@ export default class GhMembersSegmentSelect extends Component {
             options.push(labelsGroup);
         }
 
-        const offers = yield this.store.query('offer', {limit: 'all'});
+        const offers = yield this.store.findAll('offer');
 
         if (offers.length > 0) {
             const offersGroup = {

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -252,7 +252,7 @@ export default class KoenigLexicalEditor extends Component {
         if (this.offers) {
             return this.offers;
         }
-        this.offers = yield this.store.query('offer', {limit: 'all', filter: 'status:active'});
+        this.offers = yield this.store.query('offer', {filter: 'status:active'});
         return this.offers;
     }
 

--- a/ghost/admin/app/components/members/filter.js
+++ b/ghost/admin/app/components/members/filter.js
@@ -640,7 +640,7 @@ export default class MembersFilter extends Component {
 
     @task({drop: true})
     *fetchOffers() {
-        const response = yield this.store.query('offer', {limit: 'all'});
+        const response = yield this.store.findAll('offer');
         this.offers = response;
         return response;
     }

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -69,7 +69,7 @@ export default class OffersSegmentSelect extends Component {
 
         // fetch all offers with count
         // TODO: add `include: 'count.members` to query once API supports
-        const offers = yield this.store.query('offer', {limit: 'all'});
+        const offers = yield this.store.findAll('offer');
         this.offers = offers;
         if (offers.length > 0) {
             const offersGroup = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- added a guard to the adapter's automatic page-fetching logic to abort early when an endpoint doesn't support pagination
- removed `limit` param from all `/offers/` requests as it doesn't support pagination
  - switched to `findAll()` where no filter is applied, otherwise just removed the `limit` param from the `.query()` call
