### PR TITLE
Reverted removal of trafficAnalyticsAlpha flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -12,6 +12,10 @@ const features = [{
     description: 'Enables traffic analytics',
     flag: 'trafficAnalytics'
 }, {
+    title: 'Traffic Analytics (alpha)',
+    description: 'Enables alpha stage analytics features',
+    flag: 'trafficAnalyticsAlpha'
+}, {
     title: 'Email customization (internal beta)',
     description: 'Newsletter customization settings that have been released to Ghost\'s own production sites',
     flag: 'emailCustomization'

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -12,7 +12,7 @@ export const APP_ROUTE_PREFIX = '/posts';
 
 // Wrap components with feature flag protection where needed
 //  e.g.
-// const ProtectedNewsletter = withFeatureFlag(Newsletter, 'trafficAnalytics', '/analytics/', 'Newsletter');
+// const ProtectedNewsletter = withFeatureFlag(Newsletter, 'trafficAnalyticsAlpha', '/analytics/', 'Newsletter');
 
 export const routes: RouteObject[] = [
     {

--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -10,7 +10,7 @@ export const APP_ROUTE_PREFIX = '/analytics';
 
 // Wrap all components with feature flag protection
 //  e.g.
-// const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalytics', '/', 'Overview');
+// const ProtectedOverview = withFeatureFlag(Overview, 'trafficAnalyticsAlpha', '/', 'Overview');
 
 export const routes: RouteObject[] = [
     {

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -203,7 +203,7 @@
         {{/if}}
 
         {{!-- Visitor count column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
-        {{#if (and (feature "trafficAnalyticsAlpha") (or this.settings.webAnalytics false))}}
+        {{#if (and (feature "trafficAnalyticsAlpha") this.settings.webAnalytics)}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -228,7 +228,7 @@
         {{/if}}
 
         {{!-- Member conversions column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
-        {{#if (and (feature "trafficAnalyticsAlpha") (or this.settings.webAnalytics false))}}
+        {{#if (and (feature "trafficAnalyticsAlpha") this.settings.webAnalytics)}}
             {{#if @post.isPublished}}
                 {{#if this.hasMemberData}}
                     <div class="permalink gh-list-data gh-post-list-metrics" data-tooltip={{if this.totalMemberConversions (concat (format-number this.memberCounts.free) " free " (format-number this.memberCounts.paid) " paid ")}}>

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -203,7 +203,7 @@
         {{/if}}
 
         {{!-- Visitor count column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
-        {{#if (and (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
+        {{#if (and (feature "trafficAnalyticsAlpha") (or this.settings.webAnalytics false))}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">
@@ -228,7 +228,7 @@
         {{/if}}
 
         {{!-- Member conversions column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
-        {{#if (and (feature "trafficAnalytics") (or this.settings.webAnalytics false))}}
+        {{#if (and (feature "trafficAnalyticsAlpha") (or this.settings.webAnalytics false))}}
             {{#if @post.isPublished}}
                 {{#if this.hasMemberData}}
                     <div class="permalink gh-list-data gh-post-list-metrics" data-tooltip={{if this.totalMemberConversions (concat (format-number this.memberCounts.free) " free " (format-number this.memberCounts.paid) " paid ")}}>

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -15,7 +15,7 @@ class PostsWithAnalytics extends InfinityModel {
 
     async afterInfinityModel(posts) {
         // Only fetch analytics for published/sent posts when feature is enabled AND web analytics is enabled
-        if (!this.feature.trafficAnalytics || !this.settings.webAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha || !this.settings.webAnalytics) {
             return posts;
         }
         
@@ -68,7 +68,7 @@ export default class PostsRoute extends AuthenticatedRoute {
 
     model(params) {
         // Reset analytics cache every time we load the posts index to ensure fresh data
-        if (this.feature.trafficAnalytics && this.settings.webAnalytics) {
+        if (this.feature.trafficAnalyticsAlpha && this.settings.webAnalytics) {
             this.postAnalytics.reset();
         }
         
@@ -157,7 +157,7 @@ export default class PostsRoute extends AuthenticatedRoute {
      */
     async _fetchAnalyticsForPosts(model) {
         // Only fetch analytics when feature is enabled AND web analytics is enabled
-        if (!this.feature.trafficAnalytics || !this.settings.webAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha || !this.settings.webAnalytics) {
             return;
         }
         

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -72,6 +72,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
+    @feature('trafficAnalyticsAlpha') trafficAnalyticsAlpha;
     @feature('updatedMainNav') updatedMainNav;
     @feature('trafficAnalytics') trafficAnalytics;
 

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -41,7 +41,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha) {
             return Promise.resolve();
         }
         
@@ -78,7 +78,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if traffic analytics is enabled
-        if (!this.feature.trafficAnalytics) {
+        if (!this.feature.trafficAnalyticsAlpha) {
             return Promise.resolve();
         }
         

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -23,7 +23,7 @@ describe('Unit: Service: post-analytics', function () {
             }
         };
         featureStub = {
-            trafficAnalytics: true
+            trafficAnalyticsAlpha: true
         };
 
         service.ajax = {request: ajaxStub};
@@ -43,7 +43,7 @@ describe('Unit: Service: post-analytics', function () {
         });
 
         it('returns early if feature flag is disabled', async function () {
-            featureStub.trafficAnalytics = false;
+            featureStub.trafficAnalyticsAlpha = false;
             const result = await service.loadVisitorCounts(['uuid1']);
             expect(result).to.be.undefined;
             expect(ajaxStub.called).to.be.false;
@@ -140,7 +140,7 @@ describe('Unit: Service: post-analytics', function () {
         });
 
         it('returns early if feature flag is disabled', async function () {
-            featureStub.trafficAnalytics = false;
+            featureStub.trafficAnalyticsAlpha = false;
             const result = await service.loadMemberCounts([{id: '1', uuid: 'uuid1'}]);
             expect(result).to.be.undefined;
             expect(ajaxStub.called).to.be.false;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -48,6 +48,7 @@ const PRIVATE_FEATURES = [
     'urlCache',
     'mailEvents',
     'lexicalIndicators',
+    'trafficAnalyticsAlpha',
     'updatedMainNav',
     'contentVisibilityAlpha',
     'explore',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,6 +28,7 @@ Object {
       "superEditors": true,
       "themeErrorsNotification": true,
       "trafficAnalytics": true,
+      "trafficAnalyticsAlpha": true,
       "trafficAnalyticsTracking": true,
       "updatedMainNav": true,
       "urlCache": true,


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1750906145479859?thread_ts=1750905630.132569&cid=C07HTEJMR2R

We want to make design changes before removing the alpha flag.