### PR TITLE
Added calculated setting for Social Web (ActivityPub)

### DIFF
--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -31,7 +31,7 @@ export const useBrowseSettings = createQuery<SettingsResponseType>({
     dataType,
     path: '/settings/',
     defaultSearchParams: {
-        group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security'
+        group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security,social_web'
     }
 });
 

--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -2,10 +2,10 @@ import ExitSettingsButton from './components/ExitSettingsButton';
 import Settings from './components/Settings';
 import Sidebar from './components/Sidebar';
 import Users from './components/settings/general/Users';
-import useFeatureFlag from './hooks/useFeatureFlag';
 import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {ReactNode, useEffect} from 'react';
 import {canAccessSettings, hasAdminAccess, isEditorUser} from '@tryghost/admin-x-framework/api/users';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -25,7 +25,8 @@ const MainContent: React.FC = () => {
     const {currentUser} = useGlobalData();
     const {route, updateRoute, loadingModal} = useRouting();
     const {isDirty} = useGlobalDirtyState();
-    const hasActivityPub = useFeatureFlag('ActivityPub');
+    const {settings} = useGlobalData();
+    const [hasActivityPub] = getSettingValues(settings, ['social_web_enabled']) as [boolean];
 
     const navigateAway = (escLocation: string) => {
         window.location.hash = escLocation;

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import useFeatureFlag from '../hooks/useFeatureFlag';
 import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {hasAdminAccess} from '@tryghost/admin-x-framework/api/users';
 import {useGlobalData} from './providers/GlobalDataProvider';
 
 const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
-    const {currentUser} = useGlobalData();
-    const hasActivityPub = useFeatureFlag('ActivityPub');
+    const {settings, currentUser} = useGlobalData();
+    const [hasActivityPub] = getSettingValues(settings, ['social_web_enabled']) as [boolean];
 
     const navigateAway = () => {
         window.location.hash = (hasActivityPub && hasAdminAccess(currentUser)) ? '/activitypub' : '/dashboard';

--- a/ghost/admin/app/components/admin-x/activitypub.js
+++ b/ghost/admin/app/components/admin-x/activitypub.js
@@ -3,11 +3,11 @@ import {inject as service} from '@ember/service';
 
 export default class AdminXActivityPub extends AdminXComponent {
     @service upgradeStatus;
-    @service feature;
+    @service settings;
 
     static packageName = '@tryghost/admin-x-activitypub';
 
     additionalProps = () => ({
-        activityPubEnabled: this.feature.ActivityPub
+        activityPubEnabled: this.settings.socialWebEnabled
     });
 }

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -28,7 +28,7 @@
 
             {{#if (and (feature "updatedMainNav") this.session.user.isAdmin)}}
                 <ul class="gh-nav-list gh-nav-main">
-                    {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
+                    {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
                         <li>
                             <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "ap-network" class="gh-icon-ap-network"}}Network</LinkTo>
                         </li>
@@ -53,7 +53,7 @@
                 </ul>
             {{else}}
                 <ul class="gh-nav-list gh-nav-main">
-                    {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
+                    {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
                         <li class="relative gh-nav-list-ap">
                             <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "house"}}Home
                                 {{#unless this.notificationsCount.isLoading}}
@@ -67,7 +67,7 @@
                     {{#if (gh-user-can-admin this.session.user)}}
                         <li class="relative gh-nav-list-home">
                             <LinkTo @route="dashboard" @alt="Dashboard" data-test-nav="dashboard">
-                                {{#if (and (feature "ActivityPub") this.session.user.isAdmin)}}
+                                {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
                                     {{svg-jar "gauge"}}
                                 {{else}}
                                     {{svg-jar "house"}}
@@ -94,7 +94,7 @@
                         </li>
                     {{/if}}
                     {{#if (gh-user-can-admin this.session.user)}}
-                        {{#if (not (and (feature "ActivityPub") this.session.user.isAdmin))}}
+                        {{#if (not (and this.settings.socialWebEnabled this.session.user.isAdmin))}}
                             <li class="relative">
                                 <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active" }} {{on "click" (fn
                                     this.toggleExploreWindow "" )}} data-test-nav="explore">

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -74,14 +74,14 @@ export default class Main extends Component.extend(ShortcutsMixin) {
         this._routeChangeHandler = () => {
             const current = this.router.currentRouteName || '';
             const prev = this.previousRoute || '';
-        
+
             if (prev.startsWith('activitypub-x') && !current.startsWith('activitypub-x')) {
                 this.notificationsCount.fetchCount();
             }
-        
+
             this.previousRoute = current;
         };
-        
+
         this.router.on('routeDidChange', this._routeChangeHandler);
     }
 

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -122,6 +122,11 @@ export default Model.extend(ValidationEngine, {
      */
     requireEmailMfa: attr('boolean'),
 
+    /**
+     * Social web (ActivityPub)
+     */
+    socialWebEnabled: attr('boolean'),
+
     // HACK - not a real model attribute but a workaround for Ember Data not
     //        exposing meta from save responses
     _meta: attr()

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -6,6 +6,7 @@ export default class HomeRoute extends Route {
     @service modals;
     @service router;
     @service session;
+    @service settings;
 
     beforeModel(transition) {
         super.beforeModel(...arguments);
@@ -14,7 +15,7 @@ export default class HomeRoute extends Route {
             return this.router.transitionTo('setup.done');
         }
 
-        if (this.feature.ActivityPub && this.session.user.isAdmin) {
+        if (this.settings.socialWebEnabled && this.session.user.isAdmin) {
             this.router.transitionTo('activitypub-x');
         } else {
             this.router.transitionTo('dashboard');

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -68,7 +68,6 @@ export default class FeatureService extends Service {
     @feature('mailEvents') mailEvents;
     @feature('importMemberTier') importMemberTier;
     @feature('lexicalIndicators') lexicalIndicators;
-    @feature('ActivityPub') ActivityPub;
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;

--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -55,7 +55,7 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
     _loadSettings() {
         if (!this._loadingPromise) {
             this._loadingPromise = this.store
-                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,recommendations,security'})
+                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,recommendations,security,social_web'})
                 .then((settings) => {
                     this._loadingPromise = null;
                     return settings;

--- a/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
+++ b/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
@@ -14,9 +14,9 @@ module.exports = class ActivityPubServiceWrapper {
         const logging = require('@tryghost/logging');
         const events = require('../../lib/common/events');
         const {knex} = require('../../data/db');
-        const labs = require('../../../shared/labs');
         const urlUtils = require('../../../shared/url-utils');
         const IdentityTokenServiceWrapper = require('../identity-tokens');
+        const settingsCache = require('../../../shared/settings-cache');
 
         if (!IdentityTokenServiceWrapper.instance) {
             logging.error(`IdentityTokenService needs to be initialised before ActivityPubService`);
@@ -32,12 +32,12 @@ module.exports = class ActivityPubServiceWrapper {
             IdentityTokenServiceWrapper.instance
         );
 
-        if (labs.isSet('ActivityPub')) {
+        if (settingsCache.get('social_web_enabled')) {
             await ActivityPubServiceWrapper.instance.initialiseWebhooks();
             ActivityPubServiceWrapper.initialised = true;
         } else {
             events.on('settings.labs.edited', async () => {
-                if (labs.isSet('ActivityPub') && !ActivityPubServiceWrapper.initialised) {
+                if (settingsCache.get('social_web_enabled') && !ActivityPubServiceWrapper.initialised) {
                     await ActivityPubServiceWrapper.instance.initialiseWebhooks();
                     ActivityPubServiceWrapper.initialised = true;
                 }

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -219,6 +219,19 @@ class SettingsHelpers {
         ]));
     }
 
+    /**
+     * Social web (ActivityPub) is enabled if:
+     * - Social web is enabled in the settings
+     * - 'ActivityPub' flag is enabled in the labs, for compatibility with Ghost 5.x
+     * - Config allows it (TODO)
+     * - Billing allows it (TODO)
+     *
+     * @returns {boolean}
+     */
+    isSocialWebEnabled() {
+        return this.settingsCache.get('social_web') === true && this.labs.isSet('ActivityPub');
+    }
+
     // PRIVATE
 
     #managedEmailEnabled() {

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -74,7 +74,7 @@ module.exports = {
         const settingsCollection = await models.Settings.populateDefaults();
         const settingsOverrides = config.get('hostSettings:settingsOverrides') || {};
         SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore, settingsOverrides);
-        
+
         // Validate site_uuid matches config
         await this.validateSiteUuid();
     },
@@ -105,6 +105,9 @@ module.exports = {
 
         // Blocked email domains from member signup, from both config and user settings
         fields.push(new CalculatedField({key: 'all_blocked_email_domains', type: 'string', group: 'members', fn: settingsHelpers.getAllBlockedEmailDomains.bind(settingsHelpers), dependents: ['blocked_email_domains']}));
+
+        // Social web (ActivityPub)
+        fields.push(new CalculatedField({key: 'social_web_enabled', type: 'boolean', group: 'social_web', fn: settingsHelpers.isSocialWebEnabled.bind(settingsHelpers), dependents: ['social_web', 'labs']}));
 
         return fields;
     },
@@ -156,7 +159,7 @@ module.exports = {
         if (configSiteUuid && settingSiteUuid && configSiteUuid.toLowerCase() !== settingSiteUuid.toLowerCase()) {
             const logging = require('@tryghost/logging');
             const errors = require('@tryghost/errors');
-            
+
             logging.error(`Site UUID mismatch: config has '${configSiteUuid}' but database has '${settingSiteUuid}'`);
             throw new errors.IncorrectUsageError({
                 message: 'Site UUID configuration does not match database value',

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -60,6 +60,7 @@ const _ = require('lodash');
  * @property {string|null} support_email_address - Support email address
  * @property {string|null} editor_default_email_recipients - Default email recipients for editor
  * @property {string|null} labs - JSON string of enabled labs features
+ * @property {boolean|null} social_web_enabled - Whether social web is enabled
  * @property {never} [x] - Prevent accessing undefined properties
  */
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -356,6 +356,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1155,6 +1159,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1529,6 +1537,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1901,6 +1913,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -2738,6 +2754,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3112,6 +3132,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3485,6 +3509,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -3864,6 +3892,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -4236,6 +4268,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -4614,6 +4650,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -5357,6 +5397,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -5730,6 +5774,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -6106,6 +6154,10 @@ Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
     },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -6480,6 +6532,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }
@@ -6917,6 +6973,10 @@ Object {
     Object {
       "key": "all_blocked_email_domains",
       "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
     },
   ],
 }

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -8,7 +8,7 @@ const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = 
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 88;
+const CURRENT_SETTINGS_COUNT = 89;
 
 const settingsMatcher = {};
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2172

The calculated setting `social_web_enabled` takes into account 4 elements to grant access to Social Web (ActivityPub):
   1. whether the setting is enabled in Admin (todo UI, defaults to true)
   2. whether the existing beta lab is true (remove once we're no longer in beta)
   3. whether billing allows it (todo, follow-up commit)
   4. whether config allows it (todo, follow-up commit)