### PR TITLE
Renamed Inbox and Feed to Reader and Notes in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -315,7 +315,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes`]: {
                     response: JSONResponse({
                         posts: [
                             {
@@ -358,7 +358,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes`]: {
                     response: JSONResponse({
                         posts: [],
                         next: 'abc123'
@@ -388,7 +388,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed?next=${next}`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes?next=${next}`]: {
                     response: JSONResponse({
                         posts: [
                             {
@@ -429,7 +429,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes`]: {
                     response: JSONResponse(null)
                 }
             });
@@ -459,7 +459,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes`]: {
                     response: JSONResponse({})
                 }
             });
@@ -489,7 +489,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/feed`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/notes`]: {
                     response: JSONResponse({
                         posts: []
                     })
@@ -518,7 +518,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader`]: {
                     response: JSONResponse({
                         posts: [
                             {
@@ -561,7 +561,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader`]: {
                     response: JSONResponse({
                         posts: [],
                         next: 'abc123'
@@ -592,7 +592,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox?next=${next}`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader?next=${next}`]: {
                     response: JSONResponse({
                         posts: [
                             {
@@ -633,7 +633,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader`]: {
                     response: JSONResponse(null)
                 }
             });
@@ -663,7 +663,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader`]: {
                     response: JSONResponse({})
                 }
             });
@@ -693,7 +693,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/inbox`]: {
+                [`https://activitypub.api/.ghost/activitypub/feed/reader`]: {
                     response: JSONResponse({
                         posts: []
                     })

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -396,11 +396,11 @@ export class ActivityPubAPI {
     }
 
     async getFeed(next?: string): Promise<PaginatedPostsResponse> {
-        return this.getPaginatedPosts('.ghost/activitypub/feed', next);
+        return this.getPaginatedPosts('.ghost/activitypub/feed/notes', next);
     }
 
     async getInbox(next?: string): Promise<PaginatedPostsResponse> {
-        return this.getPaginatedPosts('.ghost/activitypub/inbox', next);
+        return this.getPaginatedPosts('.ghost/activitypub/feed/reader', next);
     }
 
     async getPostsByAccount(handle: string, next?: string): Promise<PaginatedPostsResponse> {

--- a/apps/admin-x-activitypub/src/components/layout/Header/Header.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Header/Header.tsx
@@ -30,7 +30,7 @@ const Header: React.FC = () => {
         onlyBackButton = true;
     }
 
-    if (baseRoute === 'feed' && canGoBack) {
+    if (baseRoute === 'notes' && canGoBack) {
         onlyBackButton = true;
     }
 

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
@@ -7,7 +7,7 @@ const FeedbackBox: React.FC = () => {
 
     function showFeedbackReply() {
         const targetPostId = 'https://activitypub.ghost.org/.ghost/activitypub/note/84eb47c6-4e5d-4d1a-bb6e-089a5890cc2';
-        navigate(`/feed/${encodeURIComponent(targetPostId)}`);
+        navigate(`/notes/${encodeURIComponent(targetPostId)}`);
     }
 
     return (

--- a/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -48,13 +48,13 @@ const Sidebar: React.FC = () => {
                         </Dialog>
                     </div>
                     <div className='flex w-full flex-col gap-px'>
-                        <SidebarMenuLink to='/inbox'>
-                            <LucideIcon.Inbox size={18} strokeWidth={1.5} />
-                            Inbox
+                        <SidebarMenuLink to='/reader'>
+                            <LucideIcon.BookOpen size={18} strokeWidth={1.5} />
+                            Reader
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/feed'>
-                            <LucideIcon.Hash size={18} strokeWidth={1.5} />
-                            Feed
+                        <SidebarMenuLink to='/notes'>
+                            <LucideIcon.MessageCircle size={18} strokeWidth={1.5} />
+                            Notes
                         </SidebarMenuLink>
                         <SidebarMenuLink
                             count={location.pathname !== '/notifications' ? notificationsCount : undefined}

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -81,7 +81,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                 onReply?.();
             } else {
                 await noteMutation.mutateAsync({content: trimmedContent, imageUrl: uploadedImageUrl || undefined});
-                navigate('/feed');
+                navigate('/notes');
             }
 
             setIsOpen(false);

--- a/apps/admin-x-activitypub/src/hooks/use-keyboard-shortcuts.tsx
+++ b/apps/admin-x-activitypub/src/hooks/use-keyboard-shortcuts.tsx
@@ -54,7 +54,7 @@ export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions = {}) => 
                 break;
             case 'r':
                 if (options.isReplyAvailable && options.onOpenReply) {
-                    const isReaderOrNote = location.pathname.includes('/feed/') || location.pathname.includes('/inbox/');
+                    const isReaderOrNote = location.pathname.includes('/notes/') || location.pathname.includes('/reader/');
 
                     if (isReaderOrNote) {
                         e.preventDefault();

--- a/apps/admin-x-activitypub/src/routes.tsx
+++ b/apps/admin-x-activitypub/src/routes.tsx
@@ -30,25 +30,25 @@ export const routes: CustomRouteObject[] = [
         children: [
             {
                 index: true,
-                element: <Navigate to="inbox" />
+                element: <Navigate to="reader" />
             },
             {
-                path: 'inbox',
+                path: 'reader',
                 element: <Inbox />,
-                pageTitle: 'Inbox'
+                pageTitle: 'Reader'
             },
             {
-                path: 'inbox/:postId',
+                path: 'reader/:postId',
                 element: <Inbox />,
-                pageTitle: 'Inbox'
+                pageTitle: 'Reader'
             },
             {
-                path: 'feed',
+                path: 'notes',
                 element: <Feed />,
-                pageTitle: 'Feed'
+                pageTitle: 'Notes'
             },
             {
-                path: 'feed/:postId',
+                path: 'notes/:postId',
                 element: <Note />,
                 pageTitle: 'Note'
             },

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -235,7 +235,7 @@ const Note = () => {
                                             repostCount={item.object.repostCount ?? 0}
                                             type='Note'
                                             onClick={() => {
-                                                navigate(`/${item.object.type === 'Article' ? 'inbox' : 'feed'}/${encodeURIComponent(item.object.id)}`);
+                                                navigate(`/${item.object.type === 'Article' ? 'reader' : 'notes'}/${encodeURIComponent(item.object.id)}`);
                                             }}
                                         />
                                     )
@@ -288,7 +288,7 @@ const Note = () => {
                                                             repostCount={replyGroup.mainReply.object.repostCount ?? 0}
                                                             type='Note'
                                                             onClick={() => {
-                                                                navigate(`/feed/${encodeURIComponent(replyGroup.mainReply.id)}`);
+                                                                navigate(`/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
                                                             }}
                                                             onDelete={handleDelete}
                                                         />
@@ -309,7 +309,7 @@ const Note = () => {
                                                                 repostCount={replyGroup.chain[0].object.repostCount ?? 0}
                                                                 type='Note'
                                                                 onClick={() => {
-                                                                    navigate(`/feed/${encodeURIComponent(replyGroup.chain[0].id)}`);
+                                                                    navigate(`/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
                                                                 }}
                                                                 onDelete={handleDelete}
                                                             />
@@ -336,7 +336,7 @@ const Note = () => {
                                                                     repostCount={chainItem.object.repostCount ?? 0}
                                                                     type='Note'
                                                                     onClick={() => {
-                                                                        navigate(`/feed/${encodeURIComponent(chainItem.id)}`);
+                                                                        navigate(`/notes/${encodeURIComponent(chainItem.id)}`);
                                                                     }}
                                                                     onDelete={handleDelete}
                                                                 />

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -94,7 +94,7 @@ const FeedList:React.FC<FeedListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            navigate(`/feed/${encodeURIComponent(activity.id)}`);
+                                                            navigate(`/notes/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (

--- a/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/InboxList.tsx
@@ -94,7 +94,7 @@ const InboxList:React.FC<InboxListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            navigate(`/inbox/${encodeURIComponent(activity.id)}`);
+                                                            navigate(`/reader/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (
@@ -140,7 +140,7 @@ const InboxList:React.FC<InboxListProps> = ({
                         if (canGoBack) {
                             goBack();
                         } else {
-                            navigate('/inbox');
+                            navigate('/reader');
                         }
                     }
                     setIsReaderOpen(open);
@@ -155,7 +155,7 @@ const InboxList:React.FC<InboxListProps> = ({
                         if (canGoBack) {
                             goBack();
                         } else {
-                            navigate('/inbox');
+                            navigate('/reader');
                         }
                     }} />}
                 </DialogContent>

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -900,7 +900,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                             repostCount={replyGroup.mainReply.object.repostCount ?? 0}
                                                             type='Note'
                                                             onClick={() => {
-                                                                navigate(`/feed/${encodeURIComponent(replyGroup.mainReply.id)}`);
+                                                                navigate(`/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
                                                             }}
                                                             onDelete={handleDelete}
                                                         />
@@ -921,7 +921,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                                 repostCount={replyGroup.chain[0].object.repostCount ?? 0}
                                                                 type='Note'
                                                                 onClick={() => {
-                                                                    navigate(`/feed/${encodeURIComponent(replyGroup.chain[0].id)}`);
+                                                                    navigate(`/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
                                                                 }}
                                                                 onDelete={handleDelete}
                                                             />
@@ -948,7 +948,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                                     repostCount={chainItem.object.repostCount ?? 0}
                                                                     type='Note'
                                                                     onClick={() => {
-                                                                        navigate(`/feed/${encodeURIComponent(chainItem.id)}`);
+                                                                        navigate(`/notes/${encodeURIComponent(chainItem.id)}`);
                                                                     }}
                                                                     onDelete={handleDelete}
                                                                 />

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -229,17 +229,17 @@ const Notifications: React.FC = () => {
         switch (group.type) {
         case 'like':
             if (group.post) {
-                navigate(`/${group.post.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
+                navigate(`/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'reply':
             if (group.post && group.inReplyTo) {
-                navigate(`/feed/${encodeURIComponent(group.post.id)}`);
+                navigate(`/notes/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'repost':
             if (group.post) {
-                navigate(`/${group.post.type === 'article' ? 'inbox' : 'feed'}/${encodeURIComponent(group.post.id)}`);
+                navigate(`/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'follow':
@@ -251,7 +251,7 @@ const Notifications: React.FC = () => {
             break;
         case 'mention':
             if (group.post) {
-                navigate(`/feed/${encodeURIComponent(group.post.id)}`);
+                navigate(`/notes/${encodeURIComponent(group.post.id)}`);
             }
             break;
         }

--- a/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Likes.tsx
@@ -80,9 +80,9 @@ const Likes: React.FC<LikesProps> = ({
                             type={activity.type}
                             onClick={() => {
                                 if (activity.object.type === 'Note') {
-                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/notes/${encodeURIComponent(activity.object.id)}`);
                                 } else if (activity.object.type === 'Article') {
-                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/reader/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />

--- a/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/Posts.tsx
@@ -82,9 +82,9 @@ const Posts: React.FC<PostsProps> = ({
                             type={activity.type}
                             onClick={() => {
                                 if (activity.object.type === 'Note') {
-                                    navigate(`/feed/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/notes/${encodeURIComponent(activity.object.id)}`);
                                 } else if (activity.object.type === 'Article') {
-                                    navigate(`/inbox/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/reader/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -49,7 +49,7 @@ test.describe('Feed', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/feed');
+        await page.goto('#/notes');
 
         // Wait for the feed to load
         const feedList = page.getByRole('list');
@@ -91,7 +91,7 @@ test.describe('Feed', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/feed');
+        await page.goto('#/notes');
 
         // Wait for the feed list to be visible
         const feedList = page.getByTestId('feed-list');
@@ -128,7 +128,7 @@ test.describe('Feed', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/feed');
+        await page.goto('#/notes');
 
         // Wait for the feed list to be visible
         const feedList = page.getByTestId('feed-list');
@@ -175,7 +175,7 @@ test.describe('Feed', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/feed');
+        await page.goto('#/notes');
 
         // Wait for the feed list to be visible
         const feedList = page.getByTestId('feed-list');
@@ -247,7 +247,7 @@ test.describe('Feed', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/feed');
+        await page.goto('#/notes');
 
         // Wait for the feed list to be visible
         const feedList = page.getByTestId('feed-list');

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -13,7 +13,7 @@ test.describe('Feed', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',
-                path: '/feed',
+                path: '/feed/notes',
                 response: feedFixture
             },
             getActivityPubUser: {
@@ -86,7 +86,7 @@ test.describe('Feed', async () => {
         await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',
-                path: '/feed',
+                path: '/feed/notes',
                 response: feedFixture
             }
         }, options: {useActivityPub: true}});
@@ -118,7 +118,7 @@ test.describe('Feed', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',
-                path: '/feed',
+                path: '/feed/notes',
                 response: feedFixture
             },
             likePost: {
@@ -165,7 +165,7 @@ test.describe('Feed', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',
-                path: '/feed',
+                path: '/feed/notes',
                 response: feedFixture
             },
             repostPost: {
@@ -207,7 +207,7 @@ test.describe('Feed', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
                 method: 'GET',
-                path: '/feed',
+                path: '/feed/notes',
                 response: feedFixture
             },
             getPost: {

--- a/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
@@ -13,7 +13,7 @@ test.describe('Inbox', async () => {
         await mockApi({page, requests: {
             getInbox: {
                 method: 'GET',
-                path: '/inbox',
+                path: '/feed/reader',
                 response: inboxFixture
             }
         }, options: {useActivityPub: true}});
@@ -45,7 +45,7 @@ test.describe('Inbox', async () => {
         await mockApi({page, requests: {
             getInbox: {
                 method: 'GET',
-                path: '/inbox',
+                path: '/feed/reader',
                 response: inboxFixture
             },
             getPost: {
@@ -110,7 +110,7 @@ test.describe('Inbox', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getInbox: {
                 method: 'GET',
-                path: '/inbox',
+                path: '/feed/reader',
                 response: inboxFixture
             },
             likePost: {
@@ -156,7 +156,7 @@ test.describe('Inbox', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getInbox: {
                 method: 'GET',
-                path: '/inbox',
+                path: '/feed/reader',
                 response: inboxFixture
             },
             getPost: {
@@ -245,7 +245,7 @@ test.describe('Inbox', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             getInbox: {
                 method: 'GET',
-                path: '/inbox',
+                path: '/feed/reader',
                 response: inboxFixture
             },
             repostPost: {

--- a/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
@@ -18,7 +18,7 @@ test.describe('Inbox', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/inbox');
+        await page.goto('#/reader');
 
         // Wait for the inbox list to be visible
         const inboxList = page.getByTestId('inbox-list');
@@ -70,7 +70,7 @@ test.describe('Inbox', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/inbox');
+        await page.goto('#/reader');
 
         // Wait for the inbox list to be visible
         const inboxList = page.getByTestId('inbox-list');
@@ -84,7 +84,7 @@ test.describe('Inbox', async () => {
         await posts.nth(postIndex).click();
 
         // Verify the route changed
-        await expect(page).toHaveURL(new RegExp(`/inbox/${encodeURIComponent(postFixture.id)}`));
+        await expect(page).toHaveURL(new RegExp(`/reader/${encodeURIComponent(postFixture.id)}`));
 
         // Wait for the modal to show
         await page.waitForSelector('[role="dialog"]', {timeout: 10000});
@@ -120,7 +120,7 @@ test.describe('Inbox', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/inbox');
+        await page.goto('#/reader');
 
         // Wait for the inbox list to be visible
         const inboxList = page.getByTestId('inbox-list');
@@ -196,7 +196,7 @@ test.describe('Inbox', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/inbox');
+        await page.goto('#/reader');
 
         // Wait for the inbox list to be visible
         const inboxList = page.getByTestId('inbox-list');
@@ -255,7 +255,7 @@ test.describe('Inbox', async () => {
             }
         }, options: {useActivityPub: true}});
 
-        await page.goto('#/inbox');
+        await page.goto('#/reader');
 
         // Wait for the inbox list to be visible
         const inboxList = page.getByTestId('inbox-list');

--- a/apps/admin-x-framework/src/api/activitypub.ts
+++ b/apps/admin-x-framework/src/api/activitypub.ts
@@ -112,7 +112,7 @@ export const useBrowseInboxForUser = createQueryWithId<InboxResponseData>({
     headers: {
         Accept: 'application/activity+json'
     },
-    path: id => `/inbox/${id}`
+    path: id => `/reader/${id}`
 });
 
 // This is a frontend root, not using the Ghost admin API


### PR DESCRIPTION
no issues

- Changed "Inbox" to "Reader" and "Feed" to "Notes" throughout the app
- Modified corresponding URLs to reflect new naming convention