### PR TITLE
Removed `updatedBy` & `createdBy` fields in the admin app

### DIFF
--- a/ghost/admin/app/models/api-key.js
+++ b/ghost/admin/app/models/api-key.js
@@ -5,9 +5,7 @@ export default Model.extend({
     secret: attr('string'),
     lastSeenAtUTC: attr('moment-utc'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
 
     integration: belongsTo('integration')
 });

--- a/ghost/admin/app/models/email.js
+++ b/ghost/admin/app/models/email.js
@@ -24,9 +24,7 @@ export default Model.extend({
     feedbackEnabled: attr('boolean'),
 
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('string'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('string'),
 
     post: belongsTo('post'),
 

--- a/ghost/admin/app/models/integration.js
+++ b/ghost/admin/app/models/integration.js
@@ -11,9 +11,7 @@ export default Model.extend(ValidationEngine, {
     iconImage: attr('string'),
     description: attr('string'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
 
     apiKeys: hasMany('api-key', {
         embedded: 'always',

--- a/ghost/admin/app/models/invite.js
+++ b/ghost/admin/app/models/invite.js
@@ -6,9 +6,7 @@ export default Model.extend({
     email: attr('string'),
     expires: attr('number'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
     status: attr('string'),
 
     role: belongsTo('role', {async: false}),

--- a/ghost/admin/app/models/label.js
+++ b/ghost/admin/app/models/label.js
@@ -9,8 +9,6 @@ export default Model.extend(ValidationEngine, {
     slug: attr('string'),
     createdAtUTC: attr('moment-utc'),
     updatedAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
-    updatedBy: attr('number'),
     count: attr('raw'),
 
     feature: service()

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -111,7 +111,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     status: attr('string', {defaultValue: 'draft'}),
     title: attr('string', {defaultValue: ''}),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
     url: attr('string'),
     uuid: attr('string'),
     emailSegment: attr('members-segment-string', {defaultValue: null}),
@@ -123,7 +122,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     showTitleAndFeatureImage: attr('boolean', {defaultValue: true}),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
-    createdBy: belongsTo('user', {async: true}),
     email: belongsTo('email', {async: false}),
     newsletter: belongsTo('newsletter', {embedded: 'always', async: false}),
     publishedBy: belongsTo('user', {async: true}),

--- a/ghost/admin/app/models/role.js
+++ b/ghost/admin/app/models/role.js
@@ -7,8 +7,6 @@ export default Model.extend({
     description: attr('string'),
     createdAtUTC: attr('moment-utc'),
     updatedAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
-    updatedBy: attr('number'),
 
     lowerCaseName: computed('name', function () {
         return (this.name || '').toLocaleLowerCase();

--- a/ghost/admin/app/models/tag.js
+++ b/ghost/admin/app/models/tag.js
@@ -28,8 +28,6 @@ export default Model.extend(ValidationEngine, {
     visibility: attr('string', {defaultValue: 'public'}),
     createdAtUTC: attr('moment-utc'),
     updatedAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
-    updatedBy: attr('number'),
     count: attr('raw'),
 
     isInternal: equal('visibility', 'internal'),

--- a/ghost/admin/app/models/user.js
+++ b/ghost/admin/app/models/user.js
@@ -35,9 +35,7 @@ export default BaseModel.extend(ValidationEngine, {
     metaDescription: attr('string'),
     lastLoginUTC: attr('moment-utc'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
     roles: hasMany('role', {
         embedded: 'always',
         async: false

--- a/ghost/admin/app/models/webhook.js
+++ b/ghost/admin/app/models/webhook.js
@@ -10,9 +10,7 @@ export default Model.extend(ValidationEngine, {
     secret: attr('string'),
     lastTriggeredAtUTC: attr('moment-utc'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr('number'),
     updatedAtUTC: attr('moment-utc'),
-    updatedBy: attr('number'),
 
     integration: belongsTo('integration')
 });

--- a/ghost/admin/mirage/config/invites.js
+++ b/ghost/admin/mirage/config/invites.js
@@ -29,9 +29,7 @@ export default function mockInvites(server) {
         attrs.token = `${invites.all().models.length}-token`;
         attrs.expires = moment.utc().add(1, 'day').valueOf();
         attrs.createdAt = moment.utc().format();
-        attrs.createdBy = 1;
         attrs.updatedAt = moment.utc().format();
-        attrs.updatedBy = 1;
         attrs.status = 'sent';
         /* eslint-enable camelcase */
 

--- a/ghost/admin/mirage/factories/api-key.js
+++ b/ghost/admin/mirage/factories/api-key.js
@@ -14,7 +14,5 @@ export default Factory.extend({
     },
 
     createdAt() { return moment.utc().format(); },
-    createdBy: 1,
-    updatedAt() { return moment.utc().format(); },
-    updatedBy: 1
+    updatedAt() { return moment.utc().format(); }
 });

--- a/ghost/admin/mirage/factories/email.js
+++ b/ghost/admin/mirage/factories/email.js
@@ -13,9 +13,7 @@ export default Factory.extend({
     uuid(i) { return `email-${i}`; },
 
     createdAtUTC: '2019-11-06T12:44:30.000Z',
-    createdBy: 1,
     updatedAtUTC: '2019-11-06T12:44:30.000Z',
-    updatedBy: 1,
 
     sent: trait({
         status: 'sent',

--- a/ghost/admin/mirage/factories/integration.js
+++ b/ghost/admin/mirage/factories/integration.js
@@ -9,9 +9,7 @@ export default Factory.extend({
     type: 'custom',
 
     createdAt() { return moment.utc().format(); },
-    createdBy: 1,
     updatedAt() { return moment.utc().format(); },
-    updatedBy: 1,
 
     afterCreate(integration, server) {
         let contentKey = server.create('api-key', {type: 'content', integration});

--- a/ghost/admin/mirage/factories/invite.js
+++ b/ghost/admin/mirage/factories/invite.js
@@ -6,8 +6,6 @@ export default Factory.extend({
     email(i) { return `invited-user-${i}@example.com`; },
     expires() { return moment.utc().add(1, 'day').valueOf(); },
     createdAt() { return moment.utc().format(); },
-    createdBy() { return 1; },
     updatedAt() { return moment.utc().format(); },
-    updatedBy() { return 1; },
     status() { return 'sent'; }
 });

--- a/ghost/admin/mirage/factories/label.js
+++ b/ghost/admin/mirage/factories/label.js
@@ -3,11 +3,9 @@ import {Factory} from 'miragejs';
 
 export default Factory.extend({
     createdAt() { return moment.utc().toISOString(); },
-    createdBy: 1,
     name(i) { return `Label ${i}`; },
     slug(i) { return `label-${i}`; },
     updatedAt() { return moment.utc().toISOString(); },
-    updatedBy: 1,
     count() {
         // this gets updated automatically by the label serializer
         return {members: 0};

--- a/ghost/admin/mirage/factories/page.js
+++ b/ghost/admin/mirage/factories/page.js
@@ -5,7 +5,6 @@ export default Factory.extend({
     codeinjectionFoot: null,
     codeinjectionHead: null,
     createdAt: '2015-09-11T09:44:29.871Z',
-    createdBy: 1,
     customExcerpt: null,
     customTemplate: null,
     description(i) { return `Title for page ${i}.`; },
@@ -32,7 +31,6 @@ export default Factory.extend({
     twitterTitle: null,
     emailSubject: null,
     updatedAt: '2015-10-19T16:25:07.756Z',
-    updatedBy: 1,
     uuid(i) { return `page-${i}`; },
 
     authors() { return []; },

--- a/ghost/admin/mirage/factories/post.js
+++ b/ghost/admin/mirage/factories/post.js
@@ -6,7 +6,6 @@ export default Factory.extend({
     codeinjectionFoot: null,
     codeinjectionHead: null,
     createdAt: '2015-09-11T09:44:29.871Z',
-    createdBy: 1,
     customExcerpt: null,
     customTemplate: null,
     description(i) { return `Title for post ${i}.`; },
@@ -34,7 +33,6 @@ export default Factory.extend({
     twitterTitle: null,
     emailSubject: null,
     updatedAt: '2015-10-19T16:25:07.756Z',
-    updatedBy: 1,
     uuid(i) { return `post-${i}`; },
 
     authors() { return []; },

--- a/ghost/admin/mirage/factories/role.js
+++ b/ghost/admin/mirage/factories/role.js
@@ -2,9 +2,7 @@ import {Factory} from 'miragejs';
 
 export default Factory.extend({
     createdAt: '2013-11-25T14:48:11.000Z',
-    createdBy: 1,
     description(i) { return `Role ${i}`; },
     name: '',
-    updatedAt: '2013-11-25T14:48:11.000Z',
-    updatedBy: 1
+    updatedAt: '2013-11-25T14:48:11.000Z'
 });

--- a/ghost/admin/mirage/factories/tag.js
+++ b/ghost/admin/mirage/factories/tag.js
@@ -2,7 +2,6 @@ import {Factory} from 'miragejs';
 
 export default Factory.extend({
     createdAt: '2015-09-11T09:44:29.871Z',
-    createdBy: 1,
     description(i) { return `Description for tag ${i}.`; },
     visibility: 'public',
     featureImage(i) { return `/content/images/2015/10/tag-${i}.jpg`; },
@@ -12,7 +11,6 @@ export default Factory.extend({
     parent: null,
     slug(i) { return `tag-${i}`; },
     updatedAt: '2015-10-19T16:25:07.756Z',
-    updatedBy: 1,
     count() {
         // this gets updated automatically by the tag serializer
         return {posts: 0};

--- a/ghost/admin/mirage/factories/user.js
+++ b/ghost/admin/mirage/factories/user.js
@@ -5,7 +5,6 @@ export default Factory.extend({
     bio: null,
     coverImage: null,
     createdAt: '2015-09-02T13:41:50.000Z',
-    createdBy: null,
     email(i) { return `user-${i}@example.com`; },
     profileImage: '//www.gravatar.com/avatar/3ae045bc198a157401827c8455cd7c99?s=250&d=mm&r=x',
     lastLogin: '2015-11-02T16:12:05.000Z',
@@ -17,7 +16,6 @@ export default Factory.extend({
     status: 'active',
     tour: null,
     updatedAt: '2015-11-02T16:12:05.000Z',
-    updatedBy: '1',
     website: 'http://example.com',
     posts() { return []; },
     roles() { return []; }

--- a/ghost/admin/mirage/factories/webhook.js
+++ b/ghost/admin/mirage/factories/webhook.js
@@ -12,7 +12,5 @@ export default Factory.extend({
     lastTriggeredAt: null,
 
     createdAt() { return moment.utc().format(); },
-    createdBy: 1,
-    updatedAt() { return moment.utc().format(); },
-    updatedBy: 1
+    updatedAt() { return moment.utc().format(); }
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1597
ref https://github.com/TryGhost/Ghost/pull/24053

Removed `updatedBy` & `createdBy` fields in the admin app as they are deprecated and should not be being used anywhere meaningful in the codebase