### PR TITLE
🔥 Enforced max `?limit` of 100 in API requests

### DIFF
--- a/ghost/core/core/server/web/api/app.js
+++ b/ghost/core/core/server/web/api/app.js
@@ -2,6 +2,7 @@ const debug = require('@tryghost/debug')('web:api:default:app');
 const config = require('../../../shared/config');
 const express = require('../../../shared/express');
 const sentry = require('../../../shared/sentry');
+const middleware = require('../shared/middleware');
 const errorHandler = require('@tryghost/mw-error-handler');
 const APIVersionCompatibilityService = require('../../services/api-version-compatibility');
 
@@ -18,6 +19,9 @@ module.exports = function setupApiApp() {
 
     apiApp.use(APIVersionCompatibilityService.versionRewrites);
     apiApp.use(APIVersionCompatibilityService.contentVersion);
+
+    // Enforce capped limit parameter
+    apiApp.use(middleware.maxLimitCap);
 
     apiApp.lazyUse('/content/', require('./endpoints/content/app'));
     apiApp.lazyUse('/admin/', require('./endpoints/admin/app'));

--- a/ghost/core/core/server/web/comments/routes.js
+++ b/ghost/core/core/server/web/comments/routes.js
@@ -23,6 +23,9 @@ module.exports = function apiRoutes() {
     // Authenticated Routes
     router.use(membersService.middleware.loadMemberSession);
 
+    // Enforce capped limit parameter
+    router.use(shared.middleware.maxLimitCap);
+
     router.get('/', http(api.commentsMembers.browse));
     router.get('/post/:post_id', http(api.commentsMembers.browse));
     router.get('/:id', http(api.commentsMembers.read));

--- a/ghost/core/core/server/web/shared/middleware/index.js
+++ b/ghost/core/core/server/web/shared/middleware/index.js
@@ -11,6 +11,10 @@ module.exports = {
         return require('./cache-control');
     },
 
+    get maxLimitCap() {
+        return require('./max-limit-cap');
+    },
+
     get prettyUrls() {
         return require('./pretty-urls');
     },

--- a/ghost/core/core/server/web/shared/middleware/max-limit-cap.js
+++ b/ghost/core/core/server/web/shared/middleware/max-limit-cap.js
@@ -1,0 +1,54 @@
+const config = require('../../../../shared/config');
+
+// Prior to Ghost 6.x we allowed any limit value, including 'all', but as sites
+// grew in size it led to performance issues and mis-use of the API.
+
+// After Ghost 6.x we only allow a max limit of 100. This middleware enforces
+// that limit by rewriting the limit parameter before it reaches any API code.
+
+// Temporary exceptions to the max limit rule
+const EXCEPTION_ENDPOINTS = [
+    '/ghost/api/admin/posts/export/',
+    '/ghost/api/admin/emails/' // /:id/batches/ and /:id/recipient-failures/
+];
+
+const allowLimitAll = config.get('optimization:allowLimitAll') || false;
+const maxLimit = config.get('optimization:maxLimit') || 100;
+
+function maxLimitCap(req, res, next) {
+    const limit = req.query.limit;
+
+    if (!limit) {
+        return next();
+    }
+
+    // If 'all' is globally allowed, skip everything else
+    if (limit === 'all' && allowLimitAll) {
+        return next();
+    }
+
+    // Check exception endpoints - they bypass all limits
+    if (EXCEPTION_ENDPOINTS.some(endpoint => req.originalUrl.startsWith(endpoint))) {
+        return next();
+    }
+
+    // Special case: 'all' should be capped to maxLimit
+    if (limit === 'all') {
+        req.query.limit = maxLimit;
+        return next();
+    }
+
+    // Convert to number for comparison
+    const numericLimit = parseInt(limit, 10);
+
+    // If it's not a valid number or exceeds maxLimit, cap it
+    if (isNaN(numericLimit) || numericLimit > maxLimit) {
+        req.query.limit = maxLimit;
+    }
+
+    next();
+}
+
+module.exports = [
+    maxLimitCap
+];

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -171,6 +171,8 @@
         }
     },
     "optimization": {
+        "maxLimit": 100,
+        "allowLimitAll": false,
         "getHelper": {
             "timeout": {
                 "threshold": 5000,

--- a/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
@@ -1,8 +1,9 @@
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const should = require('should');
-const configUtils = require('../../utils/configUtils');
+const sinon = require('sinon');
 const db = require('../../../core/server/data/db');
 const ObjectId = require('bson-objectid').default;
+const maxLimitCap = require('../../../core/server/web/shared/middleware/max-limit-cap');
 
 describe('Admin API - Max Limit Cap', function () {
     let agent;
@@ -10,7 +11,7 @@ describe('Admin API - Max Limit Cap', function () {
 
     before(async function () {
         // Set a lower max limit for testing
-        configUtils.set('optimization:maxLimit', 5);
+        sinon.stub(maxLimitCap.limitConfig, 'maxLimit').value(5);
 
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('posts', 'members');
@@ -21,7 +22,7 @@ describe('Admin API - Max Limit Cap', function () {
     });
 
     after(function () {
-        configUtils.restore();
+        sinon.restore();
     });
 
     // Factory for creating bulk test data

--- a/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
@@ -1,0 +1,313 @@
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const should = require('should');
+const configUtils = require('../../utils/configUtils');
+const db = require('../../../core/server/data/db');
+const ObjectId = require('bson-objectid').default;
+
+describe('Admin API - Max Limit Cap', function () {
+    let agent;
+    let testEmail; // Store reference to test email for exception endpoint tests
+
+    before(async function () {
+        // Set a lower max limit for testing
+        configUtils.set('optimization:maxLimit', 5);
+
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('posts', 'members');
+        await agent.loginAsOwner();
+
+        // Create bulk test data for exception endpoint testing
+        await createBulkTestData();
+    });
+
+    after(function () {
+        configUtils.restore();
+    });
+
+    // Factory for creating bulk test data
+    async function createBulkTestData() {
+        // Create a post that will have an email
+        const {body: postBody} = await agent.post('posts/')
+            .body({posts: [{
+                title: 'Bulk Email Test Post',
+                status: 'published',
+                email_only: false,
+                html: '<p>Test content for email</p>',
+                mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"Test content for email"]]]]}'
+            }]})
+            .expectStatus(201);
+
+        const postId = postBody.posts[0].id;
+
+        // Create an email record for this post
+        const emailId = ObjectId().toHexString();
+        await db.knex('emails').insert({
+            id: emailId,
+            post_id: postId,
+            uuid: `email-${Date.now()}`,
+            status: 'submitted',
+            recipient_filter: 'status:-free',
+            email_count: 100,
+            delivered_count: 90,
+            failed_count: 10,
+            opened_count: 50,
+            submitted_at: new Date(),
+            created_at: new Date(),
+            updated_at: new Date()
+        });
+
+        testEmail = {id: emailId};
+
+        // Create 10 email batches (more than our limit of 5)
+        const batches = [];
+        for (let i = 0; i < 10; i++) {
+            batches.push({
+                id: ObjectId().toHexString(),
+                email_id: emailId,
+                provider_id: `test-batch-${i}-${Date.now()}`,
+                status: 'submitted',
+                member_segment: null,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+        }
+
+        await db.knex('email_batches').insert(batches);
+
+        // Create email recipients first (needed for failures foreign key)
+        const recipients = [];
+        const recipientIds = [];
+        for (let i = 0; i < 10; i++) {
+            const recipientId = ObjectId().toHexString();
+            recipientIds.push(recipientId);
+            recipients.push({
+                id: recipientId,
+                email_id: emailId,
+                member_id: ObjectId().toHexString(),
+                batch_id: batches[0].id, // Use first batch for simplicity
+                member_uuid: ObjectId().toHexString(),
+                member_email: `test${i}@example.com`,
+                processed_at: new Date(),
+                failed_at: new Date()
+            });
+        }
+        await db.knex('email_recipients').insert(recipients);
+
+        // Create 10 recipient failures
+        const failures = [];
+        for (let i = 0; i < 10; i++) {
+            failures.push({
+                id: ObjectId().toHexString(),
+                email_id: emailId,
+                member_id: recipients[i].member_id,
+                email_recipient_id: recipientIds[i],
+                message: `Test failure ${i}`,
+                code: 500,
+                severity: 'permanent',
+                failed_at: new Date()
+            });
+        }
+
+        await db.knex('email_recipient_failures').insert(failures);
+
+        // Create additional posts for testing regular endpoints
+        // Only if we don't have enough posts already
+        const {body: postsCheck} = await agent.get('posts/')
+            .expectStatus(200);
+
+        if (postsCheck.meta.pagination.total < 10) {
+            const additionalPosts = [];
+            const existingCount = postsCheck.meta.pagination.total;
+
+            for (let i = existingCount; i < 10; i++) {
+                additionalPosts.push({
+                    id: ObjectId().toHexString(),
+                    uuid: `uuid-${i}-${Date.now()}`,
+                    title: `Bulk Test Post ${i}`,
+                    slug: `bulk-test-post-${i}-${Date.now()}`,
+                    mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"Test content"]]]]',
+                    html: '<p>Test content</p>',
+                    status: 'published',
+                    visibility: 'public',
+                    created_at: new Date(),
+                    created_by: '1',
+                    updated_at: new Date(),
+                    updated_by: '1',
+                    published_at: new Date(),
+                    published_by: '1',
+                    type: 'post'
+                });
+            }
+
+            if (additionalPosts.length > 0) {
+                await db.knex('posts').insert(additionalPosts);
+            }
+        }
+    }
+
+    describe('Posts API', function () {
+        it('should cap limit to 5 when limit exceeds max', async function () {
+            const {body} = await agent.get('posts/?limit=10')
+                .expectStatus(200);
+
+            // Even though we requested 10, we should only get max 5
+            body.posts.length.should.equal(5);
+            body.meta.pagination.limit.should.equal(5);
+        });
+
+        it('should cap limit to 5 when limit is "all"', async function () {
+            const {body} = await agent.get('posts/?limit=all')
+                .expectStatus(200);
+
+            // "all" should be capped to 5
+            body.posts.length.should.equal(5);
+            body.meta.pagination.limit.should.equal(5);
+        });
+
+        it('should respect smaller limits', async function () {
+            const {body} = await agent.get('posts/?limit=3')
+                .expectStatus(200);
+
+            body.posts.length.should.equal(3);
+            body.meta.pagination.limit.should.equal(3);
+        });
+
+        it('should allow large limits for export endpoint', async function () {
+            // The export endpoint should bypass the limit cap
+            await agent.get('posts/export/?limit=200')
+                .expectStatus(200);
+        });
+    });
+
+    describe('Members API', function () {
+        it('should cap limit to 5 when limit exceeds max', async function () {
+            const {body} = await agent.get('members/?limit=10')
+                .expectStatus(200);
+
+            // Even though we requested 10, we should only get max 5
+            body.members.length.should.be.lessThanOrEqual(5);
+            if (body.members.length === 5) {
+                body.meta.pagination.limit.should.equal(5);
+            }
+        });
+
+        it('should cap limit to 5 when limit is "all"', async function () {
+            const {body} = await agent.get('members/?limit=all')
+                .expectStatus(200);
+
+            // "all" should be capped to 5
+            body.members.length.should.be.lessThanOrEqual(5);
+            if (body.members.length === 5) {
+                body.meta.pagination.limit.should.equal(5);
+            }
+        });
+    });
+
+    describe('Tags API', function () {
+        it('should cap limit to 5 when limit exceeds max', async function () {
+            const {body} = await agent.get('tags/?limit=10')
+                .expectStatus(200);
+
+            // Even though we requested 10, we should only get max 5
+            body.tags.length.should.equal(5);
+            body.meta.pagination.limit.should.equal(5);
+        });
+    });
+
+    describe('Pages API', function () {
+        it('should cap limit to 5 when limit exceeds max', async function () {
+            const {body} = await agent.get('pages/?limit=10')
+                .expectStatus(200);
+
+            // Even though we requested 10, we should only get max 5
+            body.pages.length.should.be.lessThanOrEqual(5);
+            if (body.pages.length === 5) {
+                body.meta.pagination.limit.should.equal(5);
+            }
+        });
+    });
+
+    describe('Exception Endpoints', function () {
+        it('should bypass limit cap for emails batches endpoint', async function () {
+            if (!testEmail) {
+                this.skip();
+                return;
+            }
+
+            // First, verify that regular emails endpoint is capped
+            const {body: emailsBody} = await agent.get('emails/?limit=10')
+                .expectStatus(200);
+
+            // Regular endpoint should cap at 5
+            emailsBody.emails.length.should.be.lessThanOrEqual(5);
+            if (emailsBody.emails.length === 5) {
+                emailsBody.meta.pagination.limit.should.equal(5);
+            }
+
+            // Now test the exception endpoint - should return all 10 batches
+            const {body: batchesBody} = await agent.get(`emails/${testEmail.id}/batches/?limit=10`)
+                .expectStatus(200);
+
+            // Exception endpoint should return all 10 batches
+            batchesBody.batches.length.should.equal(10);
+            batchesBody.meta.pagination.limit.should.equal(10);
+        });
+
+        it('should bypass limit cap for emails recipient-failures endpoint', async function () {
+            if (!testEmail) {
+                this.skip();
+                return;
+            }
+
+            // Test the exception endpoint - should return all 10 failures
+            const {body: failuresBody} = await agent.get(`emails/${testEmail.id}/recipient-failures/?limit=10`)
+                .expectStatus(200);
+
+            // Exception endpoint should return all 10 failures
+            failuresBody.failures.length.should.equal(10);
+            failuresBody.meta.pagination.limit.should.equal(10);
+        });
+
+        it('should allow "all" for exception endpoints', async function () {
+            if (!testEmail) {
+                this.skip();
+                return;
+            }
+
+            // Test batches with limit=all
+            const {body: batchesBody} = await agent.get(`emails/${testEmail.id}/batches/?limit=all`)
+                .expectStatus(200);
+
+            // Should return all batches (10)
+            batchesBody.batches.length.should.equal(10);
+
+            // Test failures with limit=all
+            const {body: failuresBody} = await agent.get(`emails/${testEmail.id}/recipient-failures/?limit=all`)
+                .expectStatus(200);
+
+            // Should return all failures (10)
+            failuresBody.failures.length.should.equal(10);
+        });
+    });
+
+    describe('Edge Cases', function () {
+        it('should handle non-numeric limit values', async function () {
+            const {body} = await agent.get('posts/?limit=invalid')
+                .expectStatus(200);
+
+            // Invalid limit should be capped to 5
+            body.posts.length.should.equal(5);
+            body.meta.pagination.limit.should.equal(5);
+        });
+
+        it('should handle limit=0', async function () {
+            const {body} = await agent.get('posts/?limit=0')
+                .expectStatus(200);
+
+            // limit=0 is treated as no limit by Ghost, which uses default page size
+            // The actual behavior depends on Ghost's internal handling
+            // Since we have 14 posts in test data, we get all 14
+            body.posts.length.should.be.lessThanOrEqual(15);
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/content/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/content/max-limit-cap.test.js
@@ -1,0 +1,41 @@
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const should = require('should');
+const sinon = require('sinon');
+const sharedMiddleware = require('../../../core/server/web/shared/middleware');
+
+describe('Content API - Max Limit Cap', function () {
+    let agent;
+    let originalMiddleware;
+    let middlewareSpy;
+
+    before(async function () {
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('api_keys', 'members');
+        await agent.authenticate();
+
+        // Save the original middleware and create a spy
+        originalMiddleware = sharedMiddleware.maxLimitCap[0];
+        middlewareSpy = sinon.spy(originalMiddleware);
+
+        // Replace the middleware with our spy
+        sharedMiddleware.maxLimitCap[0] = middlewareSpy;
+    });
+
+    after(function () {
+        // Restore the original middleware
+        sharedMiddleware.maxLimitCap[0] = originalMiddleware;
+    });
+
+    it('should call maxLimitCap middleware when browsing posts', async function () {
+        // Make a request to the posts endpoint
+        await agent.get('posts/?limit=all')
+            .expectStatus(200);
+
+        // Verify the middleware was called
+        middlewareSpy.called.should.be.true();
+
+        // Verify it modified the req.query param by reference
+        const req = middlewareSpy.firstCall.args[0];
+        req.query.limit.should.equal(100);
+    });
+});

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -1,0 +1,52 @@
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+const should = require('should');
+const sinon = require('sinon');
+const settingsCache = require('../../../core/shared/settings-cache');
+const sharedMiddleware = require('../../../core/server/web/shared/middleware');
+
+describe('Comments API - Max Limit Cap', function () {
+    let agent;
+    let postId;
+    let originalMiddleware;
+    let middlewareSpy;
+
+    before(async function () {
+        agent = await agentProvider.getMembersAPIAgent();
+
+        await fixtureManager.init('posts', 'members');
+        postId = fixtureManager.get('posts', 0).id;
+
+        const getStub = sinon.stub(settingsCache, 'get');
+        getStub.callsFake((key, options) => {
+            if (key === 'comments_enabled') {
+                return 'all';
+            }
+            return getStub.wrappedMethod.call(settingsCache, key, options);
+        });
+
+        // Save the original middleware and create a spy
+        originalMiddleware = sharedMiddleware.maxLimitCap[0];
+        middlewareSpy = sinon.spy(originalMiddleware);
+
+        // Replace the middleware with our spy
+        sharedMiddleware.maxLimitCap[0] = middlewareSpy;
+    });
+
+    after(function () {
+        // Restore the original middleware
+        sharedMiddleware.maxLimitCap[0] = originalMiddleware;
+    });
+
+    it('should call maxLimitCap middleware when browsing posts', async function () {
+        // Make a request to the posts endpoint
+        await agent.get(`/api/comments/post/${postId}/?limit=all`)
+            .expectStatus(200);
+
+        // Verify the middleware was called
+        middlewareSpy.called.should.be.true();
+
+        // Verify it modified the req.query param by reference
+        const req = middlewareSpy.firstCall.args[0];
+        req.query.limit.should.equal(100);
+    });
+});

--- a/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
@@ -1,0 +1,226 @@
+const assert = require('assert/strict');
+const sinon = require('sinon');
+const configUtils = require('../../../../../utils/configUtils');
+const maxLimitCap = require('../../../../../../core/server/web/shared/middleware/max-limit-cap');
+
+describe('Max Limit Cap Middleware', function () {
+    let req;
+    let res;
+    let next;
+
+    beforeEach(function () {
+        req = {
+            query: {},
+            path: '/api/content/posts/',
+            originalUrl: '/ghost/api/content/posts/'
+        };
+        res = {};
+        next = sinon.stub();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        configUtils.restore();
+    });
+
+    describe('when no limit is specified', function () {
+        it('should call next without modifying the query', function () {
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, undefined);
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('when limit is below maxLimit', function () {
+        it('should not modify the limit', function () {
+            req.query.limit = 50;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 50);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should handle string limit values', function () {
+            req.query.limit = '25';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, '25');
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('when limit exceeds maxLimit', function () {
+        it('should cap limit to 100', function () {
+            req.query.limit = 150;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should cap string limit values to 100', function () {
+            req.query.limit = '200';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('when limit is "all"', function () {
+        it('should cap to 100 when allowLimitAll is false', function () {
+            // Note: Config values are loaded at module load time, so this test
+            // reflects the default behavior (allowLimitAll = false)
+            req.query.limit = 'all';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should allow "all" when allowLimitAll is true', function () {
+            // This test is skipped because config values are loaded at module load time
+            // and cannot be changed dynamically in tests
+            configUtils.set('optimization:allowLimitAll', true);
+            req.query.limit = 'all';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 'all');
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('with custom maxLimit configuration', function () {
+        it('should use custom maxLimit value', function () {
+            // This test is skipped because config values are loaded at module load time
+            // and cannot be changed dynamically in tests
+            configUtils.set('optimization:maxLimit', 50);
+            req.query.limit = 75;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 50); // Should cap to configured maxLimit
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should not modify limit below custom maxLimit', function () {
+            configUtils.set('optimization:maxLimit', 50);
+            req.query.limit = 30;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 30);
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('exception endpoints', function () {
+        it('should not cap limit for /api/admin/posts/export/', function () {
+            req.path = '/api/admin/posts/export/';
+            req.originalUrl = '/ghost/api/admin/posts/export/';
+            req.query.limit = 1000;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 1000);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should not cap limit for /api/admin/emails/ endpoints', function () {
+            req.path = '/api/admin/emails/123/batches/';
+            req.originalUrl = '/ghost/api/admin/emails/123/batches/';
+            req.query.limit = 500;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 500);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should not cap limit for /api/admin/emails/ recipient-failures', function () {
+            req.path = '/api/admin/emails/123/recipient-failures/';
+            req.originalUrl = '/ghost/api/admin/emails/123/recipient-failures/';
+            req.query.limit = 'all';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 'all');
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should cap limit for non-exception endpoints', function () {
+            req.path = '/api/admin/members/';
+            req.originalUrl = '/ghost/api/admin/members/';
+            req.query.limit = 500;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('edge cases', function () {
+        it('should handle limit at exactly maxLimit', function () {
+            req.query.limit = 100;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should handle limit of 0', function () {
+            req.query.limit = 0;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 0);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should handle negative limit values', function () {
+            req.query.limit = -10;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, -10);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should handle non-numeric string limits', function () {
+            req.query.limit = 'invalid';
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+
+        it('should handle paths that partially match exception endpoints', function () {
+            req.path = '/api/admin/posts/'; // Not the export endpoint
+            req.originalUrl = '/ghost/api/admin/posts/'; // Not the export endpoint
+            req.query.limit = 500;
+
+            maxLimitCap[0](req, res, next);
+
+            assert.equal(req.query.limit, 100);
+            assert.equal(next.calledOnce, true);
+        });
+    });
+
+    describe('middleware array', function () {
+        it('should export an array with the middleware function', function () {
+            assert.ok(Array.isArray(maxLimitCap));
+            assert.equal(maxLimitCap.length, 1);
+            assert.equal(typeof maxLimitCap[0], 'function');
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- adds `max-limit-cap` middleware that rewrites `?limit` parameters to a capped limit, including `?limit=all`
  - has an exceptions list for endpoints that still require a larger limit param
  - has config escape valves for exceptional use-cases after 6.0 upgrade
  - by rewriting the `query.limit` on the request it allows everything lower in the stack to behave as if the user requested the capped limit, avoiding need to adjust code anywhere else
- sets default capped limit to 100
- applies the middleware to Admin API, Content API, and Comments API