### PR TITLE
Update self-service migration token expiration time to 24 hours

### DIFF
--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -53,7 +53,7 @@ export default class MigrateService extends Service {
                     kid: id
                 })
                 .setIssuedAt()
-                .setExpirationTime('15m')
+                .setExpirationTime('24h')
                 .setAudience('/admin/')
                 .sign(encodedSecret);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/CON-307/

- The current token expiration time of 15 minutes only allows enough time to process uploaded files, with no external network requests
- Increasing the expiration time to 24 hours will give self-service migrations plenty of time to perform external requests and scrape information that's only available on the source website.
- It also allows the service to queue migrations so we can run at a set concurrency to limit total requests to any specific platform.