### PR TITLE
Added AP notification badge for new nav bar

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -29,8 +29,14 @@
             {{#if (and (feature "updatedMainNav") this.session.user.isAdmin)}}
                 <ul class="gh-nav-list gh-nav-main">
                     {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
-                        <li>
-                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "ap-network" class="gh-icon-ap-network"}}Network</LinkTo>
+                        <li class="relative gh-nav-list-ap">
+                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "ap-network" class="gh-icon-ap-network"}}Network
+                                {{#unless this.notificationsCount.isLoading}}
+                                    {{#if (gt this.notificationsCount.count 0)}}
+                                        <span class="gh-nav-member-count">{{format-number this.notificationsCount.count}}</span>
+                                    {{/if}}
+                                {{/unless}}
+                            </LinkTo>
                         </li>
                     {{/if}}
                     {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -67,7 +67,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
         const currentRoute = this.router.currentRouteName || '';
         // Fetch notifications count if not on activitypub-x route
-        if (!currentRoute.startsWith('activitypub-x')) {
+        if (this.settings.socialWebEnabled && !currentRoute.startsWith('activitypub-x')) {
             this.notificationsCount.fetchCount();
         }
 
@@ -75,7 +75,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
             const current = this.router.currentRouteName || '';
             const prev = this.previousRoute || '';
 
-            if (prev.startsWith('activitypub-x') && !current.startsWith('activitypub-x')) {
+            if (this.settings.socialWebEnabled && prev.startsWith('activitypub-x') && !current.startsWith('activitypub-x')) {
                 this.notificationsCount.fetchCount();
             }
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2179/

- New nav bar should show AP notification count if AP is enabled
- The notification count should be fetched only when AP is enabled 
