### PR TITLE
Added handling for single data points in Newsletters > Members chart

### DIFF
--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -298,9 +298,30 @@ const Newsletters: React.FC = () => {
             return [];
         }
 
+        const deltas = subscriberStatsData.stats[0].deltas;
+        
+        // If we only have one data point, create two points spanning the range
+        if (deltas.length === 1) {
+            const singlePoint = deltas[0];
+            const now = new Date();
+            const rangeInDays = range;
+            const startDate = new Date(now.getTime() - (rangeInDays * 24 * 60 * 60 * 1000));
+            
+            return [
+                {
+                    ...singlePoint,
+                    date: startDate.toISOString().split('T')[0] // Start of range
+                },
+                {
+                    ...singlePoint,
+                    date: now.toISOString().split('T')[0] // End of range (today)
+                }
+            ];
+        }
+
         // Convert to the required format - already in the correct format
-        return subscriberStatsData.stats[0].deltas;
-    }, [subscriberStatsData]);
+        return deltas;
+    }, [subscriberStatsData, range]);
 
     // Create avgsData from newsletter stats for the bar charts
     const avgsData: AvgsDataItem[] = useMemo(() => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1851/
- added handling for single data point responses from the backend

We don't want a single data point displayed in the graph. We need a starting and end data point so that we have a line to work with, even if it's flat, to keep data presentation consistent.