### PR TITLE
Updated Sodo-Search to use new search index endpoint for posts

### DIFF
--- a/apps/sodo-search/src/App.test.js
+++ b/apps/sodo-search/src/App.test.js
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 test('renders Sodo Search app component', () => {
     nock('http://localhost:3000/ghost/api/content')
-        .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+        .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
         .reply(200, {
             posts: []
         })

--- a/apps/sodo-search/src/search-index.js
+++ b/apps/sodo-search/src/search-index.js
@@ -104,7 +104,7 @@ export default class SearchIndex {
         this.search = this.search.bind(this);
     }
 
-    async #initPostIndex() {
+    async #populatePostIndex() {
         const posts = await this.#fetchPosts();
 
         if (posts.length > 0) {
@@ -113,11 +113,17 @@ export default class SearchIndex {
     }
 
     async #fetchPosts() {
-        const url = `${this.apiUrl}/ghost/api/content/search-index/posts/?key=${this.apiKey}`;
-        const response = await fetch(url);
-        const json = await response.json();
+        try {
+            const url = `${this.apiUrl}/ghost/api/content/search-index/posts/?key=${this.apiKey}`;
+            const response = await fetch(url);
+            const json = await response.json();
 
-        return json.posts;
+            return json.posts;
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Error fetching posts:', error);
+            return [];
+        }
     }
 
     #updatePostIndex(posts) {
@@ -139,7 +145,7 @@ export default class SearchIndex {
     }
 
     async init() {
-        await this.#initPostIndex();
+        await this.#populatePostIndex();
 
         let authors = await this.api.authors.browse({
             limit: '10000',

--- a/apps/sodo-search/src/search-index.test.js
+++ b/apps/sodo-search/src/search-index.test.js
@@ -8,7 +8,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, storage: localStorage});
 
         const scope = nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: []
             })
@@ -38,7 +38,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, storage: localStorage});
 
         nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: [{
                     id: 'sounique',
@@ -115,7 +115,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, dir: 'ltr', storage: localStorage});
 
         nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: [{
                     id: 'sounique',
@@ -191,7 +191,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, dir: 'ltr', storage: localStorage});
 
         nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: [{
                     id: 'sounique',
@@ -272,7 +272,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, storage: localStorage});
 
         nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: [{
                     id: 'post',
@@ -344,7 +344,7 @@ describe('search index', function () {
         const searchIndex = new SearchIndex({adminUrl, apiKey, dir: 'ltr', storage: localStorage});
 
         nock('http://localhost:3000/ghost/api/content')
-            .get('/posts/?key=69010382388f9de5869ad6e558&limit=10000&fields=id%2Cslug%2Ctitle%2Cexcerpt%2Curl%2Cupdated_at%2Cvisibility&order=updated_at%20DESC')
+            .get('/search-index/posts/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 posts: [{
                     id: 'sounique',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106
ref https://github.com/TryGhost/Ghost/pull/24077

- the Content API now exposes a new endpoint for building a search index for posts, which returns up to 10k results
