### PR TITLE
Updated top posts to sort by open rate desc

### DIFF
--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -6,7 +6,7 @@ import {useNewsletterBasicStats, useNewsletterClickStats, useNewsletterStats, us
 /**
  * Represents the possible fields to order top newsletters by.
  */
-export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate desc' | 'sent_to desc' | 'date asc' | 'open_rate asc' | 'click_rate asc' | 'sent_to asc';
+export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate desc' | 'sent_to desc';
 
 /**
  * Hook to fetch Newsletter Stats, handling the conversion from a numeric range

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -197,7 +197,7 @@ const TopNewslettersTable: React.FC<{
     selectedNewsletterId: string | null | undefined;
     shouldFetchStats: boolean;
 }> = React.memo(({range, selectedNewsletterId, shouldFetchStats}) => {
-    const [sortBy, setSortBy] = useState<TopNewslettersOrder>('date desc');
+    const [sortBy, setSortBy] = useState<TopNewslettersOrder>('open_rate desc');
 
     return (
         <Card className='w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]'>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2180/
- removed asc options as they aren't in use
- default is not open_rate desc