### PR TITLE
Shipped inline follow and follow suggestions in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -16,7 +16,6 @@ import {
     PopoverTrigger,
     buttonVariants
 } from '@tryghost/shade';
-import {useFeatureFlags} from '../../lib/feature-flags';
 
 interface FeedItemMenuProps {
     trigger: React.ReactNode;
@@ -43,7 +42,6 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
     onFollow = () => {},
     onUnfollow = () => {}
 }) => {
-    const {isEnabled} = useFeatureFlags();
     const handleCopyLinkClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         onCopyLink();

--- a/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
+++ b/apps/admin-x-activitypub/src/components/feed/FeedItemMenu.tsx
@@ -79,7 +79,7 @@ const FeedItemMenu: React.FC<FeedItemMenuProps> = ({
                                 </Button>
                             </PopoverClose>
                         }
-                        {!authoredByMe && isEnabled('follow') &&
+                        {!authoredByMe &&
                             <PopoverClose asChild>
                                 <Button className='justify-start' variant='ghost' onClick={handleFollowClick}>
                                     {followedByMe ? <LucideIcon.UserRoundMinus /> : <LucideIcon.UserRoundPlus />}

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -4,7 +4,6 @@ import getUsername from '@utils/get-username';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LucideIcon, Skeleton} from '@tryghost/shade';
 import {toast} from 'sonner';
-import {useFeatureFlags} from '../../lib/feature-flags';
 import {useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -76,7 +75,6 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
     let imageClass = 'z-10 object-cover rounded-full outline outline-[0.5px] outline-offset-[-0.5px] outline-black/10';
     const [iconUrl, setIconUrl] = useState(author?.icon?.url);
     const navigate = useNavigate();
-    const {isEnabled} = useFeatureFlags();
 
     const followMutation = useFollowMutationForUser(
         'index',

--- a/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
+++ b/apps/admin-x-activitypub/src/components/global/APAvatar.tsx
@@ -160,7 +160,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
 
     const title = `${author?.name} ${handle}`;
     const isClickedUser = avatarClickedUser === handle;
-    const displayFollowButton = isEnabled('follow') && (showFollowButton || isClickedUser);
+    const displayFollowButton = showFollowButton || isClickedUser;
 
     if (iconUrl) {
         return (

--- a/apps/admin-x-activitypub/src/lib/feature-flags.tsx
+++ b/apps/admin-x-activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['follow'] as const;
+export const FEATURE_FLAGS = [] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -100,7 +100,7 @@ const FeedList:React.FC<FeedListProps> = ({
                                                     {index < activities.length - 1 && (
                                                         <Separator />
                                                     )}
-                                                    {index === 3 && isEnabled('follow') && (
+                                                    {index === 3 && (
                                                         <SuggestedProfiles />
                                                     )}
                                                     {index === loadMoreIndex && (

--- a/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/components/FeedList.tsx
@@ -9,7 +9,6 @@ import {Button, LoadingIndicator, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
 export type FeedListProps = {
@@ -30,7 +29,6 @@ const FeedList:React.FC<FeedListProps> = ({
     isFetchingNextPage
 }) => {
     const navigate = useNavigate();
-    const {isEnabled} = useFeatureFlags();
 
     const observerRef = useRef<IntersectionObserver | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
ref PROD-1957, PROD-1947, PROD-2065

- removed feature flag `follow` that was used in all three features
- enabled inline follow suggestions in Notes
- enabled follow/unfollow menu to feed menu item
- enabled follow icon besides user avatars