### PR TITLE
Added search index endpoint for authors in Content API

### DIFF
--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -11,6 +11,15 @@ const controller = {
         query() {
             return searchIndexService.fetchPosts();
         }
+    },
+    fetchAuthors: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: true,
+        query() {
+            return searchIndexService.fetchAuthors();
+        }
     }
 };
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -29,5 +29,29 @@ module.exports = {
         frame.response = {
             posts
         };
+    },
+
+    async fetchAuthors(models, apiConfig, frame) {
+        debug('fetchAuthors');
+
+        let authors = [];
+
+        const keys = [
+            'id',
+            'slug',
+            'name',
+            'url',
+            'profile_image'
+        ];
+
+        for (let model of models.data) {
+            let author = await mappers.authors(model, frame);
+            author = _.pick(author, keys);
+            authors.push(author);
+        }
+
+        frame.response = {
+            authors
+        };
     }
 };

--- a/ghost/core/core/server/services/search-index/SearchIndexService.js
+++ b/ghost/core/core/server/services/search-index/SearchIndexService.js
@@ -1,6 +1,7 @@
 module.exports = class SearchIndexService {
-    constructor({PostsService}) {
+    constructor({PostsService, models}) {
         this.PostsService = PostsService;
+        this.models = models;
     }
 
     async fetchPosts() {
@@ -13,5 +14,17 @@ module.exports = class SearchIndexService {
         const posts = await this.PostsService.browsePosts(options);
 
         return posts;
+    }
+
+    async fetchAuthors() {
+        const options = {
+            limit: '10000',
+            order: 'updated_at DESC',
+            columns: ['id', 'slug', 'name', 'url', 'profile_image']
+        };
+
+        const authors = await this.models.Author.findPage(options);
+
+        return authors;
     }
 };

--- a/ghost/core/core/server/services/search-index/index.js
+++ b/ghost/core/core/server/services/search-index/index.js
@@ -1,6 +1,8 @@
 const SearchIndexService = require('./SearchIndexService');
 const PostsService = require('../posts/posts-service')();
+const models = require('../../models');
 
 module.exports = new SearchIndexService({
-    PostsService
+    PostsService,
+    models
 });

--- a/ghost/core/core/server/web/api/endpoints/content/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/content/routes.js
@@ -46,6 +46,7 @@ module.exports = function apiRoutes() {
 
     // ## Search index
     router.get('/search-index/posts', mw.authenticatePublic, http(api.searchIndex.fetchPosts));
+    router.get('/search-index/authors', mw.authenticatePublic, http(api.searchIndex.fetchAuthors));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
@@ -4,14 +4,14 @@ exports[`Search Index Content API fetchAuthors should return a list of authors 1
 Object {
   "authors": Array [
     Object {
-      "id": "1",
+      "id": Any<String>,
       "name": Any<String>,
       "profile_image": Any<String>,
       "slug": Any<String>,
       "url": Any<String>,
     },
     Object {
-      "id": "5951f5fca366002ebd5dbef7",
+      "id": Any<String>,
       "name": Any<String>,
       "profile_image": Any<String>,
       "slug": Any<String>,
@@ -40,7 +40,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a77",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -51,7 +51,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a76",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -62,7 +62,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a75",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -73,7 +73,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a74",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -84,7 +84,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a73",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -95,7 +95,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a72",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -106,7 +106,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "6194d3ce51e2700162531a71",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -117,7 +117,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "618ba1ffbe2896088840a6e7",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -128,7 +128,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "618ba1ffbe2896088840a6e3",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -139,7 +139,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "618ba1ffbe2896088840a6e1",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,
@@ -150,7 +150,7 @@ Object {
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "excerpt": Any<String>,
-      "id": "618ba1ffbe2896088840a6df",
+      "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "slug": Any<String>,
       "title": Any<String>,

--- a/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Search Index Content API fetchAuthors should return a list of authors 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "id": "1",
+      "name": Any<String>,
+      "profile_image": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": "5951f5fca366002ebd5dbef7",
+      "name": Any<String>,
+      "profile_image": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index Content API fetchAuthors should return a list of authors 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "347",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Search Index Content API fetchPosts should return a list of posts 1: [body] 1`] = `
 Object {
   "posts": Array [

--- a/ghost/core/test/e2e-api/content/search-index.test.js
+++ b/ghost/core/test/e2e-api/content/search-index.test.js
@@ -14,6 +14,7 @@ describe('Search Index Content API', function () {
 
     describe('fetchPosts', function () {
         const searchIndexPostMatcher = {
+            id: anyString,
             slug: anyString,
             title: anyString,
             excerpt: anyString,
@@ -47,6 +48,7 @@ describe('Search Index Content API', function () {
 
     describe('fetchAuthors', function () {
         const searchIndexAuthorMatcher = {
+            id: anyString,
             slug: anyString,
             name: anyString,
             url: anyString,

--- a/ghost/core/test/e2e-api/content/search-index.test.js
+++ b/ghost/core/test/e2e-api/content/search-index.test.js
@@ -3,17 +3,6 @@ const assert = require('assert/strict');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyISODateTimeWithTZ, anyString} = matchers;
 
-const searchIndexPostMatcher = {
-    slug: anyString,
-    title: anyString,
-    excerpt: anyString,
-    url: anyString,
-    visibility: anyString,
-    published_at: anyISODateTimeWithTZ,
-    created_at: anyISODateTimeWithTZ,
-    updated_at: anyISODateTimeWithTZ
-};
-
 describe('Search Index Content API', function () {
     let agent;
 
@@ -24,6 +13,17 @@ describe('Search Index Content API', function () {
     });
 
     describe('fetchPosts', function () {
+        const searchIndexPostMatcher = {
+            slug: anyString,
+            title: anyString,
+            excerpt: anyString,
+            url: anyString,
+            visibility: anyString,
+            published_at: anyISODateTimeWithTZ,
+            created_at: anyISODateTimeWithTZ,
+            updated_at: anyISODateTimeWithTZ
+        };
+
         it('should return a list of posts', async function () {
             const res = await agent.get('search-index/posts')
                 .expectStatus(200)
@@ -42,6 +42,28 @@ describe('Search Index Content API', function () {
             assert.equal(post.plaintext, undefined, 'plaintext field should be not included in the response');
             assert.equal(post.mobiledoc, undefined, 'mobiledoc field should be not included in the response');
             assert.equal(post.lexical, undefined, 'lexical field should be not included in the response');
+        });
+    });
+
+    describe('fetchAuthors', function () {
+        const searchIndexAuthorMatcher = {
+            slug: anyString,
+            name: anyString,
+            url: anyString,
+            profile_image: anyString
+        };
+
+        it('should return a list of authors', async function () {
+            await agent.get('search-index/authors')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    authors: new Array(2)
+                        .fill(searchIndexAuthorMatcher)
+                });
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added `GET /ghost/api/content/search-index/authors` API endpoint
- the endpoint returns the most recently updated 10k authors, with relevant fields for search (`'name', 'slug', 'url', 'profile_image'`)

