### PR TITLE
Added search index endpoint for tags in Content API (#24138)

### DIFF
--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -20,6 +20,15 @@ const controller = {
         query() {
             return searchIndexService.fetchAuthors();
         }
+    },
+    fetchTags: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: true,
+        query() {
+            return searchIndexService.fetchTags();
+        }
     }
 };
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -53,5 +53,28 @@ module.exports = {
         frame.response = {
             authors
         };
+    },
+
+    async fetchTags(models, apiConfig, frame) {
+        debug('fetchTags');
+
+        let tags = [];
+
+        const keys = [
+            'id',
+            'slug',
+            'name',
+            'url'
+        ];
+
+        for (let model of models.data) {
+            let tag = await mappers.tags(model, frame);
+            tag = _.pick(tag, keys);
+            tags.push(tag);
+        }
+
+        frame.response = {
+            tags
+        };
     }
 };

--- a/ghost/core/core/server/services/search-index/SearchIndexService.js
+++ b/ghost/core/core/server/services/search-index/SearchIndexService.js
@@ -27,4 +27,17 @@ module.exports = class SearchIndexService {
 
         return authors;
     }
+
+    async fetchTags() {
+        const options = {
+            limit: '10000',
+            order: 'updated_at DESC',
+            columns: ['id', 'slug', 'name', 'url'],
+            filter: 'visibility:public'
+        };
+
+        const tags = await this.models.Tag.findPage(options);
+
+        return tags;
+    }
 };

--- a/ghost/core/core/server/web/api/endpoints/content/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/content/routes.js
@@ -47,6 +47,7 @@ module.exports = function apiRoutes() {
     // ## Search index
     router.get('/search-index/posts', mw.authenticatePublic, http(api.searchIndex.fetchPosts));
     router.get('/search-index/authors', mw.authenticatePublic, http(api.searchIndex.fetchAuthors));
+    router.get('/search-index/tags', mw.authenticatePublic, http(api.searchIndex.fetchTags));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/search-index.test.js.snap
@@ -174,3 +174,115 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Search Index Content API fetchTags does not return internal tags 1: [body] 1`] = `
+Object {
+  "tags": Array [
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index Content API fetchTags does not return internal tags 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "693",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Search Index Content API fetchTags should return a list of tags 1: [body] 1`] = `
+Object {
+  "tags": Array [
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index Content API fetchTags should return a list of tags 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "693",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added `GET /ghost/api/content/search-index/tags` API endpoint
- the endpoint returns the most recently updated 10k tags, with relevant fields for search (`'name', 'slug', 'url'`)