### PR TITLE
Updated Sodo-Search to use new search index endpoint for tags (#24140)

### DIFF
--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -17,7 +17,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@tryghost/content-api": "1.11.26",
     "flexsearch": "0.8.153",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/apps/sodo-search/src/search-index.test.js
+++ b/apps/sodo-search/src/search-index.test.js
@@ -16,7 +16,7 @@ describe('search index', function () {
             .reply(200, {
                 authors: []
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: []
             });
@@ -63,7 +63,7 @@ describe('search index', function () {
                     url: 'http://localhost/ghost/authors/bob/'
                 }]
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: [{
                     id: 'uniq_tag',
@@ -146,7 +146,7 @@ describe('search index', function () {
                     url: 'http://localhost/ghost/authors/bob/'
                 }]
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: [{
                     id: 'uniq_tag',
@@ -228,7 +228,7 @@ describe('search index', function () {
                     url: 'http://localhost/ghost/authors/bob/'
                 }]
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: [{
                     id: 'uniq_tag',
@@ -290,7 +290,7 @@ describe('search index', function () {
                     url: 'http://localhost/ghost/authors/svpr/'
                 }]
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: [{
                     id: 'tag',
@@ -381,7 +381,7 @@ describe('search index', function () {
                     url: 'http://localhost/ghost/authors/bob/'
                 }]
             })
-            .get('/tags/?key=69010382388f9de5869ad6e558&&limit=10000&fields=id,slug,name,url&order=updated_at%20DESC&filter=visibility%3Apublic')
+            .get('/search-index/tags/?key=69010382388f9de5869ad6e558')
             .reply(200, {
                 tags: [{
                     id: 'uniq_tag',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106
ref https://github.com/TryGhost/Ghost/pull/24142

 - the Content API now exposes a new endpoint for building a search index for tags, which returns up to 10k results


