### PR TITLE
🔥 Enforced max `limit` of 100 in `{{#get}}` helper

### DIFF
--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -3,6 +3,7 @@
 // Fetches data from the API
 const {config, api, prepareContextResource} = require('../services/proxy');
 const {hbs, SafeString} = require('../services/handlebars');
+const {applyLimitCap} = require('../../shared/max-limit-cap');
 
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
@@ -114,9 +115,8 @@ function parseOptions(globals, data, options) {
         options.filter = resolvePaths(globals, data, options.filter);
     }
 
-    if (options.limit === 'all' && config.get('getHelperLimitAllMax')) {
-        options.limit = config.get('getHelperLimitAllMax');
-    }
+    // Adjust limit to Ghost's max allowed value (default: 100 and no limit=all)
+    options.limit = applyLimitCap(options.limit);
 
     return options;
 }

--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -116,7 +116,9 @@ function parseOptions(globals, data, options) {
     }
 
     // Adjust limit to Ghost's max allowed value (default: 100 and no limit=all)
-    options.limit = applyLimitCap(options.limit);
+    if (options.limit) {
+        options.limit = applyLimitCap(options.limit);
+    }
 
     return options;
 }

--- a/ghost/core/core/shared/max-limit-cap.js
+++ b/ghost/core/core/shared/max-limit-cap.js
@@ -1,0 +1,61 @@
+const config = require('../shared/config');
+
+// Prior to Ghost 6.x we allowed any limit value, including 'all', but as sites
+// grew in size it led to performance issues and mis-use of the API.
+
+// After Ghost 6.x we only allow a max limit of 100. This shared module provides
+// the core limit capping logic that can be used by both middleware and helpers.
+
+const limitConfig = {
+    allowLimitAll: config.get('optimization:allowLimitAll') || false,
+    maxLimit: config.get('optimization:maxLimit') || 100,
+    // Temporary exceptions to the max limit rule (HTTP-specific)
+    exceptionEndpoints: [
+        '/ghost/api/admin/posts/export/',
+        '/ghost/api/admin/emails/' // /:id/batches/ and /:id/recipient-failures/
+    ]
+};
+
+/**
+ * Apply limit capping logic to a limit value
+ * @param {string|number} limit - The limit value to cap
+ * @param {Object} options - Optional settings
+ * @param {string} [options.url] - URL to check against exception endpoints (for middleware)
+ * @returns {string|number} The capped limit value
+ */
+function applyLimitCap(limit, options = {}) {
+    if (!limit) {
+        return limit;
+    }
+
+    // If 'all' is globally allowed, skip everything else
+    if (limit === 'all' && limitConfig.allowLimitAll) {
+        return limit;
+    }
+
+    // Check exception endpoints - they bypass all limits (HTTP-specific)
+    if (options.url && limitConfig.exceptionEndpoints.some(endpoint => options.url.startsWith(endpoint))) {
+        return limit;
+    }
+
+    // 'all' is no longer supported so gets capped to maxLimit
+    if (limit === 'all') {
+        return limitConfig.maxLimit;
+    }
+
+    // Convert to number for comparison
+    const numericLimit = parseInt(String(limit), 10);
+
+    // If it's not a valid number or exceeds maxLimit, cap it
+    if (isNaN(numericLimit) || numericLimit > limitConfig.maxLimit) {
+        return limitConfig.maxLimit;
+    }
+
+    // Return the original limit if it's within bounds
+    return limit;
+}
+
+module.exports = {
+    applyLimitCap,
+    limitConfig
+};

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -213,7 +213,8 @@ describe('e2e {{#get}} helper', function () {
                 inverse
             });
             assert.equal(fn.secondCall.args[0].posts.length, initialCount - 1);
-            assert.equal(fn.secondCall.args[0].meta.pagination.limit, 'all');
+            // 'all' is capped to 100 since 6.x
+            assert.equal(fn.secondCall.args[0].meta.pagination.limit, 100);
             assert.equal(fn.secondCall.args[0].meta.cacheabilityOptimisation, true);
             const foundFilteredPost = fn.secondCall.args[0].posts.find(post => post.id === firstPostUsually.id);
             assert.equal(foundFilteredPost, undefined);

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -8,8 +8,8 @@ const loggingLib = require('@tryghost/logging');
 // Stuff we are testing
 const get = require('../../../../core/frontend/helpers/get');
 const models = require('../../../../core/server/models');
-const proxy = require('../../../../core/frontend/services/proxy');
 const api = require('../../../../core/server/api').endpoints;
+const maxLimitCap = require('../../../../core/shared/max-limit-cap');
 
 describe('{{#get}} helper', function () {
     let fn;
@@ -331,7 +331,7 @@ describe('{{#get}} helper', function () {
         });
     });
 
-    describe('limit=all max', function () {
+    describe('limit capping', function () {
         let browseStub;
 
         beforeEach(function () {
@@ -344,7 +344,19 @@ describe('{{#get}} helper', function () {
             });
         });
 
-        it('Behaves normally without config', async function () {
+        it('caps "all" to maxLimit (100 by default)', async function () {
+            locals = {root: {_locals: {}}};
+            await get.call(
+                {},
+                'posts',
+                {hash: {limit: 'all'}, data: locals, fn: fn, inverse: inverse}
+            );
+            browseStub.firstCall.args[0].limit.should.eql(100);
+        });
+
+        it('allows "all" when allowLimitAll is true', async function () {
+            sinon.stub(maxLimitCap.limitConfig, 'allowLimitAll').value(true);
+
             locals = {root: {_locals: {}}};
             await get.call(
                 {},
@@ -354,8 +366,28 @@ describe('{{#get}} helper', function () {
             browseStub.firstCall.args[0].limit.should.eql('all');
         });
 
-        it('Replaces "all" with "getHelperLimitAllMax" config, if present', async function () {
-            sinon.stub(proxy.config, 'get').withArgs('getHelperLimitAllMax').returns(2);
+        it('caps numeric limits exceeding maxLimit', async function () {
+            locals = {root: {_locals: {}}};
+            await get.call(
+                {},
+                'posts',
+                {hash: {limit: 150}, data: locals, fn: fn, inverse: inverse}
+            );
+            browseStub.firstCall.args[0].limit.should.eql(100);
+        });
+
+        it('leaves numeric limits below maxLimit unchanged', async function () {
+            locals = {root: {_locals: {}}};
+            await get.call(
+                {},
+                'posts',
+                {hash: {limit: 50}, data: locals, fn: fn, inverse: inverse}
+            );
+            browseStub.firstCall.args[0].limit.should.eql(50);
+        });
+
+        it('uses custom maxLimit when configured', async function () {
+            sinon.stub(maxLimitCap.limitConfig, 'maxLimit').value(50);
 
             locals = {root: {_locals: {}}};
             await get.call(
@@ -363,7 +395,17 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 'all'}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(2);
+            browseStub.firstCall.args[0].limit.should.eql(50);
+        });
+
+        it('caps invalid string limits to maxLimit', async function () {
+            locals = {root: {_locals: {}}};
+            await get.call(
+                {},
+                'posts',
+                {hash: {limit: 'invalid'}, data: locals, fn: fn, inverse: inverse}
+            );
+            browseStub.firstCall.args[0].limit.should.eql(100);
         });
     });
 

--- a/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
@@ -1,9 +1,7 @@
 const assert = require('assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../../../../utils/configUtils');
-
-let maxLimitCap = rewire('../../../../../../core/server/web/shared/middleware/max-limit-cap');
+const maxLimitCap = require('../../../../../../core/server/web/shared/middleware/max-limit-cap');
 
 describe('Max Limit Cap Middleware', function () {
     let req;
@@ -11,8 +9,6 @@ describe('Max Limit Cap Middleware', function () {
     let next;
 
     beforeEach(function () {
-        maxLimitCap = rewire('../../../../../../core/server/web/shared/middleware/max-limit-cap');
-
         req = {
             query: {},
             path: '/api/content/posts/',
@@ -32,16 +28,6 @@ describe('Max Limit Cap Middleware', function () {
             assert.equal(maxLimitCap.limitConfig.allowLimitAll, false);
             assert.equal(maxLimitCap.limitConfig.maxLimit, 100);
             assert.equal(maxLimitCap.limitConfig.exceptionEndpoints.length, 2);
-        });
-
-        it('reads from config', function () {
-            configUtils.set('optimization:allowLimitAll', true);
-            configUtils.set('optimization:maxLimit', 50);
-
-            maxLimitCap = rewire('../../../../../../core/server/web/shared/middleware/max-limit-cap');
-
-            assert.equal(maxLimitCap.limitConfig.allowLimitAll, true);
-            assert.equal(maxLimitCap.limitConfig.maxLimit, 50);
         });
     });
 

--- a/ghost/core/test/unit/shared/max-limit-cap.test.js
+++ b/ghost/core/test/unit/shared/max-limit-cap.test.js
@@ -1,0 +1,112 @@
+const assert = require('assert/strict');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const configUtils = require('../../utils/configUtils');
+
+describe('Shared Max Limit Cap', function () {
+    let maxLimitCap;
+
+    beforeEach(function () {
+        maxLimitCap = rewire('../../../core/shared/max-limit-cap');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        return configUtils.restore();
+    });
+
+    describe('limitConfig', function () {
+        it('should have the correct default values', function () {
+            assert.equal(maxLimitCap.limitConfig.allowLimitAll, false);
+            assert.equal(maxLimitCap.limitConfig.maxLimit, 100);
+            assert.equal(maxLimitCap.limitConfig.exceptionEndpoints.length, 2);
+        });
+
+        it('reads from config dynamically', function () {
+            configUtils.set('optimization:allowLimitAll', true);
+            configUtils.set('optimization:maxLimit', 50);
+
+            maxLimitCap = rewire('../../../core/shared/max-limit-cap');
+
+            assert.equal(maxLimitCap.limitConfig.allowLimitAll, true);
+            assert.equal(maxLimitCap.limitConfig.maxLimit, 50);
+        });
+    });
+
+    describe('applyLimitCap', function () {
+        it('returns undefined/null limits unchanged', function () {
+            assert.equal(maxLimitCap.applyLimitCap(undefined), undefined);
+            assert.equal(maxLimitCap.applyLimitCap(null), null);
+            assert.equal(maxLimitCap.applyLimitCap(''), '');
+        });
+
+        it('caps "all" to maxLimit by default', function () {
+            const result = maxLimitCap.applyLimitCap('all');
+            assert.equal(result, 100);
+        });
+
+        it('allows "all" when allowLimitAll is true', function () {
+            sinon.stub(maxLimitCap.limitConfig, 'allowLimitAll').value(true);
+
+            const result = maxLimitCap.applyLimitCap('all');
+            assert.equal(result, 'all');
+        });
+
+        it('caps numeric limits exceeding maxLimit', function () {
+            const result = maxLimitCap.applyLimitCap(150);
+            assert.equal(result, 100);
+        });
+
+        it('leaves numeric limits below maxLimit unchanged', function () {
+            const result = maxLimitCap.applyLimitCap(50);
+            assert.equal(result, 50);
+        });
+
+        it('uses custom maxLimit when configured', function () {
+            sinon.stub(maxLimitCap.limitConfig, 'maxLimit').value(50);
+
+            const result = maxLimitCap.applyLimitCap('all');
+            assert.equal(result, 50);
+        });
+
+        it('caps invalid string limits to maxLimit', function () {
+            const result = maxLimitCap.applyLimitCap('invalid');
+            assert.equal(result, 100);
+        });
+
+        it('handles string numeric limits', function () {
+            const result1 = maxLimitCap.applyLimitCap('25');
+            assert.equal(result1, '25');
+
+            const result2 = maxLimitCap.applyLimitCap('150');
+            assert.equal(result2, 100);
+        });
+
+        it('bypasses limits for exception endpoints', function () {
+            const result1 = maxLimitCap.applyLimitCap(1000, {url: '/ghost/api/admin/posts/export/'});
+            assert.equal(result1, 1000);
+
+            const result2 = maxLimitCap.applyLimitCap('all', {url: '/ghost/api/admin/emails/123/batches/'});
+            assert.equal(result2, 'all');
+        });
+
+        it('applies limits for non-exception endpoints', function () {
+            const result = maxLimitCap.applyLimitCap(1000, {url: '/ghost/api/admin/members/'});
+            assert.equal(result, 100);
+        });
+
+        it('handles edge cases', function () {
+            // Limit exactly at maxLimit
+            const result1 = maxLimitCap.applyLimitCap(100);
+            assert.equal(result1, 100);
+
+            // Zero limit
+            const result2 = maxLimitCap.applyLimitCap(0);
+            assert.equal(result2, 0);
+
+            // Negative limit (should be left as-is since it's <= maxLimit)
+            const result3 = maxLimitCap.applyLimitCap(-10);
+            assert.equal(result3, -10);
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- extracted core `limit` value capping logic into a shared util
- updated `max-limit-cap` middleware to use shared util
- replaced old/unused `getHelperLimitAllMax` config in `{{#get}}` helper's options parser with a call to the new limit cap util
  - rewrites any `limit` option used in `{{#get}}` (including `'all'`) so it matches Ghost's configured max API limit