### PR TITLE
Released @tryghost/sodo-search v1.8.0

### DIFF
--- a/.github/scripts/release-apps.js
+++ b/.github/scripts/release-apps.js
@@ -130,20 +130,20 @@ async function getChangelog(newVersion) {
 
     if (indexOfLastRelease === -1) {
         console.warn(`Could not find commit for previous release. Will include recent commits affecting this app.`);
-        
+
         // Fallback: get recent commits for this app (last 20)
         const recentCommits = await safeExec(`git log -n 20 --pretty=format:"%h%n%B__SPLIT__" -- .`);
         if (recentCommits.stderr) {
             console.error(`There was an error getting recent commits`);
             process.exit(1);
         }
-        
+
         const recentCommitsList = recentCommits.stdout.split('__SPLIT__');
-        
+
         const recentCommitsWhichMentionLinear = recentCommitsList.filter((commitBlock) => {
             return commitBlock.includes('https://linear.app/ghost');
         });
-        
+
         const commitChangelogItems = recentCommitsWhichMentionLinear.map((commitBlock) => {
             const lines = commitBlock.split('\n');
             if (!lines.length || !lines[0].trim()) {
@@ -152,7 +152,7 @@ async function getChangelog(newVersion) {
             const hash = lines[0].trim();
             return `https://github.com/TryGhost/Ghost/commit/${hash}`;
         }).filter(Boolean); // Filter out any null entries
-        
+
         changelogItems.push(...commitChangelogItems);
     } else {
         const lastReleaseCommit = lastFiftyCommitsList[indexOfLastRelease];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1115,8 +1115,8 @@ jobs:
           - package_name: '@tryghost/sodo-search'
             package_path: 'apps/sodo-search'
             cdn_paths: |
-              'https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/sodo-search.min.js'
-              'https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/main.css'
+              https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/sodo-search.min.js
+              https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/main.css
           - package_name: '@tryghost/comments-ui'
             package_path: 'apps/comments-ui'
             cdn_paths: 'https://cdn.jsdelivr.net/ghost/comments-ui@~CURRENT_MINOR/umd/comments-ui.min.js'

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -209,7 +209,7 @@
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",
         "styles": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/main.css",
-        "version": "1.7"
+        "version": "1.8"
     },
     "announcementBar": {
         "url": "https://cdn.jsdelivr.net/ghost/announcement-bar@~{version}/umd/announcement-bar.min.js",


### PR DESCRIPTION
Changelog for v1.7.0 -> 1.8.0:
    - https://github.com/TryGhost/Ghost/commit/3ac6998645
    
Also fixed the "Purge CDN cache" step for Sodo-Search