### PR TITLE
Added redirects for old inbox and feed URLs in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/routes.tsx
+++ b/apps/admin-x-activitypub/src/routes.tsx
@@ -33,6 +33,14 @@ export const routes: CustomRouteObject[] = [
                 element: <Navigate to="reader" />
             },
             {
+                path: 'inbox',
+                element: <Navigate to="../reader" replace />
+            },
+            {
+                path: 'feed',
+                element: <Navigate to="../notes" replace />
+            },
+            {
                 path: 'reader',
                 element: <Inbox />,
                 pageTitle: 'Reader'


### PR DESCRIPTION
no issues

- Implemented route rules to redirect "inbox" to "reader"
- Added redirect from "feed" to "notes"
- Ensured smooth transition to new URL structure without breaking existing links