### PR TITLE
🔥 Removed GET /session/ endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/session.js
+++ b/ghost/core/core/server/api/endpoints/session.js
@@ -10,15 +10,6 @@ const messages = {
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
-    read(frame) {
-        /*
-         * TODO
-         * Don't query db for user, when new api http wrapper is in we can
-         * have direct access to req.user, we can also get access to some session
-         * inofrmation too and send it back
-         */
-        return models.User.findOne({id: frame.options.context.user});
-    },
     add(frame) {
         const object = frame.data;
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -243,7 +243,6 @@ module.exports = function apiRoutes() {
     router.post('/slack/test', mw.authAdminApi, http(api.slack.sendTest));
 
     // ## Sessions
-    router.get('/session', mw.authAdminApi, http(api.session.read));
     // We don't need auth when creating a new session (logging in)
     router.post('/session',
         shared.middleware.brute.globalBlock,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
@@ -68,7 +68,7 @@ Object {
 }
 `;
 
-exports[`Sessions API can create session (log in) 1: [headers] 1`] = `
+exports[`Sessions API can create session (log in) and access user data 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -84,7 +84,7 @@ Object {
 }
 `;
 
-exports[`Sessions API can delete session (log out) 1: [headers] 1`] = `
+exports[`Sessions API can delete session (log out) and requests will fail 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -94,91 +94,6 @@ Object {
     StringMatching /\\^ghost-admin-api-session=/,
   ],
   "vary": "Accept-Version, Origin",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Sessions API can read session now the owner is logged in 1: [body] 1`] = `
-Object {
-  "accessibility": null,
-  "bio": "bio",
-  "bluesky": null,
-  "comment_notifications": true,
-  "cover_image": null,
-  "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-  "donation_notifications": true,
-  "email": "jbloggs@example.com",
-  "facebook": null,
-  "free_member_signup_notification": true,
-  "id": "5951f5fc0000000000000000",
-  "instagram": null,
-  "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-  "linkedin": null,
-  "locale": null,
-  "location": "location",
-  "mastodon": null,
-  "mention_notifications": true,
-  "meta_description": null,
-  "meta_title": null,
-  "milestone_notifications": true,
-  "name": "Joe Bloggs",
-  "paid_subscription_canceled_notification": true,
-  "paid_subscription_started_notification": true,
-  "profile_image": "https://example.com/super_photo.jpg",
-  "recommendation_notifications": true,
-  "slug": "joe-bloggs",
-  "status": "active",
-  "threads": null,
-  "tiktok": null,
-  "tour": null,
-  "twitter": null,
-  "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-  "visibility": "public",
-  "website": null,
-  "youtube": null,
-}
-`;
-
-exports[`Sessions API can read session now the owner is logged in 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "899",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Sessions API errors when reading session again now owner is not logged in 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "Unable to determine the authenticated user or integration. Check that cookies are being passed through if using session authentication.",
-      "details": null,
-      "ghostErrorCode": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Authorization failed",
-      "property": null,
-      "type": "NoPermissionError",
-    },
-  ],
-}
-`;
-
-exports[`Sessions API errors when reading session again now owner is not logged in 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "343",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/session.test.js
+++ b/ghost/core/test/e2e-api/admin/session.test.js
@@ -1,6 +1,6 @@
 const {agentProvider, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {mockMail, assert, restore} = require('../../utils/e2e-framework-mock-manager');
-const {anyContentVersion, anyEtag, anyErrorId, stringMatching, anyISODateTime, anyUuid} = matchers;
+const {anyContentVersion, anyEtag, stringMatching, anyUuid} = matchers;
 
 describe('Sessions API', function () {
     let agent;
@@ -10,7 +10,7 @@ describe('Sessions API', function () {
         await fixtureManager.init();
     });
 
-    it('can create session (log in)', async function () {
+    it('can create session (log in) and access user data', async function () {
         const owner = await fixtureManager.get('users', 0);
         await agent
             .post('session/')
@@ -28,25 +28,13 @@ describe('Sessions API', function () {
                     stringMatching(/^ghost-admin-api-session=/)
                 ]
             });
-    });
 
-    it('can read session now the owner is logged in', async function () {
         await agent
-            .get('session/')
-            .expectStatus(200)
-            .matchBodySnapshot({
-                // id is 1, but should be anyObjectID :(
-                last_seen: anyISODateTime,
-                created_at: anyISODateTime,
-                updated_at: anyISODateTime
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag
-            });
+            .get('/users/me/')
+            .expectStatus(200);
     });
 
-    it('can delete session (log out)', async function () {
+    it('can delete session (log out) and requests will fail', async function () {
         await agent
             .delete('session/')
             .expectStatus(204)
@@ -58,21 +46,10 @@ describe('Sessions API', function () {
                     stringMatching(/^ghost-admin-api-session=/)
                 ]
             });
-    });
 
-    it('errors when reading session again now owner is not logged in', async function () {
         await agent
-            .get('session/')
-            .expectStatus(403)
-            .matchBodySnapshot({
-                errors: [{
-                    id: anyErrorId
-                }]
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag
-            });
+            .get('/users/me/')
+            .expectStatus(403);
     });
 
     describe('Staff 2FA', function () {

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -438,7 +438,7 @@ describe('User API', function () {
         should.exist(res.body.password[0].message);
 
         await request
-            .get(localUtils.API.getApiQuery('session/'))
+            .get(localUtils.API.getApiQuery('users/me/'))
             .set('Origin', config.get('url'))
             .expect(200);
     });

--- a/ghost/core/test/unit/api/canary/session.test.js
+++ b/ghost/core/test/unit/api/canary/session.test.js
@@ -193,24 +193,4 @@ describe('Session controller', function () {
             });
         });
     });
-
-    describe('#get', function () {
-        it('returns the result of User.findOne', function () {
-            const findOneReturnVal = new Promise(() => {});
-            const findOneStub = sinon.stub(models.User, 'findOne')
-                .returns(findOneReturnVal);
-
-            const result = sessionController.read({
-                options: {
-                    context: {
-                        user: 108
-                    }
-                }
-            });
-            should.equal(result, findOneReturnVal);
-            should.deepEqual(findOneStub.args[0][0], {
-                id: 108
-            });
-        });
-    });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/23924 closes https://linear.app/ghost/issue/PROD-2191/breaking-change-drop-get-session-endpoint

- This endpoint was originally created with an intent to return some other data
- It was never needed or updated, and has sat unused
- Meanwhile, we have a /users/me/ endpoint which correctly returns the logged in user data
- Therefore we're deleting the endpoint for cleanliness


