### PR TITLE
Added new types for updated limits

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -39,6 +39,22 @@ export type Config = {
             newsletters?: {
                 max?: number
                 error?: string
+            },
+            customThemes?: {
+                allowlist?: string[],
+                error?: string
+            },
+            limitStripeConnect?: {
+                disabled: boolean,
+                error?: string
+            },
+            limitAnalytics?: {
+                disabled: boolean,
+                error?: string
+            },
+            limitSocialWeb?: {
+                disabled: boolean,
+                error?: string
             }
         }
         billing?: {


### PR DESCRIPTION
ref BAE-336

To ensure correct typing within the admin-x apps, we need to have the new limits typed correctly. Furthermore, the existing theme limit was missing in the list.