### PR TITLE
Updated @tryghost/limit-service to v1.3.1

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -37,7 +37,7 @@
     "@codemirror/lang-html": "6.4.9",
     "@tryghost/color-utils": "0.2.6",
     "@tryghost/kg-unsplash-selector": "0.3.6",
-    "@tryghost/limit-service": "1.2.18",
+    "@tryghost/limit-service": "1.3.1",
     "@tryghost/nql": "0.12.7",
     "@tryghost/timezone-data": "0.4.8",
     "react": "18.3.1",

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -37,7 +37,7 @@
     "@codemirror/lang-html": "6.4.9",
     "@tryghost/color-utils": "0.2.6",
     "@tryghost/kg-unsplash-selector": "0.3.6",
-    "@tryghost/limit-service": "1.3.1",
+    "@tryghost/limit-service": "1.3.2",
     "@tryghost/nql": "0.12.7",
     "@tryghost/timezone-data": "0.4.8",
     "react": "18.3.1",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -100,7 +100,7 @@
     "@tryghost/kg-lexical-html-renderer": "1.3.24",
     "@tryghost/kg-markdown-html-renderer": "7.1.3",
     "@tryghost/kg-mobiledoc-html-renderer": "7.1.3",
-    "@tryghost/limit-service": "1.3.1",
+    "@tryghost/limit-service": "1.3.2",
     "@tryghost/logging": "2.4.22",
     "@tryghost/members-csv": "2.0.3",
     "@tryghost/metrics": "1.0.38",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -100,7 +100,7 @@
     "@tryghost/kg-lexical-html-renderer": "1.3.24",
     "@tryghost/kg-markdown-html-renderer": "7.1.3",
     "@tryghost/kg-mobiledoc-html-renderer": "7.1.3",
-    "@tryghost/limit-service": "1.2.18",
+    "@tryghost/limit-service": "1.3.1",
     "@tryghost/logging": "2.4.22",
     "@tryghost/members-csv": "2.0.3",
     "@tryghost/metrics": "1.0.38",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -1235,6 +1235,28 @@ Object {
 }
 `;
 
+exports[`Newsletters API Host Settings: newsletter limits Disabled Newsletter / Max limit 0 Request fails when newsletter limit is 0 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Nuh uh",
+      "details": Object {
+        "limit": 0,
+        "name": "newsletters",
+        "total": 3,
+      },
+      "ghostErrorCode": null,
+      "help": "https://ghost.org/help/",
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Host Limit error, cannot save newsletter.",
+      "property": null,
+      "type": "HostLimitError",
+    },
+  ],
+}
+`;
+
 exports[`Newsletters API Host Settings: newsletter limits Max limit Adding a newsletter now doesn't fail 1: [body] 1`] = `
 Object {
   "meta": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8179,10 +8179,10 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/limit-service@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/limit-service/-/limit-service-1.3.1.tgz#44a8847da0595564443e19a44f8e293002eca42f"
-  integrity sha512-ewUaS/TXtBucf88OOhUSkj2C2aIXIkedXYG4NTJiefTLRPhrHOU907AOETqXHlzQAAGpRpOdbEwCNNkn1M4gOw==
+"@tryghost/limit-service@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/limit-service/-/limit-service-1.3.2.tgz#d60342f4f418e6e85b04bcfe73d78022594d3aa5"
+  integrity sha512-8IT/6DIFIZNwrxh2XAjoAmbcReyACpnI/R5N1XokLLLFcvS0cmI/91DsvhjD759digsedlwK+ndgA2ah1+mh2g==
   dependencies:
     "@tryghost/errors" "^1.2.26"
     lodash "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7876,7 +7876,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/domain-events/-/domain-events-1.0.1.tgz#6bf1c4dffd26a2eecb032c3e57be80802dfd4832"
   integrity sha512-rMqN+KYwpPpZCTIPspa9ecexW82wLm0kD/t2lZW0+Xpc5eQoF9EDFNFSA+QJIi4FycXlb1vsl8xEmWyfHyLKNw==
 
-"@tryghost/elasticsearch@^3.0.24":
+"@tryghost/elasticsearch@^3.0.22", "@tryghost/elasticsearch@^3.0.24":
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/@tryghost/elasticsearch/-/elasticsearch-3.0.24.tgz#291d51d6a6cc607fa860612dfc37098c4ebdedc4"
   integrity sha512-/ocoCYS74+Dc1qH9yJCgqHtOyxQMvwmY71MPAqhfLHAfa4vpsd8VJNa2EsO/rkLRsw+cmf8p/8ZILUXXnBOheg==
@@ -7906,7 +7906,15 @@
     focus-trap "^6.7.2"
     postcss-preset-env "^7.3.1"
 
-"@tryghost/errors@1.3.6", "@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.7", "@tryghost/errors@^1.3.8":
+"@tryghost/errors@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.6.tgz#b34993d03122a59f29bf7050a3c0bc90a23a7254"
+  integrity sha512-qxl6wF5tlhr646Earjmfcz3km6d+B0tzUmocyVu3tY8StI4pH8mLgzHDtkiTAls9ABPichBxZQe6a8PDcVJbFw==
+  dependencies:
+    "@stdlib/utils-copy" "^0.2.0"
+    uuid "^9.0.0"
+
+"@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.8.tgz#d4212b52e876360b4fa8e303ae13ef86f3e95846"
   integrity sha512-2+4ExAAWM0rFWC7FlzxQMzIvIEQKt/vQLxLyqJqCmAcJa4i2uqUPJHqd/X5BBRuSTuftgca7EAo7adESbHEkZw==
@@ -7954,7 +7962,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/http-cache-utils/-/http-cache-utils-0.1.20.tgz#5a513593a2d5d944389a88eb56a8614cd0599350"
   integrity sha512-8+GbDQ/xo97orv5UUYv2x92e3RovVurYoFcBY+e0IJlExgSxP7oOqskqgFfZVs5Hhwi+SpZs6gFw2cv1OlUY9g==
 
-"@tryghost/http-stream@^0.1.36":
+"@tryghost/http-stream@^0.1.34", "@tryghost/http-stream@^0.1.36":
   version "0.1.36"
   resolved "https://registry.yarnpkg.com/@tryghost/http-stream/-/http-stream-0.1.36.tgz#fe29531c80de3c82a2c51add73113abdf1e7d65c"
   integrity sha512-zKmJsyGMavNOhuIA8329hc3x9sqB6Pqp8BaFLJMox4j7aqcpfdq1PmJD6IDiraXNJuQ0E08nM33LfjR+jy6fOg==
@@ -8171,7 +8179,33 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/logging@2.4.19", "@tryghost/logging@2.4.22", "@tryghost/logging@^2.4.22", "@tryghost/logging@^2.4.7":
+"@tryghost/limit-service@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/limit-service/-/limit-service-1.3.1.tgz#44a8847da0595564443e19a44f8e293002eca42f"
+  integrity sha512-ewUaS/TXtBucf88OOhUSkj2C2aIXIkedXYG4NTJiefTLRPhrHOU907AOETqXHlzQAAGpRpOdbEwCNNkn1M4gOw==
+  dependencies:
+    "@tryghost/errors" "^1.2.26"
+    lodash "^4.17.21"
+    luxon "^1.26.0"
+
+"@tryghost/logging@2.4.19":
+  version "2.4.19"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.19.tgz#8aab372486268b6fc8e31615b6e79d59b299a44f"
+  integrity sha512-NCCElue4AqvfhLnJLjDDR1uXBXQwfDOuGZTSI9/relqj+cfxwezQuPGG66EkPEB29ZAdtnHLOqMJTF2k6/s/hw==
+  dependencies:
+    "@tryghost/bunyan-rotating-filestream" "^0.0.7"
+    "@tryghost/elasticsearch" "^3.0.22"
+    "@tryghost/http-stream" "^0.1.34"
+    "@tryghost/pretty-stream" "^0.1.27"
+    "@tryghost/root-utils" "^0.3.31"
+    bunyan "^1.8.15"
+    bunyan-loggly "^1.4.2"
+    fs-extra "^11.0.0"
+    gelf-stream "^1.1.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+
+"@tryghost/logging@2.4.22", "@tryghost/logging@^2.4.22", "@tryghost/logging@^2.4.7":
   version "2.4.22"
   resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.22.tgz#d5c6607d2ea30554d05e75ea4558827da0181e05"
   integrity sha512-hvtV2I2Tn3zZljhJgHJhb4sS7r1FG19mJxBpEaoqLlrO9uiesLszA1BlnzpS+KsEGWatMbdfqRL8cVgKEggq5w==
@@ -8295,6 +8329,15 @@
     chalk "^4.1.0"
     sywac "^1.3.0"
 
+"@tryghost/pretty-stream@^0.1.27":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.29.tgz#e0bbab7333a6cac38fdfa19d3da86aeaaded7f02"
+  integrity sha512-HByPoCd5R63bRg34wZ4D7bfCeBsLTP3gLCi5xVsOnETxB4GiHHo31/vm+kI8pZd7mnWMre3nnDdVR0Sf72U0eQ==
+  dependencies:
+    date-format "^4.0.14"
+    lodash "^4.17.21"
+    prettyjson "^1.2.5"
+
 "@tryghost/pretty-stream@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.2.0.tgz#622e6c37a6a8f3f724e10e2980f51ec8efae96bc"
@@ -8341,7 +8384,7 @@
     got "13.0.0"
     lodash "^4.17.21"
 
-"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.33":
+"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.31", "@tryghost/root-utils@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.33.tgz#208e3d15520131c2d4157c7e62fe74771a7a110f"
   integrity sha512-Gmc/TrKtiRT7PV9JOPoSZ7jAOl/jJDWJFKNaLZbDQaiJIBP5C6PucqEfRqGb2Ko/S9j73HzEEBu6B7+qZMvbBg==
@@ -21290,10 +21333,10 @@ iterator.prototype@^1.1.4:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jackspeak@2.3.6, jackspeak@^3.1.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
-  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
@@ -24254,17 +24297,34 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
-moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33, moment-timezone@^0.5.48:
+moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33:
   version "0.5.45"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
   integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
     moment "^2.29.4"
 
-moment@2.24.0, moment@2.27.0, moment@2.30.1, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3, moment@^2.27.0, moment@^2.29.4:
+moment-timezone@^0.5.48:
+  version "0.5.48"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
+  dependencies:
+    moment "^2.29.4"
+
+moment@2.24.0, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moment@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@2.30.1, moment@^2.27.0, moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.2"


### PR DESCRIPTION
ref BAE-336

We're introducting new limits that are now available within the default config of the Limit Service. The updated version also introduces the ability of setting a `currentCountQuery` on `Flag` type limits, which opens the ability of not enforcing a limit if the feature is already in use.