### PR TITLE
Added eslint rule to prevent `created_by` / `updated_by` in schema

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -86,6 +86,21 @@ module.exports = {
             }
         },
         {
+            files: 'core/server/data/schema/schema.js',
+            rules: {
+                'no-restricted-syntax': ['error',
+                    {
+                        selector: 'Property[key.name="created_by"]',
+                        message: '`created_by` is not allowed - The action log should be used to record user actions.'
+                    },
+                    {
+                        selector: 'Property[key.name="updated_by"]',
+                        message: '`updated_by` is not allowed - The action log should be used to record user actions.'
+                    }
+                ]
+            }
+        },
+        {
             files: ['core/frontend/helpers/**', 'core/frontend/apps/*/lib/helpers/**'],
             rules: {
                 'ghost/filenames/match-regex': ['off', '^[a-z0-9-.]$', null, true]


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1597

Added eslint rule to prevent `created_by` / `updated_by` from being added to a database schema - User actions should be logged using the action log system instead