### PR TITLE
Fixed Stats > Growth paid members count chart data

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -94,7 +94,10 @@ export type MrrTotalItem = {
 export type MrrHistoryResponseType = {
     stats: MrrHistoryItem[];
     meta: {
-        totals: MrrTotalItem[];
+        totals: {
+            mrr: number;
+            currency: string;
+        }[];
     };
 };
 
@@ -157,6 +160,31 @@ export type TopPostViewsResponseType = {
     stats: TopPostViewsStats[];
 };
 
+// Types for subscription stats
+export type SubscriptionStatItem = {
+    date: string;
+    tier: string;
+    cadence: string;
+    positive_delta: number;
+    negative_delta: number;
+    signups: number;
+    cancellations: number;
+    count: number;
+};
+
+export type SubscriptionStatsResponseType = {
+    stats: SubscriptionStatItem[];
+    meta: {
+        tiers: string[];
+        cadences: string[];
+        totals: {
+            tier: string;
+            cadence: string;
+            count: number;
+        }[];
+    };
+};
+
 // Requests
 
 const dataType = 'TopContentResponseType';
@@ -169,6 +197,7 @@ const newsletterSubscriberStatsDataType = 'NewsletterSubscriberStatsResponseType
 const postGrowthStatsDataType = 'PostGrowthStatsResponseType';
 const mrrHistoryDataType = 'MrrHistoryResponseType';
 const topPostViewsDataType = 'TopPostViewsResponseType';
+const subscriptionStatsDataType = 'SubscriptionStatsResponseType';
 
 export const useTopContent = createQuery<TopContentResponseType>({
     dataType,
@@ -197,6 +226,11 @@ export const usePostGrowthStats = createQueryWithId<PostGrowthStatsResponseType>
 export const useMrrHistory = createQuery<MrrHistoryResponseType>({
     dataType: mrrHistoryDataType,
     path: '/stats/mrr/'
+});
+
+export const useSubscriptionStats = createQuery<SubscriptionStatsResponseType>({
+    dataType: subscriptionStatsDataType,
+    path: '/stats/subscriptions/'
 });
 
 export const usePostStats = createQueryWithId<PostStatsResponseType>({

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -50,7 +50,7 @@ const Growth: React.FC = () => {
     const initialTab = searchParams.get('tab') || 'total-members';
 
     // Get stats from custom hook once
-    const {isLoading, chartData, totals, currencySymbol} = useGrowthStats(range);
+    const {isLoading, chartData, totals, currencySymbol, subscriptionData} = useGrowthStats(range);
 
     // Get growth data with post_type filtering - only call when not on Sources tab
     const {data: topPostsData} = useTopPostsStatsWithRange(
@@ -134,6 +134,7 @@ const Growth: React.FC = () => {
                             currencySymbol={currencySymbol}
                             initialTab={initialTab}
                             isLoading={isPageLoading}
+                            subscriptionData={subscriptionData}
                             totals={totals}
                         />
                     </CardContent>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2182/
- change chart is now appropriately looking to subscription changes, not member deltas
- paid member count now includes comped members in the total count, matching the Ember dashboard