### PR TITLE
Removed hard-coded ghost version check when validating themes

### DIFF
--- a/ghost/core/core/server/services/themes/validate.js
+++ b/ghost/core/core/server/services/themes/validate.js
@@ -48,7 +48,8 @@ const check = async function check(themeName, theme, options = {}) {
     debug('Begin: Check');
     // gscan can slow down boot time if we require on boot, for now nest the require.
     const gscan = require('gscan');
-    const checkedVersion = 'v5';
+    const ghostVersion = require('@tryghost/version');
+    const checkedVersion = `v${ghostVersion.safe.split('.')[0]}`;
     let checkedTheme;
 
     if (options.isZip === true) {


### PR DESCRIPTION
no issue

- it's easy to miss/forget the hard-coded gscan version check when bumping major versions
- switched to reading the real Ghost version and using that to pass the check version to gscan
