### PR TITLE
Added limit enforcement for Web Analytics

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -46,7 +46,7 @@ const AlphaFeatures: React.FC = () => {
             for (const feature of features) {
                 if (feature.limitName && limiter?.isLimited(feature.limitName)) {
                     try {
-                        await limiter.errorIfIsOverLimit(feature.limitName);
+                        await limiter.errorIfWouldGoOverLimit(feature.limitName);
                         filtered.push(feature);
                     } catch (error) {
                         if (!(error instanceof HostLimitError)) {

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -1,6 +1,7 @@
 import FeatureToggle from './FeatureToggle';
 import LabItem from './LabItem';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
+import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {List} from '@tryghost/admin-x-design-system';
 
 const features = [{
@@ -10,7 +11,8 @@ const features = [{
 }, {
     title: 'Traffic Analytics (private beta)',
     description: 'Enables traffic analytics',
-    flag: 'trafficAnalytics'
+    flag: 'trafficAnalytics',
+    limitName: 'limitAnalytics' // the limit name as set in hostSettings.limits in config.json
 }, {
     title: 'Traffic Analytics (alpha)',
     description: 'Enables alpha stage analytics features',
@@ -34,9 +36,37 @@ const features = [{
 }];
 
 const AlphaFeatures: React.FC = () => {
+    const limiter = useLimiter();
+    const [allowedFeatures, setAllowedFeatures] = useState<typeof features>([]);
+
+    useEffect(() => {
+        const filterFeatures = async () => {
+            const filtered = [];
+            // Remove all features that are limited according to the subscribed plan
+            for (const feature of features) {
+                if (feature.limitName && limiter?.isLimited(feature.limitName)) {
+                    try {
+                        await limiter.errorIfIsOverLimit(feature.limitName);
+                        filtered.push(feature);
+                    } catch (error) {
+                        if (!(error instanceof HostLimitError)) {
+                            filtered.push(feature);
+                        }
+                    }
+                } else {
+                    filtered.push(feature);
+                }
+            }
+            setAllowedFeatures(filtered);
+        };
+        if (limiter) {
+            filterFeatures();
+        }
+    }, [limiter]);
+
     return (
         <List titleSeparator={false}>
-            {features.map(feature => (
+            {allowedFeatures.map(feature => (
                 <LabItem
                     action={<FeatureToggle flag={feature.flag} label={feature.title} />}
                     detail={feature.description}

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -16,7 +16,8 @@ const features = [{
 }, {
     title: 'Traffic Analytics (alpha)',
     description: 'Enables alpha stage analytics features',
-    flag: 'trafficAnalyticsAlpha'
+    flag: 'trafficAnalyticsAlpha',
+    limitName: 'limitAnalytics' // the limit name as set in hostSettings.limits in config.json
 }, {
     title: 'Email customization (internal beta)',
     description: 'Newsletter customization settings that have been released to Ghost\'s own production sites',

--- a/apps/admin-x-settings/src/hooks/useLimiter.tsx
+++ b/apps/admin-x-settings/src/hooks/useLimiter.tsx
@@ -44,16 +44,11 @@ interface LimiterLimits {
         max?: number
         error?: string
         currentCountQuery?: () => Promise<number>
-    },
-    limitAnalytics?: {
-        disabled?: boolean
-        error?: string
-        currentCountQuery?: () => Promise<boolean>
     }
 }
 
 export const useLimiter = () => {
-    const {config, settings} = useGlobalData();
+    const {config} = useGlobalData();
     const [LimitService, setLimitService] = useState<typeof import('@tryghost/limit-service') | null>(null);
 
     useEffect(() => {
@@ -111,21 +106,6 @@ export const useLimiter = () => {
             };
         }
 
-        if (limits.limitAnalytics) {
-            limits.limitAnalytics.currentCountQuery = async () => {
-                // TODO: It's not clear yet how and where traffic analytics will be stored,
-                // for now we check the settings key and the labs settings for it.
-                // See https://linear.app/ghost/issue/BAE-447/validate-how-to-get-information-about-analytics-and-social-web-usage
-                const key = 'trafficAnalytics';
-                const analyticsSetting = settings.find(s => s.key === key);
-                const labSettings = settings.find(s => s.key === 'labs');
-                const parsedLabsSetting = labSettings?.value ? JSON.parse(labSettings.value as string) : {};
-                const labsSettingEnabled = parsedLabsSetting[key] || false;
-
-                return (analyticsSetting && analyticsSetting.value === true) || labsSettingEnabled;
-            };
-        }
-
         limiter.loadLimits({
             limits,
             helpLink,
@@ -141,5 +121,5 @@ export const useLimiter = () => {
             errorIfWouldGoOverLimit: (limitName: string, metadata: Record<string, unknown> = {}): Promise<void> => limiter.errorIfWouldGoOverLimit(limitName, metadata),
             errorIfIsOverLimit: (limitName: string): Promise<void> => limiter.errorIfIsOverLimit(limitName)
         };
-    }, [LimitService, config.hostSettings?.limits, contributorUsers, fetchMembers, fetchNewsletters, helpLink, invites, isLoading, users, settings]);
+    }, [LimitService, config.hostSettings?.limits, contributorUsers, fetchMembers, fetchNewsletters, helpLink, invites, isLoading, users]);
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BAE-336/ghost-hide-uishow-limit-modal-in-admin-x-when-limits-reached

Ghost is introducing new pricing tiers with gated features based on subscription plans. Analytics features in the private Labs settings and the general settings need to be restricted appropriately according to these new plan limits to support the upcoming pricing structure.

If the limit is present, the new checks will prevent the toggles from being displayed, thereby preventing the feature from being turned on.