### PR TITLE
Added limit enforcement for Stripe Connect

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
@@ -1,8 +1,10 @@
+import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import TiersList from './tiers/TiersList';
 import TopLevelGroup from '../../TopLevelGroup';
 import clsx from 'clsx';
-import {Button, StripeButton, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, LimitModal, StripeButton, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {Tier, getActiveTiers, getArchivedTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
@@ -28,8 +30,22 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const activeTiers = getActiveTiers(tiers || []);
     const archivedTiers = getArchivedTiers(tiers || []);
     const {updateRoute} = useRouting();
+    const limiter = useLimiter();
 
-    const openConnectModal = () => {
+    const openConnectModal = async () => {
+        if (limiter?.isLimited('limitStripeConnect')) {
+            try {
+                await limiter.errorIfWouldGoOverLimit('limitStripeConnect');
+            } catch (error) {
+                if (error instanceof HostLimitError) {
+                    NiceModal.show(LimitModal, {
+                        prompt: error.message || `Your current plan doesn't support Stripe Connect.`,
+                        onOk: () => updateRoute({route: '/pro', isExternal: true})
+                    });
+                    return;
+                }
+            }
+        }
         updateRoute('stripe-connect');
     };
 

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
@@ -2,10 +2,11 @@ import BookmarkThumb from '../../../../assets/images/stripe-thumb.jpg';
 import GhostLogo from '../../../../assets/images/orb-squircle.png';
 import GhostLogoPink from '../../../../assets/images/orb-pink.png';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import StripeLogo from '../../../../assets/images/stripe-emblem.svg';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
-import {Button, ConfirmationModal, Form, Heading, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, Form, Heading, LimitModal, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
+import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {ReactComponent as StripeVerified} from '../../../../assets/images/stripe-verified.svg';
 import {checkStripeEnabled, getSettingValue, getSettingValues, useDeleteStripeSettings, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -253,6 +254,27 @@ const StripeConnectModal: React.FC = () => {
     const {updateRoute} = useRouting();
     const [step, setStep] = useState<'start' | 'connect'>('start');
     const mainModal = useModal();
+    const limiter = useLimiter();
+
+    useEffect(() => {
+        const checkLimit = async () => {
+            if (limiter?.isLimited('limitStripeConnect')) {
+                try {
+                    await limiter.errorIfWouldGoOverLimit('limitStripeConnect');
+                } catch (error) {
+                    if (error instanceof HostLimitError) {
+                        mainModal.remove();
+                        NiceModal.show(LimitModal, {
+                            prompt: error.message || `Your current plan doesn't support Stripe Connect.`,
+                            onOk: () => updateRoute({route: '/pro', isExternal: true})
+                        });
+                    }
+                }
+            }
+        };
+
+        checkLimit();
+    }, [limiter, mainModal, updateRoute]);
 
     const startFlow = () => {
         setStep('connect');

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
@@ -2,11 +2,10 @@ import BookmarkThumb from '../../../../assets/images/stripe-thumb.jpg';
 import GhostLogo from '../../../../assets/images/orb-squircle.png';
 import GhostLogoPink from '../../../../assets/images/orb-pink.png';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import StripeLogo from '../../../../assets/images/stripe-emblem.svg';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
-import {Button, ConfirmationModal, Form, Heading, LimitModal, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
-import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
+import {Button, ConfirmationModal, Form, Heading, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {ReactComponent as StripeVerified} from '../../../../assets/images/stripe-verified.svg';
 import {checkStripeEnabled, getSettingValue, getSettingValues, useDeleteStripeSettings, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -254,22 +253,6 @@ const StripeConnectModal: React.FC = () => {
     const {updateRoute} = useRouting();
     const [step, setStep] = useState<'start' | 'connect'>('start');
     const mainModal = useModal();
-    const limiter = useLimiter();
-
-    useEffect(() => {
-        if (limiter?.isLimited('limitStripeConnect')) {
-            limiter.errorIfWouldGoOverLimit('limitStripeConnect').catch((error) => {
-                if (error instanceof HostLimitError) {
-                    NiceModal.show(LimitModal, {
-                        prompt: error.message || `Your current plan doesn't support Stripe Connect.`,
-                        onOk: () => updateRoute({route: '/pro', isExternal: true})
-                    });
-                    mainModal.remove();
-                    updateRoute('tiers');
-                }
-            });
-        }
-    }, [limiter, mainModal, updateRoute]);
 
     const startFlow = () => {
         setStep('connect');

--- a/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
@@ -1,11 +1,12 @@
 import {expect, test} from '@playwright/test';
 import {globalDataRequests} from '../../utils/acceptance';
-import {mockApi, responseFixtures, settingsWithStripe} from '@tryghost/admin-x-framework/test/acceptance';
+import {limitRequests, mockApi, responseFixtures, settingsWithStripe} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Tier settings', async () => {
     test('Supports creating a new tier', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
+            ...limitRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers}
         }});
@@ -70,6 +71,7 @@ test.describe('Tier settings', async () => {
     test('Supports updating a tier', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            ...limitRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers},
             editTier: {method: 'PUT', path: `/tiers/${responseFixtures.tiers.tiers[1].id}/`, response: {
@@ -159,6 +161,7 @@ test.describe('Tier settings', async () => {
     test('Supports editing the free tier', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            ...limitRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
             browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers},
             editTier: {method: 'PUT', path: `/tiers/${responseFixtures.tiers.tiers[0].id}/`, response: {
@@ -203,5 +206,58 @@ test.describe('Tier settings', async () => {
                 ]
             }]
         });
+    });
+
+    test('Shows limit modal when connecting Stripe with limitStripeConnect', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseSettings: globalDataRequests.browseSettings, // No Stripe configured
+            browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                limitStripeConnect: {
+                                    disabled: true,
+                                    error: 'Your current plan doesn\'t support Stripe Connect.'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('tiers');
+
+        // Click on "Connect with Stripe" button
+        await section.getByRole('button', {name: 'Connect with Stripe'}).click();
+
+        // Wait for limit modal to appear (limit check happens in useEffect)
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
+        // Should show limit modal instead of Stripe Connect modal
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Your current plan doesn't support Stripe Connect/);
+
+        // Stripe modal should not be visible
+        await expect(page.getByTestId('stripe-modal')).not.toBeVisible();
+
+        // Click upgrade
+        const limitModal = page.getByTestId('limit-modal');
+        await limitModal.getByRole('button', {name: 'Upgrade'}).click();
+
+        // The route should be updated to /pro
+        const newPageUrl = page.url();
+        const newPageUrlObject = new URL(newPageUrl);
+        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
+
+        expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
     });
 });


### PR DESCRIPTION
ref [BAE-336](https://linear.app/ghost/issue/BAE-336/ghost-hide-ui-in-admin-x-when-limits-reached)

Ghost is introducing new pricing tiers with gated features based on subscription plans. The Stripe Connect button needed to be restricted appropriately according to these new plan limits to support the upcoming pricing structure.

If the limit is present, we'll show the limit modal to upgrade the plan when the Stripe Connect button is clicked. Access to the route directly will also show the limit modal. The implementation required two `useEffect` hooks: one to prevent the button click and the rendering of the `StripeConnectModal` at all (in `Tiers`), and one to prevent the direct route access to `/settings/stripe-connect` in the `StripeConnectModal`.
