### PR TITLE
Removed range 'Today' on Stats > Overview

### DIFF
--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -180,7 +180,7 @@ const Overview: React.FC = () => {
     return (
         <StatsLayout>
             <StatsHeader>
-                <DateRangeSelect />
+                <DateRangeSelect excludeRanges={['today']} />
             </StatsHeader>
             <StatsView isLoading={isPageLoading} loadingComponent={<></>}>
                 <OverviewKPIs

--- a/apps/stats/src/views/Stats/components/DateRangeSelect.tsx
+++ b/apps/stats/src/views/Stats/components/DateRangeSelect.tsx
@@ -1,10 +1,28 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {LucideIcon, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue} from '@tryghost/shade';
-import {STATS_RANGE_OPTIONS} from '@src/utils/constants';
+import {STATS_RANGES, STATS_RANGE_OPTIONS} from '@src/utils/constants';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 
-const DateRangeSelect: React.FC = () => {
+interface DateRangeSelectProps {
+    excludeRanges?: (keyof typeof STATS_RANGES)[];
+}
+
+const DateRangeSelect: React.FC<DateRangeSelectProps> = ({excludeRanges = []}) => {
     const {range, setRange} = useGlobalData();
+
+    const excludeValues = excludeRanges.map(key => STATS_RANGES[key].value);
+    const filteredOptions = STATS_RANGE_OPTIONS.filter(option => !excludeValues.includes(option.value)
+    );
+
+    // If the current range is excluded, switch to a sensible fallback
+    useEffect(() => {
+        if (excludeValues.includes(range) && filteredOptions.length > 0) {
+            // Prefer "Last 7 days" if available, otherwise use the first available option
+            const preferredFallback = filteredOptions.find(option => option.value === STATS_RANGES.last7Days.value);
+            const fallbackRange = preferredFallback ? preferredFallback.value : filteredOptions[0].value;
+            setRange(fallbackRange);
+        }
+    }, [range, excludeValues, filteredOptions, setRange]);
 
     return (
         <Select value={`${range}`} onValueChange={(value) => {
@@ -17,7 +35,7 @@ const DateRangeSelect: React.FC = () => {
             <SelectContent align='end'>
                 <SelectGroup>
                     <SelectLabel>Period</SelectLabel>
-                    {STATS_RANGE_OPTIONS.map(option => (
+                    {filteredOptions.map(option => (
                         <SelectItem key={option.value} value={`${option.value}`}>
                             {option.name}
                         </SelectItem>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2183/
- added an exclude prop for DateRangeSelect
- removed Today for Stats > Overview

We don't currently want to show the Today because we need to figure out how to mesh the data with a lookback of 24h. Currently the Tinybird (Visits) data returns hourly entries (~24 points), while the MRR and Members data doesn't change enough throughout a day to warrant hourly data, and the endponits only currently return EOD values (2 points).

The chart lib we use doesn't support having different #s of data points, and it doesn't make sense to fill the range and have any change happen at an arbitrary point in the day.

We may end up implementing a hourly range for Members and MRR counts.
