### PR TITLE
Added limit enforcement for theme limits

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/ChangeTheme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/ChangeTheme.tsx
@@ -2,16 +2,14 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import {Button, LimitModal, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
-import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {useCheckThemeLimitError} from '../../../hooks/useCheckThemeLimitError';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
-    const limiter = useLimiter();
-    const {config} = useGlobalData();
+    const {checkThemeLimitError} = useCheckThemeLimitError();
     const {updateRoute} = useRouting();
     const {data: themesData} = useBrowseThemes();
     const activeTheme = themesData?.themes.find((theme: Theme) => theme.active);
@@ -19,29 +17,13 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     useEffect(() => {
         const checkIfThemeChangeAllowed = async () => {
             setIsCheckingLimit(true);
-            // If the allowlist only contains one single entry, we can assume that the user
-            // is not allowed to change themes at all.
-            const numberOfAllowedThemes = config.hostSettings?.limits?.customThemes?.allowlist?.length;
-            if (numberOfAllowedThemes === 1) {
-                await limiter?.errorIfWouldGoOverLimit('customThemes', {value: '.'}).catch((error) => {
-                    if (error instanceof HostLimitError) {
-                        setThemeLimitError(error?.message ?? 'Your current plan doesn\'t support changing themes.');
-                    }
-                });
-            } else {
-                // Ensure no error, if more than one theme is allowed
-                setThemeLimitError(null);
-            }
+            const error = await checkThemeLimitError();
+            setThemeLimitError(error);
             setIsCheckingLimit(false);
         };
 
-        if (limiter?.isLimited('customThemes')) {
-            checkIfThemeChangeAllowed();
-        } else {
-            setThemeLimitError(null);
-            setIsCheckingLimit(false);
-        }
-    }, [limiter, config.hostSettings?.limits?.customThemes?.allowlist?.length]);
+        checkIfThemeChangeAllowed();
+    }, [checkThemeLimitError]);
 
     const openPreviewModal = async () => {
         // Wait for limit check if still in progress

--- a/apps/admin-x-settings/src/components/settings/site/ChangeTheme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/ChangeTheme.tsx
@@ -1,16 +1,62 @@
-import React from 'react';
+import NiceModal from '@ebay/nice-modal-react';
+import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
-import {Button, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, LimitModal, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
+import {useGlobalData} from '../../providers/GlobalDataProvider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
+    const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
+    const [isCheckingLimit, setIsCheckingLimit] = useState(false);
+    const limiter = useLimiter();
+    const {config} = useGlobalData();
     const {updateRoute} = useRouting();
     const {data: themesData} = useBrowseThemes();
     const activeTheme = themesData?.themes.find((theme: Theme) => theme.active);
 
-    const openPreviewModal = () => {
-        updateRoute('design/change-theme');
+    useEffect(() => {
+        const checkIfThemeChangeAllowed = async () => {
+            setIsCheckingLimit(true);
+            // If the allowlist only contains one single entry, we can assume that the user
+            // is not allowed to change themes at all.
+            const numberOfAllowedThemes = config.hostSettings?.limits?.customThemes?.allowlist?.length;
+            if (numberOfAllowedThemes === 1) {
+                await limiter?.errorIfWouldGoOverLimit('customThemes', {value: '.'}).catch((error) => {
+                    if (error instanceof HostLimitError) {
+                        setThemeLimitError(error?.message ?? 'Your current plan doesn\'t support changing themes.');
+                    }
+                });
+            } else {
+                // Ensure no error, if more than one theme is allowed
+                setThemeLimitError(null);
+            }
+            setIsCheckingLimit(false);
+        };
+
+        if (limiter?.isLimited('customThemes')) {
+            checkIfThemeChangeAllowed();
+        } else {
+            setThemeLimitError(null);
+            setIsCheckingLimit(false);
+        }
+    }, [limiter, config.hostSettings?.limits?.customThemes?.allowlist?.length]);
+
+    const openPreviewModal = async () => {
+        // Wait for limit check if still in progress
+        if (isCheckingLimit) {
+            return;
+        }
+
+        if (themeLimitError) {
+            NiceModal.show(LimitModal, {
+                prompt: themeLimitError,
+                onOk: () => updateRoute({route: '/pro', isExternal: true})
+            });
+        } else {
+            updateRoute('design/change-theme');
+        }
     };
 
     const values = (

--- a/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
@@ -1,14 +1,66 @@
 import ChangeThemeModal from './ThemeModal';
 import DesignModal from './DesignModal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import {RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import React, {useEffect, useState} from 'react';
+import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
+import {LimitModal} from '@tryghost/admin-x-design-system';
+import {RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {useGlobalData} from '../../providers/GlobalDataProvider';
 
 const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const modal = useModal();
+    const limiter = useLimiter();
+    const {config} = useGlobalData();
+    const {updateRoute} = useRouting();
+    const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
+    const [isCheckingLimit, setIsCheckingLimit] = useState(false);
+
+    useEffect(() => {
+        const checkIfThemeChangeAllowed = async () => {
+            setIsCheckingLimit(true);
+            // If the allowlist only contains one single entry, we can assume that the user
+            // is not allowed to change themes at all.
+            const numberOfAllowedThemes = config.hostSettings?.limits?.customThemes?.allowlist?.length;
+            if (numberOfAllowedThemes === 1) {
+                // Sending a bad string to make sure it fails (empty string isn't valid)
+                await limiter?.errorIfWouldGoOverLimit('customThemes', {value: '.'}).catch((error) => {
+                    if (error instanceof HostLimitError) {
+                        setThemeLimitError(error?.message ?? 'Your current plan doesn\'t support changing themes.');
+                    }
+                });
+            } else {
+                // Ensure no error, if more than one theme is allowed
+                setThemeLimitError(null);
+            }
+            setIsCheckingLimit(false);
+        };
+
+        if (pathName === 'design/change-theme' && limiter?.isLimited('customThemes')) {
+            checkIfThemeChangeAllowed();
+        } else {
+            setThemeLimitError(null);
+            setIsCheckingLimit(false);
+        }
+    }, [limiter, config.hostSettings?.limits?.customThemes?.allowlist?.length, pathName]);
+
+    // Show limit modal if there's an error when accessing design/change-theme
+    useEffect(() => {
+        if (pathName === 'design/change-theme' && themeLimitError && !isCheckingLimit) {
+            NiceModal.show(LimitModal, {
+                prompt: themeLimitError,
+                onOk: () => updateRoute({route: '/pro', isExternal: true})
+            });
+            modal.remove(); // Close the current modal
+        }
+    }, [themeLimitError, isCheckingLimit, pathName, updateRoute, modal]);
 
     if (pathName === 'design/edit') {
         return <DesignModal />;
     } else if (pathName === 'design/change-theme') {
+        // Don't show the theme modal if we're still checking limits or if there's an error
+        if (isCheckingLimit || themeLimitError) {
+            return null;
+        }
         return <ChangeThemeModal />;
     } else if (pathName === 'theme/install') {
         const url = window.location.href;

--- a/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
@@ -9,17 +9,19 @@ import {useCheckThemeLimitError} from '../../../hooks/useCheckThemeLimitError';
 const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const modal = useModal();
     const {updateRoute} = useRouting();
-    const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
+    const [themeChangeError, setThemeChangeError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
-    const {checkThemeLimitError, isThemeLimitCheckReady, allowedThemesList} = useCheckThemeLimitError();
+    const [isCheckingInstallation, setIsCheckingInstallation] = useState(false);
+    const {checkThemeLimitError, isThemeLimitCheckReady, noThemeChangesAllowed, isThemeLimited} = useCheckThemeLimitError();
+    const [installationAllowed, setInstallationAllowed] = useState<boolean | null>(null);
 
     useEffect(() => {
         const checkIfThemeChangeAllowed = async () => {
             setIsCheckingLimit(true);
             const error = await checkThemeLimitError();
-            setThemeLimitError(error);
+            setThemeChangeError(error);
             setIsCheckingLimit(false);
-            
+
             // Show limit modal immediately if there's an error
             if (error) {
                 NiceModal.show(LimitModal, {
@@ -33,63 +35,93 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         if (pathName === 'design/change-theme' && isThemeLimitCheckReady) {
             checkIfThemeChangeAllowed();
         } else {
-            setThemeLimitError(null);
+            setThemeChangeError(null);
             setIsCheckingLimit(false);
         }
     }, [checkThemeLimitError, isThemeLimitCheckReady, pathName, modal, updateRoute]);
 
-
     // Check theme installation limits
     useEffect(() => {
         const checkThemeInstallation = async () => {
-            if (pathName === 'theme/install' && isThemeLimitCheckReady) {
-                // Parse URL params
+            if (pathName === 'theme/install') {
+                if (!isThemeLimitCheckReady) {
+                    // Still loading limit check
+                    setIsCheckingInstallation(true);
+                    return;
+                }
+                
+                setIsCheckingInstallation(true);
                 const url = window.location.href;
                 const fragment = url.split('#')[1];
                 const queryParams = fragment?.split('?')[1];
-                
+
                 if (queryParams) {
                     const searchParams = new URLSearchParams(queryParams);
                     const ref = searchParams.get('ref');
-                    
+
                     if (ref) {
                         const themeName = ref.split('/')[1]?.toLowerCase();
-                        const isSingleTheme = allowedThemesList?.length === 1;
                         
-                        // Check if theme installation will be blocked
-                        const isThemeInstallationBlocked = isSingleTheme || (allowedThemesList && !allowedThemesList.includes(themeName));
-                        
-                        if (isThemeInstallationBlocked) {
-                            const error = await checkThemeLimitError(themeName);
-                            if (error) {
+                        // Let the hook handle all the logic about whether to show an error
+                        const error = await checkThemeLimitError(themeName);
+                        if (error) {
+                            setInstallationAllowed(false);
+                            
+                            // Redirect based on whether theme changes are allowed
+                            if (noThemeChangesAllowed) {
+                                // Single theme - show limit modal and redirect to /theme
                                 NiceModal.show(LimitModal, {
                                     prompt: error,
                                     onOk: () => updateRoute({route: '/pro', isExternal: true})
                                 });
-                                
-                                if (isSingleTheme) {
-                                    modal.remove();
-                                    updateRoute('theme');
-                                } else {
-                                    updateRoute('design/change-theme');
-                                }
+                                modal.remove();
+                                updateRoute('theme');
+                            } else {
+                                // Multiple themes allowed - redirect to change-theme and show limit modal there
+                                // Clear the current modal first
+                                modal.remove();
+                                updateRoute('design/change-theme');
+                                // Show the limit modal after a small delay to ensure the route change happens first
+                                setTimeout(() => {
+                                    NiceModal.show(LimitModal, {
+                                        prompt: error,
+                                        onOk: () => updateRoute({route: '/pro', isExternal: true})
+                                    });
+                                }, 100);
                             }
+                        } else {
+                            // Installation is allowed
+                            setInstallationAllowed(true);
                         }
+                        setIsCheckingInstallation(false);
+                    } else {
+                        // No ref param, don't allow installation (invalid URL)
+                        setInstallationAllowed(false);
+                        setIsCheckingInstallation(false);
                     }
+                } else {
+                    // No query params, don't allow installation (invalid URL)
+                    setInstallationAllowed(false);
+                    setIsCheckingInstallation(false);
                 }
+            } else {
+                // Not on theme/install path
+                setIsCheckingInstallation(false);
             }
         };
-        
+
         checkThemeInstallation();
-    }, [pathName, isThemeLimitCheckReady, allowedThemesList, checkThemeLimitError, modal, updateRoute]);
+    }, [pathName, isThemeLimitCheckReady, checkThemeLimitError, noThemeChangesAllowed, isThemeLimited, modal, updateRoute]);
 
     if (pathName === 'design/edit') {
         return <DesignModal />;
     } else if (pathName === 'design/change-theme') {
-        // Don't show the theme modal if we're still checking limits or if there's an error
-        if (isCheckingLimit || themeLimitError) {
+        // Don't show the change theme modal if we're still checking limits or if there's
+        // a theme limit error
+        if (isCheckingLimit || themeChangeError) {
             return null;
         }
+        
         return <ChangeThemeModal />;
     } else if (pathName === 'theme/install') {
         // Parse URL params inline since we need them immediately
@@ -98,30 +130,25 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         const queryParams = fragment?.split('?')[1];
         let ref: string | null = null;
         let source: string | null = null;
-        
+
         if (queryParams) {
             const searchParams = new URLSearchParams(queryParams);
             ref = searchParams.get('ref');
             source = searchParams.get('source');
         }
 
-        // Don't render the modal if limits aren't ready yet
-        if (!isThemeLimitCheckReady) {
+        // Don't render the modal if limits aren't ready yet or we're still checking
+        // or if we haven't determined if installation is allowed yet
+        if (!isThemeLimitCheckReady || isCheckingInstallation || installationAllowed === null) {
             return null;
         }
 
-        // Only check for blocking if there are actual limits (allowedThemesList is defined)
-        if (ref && allowedThemesList) {
-            const themeName = ref.split('/')[1]?.toLowerCase();
-            const isSingleTheme = allowedThemesList.length === 1;
-            const isThemeInstallationBlocked = isSingleTheme || !allowedThemesList.includes(themeName);
-            
-            if (isThemeInstallationBlocked) {
-                // The useEffect will handle showing the limit modal
-                return null;
-            }
+        // If installation is not allowed, we've already shown the limit modal
+        if (!installationAllowed) {
+            return null;
         }
 
+        // Installation is allowed, render the ChangeThemeModal with the source and ref
         return <ChangeThemeModal source={source} themeRef={ref} />;
     } else {
         modal.remove();

--- a/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
@@ -327,7 +327,6 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
             // Only show confirmation if we have explicit source and themeRef props (not from URL params after redirect)
             if (source && themeRef && !installedFromMarketplace) {
                 const themeName = themeRef.split('/')[1];
-                
                 let titleText = 'Install Theme';
                 const existingThemeNames = themes?.map(t => t.name) || [];
                 let willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
@@ -420,9 +419,6 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                         onOk: async (confirmModal) => {
                             confirmModal?.remove();
                             await performInstallation();
-                            resolve();
-                        },
-                        onCancel: () => {
                             resolve();
                         }
                     });

--- a/apps/admin-x-settings/src/components/settings/site/theme/ThemePreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/ThemePreview.tsx
@@ -1,6 +1,5 @@
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
-import {Breadcrumbs, Button, ButtonGroup, ConfirmationModal, DesktopChrome, MobileChrome, PageHeader, Select, SelectOption} from '@tryghost/admin-x-design-system';
+import {Breadcrumbs, Button, ButtonGroup, DesktopChrome, MobileChrome, PageHeader, Select, SelectOption} from '@tryghost/admin-x-design-system';
 import {OfficialTheme, ThemeVariant} from '../../../providers/SettingsAppProvider';
 import {Theme, isDefaultOrLegacyTheme} from '@tryghost/admin-x-framework/api/themes';
 
@@ -71,26 +70,8 @@ const ThemePreview: React.FC<{
     }
 
     const handleInstall = () => {
-        if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
-            NiceModal.show(ConfirmationModal, {
-                title: 'Overwrite theme',
-                prompt: (
-                    <>
-                        This will overwrite your existing version of {selectedTheme.name}{installedTheme?.active ? ', which is your active theme' : ''}. All custom changes will be lost.
-                    </>
-                ),
-                okLabel: 'Overwrite',
-                okRunningLabel: 'Installing...',
-                cancelLabel: 'Cancel',
-                okColor: 'red',
-                onOk: async (confirmModal) => {
-                    await onInstall?.();
-                    confirmModal?.remove();
-                }
-            });
-        } else {
-            onInstall?.();
-        }
+        // The parent component handles all limit checks and confirmation modals
+        onInstall?.();
     };
 
     const left =

--- a/apps/admin-x-settings/src/hooks/useCheckThemeLimitError.tsx
+++ b/apps/admin-x-settings/src/hooks/useCheckThemeLimitError.tsx
@@ -46,7 +46,7 @@ export const useCheckThemeLimitError = (): UseCheckThemeLimitErrorReturn => {
     return {
         checkThemeLimitError: checkError,
         isThemeLimited: limiter?.isLimited('customThemes') || false,
-        isThemeLimitCheckReady: true, // Always ready - if limiter is undefined, there are no limits
+        isThemeLimitCheckReady: limiter !== undefined,
         allowedThemesList,
         noThemeChangesAllowed
     };

--- a/apps/admin-x-settings/src/hooks/useCheckThemeLimitError.tsx
+++ b/apps/admin-x-settings/src/hooks/useCheckThemeLimitError.tsx
@@ -1,0 +1,51 @@
+import {HostLimitError, useLimiter} from './useLimiter';
+import {useCallback} from 'react';
+import {useGlobalData} from '../components/providers/GlobalDataProvider';
+
+interface UseCheckThemeLimitErrorReturn {
+    checkThemeLimitError: (themeName?: string) => Promise<string | null>;
+    isThemeLimited: boolean;
+    isThemeLimitCheckReady: boolean;
+    allowedThemesList: string[] | undefined;
+}
+
+export const useCheckThemeLimitError = (): UseCheckThemeLimitErrorReturn => {
+    const limiter = useLimiter();
+    const {config} = useGlobalData();
+    
+    const checkError = useCallback(async (themeName?: string): Promise<string | null> => {
+        if (!limiter?.isLimited('customThemes')) {
+            return null;
+        }
+        
+        const allowlist = config.hostSettings?.limits?.customThemes?.allowlist as string[] | undefined;
+        const isSingleTheme = allowlist?.length === 1;
+        
+        // Single theme: always error
+        // Multiple themes: error if specific theme not in allowlist
+        const shouldError = isSingleTheme || (themeName && allowlist && !allowlist.includes(themeName.toLowerCase()));
+        
+        if (!shouldError) {
+            return null;
+        }
+        
+        try {
+            // Use '.' for single theme to force error, or specific theme name
+            const value = isSingleTheme ? '.' : (themeName || '.');
+            await limiter.errorIfWouldGoOverLimit('customThemes', {value});
+            return null; // No error
+        } catch (error) {
+            if (error instanceof HostLimitError) {
+                return error.message || 'Your current plan doesn\'t support changing themes.';
+            }
+            return null;
+        }
+    }, [limiter, config.hostSettings?.limits?.customThemes?.allowlist]);
+    
+    return {
+        checkThemeLimitError: checkError,
+        isThemeLimited: limiter?.isLimited('customThemes') || false,
+        isThemeLimitCheckReady: limiter !== undefined,
+        allowedThemesList: config.hostSettings?.limits?.customThemes?.allowlist as string[] | undefined
+    };
+};

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -274,9 +274,27 @@ test.describe('Theme settings', async () => {
     });
 
     test('fires Install Theme modal when redirected from marketplace url', async ({page}) => {
+        // Positive test: Taste is in the allowlist
         await mockApi({page, requests: {
             ...globalDataRequests,
-            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes}
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper', 'headline', 'taste'], // Taste IS in the allowlist
+                                    error: 'Upgrade to use more themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }});
         await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
 
@@ -531,8 +549,6 @@ test.describe('Theme settings', async () => {
         }});
 
         await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
-
-        await page.waitForSelector('[data-testid="theme-modal"]');
 
         // Should show limit modal because 'taste' is not in the allowlist
         await expect(page.getByTestId('limit-modal')).toBeVisible();

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -440,6 +440,23 @@ test.describe('Theme settings', async () => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                staff: {
+                                    max: 10,
+                                    error: 'You have reached the maximum number of staff users'
+                                }
+                                // No customThemes limit
+                            }
+                        }
+                    }
+                }
+            },
             installTheme: {method: 'POST', path: /^\/themes\/install\/\?/, response: {
                 themes: [{
                     name: 'taste',
@@ -525,7 +542,7 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('toast-success')).toHaveText(/taste is now your active theme/);
     });
 
-    test('Theme install route blocks installation when theme is NOT in allowlist', async ({page}) => {
+    test('Theme install route blocks installation, but shows change theme modal when theme is NOT in allowlist', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             ...limitRequests,
@@ -550,12 +567,26 @@ test.describe('Theme settings', async () => {
 
         await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
 
+        // Should be redirected to design/change-theme
+        await expect(page).toHaveURL(/#\/settings\/design\/change-theme/);
+
         // Should show limit modal because 'taste' is not in the allowlist
         await expect(page.getByTestId('limit-modal')).toBeVisible();
         await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use more themes/);
 
-        // Theme install modal should not be visible
+        // Theme modal should be visible (behind the limit modal) but NO confirmation modal
+        await expect(page.getByTestId('theme-modal')).toBeVisible();
+        
+        // Wait a bit to ensure no confirmation modal appears
+        await page.waitForTimeout(1000);
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
+
+        // Close the limit modal
+        await page.getByRole('button', {name: 'Cancel'}).click();
+
+        // Should stay on design/change-theme with the change theme modal visible
+        await expect(page).toHaveURL(/#\/settings\/design\/change-theme/);
+        await expect(page.getByTestId('theme-modal')).toBeVisible();
     });
 
     test('Theme install route blocks installation with single-theme allowlist', async ({page}) => {
@@ -588,8 +619,14 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('limit-modal')).toBeVisible();
         await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use custom themes/);
 
+        // Should be redirected to /theme (not change-theme)
+        await expect(page).toHaveURL(/#\/settings\/theme/);
+
         // Theme modal should not be visible at all
         await expect(page.getByTestId('theme-modal')).not.toBeVisible();
+        
+        // Wait a bit to ensure no confirmation modal appears
+        await page.waitForTimeout(1000);
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
     });
 

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -221,6 +221,9 @@ test.describe('Theme settings', async () => {
 
         await modal.getByRole('button', {name: 'Upload theme'}).click();
 
+        // Wait for limit modal to appear
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
         await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to enable custom themes/);
 
         const limitModal = page.getByTestId('limit-modal');
@@ -233,7 +236,7 @@ test.describe('Theme settings', async () => {
         const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
 
         // expect the route to be updated to /pro
-        await expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
+        expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
     });
 
     test('Prevents overwriting the default theme', async ({page}) => {
@@ -270,7 +273,7 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('confirmation-modal')).toHaveText(/Upload failed/);
     });
 
-    test('fires Install Theme modal when redirected from markerplace url', async ({page}) => {
+    test('fires Install Theme modal when redirected from marketplace url', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes}
@@ -283,5 +286,296 @@ test.describe('Theme settings', async () => {
 
         await expect(confirmation).toHaveText(/Install Theme/);
         await expect(confirmation).toHaveText(/By clicking below, Taste will automatically be activated as the theme for your site/);
+    });
+
+    test('Prevents changing theme when only one theme is allowed', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['one-theme-only'],
+                                    error: 'Upgrade to use custom themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const themeSection = page.getByTestId('theme');
+
+        // Wait for the theme section to be ready
+        await expect(themeSection).toBeVisible();
+
+        // Give the component time to check limits
+        await page.waitForTimeout(1000);
+
+        await themeSection.getByRole('button', {name: 'Change theme'}).click();
+
+        // Should show limit modal instead of theme modal
+        // Wait for the limit modal to appear (async limit check needs time)
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use custom themes/);
+
+        // Theme modal should not be visible
+        await expect(page.getByTestId('theme-modal')).not.toBeVisible();
+
+        const limitModal = page.getByTestId('limit-modal');
+        await limitModal.getByRole('button', {name: 'Upgrade'}).click();
+
+        // The route should be updated to /pro
+        const newPageUrl = page.url();
+        const newPageUrlObject = new URL(newPageUrl);
+        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
+
+        expect(decodedUrl).toMatch(/\/\{"route":"\/pro","isExternal":true\}$/);
+    });
+
+    test('Allows changing theme when multiple themes are allowed', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper', 'headline', 'edition'],
+                                    error: 'Upgrade to use more themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const themeSection = page.getByTestId('theme');
+
+        await themeSection.getByRole('button', {name: 'Change theme'}).click();
+
+        // Should show theme modal, not limit modal
+        await expect(page.getByTestId('theme-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).not.toBeVisible();
+
+        // Can interact with themes normally
+        await expect(page.getByTestId('theme-modal').getByRole('button', {name: /Casper/})).toBeVisible();
+    });
+
+    test('Prevents direct access to design/change-theme route when limited', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper'],
+                                    error: 'Upgrade to use custom themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        // Navigate directly to the change theme route
+        await page.goto('/#/settings/design/change-theme');
+
+        // Should show limit modal instead of theme modal
+        // Wait for the limit modal to appear (async limit check needs time)
+        await page.waitForSelector('[data-testid="limit-modal"]', {timeout: 10000});
+
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use custom themes/);
+
+        // Theme modal should not be visible
+        await expect(page.getByTestId('theme-modal')).not.toBeVisible();
+    });
+
+    test('Theme install route works without limits', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            installTheme: {method: 'POST', path: /^\/themes\/install\/\?/, response: {
+                themes: [{
+                    name: 'taste',
+                    package: {},
+                    active: false,
+                    templates: []
+                }]
+            }},
+            activateTheme: {method: 'PUT', path: '/themes/taste/activate/', response: {
+                themes: [{
+                    name: 'taste',
+                    package: {},
+                    active: true,
+                    templates: []
+                }]
+            }}
+        }});
+
+        await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
+
+        await page.waitForSelector('[data-testid="theme-modal"]');
+
+        const confirmation = page.getByTestId('confirmation-modal');
+
+        await expect(confirmation).toHaveText(/Install Theme/);
+        await expect(confirmation).toHaveText(/By clicking below, Taste will automatically be activated as the theme for your site/);
+
+        // Can proceed with installation
+        await confirmation.getByRole('button', {name: 'Install'}).click();
+        await expect(page.getByTestId('toast-success')).toHaveText(/taste is now your active theme/);
+    });
+
+    test('Theme install route allows installation when theme is in allowlist', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper', 'headline', 'taste'],
+                                    error: 'Upgrade to use more themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            installTheme: {method: 'POST', path: /^\/themes\/install\/\?/, response: {
+                themes: [{
+                    name: 'taste',
+                    package: {},
+                    active: false,
+                    templates: []
+                }]
+            }},
+            activateTheme: {method: 'PUT', path: '/themes/taste/activate/', response: {
+                themes: [{
+                    name: 'taste',
+                    package: {},
+                    active: true,
+                    templates: []
+                }]
+            }}
+        }});
+
+        await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
+
+        await page.waitForSelector('[data-testid="theme-modal"]');
+
+        const confirmation = page.getByTestId('confirmation-modal');
+
+        await expect(confirmation).toHaveText(/Install Theme/);
+        await expect(confirmation).toHaveText(/By clicking below, Taste will automatically be activated as the theme for your site/);
+
+        // Can proceed with installation because 'taste' is in the allowlist
+        await confirmation.getByRole('button', {name: 'Install'}).click();
+        await expect(page.getByTestId('toast-success')).toHaveText(/taste is now your active theme/);
+    });
+
+    test('Theme install route blocks installation when theme is NOT in allowlist', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper', 'headline', 'edition'], // 'taste' is NOT in the allowlist
+                                    error: 'Upgrade to use more themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
+
+        await page.waitForSelector('[data-testid="theme-modal"]');
+
+        // Should show limit modal because 'taste' is not in the allowlist
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use more themes/);
+
+        // Theme install modal should not be visible
+        await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
+    });
+
+    test('Theme install route blocks installation when theme is NOT in single-theme allowlist', async ({page}) => {
+        // When allowlist has only one theme and the theme being installed is NOT in that list,
+        // it should show the limit modal
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper'],
+                                    error: 'Upgrade to use custom themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/#/settings/theme/install?source=github&ref=TryGhost/Taste');
+
+        await page.waitForSelector('[data-testid="theme-modal"]');
+
+        // Should show limit modal because 'taste' is not in the single-theme allowlist
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use custom themes/);
+
+        // Theme install modal should not be visible
+        await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
     });
 });

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -576,9 +576,6 @@ test.describe('Theme settings', async () => {
 
         // Theme modal should be visible (behind the limit modal) but NO confirmation modal
         await expect(page.getByTestId('theme-modal')).toBeVisible();
-        
-        // Wait a bit to ensure no confirmation modal appears
-        await page.waitForTimeout(1000);
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
 
         // Close the limit modal
@@ -624,9 +621,6 @@ test.describe('Theme settings', async () => {
 
         // Theme modal should not be visible at all
         await expect(page.getByTestId('theme-modal')).not.toBeVisible();
-        
-        // Wait a bit to ensure no confirmation modal appears
-        await page.waitForTimeout(1000);
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
     });
 

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -578,8 +578,12 @@ test.describe('Theme settings', async () => {
         await expect(page.getByTestId('theme-modal')).toBeVisible();
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
 
-        // Close the limit modal
-        await page.getByRole('button', {name: 'Cancel'}).click();
+        // Wait for the limit modal to be fully interactive before clicking
+        const limitModalCancelButton = page.getByTestId('limit-modal').getByRole('button', {name: 'Cancel'});
+        await expect(limitModalCancelButton).toBeEnabled();
+        
+        // Close the limit modal - be more specific to avoid clicking through to theme modal
+        await limitModalCancelButton.click();
 
         // Should stay on design/change-theme with the change theme modal visible
         await expect(page).toHaveURL(/#\/settings\/design\/change-theme/);

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -201,7 +201,7 @@ test.describe('Theme settings', async () => {
                         hostSettings: {
                             limits: {
                                 customThemes: {
-                                    allowlist: ['casper'],
+                                    allowlist: ['casper', 'source', 'edition'],
                                     error: 'Upgrade to enable custom themes'
                                 }
                             }
@@ -623,7 +623,7 @@ test.describe('Theme settings', async () => {
         await themeSection.getByRole('button', {name: 'Change theme'}).click();
 
         const modal = page.getByTestId('theme-modal');
-        
+
         // Try to install a theme that's not in the allowlist
         await modal.getByRole('button', {name: /Headline/}).click();
 
@@ -636,5 +636,61 @@ test.describe('Theme settings', async () => {
 
         // Installation confirmation should not be visible
         await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
+    });
+
+    test('Shows limit modal before overwrite confirmation for already installed themes', async ({page}) => {
+        // Test case: User has Edition theme installed (from fixtures), tries to update it when it's not in the allowlist
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseThemes: {method: 'GET', path: '/themes/', response: responseFixtures.themes},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                customThemes: {
+                                    allowlist: ['casper', 'headline'], // Edition is NOT in the allowlist
+                                    error: 'Upgrade to use more themes'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const themeSection = page.getByTestId('theme');
+        await themeSection.getByRole('button', {name: 'Change theme'}).click();
+
+        const modal = page.getByTestId('theme-modal');
+
+        // Wait for modal to be ready
+        await expect(modal).toBeVisible();
+
+        await modal.getByRole('button', {name: /Edition/}).click();
+
+        // Wait for the theme preview to load
+        await expect(modal).toContainText('Edition');
+
+        // Edition is already installed, so the button should say "Update Edition"
+        // and would normally trigger the overwrite confirmation modal, but because
+        // we have a limit now that doesn't allow this theme, it should show the limit modal instead.
+        const installButton = modal.getByRole('button', {name: 'Update Edition'});
+        await expect(installButton).toBeVisible();
+
+        // Click the install/update button
+        await installButton.click();
+
+        // Should show limit modal FIRST, not the overwrite confirmation
+        await expect(page.getByTestId('limit-modal')).toBeVisible();
+        await expect(page.getByTestId('limit-modal')).toHaveText(/Upgrade to use more themes/);
+
+        // Overwrite confirmation should NOT be visible
+        await expect(page.getByTestId('confirmation-modal').filter({hasText: /overwrite/i})).not.toBeVisible();
     });
 });


### PR DESCRIPTION
ref [BAE-336](https://linear.app/ghost/issue/BAE-336/ghost-hide-ui-in-admin-x-when-limits-reached)

Ghost is introducing new pricing tiers with theme restrictions. The admin interface needed support for enforcing these limits before the pricing changes go live.

Without these changes, users on restricted plans would be able to install, upload, and activate any theme, bypassing their plan's intended limitations. The UI had no mechanism to enforce theme allowlists or provide feedback about restrictions.

We implemented comprehensive theme limit enforcement by creating a centralized `useCheckThemeLimitError` hook that handles all limit logic. This hook is integrated at every theme interaction point - the change theme button, direct route navigation, marketplace installations, uploads, and preview actions. When limits apply, users see upgrade modals explaining their plan's restrictions. The centralized approach ensures consistent behavior across all components. We added extensive acceptance tests covering single-theme limits, multi-theme allowlists, and edge cases. During implementation, we also resolved a modal interaction issue where the Cancel button wasn't properly closing the overwrite confirmation.

Once the new pricing goes live, users on restricted plans will see appropriate messaging and upgrade paths that align with their plan's theme allowances. The modular implementation makes it easy to adjust restrictions as pricing models evolve.
