### PR TITLE
Added search index endpoint for posts in Admin

### DIFF
--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -40,6 +40,7 @@ export default class SearchProviderBasicService extends Service {
     @service ajax;
     @service notifications;
     @service store;
+    @service ghostPaths;
 
     content = [];
 
@@ -85,9 +86,15 @@ export default class SearchProviderBasicService extends Service {
     }
 
     async _loadSearchable(searchable, content) {
-        const url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
-        const maxSearchableLimit = '10000';
-        const query = {fields: searchable.fields, limit: maxSearchableLimit};
+        let url;
+        let query;
+        if (searchable.model === 'post') {
+            url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
+            query = {};
+        } else {
+            url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
+            query = {fields: searchable.fields, limit: '10000'};
+        }
 
         try {
             const response = await this.ajax.request(url, {data: query});

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -49,6 +49,7 @@ export default class SearchProviderFlexService extends Service {
     @service ajax;
     @service notifications;
     @service store;
+    @service ghostPaths;
 
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
         indexes[searchable.model] = new Document({
@@ -119,8 +120,15 @@ export default class SearchProviderFlexService extends Service {
     }
 
     async #loadSearchable(searchable) {
-        const url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
-        const query = {fields: searchable.fields, limit: 10000, order: searchable.order};
+        let url;
+        let query;
+        if (searchable.model === 'post') {
+            url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
+            query = {};
+        } else {
+            url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
+            query = {fields: searchable.fields, limit: 10000, order: searchable.order};
+        }
 
         try {
             const response = await this.ajax.request(url, {data: query});

--- a/ghost/admin/mirage/config/search-index.js
+++ b/ghost/admin/mirage/config/search-index.js
@@ -1,0 +1,20 @@
+export default function mockSearchIndex(server) {
+    server.get('/search-index/posts', function ({posts}) {
+        const searchPosts = posts.all().models.map((post, index) => {
+            const url = `http://localhost:4200/p/post-${index}/`;
+
+            return {
+                id: post.id,
+                url: url,
+                title: post.title,
+                status: post.status,
+                published_at: post.publishedAt,
+                visibility: post.visibility
+            };
+        });
+
+        return {
+            posts: searchPosts
+        };
+    });
+}

--- a/ghost/admin/mirage/routes-test.js
+++ b/ghost/admin/mirage/routes-test.js
@@ -15,6 +15,7 @@ import mockOffers from './config/offers';
 import mockPages from './config/pages';
 import mockPosts from './config/posts';
 import mockRoles from './config/roles';
+import mockSearchIndex from './config/search-index';
 import mockSettings from './config/settings';
 import mockSite from './config/site';
 import mockSlugs from './config/slugs';
@@ -45,6 +46,7 @@ export default function () {
     mockPages(this);
     mockPosts(this);
     mockRoles(this);
+    mockSearchIndex(this);
     mockSettings(this);
     mockSite(this);
     mockSlugs(this);

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -213,6 +213,10 @@ module.exports = {
         return apiFramework.pipeline(require('./incoming-recommendations'), localUtils);
     },
 
+    get searchIndex() {
+        return apiFramework.pipeline(require('./search-index'), localUtils);
+    },
+
     /**
      * Content API Controllers
      *
@@ -265,7 +269,7 @@ module.exports = {
         return apiFramework.pipeline(require('./recommendations-public'), localUtils, 'content');
     },
 
-    get searchIndex() {
+    get searchIndexPublic() {
         return apiFramework.pipeline(require('./search-index-public'), localUtils, 'content');
     }
 };

--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -9,7 +9,12 @@ const controller = {
         },
         permissions: true,
         query() {
-            return searchIndexService.fetchPosts();
+            const options = {
+                limit: '10000',
+                order: 'updated_at DESC',
+                columns: ['id', 'slug', 'title', 'excerpt', 'url', 'created_at', 'updated_at', 'published_at', 'visibility']
+            };
+            return searchIndexService.fetchPosts(options);
         }
     },
     fetchAuthors: {

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -1,0 +1,25 @@
+const searchIndexService = require('../../services/search-index');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'search_index',
+    fetchPosts: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        query() {
+            const options = {
+                limit: '10000',
+                order: 'updated_at DESC',
+                columns: ['id', 'url', 'title', 'status', 'published_at', 'visibility']
+            };
+            return searchIndexService.fetchPosts(options);
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -14,6 +14,7 @@ module.exports = {
             'title',
             'excerpt',
             'url',
+            'status',
             'created_at',
             'updated_at',
             'published_at',

--- a/ghost/core/core/server/services/search-index/SearchIndexService.js
+++ b/ghost/core/core/server/services/search-index/SearchIndexService.js
@@ -4,15 +4,8 @@ module.exports = class SearchIndexService {
         this.models = models;
     }
 
-    async fetchPosts() {
-        const options = {
-            limit: '10000',
-            order: 'updated_at DESC',
-            columns: ['id', 'slug', 'title', 'excerpt', 'url', 'created_at', 'updated_at', 'published_at', 'visibility']
-        };
-
+    async fetchPosts(options) {
         const posts = await this.PostsService.browsePosts(options);
-
         return posts;
     }
 

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -66,10 +66,11 @@ const notImplemented = function notImplemented(req, res, next) {
         media: ['POST'],
         db: ['POST'],
         settings: ['GET'],
-        oembed: ['GET']
+        oembed: ['GET'],
+        'search-index': ['GET']
     };
 
-    const match = req.url.match(/^\/(\w+)\/?/);
+    const match = req.url.match(/^\/([^/?]+)\/?/);
 
     if (match) {
         const entity = match[1];

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -375,5 +375,8 @@ module.exports = function apiRoutes() {
     // Feedback
     router.get('/feedback/:id', mw.authAdminApi, http(api.feedbackMembers.browse));
 
+    // Search index
+    router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
+
     return router;
 };

--- a/ghost/core/core/server/web/api/endpoints/content/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/content/routes.js
@@ -45,9 +45,9 @@ module.exports = function apiRoutes() {
     router.get('/recommendations', mw.authenticatePublic, http(api.recommendationsPublic.browse));
 
     // ## Search index
-    router.get('/search-index/posts', mw.authenticatePublic, http(api.searchIndex.fetchPosts));
-    router.get('/search-index/authors', mw.authenticatePublic, http(api.searchIndex.fetchAuthors));
-    router.get('/search-index/tags', mw.authenticatePublic, http(api.searchIndex.fetchTags));
+    router.get('/search-index/posts', mw.authenticatePublic, http(api.searchIndexPublic.fetchPosts));
+    router.get('/search-index/authors', mw.authenticatePublic, http(api.searchIndexPublic.fetchAuthors));
+    router.get('/search-index/tags', mw.authenticatePublic, http(api.searchIndexPublic.fetchTags));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search Index API fetchPosts should return a list of posts 1: [body] 1`] = `
+Object {
+  "posts": Array [
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index API fetchPosts should return a list of posts 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "106403",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Search Index API fetchPosts should return a list of posts 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "2313",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -32,7 +32,7 @@ describe('Search Index API', function () {
                     posts: new Array(11).fill(searchIndexPostMatcher)
                 });
 
-            // Explicitely check that expensive fields are not included
+            // Explicitly double-check that expensive fields are not included
             const post = response.body.posts[0];
             assert.equal(post.excerpt, undefined);
             assert.equal(post.html, undefined);

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -1,0 +1,44 @@
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyEtag, anyISODateTime, anyString} = matchers;
+const assert = require('node:assert');
+
+describe('Search Index API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('posts');
+        await agent.loginAsOwner();
+    });
+
+    describe('fetchPosts', function () {
+        const searchIndexPostMatcher = {
+            id: anyString,
+            title: anyString,
+            url: anyString,
+            status: anyString,
+            published_at: anyISODateTime,
+            visibility: anyString
+        };
+
+        it('should return a list of posts', async function () {
+            const response = await agent.get('/search-index/posts')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    posts: new Array(11).fill(searchIndexPostMatcher)
+                });
+
+            // Explicitely check that expensive fields are not included
+            const post = response.body.posts[0];
+            assert.equal(post.excerpt, undefined);
+            assert.equal(post.html, undefined);
+            assert.equal(post.mobiledoc, undefined);
+            assert.equal(post.lexical, undefined);
+            assert.equal(post.plaintext, undefined);
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/content/search-index.test.js
+++ b/ghost/core/test/e2e-api/content/search-index.test.js
@@ -39,7 +39,7 @@ describe('Search Index Content API', function () {
                         .fill(searchIndexPostMatcher)
                 });
 
-            // Explicitely double-check that expensive fields are not included
+            // Explicitly double-check that expensive fields are not included
             const post = res.body.posts[0];
             assert.equal(post.html, undefined, 'html field should be not included in the response');
             assert.equal(post.plaintext, undefined, 'plaintext field should be not included in the response');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added `GET /ghost/api/admin/search-index/posts` Admin API endpoint 
- this endpoint returns up to 10k posts, sorted by most recently updated and with only the necessary fields for search in Admin or the editor
- wired up the new endpoint with the basic search and flex search providers in Admin