### PR TITLE
Added `event_id` uuid field to `ghost-stats` script event payload

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -58,6 +58,18 @@ export class GhostStats {
         return !!(config.host && config.token);
     }
 
+    generateUUID() {
+        if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+            return crypto.randomUUID();
+        }
+
+        // Fallback to a simple UUID generator
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        });
+    }
+
     async trackEvent(name, payload) {
         try {
             // Check if we have required configuration
@@ -66,6 +78,7 @@ export class GhostStats {
             }
 
             const url = `${config.host}?name=${encodeURIComponent(config.datasource)}&token=${encodeURIComponent(config.token)}`;
+            payload.event_id = this.generateUUID();
 
             // Process the payload, masking sensitive data
             const processedPayload = processPayload(payload, config.globalAttributes, config.stringifyPayload);

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -67,6 +67,7 @@ export class GhostStats {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
             const r = Math.random() * 16 | 0;
             const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
         });
     }
 

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -341,6 +341,7 @@ describe('ghost-stats.js', function () {
             expect(innerPayload.locale).to.be.a('string');
             expect(innerPayload.location).to.be.a('string');
             expect(innerPayload.site_uuid).to.be.a('string');
+            expect(innerPayload.event_id).to.be.a('string');
         });
     });
 
@@ -478,6 +479,20 @@ describe('ghost-stats.js', function () {
             // Test the global API works
             mockWindow.Tinybird.trackEvent('test', {data: 'value'});
             expect(mockFetch.calledOnce).to.be.true;
+        });
+    });
+
+    describe('GhostStats UUID Generation', function () {
+        it('should generate a valid UUID', function () {
+            const uuid = ghostStats.generateUUID();
+            expect(uuid).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        it('should generate a valid UUID with fallback', function () {
+            mockWindow.crypto = undefined;
+
+            const uuid = ghostStats.generateUUID();
+            expect(uuid).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-661/analytics-service-should-batch-events-when-sending-to-tinybird

Each event that is sent to the analytics service should have an `event_id` attached to it, which uniquely identifies the event. This will be useful for debugging and auditing the event processing pipeline in the analytics service, and for finding and eliminating any duplicate events, should they ever be created.

This adds the event_id to the payload of the event, so it won't be stored at the top level of the datasource, but it will still be easily accessible and queryable.