### PR TITLE
Updated admin apps to use Tinybird JWTs with automatic refresh

### DIFF
--- a/apps/admin-x-framework/src/api/tinybird.ts
+++ b/apps/admin-x-framework/src/api/tinybird.ts
@@ -1,0 +1,17 @@
+import {Meta, createQuery} from '../utils/api/hooks';
+
+export interface TinybirdToken {
+    token: string;
+}
+
+export interface TinybirdTokenResponseType {
+    meta?: Meta;
+    tinybird: TinybirdToken;
+}
+
+const dataType = 'TinybirdTokenResponseType';
+
+export const getTinybirdToken = createQuery<TinybirdTokenResponseType>({
+    dataType,
+    path: '/tinybird/token/'
+});

--- a/apps/admin-x-framework/src/api/tinybird.ts
+++ b/apps/admin-x-framework/src/api/tinybird.ts
@@ -2,6 +2,7 @@ import {Meta, createQuery} from '../utils/api/hooks';
 
 export interface TinybirdToken {
     token: string;
+    exp?: number;
 }
 
 export interface TinybirdTokenResponseType {

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -38,3 +38,7 @@ export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';
 export {useQueryClient} from '@tanstack/react-query';
+
+// API
+export type {TinybirdToken, TinybirdTokenResponseType} from './api/tinybird';
+export {getTinybirdToken} from './api/tinybird';

--- a/apps/admin-x-framework/src/utils/stats-config.ts
+++ b/apps/admin-x-framework/src/utils/stats-config.ts
@@ -1,4 +1,5 @@
 import {StatsConfig} from '../providers/FrameworkProvider';
+import {getTinybirdToken} from '../api/tinybird';
 
 export const getStatEndpointUrl = (config?: StatsConfig | null, endpoint?: string, params = '') => {
     if (!config) {
@@ -11,5 +12,14 @@ export const getStatEndpointUrl = (config?: StatsConfig | null, endpoint?: strin
 };
 
 export const getToken = (config?: StatsConfig) => {
+    // Try to get token from getTinybirdToken first
+    const tinybirdQuery = getTinybirdToken();
+    const apiToken = tinybirdQuery.data?.tinybird?.token;
+    
+    if (apiToken && typeof apiToken === 'string') {
+        return apiToken;
+    }
+    
+    // Fallback to config-based token
     return config?.local?.enabled ? config?.local?.token : config?.token;
 }; 

--- a/apps/admin-x-framework/src/utils/stats-config.ts
+++ b/apps/admin-x-framework/src/utils/stats-config.ts
@@ -12,8 +12,12 @@ export const getStatEndpointUrl = (config?: StatsConfig | null, endpoint?: strin
 };
 
 export const getToken = (config?: StatsConfig) => {
-    // Try to get token from getTinybirdToken first
-    const tinybirdQuery = getTinybirdToken();
+    // Try to get token from getTinybirdToken first with automatic refresh
+    const tinybirdQuery = getTinybirdToken({
+        refetchInterval: 120 * 60 * 1000, // 2 hours — tokens expire after 3 hours
+        refetchIntervalInBackground: true,
+        notifyOnChangeProps: [] // Never trigger re-renders
+    });
     const apiToken = tinybirdQuery.data?.tinybird?.token;
     
     if (apiToken && typeof apiToken === 'string') {

--- a/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
@@ -25,7 +25,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
         mockGetStatEndpointUrl.mockImplementation((_config: any, endpoint: any) => `https://api.example.com/${endpoint}`);
         mockGetToken.mockReturnValue('mock-token');
@@ -61,7 +66,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: true,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -76,7 +86,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 25}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -86,7 +101,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: true,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         rerender();
@@ -99,7 +119,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 42}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -109,11 +134,16 @@ describe('useActiveVisitors', () => {
     });
 
     it('handles error state', () => {
-        const mockError = new Error('Network error');
+        const mockError = 'Network error';
         mockUseQuery.mockReturnValue({
             data: null,
             loading: false,
-            error: mockError
+            error: mockError,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -246,7 +276,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 25}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -256,7 +291,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: true,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         rerender();
@@ -270,7 +310,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 0}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -282,7 +327,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{some_other_field: 42}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -306,7 +356,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}));
@@ -316,7 +371,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 15}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         rerender();
@@ -327,7 +387,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: null,
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         rerender();
@@ -368,7 +433,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 20}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         const {result, rerender} = renderHook(
@@ -382,7 +452,12 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockReturnValue({
             data: [{active_visitors: 30}],
             loading: false,
-            error: null
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/api_active_visitors',
+            token: 'mock-token',
+            refresh: vi.fn()
         });
 
         rerender({enabled: false});

--- a/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
@@ -1,5 +1,12 @@
 import {getStatEndpointUrl, getToken} from '../../../src/utils/stats-config';
 import {StatsConfig} from '../../../src/providers/FrameworkProvider';
+import {getTinybirdToken} from '../../../src/api/tinybird';
+import {vi} from 'vitest';
+
+// Mock getTinybirdToken
+vi.mock('../../../src/api/tinybird', () => ({
+    getTinybirdToken: vi.fn()
+}));
 
 describe('stats-config utils', () => {
     describe('getStatEndpointUrl', () => {
@@ -153,6 +160,16 @@ describe('stats-config utils', () => {
 
         it('handles null config object', () => {
             expect(getToken(null as any)).toBeUndefined();
+        });
+
+        it('returns token from getTinybirdToken when no config is provided', () => {
+            const mockToken = 'api-fetched-token';
+            vi.mocked(getTinybirdToken).mockReturnValue({
+                data: { tinybird: { token: mockToken } },
+                refetch: vi.fn()
+            } as any);
+
+            expect(getToken()).toBe(mockToken);
         });
     });
 });

--- a/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
@@ -9,6 +9,9 @@ vi.mock('../../../src/api/tinybird', () => ({
 }));
 
 describe('stats-config utils', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
     describe('getStatEndpointUrl', () => {
         it('returns empty string when config is null', () => {
             expect(getStatEndpointUrl(null, 'endpoint')).toBe('');
@@ -101,75 +104,91 @@ describe('stats-config utils', () => {
     });
 
     describe('getToken', () => {
-        it('returns undefined when config is undefined', () => {
-            expect(getToken(undefined)).toBeUndefined();
+        const mockTokenFromApi: string = 'api-fetched-token';
+        
+        describe('when getTinybirdToken returns a token', () => {
+            beforeEach(() => {
+                vi.clearAllMocks();
+                vi.mocked(getTinybirdToken).mockReturnValue({
+                    data: {tinybird: {token: mockTokenFromApi}},
+                    refetch: vi.fn()
+                } as any);
+            });     
+
+            it('returns token from getTinybirdToken when it returns a token', () => {
+                expect(getToken()).toBe(mockTokenFromApi);
+            });
         });
 
-        it('returns production token when local is not enabled', () => {
-            const config: StatsConfig = {
-                token: 'prod-token'
-            };
-            expect(getToken(config)).toBe('prod-token');
-        });
+        describe('when getTinybirdToken returns a null token', () => {
+            beforeEach(() => {
+                vi.clearAllMocks();
+                vi.mocked(getTinybirdToken).mockReturnValue({
+                    data: {tinybird: {token: null}},
+                    refetch: vi.fn()
+                } as any);
+            });
 
-        it('returns local token when local is enabled', () => {
-            const config: StatsConfig = {
-                token: 'prod-token',
-                local: {
-                    enabled: true,
-                    token: 'local-token'
-                }
-            };
-            expect(getToken(config)).toBe('local-token');
-        });
+            it('returns undefined when config is undefined', () => {
+                expect(getToken(undefined)).toBeUndefined();
+            });
 
-        it('returns undefined when local is enabled but local token is missing', () => {
-            const config: StatsConfig = {
-                token: 'prod-token',
-                local: {
-                    enabled: true
-                }
-            };
-            expect(getToken(config)).toBeUndefined();
-        });
+            it('returns production token when local is not enabled', () => {
+                const config: StatsConfig = {
+                    token: 'prod-token'
+                };
+                expect(getToken(config)).toBe('prod-token');
+            });
 
-        it('returns production token when local.enabled is false', () => {
-            const config: StatsConfig = {
-                token: 'prod-token',
-                local: {
-                    enabled: false,
-                    token: 'local-token'
-                }
-            };
-            expect(getToken(config)).toBe('prod-token');
-        });
+            it('returns local token when local is enabled', () => {
+                const config: StatsConfig = {
+                    token: 'prod-token',
+                    local: {
+                        enabled: true,
+                        token: 'local-token'
+                    }
+                };
+                expect(getToken(config)).toBe('local-token');
+            });
 
-        it('returns undefined when no tokens are provided', () => {
-            const config: StatsConfig = {
-                endpoint: 'https://api.example.com'
-            };
-            expect(getToken(config)).toBeUndefined();
-        });
+            it('returns undefined when local is enabled but local token is missing', () => {
+                const config: StatsConfig = {
+                    token: 'prod-token',
+                    local: {
+                        enabled: true
+                    }
+                };
+                expect(getToken(config)).toBeUndefined();
+            });
 
-        it('handles empty token strings', () => {
-            const config: StatsConfig = {
-                token: ''
-            };
-            expect(getToken(config)).toBe('');
-        });
+            it('returns production token when local.enabled is false', () => {
+                const config: StatsConfig = {
+                    token: 'prod-token',
+                    local: {
+                        enabled: false,
+                        token: 'local-token'
+                    }
+                };
+                expect(getToken(config)).toBe('prod-token');
+            });
 
-        it('handles null config object', () => {
-            expect(getToken(null as any)).toBeUndefined();
-        });
+            it('returns undefined when no tokens are provided', () => {
+                const config: StatsConfig = {
+                    endpoint: 'https://api.example.com'
+                };
+                expect(getToken(config)).toBeUndefined();
+            });
 
-        it('returns token from getTinybirdToken when no config is provided', () => {
-            const mockToken = 'api-fetched-token';
-            vi.mocked(getTinybirdToken).mockReturnValue({
-                data: { tinybird: { token: mockToken } },
-                refetch: vi.fn()
-            } as any);
+            it('handles empty token strings', () => {
+                const config: StatsConfig = {
+                    token: ''
+                };
+                expect(getToken(config)).toBe('');
+            });
 
-            expect(getToken()).toBe(mockToken);
+            it('handles null config object', () => {
+                expect(getToken(null as any)).toBeUndefined();
+            });
         });
     });
 });

--- a/ghost/core/core/server/api/endpoints/tinybird.js
+++ b/ghost/core/core/server/api/endpoints/tinybird.js
@@ -14,8 +14,16 @@ const controller = {
         },
         async query() {
             TinybirdServiceWrapper.init();
-            const token = TinybirdServiceWrapper.instance ? TinybirdServiceWrapper.instance.getToken() : null;
-            return {token};
+            const tokenData = TinybirdServiceWrapper.instance?.getToken() ?? null;
+            
+            if (tokenData?.exp) {
+                return {
+                    token: tokenData.token,
+                    exp: new Date(tokenData.exp * 1000).toISOString()
+                };
+            }
+            
+            return tokenData;
         }
     }
 };

--- a/ghost/core/core/server/services/stats/utils/tinybird.js
+++ b/ghost/core/core/server/services/stats/utils/tinybird.js
@@ -30,7 +30,8 @@ const create = ({config, request, settingsCache, tinybirdService}) => {
         const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
         const localEnabled = statsConfig?.local?.enabled ?? false;
         const endpoint = localEnabled ? statsConfig.local.endpoint : statsConfig.endpoint;
-        const token = tinybirdService.getToken();
+        const tokenData = tinybirdService.getToken();
+        const token = tokenData?.token;
 
         // Use tbVersion if provided for constructing the URL
         const pipeUrl = (options.tbVersion && !localEnabled) ? 

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -87,7 +87,8 @@ class TinybirdService {
         if (this.isJwtEnabled) {
             // Generate a new JWT token if it doesn't exist or is expired
             if (!this._serverToken || this._isJWTExpired(this._serverToken)) {
-                this._serverToken = this._generateToken({name, expiresInMinutes});
+                const tokenData = this._generateToken({name, expiresInMinutes});
+                this._serverToken = tokenData.token;
             }
             return this._serverToken;
         }
@@ -106,7 +107,7 @@ class TinybirdService {
     /**
      * Generates a Tinybird JWT token with specified options
      * @param {JWTGenerationOptions} [options={}] - Token generation options
-     * @returns {string} The signed JWT token
+     * @returns {{token: string, exp: number}} Object containing the signed JWT token and expiration timestamp
      * @private
      */
     _generateToken({name = `tinybird-jwt-${this.siteUuid}`, expiresInMinutes = 60} = {}) {
@@ -128,7 +129,12 @@ class TinybirdService {
             })
         };
 
-        return jwt.sign(payload, this.tinybirdConfig.adminToken, {noTimestamp: true});
+        const token = jwt.sign(payload, this.tinybirdConfig.adminToken, {noTimestamp: true});
+        
+        return {
+            token,
+            exp: expiresAt
+        };
     }
 
     /**

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -83,7 +83,7 @@ class TinybirdService {
      * For now we need to remain backwards compatible with the old stats token
      * @returns {{token: string, exp?: number}|null} Object with token and optional exp, or null if generation fails
      */
-    getToken({name = `tinybird-jwt-${this.siteUuid}`, expiresInMinutes = 60} = {}) {
+    getToken({name = `tinybird-jwt-${this.siteUuid}`, expiresInMinutes = 180} = {}) {
         // Prefer JWT tokens if enabled
         if (this.isJwtEnabled) {
             // Generate a new JWT token if it doesn't exist or is expired

--- a/ghost/core/test/e2e-api/admin/tinybird.test.js
+++ b/ghost/core/test/e2e-api/admin/tinybird.test.js
@@ -43,17 +43,79 @@ describe('Tinybird API', function () {
                 assert(response.body.tinybird.token);
                 assert.equal(typeof response.body.tinybird.token, 'string');
                 assert(response.body.tinybird.token.length > 0);
+                
+                // JWT tokens should include expiration in ISO format
+                assert(response.body.tinybird.exp);
+                assert.equal(typeof response.body.tinybird.exp, 'string');
+                assert(new Date(response.body.tinybird.exp).getTime() > Date.now());
+                
+                // Verify that the ISO8601 string matches the JWT payload exp
+                const jwt = require('jsonwebtoken');
+                const decoded = jwt.decode(response.body.tinybird.token);
+                assert(typeof decoded === 'object' && decoded.exp);
+                const expectedExpiration = new Date(decoded.exp * 1000).toISOString();
+                assert.equal(response.body.tinybird.exp, expectedExpiration);
             });
         });
 
         describe('Without Tinybird configuration', function () {
-            it('Returns null token when not configured', async function () {
+            it('Returns null when not configured', async function () {
+                const response = await agent
+                    .get('/tinybird/token/')
+                    .expectStatus(200);
+
+                assert.equal(response.body.tinybird, null);
+            });
+        });
+
+        describe('With stats token only (no JWT)', function () {
+            before(async function () {
+                configUtils.set('tinybird', {
+                    stats: {
+                        token: 'static-stats-token'
+                    }
+                });
+            });
+
+            after(async function () {
+                await configUtils.restore();
+            });
+
+            it('Returns static token without exp field', async function () {
                 const response = await agent
                     .get('/tinybird/token/')
                     .expectStatus(200);
 
                 assert(response.body.tinybird);
-                assert.equal(response.body.tinybird.token, null);
+                assert.equal(response.body.tinybird.token, 'static-stats-token');
+                assert.equal(response.body.tinybird.exp, undefined);
+            });
+        });
+
+        describe('With local stats token only (no JWT)', function () {
+            before(async function () {
+                configUtils.set('tinybird', {
+                    stats: {
+                        local: {
+                            enabled: true,
+                            token: 'local-stats-token'
+                        }
+                    }
+                });
+            });
+
+            after(async function () {
+                await configUtils.restore();
+            });
+
+            it('Returns local token without exp field', async function () {
+                const response = await agent
+                    .get('/tinybird/token/')
+                    .expectStatus(200);
+
+                assert(response.body.tinybird);
+                assert.equal(response.body.tinybird.token, 'local-stats-token');
+                assert.equal(response.body.tinybird.exp, undefined);
             });
         });
     });
@@ -61,11 +123,20 @@ describe('Tinybird API', function () {
     describe('As Admin', function () {
         before(async function () {
             await agent.loginAsAdmin();
+            configUtils.set('tinybird', {
+                workspaceId: 'test-workspace-id',
+                adminToken: 'test-admin-token'
+            });
+        });
+
+        after(async function () {
+            await configUtils.restore();
         });
 
         it('Can get a Tinybird JWT token', async function () {
             const response = await agent.get('/tinybird/token/').expectStatus(200);
             assert(response.body.tinybird);
+            assert(response.body.tinybird.token);
         });
     });
 

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -31,7 +31,10 @@ describe('Tinybird Client', function () {
         });
         mockSettingsCache.get.withArgs('site_uuid').returns('931ade9e-a4f1-4217-8625-34bd34250c16');
         mockTinybirdService = {
-            getToken: sinon.stub().returns('mock-jwt-token')
+            getToken: sinon.stub().returns({
+                token: 'mock-jwt-token',
+                exp: 1719859200
+            })
         };
 
         // Create tinybird client with mocked dependencies

--- a/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
+++ b/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
@@ -125,7 +125,7 @@ describe('TinybirdService', function () {
         it('should return a new server token if the existing one is about to expire', function () {
             const initialResult = tinybirdService.getToken();
             const initialToken = initialResult.token;
-            clock.tick(56 * 60 * 1000); // 56 minutes - past the 5 minute buffer for a 60 minute token
+            clock.tick(176 * 60 * 1000); // 176 minutes - past the 5 minute buffer for a 3 hour token
             const newResult = tinybirdService.getToken();
             assert.notEqual(initialToken, newResult.token);
             assert.ok(typeof newResult.exp === 'number');
@@ -134,7 +134,7 @@ describe('TinybirdService', function () {
         it('should return a new server token if the existing one is expired', function () {
             const initialResult = tinybirdService.getToken();
             const initialToken = initialResult.token;
-            clock.tick(60 * 60 * 1000); // 1 hour
+            clock.tick(180 * 60 * 1000); // 3 hours
             const newResult = tinybirdService.getToken();
             assert.notEqual(initialToken, newResult.token);
             assert.ok(typeof newResult.exp === 'number');

--- a/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
+++ b/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
@@ -115,23 +115,29 @@ describe('TinybirdService', function () {
         });
         
         it('should return the existing server JWT token if it is not expired', async function () {
-            const token = tinybirdService.getToken();
-            const newToken = tinybirdService.getToken();
-            assert.equal(token, newToken);
+            const tokenResult = tinybirdService.getToken();
+            const newTokenResult = tinybirdService.getToken();
+            assert.deepEqual(tokenResult, newTokenResult);
+            assert.ok(tokenResult.token);
+            assert.ok(typeof tokenResult.exp === 'number');
         });
 
         it('should return a new server token if the existing one is about to expire', function () {
-            const token = tinybirdService._serverToken;
+            const initialResult = tinybirdService.getToken();
+            const initialToken = initialResult.token;
             clock.tick(56 * 60 * 1000); // 56 minutes - past the 5 minute buffer for a 60 minute token
-            const newToken = tinybirdService.getToken();
-            assert.notEqual(token, newToken);
+            const newResult = tinybirdService.getToken();
+            assert.notEqual(initialToken, newResult.token);
+            assert.ok(typeof newResult.exp === 'number');
         });
 
         it('should return a new server token if the existing one is expired', function () {
-            const token = tinybirdService._serverToken;
+            const initialResult = tinybirdService.getToken();
+            const initialToken = initialResult.token;
             clock.tick(60 * 60 * 1000); // 1 hour
-            const newToken = tinybirdService.getToken();
-            assert.notEqual(token, newToken);
+            const newResult = tinybirdService.getToken();
+            assert.notEqual(initialToken, newResult.token);
+            assert.ok(typeof newResult.exp === 'number');
         });
 
         it('should return the local token if jwt is not enabled and local is enabled', function () {
@@ -144,8 +150,9 @@ describe('TinybirdService', function () {
                 }
             };
             tinybirdService = new TinybirdService({tinybirdConfig, siteUuid});
-            const token = tinybirdService.getToken();
-            assert.equal(token, 'local-token');
+            const result = tinybirdService.getToken();
+            assert.equal(result.token, 'local-token');
+            assert.equal(result.exp, undefined);
         });
 
         it('should return the stats token if jwt is not enabled and local is not enabled', function () {
@@ -155,8 +162,9 @@ describe('TinybirdService', function () {
                 token: 'stats-token'
             };
             tinybirdService = new TinybirdService({tinybirdConfig, siteUuid});
-            const token = tinybirdService.getToken();
-            assert.equal(token, 'stats-token');
+            const result = tinybirdService.getToken();
+            assert.equal(result.token, 'stats-token');
+            assert.equal(result.exp, undefined);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
+++ b/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
@@ -33,28 +33,32 @@ describe('TinybirdService', function () {
             assert.ok(tinybirdService._generateToken);
         });
 
-        it('should return a string', async function () {
-            const token = tinybirdService._generateToken();
-            assert.ok(token);
-            assert.equal(typeof token, 'string');
+        it('should return an object with token and exp properties', async function () {
+            const result = tinybirdService._generateToken();
+            assert.ok(result);
+            assert.equal(typeof result, 'object');
+            assert.ok(result.token);
+            assert.equal(typeof result.token, 'string');
+            assert.ok(result.exp);
+            assert.equal(typeof result.exp, 'number');
         });
 
         it('should return a valid JWT', async function () {
-            const token = tinybirdService._generateToken();
-            const decoded = jwt.verify(token, tinybirdConfig.adminToken);
+            const result = tinybirdService._generateToken();
+            const decoded = jwt.verify(result.token, tinybirdConfig.adminToken);
             assert.ok(decoded);
         });
 
         it('should return a JWT with the correct name', async function () {
-            const token = tinybirdService._generateToken({name: 'test-name'});
-            const decoded = jwt.verify(token, tinybirdConfig.adminToken);
+            const result = tinybirdService._generateToken({name: 'test-name'});
+            const decoded = jwt.verify(result.token, tinybirdConfig.adminToken);
             assert.ok(decoded);
             assert.equal(decoded.name, 'test-name');
         });
 
         it('should return a JWT with the correct scopes', async function () {
-            const token = tinybirdService._generateToken();
-            const decoded = jwt.verify(token, tinybirdConfig.adminToken);
+            const result = tinybirdService._generateToken();
+            const decoded = jwt.verify(result.token, tinybirdConfig.adminToken);
             assert.ok(decoded);
             decoded.scopes.forEach((scope) => {
                 assert.ok(scope.type === 'PIPES:READ');
@@ -62,6 +66,13 @@ describe('TinybirdService', function () {
                 assert.ok(scope.fixed_params);
                 assert.ok(scope.fixed_params.site_uuid === siteUuid);
             });
+        });
+
+        it('should return exp that matches the JWT payload exp', async function () {
+            const result = tinybirdService._generateToken();
+            const decoded = jwt.verify(result.token, tinybirdConfig.adminToken);
+            assert.ok(typeof decoded === 'object' && decoded.exp);
+            assert.equal(result.exp, decoded.exp);
         });
     });
 
@@ -71,8 +82,8 @@ describe('TinybirdService', function () {
         });
 
         it('should return false for a valid JWT', async function () {
-            const token = tinybirdService._generateToken();
-            const isExpired = tinybirdService._isJWTExpired(token);
+            const result = tinybirdService._generateToken();
+            const isExpired = tinybirdService._isJWTExpired(result.token);
             assert.ok(!isExpired);
         });
 
@@ -83,17 +94,17 @@ describe('TinybirdService', function () {
 
         it('should return true for a JWT that is about to expire', async function () {
             // Create token that expires in 1 minute
-            const token = tinybirdService._generateToken({expiresInMinutes: 1});
+            const result = tinybirdService._generateToken({expiresInMinutes: 1});
             // Check if the token is expired with a buffer of 300 seconds = 5 minutes
-            const isExpired = tinybirdService._isJWTExpired(token);
+            const isExpired = tinybirdService._isJWTExpired(result.token);
             assert.ok(isExpired);
         });
 
         it('should return false for a JWT that is not about to expire', async function () {
             // Create token that expires in 10 minutes
-            const token = tinybirdService._generateToken({expiresInMinutes: 10});
+            const result = tinybirdService._generateToken({expiresInMinutes: 10});
             // Check if the token is expired with a buffer of 300 seconds = 5 minutes
-            const isExpired = tinybirdService._isJWTExpired(token);
+            const isExpired = tinybirdService._isJWTExpired(result.token);
             assert.ok(!isExpired);
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-48/generate-scoped-jwts-for-reading-api-data-from-tinybird

The frontend admin apps like stats and posts should use scoped JWTs for authenticating with the Tinybird API, but JWTs have a scheduled expiration time. This means the frontend apps need a mechanism to request a fresh JWT from the backend to avoid hitting 403 errors when requesting data from Tinybird. 

This commit changes how the frontend gets its tokens — rather than requesting the config endpoint and reusing the token provided therein, it will now fetch a token from the admin API, and refresh it automatically in the background every 2 hours. 
