### PR TITLE
Fixed `TinybirdService` throwing error when tinybird config is missing

### DIFF
--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -66,13 +66,13 @@ class TinybirdService {
      */
     constructor({tinybirdConfig, siteUuid}) {
         this.tinybirdConfig = tinybirdConfig;
-        this.siteUuid = tinybirdConfig.stats?.id || siteUuid;
+        this.siteUuid = tinybirdConfig?.stats?.id || siteUuid;
 
         // Flags for determining which token to use
         // We should aim to simplify this in the future
-        this.isJwtEnabled = !!tinybirdConfig.workspaceId && !!tinybirdConfig.adminToken;
-        this.isLocalEnabled = !!tinybirdConfig.stats?.local?.enabled;
-        this.isStatsEnabled = !!tinybirdConfig.stats?.token;
+        this.isJwtEnabled = !!tinybirdConfig?.workspaceId && !!tinybirdConfig?.adminToken;
+        this.isLocalEnabled = !!tinybirdConfig?.stats?.local?.enabled;
+        this.isStatsEnabled = !!tinybirdConfig?.stats?.token;
         this._serverToken = null;
         this._serverTokenExp = null;
     }
@@ -111,6 +111,27 @@ class TinybirdService {
         }
         // If no token is available, return null
         return null;
+    }
+
+    getConfig() {
+        if (this.tinybirdConfig && this.tinybirdConfig?.stats) {
+            const tokenData = this.getToken();
+            return {
+                id: this.siteUuid,
+                token: tokenData.token,
+                tokenExp: tokenData.exp,
+                endpoint: this.tinybirdConfig.stats.endpoint,
+                datasource: this.tinybirdConfig.stats.datasource,
+                local: {
+                    enabled: this.isLocalEnabled,
+                    token: this.tinybirdConfig.stats.local?.token,
+                    endpoint: this.tinybirdConfig.stats.local?.endpoint,
+                    datasource: this.tinybirdConfig.stats.local?.datasource
+                }
+            };
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -113,27 +113,6 @@ class TinybirdService {
         return null;
     }
 
-    getConfig() {
-        if (this.tinybirdConfig && this.tinybirdConfig?.stats) {
-            const tokenData = this.getToken();
-            return {
-                id: this.siteUuid,
-                token: tokenData.token,
-                tokenExp: tokenData.exp,
-                endpoint: this.tinybirdConfig.stats.endpoint,
-                datasource: this.tinybirdConfig.stats.datasource,
-                local: {
-                    enabled: this.isLocalEnabled,
-                    token: this.tinybirdConfig.stats.local?.token,
-                    endpoint: this.tinybirdConfig.stats.local?.endpoint,
-                    datasource: this.tinybirdConfig.stats.local?.datasource
-                }
-            };
-        } else {
-            return null;
-        }
-    }
-
     /**
      * Generates a Tinybird JWT token with specified options
      * @param {JWTGenerationOptions} [options={}] - Token generation options

--- a/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
+++ b/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
@@ -28,6 +28,12 @@ describe('TinybirdService', function () {
         assert.ok(tinybirdService);
     });
 
+    it('should not throw an error if tinybirdConfig is not set', function () {
+        tinybirdConfig = null;
+        tinybirdService = new TinybirdService({tinybirdConfig, siteUuid});
+        assert.ok(tinybirdService);
+    });
+
     describe('_generateToken', function () {
         it('should exist', function () {
             assert.ok(tinybirdService._generateToken);
@@ -165,6 +171,19 @@ describe('TinybirdService', function () {
             const result = tinybirdService.getToken();
             assert.equal(result.token, 'stats-token');
             assert.equal(result.exp, undefined);
+        });
+    });
+
+    describe('getConfig', function () {
+        it('should exist', function () {
+            assert.ok(tinybirdService.getConfig);
+        });
+
+        it('should return null if tinybirdConfig is not set', function () {
+            tinybirdConfig = null;
+            tinybirdService = new TinybirdService({tinybirdConfig, siteUuid});
+            const result = tinybirdService.getConfig();
+            assert.equal(result, null);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
+++ b/ghost/core/test/unit/server/services/tinybird/TinybirdService.test.js
@@ -173,17 +173,4 @@ describe('TinybirdService', function () {
             assert.equal(result.exp, undefined);
         });
     });
-
-    describe('getConfig', function () {
-        it('should exist', function () {
-            assert.ok(tinybirdService.getConfig);
-        });
-
-        it('should return null if tinybirdConfig is not set', function () {
-            tinybirdConfig = null;
-            tinybirdService = new TinybirdService({tinybirdConfig, siteUuid});
-            const result = tinybirdService.getConfig();
-            assert.equal(result, null);
-        });
-    });
 });


### PR DESCRIPTION
If the Tinybird configuration was completely missing, trying to create the Tinybird service would throw an error. We shouldn't ever assume that tinybird is configured, so the service needs to fail gracefully if it's not configured.