### PR TITLE
Added app settings to browser tests

### DIFF
--- a/apps/stats/src/standalone.tsx
+++ b/apps/stats/src/standalone.tsx
@@ -1,5 +1,20 @@
 import './styles/index.css';
 import App from './App';
 import renderShadeApp from '@tryghost/admin-x-framework/test/render-shade';
+import {AppSettings} from '@tryghost/admin-x-framework';
 
-renderShadeApp(App, {});
+// Use test overrides if available, otherwise use defaults
+const defaultAppSettings: AppSettings = {
+    paidMembersEnabled: true,
+    newslettersEnabled: true,
+    analytics: {
+        emailTrackOpens: true,
+        emailTrackClicks: true,
+        membersTrackSources: true,
+        outboundLinkTagging: true,
+        webAnalytics: true
+    }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+renderShadeApp(App, {appSettings: defaultAppSettings} as any);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2194/

Adding this at least allows the tests to behave appropriately. We need to figure out a way to make this dynamic so that we can flip settings within the test, or at least re-mount the app with new state for each page view.