### PR TITLE
Removed unused dependencies from ghost core

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -172,7 +172,6 @@
     "intl": "1.2.5",
     "intl-messageformat": "5.4.3",
     "js-yaml": "4.1.0",
-    "json-stable-stringify": "1.3.0",
     "jsonc-parser": "3.3.1",
     "jsonpath": "1.1.1",
     "jsonwebtoken": "8.5.1",
@@ -217,9 +216,7 @@
     "superagent-throttle": "1.0.1",
     "terser": "5.43.1",
     "tiny-glob": "0.2.9",
-    "tough-cookie": "4.1.4",
     "ua-parser-js": "1.0.40",
-    "uuid": "9.0.1",
     "xml": "1.0.1"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31151,7 +31151,15 @@ totalist@^3.0.0:
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.0.tgz#4ef9c58c5f095255cdc3ff2a0a55091c57a3a1bd"
   integrity sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==
 
-tough-cookie@4.1.4, tough-cookie@^4.0.0, tough-cookie@^4.1.4:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@^4.0.0, tough-cookie@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
   integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
@@ -31160,14 +31168,6 @@ tough-cookie@4.1.4, tough-cookie@^4.0.0, tough-cookie@^4.1.4:
     punycode "^2.1.1"
     universalify "^0.2.0"
     url-parse "^1.5.3"
-
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
 
 tr46@^2.1.0:
   version "2.1.0"
@@ -31963,11 +31963,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@9.0.1, uuid@^9.0.0, uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
-
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -31982,6 +31977,11 @@ uuid@^8.3.1, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0, uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
- Unused dependencies add package bloat and renovate overhead

- json-stable-stringify is used in api-framework, which has been moved to the framework repo

ref https://github.com/TryGhost/Ghost/commit/cfef41cd8f80b81f935ae63332649e5409aad75e ref https://github.com/TryGhost/Ghost/pull/23309

- tough-cookie was originally used in our oembed-service, but it was cleaned up when we upgraded from got 9 to 11:

ref https://github.com/TryGhost/Ghost/commit/2d84b7d990f7e34a76d2d741d012c4fa5e35cd4f#diff-742a255f8a8199564e32841817d7be5d79b61dfe7aa71d4756b995c9d53a8e88L31

- uuid was removed by a contributor, but not cleaned from the members-api package, and then moved back into ghost/core with that package

ref https://github.com/TryGhost/Ghost/commit/58ca6f3d95d273fcce3ec92c1a995c256cd89d01#diff-bf18f8caf848e17b35e266db04bcaeaad05a3e5d069846615d2b1260482396e1 ref https://github.com/TryGhost/Ghost/commit/182944886340d42581ef663772a704fcd91c5529#diff-1f13c9d671bbaf29e33023dfff8d1b2a0a0a52bd923a082142df6c9d45c42963

