### PR TITLE
Fixed staff tokens not giving user permissions

### DIFF
--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -81,9 +81,16 @@ class CanThisResult {
                     // Check api key permissions if they were passed
                     hasApiKeyPermission = true;
                     if (!_.isNull(apiKeyPermissions)) {
-                        // api key request have no user, but we want the user permissions checks to pass
-                        hasUserPermission = true;
-                        hasApiKeyPermission = _.some(apiKeyPermissions, checkPermission);
+                        if (loadedPermissions.user) {
+                            // Staff API key scenario: both user and API key present
+                            // Use USER permissions and ignore API key permissions
+                            hasApiKeyPermission = true; // Allow API key check to pass
+                        } else {
+                            // Traditional API key scenario: API key only, no user
+                            // Use API key permissions as before
+                            hasUserPermission = true;
+                            hasApiKeyPermission = _.some(apiKeyPermissions, checkPermission);
+                        }
                     }
 
                     // Offer a chance for the TargetModel to override the results

--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -137,7 +137,7 @@ describe('Admin API', function () {
 
     // Make sure that staff tokens are blocked from certain endpoints
     describe('Staff Token Blocklist', function () {
-        describe('DELETE /db endpoint', function () {
+        describe('DELETE /db endpoint (delete all content)', function () {
             it('Owner staff token should be blocked', async function () {
                 await agent.useStaffTokenForOwner();
                 await agent
@@ -169,7 +169,7 @@ describe('Admin API', function () {
             });
         });
 
-        describe('PUT /users/owner endpoint', function () {
+        describe('PUT /users/owner endpoint (transfer ownership)', function () {
             it('Owner staff token should be blocked', async function () {
                 await agent.useStaffTokenForOwner();
                 await agent
@@ -218,22 +218,85 @@ describe('Admin API', function () {
             });
         });
 
-        describe('Other endpoints should work normally', function () {
-            it('Staff tokens can still access GET /users', async function () {
-                await agent.useStaffTokenForAdmin();
+        describe('Everything else should get access according to their permissions', function () {
+            it('Owner staff tokens can access GET /db', async function () {
+                await agent.useStaffTokenForOwner();
                 await agent
-                    .get('users')
+                    .get('db')
                     .expectStatus(200);
             });
 
-            it('Staff tokens can get invites, which integrations cannot', async function () {
+            it('Owner staff tokens can access GET /invites', async function () {
+                await agent.useStaffTokenForOwner();
+                await agent
+                    .get('invites')
+                    .expectStatus(200);
+            });
+
+            it('Admin staff tokens can access GET /db', async function () {
+                await agent.useStaffTokenForAdmin();
+                await agent
+                    .get('db')
+                    .expectStatus(200);
+            });
+
+            it('Admin staff tokens can access GET /invites', async function () {
+                await agent.useStaffTokenForAdmin();
+                await agent
+                    .get('invites')
+                    .expectStatus(200);
+            });
+
+            it('Editor staff tokens cannot access GET /db', async function () {
+                await agent.useStaffTokenForEditor();
+                await agent
+                    .get('db')
+                    .expectStatus(403);
+            });
+
+            it('Editor staff tokens can access GET /invites', async function () {
                 await agent.useStaffTokenForEditor();
                 await agent
                     .get('invites')
                     .expectStatus(200);
             });
 
-            it('Integrations still cannot access invites', async function () {
+            it('Author staff tokens cannot access GET /db', async function () {
+                await agent.useStaffTokenForAuthor();
+                await agent
+                    .get('db')
+                    .expectStatus(403);
+            });
+
+            it('Author staff tokens cannot access GET /invites', async function () {
+                await agent.useStaffTokenForAuthor();
+                await agent
+                    .get('invites')
+                    .expectStatus(403);
+            });
+
+            it('Contributor staff tokens cannot access GET /db', async function () {
+                await agent.useStaffTokenForContributor();
+                await agent
+                    .get('db')
+                    .expectStatus(403);
+            });
+
+            it('Contributor staff tokens cannot access GET /invites', async function () {
+                await agent.useStaffTokenForContributor();
+                await agent
+                    .get('invites')
+                    .expectStatus(403);
+            });
+
+            it('Integrations cannot access GET /db', async function () {
+                await agent.useZapierAdminAPIKey();
+                await agent
+                    .get('db')
+                    .expectStatus(501);
+            });
+
+            it('Integrations cannot access GET /invites', async function () {
                 await agent.useZapierAdminAPIKey();
                 await agent
                     .get('invites')

--- a/ghost/core/test/unit/server/services/permissions/parse-context.test.js
+++ b/ghost/core/test/unit/server/services/permissions/parse-context.test.js
@@ -86,6 +86,27 @@ describe('Permissions', function () {
             });
         });
 
+        it('should return both user and api_key when both provided (staff API key scenario)', function () {
+            parseContext({
+                user: {id: 1},
+                api_key: {
+                    id: 2,
+                    type: 'admin'
+                },
+                integration: {id: 3}
+            }).should.eql({
+                internal: false,
+                user: {id: 1},
+                api_key: {
+                    id: 2,
+                    type: 'admin'
+                },
+                member: null,
+                public: false,
+                integration: {id: 3}
+            });
+        });
+
         it('should return internal if internal provided', function () {
             parseContext({internal: true}).should.eql({
                 internal: true,


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/2336
ref https://github.com/TryGhost/Ghost/pull/23585/files#diff-3d98e1fd51a0472fe91d09aa0749a46250023b50945524e5e0815f24ed6522a6R25-R36


A long time ago now, we added staff tokens - these are tokens you can get from your user profile, and use to authenticate with the Admin API as if you were logged in with your username and password.

Given the intention of staff tokens is that access is granted as if the user tied to the token was logged in normally - the permissions were intended to be the same.

However, that was never implemented. Staff tokens were adding the user and the api_key to req, but there was no handling to make sure that resulted in the correct logic.

A while ago I started adding testing for staff tokens [[ref](https://github.com/TryGhost/Ghost/pull/23360)] 

And then I added some logic to bypass our weird 'NotImplemented' middleware [[ref](https://github.com/TryGhost/Ghost/pull/23585/files#diff-3d98e1fd51a0472fe91d09aa0749a46250023b50945524e5e0815f24ed6522a6R25-R36)]

NOTE: I left 2 things unsupported, delete all content and transfer ownership, because it felt wrong to suddenly give existing tokens access to dangerous operations.

I thought I'd cracked it - but it turned out that wasn't the case as [reported here](https://github.com/TryGhost/Ghost-CLI/issues/1952#issuecomment-2927594223).

Although the request is getting passed to our canThis logic now to determine permissions - that is STILL making the wrong choice. 

The logic in canThis states if an api_key is present, ignore the user permissions and use the api_key permissions. That was because it was implemented in a world where you could not have both.

So this PR updates that logic. If a user and an api key are present, we use the user permissions and ignore the api_key.

Note: this goes hand in hand with a change to make sure our AdminAPIAgent properly resets authentication when using a new type [[ref](https://github.com/TryGhost/Ghost/commit/8ae5aa0100d04006b629cc0f7fbe28166595ac89)]. This wasn't working properly and was making the tests not behave as expected / masking some broken cases.

Note 2: This changeset is a bunch of tests and the minimal amount of change to the permission system as possible to achieve the logical change. There's obviously a heap more that could be done to make this more readable.
