### PR TITLE
Added search index endpoint for Pages in Admin API

### DIFF
--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -88,7 +88,7 @@ export default class SearchProviderBasicService extends Service {
     async _loadSearchable(searchable, content) {
         let url;
         let query;
-        if (searchable.model === 'post') {
+        if (searchable.model === 'post' || searchable.model === 'page') {
             url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
             query = {};
         } else {

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -122,7 +122,7 @@ export default class SearchProviderFlexService extends Service {
     async #loadSearchable(searchable) {
         let url;
         let query;
-        if (searchable.model === 'post') {
+        if (searchable.model === 'post' || searchable.model === 'page') {
             url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
             query = {};
         } else {

--- a/ghost/admin/mirage/config/search-index.js
+++ b/ghost/admin/mirage/config/search-index.js
@@ -17,4 +17,23 @@ export default function mockSearchIndex(server) {
             posts: searchPosts
         };
     });
+
+    server.get('/search-index/pages', function ({pages}) {
+        const searchPages = pages.all().models.map((page, index) => {
+            const url = `http://localhost:4200/p/page-${index}/`;
+
+            return {
+                id: page.id,
+                url: url,
+                title: page.title,
+                status: page.status,
+                published_at: page.publishedAt,
+                visibility: page.visibility
+            };
+        });
+
+        return {
+            pages: searchPages
+        };
+    });
 }

--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -12,6 +12,7 @@ const controller = {
         permissions: true,
         query() {
             const options = {
+                filter: 'type:post',
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'slug', 'title', 'excerpt', 'url', 'created_at', 'updated_at', 'published_at', 'visibility']

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -14,6 +14,26 @@ const controller = {
         },
         query() {
             const options = {
+                filter: 'type:post',
+                limit: '10000',
+                order: 'updated_at DESC',
+                columns: ['id', 'url', 'title', 'status', 'published_at', 'visibility']
+            };
+
+            return postsService.browsePosts(options);
+        }
+    },
+    fetchPages: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        query() {
+            const options = {
+                filter: 'type:page',
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'url', 'title', 'status', 'published_at', 'visibility']

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -32,6 +32,31 @@ module.exports = {
         };
     },
 
+    async fetchPages(models, apiConfig, frame) {
+        debug('fetchPages');
+
+        let pages = [];
+
+        const keys = [
+            'id',
+            'url',
+            'title',
+            'status',
+            'published_at',
+            'visibility'
+        ];
+
+        for (let model of models.data) {
+            let page = await mappers.pages(model, frame, {});
+            page = _.pick(page, keys);
+            pages.push(page);
+        }
+
+        frame.response = {
+            pages
+        };
+    },
+
     async fetchAuthors(models, apiConfig, frame) {
         debug('fetchAuthors');
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -380,6 +380,7 @@ module.exports = function apiRoutes() {
 
     // Search index
     router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
+    router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Search Index API fetchPages should return a list of pages 1: [body] 1`] = `
+Object {
+  "pages": Array [
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index API fetchPages should return a list of pages 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "926",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Search Index API fetchPosts should return a list of posts 1: [body] 1`] = `
 Object {
   "posts": Array [

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -41,4 +41,35 @@ describe('Search Index API', function () {
             assert.equal(post.plaintext, undefined);
         });
     });
+
+    describe('fetchPages', function () {
+        const searchIndexPageMatcher = {
+            id: anyString,
+            title: anyString,
+            url: anyString,
+            status: anyString,
+            published_at: anyISODateTime,
+            visibility: anyString
+        };
+
+        it('should return a list of pages', async function () {
+            const response = await agent.get('/search-index/pages')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    pages: new Array(5).fill(searchIndexPageMatcher)
+                });
+
+            // Explicitly double-check that expensive fields are not included
+            const page = response.body.pages[0];
+            assert.equal(page.excerpt, undefined);
+            assert.equal(page.html, undefined);
+            assert.equal(page.mobiledoc, undefined);
+            assert.equal(page.lexical, undefined);
+            assert.equal(page.plaintext, undefined);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added GET /ghost/api/admin/search-index/pages Admin API endpoint
- this endpoint returns up to 10k pages, sorted by most recently updated and with only the necessary fields for search in Admin or the editor
- wired up the new endpoint with the basic search and flex search providers in Admin
