### PR TITLE
Added search index endpoint for Tags in Admin API

### DIFF
--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -88,7 +88,7 @@ export default class SearchProviderBasicService extends Service {
     async _loadSearchable(searchable, content) {
         let url;
         let query;
-        if (searchable.model === 'post' || searchable.model === 'page') {
+        if (searchable.model === 'post' || searchable.model === 'page' || searchable.model === 'tag') {
             url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
             query = {};
         } else {

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -122,7 +122,7 @@ export default class SearchProviderFlexService extends Service {
     async #loadSearchable(searchable) {
         let url;
         let query;
-        if (searchable.model === 'post' || searchable.model === 'page') {
+        if (searchable.model === 'post' || searchable.model === 'page' || searchable.model === 'tag') {
             url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
             query = {};
         } else {

--- a/ghost/admin/mirage/config/search-index.js
+++ b/ghost/admin/mirage/config/search-index.js
@@ -36,4 +36,21 @@ export default function mockSearchIndex(server) {
             pages: searchPages
         };
     });
+
+    server.get('/search-index/tags', function ({tags}) {
+        const searchTags = tags.all().models.map((tag) => {
+            const url = `http://localhost:4200/tag/${tag.slug}/`;
+
+            return {
+                id: tag.id,
+                slug: tag.slug,
+                name: tag.name,
+                url: url
+            };
+        });
+
+        return {
+            tags: searchTags
+        };
+    });
 }

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -1,3 +1,4 @@
+const models = require('../../models');
 const getPostServiceInstance = require('../../services/posts/posts-service');
 const postsService = getPostServiceInstance();
 
@@ -40,6 +41,24 @@ const controller = {
             };
 
             return postsService.browsePosts(options);
+        }
+    },
+    fetchTags: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'tags',
+            method: 'browse'
+        },
+        query() {
+            const options = {
+                limit: '10000',
+                order: 'updated_at DESC',
+                columns: ['id', 'slug', 'name', 'url']
+            };
+
+            return models.Tag.findPage(options);
         }
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -381,6 +381,7 @@ module.exports = function apiRoutes() {
     // Search index
     router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
     router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
+    router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
@@ -180,3 +180,72 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Search Index API fetchTags should return a list of tags 1: [body] 1`] = `
+Object {
+  "tags": Array [
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index API fetchTags should return a list of tags 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "693",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Search Index API fetchTags should return a list of tags 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "693",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -72,4 +72,25 @@ describe('Search Index API', function () {
             assert.equal(page.plaintext, undefined);
         });
     });
+
+    describe('fetchTags', function () {
+        const searchIndexTagMatcher = {
+            id: anyString,
+            slug: anyString,
+            name: anyString,
+            url: anyString
+        };
+
+        it('should return a list of tags', async function () {
+            await agent.get('/search-index/tags')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    tags: new Array(6).fill(searchIndexTagMatcher)
+                });
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added `GET /ghost/api/admin/search-index/tags` Admin API endpoint
- this endpoint returns up to 10k tags, sorted by most recently updated and with only the necessary fields for search in Admin or the editor
- wired up the new endpoint with the basic search and flex search providers in Admin
