### PR TITLE
Fixed link display with Direct traffc in Growth tab

### DIFF
--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -141,7 +141,8 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
             const iconSrc = faviconDomain
                 ? `https://www.faviconextractor.com/favicon/${faviconDomain}?larger=true`
                 : defaultSourceIconUrl;
-            const linkUrl = faviconDomain ? `https://${faviconDomain}` : undefined;
+            // Don't link Direct sources since they represent direct traffic to the site
+            const linkUrl = (faviconDomain && source !== 'Direct') ? `https://${faviconDomain}` : undefined;
 
             return {
                 source,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2057/

In the web traffic components where we show sources, we don't link to Direct. We will no longer do that within the Growth tab (Ghost data) in order to be consistent.