### PR TITLE
🎨 Added search to tags filter dropdown on posts list

### DIFF
--- a/ghost/admin/app/components/posts-list/content-filter.hbs
+++ b/ghost/admin/app/components/posts-list/content-filter.hbs
@@ -58,6 +58,9 @@
             <PowerSelect
                 @selected={{@selectedTag}}
                 @options={{@availableTags}}
+                @onOpen={{@loadInitialTags}}
+                @searchEnabled={{true}}
+                @search={{perform @searchTagsTask}}
                 @searchField="name"
                 @onChange={{@onTagChange}}
                 @triggerComponent={{component "gh-power-select/trigger"}}
@@ -65,7 +68,8 @@
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @searchPlaceholder="Search tags"
                 @matchTriggerWidth={{false}}
-                @optionsComponent={{component "power-select-vertical-collection-options"}}
+                @optionsComponent={{component "power-select-vertical-collection-options" lastReached=this.onLastReached}}
+                @registerAPI={{this.registerTagsPowerSelect}}
                 as |tag|
             >
                 {{#if tag.name}}{{tag.name}}{{else}}<span class="red">Unknown tag</span>{{/if}}

--- a/ghost/admin/app/components/posts-list/content-filter.js
+++ b/ghost/admin/app/components/posts-list/content-filter.js
@@ -1,11 +1,12 @@
 import Component from '@glimmer/component';
-import {get} from '@ember/object';
+import {action, get} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default class PostsListContentFilter extends Component {
     @service customViews;
     @service feature;
     @service router;
+    @service tagsManager;
 
     get showCustomViewManagement() {
         let isAdmin = get(this.args.currentUser || {}, 'isAdmin');
@@ -31,5 +32,16 @@ export default class PostsListContentFilter extends Component {
         };
 
         return {style};
+    }
+
+    @action
+    registerTagsPowerSelect(api) {
+        this.tagsPowerSelectApi = api;
+    }
+
+    @action
+    onLastReached() {
+        const search = this.tagsPowerSelectApi?.searchText;
+        this.args.loadMoreTagsTask.perform(!!search);
     }
 }

--- a/ghost/admin/app/components/power-select-vertical-collection-options.hbs
+++ b/ghost/admin/app/components/power-select-vertical-collection-options.hbs
@@ -6,7 +6,7 @@
         {{/if}}
     {{/if}}
 
-    {{#vertical-collection @options minHeight=30 estimateHeight=6 bufferSize=10 as |opt index|}}
+    {{#vertical-collection @options minHeight=30 estimateHeight=6 bufferSize=10 lastReached=@lastReached as |opt index|}}
         <li class="ember-power-select-option"
             aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
             aria-disabled={{if opt.disabled "true"}}

--- a/ghost/admin/app/controllers/posts.js
+++ b/ghost/admin/app/controllers/posts.js
@@ -1,9 +1,11 @@
 import Controller from '@ember/controller';
 import SelectionList from 'ghost-admin/components/posts-list/selection-list';
 import {DEFAULT_QUERY_PARAMS} from 'ghost-admin/helpers/reset-query-params';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 const TYPES = [{
@@ -56,6 +58,7 @@ export default class PostsController extends Controller {
     @service router;
     @service session;
     @service store;
+    @service tagsManager;
 
     @inject config;
 
@@ -73,11 +76,18 @@ export default class PostsController extends Controller {
     availableVisibilities = VISIBILITIES;
     availableOrders = ORDERS;
 
-    _availableTags = this.store.peekAll('tag');
     _availableAuthors = this.store.peekAll('user');
 
-    _hasLoadedTags = false;
+    // Set & used by the posts route
     _hasLoadedAuthors = false;
+    _hasLoadedFilteredTag = false;
+
+    @tracked _initialTags = new TrackedArray();
+    _initialTagsMeta = null;
+    _hasLoadedInitialTags = false;
+    @tracked _searchedTags = new TrackedArray();
+    _searchedTagsQuery = null;
+    _searchedTagsMeta = null;
 
     constructor() {
         super(...arguments);
@@ -104,21 +114,78 @@ export default class PostsController extends Controller {
     }
 
     get availableTags() {
-        const tags = this._availableTags
-            .filter(tag => tag.get('id') !== null)
-            .sort((tagA, tagB) => tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true}));
+        let options = [{name: 'All tags', slug: null}];
 
-        const options = tags.toArray();
-        options.unshift({name: 'All tags', slug: null});
+        options = options.concat(this.tagsManager.sortTags(this._initialTags));
+
+        if (this.tag && !options.findBy('slug', this.tag)) {
+            const foundTag = this.tagsManager.loadedTags.findBy('slug', this.tag);
+            if (foundTag) {
+                options.push(foundTag);
+            }
+        }
 
         return options;
     }
 
-    get selectedTag() {
-        const tag = this.tag;
-        const tags = this.availableTags;
+    @action
+    async loadInitialTags() {
+        if (!this._hasLoadedInitialTags) {
+            await this.loadMoreTagsTask.perform(false);
+            this._hasLoadedInitialTags = true;
+        }
+    }
 
-        return tags.findBy('slug', tag) || {slug: '!unknown'};
+    @task({drop: true})
+    *loadMoreTagsTask(isSearch = false) {
+        if (isSearch) {
+            if (this.searchTagsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedTagsMeta && this._searchedTagsMeta.pagination.pages <= this._searchedTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedTagsMeta.pagination.page + 1;
+            const tags = yield this.tagsManager.searchTagsTask.perform(this._searchedTagsQuery, {page});
+            this._searchedTags.push(...this.tagsManager.sortTags(tags.toArray()));
+            this._searchedTagsMeta = tags.meta;
+            return tags;
+        } else {
+            if (this._initialTagsMeta && this._initialTagsMeta?.pagination.pages <= this._initialTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialTagsMeta?.pagination.page ? this._initialTagsMeta.pagination.page + 1 : 1;
+            const tags = yield this.store.query('tag', {limit: 100, page, order: 'name asc'});
+            if (page === 1) {
+                this._initialTags = new TrackedArray(tags.toArray());
+            } else {
+                this._initialTags.push(...tags.toArray());
+            }
+            this._initialTagsMeta = tags.meta;
+        }
+    }
+
+    @task
+    *searchTagsTask(term) {
+        this._searchedTagsQuery = term;
+        const tags = yield this.tagsManager.searchTagsTask.perform(term);
+        this._searchedTagsMeta = tags.meta;
+
+        // we need to create a tracked array for vertical-collection to update as new options are loaded
+        // because we can't rely on power-select re-rendering as @options changes via auto template updates
+        this._searchedTags = new TrackedArray(this.tagsManager.sortTags(tags.toArray()));
+        return this._searchedTags;
+    }
+
+    get selectedTag() {
+        if (this.tag === null) {
+            return this.availableTags[0];
+        } else {
+            return this.tagsManager.loadedTags.findBy('slug', this.tag) || {slug: '!unknown'};
+        }
     }
 
     get availableAuthors() {

--- a/ghost/admin/app/services/tags-manager.js
+++ b/ghost/admin/app/services/tags-manager.js
@@ -1,0 +1,26 @@
+import Service, {inject as service} from '@ember/service';
+import {task, timeout} from 'ember-concurrency';
+
+export default class TagsManagerService extends Service {
+    @service store;
+
+    _loadedTags = this.store.peekAll('tag');
+
+    get loadedTags() {
+        return this.sortTags(this._loadedTags);
+    }
+
+    sortTags(tags = []) {
+        return tags
+            .filter(tag => tag.get('id') !== null) // exclude unsaved tags
+            .sort((tagA, tagB) => tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true}));
+    }
+
+    @task({restartable: true})
+    *searchTagsTask(term, {page = 1} = {}) {
+        // debounce the search
+        yield timeout(250);
+        const safeTerm = encodeURIComponent(term).replace(/'/g, '%27'); // encodeURIComponent doesn't escape single quotes
+        return yield this.store.query('tag', {filter: `tags.name:~'${safeTerm}'`, limit: 100, page, order: 'name asc'});
+    }
+}

--- a/ghost/admin/app/templates/posts.hbs
+++ b/ghost/admin/app/templates/posts.hbs
@@ -16,6 +16,9 @@
                 @onAuthorChange={{this.changeAuthor}}
                 @selectedTag={{this.selectedTag}}
                 @availableTags={{this.availableTags}}
+                @loadInitialTags={{this.loadInitialTags}}
+                @loadMoreTagsTask={{this.loadMoreTagsTask}}
+                @searchTagsTask={{this.searchTagsTask}}
                 @onTagChange={{this.changeTag}}
                 @selectedOrder={{this.selectedOrder}}
                 @availableOrders={{this.availableOrders}}

--- a/ghost/admin/mirage/config/posts.js
+++ b/ghost/admin/mirage/config/posts.js
@@ -32,11 +32,13 @@ export function getPosts({posts}, {queryParams}) {
     let statusFilter = extractFilterParam('status', filter);
     let authorsFilter = extractFilterParam('authors', filter);
     let visibilityFilter = extractFilterParam('visibility', filter);
+    let tags = extractFilterParam('tag', filter);
 
     let collection = posts.all().filter((post) => {
         let matchesStatus = true;
         let matchesAuthors = true;
         let matchesVisibility = true;
+        let matchesTags = true;
 
         if (!isEmpty(statusFilter)) {
             matchesStatus = statusFilter.includes(post.status);
@@ -50,8 +52,18 @@ export function getPosts({posts}, {queryParams}) {
             matchesVisibility = visibilityFilter.includes(post.visibility);
         }
 
-        return matchesStatus && matchesAuthors && matchesVisibility;
+        if (!isEmpty(tags)) {
+            matchesTags = tags.some(filterTag => post.tags.models.some(tag => tag.slug === filterTag));
+        }
+
+        return matchesStatus && matchesAuthors && matchesVisibility && matchesTags;
     });
+
+    if (queryParams.order) {
+        if (queryParams.order.startsWith('name')) {
+            collection.sort((a, b) => a.title.localeCompare(b.title));
+        }
+    }
 
     return paginateModelCollection('posts', collection, page, limit);
 }

--- a/ghost/admin/mirage/routes-test.js
+++ b/ghost/admin/mirage/routes-test.js
@@ -78,7 +78,10 @@ export default function () {
     }, 204);
 
     /* limit=all blocker ---------------------------------------------------- */
+    const originalHandledRequest = this.pretender.handledRequest;
     this.pretender.handledRequest = function (verb, path, request) {
+        originalHandledRequest.call(this, verb, path, request);
+
         const url = new URL(request.url, window.location.origin);
         const limit = url.searchParams.get('limit');
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

When posts list filtering was first implemented we had no way of filtering tags server-side so we resorted to fetching all tags to populate the tags filter dropdown in one big list. Many things have changed since:
  - sites have grown, some now have 10s of thousands of tags
  - we're removing `?limit=all` support so we can no longer get every tag in one API request
  - our API now supports "contains" queries with `?filter=tags.name:~'query'`

To improve this, we've:
- removed the all-tags fetch from the `posts` route
- updated tags filter dropdown behaviour
  - added search field
  - added initial load of 100 entries when filter is opened
  - search is performed via a new `tags-manager` service so the functionality can be re-used in other parts of the app later on
- added infinite scroll to tags filter dropdown
  - uses `vertical-collection`'s `lastReached` option to call a new `loadMoreTags` action when fired
  - `posts` controller keeps track of the initial tags list and the searched tags list  so it can add tags to them as needed
- updated mirage posts endpoint to filter by tag for easier testing
- fixed missing logging of mirage requests when logging is enabled
