### PR TITLE
Replaced loadedPermissions with role

### DIFF
--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -157,7 +157,7 @@ const Comment = ghostBookshelf.Model.extend({
         return softDelete();
     },
 
-    async permissible(commentModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission, hasMemberPermission) {
+    async permissible(commentModelOrId, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission, hasMemberPermission) {
         const self = this;
 
         if (hasUserPermission) {

--- a/ghost/core/core/server/models/invite.js
+++ b/ghost/core/core/server/models/invite.js
@@ -54,7 +54,7 @@ Invite = ghostBookshelf.Model.extend({
         return ghostBookshelf.Model.add.call(this, data, options);
     },
 
-    async permissible(inviteModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
+    async permissible(inviteModel, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission) {
         const isAdd = (action === 'add');
 
         if (!isAdd) {
@@ -90,15 +90,17 @@ Invite = ghostBookshelf.Model.extend({
                 }
 
                 let allowed = [];
-                if (loadedPermissions.user) {
-                    const {isOwner, isAdmin, isEitherEditor} = setIsRoles(loadedPermissions);
-                    if (isOwner || isAdmin) {
-                        allowed = ['Administrator', 'Editor', 'Author', 'Contributor', 'Super Editor'];
-                    } else if (isEitherEditor) {
-                        allowed = ['Author', 'Contributor'];
-                    }
-                } else if (loadedPermissions.apiKey) {
+                if (role === 'Owner' || role === 'Administrator') {
+                    allowed = ['Administrator', 'Editor', 'Author', 'Contributor'];
+                } else if (role === 'Admin Integration') {
                     allowed = ['Editor', 'Author', 'Contributor', 'Super Editor'];
+                } else if (role === 'Editor' || role === 'Super Editor') {
+                    allowed = ['Author', 'Contributor'];
+                }
+
+                // Cannot invite administrators when using an api key
+                if (context.api_key) {
+                    allowed = allowed.filter(item => item !== 'Administrator');
                 }
 
                 if (allowed.indexOf(roleToInvite.get('name')) === -1) {

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1368,8 +1368,11 @@ Post = ghostBookshelf.Model.extend({
     },
 
     // NOTE: the `authors` extension is the parent of the post model. It also has a permissible function.
-    permissible: async function permissible(postModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
-        let {isContributor, isOwner, isAdmin, isEitherEditor} = setIsRoles(loadedPermissions);
+    permissible: async function permissible(postModel, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission) {
+        let isContributor;
+        let isOwner;
+        let isAdmin;
+        let isEitherEditor;
         let isIntegration;
         let isEdit;
         let isAdd;
@@ -1387,7 +1390,11 @@ Post = ghostBookshelf.Model.extend({
             return postModel.get('status') === 'draft';
         }
 
-        isIntegration = loadedPermissions.apiKey && _.some(loadedPermissions.apiKey.roles, {name: 'Admin Integration'});
+        isContributor = role === 'Contributor';
+        isOwner = role === 'Owner';
+        isAdmin = role === 'Administrator';
+        isEitherEditor = role === 'Editor' || role === 'Super Editor';
+        isIntegration = role === 'Admin Integration';
 
         isEdit = (action === 'edit');
         isAdd = (action === 'add');

--- a/ghost/core/core/server/models/relations/authors.js
+++ b/ghost/core/core/server/models/relations/authors.js
@@ -302,11 +302,12 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
             return reassignPost();
         },
 
-        permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
+        permissible: function permissible(postModelOrId, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission) {
             const self = this;
             const postModel = postModelOrId;
+            let isContributor;
+            let isAuthor;
             let origArgs;
-            const {isContributor, isAuthor} = setIsRoles(loadedPermissions);
             let isEdit;
             let isAdd;
             let isDestroy;
@@ -332,6 +333,8 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                     });
             }
 
+            isContributor = role === 'Contributor';
+            isAuthor = role === 'Author';
             isEdit = (action === 'edit');
             isAdd = (action === 'add');
             isDestroy = (action === 'destroy');
@@ -390,7 +393,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                     postModelOrId,
                     action, context,
                     unsafeAttrs,
-                    loadedPermissions,
+                    role,
                     hasUserPermission,
                     hasApiKeyPermission
                 ).then(({excludedAttrs}) => {

--- a/ghost/core/core/server/models/role.js
+++ b/ghost/core/core/server/models/role.js
@@ -56,7 +56,7 @@ Role = ghostBookshelf.Model.extend({
         return options;
     },
 
-    permissible: function permissible(roleModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
+    permissible: function permissible(roleModelOrId, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission) {
         // If we passed in an id instead of a model, get the model
         // then check the permissions
         if (_.isNumber(roleModelOrId) || _.isString(roleModelOrId)) {
@@ -78,14 +78,13 @@ Role = ghostBookshelf.Model.extend({
 
         const roleModel = roleModelOrId;
 
-        if (action === 'assign' && loadedPermissions.user) {
-            const {isOwner, isAdmin, isEitherEditor} = setIsRoles(loadedPermissions);
+        if (action === 'assign' && hasUserPermission) {
             let checkAgainst;
-            if (isOwner) {
+            if (role === 'Owner') {
                 checkAgainst = ['Owner', 'Administrator', 'Super Editor', 'Editor', 'Author', 'Contributor'];
-            } else if (isAdmin) {
+            } else if (role === 'Administrator') {
                 checkAgainst = ['Administrator', 'Super Editor', 'Editor', 'Author', 'Contributor'];
-            } else if (isEitherEditor) {
+            } else if (role === 'Editor' || role === 'Super Editor') {
                 checkAgainst = ['Author', 'Contributor'];
             }
 
@@ -93,7 +92,7 @@ Role = ghostBookshelf.Model.extend({
             hasUserPermission = roleModelOrId && _.includes(checkAgainst, roleModel.get('name'));
         }
 
-        if (action === 'assign' && loadedPermissions.apiKey) {
+        if (action === 'assign' && context.api_key) {
             // apiKey cannot 'assign' the 'Owner' role
             if (roleModel.get('name') === 'Owner') {
                 return Promise.reject(new errors.NoPermissionError({

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -13,6 +13,7 @@ const urlUtils = require('../../shared/url-utils');
 const {setIsRoles} = require('./role-utils');
 const activeStates = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'];
 const ASSIGNABLE_ROLES = ['Administrator', 'Super Editor', 'Editor', 'Author', 'Contributor'];
+const models = require('./');
 
 const messages = {
     valueCannotBeBlank: 'Value in [{tableName}.{columnKey}] cannot be blank.',
@@ -76,7 +77,7 @@ User = ghostBookshelf.Model.extend({
     },
 
     format(options) {
-        if (options.website && 
+        if (options.website &&
             !validator.isURL(options.website, {
                 require_protocol: true,
                 protocols: ['http', 'https']
@@ -780,14 +781,14 @@ User = ghostBookshelf.Model.extend({
 
     /**
      * Checks if a user has permission to perform an action on another user
-     * 
+     *
      * @param {Object|string|number} userModelOrId - The user model or ID being acted upon
      * @param {'edit'|'destroy'} action - The action being performed:
      *                                     - 'edit': Edit user details, status, or role
      *                                     - 'destroy': Delete a user (Owner cannot be deleted)
      * @param {Object} context - The context of the request, containing the current user's ID
      * @param {Object} unsafeAttrs - The attributes being modified in the action
-     * @param {Object} loadedPermissions - The permissions of the user making the request
+     * @param {string} role - The role of the actor making the request
      * @param {boolean} hasUserPermission - Whether the user has permission based on user roles
      * @param {boolean} hasApiKeyPermission - Whether the user has permission based on API key
      * @returns {Promise<boolean>} Resolves if the action is permitted, rejects with NoPermissionError if not
@@ -795,11 +796,10 @@ User = ghostBookshelf.Model.extend({
      * @throws {errors.NoPermissionError} When the action is not permitted
      * @throws {errors.ValidationError} When role changes are invalid
      */
-    permissible: async function permissible(userModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission) {
+    permissible: async function permissible(userModelOrId, action, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission) {
         const self = this;
         const userModel = userModelOrId;
         let origArgs;
-        const {isOwner, isEitherEditor} = setIsRoles(loadedPermissions);
 
         // If we passed in a model without its related roles, we need to fetch it again
         if (typeof userModelOrId === 'object' && !(typeof userModelOrId.related('roles') === 'object')) {
@@ -839,10 +839,10 @@ User = ghostBookshelf.Model.extend({
             if (context.user === userModel.get('id')) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = true;
-            } else if (loadedPermissions.user && userModel.hasRole('Owner')) {
+            } else if (userModel.hasRole('Owner')) {
                 // Owner can only be edited by owner
-                hasUserPermission = isOwner;
-            } else if (isEitherEditor) {
+                hasUserPermission = role === 'Owner';
+            } else if (role === 'Editor' || role === 'Super Editor') {
                 // If the user we are trying to edit is an Author or Contributor, allow it
                 hasUserPermission = userModel.hasRole('Author') || userModel.hasRole('Contributor');
             }
@@ -857,7 +857,7 @@ User = ghostBookshelf.Model.extend({
             }
 
             // Users with the role 'Editor' have complex permissions when the action === 'destroy'
-            if (isEitherEditor) {
+            if (role === 'Editor' || role === 'Super Editor') {
                 // Alternatively, if the user we are trying to edit is an Author, allow it
                 hasUserPermission = context.user === userModel.get('id') || userModel.hasRole('Author') || userModel.hasRole('Contributor');
             }
@@ -874,19 +874,26 @@ User = ghostBookshelf.Model.extend({
 
         // CASE: i want to edit roles
         if (action === 'edit' && unsafeAttrs.roles && unsafeAttrs.roles[0]) {
-            let role = unsafeAttrs.roles[0];
-            let roleId = role.id || role;
+            let roleToSet = unsafeAttrs.roles[0];
+            let roleId = roleToSet.id || role;
+            let roleName = roleToSet.name;
+            if (!roleName) {
+                const roleModel = await models.Role.findOne({id: roleId});
+                if (roleModel) {
+                    roleName = roleModel.get('name');
+                }
+            }
             let editedUserId = userModel.id;
             // @NOTE: role id of logged in user
-            let contextRoleId = loadedPermissions.user.roles[0].id;
+            let contextRoleName = role;
 
-            if (roleId !== contextRoleId && editedUserId === context.user) {
+            if (roleName !== contextRoleName && editedUserId === context.user) {
                 return Promise.reject(new errors.NoPermissionError({
                     message: tpl(messages.cannotChangeOwnRole)
                 }));
             }
 
-            if (limitService.isLimited('staff') && userModel.hasRole('Contributor') && role.name !== 'Contributor') {
+            if (limitService.isLimited('staff') && userModel.hasRole('Contributor') && roleToSet.name !== 'Contributor') {
                 // CASE: if your site is limited to a certain number of staff users
                 // Trying to change the role of a contributor, who doesn't count towards the limit, to any other role requires a limit check
                 // To check if it's OK to add one more staff user
@@ -913,12 +920,12 @@ User = ghostBookshelf.Model.extend({
                                 message: tpl(messages.cannotChangeOwnersRole)
                             }));
                         }
-                    } else if (roleId !== contextRoleId) {
+                    } else if (roleName !== contextRoleName) {
                         // CASE: you are trying to change a role, but you are not owner
                         // @NOTE: your role is not the same than the role you try to change (!)
                         // e.g. admin can assign admin role to a user, but not owner
 
-                        return permissions.canThis(context).assign.role(role)
+                        return permissions.canThis(context).assign.role(roleToSet)
                             .then(() => {
                                 if (hasUserPermission && hasApiKeyPermission) {
                                     return Promise.resolve();

--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -58,6 +58,7 @@ class CanThisResult {
                     let hasUserPermission;
                     let hasApiKeyPermission;
                     let hasMemberPermission = false;
+                    let role;
 
                     const checkPermission = function (perm) {
                         // Look for a matching action type and object type first
@@ -67,8 +68,16 @@ class CanThisResult {
 
                         return true;
                     };
-                    const {isOwner} = setIsRoles(loadedPermissions);
-                    if (isOwner) {
+
+                    if (loadedPermissions.user) {
+                        role = loadedPermissions.user.roles[0].name;
+                    } else if (loadedPermissions.member) {
+                        role = 'Member';
+                    } else if (loadedPermissions.apiKey) {
+                        role = loadedPermissions.apiKey.roles[0].name;
+                    }
+
+                    if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Owner'})) {
                         hasUserPermission = true;
                     } else if (!_.isEmpty(userPermissions)) {
                         hasUserPermission = _.some(userPermissions, checkPermission);
@@ -89,7 +98,7 @@ class CanThisResult {
                     // Offer a chance for the TargetModel to override the results
                     if (TargetModel && _.isFunction(TargetModel.permissible)) {
                         return TargetModel.permissible(
-                            modelId, actType, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission, hasMemberPermission
+                            modelId, actType, context, unsafeAttrs, role, hasUserPermission, hasApiKeyPermission, hasMemberPermission
                         );
                     }
 

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -23,7 +23,7 @@ describe('Unit: models/invite', function () {
             let context;
             let unsafeAttrs;
             let roleModel;
-            let loadedPermissions;
+            let role;
 
             before(function () {
                 inviteModel = {};
@@ -31,11 +31,7 @@ describe('Unit: models/invite', function () {
                 unsafeAttrs = {role_id: 'role_id'};
                 roleModel = sinon.stub();
                 roleModel.get = sinon.stub();
-                loadedPermissions = {
-                    user: {
-                        roles: []
-                    }
-                };
+                role = null;
             });
 
             it('role does not exist', function () {
@@ -61,82 +57,82 @@ describe('Unit: models/invite', function () {
 
             describe('as owner', function () {
                 beforeEach(function () {
-                    loadedPermissions.user.roles = [{name: 'Owner'}];
+                    role = 'Owner';
                 });
 
                 it('invite administrator', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite editor', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite author', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
             });
 
             describe('as administrator', function () {
                 beforeEach(function () {
-                    loadedPermissions.user.roles = [{name: 'Administrator'}];
+                    role = 'Administrator';
                 });
 
                 it('invite administrator', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite editor', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite author', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
             });
 
             describe('as editor', function () {
                 beforeEach(function () {
-                    loadedPermissions.user.roles = [{name: 'Editor'}];
+                    role = 'Editor';
                 });
 
                 it('invite administrator', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -147,7 +143,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -173,27 +169,27 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, true, true, true);
                 });
             });
 
             describe('as author', function () {
                 beforeEach(function () {
-                    loadedPermissions.user.roles = [{name: 'Author'}];
+                    role = 'Author';
                 });
 
                 it('invite administrator', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -204,7 +200,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -215,7 +211,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -226,7 +222,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -236,14 +232,14 @@ describe('Unit: models/invite', function () {
 
             describe('as contributor', function () {
                 beforeEach(function () {
-                    loadedPermissions.user.roles = [{name: 'Contributor'}];
+                    role = 'Contributor';
                 });
 
                 it('invite administrator', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -254,7 +250,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -265,7 +261,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -276,7 +272,7 @@ describe('Unit: models/invite', function () {
                     sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, role, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -391,7 +391,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -419,7 +419,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -446,7 +446,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -476,7 +476,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -505,7 +505,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -534,7 +534,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -563,7 +563,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         false
@@ -589,8 +589,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
-                        true,
+                        'Contributor',
                         true,
                         true
                     ).then(() => {
@@ -614,7 +613,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -639,7 +638,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -664,7 +663,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -692,7 +691,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'destroy',
                         context,
                         {},
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -721,7 +720,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'destroy',
                         context,
                         {},
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -750,7 +749,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'destroy',
                         context,
                         {},
-                        testUtils.permissions.contributor,
+                        'Contributor',
                         true,
                         true,
                         true
@@ -781,7 +780,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -811,7 +810,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         false,
                         true
@@ -840,7 +839,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -869,7 +868,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -883,6 +882,63 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     });
                 });
 
+<<<<<<< HEAD
+=======
+                it('rejects if changing authors', function (done) {
+                    const mockPostObj = {
+                        related: sinon.stub()
+                    };
+                    const context = {user: 1};
+                    const unsafeAttrs = {authors: [{id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        'Author',
+                        false,
+                        true,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(errors.NoPermissionError);
+                        should(mockPostObj.related.calledTwice).be.true();
+                        done();
+                    });
+                });
+
+                it('rejects if changing authors', function (done) {
+                    const mockPostObj = {
+                        related: sinon.stub()
+                    };
+                    const context = {user: 1};
+                    const unsafeAttrs = {authors: [{id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        'Author',
+                        false,
+                        true,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(errors.NoPermissionError);
+                        mockPostObj.related.callCount.should.eql(2);
+                        done();
+                    });
+                });
+
+>>>>>>> 67941df299 (Replaced loadedPermissions with role)
                 it('resolves if none of the above cases are true', function () {
                     const mockPostObj = {
                         related: sinon.stub()
@@ -897,7 +953,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'edit',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -920,7 +976,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -948,7 +1004,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         'add',
                         context,
                         unsafeAttrs,
-                        testUtils.permissions.author,
+                        'Author',
                         false,
                         true,
                         true
@@ -979,7 +1035,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     'edit',
                     context,
                     unsafeAttrs,
-                    testUtils.permissions.editor,
+                    'Editor',
                     false,
                     true,
                     true
@@ -1005,7 +1061,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     'edit',
                     context,
                     unsafeAttrs,
-                    testUtils.permissions.editor,
+                    'Editor',
                     true,
                     true,
                     true
@@ -1030,7 +1086,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     'edit',
                     context,
                     unsafeAttrs,
-                    testUtils.permissions.owner,
+                    'Owner',
                     false,
                     true,
                     true
@@ -1059,7 +1115,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     'edit',
                     context,
                     unsafeAttrs,
-                    testUtils.permissions.admin,
+                    'Administrator',
                     false,
                     true,
                     true

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -165,7 +165,7 @@ describe('Unit: models/user', function () {
             const mockUser = getUserModel(1, 'Owner');
             const context = {user: 1};
 
-            models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true, true).then(() => {
+            models.User.permissible(mockUser, 'destroy', context, {}, 'Owner', true, true, true).then(() => {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
                 error.should.be.an.instanceof(errors.NoPermissionError);
@@ -178,7 +178,7 @@ describe('Unit: models/user', function () {
             const mockUser = getUserModel(3, 'Contributor');
             const context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true).then(() => {
+            return models.User.permissible(mockUser, 'edit', context, {}, 'Contributor', false, true, true).then(() => {
                 should(mockUser.get.calledOnce).be.true();
             });
         });
@@ -187,7 +187,7 @@ describe('Unit: models/user', function () {
             const mockUser = getUserModel(3, 'Editor');
             const context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {status: 'inactive'}, testUtils.permissions.editor, false, true, true)
+            return models.User.permissible(mockUser, 'edit', context, {status: 'inactive'}, 'Editor', false, true, true)
                 .then(Promise.reject)
                 .catch((err) => {
                     err.should.be.an.instanceof(errors.NoPermissionError);
@@ -203,7 +203,7 @@ describe('Unit: models/user', function () {
             const mockUser = {id: 3, related: sinon.stub().returns()};
             const context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true)
+            return models.User.permissible(mockUser, 'edit', context, {}, 'Contributor', false, true, true)
                 .then(() => {
                     models.User.findOne.calledOnce.should.be.true();
                 });
@@ -244,7 +244,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.admin.context;
                 const unsafeAttrs = testUtils.permissions.editor.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, 'Administrator', false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(errors.NoPermissionError);
@@ -256,7 +256,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.owner.context;
                 const unsafeAttrs = testUtils.permissions.owner.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.owner, false, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, 'Owner', false, true, true)
                     .then(() => {
                         models.User.getOwnerUser.calledOnce.should.be.true();
                     });
@@ -267,7 +267,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.admin.context;
                 const unsafeAttrs = testUtils.permissions.editor.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, 'Administrator', false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(errors.NoPermissionError);
@@ -285,7 +285,7 @@ describe('Unit: models/user', function () {
                     }
                 });
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, true, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, 'Administrator', true, true, true)
                     .then(() => {
                         models.User.getOwnerUser.calledOnce.should.be.true();
                         permissions.canThis.calledOnce.should.be.true();
@@ -303,7 +303,7 @@ describe('Unit: models/user', function () {
                     }
                 });
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.author, false, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, 'Author', false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(errors.NoPermissionError);
@@ -316,7 +316,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Editor');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, 'Editor', true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
@@ -330,7 +330,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Owner');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, 'Editor', true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
@@ -344,7 +344,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Administrator');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, 'Editor', true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
@@ -358,7 +358,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Author');
                 const context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, 'Editor', true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -368,7 +368,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Contributor');
                 const context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, 'Editor', true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -378,7 +378,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Editor');
                 const context = {user: 3};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, 'Editor', true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -388,7 +388,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Editor');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, 'Editor', true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
@@ -402,7 +402,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Administrator');
                 const context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, 'Editor', true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
@@ -416,7 +416,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Author');
                 const context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, 'Editor', true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -426,7 +426,7 @@ describe('Unit: models/user', function () {
                 const mockUser = getUserModel(3, 'Contributor');
                 const context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, 'Editor', true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -248,7 +248,7 @@ describe('Permissions', function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: [],
-                        roles: undefined
+                        roles: [{name: 'Administrator'}]
                     });
                 });
 
@@ -271,7 +271,7 @@ describe('Permissions', function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
-                        roles: undefined
+                        roles: [{name: 'Administrator'}]
                     });
                 });
 
@@ -292,7 +292,7 @@ describe('Permissions', function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
-                        roles: undefined
+                        roles: [{name: 'Administrator'}]
                     });
                 });
 
@@ -366,7 +366,7 @@ describe('Permissions', function () {
                 // Fake the response from providers.user, which contains permissions and roles
                 return Promise.resolve({
                     permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
-                    roles: undefined
+                    roles: [{name: 'Administrator'}]
                 });
             });
 
@@ -389,7 +389,7 @@ describe('Permissions', function () {
                     permissibleStub.firstCall.args[1].should.eql('edit');
                     permissibleStub.firstCall.args[2].should.be.an.Object();
                     permissibleStub.firstCall.args[3].should.be.an.Object();
-                    permissibleStub.firstCall.args[4].should.be.an.Object();
+                    permissibleStub.firstCall.args[4].should.eql('Administrator');
                     permissibleStub.firstCall.args[5].should.be.true();
                     permissibleStub.firstCall.args[6].should.be.true();
 
@@ -404,7 +404,7 @@ describe('Permissions', function () {
                 // Fake the response from providers.user, which contains permissions and roles
                 return Promise.resolve({
                     permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
-                    roles: undefined
+                    roles: [{name: 'Administrator'}]
                 });
             });
 
@@ -423,7 +423,7 @@ describe('Permissions', function () {
                     permissibleStub.firstCall.args[1].should.eql('edit');
                     permissibleStub.firstCall.args[2].should.be.an.Object();
                     permissibleStub.firstCall.args[3].should.be.an.Object();
-                    permissibleStub.firstCall.args[4].should.be.an.Object();
+                    permissibleStub.firstCall.args[4].should.eql('Administrator');
                     permissibleStub.firstCall.args[5].should.be.true();
                     permissibleStub.firstCall.args[6].should.be.true();
                     permissibleStub.firstCall.args[7].should.be.false();


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-728
ref https://github.com/TryGhost/Ghost/pull/19896

The loadedPermissions were only used to check roles or whether an api key was used. The later is already exposed on the `context` object, so we just need to pass the role. This allows us to internally change how permissions are loaded without having downstream effects, it also moves us closer to pulling roles out of the db and into hardcoded strings.

---

This is a reopening of https://github.com/TryGhost/Ghost/pull/19896

