### PR TITLE
Added search index endpoint for Users in Admin API (#24189)

### DIFF
--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -9,28 +9,24 @@ export const SEARCHABLES = [
     {
         name: 'Staff',
         model: 'user',
-        fields: ['id', 'slug', 'url', 'name'], // id not used but required for API to have correct url
         idField: 'slug',
         titleField: 'name'
     },
     {
         name: 'Tags',
         model: 'tag',
-        fields: ['slug', 'url', 'name'],
         idField: 'slug',
         titleField: 'name'
     },
     {
         name: 'Posts',
         model: 'post',
-        fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
         idField: 'id',
         titleField: 'title'
     },
     {
         name: 'Pages',
         model: 'page',
-        fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
         idField: 'id',
         titleField: 'title'
     }
@@ -39,7 +35,6 @@ export const SEARCHABLES = [
 export default class SearchProviderBasicService extends Service {
     @service ajax;
     @service notifications;
-    @service store;
     @service ghostPaths;
 
     content = [];
@@ -86,15 +81,8 @@ export default class SearchProviderBasicService extends Service {
     }
 
     async _loadSearchable(searchable, content) {
-        let url;
-        let query;
-        if (searchable.model === 'post' || searchable.model === 'page' || searchable.model === 'tag') {
-            url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
-            query = {};
-        } else {
-            url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
-            query = {fields: searchable.fields, limit: '10000'};
-        }
+        const url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
+        const query = {};
 
         try {
             const response = await this.ajax.request(url, {data: query});

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -12,7 +12,6 @@ export const SEARCHABLES = [
     {
         name: 'Staff',
         model: 'user',
-        fields: ['id', 'slug', 'url', 'name', 'profile_image'],
         pathField: 'slug',
         titleField: 'name',
         index: ['name']
@@ -20,7 +19,6 @@ export const SEARCHABLES = [
     {
         name: 'Tags',
         model: 'tag',
-        fields: ['id', 'slug', 'url', 'name'],
         pathField: 'slug',
         titleField: 'name',
         index: ['name']
@@ -28,8 +26,6 @@ export const SEARCHABLES = [
     {
         name: 'Posts',
         model: 'post',
-        fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
-        order: 'updated_at desc', // ensure we use a simple rather than default order for faster response
         pathField: 'id',
         titleField: 'title',
         index: ['title']
@@ -37,8 +33,6 @@ export const SEARCHABLES = [
     {
         name: 'Pages',
         model: 'page',
-        fields: ['id', 'url', 'title', 'status', 'published_at', 'visibility'],
-        order: 'updated_at desc', // ensure we use a simple rather than default order for faster response
         pathField: 'id',
         titleField: 'title',
         index: ['title']
@@ -48,7 +42,6 @@ export const SEARCHABLES = [
 export default class SearchProviderFlexService extends Service {
     @service ajax;
     @service notifications;
-    @service store;
     @service ghostPaths;
 
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
@@ -120,15 +113,8 @@ export default class SearchProviderFlexService extends Service {
     }
 
     async #loadSearchable(searchable) {
-        let url;
-        let query;
-        if (searchable.model === 'post' || searchable.model === 'page' || searchable.model === 'tag') {
-            url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
-            query = {};
-        } else {
-            url = `${this.store.adapterFor(searchable.model).urlForQuery({}, searchable.model)}/`;
-            query = {fields: searchable.fields, limit: 10000, order: searchable.order};
-        }
+        const url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
+        const query = {};
 
         try {
             const response = await this.ajax.request(url, {data: query});

--- a/ghost/admin/mirage/config/search-index.js
+++ b/ghost/admin/mirage/config/search-index.js
@@ -53,4 +53,22 @@ export default function mockSearchIndex(server) {
             tags: searchTags
         };
     });
+
+    server.get('/search-index/users', function ({users}) {
+        const searchUsers = users.all().models.map((user) => {
+            const url = `http://localhost:4200/user/${user.slug}/`;
+
+            return {
+                id: user.id,
+                slug: user.slug,
+                name: user.name,
+                url: url,
+                profile_image: user.profileImage
+            };
+        });
+
+        return {
+            users: searchUsers
+        };
+    });
 }

--- a/ghost/admin/tests/integration/services/search-test.js
+++ b/ghost/admin/tests/integration/services/search-test.js
@@ -54,6 +54,7 @@ suites.forEach((suite) => {
             secondPost = this.server.create('post', {title: 'Second post', slug: 'second-post'});
             firstPage = this.server.create('page', {title: 'First page', slug: 'first-page'});
             firstTag = this.server.create('tag', {name: 'First tag', slug: 'first-tag'});
+            firstUser = this.server.create('user', {name: 'First user', slug: 'first-user'});
         });
 
         it('is using correct provider', async function () {
@@ -63,9 +64,10 @@ suites.forEach((suite) => {
         it('returns urls for search results', async function () {
             const results = await search.searchTask.perform('first');
 
-            expect(results[0].options[0].url).to.equal('http://localhost:4200/tag/first-tag/');
-            expect(results[1].options[0].url).to.equal('http://localhost:4200/p/post-0/');
-            expect(results[2].options[0].url).to.equal('http://localhost:4200/p/page-0/');
+            expect(results[0].options[0].url).to.equal('http://localhost:4200/user/first-user/');
+            expect(results[1].options[0].url).to.equal('http://localhost:4200/tag/first-tag/');
+            expect(results[2].options[0].url).to.equal('http://localhost:4200/p/post-0/');
+            expect(results[3].options[0].url).to.equal('http://localhost:4200/p/page-0/');
         });
 
         it('returns additional post-related fields', async function () {

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -60,6 +60,24 @@ const controller = {
 
             return models.Tag.findPage(options);
         }
+    },
+    fetchUsers: {
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'users',
+            method: 'browse'
+        },
+        query() {
+            const options = {
+                limit: '10000',
+                order: 'updated_at DESC',
+                columns: ['id', 'slug', 'url', 'name', 'profile_image']
+            };
+
+            return models.User.findPage(options);
+        }
     }
 };
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -57,6 +57,29 @@ module.exports = {
         };
     },
 
+    async fetchTags(models, apiConfig, frame) {
+        debug('fetchTags');
+
+        let tags = [];
+
+        const keys = [
+            'id',
+            'slug',
+            'name',
+            'url'
+        ];
+
+        for (let model of models.data) {
+            let tag = await mappers.tags(model, frame);
+            tag = _.pick(tag, keys);
+            tags.push(tag);
+        }
+
+        frame.response = {
+            tags
+        };
+    },
+
     async fetchAuthors(models, apiConfig, frame) {
         debug('fetchAuthors');
 
@@ -81,26 +104,27 @@ module.exports = {
         };
     },
 
-    async fetchTags(models, apiConfig, frame) {
-        debug('fetchTags');
+    async fetchUsers(models, apiConfig, frame) {
+        debug('fetchUsers');
 
-        let tags = [];
+        let users = [];
 
         const keys = [
             'id',
             'slug',
             'name',
-            'url'
+            'url',
+            'profile_image'
         ];
 
         for (let model of models.data) {
-            let tag = await mappers.tags(model, frame);
-            tag = _.pick(tag, keys);
-            tags.push(tag);
+            let user = await mappers.users(model, frame);
+            user = _.pick(user, keys);
+            users.push(user);
         }
 
         frame.response = {
-            tags
+            users
         };
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -382,6 +382,7 @@ module.exports = function apiRoutes() {
     router.get('/search-index/posts', mw.authAdminApi, http(api.searchIndex.fetchPosts));
     router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
     router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
+    router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
 
     return router;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
@@ -249,3 +249,37 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Search Index API fetchUsers should return a list of users 1: [body] 1`] = `
+Object {
+  "users": Array [
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "profile_image": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "name": Any<String>,
+      "profile_image": Any<String>,
+      "slug": Any<String>,
+      "url": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Search Index API fetchUsers should return a list of users 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "345",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -93,4 +93,26 @@ describe('Search Index API', function () {
                 });
         });
     });
+
+    describe('fetchUsers', function () {
+        const searchIndexUserMatcher = {
+            id: anyString,
+            slug: anyString,
+            name: anyString,
+            url: anyString,
+            profile_image: anyString
+        };
+
+        it('should return a list of users', async function () {
+            await agent.get('/search-index/users')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    users: new Array(2).fill(searchIndexUserMatcher)
+                });
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2106

- added `'GET /ghost/api/admin/search-index/users'` Admin API endpoint
- this endpoint returns up to 10k staff users, with only the necessary fields for search in Admin or the editor
- wired up the new endpoint with the basic search and flex search providers in Admin
- cleaned up old code in basic search and flex search provicers in Admin
