### PR TITLE
Reduced likelihood of duplicate tag names when seeding data

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/TagsImporter.js
+++ b/ghost/core/core/server/data/seeders/importers/TagsImporter.js
@@ -21,7 +21,7 @@ class TagsImporter extends TableImporter {
     }
 
     generate() {
-        let name = `${faker.color.human()} ${faker.name.jobType()}`;
+        let name = `${faker.color.human()} ${faker.name.jobType()} ${faker.random.numeric(3)}`;
         name = `${name[0].toUpperCase()}${name.slice(1)}`;
         const threeYearsAgo = new Date();
         threeYearsAgo.setFullYear(threeYearsAgo.getFullYear() - 3);
@@ -30,7 +30,7 @@ class TagsImporter extends TableImporter {
         return {
             id: this.fastFakeObjectId(),
             name: name,
-            slug: `${slugify(name)}-${faker.random.numeric(3)}`,
+            slug: slugify(name),
             description: faker.lorem.sentence(),
             created_at: dateToDatabaseString(faker.date.between(threeYearsAgo, twoYearsAgo)),
             created_by: this.users[faker.datatype.number(this.users.length - 1)].id


### PR DESCRIPTION
no issue

- having duplicate tag names in the database can be confusing when working on tags-related functionality but when generating larger numbers of tags this was a frequent occurrence
- we were already adding a random number to the slug to avoid slug-level duplicates, moved that number into the name to avoid the UI looking like it has duplicate entries
