### PR TITLE
Fixed initial `useActiveVisitors` API request returning 403

### DIFF
--- a/apps/admin-x-framework/src/hooks/useActiveVisitors.ts
+++ b/apps/admin-x-framework/src/hooks/useActiveVisitors.ts
@@ -14,7 +14,7 @@ export const useActiveVisitors = (options: UseActiveVisitorsOptions = {}) => {
     const {postUuid, statsConfig, enabled = true} = options;
     const [refreshKey, setRefreshKey] = useState(0);
     const [lastKnownCount, setLastKnownCount] = useState<number | null>(null);
-    const {token} = useTinybirdToken();
+    const {token, isLoading: tokenLoading} = useTinybirdToken();
 
     // Set up 60-second interval only if enabled
     useEffect(() => {
@@ -38,7 +38,7 @@ export const useActiveVisitors = (options: UseActiveVisitorsOptions = {}) => {
     };
 
     const {data, loading, error} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig || undefined, 'api_active_visitors'),
+        endpoint: (enabled && !tokenLoading && token) ? getStatEndpointUrl(statsConfig || undefined, 'api_active_visitors') : undefined,
         token: token,
         params
     });
@@ -54,7 +54,7 @@ export const useActiveVisitors = (options: UseActiveVisitorsOptions = {}) => {
 
     const activeVisitors = enabled ? (lastKnownCount || 0) : 0;
     // Only show loading on initial load (when we have no last known count)
-    const isInitialLoading = enabled && loading && lastKnownCount === null;
+    const isInitialLoading = enabled && (tokenLoading || loading) && lastKnownCount === null;
 
     return {
         activeVisitors,

--- a/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
@@ -1,7 +1,6 @@
 import {renderHook, act} from '@testing-library/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useActiveVisitors} from '../../../src/hooks/useActiveVisitors';
-import {withMockFetch} from '../../utils/mockFetch';
 import React from 'react';
 
 // Mock the @tinybirdco/charts module
@@ -519,7 +518,7 @@ describe('useActiveVisitors', () => {
         expect(setIntervalSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('should not call useQuery when token is undefined', () => {
+    it('should call useQuery with undefined endpoint when token is loading (preventing HTTP requests)', () => {
         // Mock useTinybirdToken to return undefined token (still loading)
         mockUseTinybirdToken.mockReturnValue({
             token: undefined,
@@ -534,9 +533,14 @@ describe('useActiveVisitors', () => {
         // Render the hook
         renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
 
-        // EXPECTED: useQuery should not be called when token is undefined/loading
-        // This test should FAIL with current implementation and PASS after fix
-        expect(mockUseQuery).not.toHaveBeenCalled();
+        // EXPECTED: useQuery should be called with undefined endpoint when token is loading
+        // This prevents HTTP requests by disabling the SWR query entirely
+        expect(mockUseQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: undefined,
+                token: undefined
+            })
+        );
     });
 
     it('calls useQuery with token when token is available', () => {


### PR DESCRIPTION
The requests to the Tinybird API that are made directly to Tinybird are not properly waiting for the token to be available before initiating the request to Tinybird, which results in an HTTP 403 response. The request is then retried when the token becomes available, so there's no user-facing impact apart from the red in the network tab, but we should fix this to keep the network tab green and avoid any console errors.

This fixes the condition by:
- Unwrapping the `isLoading` state from the `useTinybirdToken` hook
- Setting the endpoint to `undefined` on the Tinybird `useQuery()` hook until the token value is defined. This prevents the HTTP request from being made initially
- Once the token comes back from the API, `isLoading` becomes false, the `token` becomes defined, and we set the endpoint to the correct value, which triggers the first API request.

This same bug is present in other requests in the stats app — I'll include a fix for those in a follow up commit.