### PR TITLE
Fixed initial 403 errors in Tinybird API requests in posts and stats apps

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -92,6 +92,7 @@
     "dependencies": {
         "@sentry/react": "7.120.3",
         "@tanstack/react-query": "4.36.1",
+        "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-design-system": "0.0.0",
         "@tryghost/shade": "0.0.0",
         "react": "18.3.1",

--- a/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
@@ -1,0 +1,28 @@
+import {useQuery} from '@tinybirdco/charts';
+import {useTinybirdToken} from './useTinybirdToken';
+import {StatsConfig} from '../providers/FrameworkProvider';
+import {getStatEndpointUrl} from '../utils/stats-config';
+
+interface UseTinybirdQueryOptions {
+    statsConfig: StatsConfig;
+    endpoint: string;
+    params: Record<string, string>;
+}
+
+// Wrapper around Tinybird's useQuery hook that handles the token loading state
+export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
+    const tokenQuery = useTinybirdToken();
+    const {statsConfig, endpoint, params} = options;
+
+    const endpointUrl = getStatEndpointUrl(statsConfig || undefined, endpoint);
+
+    // Set the endpoint to undefined if the token is not loaded
+    // Prevents an initial 403 error by waiting for the token to load before making the request
+    const {data, meta, loading, error} = useQuery({
+        endpoint: (!tokenQuery.isLoading && tokenQuery.token) ? endpointUrl : undefined,
+        token: tokenQuery.token,
+        params: params
+    });
+
+    return {data, meta, loading: tokenQuery.isLoading || loading, error};
+};

--- a/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
@@ -3,7 +3,7 @@ import {useTinybirdToken} from './useTinybirdToken';
 import {StatsConfig} from '../providers/FrameworkProvider';
 import {getStatEndpointUrl} from '../utils/stats-config';
 
-interface UseTinybirdQueryOptions {
+export interface UseTinybirdQueryOptions {
     statsConfig: StatsConfig;
     endpoint: string;
     params: Record<string, string>;

--- a/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
@@ -24,5 +24,10 @@ export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
         params: params
     });
 
-    return {data, meta, loading: tokenQuery.isLoading || loading, error};
+    return {
+        data, 
+        meta, 
+        loading: tokenQuery.isLoading || loading, 
+        error: error ?? tokenQuery.error
+    };
 };

--- a/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdQuery.ts
@@ -4,22 +4,27 @@ import {StatsConfig} from '../providers/FrameworkProvider';
 import {getStatEndpointUrl} from '../utils/stats-config';
 
 export interface UseTinybirdQueryOptions {
-    statsConfig: StatsConfig;
+    statsConfig?: StatsConfig | null;
     endpoint: string;
     params: Record<string, string>;
+    enabled?: boolean;
 }
 
 // Wrapper around Tinybird's useQuery hook that handles the token loading state
 export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
     const tokenQuery = useTinybirdToken();
-    const {statsConfig, endpoint, params} = options;
+    const {statsConfig, endpoint, params, enabled = true} = options;
 
-    const endpointUrl = getStatEndpointUrl(statsConfig || undefined, endpoint);
+    const shouldQuery = enabled && statsConfig && endpoint;
+    const endpointUrl = shouldQuery ? getStatEndpointUrl(statsConfig, endpoint) : undefined;
 
-    // Set the endpoint to undefined if the token is not loaded
-    // Prevents an initial 403 error by waiting for the token to load before making the request
+    // Set the endpoint to undefined if:
+    // - Token is not loaded (prevents 403 errors)
+    // - Query is disabled via enabled flag
+    // - No statsConfig provided
+    // - No endpoint specified
     const {data, meta, loading, error} = useQuery({
-        endpoint: (!tokenQuery.isLoading && tokenQuery.token) ? endpointUrl : undefined,
+        endpoint: (!tokenQuery.isLoading && tokenQuery.token && shouldQuery) ? endpointUrl : undefined,
         token: tokenQuery.token,
         params: params
     });

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -14,6 +14,8 @@ export {default as useHandleError} from './hooks/useHandleError';
 export {default as useFilterableApi} from './hooks/useFilterableApi';
 export {useTinybirdToken} from './hooks/useTinybirdToken';
 export type {UseTinybirdTokenResult} from './hooks/useTinybirdToken';
+export {useTinybirdQuery} from './hooks/useTinybirdQuery';
+export type {UseTinybirdQueryOptions} from './hooks/useTinybirdQuery';
 
 // Currency utilities
 export {getSymbol} from './utils/currency';

--- a/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
@@ -4,7 +4,6 @@ import React, {ReactNode} from 'react';
 import {getTinybirdToken} from '../../../src/api/tinybird';
 import {FrameworkProvider} from '../../../src/providers/FrameworkProvider';
 import {withMockFetch} from '../../utils/mockFetch';
-import {vi} from 'vitest';
 
 const queryClient = new QueryClient({
     defaultOptions: {

--- a/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useActiveVisitors.test.ts
@@ -187,10 +187,18 @@ describe('useActiveVisitors', () => {
         expect(mockUseTinybirdToken).toHaveBeenCalled();
     });
 
-    it('calls getStatEndpointUrl with undefined when no statsConfig and uses tinybirdToken', () => {
+    it('calls useTinybirdQuery with undefined endpoint when no statsConfig and uses tinybirdToken', () => {
         renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
 
-        expect(mockGetStatEndpointUrl).toHaveBeenCalledWith(undefined, 'api_active_visitors');
+        expect(mockUseQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: undefined,
+                token: 'mock-token',
+                params: expect.objectContaining({
+                    site_uuid: ''
+                })
+            })
+        );
         expect(mockUseTinybirdToken).toHaveBeenCalled();
     });
 
@@ -201,7 +209,7 @@ describe('useActiveVisitors', () => {
         expect(mockUseQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 params: expect.objectContaining({
-                    _refresh: 0
+                    _refresh: '0'
                 })
             })
         );
@@ -215,7 +223,7 @@ describe('useActiveVisitors', () => {
         expect(mockUseQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 params: expect.objectContaining({
-                    _refresh: 1
+                    _refresh: '1'
                 })
             })
         );
@@ -233,7 +241,7 @@ describe('useActiveVisitors', () => {
         expect(mockUseQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 params: expect.objectContaining({
-                    _refresh: 0
+                    _refresh: '0'
                 })
             })
         );

--- a/apps/admin-x-framework/test/unit/hooks/useTinybirdQuery.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useTinybirdQuery.test.ts
@@ -180,4 +180,22 @@ describe('useTinybirdQuery', () => {
 
         expect(result.current.error).toBe(mockError);
     });
+
+    it('should return the error from useQuery if the token query has an error', () => {
+        const mockError = new Error('Token error');
+        mockUseTinybirdToken.mockReturnValue({
+            token: undefined,
+            isLoading: false,
+            error: mockError,
+            refetch: vi.fn()
+        });
+
+        const {result} = renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(result.current.error).toBe(mockError);
+    });
 });

--- a/apps/admin-x-framework/test/unit/hooks/useTinybirdQuery.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/useTinybirdQuery.test.ts
@@ -1,0 +1,183 @@
+import {renderHook} from '@testing-library/react';
+import {useTinybirdQuery} from '../../../src/hooks/useTinybirdQuery';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('@tinybirdco/charts', () => ({
+    useQuery: vi.fn()
+}));
+
+vi.mock('../../../src/utils/stats-config', () => ({
+    getStatEndpointUrl: vi.fn()
+}));
+
+vi.mock('../../../src/hooks/useTinybirdToken', () => ({
+    useTinybirdToken: vi.fn()
+}));
+
+import {useTinybirdToken} from '../../../src/hooks/useTinybirdToken';
+import {getStatEndpointUrl} from '../../../src/utils/stats-config';
+import {useQuery} from '@tinybirdco/charts';
+
+const mockUseQuery = vi.mocked(useQuery);
+const mockUseTinybirdToken = vi.mocked(useTinybirdToken);
+const mockGetStatEndpointUrl = vi.mocked(getStatEndpointUrl);
+
+describe('useTinybirdQuery', () => {
+    let queryClient: QueryClient;
+    let wrapper: React.FC<{children: React.ReactNode}>;
+
+    beforeEach(() => {
+        queryClient = new QueryClient();
+        wrapper = ({children}) => React.createElement(QueryClientProvider, {client: queryClient}, children);
+        mockUseTinybirdToken.mockReturnValue({
+            token: undefined,
+            isLoading: true,
+            error: null,
+            refetch: vi.fn()
+        });
+        mockUseQuery.mockReturnValue({
+            data: null,
+            loading: false,
+            error: null,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/test',
+            token: undefined,
+            refresh: vi.fn()
+        });
+        mockGetStatEndpointUrl.mockImplementation((_config: any, endpoint: any) => `https://api.example.com/${endpoint}`);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return data, meta, loading, and error', () => {
+        const {result} = renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(result.current.data).toBeDefined();
+        expect(result.current.loading).toBeDefined();
+        expect(result.current.error).toBeDefined();
+    });
+
+    it('should set the endpoint to undefined if the token is not loaded', () => {
+        // This prevents an initial 403 error by waiting for the token to load before making the request
+        mockUseTinybirdToken.mockReturnValue({
+            token: undefined,
+            isLoading: true,
+            error: null,
+            refetch: vi.fn()
+        });
+
+        renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            endpoint: undefined
+        }));
+    });
+
+    it('should call useQuery with the correct token', () => {
+        mockUseTinybirdToken.mockReturnValue({
+            token: 'mock-token',
+            isLoading: false,
+            error: null,
+            refetch: vi.fn()
+        });
+
+        renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            token: 'mock-token'
+        }));
+    });
+
+    it('should call useQuery with the correct endpoint once the token is loaded', () => {
+        mockUseTinybirdToken.mockReturnValue({
+            token: 'mock-token',
+            isLoading: false,
+            error: null,
+            refetch: vi.fn()
+        });
+
+        renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            endpoint: 'https://api.example.com/test'
+        }));
+    });
+
+    it('should return loading state that includes token loading', () => {
+        mockUseTinybirdToken.mockReturnValue({
+            token: 'mock-token',
+            isLoading: true,
+            error: null,
+            refetch: vi.fn()
+        });
+
+        const {result} = renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should pass the correct params to useQuery', () => {
+        mockUseTinybirdToken.mockReturnValue({
+            token: 'mock-token',
+            isLoading: false,
+            error: null,
+            refetch: vi.fn()
+        });
+
+        renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {test: 'test'}
+        }), {wrapper});
+
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            params: {test: 'test'}
+        }));
+    });
+
+    it('handles errors from useQuery', () => {
+        const mockError = 'Network error';
+        mockUseQuery.mockReturnValue({
+            data: null,
+            loading: false,
+            error: mockError,
+            meta: null,
+            statistics: null,
+            endpoint: 'https://api.example.com/test',
+            token: undefined,
+            refresh: vi.fn()
+        });
+
+        const {result} = renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(result.current.error).toBe(mockError);
+    });
+});

--- a/apps/admin-x-framework/test/unit/hooks/useTinybirdToken.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/useTinybirdToken.test.tsx
@@ -2,7 +2,6 @@ import {renderHook} from '@testing-library/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useTinybirdToken} from '../../../src/hooks/useTinybirdToken';
 import {getTinybirdToken} from '../../../src/api/tinybird';
-import {vi} from 'vitest';
 import React from 'react';
 
 // Mock the getTinybirdToken API

--- a/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/stats-config.test.ts
@@ -1,7 +1,6 @@
 import {getStatEndpointUrl, getToken} from '../../../src/utils/stats-config';
 import {StatsConfig} from '../../../src/providers/FrameworkProvider';
 import {getTinybirdToken} from '../../../src/api/tinybird';
-import {vi} from 'vitest';
 
 // Mock getTinybirdToken
 vi.mock('../../../src/api/tinybird', () => ({

--- a/apps/admin-x-settings/test/acceptance/advanced/labs.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/labs.test.ts
@@ -1,69 +1,69 @@
-// import {expect, test} from '@playwright/test';
-// import {globalDataRequests} from '../../utils/acceptance';
-// import {mockApi} from '@tryghost/admin-x-framework/test/acceptance';
+import {expect, test} from '@playwright/test';
+import {globalDataRequests} from '../../utils/acceptance';
+import {mockApi} from '@tryghost/admin-x-framework/test/acceptance';
 
-// test.describe('Labs', async () => {
-//     test('Uploading/downloading redirects', async ({page}) => {
-//         const {lastApiRequests} = await mockApi({page, requests: {
-//             ...globalDataRequests,
-//             uploadRedirects: {method: 'POST', path: '/redirects/upload/', response: {}},
-//             downloadRedirects: {method: 'GET', path: '/redirects/download/', response: 'redirects'}
-//         }});
+test.describe('Labs', async () => {
+    test.skip('Uploading/downloading redirects', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            uploadRedirects: {method: 'POST', path: '/redirects/upload/', response: {}},
+            downloadRedirects: {method: 'GET', path: '/redirects/download/', response: 'redirects'}
+        }});
 
-//         await page.goto('/');
+        await page.goto('/');
 
-//         const labsSection = page.getByTestId('labs');
+        const labsSection = page.getByTestId('labs');
 
-//         await labsSection.getByRole('button', {name: 'Open'}).click();
-//         await labsSection.getByRole('tab', {name: 'Beta features'}).click();
+        await labsSection.getByRole('button', {name: 'Open'}).click();
+        await labsSection.getByRole('tab', {name: 'Beta features'}).click();
 
-//         const fileChooserPromise = page.waitForEvent('filechooser');
+        const fileChooserPromise = page.waitForEvent('filechooser');
 
-//         await labsSection.getByText('Upload redirects file').click();
+        await labsSection.getByText('Upload redirects file').click();
 
-//         const fileChooser = await fileChooserPromise;
-//         await fileChooser.setFiles(`${__dirname}/../../utils/files/redirects.yml`);
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(`${__dirname}/../../utils/files/redirects.yml`);
 
-//         await expect(page.getByTestId('toast-success')).toContainText('Redirects uploaded');
+        await expect(page.getByTestId('toast-success')).toContainText('Redirects uploaded');
 
-//         expect(lastApiRequests.uploadRedirects).toBeTruthy();
+        expect(lastApiRequests.uploadRedirects).toBeTruthy();
 
-//         await labsSection.getByRole('button', {name: 'Download current redirects'}).click();
+        await labsSection.getByRole('button', {name: 'Download current redirects'}).click();
 
-//         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/redirects\/download\//);
+        await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/redirects\/download\//);
 
-//         expect(lastApiRequests.downloadRedirects).toBeTruthy();
-//     });
+        expect(lastApiRequests.downloadRedirects).toBeTruthy();
+    });
 
-//     test('Uploading/downloading routes', async ({page}) => {
-//         const {lastApiRequests} = await mockApi({page, requests: {
-//             ...globalDataRequests,
-//             uploadRoutes: {method: 'POST', path: '/settings/routes/yaml/', response: {}},
-//             downloadRoutes: {method: 'GET', path: '/settings/routes/yaml/', response: 'routes'}
-//         }});
+    test.skip('Uploading/downloading routes', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            uploadRoutes: {method: 'POST', path: '/settings/routes/yaml/', response: {}},
+            downloadRoutes: {method: 'GET', path: '/settings/routes/yaml/', response: 'routes'}
+        }});
 
-//         await page.goto('/');
+        await page.goto('/');
 
-//         const labsSection = page.getByTestId('labs');
+        const labsSection = page.getByTestId('labs');
 
-//         await labsSection.getByRole('button', {name: 'Open'}).click();
-//         await labsSection.getByRole('tab', {name: 'Beta features'}).click();
+        await labsSection.getByRole('button', {name: 'Open'}).click();
+        await labsSection.getByRole('tab', {name: 'Beta features'}).click();
 
-//         const fileChooserPromise = page.waitForEvent('filechooser');
+        const fileChooserPromise = page.waitForEvent('filechooser');
 
-//         await labsSection.getByText('Upload routes file').click();
+        await labsSection.getByText('Upload routes file').click();
 
-//         const fileChooser = await fileChooserPromise;
-//         await fileChooser.setFiles(`${__dirname}/../../utils/files/routes.yml`);
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(`${__dirname}/../../utils/files/routes.yml`);
 
-//         await expect(page.getByTestId('toast-success')).toContainText('Routes uploaded');
+        await expect(page.getByTestId('toast-success')).toContainText('Routes uploaded');
 
-//         expect(lastApiRequests.uploadRoutes).toBeTruthy();
+        expect(lastApiRequests.uploadRoutes).toBeTruthy();
 
-//         await labsSection.getByRole('button', {name: 'Download current routes'}).click();
+        await labsSection.getByRole('button', {name: 'Download current routes'}).click();
 
-//         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/settings\/routes\/yaml\//);
+        await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/settings\/routes\/yaml\//);
 
-//         expect(lastApiRequests.downloadRoutes).toBeTruthy();
-//     });
-// });
+        expect(lastApiRequests.downloadRoutes).toBeTruthy();
+    });
+});

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -38,7 +38,6 @@
         "vitest": "1.6.1"
     },
     "dependencies": {
-        "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-framework": "0.0.0",
         "@tryghost/shade": "0.0.0",
         "i18n-iso-countries": "7.14.0",

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -9,15 +9,14 @@ import {KpiDataItem} from '@src/utils/kpi-helpers';
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {STATS_RANGES} from '@src/utils/constants';
 import {centsToDollars} from '../Growth/Growth';
-import {getStatEndpointUrl, hasBeenEmailed, isPublishedOnly, useNavigate} from '@tryghost/admin-x-framework';
+import {hasBeenEmailed, isPublishedOnly, useNavigate, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/App';
 import {useEffect, useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
-import {useQuery} from '@tinybirdco/charts';
 
 const Overview: React.FC = () => {
     const navigate = useNavigate();
-    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId, tinybirdToken} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId} = useGlobalData();
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {startDate, endDate, timezone} = getRangeDates(STATS_RANGES.ALL_TIME.value);
     const {appSettings} = useAppContext();
@@ -74,15 +73,15 @@ const Overview: React.FC = () => {
         return baseParams;
     }, [isPostLoading, post, statsConfig?.id, chartStartDate, chartEndDate, chartTimezone]);
 
-    const {data, loading: tbLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: tinybirdToken,
+    const {data, loading: tbLoading} = useTinybirdQuery({
+        endpoint: 'api_kpis',
+        statsConfig: statsConfig || {id: ''},
         params: params
     });
 
-    const {data: chartData, loading: chartLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: tinybirdToken,
+    const {data: chartData, loading: chartLoading} = useTinybirdQuery({
+        endpoint: 'api_kpis',
+        statsConfig: statsConfig || {id: ''},
         params: chartParams
     });
 
@@ -110,9 +109,9 @@ const Overview: React.FC = () => {
     });
 
     // Get sources data
-    const {data: sourcesData, loading: isSourcesLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
-        token: tinybirdToken,
+    const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
+        endpoint: 'api_top_sources',
+        statsConfig: statsConfig || {id: ''},
         params: params
     });
 

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -7,14 +7,13 @@ import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import Sources from './components/Sources';
 import {BarChartLoadingIndicator, Card, CardContent, formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade';
-import {BaseSourceData, getStatEndpointUrl, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {BaseSourceData, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 
 import {useEffect, useMemo} from 'react';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
 import {STATS_RANGES} from '@src/utils/constants';
-import {useQuery} from '@tinybirdco/charts';
 
 // Array of values that represent unknown locations
 const UNKNOWN_LOCATIONS = ['NULL', 'ᴺᵁᴸᴸ', ''];
@@ -30,7 +29,7 @@ interface postAnalyticsProps {}
 const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
-    const {statsConfig, isLoading: isConfigLoading, range, audience, data: globalData, post, isPostLoading, tinybirdToken} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience, data: globalData, post, isPostLoading} = useGlobalData();
 
     // Redirect to Overview if this is an email-only post
     useEffect(() => {
@@ -75,23 +74,23 @@ const Web: React.FC<postAnalyticsProps> = () => {
     }, [isPostLoading, post, statsConfig?.id, startDate, endDate, timezone, audience]);
 
     // Get web kpi data
-    const {data: kpiData, loading: isKpisLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: tinybirdToken,
+    const {data: kpiData, loading: isKpisLoading} = useTinybirdQuery({
+        endpoint: 'api_kpis',
+        statsConfig: statsConfig || {id: ''},
         params: params
     });
 
     // Get locations data
-    const {data: locationsData, loading: isLocationsLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_locations'),
-        token: tinybirdToken,
+    const {data: locationsData, loading: isLocationsLoading} = useTinybirdQuery({
+        endpoint: 'api_top_locations',
+        statsConfig: statsConfig || {id: ''},
         params: params
     });
 
     // Get sources data
-    const {data: sourcesData, loading: isSourcesLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
-        token: tinybirdToken,
+    const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
+        endpoint: 'api_top_sources',
+        statsConfig: statsConfig || {id: ''},
         params: params
     });
 

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -50,7 +50,6 @@
     },
     "dependencies": {
         "@svg-maps/world": "1.0.1",
-        "@tinybirdco/charts": "0.2.4",
         "@tryghost/admin-x-framework": "0.0.0",
         "@tryghost/shade": "0.0.0",
         "i18n-iso-countries": "7.14.0",

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -71,7 +71,7 @@ const Locations:React.FC = () => {
 
     const {data, loading} = useTinybirdQuery({
         endpoint: 'api_top_locations',
-        statsConfig: statsConfig || {id: ''},
+        statsConfig,
         params
     });
 

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -8,12 +8,11 @@ import World from '@svg-maps/world';
 import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, Flag, Icon, SimplePagination, SimplePaginationNavigation, SimplePaginationNextButton, SimplePaginationPages, SimplePaginationPreviousButton, SkeletonTable, cn, formatNumber, formatPercentage, formatQueryDate, getRangeDates, useSimplePagination} from '@tryghost/shade';
-import {Navigate, getStatEndpointUrl, useAppContext} from '@tryghost/admin-x-framework';
+import {Navigate, useAppContext, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {STATS_LABEL_MAPPINGS} from '@src/utils/constants';
 import {SVGMap} from 'react-svg-map';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useQuery} from '@tinybirdco/charts';
 
 countries.registerLocale(enLocale);
 const getCountryName = (label: string) => {
@@ -56,7 +55,7 @@ interface ProcessedLocationData {
 }
 
 const Locations:React.FC = () => {
-    const {statsConfig, isLoading: isConfigLoading, range, audience, tinybirdToken} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
     const ITEMS_PER_PAGE = 10;
@@ -70,9 +69,9 @@ const Locations:React.FC = () => {
         member_status: getAudienceQueryParam(audience)
     };
 
-    const {data, loading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_locations'),
-        token: tinybirdToken,
+    const {data, loading} = useTinybirdQuery({
+        endpoint: 'api_top_locations',
+        statsConfig: statsConfig || {id: ''},
         params
     });
 

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -8,12 +8,11 @@ import StatsView from '../layout/StatsView';
 import TopPosts from './components/TopPosts';
 import {GhAreaChartDataItem, centsToDollars, cn, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
 import {getAudienceQueryParam} from '../components/AudienceSelect';
-import {getStatEndpointUrl} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/App';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
 import {useGrowthStats} from '@src/hooks/useGrowthStats';
 import {useLatestPostStats} from '@src/hooks/useLatestPostStats';
-import {useQuery} from '@tinybirdco/charts';
+import {useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {useTopPostsViews} from '@tryghost/admin-x-framework/api/stats';
 
 interface HelpCardProps {
@@ -65,7 +64,7 @@ type GrowthChartDataItem = {
 
 const Overview: React.FC = () => {
     const {appSettings} = useAppContext();
-    const {statsConfig, isLoading: isConfigLoading, range, audience, tinybirdToken} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
@@ -88,9 +87,9 @@ const Overview: React.FC = () => {
         member_status: getAudienceQueryParam(audience)
     };
 
-    const {data: visitorsData, loading: isVisitorsLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: tinybirdToken,
+    const {data: visitorsData, loading: isVisitorsLoading} = useTinybirdQuery({
+        endpoint: 'api_kpis',
+        statsConfig: statsConfig || {id: ''},
         params: visitorsParams
     });
 

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -89,7 +89,7 @@ const Overview: React.FC = () => {
 
     const {data: visitorsData, loading: isVisitorsLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
-        statsConfig: statsConfig || {id: ''},
+        statsConfig,
         params: visitorsParams
     });
 

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -78,14 +78,14 @@ const Web: React.FC = () => {
     // Get KPI data
     const {data: kpiData, loading: kpiLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
-        statsConfig: statsConfig || {id: ''},
+        statsConfig,
         params
     });
 
     // Get top sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
-        statsConfig: statsConfig || {id: ''},
+        statsConfig,
         params
     });
 

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -9,10 +9,9 @@ import TopContent from './components/TopContent';
 import WebKPIs, {KpiDataItem} from './components/WebKPIs';
 import {Card, CardContent, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
-import {Navigate, getStatEndpointUrl, useAppContext} from '@tryghost/admin-x-framework';
+import {Navigate, useAppContext, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useQuery} from '@tinybirdco/charts';
 
 interface SourcesData {
     source?: string | number;
@@ -49,7 +48,7 @@ export const KPI_METRICS: Record<string, KpiMetric> = {
 };
 
 const Web: React.FC = () => {
-    const {statsConfig, isLoading: isConfigLoading, range, audience, data, tinybirdToken} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {appSettings} = useAppContext();
 
@@ -77,16 +76,16 @@ const Web: React.FC = () => {
     }
 
     // Get KPI data
-    const {data: kpiData, loading: kpiLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_kpis'),
-        token: tinybirdToken,
+    const {data: kpiData, loading: kpiLoading} = useTinybirdQuery({
+        endpoint: 'api_kpis',
+        statsConfig: statsConfig || {id: ''},
         params
     });
 
     // Get top sources data
-    const {data: sourcesData, loading: isSourcesLoading} = useQuery({
-        endpoint: getStatEndpointUrl(statsConfig, 'api_top_sources'),
-        token: tinybirdToken,
+    const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
+        endpoint: 'api_top_sources',
+        statsConfig: statsConfig || {id: ''},
         params
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15310,12 +15310,12 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 echarts@^5.5.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.5.1.tgz#8dc9c68d0c548934bedcb5f633db07ed1dd2101c"
-  integrity sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.6.0.tgz#2377874dca9fb50f104051c3553544752da3c9d6"
+  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.6.0"
+    zrender "5.6.1"
 
 editions@^1.1.1:
   version "1.3.4"
@@ -30626,12 +30626,12 @@ svgo@^3.0.2, svgo@^3.3.2:
     picocolors "^1.0.0"
 
 swr@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
-  integrity sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.3.3.tgz#9d6a703355f15f9099f45114db3ef75764444788"
+  integrity sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==
   dependencies:
-    client-only "^0.0.1"
-    use-sync-external-store "^1.2.0"
+    dequal "^2.0.3"
+    use-sync-external-store "^1.4.0"
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -31945,7 +31945,7 @@ use-sidecar@^1.1.2, use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1, use-sync-external-store@^1.2.0, use-sync-external-store@^1.5.0:
+use-sync-external-store@^1, use-sync-external-store@^1.2.0, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
@@ -33050,9 +33050,9 @@ zod@3.25.67:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.67.tgz#62987e4078e2ab0f63b491ef0c4f33df24236da8"
   integrity sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==
 
-zrender@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.0.tgz#01325b0bb38332dd5e87a8dbee7336cafc0f4a5b"
-  integrity sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==
+zrender@5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.1.tgz#e08d57ecf4acac708c4fcb7481eb201df7f10a6b"
+  integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==
   dependencies:
     tslib "2.3.0"


### PR DESCRIPTION
The first requests directly to the Tinybird APIs after a page load are returning a 403 in some cases, because the requests aren't waiting for the token to load from the API. This commit adds a custom hook to `admin-x-framework` that wraps Tinybird's `useQuery()` hook for making requests to Tinybird, and includes the logic to delay the request until the token is returned from Ghost's API. 