### PR TITLE
Added debug logging to e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,7 +826,7 @@ jobs:
         run: yarn nx run ghost-admin:build:dev
 
       - name: Start Ghost
-        run: DEBUG=* yarn dev --portal --comments --search --signup --announcement-bar &
+        run: DEBUG=* yarn dev &
 
       - name: Wait for Ghost to be ready
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,7 +826,7 @@ jobs:
         run: yarn nx run ghost-admin:build:dev
 
       - name: Start Ghost
-        run: yarn dev --portal --comments --search --signup --announcement-bar &
+        run: DEBUG=* yarn dev --portal --comments --search --signup --announcement-bar &
 
       - name: Wait for Ghost to be ready
         run: |


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/31816867fa96c719abb21680764e792b0cf3b9b4

The e2e tests are still failing quite frequently after increasing the timeout. This commit adds debug logging to the `Start Ghost` step which seems to be hanging or timing out. It also removes portal, comments, announcementBar, etc apps from the command, which may be contributing to resource limitations in the Github Actions runner. 

Hopefully removing the apps will help Ghost boot more reliably in these tests, and if not hopefully the debug logging will point to what's going wrong.