### PR TITLE
Added explicit passthrough for Backup Integration

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -36,6 +36,17 @@ const notImplemented = function notImplemented(req, res, next) {
         return next();
     }
 
+    // Ensure ghost-backup can both backup and export
+    if (req.api_key?.related('integration')?.get('slug') === 'ghost-backup') {
+        // export
+        const isExport = req.path.startsWith('/db/') && req.method === 'GET';
+        const isBackup = req.path.startsWith('/db/backup') && req.method === 'POST';
+
+        if (isExport || isBackup) {
+            return next();
+        }
+    }
+
     // CASE: god mode is enabled & we're in development, skip to permission system
     if (req.query.god_mode && process.env.NODE_ENV === 'development') {
         return next();

--- a/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/backup.test.js.snap
@@ -23,6 +23,20 @@ Object {
 }
 `;
 
+exports[`Backup Integration Backup API Backup Integration Can do a DB export 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": StringMatching /\\^Attachment; filename="\\[A-Za-z0-9\\._-\\]\\+\\\\\\.json"\\$/,
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Backup Integration Backup API Backup Integration Can export members CSV 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -66,6 +80,37 @@ Object {
 }
 `;
 
+exports[`Backup Integration Backup API Editor: User authentication Cannot do a DB export 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "You do not have permission to exportContent db",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Editor: User authentication Cannot do a DB export 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "236",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Backup Integration Backup API Editor: User authentication Cannot export members CSV 1: [body] 1`] = `
 Object {
   "errors": Array [
@@ -92,6 +137,41 @@ Object {
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Owner: Staff token Can create a DB backup 1: [body] 1`] = `
+Object {
+  "db": Array [
+    Object {
+      "filename": StringMatching /ghost-test\\\\/data\\\\/test\\\\\\.json\\$/,
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Owner: Staff token Can create a DB backup 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Owner: Staff token Can export members CSV 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": StringMatching /attachment; filename="members\\\\\\./,
+  "content-type": "text/csv; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
@@ -167,6 +247,37 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Backup Integration Backup API Zapier Integration Cannot do a DB export 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "The server does not support the functionality required to fulfill the request.",
+      "property": null,
+      "type": "NotImplementedError",
+    },
+  ],
+}
+`;
+
+exports[`Backup Integration Backup API Zapier Integration Cannot do a DB export 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "270",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/backup.test.js
+++ b/ghost/core/test/e2e-api/admin/backup.test.js
@@ -1,5 +1,7 @@
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
 const {anyContentLength, anyContentVersion, anyEtag, anyErrorId, stringMatching} = matchers;
+const {cacheInvalidateHeaderNotSet} = assertions;
+const {exportedBodyLatest} = require('../../utils/fixtures/export/body-generator');
 const fs = require('fs-extra');
 const sinon = require('sinon');
 const assert = require('assert/strict');
@@ -51,6 +53,28 @@ describe('Backup Integration', function () {
                 assert.ok(fileJSON.data, 'Written file has a property called data');
             });
 
+            it('Can do a DB export', async function () {
+                await agent
+                    .get('db/')
+                    .expectStatus(200)
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        'content-length': anyContentLength,
+                        'content-disposition': stringMatching(/^Attachment; filename="[A-Za-z0-9._-]+\.json"$/),
+                        etag: anyEtag
+                    })
+                    .expect(cacheInvalidateHeaderNotSet())
+                    .expect(({body}) => {
+                        assert.equal(body.db.length, 1);
+                        assert.ok(body.db[0].data);
+                        const dataKeys = Object.keys(exportedBodyLatest().db[0].data).sort();
+
+                        // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
+                        //       because when `have.only.keys` fails there's no useful diff
+                        assert.deepEqual(Object.keys(body.db[0].data).sort(), dataKeys);
+                    });
+            });
+
             it('Can export members CSV', async function () {
                 await agent
                     .get('members/upload/?limit=all')
@@ -77,6 +101,21 @@ describe('Backup Integration', function () {
                     .expectStatus(403)
                     .matchHeaderSnapshot({
                         'content-length': anyContentLength,
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        errors: [{
+                            id: anyErrorId
+                        }]
+                    });
+            });
+
+            it('Cannot do a DB export', async function () {
+                await agent
+                    .get('db/')
+                    .expectStatus(501)
+                    .matchHeaderSnapshot({
                         'content-version': anyContentVersion,
                         etag: anyEtag
                     })
@@ -147,6 +186,51 @@ describe('Backup Integration', function () {
             });
         });
 
+        describe('Owner: Staff token', function () {
+            before(async function () {
+                await agent.useStaffTokenForAdmin();
+            });
+
+            it('Can create a DB backup', async function () {
+                await agent
+                    .post('db/backup?filename=test')
+                    .expectStatus(200)
+                    .matchHeaderSnapshot({
+                        'content-length': anyContentLength,
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        db: [{
+                            filename: stringMatching(/ghost-test\/data\/test\.json$/)
+                        }]
+                    });
+
+                sinon.assert.calledOnce(fsStub);
+                const args = fsStub.firstCall.args;
+                const fileJSON = JSON.parse(args[1]);
+
+                assert.match(args[0].toString(), /ghost-test\/data\/test.json$/);
+                // @TODO: make a way do this with snapshots!
+                assert.ok(fileJSON.meta, 'Written file has a property called meta');
+                assert.ok(fileJSON.data, 'Written file has a property called data');
+            });
+
+            it('Can export members CSV', async function () {
+                await agent
+                    .get('members/upload/?limit=all')
+                    .expectStatus(200)
+                    .expectEmptyBody()
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        'content-disposition': stringMatching(/attachment; filename="members\./)
+                    })
+                    .expect(({text}) => {
+                        assert.match(text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+                    });
+            });
+        });
+
         describe('Editor: User authentication', function () {
             before(async function () {
                 await agent.loginAsEditor();
@@ -154,6 +238,21 @@ describe('Backup Integration', function () {
 
             it('Cannot create a DB backup', async function () {
                 await agent.post('db/backup?filename=test')
+                    .expectStatus(403)
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        errors: [{
+                            id: anyErrorId
+                        }]
+                    });
+            });
+
+            it('Cannot do a DB export', async function () {
+                await agent
+                    .get('db/')
                     .expectStatus(403)
                     .matchHeaderSnapshot({
                         'content-version': anyContentVersion,


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost-CLI/issues/1952#issuecomment-2927594223 ref https://github.com/TryGhost/Ghost/commit/3c5f1116335abdf81d4cc6712ef8f82bebca540e ref https://github.com/TryGhost/Ghost/pull/23589

- I've been trying to resolve issues with our api tokens that were surfaced when we added 2FA to user auth, meaning many tools need to swap to using API tokens
- As well as finding that our staff tokens didn't have the same permissions as the user they represent we also discovered that the backup integration wasn't that useful, as it couldn't do a member export
- Turns out it also can only do a db backup, and not a db export, despite having all permissons on the DB because of our "NotImplemented" middleware
- I've opted to add an explicit passthrough for the backup integration so that it has permissions to export as well as backup
- I did look at just adding GET /db/ to the allowList, but that has slightly wider reaching changes in that other integrations get 403s instead of 501s
- Which is a change I want to make, but will make in 6.x instead seeing as its right around the corner

