### PR TITLE
Changed API token middleware to throw 403

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -5,7 +5,7 @@ const shared = require('../../../shared');
 const apiMw = require('../../middleware');
 
 const messages = {
-    notImplemented: 'The server does not support the functionality required to fulfill the request.',
+    apiTokenBlocked: 'API tokens do not have permission to access this endpoint',
     staffTokenBlocked: 'Staff tokens are not allowed to access this endpoint'
 };
 
@@ -14,7 +14,7 @@ const messages = {
  * @param {import('express').Response} res
  * @param {import('express').NextFunction} next
  */
-const notImplemented = function notImplemented(req, res, next) {
+const tokenPermissionCheck = function tokenPermissionCheck(req, res, next) {
     // CASE: user is logged in with user auth, skip to permission system
     if (!req.api_key) {
         return next();
@@ -81,10 +81,9 @@ const notImplemented = function notImplemented(req, res, next) {
         }
     }
 
-    next(new errors.InternalServerError({
-        errorType: 'NotImplementedError',
-        message: tpl(messages.notImplemented),
-        statusCode: 501
+    next(new errors.NoPermissionError({
+        message: tpl(messages.apiTokenBlocked),
+        statusCode: 403
     }));
 };
 
@@ -102,7 +101,7 @@ module.exports.authAdminApi = [
     apiMw.cors,
     shared.middleware.urlRedirects.adminSSLAndHostRedirect,
     shared.middleware.prettyUrls,
-    notImplemented
+    tokenPermissionCheck
 ];
 
 /**
@@ -118,7 +117,7 @@ module.exports.authAdminApiWithUrl = [
     apiMw.cors,
     shared.middleware.urlRedirects.adminSSLAndHostRedirect,
     shared.middleware.prettyUrls,
-    notImplemented
+    tokenPermissionCheck
 ];
 
 /**
@@ -130,5 +129,5 @@ module.exports.publicAdminApi = [
     apiMw.cors,
     shared.middleware.urlRedirects.adminSSLAndHostRedirect,
     shared.middleware.prettyUrls,
-    notImplemented
+    tokenPermissionCheck
 ];

--- a/ghost/core/test/e2e-api/admin/api-tokens.test.js
+++ b/ghost/core/test/e2e-api/admin/api-tokens.test.js
@@ -300,7 +300,7 @@ describe('Admin API', function () {
                 await agent.useZapierAdminAPIKey();
                 await agent
                     .get('invites')
-                    .expectStatus(501);
+                    .expectStatus(403);
             });
         });
     });

--- a/ghost/core/test/unit/server/web/api/admin/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/admin/middleware.test.js
@@ -6,7 +6,7 @@ const errors = require('@tryghost/errors');
 const middleware = require('../../../../../../core/server/web/api/endpoints/admin/middleware');
 
 describe('Admin API Middleware', function () {
-    describe('notImplemented', function () {
+    describe('tokenPermissionCheck', function () {
         let req, res, next;
 
         beforeEach(function () {
@@ -30,8 +30,8 @@ describe('Admin API Middleware', function () {
                 req.user = {id: 'abcd1234'};
 
                 // Get the notImplemented middleware from the authAdminApi array
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -51,8 +51,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/posts/';
                 req.method = 'GET';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -62,8 +62,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/db/';
                 req.method = 'DELETE';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 const error = next.firstCall.args[0];
@@ -75,8 +75,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/users/owner/';
                 req.method = 'PUT';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 const error = next.firstCall.args[0];
@@ -88,8 +88,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/db/';
                 req.method = 'POST';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -99,8 +99,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/users/owner/';
                 req.method = 'GET';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -121,8 +121,8 @@ describe('Admin API Middleware', function () {
                 req.path = '/db';
                 req.method = 'DELETE';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 // Should pass through since we're checking for exact match with trailing slash
                 assert.equal(next.calledOnce, true);
@@ -154,21 +154,21 @@ describe('Admin API Middleware', function () {
                 req.url = '/non-existent';
                 req.method = 'GET';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 const error = next.firstCall.args[0];
-                assert.equal(error instanceof errors.InternalServerError, true);
-                assert.equal(error.statusCode, 501);
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.statusCode, 403);
             });
 
             it('should allow integration tokens to POST to /db endpoint', function () {
                 req.url = '/db';
                 req.method = 'POST';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -178,13 +178,13 @@ describe('Admin API Middleware', function () {
                 req.url = '/db';
                 req.method = 'DELETE';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 const error = next.firstCall.args[0];
-                assert.equal(error instanceof errors.InternalServerError, true);
-                assert.equal(error.statusCode, 501);
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.statusCode, 403);
             });
         });
 
@@ -200,8 +200,8 @@ describe('Admin API Middleware', function () {
                 req.query.god_mode = 'true';
                 req.url = '/non-existent';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 assert.equal(next.firstCall.args.length, 0);
@@ -220,12 +220,12 @@ describe('Admin API Middleware', function () {
                 req.query.god_mode = 'true';
                 req.url = '/non-existent';
 
-                const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
-                notImplemented(req, res, next);
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
 
                 assert.equal(next.calledOnce, true);
                 const error = next.firstCall.args[0];
-                assert.equal(error instanceof errors.InternalServerError, true);
+                assert.equal(error instanceof errors.NoPermissionError, true);
 
                 process.env.NODE_ENV = originalEnv;
             });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2219/breaking-change-change-notimplemented-middleware-to-throw-403

- The intention of this middleware is to provide an allowlist of API endpoints we definitely trust to allow integrations to access
- It was meant to be a short term thing whilst we audited all the endpoints but it's ended up living a lot longer
- Given that we're blocking access to an endpoint that does exist and IS implemented, the 501 error makes no sense
- This changes the middleware to throw a 403 NoPermissionError instead so at least it makes sense
- Ideally we should move this code into the API permission layer or implement it with real permissions BUT for now this change at least makes the weirdest change (not really breaking, but different) in 6.x so it's done

