### PR TITLE
Removed all-tags load when opening post settings menu

### DIFF
--- a/ghost/admin/app/components/gh-psm-tags-input.hbs
+++ b/ghost/admin/app/components/gh-psm-tags-input.hbs
@@ -4,10 +4,14 @@
     }}
     @onChange={{this.updateTags}}
     @onCreate={{this.createTag}}
+    @onOpen={{this.loadInitialTags}}
     @options={{this.availableTags}}
+    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreTagsTask)}}
+    @registerAPI={{this.registerPowerSelectAPI}}
     @renderInPlace={{true}}
-    @selected={{this.post.tags}}
+    @search={{perform this.searchTagsTask}}
+    @selected={{@post.tags}}
     @showCreateWhen={{this.hideCreateOptionOnMatchingTag}}
-    @triggerId={{this.triggerId}}
+    @triggerId={{@triggerId}}
     @triggerClass={{@triggerClass}}
 />

--- a/ghost/admin/app/components/gh-psm-tags-input.js
+++ b/ghost/admin/app/components/gh-psm-tags-input.js
@@ -1,44 +1,106 @@
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
-import {action, computed} from '@ember/object';
+import Component from '@glimmer/component';
+import {TrackedArray} from 'tracked-built-ins';
+import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
-import {sort} from '@ember/object/computed';
-import {tagName} from '@ember-decorators/component';
+import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
 
-@classic
-@tagName('')
 export default class GhPsmTagsInput extends Component {
     @service store;
-
-    // public attrs
-    post = null;
+    @service tagsManager;
 
     // internal attrs
-    _availableTags = null;
+    @tracked _initialTags = new TrackedArray();
+    @tracked _searchedTags = new TrackedArray();
 
-    @sort('_availableTags.[]', function (tagA, tagB) {
-        // ignorePunctuation means the # in internal tag names is ignored
-        return tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true});
-    })
-        availableTags;
+    _initialTagsMeta = null;
+    _hasLoadedInitialTags = false;
+    _searchedTagsQuery = null;
+    _searchedTagsMeta = null;
 
-    @computed('availableTags.@each.name')
+    _powerSelectAPI = null;
+
+    constructor() {
+        super(...arguments);
+        this.addInitialTags(this.args.post.get('tags').toArray());
+    }
+
+    get availableTags() {
+        return this.tagsManager.sortTags(this._initialTags.filter(tag => !this.args.post.get('tags').includes(tag)));
+    }
+
+    get searchedTags() {
+        return this.tagsManager.sortTags(this._searchedTags.filter(tag => !this.args.post.get('tags').includes(tag)));
+    }
+
     get availableTagNames() {
         return this.availableTags.map(tag => tag.name.toLowerCase());
     }
 
-    init() {
-        super.init(...arguments);
-        // perform a background query to fetch all users and set `availableTags`
-        // to a live-query that will be immediately populated with what's in the
-        // store and be updated when the above query returns
-        this.store.query('tag', {limit: 'all'});
-        this.set('_availableTags', this.store.peekAll('tag'));
+    @action
+    addInitialTags(tags) {
+        const deduplicatedTags = tags.filter(tag => !this.args.post.get('tags').includes(tag));
+        this._initialTags.push(...deduplicatedTags);
     }
 
     @action
-    matchTags(tagNameAttr, term) {
-        return tagNameAttr.toLowerCase() === term.trim().toLowerCase();
+    addSearchedTags(tags) {
+        const deduplicatedTags = tags.filter(tag => !this.args.post.get('tags').includes(tag));
+        this._searchedTags.push(...deduplicatedTags);
+    }
+
+    @action
+    registerPowerSelectAPI(api) {
+        this._powerSelectAPI = api;
+    }
+
+    @action
+    async loadInitialTags() {
+        if (!this._hasLoadedInitialTags) {
+            await this.loadMoreTagsTask.perform(false);
+            this._hasLoadedInitialTags = true;
+        }
+    }
+
+    @task
+    *loadMoreTagsTask() {
+        const isSearch = !!this._powerSelectAPI.searchText;
+        if (isSearch) {
+            if (this.searchTagsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedTagsMeta && this._searchedTagsMeta.pagination.pages <= this._searchedTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedTagsMeta.pagination.page + 1;
+            const tags = yield this.tagsManager.searchTagsTask.perform(this._searchedTagsQuery, {page});
+            this.addSearchedTags(tags.toArray());
+            this._searchedTagsMeta = tags.meta;
+        } else {
+            if (this._initialTagsMeta && this._initialTagsMeta?.pagination.pages <= this._initialTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialTagsMeta?.pagination.page ? this._initialTagsMeta.pagination.page + 1 : 1;
+            const tags = yield this.store.query('tag', {limit: 100, page, order: 'name asc'});
+            this.addInitialTags(tags.toArray());
+            this._initialTagsMeta = tags.meta;
+        }
+    }
+
+    @task
+    *searchTagsTask(term) {
+        this._searchedTagsQuery = term;
+        const tags = yield this.tagsManager.searchTagsTask.perform(term);
+        this._searchedTagsMeta = tags.meta;
+
+        // we need to create a tracked array for vertical-collection to update as new options are loaded
+        // because we can't rely on power-select re-rendering as @options changes via auto template updates
+        this._searchedTags = new TrackedArray();
+        this.addSearchedTags(tags.toArray());
+        return this._searchedTags;
     }
 
     @action
@@ -48,7 +110,7 @@ export default class GhPsmTagsInput extends Component {
 
     @action
     updateTags(newTags) {
-        let currentTags = this.get('post.tags');
+        let currentTags = this.args.post.get('tags');
 
         // destroy new+unsaved tags that are no longer selected
         currentTags.forEach(function (tag) {
@@ -58,7 +120,7 @@ export default class GhPsmTagsInput extends Component {
         });
 
         // update tags
-        this.set('post.tags', newTags);
+        this.args.post.set('tags', newTags);
         if (this.savePostOnChange) {
             return this.savePostOnChange();
         }
@@ -66,7 +128,7 @@ export default class GhPsmTagsInput extends Component {
 
     @action
     createTag(tagNameAttr) {
-        let currentTags = this.get('post.tags');
+        let currentTags = this.args.post.get('tags');
         let currentTagNames = currentTags.map(tag => tag.get('name').toLowerCase());
         let tagToAdd;
 

--- a/ghost/admin/app/components/gh-token-input.js
+++ b/ghost/admin/app/components/gh-token-input.js
@@ -162,10 +162,6 @@ export default class GhTokenInput extends Component {
         if (searchAction) {
             let results = yield searchAction(term, select);
 
-            if (results.toArray) {
-                results = results.toArray();
-            }
-
             this._addCreateOption(term, results);
             return results;
         }

--- a/ghost/admin/app/controllers/posts.js
+++ b/ghost/admin/app/controllers/posts.js
@@ -151,7 +151,6 @@ export default class PostsController extends Controller {
             const tags = yield this.tagsManager.searchTagsTask.perform(this._searchedTagsQuery, {page});
             this._searchedTags.push(...this.tagsManager.sortTags(tags.toArray()));
             this._searchedTagsMeta = tags.meta;
-            return tags;
         } else {
             if (this._initialTagsMeta && this._initialTagsMeta?.pagination.pages <= this._initialTagsMeta.pagination.page) {
                 return;
@@ -159,11 +158,7 @@ export default class PostsController extends Controller {
 
             const page = this._initialTagsMeta?.pagination.page ? this._initialTagsMeta.pagination.page + 1 : 1;
             const tags = yield this.store.query('tag', {limit: 100, page, order: 'name asc'});
-            if (page === 1) {
-                this._initialTags = new TrackedArray(tags.toArray());
-            } else {
-                this._initialTags.push(...tags.toArray());
-            }
+            this._initialTags.push(...tags.toArray());
             this._initialTagsMeta = tags.meta;
         }
     }

--- a/ghost/admin/app/services/tags-manager.js
+++ b/ghost/admin/app/services/tags-manager.js
@@ -20,7 +20,7 @@ export default class TagsManagerService extends Service {
     *searchTagsTask(term, {page = 1} = {}) {
         // debounce the search
         yield timeout(250);
-        const safeTerm = encodeURIComponent(term).replace(/'/g, '%27'); // encodeURIComponent doesn't escape single quotes
+        const safeTerm = term.replace(/'/g, `\\'`);
         return yield this.store.query('tag', {filter: `tags.name:~'${safeTerm}'`, limit: 100, page, order: 'name asc'});
     }
 }

--- a/ghost/admin/mirage/config/tags.js
+++ b/ghost/admin/mirage/config/tags.js
@@ -1,6 +1,6 @@
 import {dasherize} from '@ember/string';
+import {extractFilterParam, paginateModelCollection} from '../utils';
 import {isBlank} from '@ember/utils';
-import {paginatedResponse} from '../utils';
 
 export default function mockTags(server) {
     server.post('/tags/', function ({tags}) {
@@ -19,7 +19,18 @@ export default function mockTags(server) {
         return tags.findBy({slug});
     });
 
-    server.get('/tags/', paginatedResponse('tags'));
+    server.get('/tags/', function ({tags}, {queryParams}) {
+        const {filter, page = 1, limit = 15} = queryParams;
+        const tagsName = extractFilterParam('tags.name', filter);
+
+        let collection = tags.all();
+
+        if (tagsName) {
+            collection = collection.filter(tag => tag.name.toLowerCase().includes(tagsName.toLowerCase()));
+        }
+
+        return paginateModelCollection('tags', collection, page, limit);
+    });
     server.get('/tags/:id/');
     server.put('/tags/:id/');
     server.del('/tags/:id/');

--- a/ghost/admin/mirage/utils.js
+++ b/ghost/admin/mirage/utils.js
@@ -116,6 +116,8 @@ export function extractFilterParam(param, filter = '') {
 
     if (result.startsWith('[')) {
         match = result.replace(/^\[|\]$/g, '').split(',');
+    } else if (result.startsWith('~')) {
+        match = result.replace(/^~/, '').replace(/\\'/g, `'`).replace(/^'|'$/g, '');
     } else {
         match = [result];
     }

--- a/ghost/admin/tests/integration/components/gh-psm-tags-input-test.js
+++ b/ghost/admin/tests/integration/components/gh-psm-tags-input-test.js
@@ -122,6 +122,23 @@ describe('Integration: Component: gh-psm-tags-input', function () {
         expect(selected[1]).to.not.have.class('tag-token--internal');
     });
 
+    it('can search for tags with single quotes', async function () {
+        server.create('tag', {name: 'O\'Nolan', slug: 'quote-test'});
+
+        this.set('post', this.store.findRecord('post', 1));
+        await settled();
+
+        await render(hbs`<GhPsmTagsInput @post={{post}} />`);
+        await clickTrigger();
+        await typeInSearch(`O'`);
+        await settled();
+
+        let options = findAll('.ember-power-select-option');
+        expect(options.length).to.equal(2);
+        expect(options[0]).to.contain.text(`Add "O'"...`);
+        expect(options[1]).to.contain.text(`O'Nolan`);
+    });
+
     describe('updateTags', function () {
         it('modifies post.tags', async function () {
             await assignPostWithTags(this, 'two', 'three');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/
ref https://github.com/TryGhost/Ghost/commit/05666f445ddc821d1e11e19a87b202da98fbb5be

- updated `<GhPsmTagsInput />`
  - now uses server-side "contains" filter when searching instead of a client-side contains filter
  - loads first 100 tags on open
  - has infinite scroll pagination
- fixed double-encoding of search string when performing server-side filtering
- added "contains" filter param extraction to `extractFilterParam` mirage util
- added "contains" filtering to mocked tags endpoint
