### PR TITLE
Fixed labs display for configs missing limiter

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -60,9 +60,7 @@ const AlphaFeatures: React.FC = () => {
             }
             setAllowedFeatures(filtered);
         };
-        if (limiter) {
-            filterFeatures();
-        }
+        filterFeatures();
     }, [limiter]);
 
     return (


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/71967d3854ee3da58be0a28b48eed8028a305c63

We want the filterFeatures function to always run, otherwise if we don't have a limiter, it never runs and populates the `allowedFeatures` array.