### PR TITLE
Fixed editor breadcrumbs pointing to new analytics page

### DIFF
--- a/ghost/admin/app/routes/lexical-editor.js
+++ b/ghost/admin/app/routes/lexical-editor.js
@@ -28,7 +28,7 @@ export default AuthenticatedRoute.extend({
     },
 
     resetController(controller) {
-        controller.fromAnalytics = null;
+        controller.fromAnalytics = false;
     },
 
     deactivate() {

--- a/ghost/admin/app/routes/lexical-editor.js
+++ b/ghost/admin/app/routes/lexical-editor.js
@@ -17,13 +17,18 @@ export default AuthenticatedRoute.extend({
     },
 
     setupController(controller, model, transition) {
-        if (transition.from?.name === 'posts.analytics' && transition.to?.name !== 'lexical-editor.new') {
-            controller.fromAnalytics = true;
+        if ((transition.from?.name === 'posts.analytics' || transition.from?.name?.startsWith('posts-x')) && transition.to?.name !== 'lexical-editor.new') {
+            // Extract the analytics path from window.location.href to preserve the exact tab
+            let currentUrl = window.location.href;
+            // Convert editor URL back to analytics URL and extract just the hash portion
+            let analyticsUrl = currentUrl.replace('/editor/', '/').replace(/\/edit$/, '');
+            let hashMatch = analyticsUrl.match(/#(.+)/);
+            controller.fromAnalytics = hashMatch ? hashMatch[1] : 'posts-x';
         }
     },
 
     resetController(controller) {
-        controller.fromAnalytics = false;
+        controller.fromAnalytics = null;
     },
 
     deactivate() {

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -18,10 +18,10 @@
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
                             {{#if this.fromAnalytics }}
-                                <LinkTo @route="posts.analytics" @model={{this.post}} class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
+                                <a href="#{{this.fromAnalytics}}" class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}
                                     <span>Analytics</span>
-                                </LinkTo>
+                                </a>
                             {{else}}
                                 <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}} data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -17,11 +17,16 @@
                 >
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
-                            {{#if this.fromAnalytics }}
+                            {{#if (and this.fromAnalytics (feature "trafficAnalytics"))}}
                                 <a href="#{{this.fromAnalytics}}" class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}
                                     <span>Analytics</span>
                                 </a>
+                            {{else if this.fromAnalytics}}
+                                <LinkTo @route="posts.analytics" @model={{this.post}} class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
+                                    {{svg-jar "arrow-left"}}
+                                    <span>Analytics</span>
+                                </LinkTo>
                             {{else}}
                                 <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}} data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2433/
- breadcrumb will now show analytics instead of posts, including the tab
- solution doesn't require the beta flag because we're directly parsing the url to return to, and only in the case of coming from analytics.