### PR TITLE
Improved empty states on post analytics screens

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -173,7 +173,7 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
                             description={mode === 'growth' && `Once someone signs up on this post, sources will show here`}
                             title={`No sources data available ${getPeriodText ? getPeriodText(range) : ''}`}
                         >
-                            <LucideIcon.Globe strokeWidth={1.5} />
+                            <LucideIcon.UserPlus strokeWidth={1.5} />
                         </EmptyIndicator>
                     </div>
                 )}

--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -168,10 +168,13 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
                     </SourcesTable>
                 ) : (
                     <div className='py-20 text-center text-sm text-gray-700'>
-                        {mode === 'growth'
-                            ? 'Once someone signs up on this post, sources will show here.'
-                            : 'No sources data available.'
-                        }
+                        <EmptyIndicator
+                            className='h-full'
+                            description={mode === 'growth' && `Once someone signs up on this post, sources will show here`}
+                            title={`No sources data available ${getPeriodText ? getPeriodText(range) : ''}`}
+                        >
+                            <LucideIcon.Globe strokeWidth={1.5} />
+                        </EmptyIndicator>
                     </div>
                 )}
             </CardContent>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import Sources from '../../Web/components/Sources';
-import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, GhAreaChart, GhAreaChartDataItem, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, formatNumber} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, EmptyIndicator, GhAreaChart, GhAreaChartDataItem, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, formatNumber} from '@tryghost/shade';
 import {BaseSourceData, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
@@ -93,9 +93,13 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
                                     totalVisitors={totalSourcesVisits}
                                 />
                                 :
-                                <div className='py-10 text-center text-sm text-muted-foreground'>
-                                    No data available.
-                                </div>
+                                <EmptyIndicator
+                                    className='h-full py-10'
+                                    description='Once someone visits this post, sources will show here'
+                                    title={`No visitors since you published this post`}
+                                >
+                                    <LucideIcon.Globe strokeWidth={1.5} />
+                                </EmptyIndicator>
                             }
                         </div>
                     }

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -1,12 +1,11 @@
 import AudienceSelect, {getAudienceQueryParam} from '../components/AudienceSelect';
 import DateRangeSelect from '../components/DateRangeSelect';
-import EmptyStatView from '../components/EmptyStatView';
 import Kpis from './components/Kpis';
 import Locations from './components/Locations';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import Sources from './components/Sources';
-import {BarChartLoadingIndicator, Card, CardContent, formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Card, CardContent, EmptyIndicator, LucideIcon, formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade';
 import {BaseSourceData, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 
@@ -14,6 +13,7 @@ import {useEffect, useMemo} from 'react';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
 import {STATS_RANGES} from '@src/utils/constants';
+import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Array of values that represent unknown locations
 const UNKNOWN_LOCATIONS = ['NULL', 'ᴺᵁᴸᴸ', ''];
@@ -178,8 +178,14 @@ const Web: React.FC<postAnalyticsProps> = () => {
                             </div>
                         </>
                         :
-                        <div className='mt-10 grow'>
-                            <EmptyStatView />
+                        <div className='grow'>
+                            <EmptyIndicator
+                                className='h-full'
+                                description='Try adjusting your date range to see more data.'
+                                title={`No visitors ${getPeriodText(range)}`}
+                            >
+                                <LucideIcon.Globe strokeWidth={1.5} />
+                            </EmptyIndicator>
                         </div>
                 }
             </PostAnalyticsContent>

--- a/apps/shade/src/components/ui/empty-indicator.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.tsx
@@ -37,10 +37,10 @@ const EmptyIndicator = React.forwardRef<HTMLDivElement, EmptyIndicatorProps>(({c
                 {children}
             </EmptyBadge>
             <div className='max-w-[320px] space-y-1.5'>
-                <h3 className='text-sm font-medium tracking-normal text-foreground'>
+                <h3 className='text-pretty text-sm font-medium tracking-normal text-foreground'>
                     {title}
                 </h3>
-                <p className='text-sm leading-tight text-muted-foreground'>
+                <p className='text-pretty text-sm leading-tight text-muted-foreground'>
                     {description}
                 </p>
             </div>

--- a/apps/stats/src/views/Stats/components/FeatureImagePlaceholder.tsx
+++ b/apps/stats/src/views/Stats/components/FeatureImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {cn} from '@tryghost/shade';
+import {LucideIcon, cn} from '@tryghost/shade';
 
 interface FeatureImagePlaceholderProps {
     className?: string;
@@ -9,12 +9,8 @@ const FeatureImagePlaceholder:React.FC<FeatureImagePlaceholderProps> = ({
     className
 }) => {
     return (
-        <div className={cn('rounded-sm bg-muted dark:bg-[#36373a] flex flex-col items-stretch justify-center gap-1', className)}>
-            <div className='flex flex-col items-stretch gap-[5px] px-[15%]'>
-                <div className='h-[3px] bg-muted-foreground/20'></div>
-                <div className='h-[3px] w-[80%] bg-muted-foreground/20'></div>
-                <div className='h-[3px] w-[90%] bg-muted-foreground/20'></div>
-            </div>
+        <div className={cn('rounded-sm bg-muted dark:bg-[#36373a] flex flex-col items-center justify-center gap-1 p-6', className)}>
+            <LucideIcon.Image className='text-muted-foreground/50' size={18} strokeWidth={1.5} />
         </div>
     );
 };

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -56,7 +56,9 @@
             <div class="gh-post-list-feature-image" style={{html-safe (concat "background-image: url(" @post.featureImage ");")}}>
                 {{!-- Fallback to placeholder --}}
                 {{#unless @post.featureImage}}
-                    <div class="gh-post-list-feature-image-placeholder"></div>
+                    <div class="gh-post-list-feature-image-placeholder">
+                        {{svg-jar "post-feature-image-placeholder"}}
+                    </div>
                 {{/unless}}
             </div>
             <div>

--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -1598,8 +1598,8 @@ New form styles */
     background-color: #36373A;
 }
 
-.gh-post-list-feature-image-placeholder,
+/* .gh-post-list-feature-image-placeholder,
 .gh-post-list-feature-image-placeholder:before,
 .gh-post-list-feature-image-placeholder:after {
     background-color: var(--whitegrey-d2);
-}
+} */

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -394,14 +394,21 @@
 
 .gh-post-list-feature-image-placeholder {
     position: relative;
-    background-color: var(--lightgrey);
-    height: 3px;
+    height: 100%;
     width: 100%;
-    margin-top: -16px;
-    opacity: 0.6;
+    opacity: 0.5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--midgrey);
 }
 
-.gh-post-list-feature-image-placeholder:before,
+.gh-post-list-feature-image-placeholder svg {
+    width: 18px;
+    height: 18px;
+}
+
+/* .gh-post-list-feature-image-placeholder:before,
 .gh-post-list-feature-image-placeholder:after {
     position: absolute;
     display: block;
@@ -423,7 +430,7 @@
 .gh-post-list-feature-image-placeholder:after {
     top: 16px;
     right: 8px;
-}
+} */
 
 .gh-post-list-external path {
     fill: var(--midgrey);

--- a/ghost/admin/public/assets/icons/post-feature-image-placeholder.svg
+++ b/ghost/admin/public/assets/icons/post-feature-image-placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-image-icon lucide-image"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2178/handling-empty-states

- Added empty states to Growth sources and Web visitors charts
- Updated web overview on post analytics right after posting
- Updated post placeholder image when missing feature image