### PR TITLE
Added custom domain check to freeze Social Web adoption

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -1,42 +1,59 @@
 import FeatureToggle from './FeatureToggle';
 import LabItem from './LabItem';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {Button, FileUpload, List, showToast} from '@tryghost/admin-x-design-system';
-import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {downloadRedirects, useUploadRedirects} from '@tryghost/admin-x-framework/api/redirects';
 import {downloadRoutes, useUploadRoutes} from '@tryghost/admin-x-framework/api/routes';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const BetaFeatures: React.FC = () => {
-    const limiter = useLimiter();
-    const [limitSocialWeb, setLimitSocialWeb] = useState<boolean>(false);
     const {mutateAsync: uploadRedirects} = useUploadRedirects();
     const {mutateAsync: uploadRoutes} = useUploadRoutes();
     const handleError = useHandleError();
     const [redirectsUploading, setRedirectsUploading] = useState(false);
     const [routesUploading, setRoutesUploading] = useState(false);
-    const {config} = useGlobalData();
-    const isPro = !!config.hostSettings?.siteId;
+    const {config, siteData} = useGlobalData();
+    const isPro = !config.hostSettings?.siteId;
+    const homepageUrl = getHomepageUrl(siteData!);
+    const noCustomDomainSetup = !!homepageUrl?.match(/ghost\.io\/?$/) || false;
+    const {subdir} = getGhostPaths();
+    const hasSubdir = subdir?.length > 0;
+    const noCustomDomainOrHasSubdir = noCustomDomainSetup || hasSubdir;
+    const socialWebNotAvailableMsg = hasSubdir ?
+        'Not compatible with /subdirectory installations.' :
+        'Please setup a custom domain to enable.';
 
-    useEffect(() => {
-        if (limiter?.isLimited('limitSocialWeb')) {
-            limiter.errorIfWouldGoOverLimit('limitSocialWeb').catch ((error) => {
-                if (error instanceof HostLimitError) {
-                    setLimitSocialWeb(true);
-                } else {
-                    handleError(error);
-                }
-            });
-        }
-    }, [limiter, setLimitSocialWeb, handleError]);
+    //TODO: Temporarily disabled until general rollout of limit
+    // useEffect(() => {
+    //     if (limiter?.isLimited('limitSocialWeb')) {
+    //         limiter.errorIfWouldGoOverLimit('limitSocialWeb').catch ((error) => {
+    //             if (error instanceof HostLimitError) {
+    //                 setLimitSocialWeb(true);
+    //             } else {
+    //                 handleError(error);
+    //             }
+    //         });
+    //     }
+    // }, [limiter, setLimitSocialWeb, handleError]);
 
     return (
         <List titleSeparator={false}>
-            { isPro && !limitSocialWeb && (
+            {isPro && (
                 <LabItem
-                    action={<FeatureToggle flag="ActivityPub" />}
-                    detail={<>Federate your site with ActivityPub to join the world&apos;s largest open network. <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></>}
+                    action={<FeatureToggle disabled={noCustomDomainOrHasSubdir} flag="ActivityPub"/>}
+                    detail={
+                        <>
+                        Federate your site with ActivityPub to join the world&apos;s largest open network.
+                            {noCustomDomainOrHasSubdir &&
+                                (<><br></br>{socialWebNotAvailableMsg} </>)
+                            }
+                            &nbsp;
+                            <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                        </>
+                    }
                     title='Social web (beta)' />
             )}
             <LabItem

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
@@ -7,14 +7,14 @@ import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tanstack/react-query';
 
-const FeatureToggle: React.FC<{ flag: string; label?: string; }> = ({label, flag}) => {
+const FeatureToggle: React.FC<{ flag: string; label?: string; disabled?: boolean }> = ({label, flag, disabled}) => {
     const {settings} = useGlobalData();
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
     const {mutateAsync: editSettings} = useEditSettings();
     const client = useQueryClient();
     const handleError = useHandleError();
 
-    return <Toggle checked={labs[flag]} label={label} labelClasses='sr-only' name={`feature-${flag}`} onChange={async () => {
+    return <Toggle checked={labs[flag]} disabled={disabled} label={label} labelClasses='sr-only' name={`feature-${flag}`} onChange={async () => {
         const newValue = !labs[flag];
         try {
             await editSettings([{


### PR DESCRIPTION
ref [BAE-458](https://linear.app/ghost/issue/BAE-458/add-custom-domain-related-limit-for-limitsocialweb)

The Social Web feature needed to be temporarily frozen for new adoptions to allow collecting a grandfathering list before the `limitSocialWeb` rollout.

This change disables the Social Web toggle for sites without custom domains or with subdirectory installations, effectively freezing the current usage. The implementation uses domain and path checks instead of the new limit system, ensuring no unexpected changes to the existing user base while we prepare for the proper limit rollout.

Once the grandfathering list is collected and `limitSocialWeb` is deployed, this temporary restriction will be replaced with the proper limit-based implementation that's currently commented out in the code.