### PR TITLE
Fixed accidental inversion of Pro flag in BetaFeatures

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -16,7 +16,7 @@ const BetaFeatures: React.FC = () => {
     const [redirectsUploading, setRedirectsUploading] = useState(false);
     const [routesUploading, setRoutesUploading] = useState(false);
     const {config, siteData} = useGlobalData();
-    const isPro = !config.hostSettings?.siteId;
+    const isPro = !!config.hostSettings?.siteId;
     const homepageUrl = getHomepageUrl(siteData!);
     const noCustomDomainSetup = !!homepageUrl?.match(/ghost\.io\/?$/) || false;
     const {subdir} = getGhostPaths();
@@ -25,19 +25,6 @@ const BetaFeatures: React.FC = () => {
     const socialWebNotAvailableMsg = hasSubdir ?
         'Not compatible with /subdirectory installations.' :
         'Please setup a custom domain to enable.';
-
-    //TODO: Temporarily disabled until general rollout of limit
-    // useEffect(() => {
-    //     if (limiter?.isLimited('limitSocialWeb')) {
-    //         limiter.errorIfWouldGoOverLimit('limitSocialWeb').catch ((error) => {
-    //             if (error instanceof HostLimitError) {
-    //                 setLimitSocialWeb(true);
-    //             } else {
-    //                 handleError(error);
-    //             }
-    //         });
-    //     }
-    // }, [limiter, setLimitSocialWeb, handleError]);
 
     return (
         <List titleSeparator={false}>


### PR DESCRIPTION
ref 3c43932f1c63673beb03b6a98f49d66315da1264
ref [BAE-458](https://linear.app/ghost/issue/BAE-458/add-custom-domain-related-limit-for-limitsocialweb)

During manual tests, I had to invert the logic for the `isPro` flag to be truthy, but forgot to switch it back before commiting with 3c43932f1c63673beb03b6a98f49d66315da1264. Furthermore, we can safely remove old limit-based implementation and revert back to Git history when we enable it again.