### PR TITLE
Changed e2e tests to only run Ghost backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,6 +826,7 @@ jobs:
         run: yarn nx run ghost-admin:build:dev
 
       - name: Start Ghost
+        working-directory: ghost/core
         run: DEBUG=* yarn dev &
 
       - name: Wait for Ghost to be ready


### PR DESCRIPTION
The e2e test suite continue timing out when starting ghost with `yarn dev`. The debugging logs don't reveal any useful information, but my best guess based on things I've seen when running `yarn dev` locally in a resource constrained docker container is that the admin build, which is a sub-process of `yarn dev`, is OOMing and causing the whole process to crash. 

This commit changes the working directory to `ghost/core`, so we are effectively only running Ghost's backend. The previous step builds Ghost Admin, so the built files should be ready, and Ghost serves them anyways — so running the full development build of admin while watching files for changes is not necessary. 

Hopefully this will make things more stable — as an added benefit, it gets the e2e tests down to ~3 minutes from 4+ minutes.