### PR TITLE
🐛 Fixed x username validation failing on www and http

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -15,13 +15,10 @@ export function validateTwitterUrl(newUrl: string) {
             username = username.slice(1);
         }
 
-        // check if username starts with http:, https:, or www. and show error if so
-        if (username.match(/^(http:|www\.|https:)|(\/)/) || !username.match(/^[a-z\d_]{1,15}$/mi)) {
-            const message = !username.match(/^[a-z\d_]{1,15}$/mi)
-                ? 'Your Username is not a valid Twitter Username'
-                : 'The URL must be in a format like https://x.com/yourUsername';
-            throw new Error(message);
+        if (!username.match(/^[a-z\d_]{1,15}$/mi)) {
+            throw new Error('Your Username is not a valid Twitter Username');
         }
+        
         return `https://x.com/${username}`;
     } else {
         const message = 'The URL must be in a format like https://x.com/yourUsername';

--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -16,8 +16,8 @@ export function validateTwitterUrl(newUrl: string) {
         }
 
         // check if username starts with http:, https:, or www. and show error if so
-        if (username.match(/^(http:|www\.|https:)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
-            const message = !username.match(/^[a-z\d._]{1,15}$/mi)
+        if (username.match(/^(http:|www\.|https:)|(\/)/) || !username.match(/^[a-z\d_]{1,15}$/mi)) {
+            const message = !username.match(/^[a-z\d_]{1,15}$/mi)
                 ? 'Your Username is not a valid Twitter Username'
                 : 'The URL must be in a format like https://x.com/yourUsername';
             throw new Error(message);

--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -15,8 +15,8 @@ export function validateTwitterUrl(newUrl: string) {
             username = username.slice(1);
         }
 
-        // check if username starts with http or www and show error if so
-        if (username.match(/^(http|www)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
+        // check if username starts with http:, https:, or www. and show error if so
+        if (username.match(/^(http:|www\.|https:)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
             const message = !username.match(/^[a-z\d._]{1,15}$/mi)
                 ? 'Your Username is not a valid Twitter Username'
                 : 'The URL must be in a format like https://x.com/yourUsername';

--- a/apps/admin-x-settings/test/unit/utils/twitterUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/twitterUrls.test.ts
@@ -11,6 +11,8 @@ describe('Twitter URLs', () => {
             assert.equal(validateTwitterUrl('x.com/username'), 'https://x.com/username');
             assert.equal(validateTwitterUrl('https://x.com/username'), 'https://x.com/username');
             assert.equal(validateTwitterUrl('@username'), 'https://x.com/username');
+            assert.equal(validateTwitterUrl('wwwUsername'), 'https://x.com/wwwUsername');
+            assert.equal(validateTwitterUrl('httpUsername'), 'https://x.com/httpUsername');
         });
 
         it('should reject invalid Twitter usernames', () => {


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/PROD-1536/unable-to-save-x-handle-with-www-in-the-the-handle-name

- the check on X usernames makes sure it's not a url first, but it was incorrectly throwing an error on valid usernames like `wwwUsername` and `httpUsername`
- this is a minimal fix to make sure those valid usernames pass
