### PR TITLE
🎨 Added DID as a valid Bluesky username pattern

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/bluesky.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/bluesky.ts
@@ -1,5 +1,10 @@
 import validator from 'validator';
 
+const ERRORS = {
+    INVALID_USERNAME: 'Your Username is not a valid Bluesky Username',
+    INVALID_URL: 'The URL must be in a format like https://bsky.app/profile/yourUsername'
+};
+
 function isValidBlueskyUsername(username: string): boolean {
     const validUsernamePatterns = [
         // DID username: did:plc: + 24 chars
@@ -15,7 +20,6 @@ function isValidBlueskyUsername(username: string): boolean {
 }
 
 export function validateBlueskyUrl(newUrl: string) {
-    const errMessage = 'The URL must be in a format like https://bsky.app/profile/yourUsername';
     if (!newUrl) {
         return '';
     }
@@ -26,13 +30,13 @@ export function validateBlueskyUrl(newUrl: string) {
     if (newUrl.startsWith('http') || newUrl.startsWith('www.') || newUrl.includes('bsky.app')) {
         // Only allow bsky.app domain
         if (!newUrl.includes('bsky.app')) {
-            throw new Error(errMessage);
+            throw new Error(ERRORS.INVALID_URL);
         }
 
         // Extract username from URL
         const usernameMatch = newUrl.match(/bsky\.app\/profile\/@?([^/]+)/);
         if (!usernameMatch) {
-            throw new Error(errMessage);
+            throw new Error(ERRORS.INVALID_URL);
         }
         username = usernameMatch[1];
     } else {
@@ -42,22 +46,21 @@ export function validateBlueskyUrl(newUrl: string) {
 
     // Validate username
     if (!isValidBlueskyUsername(username)) {
-        throw new Error('Your Username is not a valid Bluesky Username');
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
     // Construct and validate full URL
     const normalizedUrl = `https://bsky.app/profile/${username}`;
     if (!validator.isURL(normalizedUrl)) {
-        throw new Error(errMessage);
+        throw new Error(ERRORS.INVALID_URL);
     }
 
     return normalizedUrl;
 }
 
 export const blueskyHandleToUrl = (handle: string) => {
-    const errMessage = 'Your Username is not a valid Bluesky Username';
     if (!handle) {
-        throw new Error(errMessage);
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
     let username = handle;
@@ -67,7 +70,7 @@ export const blueskyHandleToUrl = (handle: string) => {
 
     // Validate username
     if (!isValidBlueskyUsername(username)) {
-        throw new Error(errMessage);
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
     return `https://bsky.app/profile/${username}`;

--- a/apps/admin-x-settings/src/utils/socialUrls/bluesky.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/bluesky.ts
@@ -28,9 +28,14 @@ export function validateBlueskyUrl(newUrl: string) {
     }
 
     // Validate username
-    // Regular username: alphanumeric, underscore, max 15 chars
-    const isRegularUsername = !username.includes('.');
-    if (isRegularUsername) {
+    if (username.startsWith('did:plc:')) {
+        // Bluesky DID starts with did:plc: followed by 24 alphanumeric characters 
+        // see https://github.com/did-method-plc/did-method-plc
+        if (!username.match(/^did:plc:[a-zA-Z0-9._]{24}$/)) {
+            throw new Error(invalidUsernameMessage);
+        }
+        // Regular username: alphanumeric, underscore, max 15 chars
+    } else if (!username.includes('.')) {
         if (!username.match(/^[a-zA-Z0-9._]{1,15}$/)) {
             throw new Error(invalidUsernameMessage);
         }
@@ -62,8 +67,13 @@ export const blueskyHandleToUrl = (handle: string) => {
     }
 
     // Validate username
-    const isRegularUsername = !username.includes('.');
-    if (isRegularUsername) {
+    if (username.startsWith('did:plc:')) {
+        // https://github.com/did-method-plc/did-method-plc
+        if (!username.match(/^did:plc:[a-zA-Z0-9._]{24}$/)) {
+            throw new Error(errMessage);
+        }
+        // Regular username: alphanumeric, underscore, max 15 chars
+    } else if (!username.includes('.')) {
         if (!username.match(/^[a-zA-Z0-9._]{1,15}$/)) {
             throw new Error(errMessage);
         }

--- a/apps/admin-x-settings/test/unit/utils/blueskyUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/blueskyUrls.test.ts
@@ -17,6 +17,7 @@ describe('Bluesky URLs', () => {
             assert.equal(validateBlueskyUrl('www.bsky.app/profile/username'), 'https://bsky.app/profile/username');
             assert.equal(validateBlueskyUrl('www.bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq'), 'https://bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq');
             assert.equal(validateBlueskyUrl('did:plc:g67wcylkodj4rrrgh26eifkq'), 'https://bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq');
+            assert.equal(validateBlueskyUrl('did:plc:THISWILLBELOWERCASED4567'), 'https://bsky.app/profile/did:plc:thiswillbelowercased4567');
             assert.equal(validateBlueskyUrl('@username'), 'https://bsky.app/profile/username');
             assert.equal(validateBlueskyUrl('username'), 'https://bsky.app/profile/username');
         });
@@ -29,6 +30,7 @@ describe('Bluesky URLs', () => {
         it('should reject invalid Bluesky usernames', () => {
             assert.throws(() => validateBlueskyUrl('bsky.app/profile/username@'), /Your Username is not a valid Bluesky Username/);
             assert.throws(() => validateBlueskyUrl('bsky.app/profile/username!'), /Your Username is not a valid Bluesky Username/);
+            assert.throws(() => validateBlueskyUrl('bsky.app/profile/did:plc:thisisnotavalidformat'), /Your Username is not a valid Bluesky Username/);
             assert.throws(() => validateBlueskyUrl('bsky.app/profile/thisusernameistoolongforbluesky'), /Your Username is not a valid Bluesky Username/);
         });
     });

--- a/apps/admin-x-settings/test/unit/utils/blueskyUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/blueskyUrls.test.ts
@@ -15,6 +15,8 @@ describe('Bluesky URLs', () => {
             assert.equal(validateBlueskyUrl('bsky.app/profile/username'), 'https://bsky.app/profile/username');
             assert.equal(validateBlueskyUrl('https://bsky.app/profile/username'), 'https://bsky.app/profile/username');
             assert.equal(validateBlueskyUrl('www.bsky.app/profile/username'), 'https://bsky.app/profile/username');
+            assert.equal(validateBlueskyUrl('www.bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq'), 'https://bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq');
+            assert.equal(validateBlueskyUrl('did:plc:g67wcylkodj4rrrgh26eifkq'), 'https://bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq');
             assert.equal(validateBlueskyUrl('@username'), 'https://bsky.app/profile/username');
             assert.equal(validateBlueskyUrl('username'), 'https://bsky.app/profile/username');
         });
@@ -35,6 +37,7 @@ describe('Bluesky URLs', () => {
         it('should convert Bluesky handle to full URL', () => {
             assert.equal(blueskyHandleToUrl('username'), 'https://bsky.app/profile/username');
             assert.equal(blueskyHandleToUrl('@username'), 'https://bsky.app/profile/username');
+            assert.equal(blueskyHandleToUrl('did:plc:g67wcylkodj4rrrgh26eifkq'), 'https://bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq');
         });
 
         it('should reject invalid Bluesky handles', () => {
@@ -49,6 +52,7 @@ describe('Bluesky URLs', () => {
             assert.equal(blueskyUrlToHandle('https://bsky.app/profile/username'), 'username');
             assert.equal(blueskyUrlToHandle('https://bsky.app/profile/@username'), 'username');
             assert.equal(blueskyUrlToHandle('bsky.app/profile/username'), 'username');
+            assert.equal(blueskyUrlToHandle('bsky.app/profile/did:plc:g67wcylkodj4rrrgh26eifkq'), 'did:plc:g67wcylkodj4rrrgh26eifkq');
         });
 
         it('should return null for invalid Bluesky URLs', () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1870/allow-perma-links-in-validation-for-bluesky
reported here https://forum.ghost.org/t/bluesky-entry-on-profile-social-links-blocks-perma-links/57712

- In addition to regular handles, Bluesky also has the concept of Decentralized Identifiers (DID) as noted in the [Bluesky docs](https://docs.bsky.app/docs/advanced-guides/resolving-identities).
- This update makes it so staff users can set their Bluesky username on Ghost to a DID
- also includes tidying specifically impacted by these changes