### PR TITLE
🎨 Added ability to use company and school LinkedIn profiles

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
@@ -41,7 +41,7 @@ const extractInputParts = (input: string) => {
         }
 
         // don't need protocol from match
-        const [, regional, pathType, rawUsername] = match
+        const [, regional, pathType, rawUsername] = match;
         const username = formatUsername(rawUsername);
 
         // validate regional code is two letters if present

--- a/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
@@ -1,80 +1,120 @@
 import validator from 'validator';
 
-// Validates and normalizes LinkedIn URLs or handles
-export function validateLinkedInUrl(newUrl: string) {
-    const errMessage = 'The URL must be in a format like https://www.linkedin.com/in/yourUsername';
-    const invalidUsernameMessage = 'Your Username is not a valid LinkedIn Username';
-    if (!newUrl) {
+const ERRORS = {
+    INVALID_URL: 'The URL must be in a format like https://www.linkedin.com/in/yourUsername',
+    INVALID_USERNAME: 'Your Username is not a valid LinkedIn Username'
+} as const;
+
+const PATH_TYPES = ['in', 'pub', 'company', 'school'] as const;
+type PathType = typeof PATH_TYPES[number];
+
+// validation info: https://www.linkedin.com/help/linkedin/answer/a542685/manage-your-public-profile-url?lang=en
+// Alphanumeric, hyphen, 3–100 characters
+const USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}$/;
+// For /pub/ profiles: username optionally followed by slash-separated segments (i.e. 12/34/567)
+const PUB_USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}(?:\/[a-zA-Z0-9-]*)*$/;
+
+/* 
+* A few parts to this regex:
+* - optional protocol & www
+* - optional 2-letter regional code (like "ca")
+* - LinkedIn domain
+* - allowed path type (see PathType)
+* - username (captured until a query/hash or string end, so it can contain nested slashes for /pub/)
+*/
+const LINKEDIN_URL_REGEX = /^(?:https?:\/\/)?(?:www\.)?(?:([a-z]{2})\.)?linkedin\.com\/(in|pub|company|school)\/([^?#]+)/i;
+
+// trims whitespace and removes leading @ if it exists
+const formatUsername = (value: string) => value.trim().replace(/^@/, '');
+
+const extractInputParts = (input: string) => {
+    // Detect full URL patterns first
+    if (/^(https?:\/\/|www\.)/.test(input) || input.includes('linkedin.com')) {
+        const match = input.match(LINKEDIN_URL_REGEX);
+        if (!match) {
+            throw new Error(ERRORS.INVALID_URL);
+        }
+
+        // Don't allow anything after the username (e.g. #fragment or ?query)
+        if (match[0].length !== input.length) {
+            throw new Error(ERRORS.INVALID_USERNAME);
+        }
+
+        // don't need protocol from match
+        const [, regional, pathType, rawUsername] = match
+        const username = formatUsername(rawUsername);
+
+        // validate regional code is two letters if present
+        // validator.js has isISO31661Alpha2, but on a later version than is currently installed
+        // so this check isn't as strict, but is sufficient for now
+        if (regional && !/^[A-Z]{2}$/.test(regional.toUpperCase())) {
+            throw new Error(ERRORS.INVALID_URL);
+        }
+
+        return {regional, pathType: pathType as PathType, username};
+    }
+
+    // if it's not a url, we expect a handle like name, @name, pub/name, company/name, school/name
+    const formatted = formatUsername(input);
+    const slashIndex = formatted.indexOf('/');
+    if (slashIndex !== -1) {
+        const maybeType = formatted.substring(0, slashIndex);
+        if ((PATH_TYPES as readonly string[]).includes(maybeType)) {
+            return {pathType: maybeType as PathType, username: formatted.substring(slashIndex + 1)};
+        }
+    }
+    return {username: formatted};
+};
+
+const isValidUsername = (pathType: PathType, username: string) => {
+    const pattern = pathType === 'pub' ? PUB_USERNAME_REGEX : USERNAME_REGEX;
+    return pattern.test(username);
+};
+
+const buildUrl = ({regional, pathType, username}: {regional?: string; pathType: PathType; username: string}) => {
+    const domainPrefix = regional ? `${regional.toLowerCase()}.` : 'www.';
+    const url = `https://${domainPrefix}linkedin.com/${pathType}/${username}`;
+    if (!validator.isURL(url)) {
+        throw new Error(ERRORS.INVALID_URL);
+    }
+    return url;
+};
+
+export function validateLinkedInUrl(input: string) {
+    if (!input) {
         return '';
     }
 
-    let username: string;
-    let regionalCode: string | undefined;
-    let pathType: string = '';
+    const {regional, pathType = 'in', username} = extractInputParts(input);
 
-    // Extract username from URL or handle
-    if (newUrl.startsWith('http') || newUrl.startsWith('www.') || newUrl.includes('linkedin.com')) {
-        // Check for linkedin.com domain (including regional, e.g., ca.linkedin.com)
-        if (!newUrl.includes('linkedin.com')) {
-            throw new Error(errMessage);
-        }
-        // Handle regional URLs (e.g., ca.linkedin.com)
-        const regionalMatch = newUrl.match(/(?:https?:\/\/)?(?:www\.)?([a-z]{2}\.)?linkedin\.com\/(in|pub|company|school)\/@?([^/]+)/);
-        if (!regionalMatch) {
-            throw new Error(errMessage);
-        }
-        regionalCode = regionalMatch[1]; // e.g., 'ca.' or undefined
-        pathType = regionalMatch[2]; // 'in', 'pub', 'company', or 'school'
-        username = `${pathType}/${regionalMatch[3]}`;
-    } else {
-        // Handle username or @username
-        username = newUrl.startsWith('@') ? newUrl.slice(1) : newUrl;
-    }
-    
-    // For /pub/ URLs, allow longer, non-custom formats
-    if (pathType === 'pub' && !username.match(/^pub\/[a-zA-Z0-9._-]{3,100}(?:-[a-f0-9]+)?$/)) {
-        throw new Error(invalidUsernameMessage);
-    } else if (pathType !== 'pub' && !username.match(/^(?:in\/|company\/|school\/)?[a-zA-Z0-9._-]{3,100}$/)) {
-        // Validate username for in/, company/, and school/ URLs (custom handles)
-        throw new Error(invalidUsernameMessage);
+    if (!isValidUsername(pathType, username)) {
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
-    const usernameWithPathType = username.includes('/') ? username : `in/${username}`;
-    // Construct and validate full URL
-    const normalizedUrl = regionalCode
-        ? `https://${regionalCode}linkedin.com/${usernameWithPathType}`
-        : `https://www.linkedin.com/${usernameWithPathType}`;
-    if (!validator.isURL(normalizedUrl)) {
-        throw new Error(errMessage);
-    }
-
-    return normalizedUrl;
+    return buildUrl({regional, pathType, username});
 }
 
-// Converts a LinkedIn handle to a full URL
 export const linkedinHandleToUrl = (handle: string) => {
-    const errMessage = 'Your Username is not a valid LinkedIn Username';
     if (!handle) {
-        throw new Error(errMessage);
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
-    let username = handle;
-    if (username.startsWith('@')) {
-        username = username.slice(1);
+    const {regional, pathType = 'in', username} = extractInputParts(handle);
+
+    if (!isValidUsername(pathType, username)) {
+        throw new Error(ERRORS.INVALID_USERNAME);
     }
 
-    // Validate username for in/, company/, and school/ URLs (alphanumeric, underscore, hyphen, period, 3–100 chars)
-    if (!username.match(/^(?:in\/|company\/|school\/)?[a-zA-Z0-9._-]{3,100}$/)) {
-        throw new Error(errMessage);
-    }
-
-    const usernameWithProfileType = username.includes('/') ? username : `in/${username}`;
-
-    return `https://www.linkedin.com/${usernameWithProfileType}`;
+    return buildUrl({regional, pathType, username});
 };
 
-// Extracts a LinkedIn handle from a URL
 export const linkedinUrlToHandle = (url: string) => {
-    const handleMatch = url.match(/(?:https?:\/\/)?(?:www\.)?(?:[a-z]{2}\.)?linkedin\.com\/(in|pub|company|school)\/@?([^/]*)/);
-    return handleMatch ? `${handleMatch[1]}/${handleMatch[2]}` : null;
+    const match = url.match(LINKEDIN_URL_REGEX);
+    if (!match) {
+        return null;
+    }
+    // don't need protocol or subdomain from match
+    const [, , pathType, username] = match;
+    const formattedUsername = formatUsername(username);
+    return pathType === 'in' ? formattedUsername : `${pathType}/${formattedUsername}`;
 };

--- a/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/linkedin.ts
@@ -10,6 +10,7 @@ export function validateLinkedInUrl(newUrl: string) {
 
     let username: string;
     let regionalCode: string | undefined;
+    let pathType: string = '';
 
     // Extract username from URL or handle
     if (newUrl.startsWith('http') || newUrl.startsWith('www.') || newUrl.includes('linkedin.com')) {
@@ -17,35 +18,32 @@ export function validateLinkedInUrl(newUrl: string) {
         if (!newUrl.includes('linkedin.com')) {
             throw new Error(errMessage);
         }
-
         // Handle regional URLs (e.g., ca.linkedin.com)
-        const regionalMatch = newUrl.match(/(?:https?:\/\/)?(?:www\.)?([a-z]{2}\.)?linkedin\.com\/(in|pub)\/@?([^/]+)/);
+        const regionalMatch = newUrl.match(/(?:https?:\/\/)?(?:www\.)?([a-z]{2}\.)?linkedin\.com\/(in|pub|company|school)\/@?([^/]+)/);
         if (!regionalMatch) {
             throw new Error(errMessage);
         }
-
         regionalCode = regionalMatch[1]; // e.g., 'ca.' or undefined
-        const pathType = regionalMatch[2]; // 'in' or 'pub'
-        username = regionalMatch[3];
-
-        // For /pub/ URLs, allow longer, non-custom formats
-        if (pathType === 'pub' && !username.match(/^[a-zA-Z0-9._-]{3,100}(?:-[a-f0-9]+)?$/)) {
-            throw new Error(invalidUsernameMessage);
-        }
+        pathType = regionalMatch[2]; // 'in', 'pub', 'company', or 'school'
+        username = `${pathType}/${regionalMatch[3]}`;
     } else {
         // Handle username or @username
         username = newUrl.startsWith('@') ? newUrl.slice(1) : newUrl;
     }
-
-    // Validate username for /in/ URLs (custom handles)
-    if (!username.match(/^[a-zA-Z0-9._-]{3,100}$/)) {
+    
+    // For /pub/ URLs, allow longer, non-custom formats
+    if (pathType === 'pub' && !username.match(/^pub\/[a-zA-Z0-9._-]{3,100}(?:-[a-f0-9]+)?$/)) {
+        throw new Error(invalidUsernameMessage);
+    } else if (pathType !== 'pub' && !username.match(/^(?:in\/|company\/|school\/)?[a-zA-Z0-9._-]{3,100}$/)) {
+        // Validate username for in/, company/, and school/ URLs (custom handles)
         throw new Error(invalidUsernameMessage);
     }
 
+    const usernameWithPathType = username.includes('/') ? username : `in/${username}`;
     // Construct and validate full URL
     const normalizedUrl = regionalCode
-        ? `https://${regionalCode}linkedin.com/in/${username}`
-        : `https://www.linkedin.com/in/${username}`;
+        ? `https://${regionalCode}linkedin.com/${usernameWithPathType}`
+        : `https://www.linkedin.com/${usernameWithPathType}`;
     if (!validator.isURL(normalizedUrl)) {
         throw new Error(errMessage);
     }
@@ -65,16 +63,18 @@ export const linkedinHandleToUrl = (handle: string) => {
         username = username.slice(1);
     }
 
-    // Validate username (alphanumeric, underscore, hyphen, period, 3–100 chars)
-    if (!username.match(/^[a-zA-Z0-9._-]{3,100}$/)) {
+    // Validate username for in/, company/, and school/ URLs (alphanumeric, underscore, hyphen, period, 3–100 chars)
+    if (!username.match(/^(?:in\/|company\/|school\/)?[a-zA-Z0-9._-]{3,100}$/)) {
         throw new Error(errMessage);
     }
 
-    return `https://www.linkedin.com/in/${username}`;
+    const usernameWithProfileType = username.includes('/') ? username : `in/${username}`;
+
+    return `https://www.linkedin.com/${usernameWithProfileType}`;
 };
 
 // Extracts a LinkedIn handle from a URL
 export const linkedinUrlToHandle = (url: string) => {
-    const handleMatch = url.match(/(?:https?:\/\/)?(?:www\.)?(?:[a-z]{2}\.)?linkedin\.com\/(in|pub)\/@?([^/]*)/);
-    return handleMatch ? `${handleMatch[2]}` : null;
+    const handleMatch = url.match(/(?:https?:\/\/)?(?:www\.)?(?:[a-z]{2}\.)?linkedin\.com\/(in|pub|company|school)\/@?([^/]*)/);
+    return handleMatch ? `${handleMatch[1]}/${handleMatch[2]}` : null;
 };

--- a/apps/admin-x-settings/test/unit/utils/linkedinUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkedinUrls.test.ts
@@ -10,12 +10,11 @@ describe('LinkedIn URLs', () => {
         it('should format various LinkedIn URL formats correctly', () => {
             assert.equal(validateLinkedInUrl('linkedin.com/in/johnsmith'), 'https://www.linkedin.com/in/johnsmith');
             assert.equal(validateLinkedInUrl('https://www.linkedin.com/in/johnsmith'), 'https://www.linkedin.com/in/johnsmith');
-            assert.equal(validateLinkedInUrl('www.linkedin.com/in/john.smith'), 'https://www.linkedin.com/in/john.smith');
             assert.equal(validateLinkedInUrl('ca.linkedin.com/in/john-smith'), 'https://ca.linkedin.com/in/john-smith');
             assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
-            assert.equal(validateLinkedInUrl('linkedin.com/company/ghost-foundation'), 'https://www.linkedin.com/in/ghost-foundation');
+            assert.equal(validateLinkedInUrl('linkedin.com/company/ghost-foundation'), 'https://www.linkedin.com/company/ghost-foundation');
             assert.equal(validateLinkedInUrl('linkedin.com/school/mit'), 'https://www.linkedin.com/school/mit');
-            assert.equal(validateLinkedInUrl('company/ghost-foundation'), 'https://www.linkedin.com/in/ghost-foundation');
+            assert.equal(validateLinkedInUrl('company/ghost-foundation'), 'https://www.linkedin.com/company/ghost-foundation');
             assert.equal(validateLinkedInUrl('school/mit'), 'https://www.linkedin.com/school/mit');
             assert.equal(validateLinkedInUrl('@johnsmith'), 'https://www.linkedin.com/in/johnsmith');
             assert.equal(validateLinkedInUrl('johnsmith'), 'https://www.linkedin.com/in/johnsmith');
@@ -30,11 +29,13 @@ describe('LinkedIn URLs', () => {
             assert.throws(() => validateLinkedInUrl('linkedin.com/in/john@smith'), /Your Username is not a valid LinkedIn Username/);
             assert.throws(() => validateLinkedInUrl('linkedin.com/in/john#smith'), /Your Username is not a valid LinkedIn Username/);
             assert.throws(() => validateLinkedInUrl('linkedin.com/in/' + 'a'.repeat(101)), /Your Username is not a valid LinkedIn Username/); // Too long
+            assert.throws(() => validateLinkedInUrl('linkedin.com/in/johnsmith#fragment'), /Your Username is not a valid LinkedIn Username/);
+            assert.throws(() => validateLinkedInUrl('linkedin.com/in/johnsmith?foo=1'), /Your Username is not a valid LinkedIn Username/);
         });
 
         it('should allow valid non-custom LinkedIn usernames', () => {
             assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
-            assert.equal(validateLinkedInUrl('linkedin.com/pub/john.smith-456789'), 'https://www.linkedin.com/pub/john.smith-456789');
+            assert.equal(validateLinkedInUrl('linkedin.com/pub/johnsmith/12/34/567'), 'https://www.linkedin.com/pub/johnsmith/12/34/567');
         });
     });
 
@@ -42,13 +43,13 @@ describe('LinkedIn URLs', () => {
         it('should convert LinkedIn handle to full URL', () => {
             assert.equal(linkedinHandleToUrl('johnsmith'), 'https://www.linkedin.com/in/johnsmith');
             assert.equal(linkedinHandleToUrl('@johnsmith'), 'https://www.linkedin.com/in/johnsmith');
-            assert.equal(linkedinHandleToUrl('john.smith'), 'https://www.linkedin.com/in/john.smith');
             assert.equal(linkedinHandleToUrl('john-smith'), 'https://www.linkedin.com/in/john-smith');
         });
 
         it('should reject invalid LinkedIn handles', () => {
             assert.throws(() => linkedinHandleToUrl('john@smith'), /Your Username is not a valid LinkedIn Username/);
             assert.throws(() => linkedinHandleToUrl('john#smith'), /Your Username is not a valid LinkedIn Username/);
+            assert.throws(() => linkedinHandleToUrl('john.smith'), /Your Username is not a valid LinkedIn Username/);
             assert.throws(() => linkedinHandleToUrl('jo'), /Your Username is not a valid LinkedIn Username/); // Too short
             assert.throws(() => linkedinHandleToUrl('a'.repeat(101)), /Your Username is not a valid LinkedIn Username/); // Too long
         });
@@ -58,9 +59,12 @@ describe('LinkedIn URLs', () => {
         it('should extract LinkedIn handle from URL', () => {
             assert.equal(linkedinUrlToHandle('https://www.linkedin.com/in/johnsmith'), 'johnsmith');
             assert.equal(linkedinUrlToHandle('https://www.linkedin.com/in/@johnsmith'), 'johnsmith');
-            assert.equal(linkedinUrlToHandle('linkedin.com/in/john.smith'), 'john.smith');
+            assert.equal(linkedinUrlToHandle('linkedin.com/in/johnsmith'), 'johnsmith');
             assert.equal(linkedinUrlToHandle('ca.linkedin.com/in/john-smith'), 'john-smith');
             assert.equal(linkedinUrlToHandle('linkedin.com/pub/john-smith-abc123'), 'pub/john-smith-abc123');
+            assert.equal(linkedinUrlToHandle('https://www.linkedin.com/company/ghost-foundation'), 'company/ghost-foundation');
+            assert.equal(linkedinUrlToHandle('linkedin.com/school/mit'), 'school/mit');
+            assert.equal(linkedinUrlToHandle('linkedin.com/pub/johnsmith/12/34/567'), 'pub/johnsmith/12/34/567');
         });
 
         it('should return null for invalid LinkedIn URLs', () => {

--- a/apps/admin-x-settings/test/unit/utils/linkedinUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkedinUrls.test.ts
@@ -12,7 +12,11 @@ describe('LinkedIn URLs', () => {
             assert.equal(validateLinkedInUrl('https://www.linkedin.com/in/johnsmith'), 'https://www.linkedin.com/in/johnsmith');
             assert.equal(validateLinkedInUrl('www.linkedin.com/in/john.smith'), 'https://www.linkedin.com/in/john.smith');
             assert.equal(validateLinkedInUrl('ca.linkedin.com/in/john-smith'), 'https://ca.linkedin.com/in/john-smith');
-            assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/in/john-smith-abc123');
+            assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
+            assert.equal(validateLinkedInUrl('linkedin.com/company/ghost-foundation'), 'https://www.linkedin.com/in/ghost-foundation');
+            assert.equal(validateLinkedInUrl('linkedin.com/school/mit'), 'https://www.linkedin.com/school/mit');
+            assert.equal(validateLinkedInUrl('company/ghost-foundation'), 'https://www.linkedin.com/in/ghost-foundation');
+            assert.equal(validateLinkedInUrl('school/mit'), 'https://www.linkedin.com/school/mit');
             assert.equal(validateLinkedInUrl('@johnsmith'), 'https://www.linkedin.com/in/johnsmith');
             assert.equal(validateLinkedInUrl('johnsmith'), 'https://www.linkedin.com/in/johnsmith');
         });
@@ -29,8 +33,8 @@ describe('LinkedIn URLs', () => {
         });
 
         it('should allow valid non-custom LinkedIn usernames', () => {
-            assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/in/john-smith-abc123');
-            assert.equal(validateLinkedInUrl('linkedin.com/pub/john.smith-456789'), 'https://www.linkedin.com/in/john.smith-456789');
+            assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
+            assert.equal(validateLinkedInUrl('linkedin.com/pub/john.smith-456789'), 'https://www.linkedin.com/pub/john.smith-456789');
         });
     });
 
@@ -56,7 +60,7 @@ describe('LinkedIn URLs', () => {
             assert.equal(linkedinUrlToHandle('https://www.linkedin.com/in/@johnsmith'), 'johnsmith');
             assert.equal(linkedinUrlToHandle('linkedin.com/in/john.smith'), 'john.smith');
             assert.equal(linkedinUrlToHandle('ca.linkedin.com/in/john-smith'), 'john-smith');
-            assert.equal(linkedinUrlToHandle('linkedin.com/pub/john-smith-abc123'), 'john-smith-abc123');
+            assert.equal(linkedinUrlToHandle('linkedin.com/pub/john-smith-abc123'), 'pub/john-smith-abc123');
         });
 
         it('should return null for invalid LinkedIn URLs', () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2409/not-possible-to-add-company-linkedin-profile-to-staff-member

- adds the ability for staff users to add company or school LinkedIn profiles, like https://www.linkedin.com/company/ghost-foundation/
- cleans up the validateLinkedInUrl function a bit: uses helper functions and more accurate regex

![Screenshot 2025-07-02 at 6 04 01 PM](https://github.com/user-attachments/assets/639f1864-31f6-424d-a092-4dac40d7b569)

