### PR TITLE
Switched to use limit-service to determine Social web is limited

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -1,41 +1,57 @@
 import FeatureToggle from './FeatureToggle';
 import LabItem from './LabItem';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Button, FileUpload, List, showToast} from '@tryghost/admin-x-design-system';
+import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {downloadRedirects, useUploadRedirects} from '@tryghost/admin-x-framework/api/redirects';
 import {downloadRoutes, useUploadRoutes} from '@tryghost/admin-x-framework/api/routes';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
-import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const BetaFeatures: React.FC = () => {
+    const limiter = useLimiter();
     const {mutateAsync: uploadRedirects} = useUploadRedirects();
     const {mutateAsync: uploadRoutes} = useUploadRoutes();
     const handleError = useHandleError();
-    const [redirectsUploading, setRedirectsUploading] = useState(false);
-    const [routesUploading, setRoutesUploading] = useState(false);
-    const {config, siteData} = useGlobalData();
+    const [redirectsUploading, setRedirectsUploading] = useState<boolean>(false);
+    const [routesUploading, setRoutesUploading] = useState<boolean>(false);
+    const [limitSocialWeb, setLimitSocialWeb] = useState<boolean>(false);
+    const [socialWebLimitMessage, setSocialWebLimitMessage] = useState<string>('Please setup a custom domain to enable.');
+    const {config} = useGlobalData();
     const isPro = !!config.hostSettings?.siteId;
-    const homepageUrl = getHomepageUrl(siteData!);
-    const noCustomDomainSetup = !!homepageUrl?.match(/ghost\.io\/?$/) || false;
-    const {subdir} = getGhostPaths();
-    const hasSubdir = subdir?.length > 0;
-    const noCustomDomainOrHasSubdir = noCustomDomainSetup || hasSubdir;
-    const socialWebNotAvailableMsg = hasSubdir ?
-        'Not compatible with /subdirectory installations.' :
-        'Please setup a custom domain to enable.';
+
+    useEffect(() => {
+        if (limiter?.isLimited('limitSocialWeb')) {
+            limiter.errorIfWouldGoOverLimit('limitSocialWeb').catch((error) => {
+                if (error instanceof HostLimitError) {
+                    const {subdir} = getGhostPaths();
+                    // ensure subdir is defined and not empty
+                    const hasSubdir = subdir?.length > 0;
+
+                    const socialWebNotAvailableMsg = hasSubdir ?
+                        'Not compatible with /subdirectory installations.' :
+                        'Please setup a custom domain to enable.';
+
+                    setSocialWebLimitMessage(socialWebNotAvailableMsg);
+                    setLimitSocialWeb(true);
+                } else {
+                    handleError(error);
+                }
+            });
+        }
+    }, [limiter, handleError]);
 
     return (
         <List titleSeparator={false}>
             {isPro && (
                 <LabItem
-                    action={<FeatureToggle disabled={noCustomDomainOrHasSubdir} flag="ActivityPub"/>}
+                    action={<FeatureToggle disabled={limitSocialWeb} flag="ActivityPub"/>}
                     detail={
                         <>
                         Federate your site with ActivityPub to join the world&apos;s largest open network.
-                            {noCustomDomainOrHasSubdir &&
-                                (<><br></br>{socialWebNotAvailableMsg} </>)
+                            {limitSocialWeb &&
+                                (<><br></br>{socialWebLimitMessage} </>)
                             }
                             &nbsp;
                             <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>


### PR DESCRIPTION
closes [BAE-336](https://linear.app/ghost/issue/BAE-336/ghost-hide-uishow-limit-modal-in-admin-x-when-limits-reached) 
closes [BAE-458](https://linear.app/ghost/issue/BAE-458/add-custom-domain-related-limit-for-limitsocialweb)

Ghost is introducing a new limit for the Social web feature. The Social Web feature is currently in the beta Labs settings and needed to be restricted appropriately according to these new plan limits to support the upcoming pricing structure. The previous check within Ghost for the presence of a custom domain, which is required to use Social web, was replaced by the usage of the limit service.

If the limit is present, the new checks will prevent the toggle from being displayed, thereby preventing the feature from being turned on.