### PR TITLE
Extracted generic `<GhTagsTokenInput>` out of `<GhPsmTagsInput>`

### DIFF
--- a/ghost/admin/app/components/gh-psm-tags-input.hbs
+++ b/ghost/admin/app/components/gh-psm-tags-input.hbs
@@ -1,17 +1,9 @@
-<GhTokenInput
-    @extra={{hash
-        tokenComponent=(component "gh-token-input/tag-token")
-    }}
+<GhTagsTokenInput
+    @allowCreation={{true}}
+    @selected={{@post.tags}}
     @onChange={{this.updateTags}}
     @onCreate={{this.createTag}}
-    @onOpen={{this.loadInitialTags}}
-    @options={{this.availableTags}}
-    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreTagsTask)}}
-    @registerAPI={{this.registerPowerSelectAPI}}
-    @renderInPlace={{true}}
-    @search={{perform this.searchTagsTask}}
-    @selected={{@post.tags}}
-    @showCreateWhen={{this.hideCreateOptionOnMatchingTag}}
     @triggerId={{@triggerId}}
     @triggerClass={{@triggerClass}}
+    @renderInPlace={{true}}
 />

--- a/ghost/admin/app/components/gh-psm-tags-input.js
+++ b/ghost/admin/app/components/gh-psm-tags-input.js
@@ -1,167 +1,21 @@
 import Component from '@glimmer/component';
-import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
-import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
-import {tracked} from '@glimmer/tracking';
 
 export default class GhPsmTagsInput extends Component {
-    @service store;
-    @service tagsManager;
-
-    // internal attrs
-    @tracked _initialTags = new TrackedArray();
-    @tracked _searchedTags = new TrackedArray();
-
-    _initialTagsMeta = null;
-    _hasLoadedInitialTags = false;
-    _searchedTagsQuery = null;
-    _searchedTagsMeta = null;
-
-    _powerSelectAPI = null;
-
-    constructor() {
-        super(...arguments);
-        this.addInitialTags(this.args.post.get('tags').toArray());
-    }
-
-    get availableTags() {
-        return this.tagsManager.sortTags(this._initialTags.filter(tag => !this.args.post.get('tags').includes(tag)));
-    }
-
-    get searchedTags() {
-        return this.tagsManager.sortTags(this._searchedTags.filter(tag => !this.args.post.get('tags').includes(tag)));
-    }
-
-    get availableTagNames() {
-        return this.availableTags.map(tag => tag.name.toLowerCase());
-    }
-
-    @action
-    addInitialTags(tags) {
-        const deduplicatedTags = tags.filter(tag => !this.args.post.get('tags').includes(tag));
-        this._initialTags.push(...deduplicatedTags);
-    }
-
-    @action
-    addSearchedTags(tags) {
-        const deduplicatedTags = tags.filter(tag => !this.args.post.get('tags').includes(tag));
-        this._searchedTags.push(...deduplicatedTags);
-    }
-
-    @action
-    registerPowerSelectAPI(api) {
-        this._powerSelectAPI = api;
-    }
-
-    @action
-    async loadInitialTags() {
-        if (!this._hasLoadedInitialTags) {
-            await this.loadMoreTagsTask.perform(false);
-            this._hasLoadedInitialTags = true;
-        }
-    }
-
-    @task
-    *loadMoreTagsTask() {
-        const isSearch = !!this._powerSelectAPI.searchText;
-        if (isSearch) {
-            if (this.searchTagsTask.isRunning) {
-                return;
-            }
-
-            if (this._searchedTagsMeta && this._searchedTagsMeta.pagination.pages <= this._searchedTagsMeta.pagination.page) {
-                return;
-            }
-
-            const page = this._searchedTagsMeta.pagination.page + 1;
-            const tags = yield this.tagsManager.searchTagsTask.perform(this._searchedTagsQuery, {page});
-            this.addSearchedTags(tags.toArray());
-            this._searchedTagsMeta = tags.meta;
-        } else {
-            if (this._initialTagsMeta && this._initialTagsMeta?.pagination.pages <= this._initialTagsMeta.pagination.page) {
-                return;
-            }
-
-            const page = this._initialTagsMeta?.pagination.page ? this._initialTagsMeta.pagination.page + 1 : 1;
-            const tags = yield this.store.query('tag', {limit: 100, page, order: 'name asc'});
-            this.addInitialTags(tags.toArray());
-            this._initialTagsMeta = tags.meta;
-        }
-    }
-
-    @task
-    *searchTagsTask(term) {
-        this._searchedTagsQuery = term;
-        const tags = yield this.tagsManager.searchTagsTask.perform(term);
-        this._searchedTagsMeta = tags.meta;
-
-        // we need to create a tracked array for vertical-collection to update as new options are loaded
-        // because we can't rely on power-select re-rendering as @options changes via auto template updates
-        this._searchedTags = new TrackedArray();
-        this.addSearchedTags(tags.toArray());
-        return this._searchedTags;
-    }
-
-    @action
-    hideCreateOptionOnMatchingTag(term) {
-        return !this.availableTagNames.includes(term.toLowerCase());
-    }
-
     @action
     updateTags(newTags) {
-        let currentTags = this.args.post.get('tags');
-
-        // destroy new+unsaved tags that are no longer selected
-        currentTags.forEach(function (tag) {
-            if (!newTags.includes(tag) && tag.get('isNew')) {
-                tag.destroyRecord();
-            }
-        });
-
-        // update tags
+        // update tags on the post
         this.args.post.set('tags', newTags);
-        if (this.savePostOnChange) {
-            return this.savePostOnChange();
+
+        // save post if configured to do so
+        if (this.args.savePostOnChange) {
+            return this.args.savePostOnChange();
         }
     }
 
     @action
-    createTag(tagNameAttr) {
-        let currentTags = this.args.post.get('tags');
-        let currentTagNames = currentTags.map(tag => tag.get('name').toLowerCase());
-        let tagToAdd;
-
-        tagNameAttr = tagNameAttr.trim();
-
-        // abort if tag is already selected
-        if (currentTagNames.includes(tagNameAttr.toLowerCase())) {
-            return;
-        }
-
-        // find existing tag if there is one
-        tagToAdd = this._findTagByName(tagNameAttr);
-
-        // create new tag if no match
-        if (!tagToAdd) {
-            tagToAdd = this.store.createRecord('tag', {
-                name: tagNameAttr
-            });
-
-            // set to public/internal based on the tag name
-            tagToAdd.updateVisibility();
-        }
-
+    createTag(tagToAdd) {
         // push tag onto post relationship
-        return currentTags.pushObject(tagToAdd);
-    }
-
-    // methods
-
-    _findTagByName(name) {
-        let withMatchingName = function (tag) {
-            return tag.name.toLowerCase() === name.toLowerCase();
-        };
-        return this.availableTags.find(withMatchingName);
+        return this.args.post.get('tags').pushObject(tagToAdd);
     }
 }

--- a/ghost/admin/app/components/gh-tags-token-input.hbs
+++ b/ghost/admin/app/components/gh-tags-token-input.hbs
@@ -1,0 +1,22 @@
+<GhTokenInput
+    @extra={{hash
+        tokenComponent=(component "gh-token-input/tag-token")
+    }}
+    @onChange={{this.updateTags}}
+    @onCreate={{this.createTag}}
+    @onOpen={{this.loadInitialTags}}
+    @options={{this.availableTags}}
+    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreTagsTask)}}
+    @registerAPI={{this.registerPowerSelectAPI}}
+    @renderInPlace={{@renderInPlace}}
+    @search={{perform this.searchTagsTask}}
+    @selected={{@selected}}
+    @showCreateWhen={{this.showCreateWhen}}
+    @triggerId={{@triggerId}}
+    @triggerClass={{@triggerClass}}
+    @placeholder={{@placeholder}}
+    @allowCreation={{@allowCreation}}
+    @disabled={{@disabled}}
+    @selectedItemComponent={{@selectedItemComponent}}
+    @class={{@class}}
+/>

--- a/ghost/admin/app/components/gh-tags-token-input.js
+++ b/ghost/admin/app/components/gh-tags-token-input.js
@@ -1,0 +1,177 @@
+import Component from '@glimmer/component';
+import {TrackedArray} from 'tracked-built-ins';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
+
+const PAGE_SIZE = 100;
+
+export default class GhTagsTokenInput extends Component {
+    @service store;
+    @service tagsManager;
+
+    // internal attrs
+    @tracked _initialTags = new TrackedArray();
+    @tracked _searchedTags = new TrackedArray();
+
+    _initialTagsMeta = null;
+    _hasLoadedInitialTags = false;
+    _searchedTagsQuery = null;
+    _searchedTagsMeta = null;
+
+    _powerSelectAPI = null;
+
+    constructor() {
+        super(...arguments);
+        this.addInitialTags(this.args.selected?.toArray ? this.args.selected.toArray() : (this.args.selected || []));
+    }
+
+    get availableTags() {
+        const selectedTags = this.args.selected || [];
+        return this.tagsManager.sortTags(this._initialTags.filter(tag => !selectedTags.includes(tag)));
+    }
+
+    @action
+    addInitialTags(tags) {
+        const selectedTags = this.args.selected || [];
+        const deduplicatedTags = tags.filter(tag => !selectedTags.includes(tag));
+        this._initialTags.push(...deduplicatedTags);
+    }
+
+    @action
+    addSearchedTags(tags) {
+        const selectedTags = this.args.selected || [];
+        const deduplicatedTags = tags.filter(tag => !selectedTags.includes(tag));
+        this._searchedTags.push(...deduplicatedTags);
+    }
+
+    @action
+    registerPowerSelectAPI(api) {
+        this._powerSelectAPI = api;
+    }
+
+    @action
+    async loadInitialTags() {
+        if (!this._hasLoadedInitialTags) {
+            await this.loadMoreTagsTask.perform(false);
+            this._hasLoadedInitialTags = true;
+        }
+    }
+
+    @task
+    *loadMoreTagsTask() {
+        const isSearch = !!this._powerSelectAPI.searchText;
+        if (isSearch) {
+            if (this.searchTagsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedTagsMeta?.pagination && this._searchedTagsMeta.pagination.pages <= this._searchedTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedTagsMeta.pagination.page + 1;
+            const tags = yield this.tagsManager.searchTagsTask.perform(this._searchedTagsQuery, {page});
+            this.addSearchedTags(tags.toArray());
+            this._searchedTagsMeta = tags.meta;
+        } else {
+            if (this._initialTagsMeta?.pagination && this._initialTagsMeta.pagination.pages <= this._initialTagsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialTagsMeta?.pagination.page ? this._initialTagsMeta.pagination.page + 1 : 1;
+            const tags = yield this.store.query('tag', {limit: PAGE_SIZE, page, order: 'name asc'});
+            this.addInitialTags(tags.toArray());
+            this._initialTagsMeta = tags.meta;
+        }
+    }
+
+    @task
+    *searchTagsTask(term) {
+        this._searchedTagsQuery = term;
+        const tags = yield this.tagsManager.searchTagsTask.perform(term);
+        this._searchedTagsMeta = tags.meta;
+
+        // we need to create a tracked array for vertical-collection to update as new options are loaded
+        // because we can't rely on power-select re-rendering as @options changes via auto template updates
+        this._searchedTags = new TrackedArray();
+        this.addSearchedTags(tags.toArray());
+        return this._searchedTags;
+    }
+
+    @action
+    showCreateWhen(term) {
+        const availableTagNames = this._searchedTags.map(tag => tag.name.toLowerCase());
+        availableTagNames.push(...this.args.selected.map(tag => tag.name.toLowerCase()));
+
+        const foundMatchingTagName = availableTagNames.includes(term.toLowerCase());
+        return !foundMatchingTagName;
+    }
+
+    @action
+    updateTags(newTags) {
+        let currentTags = this.args.selected || [];
+
+        // destroy new+unsaved tags that are no longer selected
+        currentTags.forEach(function (tag) {
+            if (!newTags.includes(tag) && tag.get('isNew')) {
+                tag.destroyRecord();
+            }
+        });
+
+        // call the onChange callback
+        if (this.args.onChange) {
+            this.args.onChange(newTags);
+        }
+    }
+
+    @action
+    createTag(tagNameAttr) {
+        let currentTags = this.args.selected || [];
+        let currentTagNames = currentTags.map(tag => tag.get('name').toLowerCase());
+        let tagToAdd;
+
+        tagNameAttr = tagNameAttr.trim();
+
+        // abort if tag is already selected
+        if (currentTagNames.includes(tagNameAttr.toLowerCase())) {
+            return;
+        }
+
+        // find existing tag if there is one
+        tagToAdd = this._findTagByName(tagNameAttr);
+
+        // create new tag if no match
+        if (!tagToAdd) {
+            tagToAdd = this.store.createRecord('tag', {
+                name: tagNameAttr
+            });
+
+            // set to public/internal based on the tag name
+            tagToAdd.updateVisibility();
+        }
+
+        // call the onCreate callback or default to adding the tag
+        if (this.args.onCreate) {
+            return this.args.onCreate(tagToAdd);
+        } else {
+            // default behavior: add to selected tags
+            const newTags = [...currentTags, tagToAdd];
+            this.updateTags(newTags);
+        }
+    }
+
+    // methods
+
+    _findTagByName(name) {
+        let withMatchingName = function (tag) {
+            if (tag.__isSuggestion__) {
+                return false;
+            }
+            return tag.name.toLowerCase() === name.toLowerCase();
+        };
+
+        return this._searchedTags.find(withMatchingName) || this._initialTags.find(withMatchingName);
+    }
+}

--- a/ghost/admin/app/components/gh-token-input.hbs
+++ b/ghost/admin/app/components/gh-token-input.hbs
@@ -57,7 +57,9 @@
     as |option|
 >
     {{#if option.__isSuggestion__}}
-        <GhTokenInput::SuggestedOption @option={{option}} />
+        {{#unless this.searchAndSuggestTask.isRunning}}
+            <GhTokenInput::SuggestedOption @option={{option}} />
+        {{/unless}}
     {{else}}
         {{#if (has-block)}}
             {{yield option}}

--- a/ghost/admin/app/components/gh-token-input.js
+++ b/ghost/admin/app/components/gh-token-input.js
@@ -139,6 +139,10 @@ export default class GhTokenInput extends Component {
         let suggestion = selection.find(option => option.__isSuggestion__);
 
         if (suggestion) {
+            // abort creating if we're still searching otherwise we could create duplicates
+            if (this.searchAndSuggestTask.isRunning) {
+                return;
+            }
             this.args.onCreate(suggestion.__value__, select);
         } else {
             this.args.onChange(selection, select);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- tag searching & infinite scroll behaviour was built into the `<GhPsmTagsInput>` component but that had some ties to it's specific use-case with using `@post.tags` and saving the post
- we have a re-implementation of the tags token input in our "Add tag" bulk-edit modal which can't use the `<GhPsmTagsInput>` due to those specific use-case ties
- added a new re-usable `<GhTagsTokenInput>` component with the guts extracted from `<GhPsmTagsInput>` ready for use in the bulk add-tag modal
