### PR TITLE
Removed timestamp links from Ghost-created notes in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/utils/render-timestamp.tsx
+++ b/apps/admin-x-activitypub/src/utils/render-timestamp.tsx
@@ -17,7 +17,7 @@ export function renderTimestamp(object: ObjectProperties, asLink = true) {
     const timestamp = formatTimestamp(date);
     const formattedTimestamp = getFormattedTimestamp(date);
 
-    if (asLink) {
+    if (asLink && !object.url?.includes('/.ghost/activitypub')) {
         return (
             <a
                 className='whitespace-nowrap text-gray-700 hover:underline'


### PR DESCRIPTION
ref PROD-2229

- Disabled clickable timestamps for notes created within Ghost
- Maintained linked timestamps for notes from other platforms
- Prevented navigation to non-existent public URLs