### PR TITLE
Renamed `updatedMainNav` flag to `ui60`

### DIFF
--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -36,7 +36,7 @@ const MainContent: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 confirmIfDirty(isDirty, () => {
-                    if (config.labs.updatedMainNav) {
+                    if (config.labs.ui60) {
                         navigateAway('/analytics');
                     } else {
                         if (hasActivityPub && hasAdminAccess(currentUser)) {
@@ -54,7 +54,7 @@ const MainContent: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isDirty, hasActivityPub, currentUser, config.labs.updatedMainNav]);
+    }, [isDirty, hasActivityPub, currentUser, config.labs.ui60]);
 
     useEffect(() => {
         // resets any toasts that may have been left open on initial load

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -10,7 +10,7 @@ const ExitSettingsButton: React.FC = () => {
     const [hasActivityPub] = getSettingValues(settings, ['social_web_enabled']) as [boolean];
 
     const navigateAway = () => {
-        if (config.labs.updatedMainNav) {
+        if (config.labs.ui60) {
             window.location.hash = '/analytics';
         } else {
             window.location.hash = (hasActivityPub && hasAdminAccess(currentUser)) ? '/activitypub' : '/dashboard';

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -27,9 +27,9 @@ const features = [{
     description: 'Enables tier to be specified when importing members',
     flag: 'importMemberTier'
 }, {
-    title: 'Updated main navigation (internal alpha)',
-    description: 'Enables simplified main navigation',
-    flag: 'updatedMainNav'
+    title: 'UI 6.0 (internal alpha)',
+    description: 'General structural changes to the admin UI in 6.0',
+    flag: 'ui60'
 }, {
     title: 'Explore',
     description: 'Enables keeping in touch with the new Explore API',

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -26,7 +26,7 @@
         {{#unless this.session.user.isContributor}}
         <div class="gh-nav-top">
 
-            {{#if (and (feature "updatedMainNav") this.session.user.isAdmin)}}
+            {{#if (and (feature "ui60") this.session.user.isAdmin)}}
                 <ul class="gh-nav-list gh-nav-main">
                     {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
                         <li class="relative">

--- a/ghost/admin/app/controllers/explore.js
+++ b/ghost/admin/app/controllers/explore.js
@@ -25,7 +25,7 @@ export default class ExploreController extends Controller {
             this.explore.sendRouteUpdate({path: '/explore'});
             this.router.transitionTo('/explore');
         } else {
-            if (this.config?.labs?.updatedMainNav) {
+            if (this.config?.labs?.ui60) {
                 this.router.transitionTo('/stats-x');
             } else {
                 this.router.transitionTo('/dashboard');

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -25,7 +25,7 @@ export default class HomeRoute extends Route {
         if (this.settings.socialWebEnabled && this.session.user?.isAdmin) {
             this.router.transitionTo('activitypub-x');
         } else {
-            if (this.config.labs?.updatedMainNav) {
+            if (this.config.labs?.ui60) {
                 this.router.transitionTo('stats-x');
             } else {
                 this.router.transitionTo('dashboard');

--- a/ghost/admin/app/routes/mentions.js
+++ b/ghost/admin/app/routes/mentions.js
@@ -25,7 +25,7 @@ export default class MentionsRoute extends AuthenticatedRoute {
     beforeModel() {
         super.beforeModel(...arguments);
         if (!this.feature.webmentions) {
-            if (this.config?.labs?.updatedMainNav) {
+            if (this.config?.labs?.ui60) {
                 return this.transitionTo('stats-x');
             } else {
                 return this.transitionTo('dashboard');

--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -22,7 +22,7 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
             return this.router.transitionTo('stats-x');
         }
 
-        if (this.config.labs?.updatedMainNav) {
+        if (this.config.labs?.ui60) {
             return this.router.transitionTo('stats-x');
         } else {
             return this.router.transitionTo('dashboard');

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -72,7 +72,7 @@ export default class FeatureService extends Service {
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
     @feature('trafficAnalyticsAlpha') trafficAnalyticsAlpha;
-    @feature('updatedMainNav') updatedMainNav;
+    @feature('ui60') ui60;
     @feature('trafficAnalytics') trafficAnalytics;
 
     _user = null;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -49,7 +49,7 @@ const PRIVATE_FEATURES = [
     'mailEvents',
     'lexicalIndicators',
     'trafficAnalyticsAlpha',
-    'updatedMainNav',
+    'ui60',
     'contentVisibilityAlpha',
     'explore',
     'emailCustomization'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,7 +30,7 @@ Object {
       "trafficAnalytics": true,
       "trafficAnalyticsAlpha": true,
       "trafficAnalyticsTracking": true,
-      "updatedMainNav": true,
+      "ui60": true,
       "urlCache": true,
       "webmentions": true,
     },


### PR DESCRIPTION
no ref

- The current `updatedMainNav` flag was renamed to be used for general structural changes to the admin UI in 6.0