### PR TITLE
Removed all-tags loads when bulk-adding tags

### DIFF
--- a/ghost/admin/app/components/posts-list/modals/add-tag.hbs
+++ b/ghost/admin/app/components/posts-list/modals/add-tag.hbs
@@ -7,16 +7,12 @@
     <div class="modal-body mb9">
         <p>
             <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="tags">
-                <GhTokenInput
-                    @extra={{hash
-                        tokenComponent=(component "gh-token-input/tag-token")
-                    }}
+                <GhTagsTokenInput
+                    @allowCreation={{true}}
+                    @selected={{this.selectedTags}}
                     @onChange={{this.handleChange}}
                     @onCreate={{this.handleCreate}}
-                    @options={{this.availableTags}}
                     @renderInPlace={{true}}
-                    @selected={{this.selectedTags}}
-                    @showCreateWhen={{this.shouldAllowCreate}}
                     @triggerId={{this.triggerId}}
                     @placeholder="Select or enter tags..."
                 />

--- a/ghost/admin/app/components/posts-list/modals/add-tag.js
+++ b/ghost/admin/app/components/posts-list/modals/add-tag.js
@@ -9,36 +9,11 @@ const {Errors} = DS;
 export default class AddTag extends Component {
     @service store;
 
-    #availableTags = null;
-
-    @tracked
-        selectedTags = [];
-
-    @tracked
-        errors = Errors.create();
-
-    get availableTags() {
-        return this.#availableTags || [];
-    }
+    @tracked selectedTags = [];
+    @tracked errors = Errors.create();
 
     get hasValidated() {
         return ['tags'];
-    }
-
-    constructor() {
-        super(...arguments);
-        // perform a background query to fetch all users and set `availableTags`
-        // to a live-query that will be immediately populated with what's in the
-        // store and be updated when the above query returns
-        this.store.query('tag', {limit: 'all'});
-        this.#availableTags = this.store.peekAll('tag');
-
-        // Destroy unsaved new tags (otherwise we could select them again -> create them again)
-        this.#availableTags.forEach((tag) => {
-            if (tag.isNew) {
-                tag.destroyRecord();
-            }
-        });
     }
 
     @action
@@ -62,37 +37,7 @@ export default class AddTag extends Component {
     }
 
     @action
-    handleCreate(nameInput) {
-        let potentialTagName = nameInput.trim();
-
-        let isAlreadySelected = !!this.#findTagByName(potentialTagName, this.selectedTags);
-
-        if (isAlreadySelected) {
-            return;
-        }
-
-        let tagToAdd = this.#findTagByName(potentialTagName, this.#availableTags);
-
-        if (!tagToAdd) {
-            tagToAdd = this.store.createRecord('tag', {
-                name: potentialTagName
-            });
-
-            tagToAdd.updateVisibility();
-        }
-
+    handleCreate(tagToAdd) {
         this.selectedTags = this.selectedTags.concat(tagToAdd);
-    }
-
-    @action
-    shouldAllowCreate(nameInput) {
-        return !this.#findTagByName(nameInput.trim(), this.#availableTags);
-    }
-
-    #findTagByName(name, tags) {
-        let withMatchingName = function (tag) {
-            return tag.name.toLowerCase() === name.toLowerCase();
-        };
-        return tags.find(withMatchingName);
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- previously we were loading every tag from the API when opening the "add tags" modal in order to populate the dropdown, and when adding a tag in order to pick new tags and assign to posts in the store
- removed the fetch when opening the modal by switching to the new `<GhTagsTokenInput>` component that uses server-side filtering and infinite scroll to avoid loading every tag
  - also allowed cleanup of duplicated functionality in the `add-tag` modal component
- removed the fetch when confirming a tag add by swapping the logic that attempted to manually edit the posts in the store with new logic that fetches all of the updated posts from the API
  - in some cases this will result in pulling more data from the API but it removes the scenario where some sites are loading 10s or 100s of pages of tags from the API
  - also ensures the posts (and related tags) are really up-to-date with the server
