### PR TITLE
Promoted all 6.x features to GA in labs

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -26,12 +26,16 @@ const GA_FEATURES = [
     'themeErrorsNotification',
     'announcementBar',
     'customFonts',
-    'contentVisibility'
+    'contentVisibility',
+    'ActivityPub',
+    'trafficAnalytics',
+    'trafficAnalyticsAlpha',
+    'trafficAnalyticsTracking',
+    'ui60'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
 const PUBLIC_BETA_FEATURES = [
-    'ActivityPub',
     'superEditors',
     'editorExcerpt',
     'additionalPaymentMethods'
@@ -42,13 +46,9 @@ const PUBLIC_BETA_FEATURES = [
 const PRIVATE_FEATURES = [
     'stripeAutomaticTax',
     'webmentions',
-    'trafficAnalytics',
-    'trafficAnalyticsTracking',
     'importMemberTier',
     'urlCache',
     'lexicalIndicators',
-    'trafficAnalyticsAlpha',
-    'ui60',
     'contentVisibilityAlpha',
     'explore',
     'emailCustomization'


### PR DESCRIPTION
- We have lots of tidying to do but for now we will just promote all the features, so that the labs flags all return true in 6.x
- This makes it seem as if we didn't have flags at all

