### PR TITLE
Removed all-tags load when accessing tags screen

### DIFF
--- a/ghost/admin/app/controllers/tag.js
+++ b/ghost/admin/app/controllers/tag.js
@@ -9,6 +9,8 @@ export default class TagController extends Controller {
     @service modals;
     @service notifications;
     @service router;
+    @service tagsManager;
+
     @inject config;
 
     get tag() {
@@ -44,6 +46,8 @@ export default class TagController extends Controller {
                 return;
             }
             yield tag.save();
+
+            this.tagsManager.tagsScreenInfinityModel?.pushObjects([tag]);
 
             // replace 'new' route with 'tag' route
             this.replaceRoute('tag', tag);

--- a/ghost/admin/app/controllers/tags.js
+++ b/ghost/admin/app/controllers/tags.js
@@ -4,7 +4,9 @@ import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
 export default class TagsController extends Controller {
+    @service infinity;
     @service router;
+    @service tagsManager;
 
     queryParams = ['type'];
     @tracked type = 'public';
@@ -15,15 +17,12 @@ export default class TagsController extends Controller {
 
     get filteredTags() {
         return this.tags.filter((tag) => {
-            return (!tag.isNew && (!this.type || tag.visibility === this.type));
+            return (!tag.isNew && !tag.isDestroyed && !tag.isDestroying && !tag.isDeleted && (!this.type || tag.visibility === this.type));
         });
     }
 
     get sortedTags() {
-        return this.filteredTags.sort((tagA, tagB) => {
-            // ignorePunctuation means the # in internal tag names is ignored
-            return tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true});
-        });
+        return this.tagsManager.sortTags(this.filteredTags);
     }
 
     @action
@@ -34,5 +33,10 @@ export default class TagsController extends Controller {
     @action
     newTag() {
         this.router.transitionTo('tag.new');
+    }
+
+    @action
+    loadMoreTags() {
+        this.infinity.infinityLoad(this.model);
     }
 }

--- a/ghost/admin/app/services/tags-manager.js
+++ b/ghost/admin/app/services/tags-manager.js
@@ -1,8 +1,11 @@
 import Service, {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
 
 export default class TagsManagerService extends Service {
     @service store;
+
+    @tracked tagsScreenInfinityModel = null;
 
     _loadedTags = this.store.peekAll('tag');
 

--- a/ghost/admin/app/templates/tags.hbs
+++ b/ghost/admin/app/templates/tags.hbs
@@ -19,7 +19,14 @@
                     <div class="gh-list-header gh-list-cellwidth-10">No. of posts</div>
                     <div class="gh-list-header gh-list-cellwidth-10"></div>
                 </li>
-                <VerticalCollection @items={{this.sortedTags}} @key="id" @containerSelector=".gh-main" @estimateHeight={{60}} @bufferSize={{20}} as |tag|>
+                <VerticalCollection
+                    @items={{this.sortedTags}}
+                    @key="id"
+                    @containerSelector=".gh-main"
+                    @estimateHeight={{60}}
+                    @bufferSize={{20}}
+                    @lastReached={{this.loadMoreTags}}
+                as |tag|>
                     <Tags::ListItem @tag={{tag}} data-test-tag={{tag.id}} />
                 </VerticalCollection>
             {{else}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1605/

- switched from performing an all-tags fetch with a `peekAll` for the tags screen model to using `InfinityModel`
  - set up to cache for 5 minutes so there are no unnecessary queries when switching between filters or to/from the create/edit tag screens
  - updated the `vertical-collection` usage to trigger the infinity model to load more when the end is reached
- updated tags filter to exclude deleted entries so there's no need to refresh after deleting a tag
- updated new tag controller to push the tag onto the infinity model (shared instance stored on the `tags-manager` service) so there's no need to refresh after adding a tag
