### PR TITLE
Fixed infinite loop when `ui60` flag is enabled without analytics

### DIFF
--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -25,7 +25,9 @@ export default class HomeRoute extends Route {
         if (this.settings.socialWebEnabled && this.session.user?.isAdmin) {
             this.router.transitionTo('activitypub-x');
         } else {
-            if (this.config.labs?.ui60) {
+            // stats-x currently redirects back to home if analytics is not enabled
+            // we need to check that here to avoid an infinite loop
+            if (this.config.labs?.ui60 && (this.config.stats && this.feature.trafficAnalytics)) {
                 this.router.transitionTo('stats-x');
             } else {
                 this.router.transitionTo('dashboard');


### PR DESCRIPTION
no issue

- the flag-on and no-analytics state resulted in an infinite home->stats-x->home redirect loop when opening Admin
- added a check to the home redirect using the same conditional as stats-x to avoid the redirect to stats-x when we'd get redirected back
