### PR TITLE
Cleaned up Admin's home routing

### DIFF
--- a/ghost/admin/app/controllers/home.js
+++ b/ghost/admin/app/controllers/home.js
@@ -1,8 +1,0 @@
-import Controller from '@ember/controller';
-import {tracked} from '@glimmer/tracking';
-
-export default class HomeController extends Controller {
-    queryParams = ['firstStart'];
-
-    @tracked firstStart = null;
-}

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -67,13 +67,15 @@ export default Route.extend(ShortcutsRoute, {
     config: inject(),
 
     async beforeModel(transition) {
-        // Intercept home route when unauthenticated
+        await this.session.setup();
+        
+        // Intercept home route when unauthenticated to prevent decorator binding issues
+        // Check AFTER session setup to ensure isAuthenticated is accurate
         if (transition.to?.name === 'home' && !this.session.isAuthenticated) {
             transition.abort();
             return this.transitionTo('signin');
         }
         
-        await this.session.setup();
         return this.prepareApp();
     },
 

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -66,7 +66,13 @@ export default Route.extend(ShortcutsRoute, {
 
     config: inject(),
 
-    async beforeModel() {
+    async beforeModel(transition) {
+        // Intercept home route when unauthenticated
+        if (transition.to?.name === 'home' && !this.session.isAuthenticated) {
+            transition.abort();
+            return this.transitionTo('signin');
+        }
+        
         await this.session.setup();
         return this.prepareApp();
     },

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -7,8 +7,13 @@ export default class HomeRoute extends AuthenticatedRoute {
     @service feature;
     @service router;
 
-    beforeModel() {
+    beforeModel(transition) {
         super.beforeModel(...arguments);
+
+        // This is needed to initialize the checklist for sites that have been already set up
+        if (transition.to?.queryParams?.firstStart === 'true') {
+            return this.router.transitionTo('setup.done');
+        }
         
         if (this.config.labs?.ui60 && this.feature.trafficAnalytics) {
             this.router.transitionTo('stats-x');

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -5,37 +5,15 @@ import {inject as service} from '@ember/service';
 export default class HomeRoute extends Route {
     @inject config;
     @service feature;
-    @service modals;
     @service router;
-    @service session;
-    @service settings;
 
-    beforeModel(transition) {
+    beforeModel() {
         super.beforeModel(...arguments);
-
-        if (transition.to?.queryParams?.firstStart === 'true') {
-            return this.router.transitionTo('setup.done');
-        }
-
-        // Redirect to Analytics if trafficAnalytics is enabled and user has access
-        if (this.config.stats && this.feature.trafficAnalytics && this.session.user?.isAdmin) {
-            return this.router.transitionTo('stats-x');
-        }
-
-        if (this.settings.socialWebEnabled && this.session.user?.isAdmin) {
-            this.router.transitionTo('activitypub-x');
+        
+        if (this.config.labs?.ui60 && this.feature.trafficAnalytics) {
+            this.router.transitionTo('stats-x');
         } else {
-            // stats-x currently redirects back to home if analytics is not enabled
-            // we need to check that here to avoid an infinite loop
-            if (this.config.labs?.ui60 && (this.config.stats && this.feature.trafficAnalytics)) {
-                this.router.transitionTo('stats-x');
-            } else {
-                this.router.transitionTo('dashboard');
-            }
+            this.router.transitionTo('dashboard');
         }
-    }
-
-    resetController(controller) {
-        controller.firstStart = false;
     }
 }

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
-export default class HomeRoute extends Route {
+export default class HomeRoute extends AuthenticatedRoute {
     @inject config;
     @service feature;
     @service router;

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -3,11 +3,12 @@ import windowProxy from 'ghost-admin/utils/window-proxy';
 import {Response} from 'miragejs';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
-import {click, currentRouteName, currentURL, fillIn, find, findAll, triggerKeyEvent, visit, waitFor, waitUntil} from '@ember/test-helpers';
+import {click, currentRouteName, currentURL, fillIn, find, findAll, triggerKeyEvent, waitFor, waitUntil} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
+import {visit} from '../helpers/visit';
 
 function setupVerificationRequired(server, responseCode = 403) {
     server.post('/session', function () {
@@ -177,7 +178,7 @@ describe('Acceptance: Authentication', function () {
         it('doesn\'t show navigation menu on invalid url when not authenticated', async function () {
             await invalidateSession();
             await visit('/');
-
+            
             expect(currentURL(), 'current url').to.equal('/signin');
             expect(findAll('nav.gh-nav').length, 'nav menu presence').to.equal(0);
 

--- a/ghost/admin/tests/acceptance/setup-test.js
+++ b/ghost/admin/tests/acceptance/setup-test.js
@@ -173,4 +173,18 @@ describe('Acceptance: Setup', function () {
                 .to.have.string('Access Denied from url: unknown.com. Please use the url configured in config.js.');
         });
     });
+
+    describe('?firstStart=true', function () {
+        beforeEach(async function () {
+            let role = this.server.create('role', {name: 'Owner'});
+            this.server.create('user', {roles: [role], slug: 'owner'});
+
+            await authenticateSession();
+        });
+
+        it('transitions to dashboard', async function () {
+            await visit('/?firstStart=true');
+            expect(currentURL()).to.equal('/dashboard');
+        });
+    });
 });

--- a/ghost/admin/tests/acceptance/setup-test.js
+++ b/ghost/admin/tests/acceptance/setup-test.js
@@ -173,18 +173,4 @@ describe('Acceptance: Setup', function () {
                 .to.have.string('Access Denied from url: unknown.com. Please use the url configured in config.js.');
         });
     });
-
-    describe('?firstStart=true', function () {
-        beforeEach(async function () {
-            let role = this.server.create('role', {name: 'Owner'});
-            this.server.create('user', {roles: [role], slug: 'owner'});
-
-            await authenticateSession();
-        });
-
-        it('transitions to dashboard', async function () {
-            await visit('/?firstStart=true');
-            expect(currentURL()).to.equal('/dashboard');
-        });
-    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2165/
- we no longer need to direct to Social/activitypub
- we should only be directing to Analytics, but need to be behind ui flag for the moment
- cleaned up what appears to be dead code for onboarding, which is in the analytics handlebars component now