### PR TITLE
🎨 Added support for "break" to the #foreach helper

### DIFF
--- a/ghost/core/core/frontend/helpers/foreach.js
+++ b/ghost/core/core/frontend/helpers/foreach.js
@@ -50,6 +50,7 @@ module.exports = function foreach(items, options) {
     let output = '';
     let frame;
     let contextPath;
+    let shouldBreak = false;
 
     limit = parseInt(limit, 10) || length;
     from = parseInt(from, 10) || 1;
@@ -67,6 +68,9 @@ module.exports = function foreach(items, options) {
 
     if (data) {
         frame = createFrame(data);
+        frame.break = () => {
+            shouldBreak = true;
+        };
     }
 
     function execIteration(field, index, last) {
@@ -98,6 +102,10 @@ module.exports = function foreach(items, options) {
         // For each post, if it is a post number that fits within the from and to
         // send the key to execIteration to set to be added to the page
         _.each(context, (value, key) => {
+            if (shouldBreak) {
+                return;
+            }
+
             if (current < from) {
                 current += 1;
                 return;


### PR DESCRIPTION
Allows to stop subsequent iterations from running by simply using `{{@break}}`. 
Useful when checking for a condition that should match only once. 
Note that the current iteration is fully rendered, no matter where `@break` is positioned.

Usage:
```hbs
{{#foreach tags}}
    {{#match slug "~^" "news-" }}
        {{!-- Do stuff --}}
        {{#get "posts" filter="tags:{{slug}}"}}{{/get}}

        {{!-- No need to continue further. Stop the loop. --}}
        {{@break}}
    {{/match}}
{{/foreach}}
```


- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
