### PR TITLE
Removed multiline check from fb and x regex

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
@@ -28,4 +28,4 @@ export function validateFacebookUrl(newUrl: string) {
 
 export const facebookHandleToUrl = (handle: string) => `https://www.facebook.com/${handle}`;
 
-export const facebookUrlToHandle = (url: string) => url.match(/(?:https:\/\/)(?:www\.)(?:facebook\.com)\/(?:#!\/)?(\w+\/?\S+)/mi)?.[1] || null; 
+export const facebookUrlToHandle = (url: string) => url.match(/(?:https:\/\/)(?:www\.)(?:facebook\.com)\/(?:#!\/)?(\w+\/?\S+)/i)?.[1] || null; 

--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -8,17 +8,17 @@ export function validateTwitterUrl(newUrl: string) {
         if (newUrl.match(/(?:x\.com\/)(\S+)/)) {
             [, username] = newUrl.match(/(?:x\.com\/)(\S+)/);
         } else {
-            [username] = newUrl.match(/([^/]+)\/?$/mi);
+            [username] = newUrl.match(/([^/]+)\/?$/i);
         }
 
         if (username.startsWith('@')) {
             username = username.slice(1);
         }
 
-        if (!username.match(/^[a-z\d_]{1,15}$/mi)) {
+        if (!username.match(/^[a-z\d_]{1,15}$/i)) {
             throw new Error('Your Username is not a valid Twitter Username');
         }
-        
+
         return `https://x.com/${username}`;
     } else {
         const message = 'The URL must be in a format like https://x.com/yourUsername';

--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -1,5 +1,4 @@
 // x.com URLs with 1-15 characters, alphanumeric and underscores
-
 const X_URL_REGEX = /^x\.com\/([a-zA-Z0-9_]{1,15})$/;
 
 export function validateTwitterUrl(newUrl: string) {

--- a/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/twitter.ts
@@ -1,12 +1,16 @@
+// x.com URLs with 1-15 characters, alphanumeric and underscores
+
+const X_URL_REGEX = /^x\.com\/([a-zA-Z0-9_]{1,15})$/;
+
 export function validateTwitterUrl(newUrl: string) {
     if (!newUrl) {
         return '';
     }
-    if (newUrl.match(/(?:x\.com\/)(\S+)/) || newUrl.match(/([a-z\d.]+)/i)) {
+    if (newUrl.match(X_URL_REGEX) || newUrl.match(/([a-z\d.]+)/i)) {
         let username = [];
 
-        if (newUrl.match(/(?:x\.com\/)(\S+)/)) {
-            [, username] = newUrl.match(/(?:x\.com\/)(\S+)/);
+        if (newUrl.match(X_URL_REGEX)) {
+            [, username] = newUrl.match(X_URL_REGEX);
         } else {
             [username] = newUrl.match(/([^/]+)\/?$/i);
         }

--- a/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
@@ -18,6 +18,10 @@ describe('Facebook URLs', () => {
             assert.throws(() => validateFacebookUrl('https://twitter.com/myPage'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
             assert.throws(() => validateFacebookUrl('http://example.com'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
         });
+
+        it('should reject URLs containing newline characters', () => {
+            assert.throws(() => validateFacebookUrl('facebook.com/my\nPage'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
+        });
     });
 
     describe('Handle to URL conversion', () => {
@@ -31,6 +35,7 @@ describe('Facebook URLs', () => {
             assert.equal(facebookUrlToHandle('https://www.facebook.com/myPage'), 'myPage');
             assert.equal(facebookUrlToHandle('https://www.facebook.com/myPage/'), 'myPage/');
             assert.equal(facebookUrlToHandle('invalid-url'), null);
+            assert.equal(facebookUrlToHandle('facebook.com/my\nPage'), null);
         });
     });
 }); 

--- a/apps/admin-x-settings/test/unit/utils/twitterUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/twitterUrls.test.ts
@@ -19,6 +19,7 @@ describe('Twitter URLs', () => {
             assert.throws(() => validateTwitterUrl('x.com/username@'), /Your Username is not a valid Twitter Username/);
             assert.throws(() => validateTwitterUrl('x.com/username!'), /Your Username is not a valid Twitter Username/);
             assert.throws(() => validateTwitterUrl('x.com/thisusernameistoolong'), /Your Username is not a valid Twitter Username/);
+            assert.throws(() => validateTwitterUrl('x.com/with\nnewline'), /Your Username is not a valid Twitter Username/);
         });
     });
 


### PR DESCRIPTION
no issue

- Regex in the Facebook and X social url validator functions allowed for multiline inputs - this removes that.
