### PR TITLE
Updated 'social_web_enabled' setting calculation

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -94,8 +94,14 @@ async function initCore({ghostServer, config, frontend}) {
     models.init();
     debug('End: models');
 
+    // Limit service is booted before settings, so that limits are available for calculated settings
+    debug('Begin: limits');
+    const limits = require('./server/services/limits');
+    await limits.init();
+    debug('End: limits');
+
     // Settings are a core concept we use settings to store key-value pairs used in critical pathways as well as public data like the site title
-    debug('Begin: settings');
+    debug('Begin: settings-service');
     const settings = require('./server/services/settings/settings-service');
     await settings.init();
     await settings.syncEmailSettings(config.get('hostSettings:emailVerification:verified'));
@@ -312,7 +318,6 @@ async function initServices() {
     const xmlrpc = require('./server/services/xmlrpc');
     const slack = require('./server/services/slack');
     const webhooks = require('./server/services/webhooks');
-    const limits = require('./server/services/limits');
     const scheduling = require('./server/adapters/scheduling');
     const comments = require('./server/services/comments');
     const staffService = require('./server/services/staff');
@@ -337,10 +342,6 @@ async function initServices() {
     const explorePingService = require('./server/services/explore-ping');
 
     const urlUtils = require('./shared/url-utils');
-
-    // NOTE: limits service has to be initialized first
-    // in case it limits initialization of any other service (e.g. webhooks)
-    await limits.init();
 
     // NOTE: Members service depends on these
     //       so they are initialized before it.

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -101,7 +101,7 @@ async function initCore({ghostServer, config, frontend}) {
     debug('End: limits');
 
     // Settings are a core concept we use settings to store key-value pairs used in critical pathways as well as public data like the site title
-    debug('Begin: settings-service');
+    debug('Begin: settings');
     const settings = require('./server/services/settings/settings-service');
     await settings.init();
     await settings.syncEmailSettings(config.get('hostSettings:emailVerification:verified'));

--- a/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
+++ b/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
@@ -42,6 +42,13 @@ module.exports = class ActivityPubServiceWrapper {
                     ActivityPubServiceWrapper.initialised = true;
                 }
             });
+
+            events.on('settings.social_web.edited', async () => {
+                if (settingsCache.get('social_web_enabled') && !ActivityPubServiceWrapper.initialised) {
+                    await ActivityPubServiceWrapper.instance.initialiseWebhooks();
+                    ActivityPubServiceWrapper.initialised = true;
+                }
+            });
         }
     }
 };

--- a/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
+++ b/ghost/core/core/server/services/activitypub/ActivityPubServiceWrapper.js
@@ -32,23 +32,22 @@ module.exports = class ActivityPubServiceWrapper {
             IdentityTokenServiceWrapper.instance
         );
 
-        if (settingsCache.get('social_web_enabled')) {
+        const initActivityPubService = async () => {
             await ActivityPubServiceWrapper.instance.initialiseWebhooks();
             ActivityPubServiceWrapper.initialised = true;
-        } else {
-            events.on('settings.labs.edited', async () => {
-                if (settingsCache.get('social_web_enabled') && !ActivityPubServiceWrapper.initialised) {
-                    await ActivityPubServiceWrapper.instance.initialiseWebhooks();
-                    ActivityPubServiceWrapper.initialised = true;
-                }
-            });
+        };
 
-            events.on('settings.social_web.edited', async () => {
+        if (settingsCache.get('social_web_enabled')) {
+            await initActivityPubService();
+        } else {
+            const initActivityPubServiceLater = async () => {
                 if (settingsCache.get('social_web_enabled') && !ActivityPubServiceWrapper.initialised) {
-                    await ActivityPubServiceWrapper.instance.initialiseWebhooks();
-                    ActivityPubServiceWrapper.initialised = true;
+                    await initActivityPubService();
                 }
-            });
+            };
+
+            events.on('settings.labs.edited', initActivityPubServiceLater);
+            events.on('settings.social_web.edited', initActivityPubServiceLater);
         }
     }
 };

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -240,12 +240,7 @@ class SettingsHelpers {
         }
 
         // Ghost (Pro) limits
-        //
-        // Implementation note: we're only checking that the limit flag 'limitSocialWeb' exists and not awaiting for "this.limitService.checkWouldGoOverLimit('limitSocialWeb')"
-        // Reason:
-        // - calculated settings currently don't support async method calls
-        // - 'limitSocialWeb' config either exists with disabled:true (for sites that don't have access to social web), or doesn't exist at all
-        if (this.limitService.isLimited('limitSocialWeb')) {
+        if (this.limitService.isDisabled('limitSocialWeb')) {
             logging.warn('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
             return false;
         }

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -4,6 +4,7 @@ const errors = require('@tryghost/errors');
 const EmailAddressParser = require('../email-address/EmailAddressParser');
 const logging = require('@tryghost/logging');
 const crypto = require('crypto');
+const debug = require('@tryghost/debug')('services:settings-helpers');
 
 const messages = {
     incorrectKeyType: 'type must be one of "direct" or "connect".'
@@ -229,26 +230,26 @@ class SettingsHelpers {
     isSocialWebEnabled() {
         // UI setting
         if (this.settingsCache.get('social_web') !== true) {
-            logging.warn('Social web is disabled in settings');
+            debug('Social web is disabled in settings');
             return false;
         }
 
         // Labs setting
         if (!this.labs.isSet('ActivityPub')) {
-            logging.warn('Social web is disabled in labs');
+            debug('Social web is disabled in labs');
             return false;
         }
 
         // Ghost (Pro) limits
         if (this.limitService.isDisabled('limitSocialWeb')) {
-            logging.warn('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
+            debug('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
             return false;
         }
 
         // Social web (ActivityPub) currently does not support Ghost sites hosted on a subdirectory, e.g. https://example.com/blog/
         const subdirectory = this.urlUtils.getSubdir();
         if (subdirectory) {
-            logging.warn('Social web is not available for Ghost sites hosted on a subdirectory');
+            debug('Social web is not available for Ghost sites hosted on a subdirectory');
             return false;
         }
 
@@ -257,7 +258,7 @@ class SettingsHelpers {
         const isLocalhost = siteUrl.hostname === 'localhost' || siteUrl.hostname === '127.0.0.1' || siteUrl.hostname === '::1';
         const isIP = net.isIP(siteUrl.hostname);
         if (process.env.NODE_ENV === 'production' && (isLocalhost || isIP)) {
-            logging.warn('Social web is not available for localhost or IPs addresses in production');
+            debug('Social web is not available from localhost or IPs addresses in production');
             return false;
         }
 

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -240,7 +240,12 @@ class SettingsHelpers {
         }
 
         // Ghost (Pro) limits
-        if (this.limitService.limits.limitSocialWeb?.disabled) {
+        //
+        // Implementation note: we're only checking that the limit flag 'limitSocialWeb' exists and not awaiting for "this.limitService.checkWouldGoOverLimit('limitSocialWeb')"
+        // Reason:
+        // - calculated settings currently don't support async method calls
+        // - 'limitSocialWeb' config either exists with disabled:true (for sites that don't have access to social web), or doesn't exist at all
+        if (this.limitService.isLimited('limitSocialWeb')) {
             logging.warn('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
             return false;
         }

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -1,3 +1,4 @@
+const net = require('net');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const EmailAddressParser = require('../email-address/EmailAddressParser');
@@ -9,11 +10,12 @@ const messages = {
 };
 
 class SettingsHelpers {
-    constructor({settingsCache, urlUtils, config, labs}) {
+    constructor({settingsCache, urlUtils, config, labs, limitService}) {
         this.settingsCache = settingsCache;
         this.urlUtils = urlUtils;
         this.config = config;
         this.labs = labs;
+        this.limitService = limitService;
     }
 
     isMembersEnabled() {
@@ -220,16 +222,46 @@ class SettingsHelpers {
     }
 
     /**
-     * Social web (ActivityPub) is enabled if:
-     * - Social web is enabled in the settings
-     * - 'ActivityPub' flag is enabled in the labs, for compatibility with Ghost 5.x
-     * - Config allows it (TODO)
-     * - Billing allows it (TODO)
+     * Calculated setting for Social web (ActivityPub)
      *
      * @returns {boolean}
      */
     isSocialWebEnabled() {
-        return this.settingsCache.get('social_web') === true && this.labs.isSet('ActivityPub');
+        // UI setting
+        if (this.settingsCache.get('social_web') !== true) {
+            logging.warn('Social web is disabled in settings');
+            return false;
+        }
+
+        // Labs setting
+        if (!this.labs.isSet('ActivityPub')) {
+            logging.warn('Social web is disabled in labs');
+            return false;
+        }
+
+        // Ghost (Pro) limits
+        if (this.limitService.limits.limitSocialWeb?.disabled) {
+            logging.warn('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
+            return false;
+        }
+
+        // Social web (ActivityPub) currently does not support Ghost sites hosted on a subdirectory, e.g. https://example.com/blog/
+        const subdirectory = this.urlUtils.getSubdir();
+        if (subdirectory) {
+            logging.warn('Social web is not available for Ghost sites hosted on a subdirectory');
+            return false;
+        }
+
+        // Self-hosters cannot connect to production ActivityPub servers from localhost or IPs addresses
+        const siteUrl = new URL(this.urlUtils.getSiteUrl());
+        const isLocalhost = siteUrl.hostname === 'localhost' || siteUrl.hostname === '127.0.0.1' || siteUrl.hostname === '::1';
+        const isIP = net.isIP(siteUrl.hostname);
+        if (process.env.NODE_ENV === 'production' && (isLocalhost || isIP)) {
+            logging.warn('Social web is not available for localhost or IPs addresses in production');
+            return false;
+        }
+
+        return true;
     }
 
     // PRIVATE

--- a/ghost/core/core/server/services/settings-helpers/index.js
+++ b/ghost/core/core/server/services/settings-helpers/index.js
@@ -3,5 +3,6 @@ const urlUtils = require('../../../shared/url-utils');
 const config = require('../../../shared/config');
 const SettingsHelpers = require('./SettingsHelpers');
 const labs = require('../../../shared/labs');
+const limitService = require('../limits');
 
-module.exports = new SettingsHelpers({settingsCache, urlUtils, config, labs});
+module.exports = new SettingsHelpers({settingsCache, urlUtils, config, labs, limitService});

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -4,7 +4,6 @@ const configUtils = require('../../../../utils/configUtils');
 const SettingsHelpers = require('../../../../../core/server/services/settings-helpers/SettingsHelpers');
 const crypto = require('crypto');
 const assert = require('assert').strict;
-const logging = require('@tryghost/logging');
 
 const mockValidationKey = 'validation_key';
 
@@ -259,11 +258,7 @@ describe('Settings Helpers', function () {
         let settingsCache;
         let urlUtils;
         let labs;
-        let loggingSpy;
-
         beforeEach(function () {
-            loggingSpy = sinon.spy(logging, 'warn');
-
             settingsCache = {
                 get: sinon.stub().withArgs('social_web').returns(true)
             };
@@ -290,7 +285,6 @@ describe('Settings Helpers', function () {
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
             assert.equal(isEnabled, false);
-            sinon.assert.calledWith(loggingSpy, 'Social web is disabled in settings');
         });
 
         it('returns false when the Labs setting is set to false', function () {
@@ -300,7 +294,6 @@ describe('Settings Helpers', function () {
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
             assert.equal(isEnabled, false);
-            sinon.assert.calledWith(loggingSpy, 'Social web is disabled in labs');
         });
 
         it('returns false when social web is disabled for a Ghost (Pro) user', function () {
@@ -310,7 +303,6 @@ describe('Settings Helpers', function () {
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
             assert.equal(isEnabled, false);
-            sinon.assert.calledWith(loggingSpy, 'Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
         });
 
         it('returns false when the site is hosted on a subdirectory', function () {
@@ -320,7 +312,6 @@ describe('Settings Helpers', function () {
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
             assert.equal(isEnabled, false);
-            sinon.assert.calledWith(loggingSpy, 'Social web is not available for Ghost sites hosted on a subdirectory');
         });
 
         it('returns false if the site is hosted on a localhost or IP address in production', function () {
@@ -331,7 +322,6 @@ describe('Settings Helpers', function () {
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
             assert.equal(isEnabled, false);
-            sinon.assert.calledWith(loggingSpy, 'Social web is not available for localhost or IPs addresses in production');
         });
 
         it('returns true otherwise', function () {

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -289,7 +289,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, false);
+            assert.equal(isEnabled, false);
             sinon.assert.calledWith(loggingSpy, 'Social web is disabled in settings');
         });
 
@@ -299,7 +299,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, false);
+            assert.equal(isEnabled, false);
             sinon.assert.calledWith(loggingSpy, 'Social web is disabled in labs');
         });
 
@@ -309,7 +309,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, false);
+            assert.equal(isEnabled, false);
             sinon.assert.calledWith(loggingSpy, 'Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
         });
 
@@ -319,7 +319,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, false);
+            assert.equal(isEnabled, false);
             sinon.assert.calledWith(loggingSpy, 'Social web is not available for Ghost sites hosted on a subdirectory');
         });
 
@@ -330,7 +330,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, false);
+            assert.equal(isEnabled, false);
             sinon.assert.calledWith(loggingSpy, 'Social web is not available for localhost or IPs addresses in production');
         });
 
@@ -338,7 +338,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();
 
-            should.equal(isEnabled, true);
+            assert.equal(isEnabled, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -275,11 +275,7 @@ describe('Settings Helpers', function () {
                 isSet: sinon.stub().withArgs('ActivityPub').returns(true)
             };
             limitService = {
-                limits: {
-                    limitSocialWeb: {
-                        disabled: false
-                    }
-                }
+                isLimited: sinon.stub().withArgs('limitSocialWeb').returns(false)
             };
         });
 
@@ -308,7 +304,7 @@ describe('Settings Helpers', function () {
         });
 
         it('returns false when social web is disabled for a Ghost (Pro) user', function () {
-            limitService.limits.limitSocialWeb.disabled = true;
+            limitService.isLimited.withArgs('limitSocialWeb').returns(true);
 
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -275,7 +275,7 @@ describe('Settings Helpers', function () {
                 isSet: sinon.stub().withArgs('ActivityPub').returns(true)
             };
             limitService = {
-                isLimited: sinon.stub().withArgs('limitSocialWeb').returns(false)
+                isDisabled: sinon.stub().withArgs('limitSocialWeb').returns(undefined)
             };
         });
 
@@ -304,7 +304,7 @@ describe('Settings Helpers', function () {
         });
 
         it('returns false when social web is disabled for a Ghost (Pro) user', function () {
-            limitService.isLimited.withArgs('limitSocialWeb').returns(true);
+            limitService.isDisabled.withArgs('limitSocialWeb').returns(true);
 
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2172

Social web feature is available for users that match all of these criteria:
1) their social web setting is toggled on in Ghost Admin (on by default in Ghost 6.0)
2) their social web labs' flag is toggled on in Ghost Admin (opt-in beta in Ghost 5.0, on-by-default GA in Ghost 6.0) 
3) their site is not hosted on localhost, an IP address, or a subdirectory
4) (Ghost (Pro) only) their access to social web is not limited by config 

Implementation notes:
- given 4), the boot order of Limit Service has changed: it's now initiated before the Settings Service, so that calculated settings such as `social_web_enabled` can use it
- in `@tryghost/limit-service@1.4.0`, we have introduced a new sync method `isDisabled()` to read whether a flag is disabled by config or not. This can be used in replacement of the existing async method `checkWouldGoOverLimit()`, which would require making an async call (and updating CalculatedField / Cache Manager / Settings Service to support async calls!)