### PR TITLE
🐛Fixed internal search bug that makes highlighted text unclickable.

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -210,6 +210,7 @@
     background: #fff6b8;
     border-radius: 1px;
     color: color-mod(var(--darkgrey) l(-10%));
+    pointer-events: none;
 }
 
 .ember-power-select-group .ember-power-select-option[aria-current="true"] {

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -145,6 +145,19 @@ suites.forEach((suite) => {
             expect(currentURL(), 'url after selecting post').to.equal(`/editor/post/${firstPost.id}`);
         });
 
+        it('navigates to editor when highlighted text is clicked', async function () {
+            await visit('/dashboard');
+            await click('[data-test-button="search"]');
+            await typeInSearch('first post');
+            
+            // Find the highlighted text span and click on it specifically
+            const highlightedText = find('.ember-power-select-option[aria-current="true"] .highlight');
+            expect(highlightedText, 'highlighted text should exist').to.exist;
+            
+            await click(highlightedText);
+            expect(currentURL(), 'url after clicking highlighted text').to.equal(`/editor/post/${firstPost.id}`);
+        });
+
         it('navigates to editor when page selected', async function () {
             await visit('/dashboard');
             await click('[data-test-button="search"]');


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/24269

Adding a pointer-events: none to prevent the span of highlighted text from interfering with click events on the containing li.

Note: This is a Chrome-specific bug. It isn't present on Firefox.  Observed on Windows 11.

Review question: I've had past trouble with off-target issues when adjusting ember css. Is there a better selector to add this change to, ensuring that it only impacts the search box, and not other uses of power select?

(Sorry for the duplicate PR - I needed to open it from the Ghost repo rather than my branch so that browser tests could run.)
