### PR TITLE
Removed `FOR UPDATE` when fetching Default Tier

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -947,9 +947,7 @@ module.exports = class MemberRepository {
             ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, options);
             // Use first Ghost product as default product in case of missing link
             if (!ghostProduct) {
-                ghostProduct = await this._productRepository.getDefaultProduct({
-                    ...options
-                });
+                ghostProduct = await this._productRepository.getDefaultProduct(options);
             }
 
             // Link Stripe Product & Price to Ghost Product

--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -948,7 +948,6 @@ module.exports = class MemberRepository {
             // Use first Ghost product as default product in case of missing link
             if (!ghostProduct) {
                 ghostProduct = await this._productRepository.getDefaultProduct({
-                    forUpdate: true,
                     ...options
                 });
             }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1758
ref https://linear.app/ghost/issue/ONC-1038
ref https://github.com/TryGhost/Ghost/commit/8bc723c64

By passing the `forUpdate` flag, we lock the row completely which causes
a lot of contention. We cannot see a legitimate use-case for locking.

Any future updates made to the row are not based on the current state of
the row, so locking doesn't make much sense. We've previously looked at
this and fixed it, but it looks like this line was forgotten about.
