### PR TITLE
Silenced noisy webpack warning logs in Admin build

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -229,7 +229,13 @@ module.exports = function (defaults) {
                     new webpack.ProvidePlugin({
                         process: 'process/browser'
                     })
-                ]
+                ],
+                // disable verbose logging about webpack resolution mismatches
+                // - this is a known issue with mismatched versions of dependencies resulting in duplication rather than a single hoisted version
+                // - we don't plan on fixing this in the short term, so we just silence the noise
+                infrastructureLogging: {
+                    level: 'error'
+                }
             }
         },
         'ember-test-selectors': {


### PR DESCRIPTION
no issue

Admin builds were outputting a lot of logs like:

```
[webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] Resolving 'resolve-package-path/package.json' in /Users/kevin/code/Ghost/node_modules/hash-for-dep/lib for build dependencies doesn't lead to expected result '/Users/kevin/code/Ghost/node_modules/resolve-package-path/package.json', but to '/Users/kevin/code/Ghost/node_modules/hash-for-dep/node_modules/resolve-package-path/package.json' instead. Resolving dependencies are ignored for this path.
```

- these logs are nothing but noise, they come from multiple versions of packages across our monorepo and dependencies/sub-dependencies which means packages are not always hoisted to the top level meaning webpack doesn't cache the package's metadata
- we don't have a good way to fix this, our Ember packages are all very out of date and won't be updated before they ultimately get replaced so duplicate versions aren't going away in the short-term meaning the constant logging is useless
- updated our webpack config to only log errors instead of warnings to keep the logs quieter
