### PR TITLE
Added CTA for trial/starter plan customers

### DIFF
--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -51,6 +51,7 @@ type PostAnalyticsContextType = {
     postId: string;
     post: Post | undefined;
     isPostLoading: boolean;
+    limitedByPlan?: boolean;
 }
 
 const PostAnalyticsContext = createContext<PostAnalyticsContextType | undefined>(undefined);
@@ -65,12 +66,12 @@ export const useGlobalData = () => {
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const {postId} = useParams();
-    
+
     // Validate that postId exists - the app cannot function without it
     if (!postId) {
         throw new Error('Post ID is required for PostAnalyticsProvider');
     }
-    
+
     const config = useBrowseConfig();
     const site = useBrowseSite();
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
@@ -113,9 +114,10 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         audience,
         setAudience,
         settings: settings.data?.settings || [],
-        postId: postId, 
-        post: post as Post | undefined, 
-        isPostLoading
+        postId: postId,
+        post: post as Post | undefined,
+        isPostLoading,
+        limitedByPlan: true
     }}>
         {children}
     </PostAnalyticsContext.Provider>;

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -3,7 +3,7 @@ import NewsletterOverview from './components/NewsletterOverview';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import WebOverview from './components/WebOverview';
-import {Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
 import {KPI_METRICS} from '../Web/components/Kpis';
 import {KpiDataItem} from '@src/utils/kpi-helpers';
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
@@ -16,7 +16,7 @@ import {usePostReferrers} from '@src/hooks/usePostReferrers';
 
 const Overview: React.FC = () => {
     const navigate = useNavigate();
-    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId, limitedByPlan} = useGlobalData();
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {startDate, endDate, timezone} = getRangeDates(STATS_RANGES.ALL_TIME.value);
     const {appSettings} = useAppContext();
@@ -124,72 +124,77 @@ const Overview: React.FC = () => {
 
     // Redirect to Growth tab if this is a published-only post with web analytics disabled
     useEffect(() => {
-        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics) {
+        if (!isPostLoading && post && isPublishedOnly(post as Post) && (!appSettings?.analytics.webAnalytics || limitedByPlan)) {
             navigate(`/analytics/beta/${postId}/growth`);
         }
-    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId]);
+    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, limitedByPlan]);
 
     return (
         <>
             <PostAnalyticsHeader currentTab='Overview'>
-                <div className='order-1 flex w-full items-center justify-center gap-1 text-nowrap rounded-md bg-purple/10 px-2 py-px pr-3 text-xs text-purple-600 lg:order-none lg:w-auto'>
-                    <LucideIcon.FlaskConical size={16} strokeWidth={1.5} />
-                    Viewing Analytics (beta)
-                    <Button className='pl-1 pr-0 text-purple-600 !underline' size='sm' variant='link' onClick={() => {
-                        navigate(`/posts/analytics/${postId}`, {crossApp: true});
-                    }}>Switch back</Button>
-                </div>
+                {!isPostLoading &&
+                    <div className='order-1 flex w-full items-center justify-center gap-1 text-nowrap rounded-md bg-purple/10 px-2 py-px pr-3 text-xs text-purple-600 lg:order-none lg:w-auto'>
+                        <LucideIcon.FlaskConical size={16} strokeWidth={1.5} />
+                        Viewing Analytics (beta)
+                        <Button className='pl-1 pr-0 text-purple-600 !underline' size='sm' variant='link' onClick={() => {
+                            navigate(`/posts/analytics/${postId}`, {crossApp: true});
+                        }}>Switch back</Button>
+                    </div>
+                }
             </PostAnalyticsHeader>
             <PostAnalyticsContent>
-                <div className='flex flex-col gap-8 lg:grid lg:grid-cols-2'>
-                    {showWebSection && (
-                        <WebOverview
-                            chartData={processedChartData}
-                            isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
-                            isNewsletterShown={showNewsletterSection}
-                            range={chartRange}
-                            sourcesData={sourcesData}
-                            visitors={totalVisitors}
-                        />
-                    )}
-                    {showNewsletterSection && (
-                        <NewsletterOverview
-                            isNewsletterStatsLoading={isPostLoading}
-                            isWebShown={showWebSection}
-                            post={post as Post}
-                        />
-                    )}
-                    <Card className='group col-span-2 overflow-hidden p-0'>
-                        <div className='relative flex items-center justify-between gap-6'>
-                            <CardHeader>
-                                <CardTitle className='flex items-center gap-1.5 text-lg'>
-                                    <LucideIcon.Sprout size={16} strokeWidth={1.5} />
+                {isPostLoading ?
+                    <BarChartLoadingIndicator />
+                    :
+                    <div className='flex flex-col gap-8 lg:grid lg:grid-cols-2'>
+                        {showWebSection && (
+                            <WebOverview
+                                chartData={processedChartData}
+                                isLoading={chartIsLoading || kpiIsLoading || isSourcesLoading}
+                                isNewsletterShown={showNewsletterSection}
+                                range={chartRange}
+                                sourcesData={sourcesData}
+                                visitors={totalVisitors}
+                            />
+                        )}
+                        {showNewsletterSection && (
+                            <NewsletterOverview
+                                isNewsletterStatsLoading={isPostLoading}
+                                isWebShown={showWebSection}
+                                post={post as Post}
+                            />
+                        )}
+                        <Card className='group col-span-2 overflow-hidden p-0'>
+                            <div className='relative flex items-center justify-between gap-6'>
+                                <CardHeader>
+                                    <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                        <LucideIcon.Sprout size={16} strokeWidth={1.5} />
                                 Growth
-                                </CardTitle>
-                            </CardHeader>
-                            <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                                navigate(`/analytics/beta/${postId}/growth`);
-                            }}>View more</Button>
-                        </div>
-                        <CardContent className='flex flex-col gap-8 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>
-                            {kpiIsLoading ?
-                                Array.from({length: 3}, (_, i) => (
-                                    <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
-                                        <Skeleton className='w-2/3' />
-                                        <Skeleton className='h-7 w-12' />
-                                    </div>
-                                ))
-                                :
-                                <>
-                                    <KpiCard className='grow gap-1 py-0'>
-                                        <KpiCardLabel>
+                                    </CardTitle>
+                                </CardHeader>
+                                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                    navigate(`/analytics/beta/${postId}/growth`);
+                                }}>View more</Button>
+                            </div>
+                            <CardContent className='flex flex-col gap-8 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>
+                                {kpiIsLoading ?
+                                    Array.from({length: 3}, (_, i) => (
+                                        <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
+                                            <Skeleton className='w-2/3' />
+                                            <Skeleton className='h-7 w-12' />
+                                        </div>
+                                    ))
+                                    :
+                                    <>
+                                        <KpiCard className='grow gap-1 py-0'>
+                                            <KpiCardLabel>
                                         Free members
-                                        </KpiCardLabel>
-                                        <KpiCardContent>
-                                            <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
-                                        </KpiCardContent>
-                                    </KpiCard>
-                                    {appSettings?.paidMembersEnabled &&
+                                            </KpiCardLabel>
+                                            <KpiCardContent>
+                                                <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
+                                            </KpiCardContent>
+                                        </KpiCard>
+                                        {appSettings?.paidMembersEnabled &&
                                 <>
                                     <KpiCard className='grow gap-1 py-0'>
                                         <KpiCardLabel>
@@ -208,12 +213,13 @@ const Overview: React.FC = () => {
                                         </KpiCardContent>
                                     </KpiCard>
                                 </>
-                                    }
-                                </>
-                            }
-                        </CardContent>
-                    </Card>
-                </div>
+                                        }
+                                    </>
+                                }
+                            </CardContent>
+                        </Card>
+                    </div>
+                }
             </PostAnalyticsContent>
         </>
     );

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -22,6 +22,7 @@ interface GlobalData {
     settings: Setting[];
     selectedNewsletterId: string | null;
     setSelectedNewsletterId: (id: string | null) => void;
+    limitedByPlan?: boolean;
 }
 
 const GlobalDataContext = createContext<GlobalData | undefined>(undefined);
@@ -71,7 +72,8 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
         setAudience,
         settings: settings.data?.settings || [],
         selectedNewsletterId,
-        setSelectedNewsletterId
+        setSelectedNewsletterId,
+        limitedByPlan: true
     }}>
         {children}
     </GlobalDataContext.Provider>;

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -55,7 +55,7 @@ interface ProcessedLocationData {
 }
 
 const Locations:React.FC = () => {
-    const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience, limitedByPlan} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
     const ITEMS_PER_PAGE = 10;
@@ -197,7 +197,7 @@ const Locations:React.FC = () => {
 
     const isLoading = isConfigLoading || loading;
 
-    if (!appSettings?.analytics.webAnalytics) {
+    if (!appSettings?.analytics.webAnalytics || limitedByPlan) {
         return (
             <Navigate to='/' />
         );

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -29,7 +29,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
 }) => {
     const navigate = useNavigate();
     const [isShareOpen, setIsShareOpen] = useState(false);
-    const {site, settings} = useGlobalData();
+    const {site, settings, limitedByPlan} = useGlobalData();
     const {appSettings} = useAppContext();
     const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
 
@@ -149,7 +149,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                         <div className='-ml-4 flex w-full flex-col items-stretch gap-2 pr-6 text-sm xl:h-full xl:max-w-none'>
                             <div className='grid grid-cols-2 gap-6 pl-10 lg:border-l xl:h-full'>
                                 {/* Web metrics - only for published posts */}
-                                {metricsToShow.showWebMetrics && appSettings?.analytics.webAnalytics &&
+                                {metricsToShow.showWebMetrics && appSettings?.analytics.webAnalytics && !limitedByPlan &&
                                     <div className={metricClassName} onClick={() => {
                                         navigate(`/posts/analytics/beta/${latestPostStats.id}/web`, {crossApp: true});
                                     }}>

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -58,11 +58,11 @@ const TopPosts: React.FC<TopPostsProps> = ({
     isLoading
 }) => {
     const navigate = useNavigate();
-    const {range} = useGlobalData();
+    const {range, limitedByPlan} = useGlobalData();
     const {appSettings} = useAppContext();
 
     // Show open rate if newsletters are enabled and email tracking is enabled
-    const showWebAnalytics = appSettings?.analytics.webAnalytics;
+    const showWebAnalytics = appSettings?.analytics.webAnalytics && !limitedByPlan;
     const showOpenRate = appSettings?.newslettersEnabled && appSettings?.analytics.emailTrackOpens;
 
     const metricClass = 'flex items-center justify-end gap-1 rounded-md px-2 py-1 font-mono text-gray-800 hover:bg-muted-foreground/10 group-hover:text-foreground';

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -48,7 +48,7 @@ export const KPI_METRICS: Record<string, KpiMetric> = {
 };
 
 const Web: React.FC = () => {
-    const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, audience, data, limitedByPlan} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {appSettings} = useAppContext();
 
@@ -95,7 +95,7 @@ const Web: React.FC = () => {
     // Calculate combined loading state
     const isPageLoading = isConfigLoading;
 
-    if (!appSettings?.analytics.webAnalytics) {
+    if (!appSettings?.analytics.webAnalytics || limitedByPlan) {
         return (
             <Navigate to='/' />
         );

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -13,7 +13,7 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
     const navigate = useNavigate();
     const location = useLocation();
     const {appSettings} = useAppContext();
-    const {site, statsConfig} = useGlobalData();
+    const {site, statsConfig, limitedByPlan} = useGlobalData();
     const {activeVisitors, isLoading: isActiveVisitorsLoading} = useActiveVisitors({
         statsConfig,
         enabled: appSettings?.analytics?.webAnalytics ?? false
@@ -26,7 +26,7 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                     <H1 className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]'>
                         Analytics
                     </H1>
-                    {appSettings?.analytics.webAnalytics && (
+                    {appSettings?.analytics.webAnalytics && !limitedByPlan && (
                         <div className='flex items-center gap-2 text-sm'>
                             {site?.url && (
                                 <div className='hidden items-center gap-1.5 sm:!visible sm:!flex'>
@@ -63,7 +63,7 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         navigate('/');
                     }}>Overview</PageMenuItem>
 
-                    {appSettings?.analytics.webAnalytics &&
+                    {(appSettings?.analytics.webAnalytics && !limitedByPlan) &&
                         <PageMenuItem value="/web/" onClick={() => {
                             navigate('/web/');
                         }}>Web traffic</PageMenuItem>
@@ -79,9 +79,11 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         navigate('/growth/');
                     }}>Growth</PageMenuItem>
 
-                    <PageMenuItem value="/locations/" onClick={() => {
-                        navigate('/locations/');
-                    }}>Locations</PageMenuItem>
+                    {(appSettings?.analytics.webAnalytics && !limitedByPlan) &&
+                        <PageMenuItem value="/locations/" onClick={() => {
+                            navigate('/locations/');
+                        }}>Locations</PageMenuItem>
+                    }
                 </PageMenu>
                 <NavbarActions>
                     {children}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2099/add-cta-for-starter-plan-trial-plan-customers

- Customers on trial or on the Starter plan will have no access to traffic analytics. For them we're going to show a CTA on the Analytics overview to upgrade their plan.