### PR TITLE
🐛 Fixed users endpoint to exclude v1 versioning

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -331,7 +331,7 @@ export class ActivityPubAPI {
     }
 
     get userApiUrl() {
-        return new URL(`.ghost/activitypub/v1/users/${this.handle}`, this.apiUrl);
+        return new URL(`.ghost/activitypub/users/${this.handle}`, this.apiUrl);
     }
 
     async getUser() {

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -18,7 +18,7 @@ test.describe('Feed', async () => {
             },
             getActivityPubUser: {
                 method: 'GET',
-                path: '/v1/users/index',
+                path: '/users/index',
                 response: activityPubUser
             },
             getAccount: {
@@ -233,7 +233,7 @@ test.describe('Feed', async () => {
             },
             getActivityPubUser: {
                 method: 'GET',
-                path: '/v1/users/index',
+                path: '/users/index',
                 response: activityPubUser
             },
             replyToPost: {

--- a/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/inbox.test.ts
@@ -182,7 +182,7 @@ test.describe('Inbox', async () => {
             },
             getActivityPubUser: {
                 method: 'GET',
-                path: '/v1/users/index',
+                path: '/users/index',
                 response: activityPubUser
             },
             replyToPost: {


### PR DESCRIPTION
  refs https://github.com/TryGhost/ActivityPub/commit/ec0ef045da156139bf4e6b5929
  8a1298e753111e

  - removed v1 prefix from the users endpoint URL
  - the users endpoint is part of the ActivityPub spec and must remain unversioned
  - as noted in the referenced commit, "AP endpoints are unversioned, as they adhere to the AP spec"
  - this was causing 404 errors when trying to fetch user data