### PR TITLE
Wired up calculated field for Web Analytics setting

### DIFF
--- a/apps/admin-x-design-system/src/assets/icons/info.svg
+++ b/apps/admin-x-design-system/src/assets/icons/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info-icon lucide-info"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>

--- a/apps/admin-x-design-system/src/global/form/Toggle.tsx
+++ b/apps/admin-x-design-system/src/global/form/Toggle.tsx
@@ -104,7 +104,7 @@ const Toggle: React.FC<ToggleProps> = ({
                 <TogglePrimitive.Root className={clsx(
                     toggleBgClass,
                     'appearance-none rounded-full bg-grey-300 transition duration-100 dark:bg-grey-800',
-                    'enabled:hover:cursor-pointer disabled:opacity-40 enabled:group-hover:opacity-80',
+                    'enabled:hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 enabled:group-hover:opacity-80',
                     sizeStyles,
                     direction === 'rtl' && ' order-2'
                 )} defaultChecked={checked} disabled={disabled} id={id} name={name} onCheckedChange={handleCheckedChange}>
@@ -114,7 +114,7 @@ const Toggle: React.FC<ToggleProps> = ({
                     )} />
                 </TogglePrimitive.Root>
                 {label &&
-                    <label className={`flex grow flex-col hover:cursor-pointer ${direction === 'rtl' && 'order-1'} ${labelStyles}`} htmlFor={id}>
+                    <label className={`flex grow flex-col ${!disabled && 'hover:cursor-pointer'} ${direction === 'rtl' && 'order-1'} ${labelStyles}`} htmlFor={id}>
                         {
                             labelStyle === 'heading' ?
                                 <span className={`${Heading6StylesGrey} mt-1`}>{label}</span>

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useFeatureFlag from '../../../hooks/useFeatureFlag';
 import useSettingGroup from '../../../hooks/useSettingGroup';
-import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, Icon, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getSettingValues, isSettingReadOnly} from '@tryghost/admin-x-framework/api/settings';
 import {usePostsExports} from '@tryghost/admin-x-framework/api/posts';
 
@@ -61,14 +61,25 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         direction='rtl'
                         disabled={!isWebAnalyticsEnabled}
                         gap='gap-0'
-                        hint={isWebAnalyticsEnabled ? (ui60 ? 'Cookie-free, first party traffic analytics for your site' : undefined) : 'Web analytics requires additional setup in your configuration'}
+                        hint={ui60 && 'Cookie-free, first party traffic analytics for your site'}
                         label='Web analytics'
                         labelClasses='py-4 w-full'
                         onChange={(e) => {
                             handleToggleChange('web_analytics', e);
                         }}
                     />
-                    <Separator className="border-grey-200 dark:border-grey-900" />
+                    {ui60 && !isWebAnalyticsEnabled ?
+                        <div className='mb-5 rounded-md border border-grey-200 bg-grey-50 px-4 py-2.5'>
+                            <span className='flex items-start gap-2'>
+                                <Icon className='-mt-px text-black' name='info-fill' size={24} />
+                                <span>
+                            Web analytics in Ghost is powered by <a className='text-green underline' href="https://tinybird.co" rel="noopener noreferrer" target='_blank'>Tinybird</a> and requires configuration to start collecting data. <a className='text-green underline' href="https://ghost.org/docs/" rel="noopener noreferrer" target='_blank'>Get started &rarr;</a>
+                                </span>
+                            </span>
+                        </div>
+                        :
+                        <Separator className="border-grey-200 dark:border-grey-900" />
+                    }
                 </>
             )}
             <Toggle

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import useFeatureFlag from '../../../hooks/useFeatureFlag';
 import useSettingGroup from '../../../hooks/useSettingGroup';
-import {Button, Icon, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getSettingValues, isSettingReadOnly} from '@tryghost/admin-x-framework/api/settings';
 import {usePostsExports} from '@tryghost/admin-x-framework/api/posts';
 

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -17,8 +17,8 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange
     } = useSettingGroup();
 
-    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, webAnalyticsUserSetting, isWebAnalyticsEnabled] = getSettingValues(localSettings, [
-        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics', 'web_analytics_enabled'
+    const [trackEmailOpens, trackEmailClicks, trackMemberSources, outboundLinkTagging, isWebAnalyticsEnabled, isWebAnalyticsConfigured] = getSettingValues(localSettings, [
+        'email_track_opens', 'email_track_clicks', 'members_track_sources', 'outbound_link_tagging', 'web_analytics_enabled', 'web_analytics_configured'
     ]) as boolean[];
 
     const taBetaFlagEnabled = useFeatureFlag('trafficAnalytics');
@@ -57,9 +57,9 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
             {taBetaFlagEnabled && (
                 <>
                     <Toggle
-                        checked={isWebAnalyticsEnabled && webAnalyticsUserSetting}
+                        checked={isWebAnalyticsEnabled}
                         direction='rtl'
-                        disabled={!isWebAnalyticsEnabled}
+                        disabled={!isWebAnalyticsConfigured}
                         gap='gap-0'
                         hint={ui60 && 'Cookie-free, first party traffic analytics for your site'}
                         label='Web analytics'
@@ -68,10 +68,10 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             handleToggleChange('web_analytics', e);
                         }}
                     />
-                    {ui60 && !isWebAnalyticsEnabled ?
+                    {ui60 && !isWebAnalyticsConfigured ?
                         <div className='mb-5 rounded-md border border-grey-200 bg-grey-50 px-4 py-2.5'>
                             <span className='flex items-start gap-2'>
-                                <Icon className='-mt-px text-black' name='info-fill' size={24} />
+                                {/* <Icon className='-mt-px text-black' name='info-fill' size={24} /> */}
                                 <span>
                             Web analytics in Ghost is powered by <a className='text-green underline' href="https://tinybird.co" rel="noopener noreferrer" target='_blank'>Tinybird</a> and requires configuration to start collecting data. <a className='text-green underline' href="https://ghost.org/docs/" rel="noopener noreferrer" target='_blank'>Get started &rarr;</a>
                                 </span>

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -58,14 +58,19 @@ test.describe('Analytics settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
-            settings: [
-                {key: 'web_analytics', value: false},
-                {key: 'members_track_sources', value: false},
-                {key: 'email_track_opens', value: false},
-                {key: 'email_track_clicks', value: false},
-                {key: 'outbound_link_tagging', value: false}
-            ]
+        const actualSettings = lastApiRequests.editSettings?.body?.settings || [];
+        const expectedSettings = [
+            {key: 'web_analytics', value: false},
+            {key: 'members_track_sources', value: false},
+            {key: 'email_track_opens', value: false},
+            {key: 'email_track_clicks', value: false},
+            {key: 'outbound_link_tagging', value: false}
+        ];
+
+        // Check that all expected settings are present, regardless of order
+        expect(actualSettings).toHaveLength(expectedSettings.length);
+        expectedSettings.forEach((expectedSetting) => {
+            expect(actualSettings).toContainEqual(expectedSetting);
         });
     });
 

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -25,7 +25,8 @@ test.describe('Analytics settings', async () => {
                     settings: [
                         ...responseFixtures.settings.settings,
                         {key: 'web_analytics', value: true},
-                        {key: 'web_analytics_enabled', value: true}
+                        {key: 'web_analytics_enabled', value: true},
+                        {key: 'web_analytics_configured', value: true}
                     ]
                 }
             },
@@ -137,7 +138,8 @@ test.describe('Analytics settings', async () => {
                     settings: [
                         ...responseFixtures.settings.settings,
                         {key: 'web_analytics', value: true},
-                        {key: 'web_analytics_enabled', value: true}
+                        {key: 'web_analytics_enabled', value: true},
+                        {key: 'web_analytics_configured', value: true}
                     ]
                 }
             }
@@ -194,7 +196,7 @@ test.describe('Analytics settings', async () => {
         await expect(section.getByLabel('Outbound link tagging')).toBeVisible();
     });
 
-    test('Shows web analytics toggle as disabled when web_analytics_enabled is false', async ({page}) => {
+    test('Shows web analytics toggle as disabled when web_analytics_configured is false', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseConfig: {
@@ -216,7 +218,8 @@ test.describe('Analytics settings', async () => {
                     settings: [
                         ...responseFixtures.settings.settings,
                         {key: 'web_analytics', value: true},
-                        {key: 'web_analytics_enabled', value: false}
+                        {key: 'web_analytics_enabled', value: false},
+                        {key: 'web_analytics_configured', value: false}
                     ]
                 }
             }
@@ -262,7 +265,8 @@ test.describe('Analytics settings', async () => {
                     settings: [
                         ...responseFixtures.settings.settings,
                         {key: 'web_analytics', value: true},
-                        {key: 'web_analytics_enabled', value: true}
+                        {key: 'web_analytics_enabled', value: true},
+                        {key: 'web_analytics_configured', value: true}
                     ]
                 }
             },

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -58,7 +58,8 @@ test.describe('Analytics settings', async () => {
 
         await section.getByRole('button', {name: 'Save'}).click();
 
-        const actualSettings = lastApiRequests.editSettings?.body?.settings || [];
+        const body = lastApiRequests.editSettings?.body as {settings: Array<{key: string, value: boolean}>} | undefined;
+        const actualSettings = body?.settings || [];
         const expectedSettings = [
             {key: 'web_analytics', value: false},
             {key: 'members_track_sources', value: false},

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -6,7 +6,31 @@ test.describe('Analytics settings', async () => {
     test('Supports toggling analytics settings', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        labs: {
+                            ...responseFixtures.config.config.labs,
+                            trafficAnalytics: true // Feature flag enabled
+                        }
+                    }
+                }
+            },
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'web_analytics', value: true},
+                        {key: 'web_analytics_enabled', value: true}
+                    ]
+                }
+            },
             editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'web_analytics', value: false},
                 {key: 'members_track_sources', value: false},
                 {key: 'email_track_opens', value: false},
                 {key: 'email_track_clicks', value: false},
@@ -20,11 +44,13 @@ test.describe('Analytics settings', async () => {
 
         await expect(section).toBeVisible();
 
+        await expect(section.getByLabel('Web analytics')).toBeChecked();
         await expect(section.getByLabel('Newsletter opens')).toBeChecked();
         await expect(section.getByLabel('Newsletter clicks')).toBeChecked();
         await expect(section.getByLabel('Member sources')).toBeChecked();
         await expect(section.getByLabel('Outbound link tagging')).toBeChecked();
 
+        await section.getByLabel(/Web analytics/).uncheck();
         await section.getByLabel(/Newsletter opens/).uncheck();
         await section.getByLabel(/Newsletter clicks/).uncheck();
         await section.getByLabel(/Member sources/).uncheck();
@@ -34,6 +60,7 @@ test.describe('Analytics settings', async () => {
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [
+                {key: 'web_analytics', value: false},
                 {key: 'members_track_sources', value: false},
                 {key: 'email_track_opens', value: false},
                 {key: 'email_track_clicks', value: false},
@@ -82,10 +109,9 @@ test.describe('Analytics settings', async () => {
         await expect(newsletterClicksToggle).toBeDisabled();
     });
 
-    test('Hides web analytics toggle when limitAnalytics is disabled', async ({page}) => {
+    test('Shows web analytics toggle when feature flag is enabled', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
-            ...limitRequests,
             browseConfig: {
                 ...globalDataRequests.browseConfig,
                 response: {
@@ -94,14 +120,52 @@ test.describe('Analytics settings', async () => {
                         labs: {
                             ...responseFixtures.config.config.labs,
                             trafficAnalytics: true // Feature flag enabled
-                        },
-                        hostSettings: {
-                            limits: {
-                                limitAnalytics: {
-                                    disabled: true,
-                                    error: 'Your current plan doesn\'t support web analytics.'
-                                }
-                            }
+                        }
+                    }
+                }
+            },
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'web_analytics', value: true},
+                        {key: 'web_analytics_enabled', value: true}
+                    ]
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('analytics');
+
+        await expect(section).toBeVisible();
+
+        // Web analytics toggle should be visible when feature flag is enabled
+        await expect(section.getByLabel('Web analytics')).toBeVisible();
+        await expect(section.getByLabel('Web analytics')).toBeEnabled();
+        await expect(section.getByLabel('Web analytics')).toBeChecked();
+
+        // Other analytics toggles should still be visible
+        await expect(section.getByLabel('Newsletter opens')).toBeVisible();
+        await expect(section.getByLabel('Newsletter clicks')).toBeVisible();
+        await expect(section.getByLabel('Member sources')).toBeVisible();
+        await expect(section.getByLabel('Outbound link tagging')).toBeVisible();
+    });
+
+    test('Hides web analytics toggle when feature flag is disabled', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        labs: {
+                            ...responseFixtures.config.config.labs,
+                            trafficAnalytics: false // Feature flag disabled
                         }
                     }
                 }
@@ -114,7 +178,7 @@ test.describe('Analytics settings', async () => {
 
         await expect(section).toBeVisible();
 
-        // Web analytics toggle should not be present when limit is applied
+        // Web analytics toggle should not be visible when feature flag is disabled
         await expect(section.getByLabel('Web analytics')).not.toBeVisible();
 
         // Other analytics toggles should still be visible
@@ -122,5 +186,149 @@ test.describe('Analytics settings', async () => {
         await expect(section.getByLabel('Newsletter clicks')).toBeVisible();
         await expect(section.getByLabel('Member sources')).toBeVisible();
         await expect(section.getByLabel('Outbound link tagging')).toBeVisible();
+    });
+
+    test('Shows web analytics toggle as disabled when web_analytics_enabled is false', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        labs: {
+                            ...responseFixtures.config.config.labs,
+                            trafficAnalytics: true // Feature flag enabled
+                        }
+                    }
+                }
+            },
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'web_analytics', value: true},
+                        {key: 'web_analytics_enabled', value: false}
+                    ]
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('analytics');
+
+        await expect(section).toBeVisible();
+
+        // Web analytics toggle should be visible but disabled
+        const webAnalyticsToggle = section.getByLabel('Web analytics');
+        await expect(webAnalyticsToggle).toBeVisible();
+        await expect(webAnalyticsToggle).toBeDisabled();
+        
+        // Should show as unchecked when disabled (even if web_analytics setting is true)
+        await expect(webAnalyticsToggle).not.toBeChecked();
+
+        // Should show the hint about additional setup required
+        await expect(section.getByText('Web analytics requires additional setup in your configuration')).toBeVisible();
+    });
+
+    test('Shows web analytics toggle as enabled and respects user setting', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        labs: {
+                            ...responseFixtures.config.config.labs,
+                            trafficAnalytics: true // Feature flag enabled
+                        }
+                    }
+                }
+            },
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'web_analytics', value: true},
+                        {key: 'web_analytics_enabled', value: true}
+                    ]
+                }
+            },
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'web_analytics', value: false}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('analytics');
+
+        await expect(section).toBeVisible();
+
+        // Web analytics toggle should be visible and enabled
+        const webAnalyticsToggle = section.getByLabel('Web analytics');
+        await expect(webAnalyticsToggle).toBeVisible();
+        await expect(webAnalyticsToggle).toBeEnabled();
+        await expect(webAnalyticsToggle).toBeChecked();
+
+        // Should be able to toggle it
+        await webAnalyticsToggle.uncheck();
+        await section.getByRole('button', {name: 'Save'}).click();
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'web_analytics', value: false}
+            ]
+        });
+    });
+
+    test('Cannot toggle web analytics when disabled', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        labs: {
+                            ...responseFixtures.config.config.labs,
+                            trafficAnalytics: true // Feature flag enabled
+                        }
+                    }
+                }
+            },
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'web_analytics', value: false},
+                        {key: 'web_analytics_enabled', value: false}
+                    ]
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('analytics');
+
+        const webAnalyticsToggle = section.getByLabel('Web analytics');
+        
+        // Toggle should be disabled
+        await expect(webAnalyticsToggle).toBeDisabled();
+        
+        // Try to click it (should not work)
+        await webAnalyticsToggle.click({force: true});
+        
+        // Should not show save/cancel buttons since nothing changed
+        await expect(section.getByRole('button', {name: 'Save'})).not.toBeVisible();
     });
 });

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test';
 import {globalDataRequests} from '../../utils/acceptance';
-import {limitRequests, mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+import {mockApi, responseFixtures, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Analytics settings', async () => {
     test('Supports toggling analytics settings', async ({page}) => {

--- a/ghost/admin/app/components/admin-x/posts.js
+++ b/ghost/admin/app/components/admin-x/posts.js
@@ -23,7 +23,7 @@ export default class Posts extends AdminXComponent {
                     emailTrackClicks: this.settings.emailTrackClicks,
                     membersTrackSources: this.settings.membersTrackSources,
                     outboundLinkTagging: this.settings.outboundLinkTagging,
-                    webAnalytics: this.feature.trafficAnalytics && (this.settings.webAnalytics ?? false)
+                    webAnalytics: this.settings.webAnalyticsEnabled // use the computed setting
                 }
             }
         };

--- a/ghost/admin/app/components/admin-x/stats.js
+++ b/ghost/admin/app/components/admin-x/stats.js
@@ -15,7 +15,7 @@ export default class Stats extends AdminXComponent {
                     emailTrackClicks: this.settings.emailTrackClicks,
                     membersTrackSources: this.settings.membersTrackSources,
                     outboundLinkTagging: this.settings.outboundLinkTagging,
-                    webAnalytics: this.feature.trafficAnalytics && (this.settings.webAnalytics ?? false)
+                    webAnalytics: this.settings.webAnalyticsEnabled // use the computed setting
                 }
             }
         };

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -165,7 +165,7 @@
         <div class="gh-post-list-metrics-container">
 
             {{!-- Visitor count column (only when web analytics is enabled) --}}
-            {{#if this.settings.webAnalytics}}
+            {{#if this.settings.webAnalyticsEnabled}}
                 {{#if @post.isPublished}}
                     {{#if this.hasVisitorData}}
                         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -203,7 +203,7 @@
         {{/if}}
 
         {{!-- Visitor count column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
-        {{#if (and this.settings.webAnalytics (feature 'trafficAnalytics'))}}
+        {{#if this.settings.webAnalyticsEnabled}}
             {{#if @post.isPublished}}
                 {{#if this.hasVisitorData}}
                     <div class="permalink gh-list-data gh-post-list-metrics">

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -53,6 +53,7 @@ export default Model.extend(ValidationEngine, {
     announcementContent: attr('string'),
     announcementBackground: attr('string'),
     announcementVisibility: attr('json-string'),
+
     /**
      * Analytics settings
      */
@@ -60,7 +61,8 @@ export default Model.extend(ValidationEngine, {
     emailTrackClicks: attr('boolean'),
     outboundLinkTagging: attr('boolean'),
     membersTrackSources: attr('boolean'),
-    webAnalytics: attr('boolean'),
+    webAnalyticsEnabled: attr('boolean'), // computed setting
+
     /**
      * Members settings
      */

--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -22,7 +22,7 @@ class PostsWithAnalytics extends InfinityModel {
         const promises = [];
         
         // Fetch visitor counts if web analytics is enabled
-        if (this.settings.webAnalytics && this.feature.trafficAnalytics) {
+        if (this.settings.webAnalyticsEnabled) {
             const postUuids = publishedPosts.map(post => post.uuid);
             promises.push(this.postAnalytics.loadVisitorCounts(postUuids));
         }
@@ -77,7 +77,7 @@ export default class PostsRoute extends AuthenticatedRoute {
 
     model(params) {
         // Reset analytics cache every time we load the posts index to ensure fresh data
-        if ((this.settings.webAnalytics && this.feature.trafficAnalytics) || this.settings.membersTrackSources) {
+        if (this.settings.webAnalyticsEnabled || this.settings.membersTrackSources) {
             this.postAnalytics.reset();
         }
 
@@ -164,7 +164,7 @@ export default class PostsRoute extends AuthenticatedRoute {
      */
     async _fetchAnalyticsForPosts(model) {
         // Early return if neither analytics feature is enabled
-        if ((!this.settings.webAnalytics || !this.feature.trafficAnalytics) && !this.settings.membersTrackSources) {
+        if (!this.settings.webAnalyticsEnabled && !this.settings.membersTrackSources) {
             return;
         }
 
@@ -180,7 +180,7 @@ export default class PostsRoute extends AuthenticatedRoute {
         const promises = [];
         
         // Fetch visitor counts if web analytics is enabled
-        if (this.settings.webAnalytics && this.feature.trafficAnalytics) {
+        if (this.settings.webAnalyticsEnabled) {
             const postUuids = posts.map(post => post.uuid);
             promises.push(this.postAnalytics.loadVisitorCounts(postUuids));
         }

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -42,7 +42,7 @@ export default class PostAnalyticsService extends Service {
         }
         
         // Check if web analytics is enabled
-        if (!this.settings.webAnalytics || !this.feature.trafficAnalytics) {
+        if (!this.settings.webAnalyticsEnabled) {
             return Promise.resolve();
         }
         

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -922,9 +922,9 @@ describe('Acceptance: Posts / Pages', function () {
                 await authenticateSession();
             });
 
-            it('hides visitor count column when webAnalytics is disabled', async function () {
-                // Disable webAnalytics setting
-                this.server.db.settings.update({key: 'web_analytics'}, {value: 'false'});
+            it('hides visitor count column when webAnalyticsEnabled is disabled', async function () {
+                // Disable webAnalyticsEnabled setting
+                this.server.db.settings.update({key: 'web_analytics_enabled'}, {value: 'false'});
 
                 await visit('/posts');
 
@@ -933,9 +933,9 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(visitorsText, 'visitor count column').to.not.exist;
             });
 
-            it('shows visitor count column when webAnalytics is enabled and trafficAnalytics feature is enabled', async function () {
-                // Enable webAnalytics setting
-                this.server.db.settings.update({key: 'web_analytics'}, {value: 'true'});
+            it('shows visitor count column when webAnalyticsEnabled is enabled and trafficAnalytics feature is enabled', async function () {
+                // Enable webAnalyticsEnabled setting
+                this.server.db.settings.update({key: 'web_analytics_enabled'}, {value: 'true'});
                 
                 // Enable trafficAnalytics feature flag
                 this.server.db.settings.update({key: 'labs'}, {value: JSON.stringify({trafficAnalytics: true})});
@@ -997,9 +997,9 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(membersText, 'member conversions column').to.not.exist;
             });
 
-            it('shows email analytics columns regardless of webAnalytics and membersTrackSources settings', async function () {
+            it('shows email analytics columns regardless of webAnalyticsEnabled and membersTrackSources settings', async function () {
                 // Disable both analytics settings
-                this.server.db.settings.update({key: 'web_analytics'}, {value: 'false'});
+                this.server.db.settings.update({key: 'web_analytics_enabled'}, {value: 'false'});
                 this.server.db.settings.update({key: 'members_track_sources'}, {value: 'false'});
 
                 await visit('/posts');

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -23,7 +23,7 @@ describe('Unit: Service: post-analytics', function () {
             }
         };
         settingsStub = {
-            webAnalytics: true,
+            webAnalyticsEnabled: true,
             membersTrackSources: true
         };
         const featureStub = {
@@ -48,7 +48,7 @@ describe('Unit: Service: post-analytics', function () {
         });
 
         it('returns early if web analytics is disabled', async function () {
-            settingsStub.webAnalytics = false;
+            settingsStub.webAnalyticsEnabled = false;
             const result = await service.loadVisitorCounts(['uuid1']);
             expect(result).to.be.undefined;
             expect(ajaxStub.called).to.be.false;

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -54,13 +54,6 @@ describe('Unit: Service: post-analytics', function () {
             expect(ajaxStub.called).to.be.false;
         });
 
-        it('returns early if trafficAnalytics feature is disabled', async function () {
-            service.feature.trafficAnalytics = false;
-            const result = await service.loadVisitorCounts(['uuid1']);
-            expect(result).to.be.undefined;
-            expect(ajaxStub.called).to.be.false;
-        });
-
         it('does not fetch already fetched UUIDs', async function () {
             service._fetchedUuids.add('uuid1');
             const result = await service.loadVisitorCounts(['uuid1']);

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_head}}`
 //
 // Outputs scripts and other assets at the top of a Ghost theme
-const {labs, metaData, settingsCache, config, blogIcon, urlUtils, getFrontendKey} = require('../services/proxy');
+const {labs, metaData, settingsCache, config, blogIcon, urlUtils, getFrontendKey, settingsHelpers} = require('../services/proxy');
 const {escapeExpression, SafeString} = require('../services/handlebars');
 const {generateCustomFontCss, isValidCustomFont, isValidCustomHeadingFont} = require('@tryghost/custom-fonts');
 // BAD REQUIRE
@@ -362,9 +362,8 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
             if (!_.isEmpty(tagCodeInjection)) {
                 head.push(tagCodeInjection);
             }
-            const isTbTrackingEnabled = labs.isSet('trafficAnalytics');
-            const hasTbConfig = config.get('tinybird') && config.get('tinybird:tracker');
-            if (isTbTrackingEnabled && hasTbConfig) {
+            // Use settingsHelpers to check if web analytics is enabled (includes all necessary checks)
+            if (settingsHelpers.isWebAnalyticsEnabled()) {
                 head.push(getTinybirdTrackerScript(dataRoot));
                 // Set a flag in response locals to indicate tracking script is being served
                 if (dataRoot._locals) {

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -1,6 +1,7 @@
 // This file contains everything that the helpers and frontend apps require from the core of Ghost
 const settingsCache = require('../../shared/settings-cache');
 const config = require('../../shared/config');
+const settingsHelpers = require('../../server/services/settings-helpers');
 
 // Require from the handlebars framework
 const {SafeString} = require('./handlebars');
@@ -46,6 +47,11 @@ module.exports = {
 
     // TODO: Only expose "get"
     settingsCache: settingsCache,
+
+    // Settings helpers for calculated settings
+    settingsHelpers: {
+        isWebAnalyticsEnabled: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers)
+    },
 
     // TODO: Expose less of the API to make this safe
     api: require('../../server/api').endpoints,

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -285,6 +285,20 @@ class SettingsHelpers {
             return false;
         }
 
+        // Check if web analytics can be configured (limit service and required config)
+        if (!this.isWebAnalyticsConfigured()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if web analytics can be configured (used for UI enable/disable state)
+     * 
+     * @returns {boolean}
+     */
+    isWebAnalyticsConfigured() {
         // Correct config is required
         if (!this._isValidTinybirdConfig()) {
             return false;
@@ -292,7 +306,7 @@ class SettingsHelpers {
 
         // Ghost (Pro) limits
         if (this.limitService.isDisabled('limitAnalytics')) {
-            debug('Web analytics is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
+            debug('Web analytics configuration is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
             return false;
         }
 

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -265,7 +265,67 @@ class SettingsHelpers {
         return true;
     }
 
+    /**
+     * Calculated setting for Web analytics
+     *
+     *  Setting > Labs Flag > Config > Limit Service
+     * 
+     * @returns {boolean}
+     */
+    isWebAnalyticsEnabled() {
+        // UI setting
+        if (this.settingsCache.get('web_analytics') !== true) {
+            debug('Web analytics is disabled in settings');
+            return false;
+        }
+
+        // Labs setting
+        if (!this.labs.isSet('trafficAnalytics')) {
+            debug('Web analytics is disabled in labs');
+            return false;
+        }
+
+        // Correct config is required
+        if (!this._isValidTinybirdConfig()) {
+            return false;
+        }
+
+        // Ghost (Pro) limits
+        if (this.limitService.isDisabled('limitAnalytics')) {
+            debug('Web analytics is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');
+            return false;
+        }
+
+        return true;
+    }
+
     // PRIVATE
+
+    /**
+     * Validates tinybird configuration for web analytics
+     * @returns {boolean} True if config is valid, false otherwise
+     * @private
+     */
+    _isValidTinybirdConfig() {
+        const tinybirdConfig = this.config.get('tinybird');
+        
+        // First requirement: tinybird:tracker:endpoint is always required
+        if (!tinybirdConfig || !tinybirdConfig.tracker?.endpoint) {
+            debug('Web analytics is not available without tinybird:tracker:endpoint');
+            return false;
+        }
+
+        // Second requirement: Either JWT config OR local stats config
+        const hasJwtConfig = !!(tinybirdConfig.workspaceId && tinybirdConfig.adminToken);
+        const hasLocalConfig = !!(tinybirdConfig.stats?.local?.enabled);
+        
+        if (!hasJwtConfig && !hasLocalConfig) {
+            debug('Web analytics requires either (workspaceId + adminToken) or stats.local.enabled');
+            return false;
+        }
+
+        return true;
+    }
 
     #managedEmailEnabled() {
         return !!this.config.get('hostSettings:managedEmail:enabled');

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -109,6 +109,9 @@ module.exports = {
         // Social web (ActivityPub)
         fields.push(new CalculatedField({key: 'social_web_enabled', type: 'boolean', group: 'social_web', fn: settingsHelpers.isSocialWebEnabled.bind(settingsHelpers), dependents: ['social_web', 'labs']}));
 
+        // Web analytics
+        fields.push(new CalculatedField({key: 'web_analytics_enabled', type: 'boolean', group: 'analytics', fn: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers), dependents: ['web_analytics', 'labs']}));
+
         return fields;
     },
 

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -111,6 +111,7 @@ module.exports = {
 
         // Web analytics
         fields.push(new CalculatedField({key: 'web_analytics_enabled', type: 'boolean', group: 'analytics', fn: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers), dependents: ['web_analytics', 'labs']}));
+        fields.push(new CalculatedField({key: 'web_analytics_configured', type: 'boolean', group: 'analytics', fn: settingsHelpers.isWebAnalyticsConfigured.bind(settingsHelpers), dependents: ['web_analytics']}));
 
         return fields;
     },

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -245,8 +245,7 @@ class StatsService {
         const request = deps.request || require('../../lib/request-external');
         const settingsCache = deps.settingsCache || require('../../../shared/settings-cache');
 
-        // Only create the client if Tinybird is configured
-        if (config.get('tinybird') && config.get('tinybird:stats')) {
+        if (settingsCache.get('web_analytics_enabled')) {
             // TODO: move the tinybird client to the tinybird service
             const TinybirdServiceWrapper = require('../tinybird');
             TinybirdServiceWrapper.init();

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -44,6 +44,33 @@ const jwt = require('jsonwebtoken');
  * @property {TinybirdScope[]} scopes - Array of permission scopes
  */
 
+/**
+ * Validates tinybird configuration
+ * @param {TinybirdConfig} tinybirdConfig - The tinybird configuration object
+ * @returns {{isValid: boolean, reason?: string}} Validation result with optional reason for failure
+ */
+function validateTinybirdConfig(tinybirdConfig) {
+    if (!tinybirdConfig) {
+        return {
+            isValid: false,
+            reason: 'Missing tinybird configuration'
+        };
+    }
+
+    // Either JWT config OR local stats config is required
+    const hasJwtConfig = !!(tinybirdConfig.workspaceId && tinybirdConfig.adminToken);
+    const hasLocalConfig = !!(tinybirdConfig.stats?.local?.enabled);
+    
+    if (!hasJwtConfig && !hasLocalConfig) {
+        return {
+            isValid: false,
+            reason: 'Requires either (workspaceId + adminToken) or stats.local.enabled'
+        };
+    }
+
+    return {isValid: true};
+}
+
 const TINYBIRD_PIPES = [
     'api_kpis',
     'api_active_visitors',
@@ -165,6 +192,15 @@ class TinybirdService {
         } catch (error) {
             return true;
         }
+    }
+
+    /**
+     * Validates tinybird configuration
+     * @param {TinybirdConfig} tinybirdConfig - The tinybird configuration object
+     * @returns {{isValid: boolean, reason?: string}} Validation result with optional reason for failure
+     */
+    static validateConfig(tinybirdConfig) {
+        return validateTinybirdConfig(tinybirdConfig);
     }
 }
 

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -44,33 +44,6 @@ const jwt = require('jsonwebtoken');
  * @property {TinybirdScope[]} scopes - Array of permission scopes
  */
 
-/**
- * Validates tinybird configuration
- * @param {TinybirdConfig} tinybirdConfig - The tinybird configuration object
- * @returns {{isValid: boolean, reason?: string}} Validation result with optional reason for failure
- */
-function validateTinybirdConfig(tinybirdConfig) {
-    if (!tinybirdConfig) {
-        return {
-            isValid: false,
-            reason: 'Missing tinybird configuration'
-        };
-    }
-
-    // Either JWT config OR local stats config is required
-    const hasJwtConfig = !!(tinybirdConfig.workspaceId && tinybirdConfig.adminToken);
-    const hasLocalConfig = !!(tinybirdConfig.stats?.local?.enabled);
-    
-    if (!hasJwtConfig && !hasLocalConfig) {
-        return {
-            isValid: false,
-            reason: 'Requires either (workspaceId + adminToken) or stats.local.enabled'
-        };
-    }
-
-    return {isValid: true};
-}
-
 const TINYBIRD_PIPES = [
     'api_kpis',
     'api_active_visitors',

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -193,15 +193,6 @@ class TinybirdService {
             return true;
         }
     }
-
-    /**
-     * Validates tinybird configuration
-     * @param {TinybirdConfig} tinybirdConfig - The tinybird configuration object
-     * @returns {{isValid: boolean, reason?: string}} Validation result with optional reason for failure
-     */
-    static validateConfig(tinybirdConfig) {
-        return validateTinybirdConfig(tinybirdConfig);
-    }
 }
 
 module.exports = TinybirdService;

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -63,6 +63,7 @@ const _ = require('lodash');
  * @property {string|null} labs - JSON string of enabled labs features
  * @property {boolean|null} social_web_enabled - Whether social web is enabled
  * @property {boolean|null} web_analytics_enabled - Whether web analytics is enabled
+ * @property {boolean|null} web_analytics_configured - Whether web analytics is configured
  * @property {never} [x] - Prevent accessing undefined properties
  */
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -62,6 +62,7 @@ const _ = require('lodash');
  * @property {string|null} editor_default_email_recipients - Default email recipients for editor
  * @property {string|null} labs - JSON string of enabled labs features
  * @property {boolean|null} social_web_enabled - Whether social web is enabled
+ * @property {boolean|null} web_analytics_enabled - Whether web analytics is enabled
  * @property {never} [x] - Prevent accessing undefined properties
  */
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -364,6 +364,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1171,6 +1175,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1553,6 +1561,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1932,6 +1944,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -2778,6 +2794,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3160,6 +3180,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3540,6 +3564,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -3928,6 +3956,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -4307,6 +4339,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -4693,6 +4729,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -5445,6 +5485,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -5825,6 +5869,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -6210,6 +6258,10 @@ Object {
       "key": "social_web_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
   ],
 }
 `;
@@ -6591,6 +6643,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],
@@ -7036,6 +7092,10 @@ Object {
     },
     Object {
       "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
       "value": false,
     },
   ],

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -368,6 +368,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1179,6 +1183,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1565,6 +1573,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -1948,6 +1960,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -2798,6 +2814,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3184,6 +3204,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -3568,6 +3592,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -3960,6 +3988,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -4343,6 +4375,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -4733,6 +4769,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -5489,6 +5529,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -5873,6 +5917,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -6262,6 +6310,10 @@ Object {
       "key": "web_analytics_enabled",
       "value": false,
     },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
   ],
 }
 `;
@@ -6647,6 +6699,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],
@@ -7096,6 +7152,10 @@ Object {
     },
     Object {
       "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
       "value": false,
     },
   ],

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -9,7 +9,7 @@ const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
-const CURRENT_SETTINGS_COUNT = 91;
+const CURRENT_SETTINGS_COUNT = 92;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -9,7 +9,7 @@ const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
-const CURRENT_SETTINGS_COUNT = 90;
+const CURRENT_SETTINGS_COUNT = 91;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -1733,6 +1733,58 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script in preview context 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"robots\\" content=\\"noindex,nofollow\\">
+    <meta name=\\"referrer\\" content=\\"same-origin\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when neither trafficAnalytics nor trafficAnalyticsTracking is set 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
@@ -1811,6 +1863,57 @@ Object {
 `;
 
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when trafficAnalytics is not set 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set does not include tracker script when web analytics is not enabled 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
@@ -2220,12 +2323,63 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script when trafficAnalyticsTracking is set 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
 }
 `;
 
-exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script when trafficAnalyticsTracking is set 1 1`] = `
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set includes tracker script when web analytics is enabled 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2162/
- limit service, config, flag, and setting are all now routed through a SettingsHelper tag as a calculated field
- frontend now disables the setting when config or limit service are disabling it
- labs setting disables the functionality in the background AND hides the setting in the frontend