### PR TITLE
Removed Network and Explore search keywords

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
@@ -9,19 +9,15 @@ import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 
 export const searchKeywords5x = {
-    network: ['network', 'social web', 'social', 'web', 'activitypub', 'activity pub', 'fediverse', 'federated'],
-    tips: ['growth', 'tips', 'donations', 'one time', 'payment'],
-    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
     recommendations: ['growth', 'recommendations', 'recommend', 'blogroll'],
-    offers: ['growth', 'offers', 'discounts', 'coupons', 'promotions']
+    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
+    offers: ['growth', 'offers', 'discounts', 'coupons', 'promotions'],
+    tips: ['growth', 'tips', 'donations', 'one time', 'payment']
 };
 
 export const searchKeywords = {
-    network: ['network', 'social web', 'social', 'web', 'activitypub', 'activity pub', 'fediverse', 'federated'],
-    explore: ['explore', 'web', 'social', 'web', 'growth', 'list'],
-    tips: ['growth', 'tips', 'donations', 'one time', 'payment'],
-    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
     recommendations: ['growth', 'recommendations', 'recommend', 'blogroll'],
+    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
     offers: ['growth', 'offers', 'discounts', 'coupons', 'promotions']
 };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2209/settings-ui-changes

The Network and Explore keywords for settings search is a leftover from a previous version of the 6.0 UI changes. They return empty results for search, therefore they are unnecessary (and confusing) until these sections actually exist in settings. 

Also changed the order of keywords to match the UI (it's just for easier readability, no functional change).
