### PR TITLE
 Added server-side limit validations for custom theme installations

### DIFF
--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -272,16 +272,80 @@ const mockLabsDisabled = (flag, alpha = true) => {
 
 const mockLimitService = (limit, options) => {
     if (!mocks.limitService) {
-        mocks.limitService = sinon.stub(limitService);
+        mocks.limitService = {
+            isLimited: sinon.stub(limitService, 'isLimited'),
+            checkWouldGoOverLimit: sinon.stub(limitService, 'checkWouldGoOverLimit'),
+            errorIfWouldGoOverLimit: sinon.stub(limitService, 'errorIfWouldGoOverLimit'),
+            originalLimits: limitService.limits || {},
+            mockedLimits: new Set() // Track which limits we've mocked
+        };
     }
 
     mocks.limitService.isLimited.withArgs(limit).returns(options.isLimited);
     mocks.limitService.checkWouldGoOverLimit.withArgs(limit).resolves(options.wouldGoOverLimit);
+
+    // Mock the limits property for checking allowlist
+    if (!limitService.limits) {
+        limitService.limits = {};
+    }
+    limitService.limits[limit] = {
+        allowlist: options.allowlist || []
+    };
+    mocks.limitService.mockedLimits.add(limit); // Track this limit
+
+    // If errorIfWouldGoOverLimit is true, reject with HostLimitError
+    if (options.errorIfWouldGoOverLimit === true) {
+        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit, sinon.match.any).rejects(
+            new errors.HostLimitError({
+                message: `Upgrade to use ${limit} feature.`
+            })
+        );
+    } else {
+        // Otherwise, resolve normally
+        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit, sinon.match.any).resolves();
+    }
+};
+
+const restoreLimitService = () => {
+    if (mocks.limitService) {
+        if (mocks.limitService.isLimited) {
+            mocks.limitService.isLimited.restore();
+        }
+        if (mocks.limitService.checkWouldGoOverLimit) {
+            mocks.limitService.checkWouldGoOverLimit.restore();
+        }
+        if (mocks.limitService.errorIfWouldGoOverLimit) {
+            mocks.limitService.errorIfWouldGoOverLimit.restore();
+        }
+
+        // Remove any limits we mocked
+        if (mocks.limitService.mockedLimits && limitService.limits) {
+            for (const limit of mocks.limitService.mockedLimits) {
+                delete limitService.limits[limit];
+            }
+        }
+
+        // If limits object is now empty and was originally empty, restore it
+        if (mocks.limitService.originalLimits !== undefined) {
+            if (Object.keys(mocks.limitService.originalLimits).length === 0 &&
+                limitService.limits && Object.keys(limitService.limits).length === 0) {
+                limitService.limits = mocks.limitService.originalLimits;
+            }
+        }
+
+        delete mocks.limitService;
+    }
 };
 
 const restore = () => {
     // eslint-disable-next-line no-console
     configUtils.restore().catch(console.error);
+
+    // Restore limit service limits if we mocked them
+    if (mocks.limitService && mocks.limitService.originalLimits) {
+        limitService.limits = mocks.limitService.originalLimits;
+    }
+
     sinon.restore();
     mocks = {};
     fakedLabsFlags = {};
@@ -316,6 +380,7 @@ module.exports = {
     mockWebhookRequests,
     mockSetting,
     mockLimitService,
+    restoreLimitService,
     disableNetwork,
     restore,
     stripeMocker,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BAE-330/ghost-implement-server-side-limit-validations

The new `customThemes` limit will include a subset of official themes in its allowlist. This required updating the theme installation logic to properly validate both TryGhost and third-party repositories against the configured limits. Enhanced the limit validation in `installer.js` to check ALL theme installations (including TryGhost repos) when the `customThemes` allowlist contains only one theme. The logic uses `limitService.errorIfWouldGoOverLimit()` to enforce restrictions based on the allowlist configuration.

The `mockLimitService` in our test suite had critical issues that prevented proper testing. It was using `sinon.stub(limitService)`, which didn't properly stub the methods, causing tests to fail as soon as the `mockLimitService` was imported. Additionally, the global `restore()` function called `sinon.restore() `, which destroyed ALL stubs across the test suite, breaking unrelated tests that created their own stubs.

Fixed this by making `mockLimitService` stub individual methods instead of the entire object. Created a new `restoreLimitService()` function that only cleans up limit-related stubs and properly removes mocked limits from `limitService.limits`, preventing test contamination without affecting other tests' stubs.