### PR TITLE
Fixed white list text in CTA cards with dark newsletter background

### DIFF
--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -1301,6 +1301,17 @@ class EmailRenderer {
             linkStyle,
             hasOutlineButtons,
 
+            // useful data
+            ctaBgColors: [
+                'grey',
+                'blue',
+                'green',
+                'yellow',
+                'red',
+                'pink',
+                'purple'
+            ],
+
             classes: {
                 container: clsx('container', {
                     'title-serif': titleFont === 'serif'

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -381,6 +381,17 @@ h6 + .kg-paywall .kg-paywall-hr td {
 }
 
 /* Exclude CTA cards with colored backgrounds from custom text color, but allow transparent ones */
+{{#hasFeature "emailCustomization"}}
+{{#each ctaBgColors}}
+.post-content-row .kg-cta-bg-{{this}} .kg-cta-text p,
+.post-content-row .kg-cta-bg-{{this}} .kg-cta-text ul,
+.post-content-row .kg-cta-bg-{{this}} .kg-cta-text ul li,
+.post-content-row .kg-cta-bg-{{this}} .kg-cta-text ol,
+.post-content-row .kg-cta-bg-{{this}} .kg-cta-text ol li {
+    color: inherit !important;
+}
+{{/each}}
+{{else}}
 .post-content-row .kg-cta-bg-grey .kg-cta-text p,
 .post-content-row .kg-cta-bg-blue .kg-cta-text p,
 .post-content-row .kg-cta-bg-green .kg-cta-text p,
@@ -390,6 +401,7 @@ h6 + .kg-paywall .kg-paywall-hr td {
 .post-content-row .kg-cta-bg-purple .kg-cta-text p {
     color: inherit !important;
 }
+{{/hasFeature}}
 
 .kg-cta-bg-none .kg-cta-sponsor-label span,
 .kg-cta-bg-white .kg-cta-sponsor-label span {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2217,6 +2217,19 @@ describe('Email renderer', function () {
             assert.equal(data.accentContrastColor, '#FFFFFF');
         });
 
+        it('Includes list of cta background colors', async function () {
+            const data = await templateDataWithSettings({});
+            assert.deepEqual(data.ctaBgColors, [
+                'grey',
+                'blue',
+                'green',
+                'yellow',
+                'red',
+                'pink',
+                'purple'
+            ]);
+        });
+
         it('Uses the correct background colors based on settings', async function () {
             const tests = [
                 {input: 'Invalid Color', expected: '#ffffff'},


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2265/

- giving specific colors to lists to fix mismatched bullet colors in Outlook meant that lists in CTA cards were no longer using the correct color
- added explicit overrides for fixed-color CTA backgrounds to ensure lists and list items inherit the color specific for the card rather than color used for general text
- added `ctaBgColors` array to our template data properties so we can loop over them to keep the template easier to manage
