### PR TITLE
🐛 Fixed white lists in CTA cards when newsletter has dark background

### DIFF
--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -381,7 +381,6 @@ h6 + .kg-paywall .kg-paywall-hr td {
 }
 
 /* Exclude CTA cards with colored backgrounds from custom text color, but allow transparent ones */
-{{#hasFeature "emailCustomization"}}
 {{#each ctaBgColors}}
 .post-content-row .kg-cta-bg-{{this}} .kg-cta-text p,
 .post-content-row .kg-cta-bg-{{this}} .kg-cta-text ul,
@@ -391,17 +390,6 @@ h6 + .kg-paywall .kg-paywall-hr td {
     color: inherit !important;
 }
 {{/each}}
-{{else}}
-.post-content-row .kg-cta-bg-grey .kg-cta-text p,
-.post-content-row .kg-cta-bg-blue .kg-cta-text p,
-.post-content-row .kg-cta-bg-green .kg-cta-text p,
-.post-content-row .kg-cta-bg-yellow .kg-cta-text p,
-.post-content-row .kg-cta-bg-red .kg-cta-text p,
-.post-content-row .kg-cta-bg-pink .kg-cta-text p,
-.post-content-row .kg-cta-bg-purple .kg-cta-text p {
-    color: inherit !important;
-}
-{{/hasFeature}}
 
 .kg-cta-bg-none .kg-cta-sponsor-label span,
 .kg-cta-bg-white .kg-cta-sponsor-label span {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2265/
ref https://github.com/TryGhost/Ghost/pull/24322

- removed feature flag around the style fixes
  - giving specific colors to lists to fix mismatched bullet colors in Outlook meant that lists in CTA cards were no longer using the correct color
  - added explicit overrides for fixed-color CTA backgrounds to ensure lists and list items inherit the color specific for the card rather than color used for general text
  - added `ctaBgColors` array to our template data properties so we can loop over them to keep the template easier to manage
