### PR TITLE
Updated explore payload to provide active_theme

### DIFF
--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -1,7 +1,7 @@
 module.exports = class ExplorePingService {
     /**
      * @param {object} deps
-     * @param {{getPublic: () => import('../../../shared/settings-cache/CacheManager').PublicSettingsCache}} deps.settingsCache
+     * @param {{get: (key: string) => string}} deps.settingsCache
      * @param {object} deps.config
      * @param {object} deps.labs
      * @param {object} deps.logging
@@ -28,9 +28,6 @@ module.exports = class ExplorePingService {
     }
 
     async constructPayload() {
-        /* eslint-disable camelcase */
-        const {title, description, icon, locale, accent_color, twitter, facebook, site_uuid} = this.settingsCache.getPublic();
-
         // Get post statistics
         const [totalPosts, lastPublishedAt, firstPublishedAt] = await Promise.all([
             this.posts.stats.getTotalPostsPublished(),
@@ -52,15 +49,16 @@ module.exports = class ExplorePingService {
 
         return {
             ghost: this.ghostVersion.full,
-            site_uuid,
             url: this.config.get('url'),
-            title,
-            description,
-            icon,
-            locale,
-            accent_color,
-            twitter,
-            facebook,
+            site_uuid: this.settingsCache.get('site_uuid'),
+            title: this.settingsCache.get('title'),
+            description: this.settingsCache.get('description'),
+            icon: this.settingsCache.get('icon'),
+            locale: this.settingsCache.get('locale'),
+            accent_color: this.settingsCache.get('accent_color'),
+            twitter: this.settingsCache.get('twitter'),
+            facebook: this.settingsCache.get('facebook'),
+            theme: this.settingsCache.get('active_theme'),
             posts_first: firstPublishedAt ? firstPublishedAt.toISOString() : null,
             posts_last: lastPublishedAt ? lastPublishedAt.toISOString() : null,
             posts_total: totalPosts,

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -16,35 +16,18 @@ describe('ExplorePingService', function () {
     beforeEach(function () {
         // Setup stubs
         settingsCacheStub = {
-            getPublic: sinon.stub().returns({
-                title: 'Test Blog',
-                description: 'Test Description',
-                icon: 'icon.png',
-                accent_color: '#000000',
-                lang: 'en',
-                timezone: 'Etc/UTC',
-                navigation: JSON.stringify([]),
-                secondary_navigation: JSON.stringify([]),
-                meta_title: null,
-                meta_description: null,
-                og_image: null,
-                og_title: null,
-                og_description: null,
-                twitter_image: null,
-                twitter_title: null,
-                twitter_description: null,
-                active_theme: 'casper',
-                cover_image: null,
-                logo: null,
-                portal_button: true,
-                portal_name: true,
-                locale: 'en',
-                twitter: '@test',
-                facebook: 'testfb',
-                labs: JSON.stringify({}),
-                site_uuid: '123e4567-e89b-12d3-a456-426614174000'
-            })
+            get: sinon.stub()
         };
+
+        settingsCacheStub.get.withArgs('title').returns('Test Blog');
+        settingsCacheStub.get.withArgs('description').returns('Test Description');
+        settingsCacheStub.get.withArgs('icon').returns('icon.png');
+        settingsCacheStub.get.withArgs('accent_color').returns('#000000');
+        settingsCacheStub.get.withArgs('locale').returns('en');
+        settingsCacheStub.get.withArgs('twitter').returns('@test');
+        settingsCacheStub.get.withArgs('facebook').returns('testfb');
+        settingsCacheStub.get.withArgs('active_theme').returns('casper');
+        settingsCacheStub.get.withArgs('site_uuid').returns('123e4567-e89b-12d3-a456-426614174000');
 
         configStub = {
             get: sinon.stub()
@@ -113,6 +96,7 @@ describe('ExplorePingService', function () {
                 locale: 'en',
                 twitter: '@test',
                 facebook: 'testfb',
+                theme: 'casper',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z',
@@ -138,10 +122,7 @@ describe('ExplorePingService', function () {
 
         // test that the payload is correct if the timezone is not UTC
         it('returns correct payload if the timezone is not UTC', async function () {
-            settingsCacheStub.getPublic.returns({
-                ...settingsCacheStub.getPublic(),
-                timezone: 'America/New_York'
-            });
+            settingsCacheStub.get.withArgs('timezone').returns('America/New_York');
 
             const payload = await explorePingService.constructPayload();
             assert.equal(payload.posts_first, '2020-01-01T00:00:00.000Z');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- We want to provide the active_theme to explore
- This moves us away from being able to use getPublic() as this isn't public info
- Therefore I've changed the explore service to use the get() method so that the code is consistent, rather than using two different ways to access settings


