### PR TITLE
Added webhook for post update, delete and unpublish

### DIFF
--- a/ghost/core/core/server/services/activitypub/ActivityPubService.ts
+++ b/ghost/core/core/server/services/activitypub/ActivityPubService.ts
@@ -25,12 +25,32 @@ export class ActivityPubService {
     ) {}
 
     getExpectedWebhooks(secret: string): ExpectedWebhook[] {
-        return [{
-            event: 'post.published',
-            target_url: new URL('.ghost/activitypub/v1/webhooks/post/published', this.siteUrl),
-            api_version: 'v5.100.0',
-            secret
-        }];
+        return [
+            {
+                event: 'post.published',
+                target_url: new URL('.ghost/activitypub/v1/webhooks/post/published', this.siteUrl),
+                api_version: 'v5.100.0',
+                secret
+            },
+            {
+                event: 'post.deleted',
+                target_url: new URL('.ghost/activitypub/v1/webhooks/post/deleted', this.siteUrl),
+                api_version: 'v5.100.0',
+                secret
+            },
+            {
+                event: 'post.unpublished',
+                target_url: new URL('.ghost/activitypub/v1/webhooks/post/unpublished', this.siteUrl),
+                api_version: 'v5.100.0',
+                secret
+            },
+            {
+                event: 'post.published.edited',
+                target_url: new URL('.ghost/activitypub/v1/webhooks/post/updated', this.siteUrl),
+                api_version: 'v5.100.0',
+                secret
+            }
+        ];
     }
 
     async checkWebhookState(expectedWebhooks: ExpectedWebhook[], integration: {id: string}) {

--- a/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
+++ b/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
@@ -108,7 +108,7 @@ describe('ActivityPubService', function () {
 
         const webhooks = await knexInstance.select('*').from('webhooks');
 
-        const expectedWebhookCount = 1;
+        const expectedWebhookCount = 4;
         const expectedWebhookSecret = 'webhook_secret_baby!!';
         const expectedWebhookIntegrationId = 'integration_id';
 
@@ -154,7 +154,7 @@ describe('ActivityPubService', function () {
 
         const webhooks = await knexInstance.select('*').from('webhooks');
 
-        const expectedWebhookCount = 1;
+        const expectedWebhookCount = 4;
         const expectedWebhookSecret = 'webhook_secret_baby!!';
         const expectedWebhookIntegrationId = 'integration_id';
 
@@ -213,7 +213,7 @@ describe('ActivityPubService', function () {
 
         const webhooks = await knexInstance.select('*').from('webhooks');
 
-        const expectedWebhookCount = 1;
+        const expectedWebhookCount = 4;
         const expectedWebhookSecret = 'webhook_secret_baby!!';
         const expectedWebhookIntegrationId = 'integration_id';
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2288/

- We want to use these post update, delete and unpublished events in AP to edit/delete a post in user's feed when a post is changed in Ghost admin