### PR TITLE
Added settings to DB for explore ping service

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.130/2025-07-11-14-14-54-add-explore-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.130/2025-07-11-14-14-54-add-explore-settings.js
@@ -1,0 +1,16 @@
+const {combineTransactionalMigrations, addSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addSetting({
+        key: 'explore_ping',
+        value: 'true',
+        type: 'boolean',
+        group: 'explore'
+    }),
+    addSetting({
+        key: 'explore_ping_growth',
+        value: 'true',
+        type: 'boolean',
+        group: 'explore'
+    })
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -628,5 +628,23 @@
             },
             "type": "boolean"
         }
+    },
+    "explore": {
+        "explore_ping": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        },
+        "explore_ping_growth": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        }
     }
 }

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 93;
+            const allowedKeysLength = 95;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99566c8c6b729dd1c516bba432a6e1a2';
     const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
-    const currentSettingsHash = 'eaaa5c08731c598ed6eb452c9ccd0470';
+    const currentSettingsHash = 'd851807432a6f065e4ae223cdb4e64d9';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- We're building out a new explore feature that receives pings from Ghost
- These settings will allow users to opt out, with additional control over whether growth data is shared or not
