### PR TITLE
Updated explore ping growth setting to be opt-in

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.130/2025-07-11-14-14-54-add-explore-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.130/2025-07-11-14-14-54-add-explore-settings.js
@@ -9,7 +9,7 @@ module.exports = combineTransactionalMigrations(
     }),
     addSetting({
         key: 'explore_ping_growth',
-        value: 'true',
+        value: 'false',
         type: 'boolean',
         group: 'explore'
     })

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -639,7 +639,7 @@
             "type": "boolean"
         },
         "explore_ping_growth": {
-            "defaultValue": "true",
+            "defaultValue": "false",
             "validations": {
                 "isEmpty": false,
                 "isIn": [["true", "false"]]

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99566c8c6b729dd1c516bba432a6e1a2';
     const currentFixturesHash = '6bf2ddb58d65ed64dc976fac4c3c2e87';
-    const currentSettingsHash = 'd851807432a6f065e4ae223cdb4e64d9';
+    const currentSettingsHash = 'db4cf51bfcb74c64b29c0128d549c744';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2286/settings-ui

- I missed the fact that although the top level setting is meant to be opt-out
- The growth setting should be opt-in

