### PR TITLE
Added explore settings to API fully

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -78,7 +78,9 @@ const EDITABLE_SETTINGS = [
     'heading_font',
     'blocked_email_domains',
     'require_email_mfa',
-    'social_web'
+    'social_web',
+    'explore_ping',
+    'explore_ping_growth'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-group-mapper.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-group-mapper.js
@@ -48,7 +48,9 @@ const keyGroupMapping = {
     portal_name: 'portal',
     portal_button: 'portal',
     portal_plans: 'portal',
-    require_email_mfa: 'security'
+    require_email_mfa: 'security',
+    explore_ping: 'explore',
+    explore_ping_growth: 'explore'
 };
 
 const mapKeyToGroup = (key) => {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-type-mapper.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/settings-key-type-mapper.js
@@ -55,7 +55,9 @@ const keyTypeMapping = {
     labs: 'object',
     unsplash: 'object',
     bulk_email_settings: 'object',
-    require_email_mfa: 'boolean'
+    require_email_mfa: 'boolean',
+    explore_ping: 'boolean',
+    explore_ping_growth: 'boolean'
 };
 
 const mapKeyToType = (key) => {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -325,6 +325,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -1140,6 +1148,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -1530,6 +1546,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -1916,6 +1940,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -2771,6 +2803,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -3161,6 +3201,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -3548,6 +3596,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -3945,6 +4001,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -4331,6 +4395,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -4725,6 +4797,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -5486,6 +5566,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -5873,6 +5961,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -6267,6 +6363,14 @@ Object {
       "value": false,
     },
     Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -6655,6 +6759,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {
@@ -7108,6 +7220,14 @@ Object {
     },
     Object {
       "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
       "value": false,
     },
     Object {

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -9,7 +9,7 @@ const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
-const CURRENT_SETTINGS_COUNT = 92;
+const CURRENT_SETTINGS_COUNT = 94;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/legacy/models/model_settings.test.js
+++ b/ghost/core/test/legacy/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 96;
+const SETTINGS_LENGTH = 98;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -604,5 +604,23 @@
             },
             "type": "boolean"
         }
+    },
+    "explore": {
+        "explore_ping": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        },
+        "explore_ping_growth": {
+            "defaultValue": "false",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        }
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore?filter=eyJhbmQiOlt7InN0YXRlIjp7InR5cGUiOnsiaW4iOlsic3RhcnRlZCIsInVuc3RhcnRlZCIsImJhY2tsb2ciLCJ0cmlhZ2UiXX19fV19

- Updating the input serializers ensures the setting works in the API as expected
- Really there should be an output serializer to update as well
- And I also think the API tests for settings should work off the live defaults
- Nonetheless, with the current state of things, this is the minimum changes we need for right now

