### PR TITLE
🐛 Fixed loading of staff profile from /edit with >100 staff

### DIFF
--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -1,5 +1,5 @@
 import {InfiniteData} from '@tanstack/react-query';
-import {Meta, createInfiniteQuery, createMutation} from '../utils/api/hooks';
+import {Meta, createInfiniteQuery, createMutation, createQueryWithId} from '../utils/api/hooks';
 import {deleteFromQueryCache, updateQueryCache} from '../utils/api/updateQueries';
 import {usersDataType} from './currentUser';
 import {UserRole} from './roles';
@@ -94,6 +94,12 @@ export const useBrowseUsers = createInfiniteQuery<UsersResponseType & {isEnd: bo
     }
 });
 
+export const useGetUserBySlug = createQueryWithId<UsersResponseType>({
+    dataType,
+    path: slug => `/users/slug/${slug}/`,
+    defaultSearchParams: {include: 'roles'}
+});
+
 export const useEditUser = createMutation<UsersResponseType, User>({
     method: 'PUT',
     path: user => `/users/${user.id}/`,
@@ -155,7 +161,7 @@ export function isAdminUser(user: User) {
 }
 
 export function isEditorUser(user: User) {
-    const isAnyEditor = user.roles.some(role => role.name === 'Editor') 
+    const isAnyEditor = user.roles.some(role => role.name === 'Editor')
         || user.roles.some(role => role.name === 'Super Editor');
     return isAnyEditor;
 }

--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -1,7 +1,7 @@
 import EmailNotificationsTab from './users/EmailNotificationsTab';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ProfileTab from './users/ProfileTab';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import SocialLinksTab from './users/SocialLinksTab';
 import clsx from 'clsx';
 import usePinturaEditor from '../../../hooks/usePinturaEditor';
@@ -12,7 +12,7 @@ import {ConfirmationModal, Heading, Icon, ImageUpload, LimitModal, Menu, MenuIte
 import {ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
-import {User, canAccessSettings, hasAdminAccess, isAdminUser, isAuthorOrContributor, isEditorUser, isOwnerUser, useDeleteUser, useEditUser, useMakeOwner} from '@tryghost/admin-x-framework/api/users';
+import {User, canAccessSettings, hasAdminAccess, isAdminUser, isAuthorOrContributor, isEditorUser, isOwnerUser, useDeleteUser, useEditUser, useGetUserBySlug, useMakeOwner} from '@tryghost/admin-x-framework/api/users';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 import {validateBlueskyUrl, validateFacebookUrl, validateInstagramUrl, validateLinkedInUrl, validateMastodonUrl, validateThreadsUrl, validateTikTokUrl, validateTwitterUrl, validateYouTubeUrl} from '../../../utils/socialUrls/index';
@@ -401,7 +401,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     const coverButtonClasses = 'flex flex-nowrap items-center justify-center px-3 h-8 opacity-80 hover:opacity-100 bg-[rgba(0,0,0,0.75)] rounded text-sm text-white transition-all cursor-pointer font-medium nowrap';
 
     const suspendedText = formState.status === 'inactive' ? ' (Suspended)' : '';
-    
+
     const [selectedTab, setSelectedTab] = useState<string>('profile');
 
     return (
@@ -424,7 +424,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         >
             <div>
                 <div className={`relative ${canAccessSettings(currentUser) ? '-mx-8 -mt-8 rounded-t' : '-mx-10 -mt-10'}`}>
-                    <div className={`flex flex-wrap items-end justify-between gap-8 p-8 ${formState.cover_image ? 'bg-cover bg-center' : ''} ${!canAccessSettings(currentUser) && 'min-h-[30vmin]'}`} 
+                    <div className={`flex flex-wrap items-end justify-between gap-8 p-8 ${formState.cover_image ? 'bg-cover bg-center' : ''} ${!canAccessSettings(currentUser) && 'min-h-[30vmin]'}`}
                         style={{
                             backgroundImage: formState.cover_image ? `url(${formState.cover_image})` : 'none'
                         }}>
@@ -555,15 +555,19 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
 };
 
 const UserDetailModal: React.FC<RoutingModalProps> = ({params}) => {
-    const {users, hasNextPage, fetchNextPage} = useStaffUsers();
     const {currentUser} = useGlobalData();
-    const user = currentUser.slug === params?.slug ? currentUser : users.find(({slug}) => slug === params?.slug);
 
-    useEffect(() => {
-        if (!user && hasNextPage) {
-            fetchNextPage();
-        }
-    }, [fetchNextPage, hasNextPage, user]);
+    // Skip API call if it's the current user (we already have their data)
+    const isCurrentUser = currentUser.slug === params?.slug;
+
+    // Fetch user by slug if it's not the current user
+    const {data: fetchedUserData} = useGetUserBySlug(
+        params?.slug || '',
+        {enabled: !isCurrentUser && !!params?.slug}
+    );
+
+    // Use current user data or fetched user data
+    const user = isCurrentUser ? currentUser : fetchedUserData?.users?.[0];
 
     if (user) {
         return <UserDetailModalContent user={user} />;

--- a/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
@@ -8,6 +8,9 @@ test.describe('User actions', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -47,17 +50,20 @@ test.describe('User actions', async () => {
     });
 
     test('Supports un-suspending a user', async ({page}) => {
-        const userToEdit = responseFixtures.users.users.find(user => user.email === 'author@test.com')!;
+        const userToEdit = {
+            ...responseFixtures.users.users.find(user => user.email === 'author@test.com'),
+            status: 'inactive'
+        };
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: {
                 users: [
                     ...responseFixtures.users.users.filter(user => user.email !== 'author@test.com'),
-                    {
-                        ...userToEdit,
-                        status: 'inactive'
-                    }
+                    userToEdit
                 ]
             }},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
@@ -104,6 +110,9 @@ test.describe('User actions', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${authorUser.slug}/?include=roles`, response: {
+                users: [authorUser]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             deleteUser: {method: 'DELETE', path: `/users/${authorUser.id}/`, response: {}}
         }});
@@ -135,6 +144,7 @@ test.describe('User actions', async () => {
 
     test('Supports transferring ownership to an administrator', async ({page}) => {
         const administrator = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+        const editor = responseFixtures.users.users.find(user => user.email === 'editor@test.com')!;
 
         const makeOwnerResponse = {
             users: [
@@ -152,6 +162,12 @@ test.describe('User actions', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getAdminBySlug: {method: 'GET', path: `/users/slug/${administrator.slug}/?include=roles`, response: {
+                users: [administrator]
+            }},
+            getEditorBySlug: {method: 'GET', path: `/users/slug/${editor.slug}/?include=roles`, response: {
+                users: [editor]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: /^\/users\/\w{24}\/\?include=roles$/, response: responseFixtures.users},
             makeOwner: {method: 'PUT', path: '/users/owner/', response: makeOwnerResponse}
@@ -202,18 +218,21 @@ test.describe('User actions', async () => {
     });
 
     test('Limits un-suspending a user when there are too many users', async ({page}) => {
-        const userToEdit = responseFixtures.users.users.find(user => user.email === 'author@test.com')!;
+        const userToEdit = {
+            ...responseFixtures.users.users.find(user => user.email === 'author@test.com'),
+            status: 'inactive'
+        };
 
         await mockApi({page, requests: {
             ...globalDataRequests,
             ...limitRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: {
                 users: [
                     ...responseFixtures.users.users.filter(user => user.email !== 'author@test.com'),
-                    {
-                        ...userToEdit,
-                        status: 'inactive'
-                    }
+                    userToEdit
                 ]
             }},
             browseConfig: {

--- a/apps/admin-x-settings/test/acceptance/general/users/password.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/password.test.ts
@@ -4,8 +4,13 @@ import {mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/accept
 
 test.describe('User passwords', async () => {
     test('Supports changing password', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getAdminBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             updatePassword: {method: 'PUT', path: '/users/password/', response: {}}
         }});

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -9,6 +9,9 @@ test.describe('User profile', async () => {
 
         await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -58,6 +61,9 @@ test.describe('User profile', async () => {
 
         await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -130,6 +136,9 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -193,6 +202,9 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -305,6 +317,9 @@ test.describe('User profile', async () => {
 
         await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                 users: [{
@@ -340,6 +355,9 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
@@ -380,8 +398,13 @@ test.describe('User profile', async () => {
     });
 
     test('Hides donation notification option when Stripe disabled', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+
         await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
         }});
 
@@ -408,6 +431,9 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: responseFixtures.users}
         }});
@@ -438,6 +464,7 @@ test.describe('User profile', async () => {
     });
 
     test('Supports managing staff token', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
         const userToEdit = responseFixtures.users.users.find(user => user.email === 'owner@test.com')!;
 
         const apiKey = {
@@ -455,6 +482,12 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getAdminBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
 
             getStaffToken: {method: 'GET', path: '/users/me/token/', response: {apiKey} satisfies StaffTokenResponseType},
@@ -513,6 +546,9 @@ test.describe('User profile', async () => {
 
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -554,9 +590,12 @@ test.describe('User profile', async () => {
 
         test('Validates Bluesky URL', async ({page}) => {
             const userToEdit = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
-            
+
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -601,6 +640,9 @@ test.describe('User profile', async () => {
 
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -645,6 +687,9 @@ test.describe('User profile', async () => {
 
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -688,6 +733,9 @@ test.describe('User profile', async () => {
             const userToEdit = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -732,6 +780,9 @@ test.describe('User profile', async () => {
 
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -775,6 +826,9 @@ test.describe('User profile', async () => {
             const userToEdit = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
+                getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                    users: [userToEdit]
+                }},
                 browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
                 editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
                     users: [{
@@ -784,7 +838,7 @@ test.describe('User profile', async () => {
             }});
 
             await page.goto('/');
-            
+
             const section = page.getByTestId('users');
             const activeTab = section.locator('[role=tabpanel]:not(.hidden)');
 

--- a/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/roles.test.ts
@@ -43,6 +43,9 @@ test.describe('User roles', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             browseRoles: {method: 'GET', path: '/roles/?limit=100', response: responseFixtures.roles},
             browseAssignableRoles: {method: 'GET', path: '/roles/?limit=100&permissions=assign', response: responseFixtures.roles},
@@ -97,10 +100,17 @@ test.describe('User roles', async () => {
     });
 
     test('Editors can only manage lower roles', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
         const userToEdit = responseFixtures.users.users.find(user => user.email === 'contributor@test.com')!;
 
         await mockApi({page, requests: {
             ...globalDataRequests,
+            getAdminBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
             browseMe: {...globalDataRequests.browseMe, response: meWithRole('Editor')},
             browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
             editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/24308
closes https://linear.app/ghost/issue/ONC-1040

- previously the `<UserDetailModal>` component was using an effect to recursively load each page of users from the API until it found the correct user. This wasn't reliable due to async actions and non-deterministic state when relying on re-renders to trigger next page loads
- switched to using an explicit API fetch to get the requested user by their `slug`
  - added `useGetUserBySlug` hook to the users api
  - updated tests that exercised the modal path so that the new API request is correctly mocked
