### PR TITLE
Wired up Network (ActivityPub) setting in Admin

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/Network.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/Network.tsx
@@ -1,22 +1,69 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
+import validator from 'validator';
 import {Icon, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useLimiter} from '../../../hooks/useLimiter';
 
 const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const enableToggle = (
-        <>
-            <Toggle
-                checked={true}
-                direction='rtl'
-                onChange={() => {}}
-            />
-        </>
-    );
+    const {settings} = useGlobalData();
+    const {mutateAsync: editSettings} = useEditSettings();
+    const handleError = useHandleError();
+    const limiter = useLimiter();
 
-    const domainIssue = true;
+    // The Network toggle is disabled in Admin settings if:
+    // 1. (Ghost (Pro) only) the feature is disabled by config
+    // 2. The site is hosted on a subdirectory, localhost or an IP address in production
+    const [isDisabledByConfig, setIsDisabledByConfig] = useState(false);
+    useEffect(() => {
+        async function checkLimiter() {
+            if (limiter?.isLimited('limitSocialWeb') && await limiter.checkWouldGoOverLimit('limitSocialWeb')) {
+                setIsDisabledByConfig(true);
+            }
+        }
+
+        checkLimiter();
+    }, [limiter]);
+
+    const {subdir} = getGhostPaths();
+    const isProduction = process.env.NODE_ENV === 'production';
+    const isHostedOnSubdirectory = isProduction && !!subdir;
+    const isHostedOnLocalhost = isProduction && ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
+    const isHostedOnIP = isProduction && validator.isIP(window.location.hostname);
+
+    const isDisabled = isDisabledByConfig || isHostedOnSubdirectory || isHostedOnLocalhost || isHostedOnIP;
+
+    // The Network toggle is displayed as checked if:
+    // 1. The setting value is true, and
+    // 2. The toggle is not disabled
+    const [socialWebSetting] = getSettingValues<boolean>(settings, ['social_web']);
+    const isChecked = !!socialWebSetting && !isDisabled;
+
+    // Handle toggle change
+    const toggleSocialWebSetting = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const updatedSetting: Setting[] = [
+            {key: 'social_web', value: event.target.checked}
+        ];
+
+        try {
+            await editSettings(updatedSetting);
+        } catch (error) {
+            handleError(error);
+        }
+    };
 
     return (<TopLevelGroup
-        customButtons={enableToggle}
+        customButtons={
+            <Toggle
+                checked={isChecked}
+                direction='rtl'
+                disabled={isDisabled}
+                onChange={toggleSocialWebSetting}
+            />
+        }
         description='Make your content visible to millions across Flipboard, Mastodon, Threads, Bluesky, and WordPress.'
         keywords={keywords}
         navid='network'
@@ -29,13 +76,13 @@ const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 {
                     key: 'private',
                     value:
-                        domainIssue &&
-                        <div className='flex w-full gap-1.5 rounded-md border border-grey-200 bg-grey-75 p-3 text-sm'>
-                            <Icon name='info' size={16} />
-                            <div className='-mt-0.5'>
-                                Network is disabled because your domain isn’t configured correctly. <a className='text-green' href="https://ghost.org/docs" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                        isDisabled &&
+                            <div className='flex w-full gap-1.5 rounded-md border border-grey-200 bg-grey-75 p-3 text-sm'>
+                                <Icon name='info' size={16} />
+                                <div className='-mt-0.5'>
+                                    Network is disabled because your domain isn’t configured correctly. <a className='text-green' href="https://ghost.org/docs" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                                </div>
                             </div>
-                        </div>
                 }
             ]}
         />

--- a/apps/admin-x-settings/src/components/settings/growth/Network.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/Network.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import TopLevelGroup from '../../TopLevelGroup';
 import validator from 'validator';
 import {Icon, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
@@ -12,21 +12,12 @@ const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const handleError = useHandleError();
-    const limiter = useLimiter();
 
     // The Network toggle is disabled in Admin settings if:
     // 1. (Ghost (Pro) only) the feature is disabled by config
     // 2. The site is hosted on a subdirectory, localhost or an IP address in production
-    const [isDisabledByConfig, setIsDisabledByConfig] = useState(false);
-    useEffect(() => {
-        async function checkLimiter() {
-            if (limiter?.isLimited('limitSocialWeb') && await limiter.checkWouldGoOverLimit('limitSocialWeb')) {
-                setIsDisabledByConfig(true);
-            }
-        }
-
-        checkLimiter();
-    }, [limiter]);
+    const limiter = useLimiter();
+    const isDisabledByConfig = limiter?.isDisabled('limitSocialWeb');
 
     const {subdir} = getGhostPaths();
     const isProduction = process.env.NODE_ENV === 'production';
@@ -58,6 +49,7 @@ const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
     return (<TopLevelGroup
         customButtons={
             <Toggle
+                key={`${isChecked}-${isDisabled}`}
                 checked={isChecked}
                 direction='rtl'
                 disabled={isDisabled}

--- a/apps/admin-x-settings/src/hooks/useLimiter.tsx
+++ b/apps/admin-x-settings/src/hooks/useLimiter.tsx
@@ -117,6 +117,7 @@ export const useLimiter = () => {
 
         return {
             isLimited: (limitName: string): boolean => limiter.isLimited(limitName),
+            isDisabled: (limitName: string): boolean => limiter.isDisabled(limitName),
             checkWouldGoOverLimit: (limitName: string): Promise<boolean> => limiter.checkWouldGoOverLimit(limitName),
             errorIfWouldGoOverLimit: (limitName: string, metadata: Record<string, unknown> = {}): Promise<void> => limiter.errorIfWouldGoOverLimit(limitName, metadata),
             errorIfIsOverLimit: (limitName: string): Promise<void> => limiter.errorIfIsOverLimit(limitName)

--- a/apps/admin-x-settings/test/acceptance/growth/network.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/network.test.ts
@@ -1,0 +1,124 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests} from '../../utils/acceptance';
+import {mockApi, responseFixtures, toggleLabsFlag, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('Network settings', async () => {
+    test.beforeEach(async () => {
+        toggleLabsFlag('ui60', true);
+    });
+
+    test('Network toggle is disabled if the feature is disabled by config', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                limitSocialWeb: {
+                                    disabled: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('network');
+        const toggle = section.getByRole('switch');
+
+        // Toggle should be unchecked and disabled
+        await expect(toggle).not.toBeChecked();
+        await expect(toggle).toBeDisabled();
+
+        // Should show disabled message
+        await expect(section.getByText('Network is disabled because your domain isn’t configured correctly')).toBeVisible();
+    });
+
+    test('Network toggle can be turned off', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'social_web', value: true}
+                    ]
+                }
+            },
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'social_web', value: false}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('network');
+        const toggle = section.getByRole('switch');
+
+        // Toggle should be checked and enabled
+        await expect(toggle).toBeChecked();
+        await expect(toggle).toBeEnabled();
+
+        // Should not show disabled message
+        await expect(section.getByText('Network is disabled because your domain isn’t configured correctly')).not.toBeVisible();
+
+        // Toggle off
+        await toggle.click();
+
+        // Verify API call
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'social_web', value: false}
+            ]
+        });
+    });
+
+    test('Network toggle can be turned on', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'social_web', value: false}
+                    ]
+                }
+            },
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'social_web', value: true}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('network');
+        const toggle = section.getByRole('switch');
+
+        // Toggle should be unchecked but enabled
+        await expect(toggle).not.toBeChecked();
+        await expect(toggle).toBeEnabled();
+
+        // Should not show disabled message
+        await expect(section.getByText('Network is disabled because your domain isn’t configured correctly')).not.toBeVisible();
+
+        // Toggle on
+        await toggle.click();
+
+        // Verify API call
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'social_web', value: true}
+            ]
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2172

The Network toggle is disabled if:
1. (Ghost (Pro) only) the feature is disabled by config
2. The site is hosted on a subdirectory, localhost or an IP address in production