### PR TITLE
Simplified explore ping payload

### DIFF
--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -1,7 +1,7 @@
 module.exports = class ExplorePingService {
     /**
      * @param {object} deps
-     * @param {{getPublic: () => import('../../../shared/settings-cache/CacheManager').PublicSettingsCache}} deps.settingsCache
+     * @param {{get: (string) => string}} deps.settingsCache
      * @param {object} deps.config
      * @param {object} deps.labs
      * @param {object} deps.logging
@@ -29,7 +29,7 @@ module.exports = class ExplorePingService {
 
     async constructPayload() {
         /* eslint-disable camelcase */
-        const {title, description, icon, locale, accent_color, twitter, facebook, site_uuid} = this.settingsCache.getPublic();
+        const site_uuid = this.settingsCache.get('site_uuid');
 
         // Get post statistics
         const [totalPosts, lastPublishedAt, firstPublishedAt] = await Promise.all([
@@ -54,13 +54,6 @@ module.exports = class ExplorePingService {
             ghost: this.ghostVersion.full,
             site_uuid,
             url: this.config.get('url'),
-            title,
-            description,
-            icon,
-            locale,
-            accent_color,
-            twitter,
-            facebook,
             posts_first: firstPublishedAt ? firstPublishedAt.toISOString() : null,
             posts_last: lastPublishedAt ? lastPublishedAt.toISOString() : null,
             posts_total: totalPosts,
@@ -98,6 +91,11 @@ module.exports = class ExplorePingService {
         const exploreUrl = this.config.get('explore:url');
         if (!exploreUrl) {
             this.logging.warn('Explore URL not set');
+            return;
+        }
+
+        if (this.settingsCache.get('explore_ping') === 'false') {
+            this.logging.info('Explore ping disabled');
             return;
         }
 

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -16,35 +16,10 @@ describe('ExplorePingService', function () {
     beforeEach(function () {
         // Setup stubs
         settingsCacheStub = {
-            getPublic: sinon.stub().returns({
-                title: 'Test Blog',
-                description: 'Test Description',
-                icon: 'icon.png',
-                accent_color: '#000000',
-                lang: 'en',
-                timezone: 'Etc/UTC',
-                navigation: JSON.stringify([]),
-                secondary_navigation: JSON.stringify([]),
-                meta_title: null,
-                meta_description: null,
-                og_image: null,
-                og_title: null,
-                og_description: null,
-                twitter_image: null,
-                twitter_title: null,
-                twitter_description: null,
-                active_theme: 'casper',
-                cover_image: null,
-                logo: null,
-                portal_button: true,
-                portal_name: true,
-                locale: 'en',
-                twitter: '@test',
-                facebook: 'testfb',
-                labs: JSON.stringify({}),
-                site_uuid: '123e4567-e89b-12d3-a456-426614174000'
-            })
+            get: sinon.stub()
         };
+
+        settingsCacheStub.get.withArgs('site_uuid').returns('123e4567-e89b-12d3-a456-426614174000');
 
         configStub = {
             get: sinon.stub()
@@ -106,13 +81,6 @@ describe('ExplorePingService', function () {
                 ghost: '4.0.0',
                 site_uuid: '123e4567-e89b-12d3-a456-426614174000',
                 url: 'https://example.com',
-                title: 'Test Blog',
-                description: 'Test Description',
-                icon: 'icon.png',
-                accent_color: '#000000',
-                locale: 'en',
-                twitter: '@test',
-                facebook: 'testfb',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z',
@@ -134,18 +102,6 @@ describe('ExplorePingService', function () {
 
             const payload = await explorePingService.constructPayload();
             assert.equal(payload.members_total, null);
-        });
-
-        // test that the payload is correct if the timezone is not UTC
-        it('returns correct payload if the timezone is not UTC', async function () {
-            settingsCacheStub.getPublic.returns({
-                ...settingsCacheStub.getPublic(),
-                timezone: 'America/New_York'
-            });
-
-            const payload = await explorePingService.constructPayload();
-            assert.equal(payload.posts_first, '2020-01-01T00:00:00.000Z');
-            assert.equal(payload.posts_last, '2023-01-01T00:00:00.000Z');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- Simplifying the explore payload to only send data that isn't already publicly available
- As the other data is available on the open /ghost/api/admin/site endpoint, there's no real reason to send it in the ping
- We're simplifying this down to bare-minimum
- Also switching from using getPublic() on the settingsCache to a straightforward get as soon we'll want to add in the theme setting, as well as using the feature settings and those are not available from getPublic
- P.S. removed timezone test which isn't testing anything useful

