### PR TITLE
🎨  Updated Facebook validation with more specific regex

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
@@ -1,31 +1,204 @@
 import validator from 'validator';
 
-export function validateFacebookUrl(newUrl: string) {
-    const errMessage = 'The URL must be in a format like https://www.facebook.com/yourPage';
-    if (!newUrl) {
+export const FB_ERRORS = {
+    INVALID_URL: 'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName',
+    INVALID_USERNAME: 'Facebook username must be 5-50 characters long and contain only letters, numbers, and periods',
+    INVALID_PAGE_FORMAT: 'Facebook page URL must be in format pages/PageName/PageId where 1) PageName must be 5-50 characters long and contain only letters, numbers, and periods, and 2) PageId is 5-50 characters long and is numeric.',
+    INVALID_GROUP_FORMAT: 'Facebook group URL must be in format groups/GroupName. GroupName must be 5-50 characters long and contain only letters, numbers, and periods.'
+} as const;
+
+const PATH_TYPES = ['pages', 'groups'] as const;
+type PathType = typeof PATH_TYPES[number];
+
+// Facebook username: 5-50 chars, alphanumeric + periods only
+// fb docs: https://www.facebook.com/help/105399436216001/
+const USERNAME_REGEX = /^[a-zA-Z0-9.]{5,50}$/;
+// page ids are numeric
+const PAGE_ID_REGEX = /^[0-9]{5,}$/;
+
+// Regex to extract handles from Facebook URLs
+// Valid formats:
+// - https://www.facebook.com/username
+// - https://fb.me/username  
+// - https://www.facebook.com/pages/company/643146772483269
+// - https://fb.me/pages/PageName/123456789
+// - https://www.facebook.com/groups/GroupName
+// - https://fb.me/groups/GroupName
+// - Optional: protocol (https://), www, legacy #! fragment, trailing slash
+// Also matches incomplete URLs like pages/company or groups (for proper error handling)
+// And URLs with extra parts like pages/company/123/extra (for proper rejection)
+const FACEBOOK_URL_REGEX = /^(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.me)\/(?:#!\/)?(?:(pages)(?:\/([^/?#]*?))?(?:\/([^/?#]*?))?(?:\/([^/?#]*?))?|(groups)(?:\/([^/?#]*?))?|([^/?#]*?))\/?$/i;
+
+// trims whitespace and removes leading @ or / if it exists
+const formatUsername = (value: string) => value.trim().replace(/^[@\/]/, '');
+
+const extractInputParts = (input: string) => {
+    // Detect full URL patterns first
+    if (/^(https?:\/\/|www\.)/.test(input) || input.includes('facebook.com') || input.includes('fb.me')) {
+        const match = input.match(FACEBOOK_URL_REGEX);
+        if (!match) {
+            throw new Error(FB_ERRORS.INVALID_URL);
+        }
+
+        const [, pagesPrefix, pageName, pageId, extraPart, groupsPrefix, groupName, regularUsername] = match;
+
+        if (pagesPrefix !== undefined) {
+            // If there's an extra part after pageId, it's invalid
+            if (extraPart) {
+                throw new Error(FB_ERRORS.INVALID_PAGE_FORMAT);
+            }
+            // Build handle even if parts are missing (for proper validation)
+            const handle = `pages/${pageName || ''}/${pageId || ''}`;
+            return {type: 'pages' as PathType, handle: handle};
+        }
+
+        if (groupsPrefix !== undefined) {
+            // Build handle even if group name is missing (for proper validation)  
+            const handle = `groups/${groupName || ''}`;
+            return {type: 'groups' as PathType, handle: handle};
+        }
+
+        if (regularUsername !== undefined) {
+            return {handle: regularUsername};
+        }
+
+        throw new Error(FB_ERRORS.INVALID_URL);
+    }
+
+    // if it's not a url, we expect a handle like username, @username, pages/name/id, groups/name
+    const formatted = formatUsername(input);
+    
+    if (formatted.startsWith('pages/')) {
+        return {type: 'pages' as PathType, handle: formatted};
+    }
+    
+    if (formatted.startsWith('groups/')) {
+        return {type: 'groups' as PathType, handle: formatted};
+    }
+    
+    return {handle: formatted};
+};
+
+const isValidUsername = (type: PathType | undefined, username: string) => {
+    if (type === 'pages') {
+        const parts = username.split('/');
+        if (parts.length !== 3) {
+            return false;
+        }
+
+        const [, pageName, pageId] = parts;
+        return pageName && pageId && PAGE_ID_REGEX.test(pageId);
+    }
+
+    if (type === 'groups') {
+        const parts = username.split('/');
+        if (parts.length !== 2) {
+            return false;
+        }
+
+        const [, groupName] = parts;
+        return groupName && USERNAME_REGEX.test(groupName);
+    }
+
+    // Regular username
+    return USERNAME_REGEX.test(username);
+};
+
+const buildUrl = (handle: string) => {
+    const url = `https://www.facebook.com/${handle}`;
+    if (!validator.isURL(url)) {
+        throw new Error(FB_ERRORS.INVALID_URL);
+    }
+    return url;
+};
+
+export function validateFacebookUrl(input: string) {
+    if (!input) {
         return '';
     }
 
-    // strip any facebook URLs out
-    newUrl = newUrl.replace(/(https?:\/\/)?(www\.)?facebook\.com/i, '');
+    const {type, handle} = extractInputParts(input);
 
-    // don't allow any non-facebook urls
-    if (newUrl.match(/^(http|\/\/)/i)) {
-        throw new Error(errMessage);
+    // Don't allow any non-facebook URLs that slipped through
+    if (handle.match(/^(http|\/\/)/i)) {
+        throw new Error(FB_ERRORS.INVALID_URL);
     }
 
-    // strip leading / if we have one then concat to full facebook URL
-    newUrl = newUrl.replace(/^\//, '');
-    newUrl = `https://www.facebook.com/${newUrl}`;
-
-    // don't allow URL if it's not valid
-    if (!validator.isURL(newUrl)) {
-        throw new Error(errMessage);
+    // Validate handle format
+    if (!isValidUsername(type, handle)) {
+        if (type === 'pages') {
+            throw new Error(FB_ERRORS.INVALID_PAGE_FORMAT);
+        } else if (type === 'groups') {
+            throw new Error(FB_ERRORS.INVALID_GROUP_FORMAT);
+        } else {
+            throw new Error(FB_ERRORS.INVALID_USERNAME);
+        }
     }
 
-    return newUrl;
+    return buildUrl(handle);
 }
 
-export const facebookHandleToUrl = (handle: string) => `https://www.facebook.com/${handle}`;
+export const facebookHandleToUrl = (handle: string) => {
+    if (!handle) {
+        throw new Error(FB_ERRORS.INVALID_USERNAME);
+    }
 
-export const facebookUrlToHandle = (url: string) => url.match(/(?:https:\/\/)(?:www\.)(?:facebook\.com)\/(?:#!\/)?(\w+\/?\S+)/i)?.[1] || null; 
+    const {type, handle: formattedHandle} = extractInputParts(handle);
+
+    // since we made the fb regex a lot more strict, there might be some pre-existing invalid handles 
+    // since facebookHandleToUrl throws, this would crash the page. so we use this helper to catch it
+    // users will need to fix it to save
+    try {
+        if (!isValidUsername(type, formattedHandle)) {
+            if (type === 'pages') {
+                throw new Error(FB_ERRORS.INVALID_PAGE_FORMAT);
+            } else if (type === 'groups') {
+                throw new Error(FB_ERRORS.INVALID_GROUP_FORMAT);
+            } else {
+                throw new Error(FB_ERRORS.INVALID_USERNAME);
+            }
+        }
+    } catch (error) {
+        return `https://www.facebook.com/${formattedHandle}`;   
+    }
+    return buildUrl(formattedHandle);
+};
+
+export const facebookUrlToHandle = (url: string) => {
+    const match = url.match(FACEBOOK_URL_REGEX);
+    if (!match) {
+        return null;
+    }
+
+    const [, pagesPrefix, pageName, pageId, extraPart, groupsPrefix, groupName, regularUsername] = match;
+
+    if (pagesPrefix !== undefined) {
+        // If there's an extra part after pageId, it's invalid
+        if (extraPart) {
+            return null;
+        }
+        // Must have both pageName and pageId for valid pages URL
+        if (!pageName || !pageId || !PAGE_ID_REGEX.test(pageId)) {
+            return null;
+        }
+        return `pages/${pageName}/${pageId}`;
+    }
+
+    if (groupsPrefix !== undefined) {
+        // Must have groupName for valid groups URL
+        if (!groupName || !USERNAME_REGEX.test(groupName)) {
+            return null;
+        }
+        return `groups/${groupName}`;
+    }
+
+    if (regularUsername !== undefined) {
+        // Validate that the username is valid
+        if (!USERNAME_REGEX.test(regularUsername)) {
+            return null;
+        }
+        return regularUsername;
+    }
+
+    return null;
+};

--- a/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
@@ -87,7 +87,7 @@ const isValidUsername = (type: PathType | undefined, username: string) => {
         }
 
         const [, pageName, pageId] = parts;
-        return pageName && pageId && PAGE_ID_REGEX.test(pageId);
+        return pageName && pageId && USERNAME_REGEX.test(pageName) && PAGE_ID_REGEX.test(pageId);
     }
 
     if (type === 'groups') {
@@ -178,7 +178,7 @@ export const facebookUrlToHandle = (url: string) => {
             return null;
         }
         // Must have both pageName and pageId for valid pages URL
-        if (!pageName || !pageId || !PAGE_ID_REGEX.test(pageId)) {
+        if (!pageName || !pageId || !USERNAME_REGEX.test(pageName) || !PAGE_ID_REGEX.test(pageId)) {
             return null;
         }
         return `pages/${pageName}/${pageId}`;

--- a/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/facebook.ts
@@ -14,19 +14,19 @@ type PathType = typeof PATH_TYPES[number];
 // fb docs: https://www.facebook.com/help/105399436216001/
 const USERNAME_REGEX = /^[a-zA-Z0-9.]{5,50}$/;
 // page ids are numeric
-const PAGE_ID_REGEX = /^[0-9]{5,}$/;
+const PAGE_ID_REGEX = /^[0-9]{5,50}$/;
 
 // Regex to extract handles from Facebook URLs
 // Valid formats:
 // - https://www.facebook.com/username
 // - https://fb.me/username  
-// - https://www.facebook.com/pages/company/643146772483269
+// - https://www.facebook.com/pages/myCompany/643146772483269
 // - https://fb.me/pages/PageName/123456789
 // - https://www.facebook.com/groups/GroupName
 // - https://fb.me/groups/GroupName
 // - Optional: protocol (https://), www, legacy #! fragment, trailing slash
-// Also matches incomplete URLs like pages/company or groups (for proper error handling)
-// And URLs with extra parts like pages/company/123/extra (for proper rejection)
+// Also matches incomplete URLs like pages/myCompany or groups (for proper error handling)
+// And URLs with extra parts like pages/myCompany/123/extra (for proper rejection)
 const FACEBOOK_URL_REGEX = /^(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.me)\/(?:#!\/)?(?:(pages)(?:\/([^/?#]*?))?(?:\/([^/?#]*?))?(?:\/([^/?#]*?))?|(groups)(?:\/([^/?#]*?))?|([^/?#]*?))\/?$/i;
 
 // trims whitespace and removes leading @ or / if it exists

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -1,3 +1,4 @@
+import {FB_ERRORS} from '../../../src/utils/socialUrls/facebook';
 import {expect, test} from '@playwright/test';
 import {globalDataRequests} from '../../utils/acceptance';
 import {mockApi, testUrlValidation, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
@@ -72,14 +73,14 @@ test.describe('Social account settings', async () => {
             facebookInput,
             'page/fb123',
             '',
-            'Facebook username must be 5-50 characters long and contain only letters, numbers, and periods'
+            FB_ERRORS.INVALID_USERNAME
         );
 
         await testUrlValidation(
             facebookInput,
             'facebook.com/pages/some-facebook-page/857469375913?ref=ts',
             '',
-            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
+            FB_ERRORS.INVALID_URL
         );
 
         await testUrlValidation(
@@ -92,21 +93,21 @@ test.describe('Social account settings', async () => {
             facebookInput,
             'http://github.com/username',
             '',
-            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
+            FB_ERRORS.INVALID_URL
         );
 
         await testUrlValidation(
             facebookInput,
             'page/*(&*(%%))',
             '',
-            'Facebook username must be 5-50 characters long and contain only letters, numbers, and periods'
+            FB_ERRORS.INVALID_USERNAME
         );
 
         await testUrlValidation(
             facebookInput,
             'http://github.com/pages/username',
             '',
-            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
+            FB_ERRORS.INVALID_URL
         );
 
         const twitterInput = section.getByLabel('URL of your X profile');

--- a/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/socialAccounts.test.ts
@@ -7,7 +7,7 @@ test.describe('Social account settings', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
-                {key: 'facebook', value: 'fb'},
+                {key: 'facebook', value: 'fb123'},
                 {key: 'twitter', value: '@tw'}
             ])}
         }});
@@ -20,18 +20,18 @@ test.describe('Social account settings', async () => {
         await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/ghost');
         await expect(section.getByLabel('URL of your X profile')).toHaveValue('https://x.com/ghost');
 
-        await section.getByLabel(`URL of your publication's Facebook Page`).fill('https://www.facebook.com/fb');
+        await section.getByLabel(`URL of your publication's Facebook Page`).fill('https://www.facebook.com/fb123');
         await section.getByLabel('URL of your X profile').fill('https://x.com/tw');
 
         await section.getByRole('button', {name: 'Save'}).click();
 
         // Check updated values in input fields
-        await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/fb');
+        await expect(section.getByLabel(`URL of your publication's Facebook Page`)).toHaveValue('https://www.facebook.com/fb123');
         await expect(section.getByLabel('URL of your X profile')).toHaveValue('https://x.com/tw');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [
-                {key: 'facebook', value: 'fb'},
+                {key: 'facebook', value: 'fb123'},
                 {key: 'twitter', value: '@tw'}
             ]
         });
@@ -64,26 +64,22 @@ test.describe('Social account settings', async () => {
 
         await testUrlValidation(
             facebookInput,
-            'ab99',
-            'https://www.facebook.com/ab99'
+            'fb123',
+            'https://www.facebook.com/fb123'
         );
 
         await testUrlValidation(
             facebookInput,
-            'page/ab99',
-            'https://www.facebook.com/page/ab99'
-        );
-
-        await testUrlValidation(
-            facebookInput,
-            'page/*(&*(%%))',
-            'https://www.facebook.com/page/*(&*(%%))'
+            'page/fb123',
+            '',
+            'Facebook username must be 5-50 characters long and contain only letters, numbers, and periods'
         );
 
         await testUrlValidation(
             facebookInput,
             'facebook.com/pages/some-facebook-page/857469375913?ref=ts',
-            'https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts'
+            '',
+            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
         );
 
         await testUrlValidation(
@@ -96,14 +92,21 @@ test.describe('Social account settings', async () => {
             facebookInput,
             'http://github.com/username',
             '',
-            'The URL must be in a format like https://www.facebook.com/yourPage'
+            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
+        );
+
+        await testUrlValidation(
+            facebookInput,
+            'page/*(&*(%%))',
+            '',
+            'Facebook username must be 5-50 characters long and contain only letters, numbers, and periods'
         );
 
         await testUrlValidation(
             facebookInput,
             'http://github.com/pages/username',
             '',
-            'The URL must be in a format like https://www.facebook.com/yourPage'
+            'The URL must be in a format like https://www.facebook.com/yourPage, https://www.facebook.com/pages/PageName/123456789, or https://www.facebook.com/groups/GroupName'
         );
 
         const twitterInput = section.getByLabel('URL of your X profile');

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -172,7 +172,7 @@ test.describe('User profile', async () => {
 
         await modal.getByTitle('Social Links').click();
         await modal.getByTestId('website-input').fill('https://example.com');
-        await modal.getByTestId('facebook-input').fill('fb');
+        await modal.getByTestId('facebook-input').fill('minfb');
         await modal.getByTestId('x-input').fill('tw');
 
         await modal.getByRole('button', {name: 'Save'}).click();
@@ -190,7 +190,7 @@ test.describe('User profile', async () => {
                 slug: 'newadmin',
                 location: 'some location',
                 website: 'https://example.com',
-                facebook: 'fb',
+                facebook: 'minfb',
                 twitter: '@tw',
                 bio: 'some bio'
             }]

--- a/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
@@ -1,6 +1,14 @@
 import * as assert from 'assert/strict';
 import {FB_ERRORS, facebookHandleToUrl, facebookUrlToHandle, validateFacebookUrl} from '../../../src/utils/socialUrls/index';
 
+// Convert FB_ERRORS to regex patterns for testing
+const FB_ERROR_PATTERNS = {
+    INVALID_URL: new RegExp(FB_ERRORS.INVALID_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    INVALID_USERNAME: new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    INVALID_PAGE_FORMAT: new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    INVALID_GROUP_FORMAT: new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+};
+
 describe('Facebook URLs', () => {
     describe('URL validation', () => {
         it('should return empty string when input is empty', () => {
@@ -17,11 +25,11 @@ describe('Facebook URLs', () => {
         });
 
         it('should format pages URLs correctly', () => {
-            assert.equal(validateFacebookUrl('facebook.com/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
-            assert.equal(validateFacebookUrl('https://www.facebook.com/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
-            assert.equal(validateFacebookUrl('fb.me/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
-            assert.equal(validateFacebookUrl('https://fb.me/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
-            assert.equal(validateFacebookUrl('pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(validateFacebookUrl('facebook.com/pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
+            assert.equal(validateFacebookUrl('https://www.facebook.com/pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
+            assert.equal(validateFacebookUrl('fb.me/pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
+            assert.equal(validateFacebookUrl('https://fb.me/pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
+            assert.equal(validateFacebookUrl('pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
         });
 
         it('should format groups URLs correctly', () => {
@@ -33,28 +41,28 @@ describe('Facebook URLs', () => {
         });
 
         it('should reject URLs from other domains', () => {
-            assert.throws(() => validateFacebookUrl('https://twitter.com/myPage'), new RegExp(FB_ERRORS.INVALID_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('http://example.com'), new RegExp(FB_ERRORS.INVALID_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('https://twitter.com/myPage'), FB_ERROR_PATTERNS.INVALID_URL);
+            assert.throws(() => validateFacebookUrl('http://example.com'), FB_ERROR_PATTERNS.INVALID_URL);
         });
 
         it('should reject invalid usernames', () => {
-            assert.throws(() => validateFacebookUrl('facebook.com/abc'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/my\nPage'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/my-page'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/abc'), FB_ERROR_PATTERNS.INVALID_USERNAME);
+            assert.throws(() => validateFacebookUrl('facebook.com/my\nPage'), FB_ERROR_PATTERNS.INVALID_USERNAME);
+            assert.throws(() => validateFacebookUrl('facebook.com/my-page'), FB_ERROR_PATTERNS.INVALID_USERNAME);
         });
 
         it('should reject invalid pages URLs', () => {
-            assert.throws(() => validateFacebookUrl('facebook.com/pages/company'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/pages/company/abc'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/pages/company/123/extra'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('pages/company/1234'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/myCompany'), FB_ERROR_PATTERNS.INVALID_PAGE_FORMAT);
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/myCompany/abc'), FB_ERROR_PATTERNS.INVALID_PAGE_FORMAT);
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/myCompany/123/extra'), FB_ERROR_PATTERNS.INVALID_PAGE_FORMAT);
+            assert.throws(() => validateFacebookUrl('pages/myCompany/1234'), FB_ERROR_PATTERNS.INVALID_PAGE_FORMAT);
         });
 
         it('should reject invalid groups URLs', () => {
-            assert.throws(() => validateFacebookUrl('facebook.com/groups'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/groups/abc'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('facebook.com/groups/my-group'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-            assert.throws(() => validateFacebookUrl('groups/my\ngroup'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/groups'), FB_ERROR_PATTERNS.INVALID_GROUP_FORMAT);
+            assert.throws(() => validateFacebookUrl('facebook.com/groups/abc'), FB_ERROR_PATTERNS.INVALID_GROUP_FORMAT);
+            assert.throws(() => validateFacebookUrl('facebook.com/groups/my-group'), FB_ERROR_PATTERNS.INVALID_GROUP_FORMAT);
+            assert.throws(() => validateFacebookUrl('groups/my\ngroup'), FB_ERROR_PATTERNS.INVALID_GROUP_FORMAT);
         });
     });
 
@@ -64,7 +72,7 @@ describe('Facebook URLs', () => {
         });
 
         it('should convert pages handle to full URL', () => {
-            assert.equal(facebookHandleToUrl('pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(facebookHandleToUrl('pages/myCompany/643146772483269'), 'https://www.facebook.com/pages/myCompany/643146772483269');
         });
 
         it('should convert groups handle to full URL', () => {
@@ -81,8 +89,8 @@ describe('Facebook URLs', () => {
         });
 
         it('should extract pages handle from URL', () => {
-            assert.equal(facebookUrlToHandle('https://www.facebook.com/pages/company/643146772483269'), 'pages/company/643146772483269');
-            assert.equal(facebookUrlToHandle('https://fb.me/pages/company/643146772483269'), 'pages/company/643146772483269');
+            assert.equal(facebookUrlToHandle('https://www.facebook.com/pages/myCompany/643146772483269'), 'pages/myCompany/643146772483269');
+            assert.equal(facebookUrlToHandle('https://fb.me/pages/myCompany/643146772483269'), 'pages/myCompany/643146772483269');
         });
 
         it('should extract groups handle from URL', () => {

--- a/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert/strict';
-import {facebookHandleToUrl, facebookUrlToHandle, validateFacebookUrl} from '../../../src/utils/socialUrls/index';
+import {FB_ERRORS, facebookHandleToUrl, facebookUrlToHandle, validateFacebookUrl} from '../../../src/utils/socialUrls/index';
 
 describe('Facebook URLs', () => {
     describe('URL validation', () => {
@@ -7,35 +7,93 @@ describe('Facebook URLs', () => {
             assert.equal(validateFacebookUrl(''), '');
         });
 
-        it('should format various Facebook URL formats correctly', () => {
+        it('should format various regular username URL formats correctly', () => {
             assert.equal(validateFacebookUrl('facebook.com/myPage'), 'https://www.facebook.com/myPage');
             assert.equal(validateFacebookUrl('https://www.facebook.com/myPage'), 'https://www.facebook.com/myPage');
             assert.equal(validateFacebookUrl('www.facebook.com/myPage'), 'https://www.facebook.com/myPage');
             assert.equal(validateFacebookUrl('/myPage'), 'https://www.facebook.com/myPage');
+            assert.equal(validateFacebookUrl('fb.me/myPage'), 'https://www.facebook.com/myPage');
+            assert.equal(validateFacebookUrl('https://fb.me/myPage'), 'https://www.facebook.com/myPage');
+        });
+
+        it('should format pages URLs correctly', () => {
+            assert.equal(validateFacebookUrl('facebook.com/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(validateFacebookUrl('https://www.facebook.com/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(validateFacebookUrl('fb.me/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(validateFacebookUrl('https://fb.me/pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+            assert.equal(validateFacebookUrl('pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+        });
+
+        it('should format groups URLs correctly', () => {
+            assert.equal(validateFacebookUrl('facebook.com/groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
+            assert.equal(validateFacebookUrl('https://www.facebook.com/groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
+            assert.equal(validateFacebookUrl('fb.me/groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
+            assert.equal(validateFacebookUrl('https://fb.me/groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
+            assert.equal(validateFacebookUrl('groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
         });
 
         it('should reject URLs from other domains', () => {
-            assert.throws(() => validateFacebookUrl('https://twitter.com/myPage'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
-            assert.throws(() => validateFacebookUrl('http://example.com'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
+            assert.throws(() => validateFacebookUrl('https://twitter.com/myPage'), new RegExp(FB_ERRORS.INVALID_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('http://example.com'), new RegExp(FB_ERRORS.INVALID_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
         });
 
-        it('should reject URLs containing newline characters', () => {
-            assert.throws(() => validateFacebookUrl('facebook.com/my\nPage'), /The URL must be in a format like https:\/\/www\.facebook\.com\/yourPage/);
+        it('should reject invalid usernames', () => {
+            assert.throws(() => validateFacebookUrl('facebook.com/abc'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/my\nPage'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/my-page'), new RegExp(FB_ERRORS.INVALID_USERNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+        });
+
+        it('should reject invalid pages URLs', () => {
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/company'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/company/abc'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/pages/company/123/extra'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('pages/company/1234'), new RegExp(FB_ERRORS.INVALID_PAGE_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+        });
+
+        it('should reject invalid groups URLs', () => {
+            assert.throws(() => validateFacebookUrl('facebook.com/groups'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/groups/abc'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('facebook.com/groups/my-group'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            assert.throws(() => validateFacebookUrl('groups/my\ngroup'), new RegExp(FB_ERRORS.INVALID_GROUP_FORMAT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
         });
     });
 
     describe('Handle to URL conversion', () => {
-        it('should convert Facebook handle to full URL', () => {
+        it('should convert regular Facebook handle to full URL', () => {
             assert.equal(facebookHandleToUrl('myPage'), 'https://www.facebook.com/myPage');
+        });
+
+        it('should convert pages handle to full URL', () => {
+            assert.equal(facebookHandleToUrl('pages/company/643146772483269'), 'https://www.facebook.com/pages/company/643146772483269');
+        });
+
+        it('should convert groups handle to full URL', () => {
+            assert.equal(facebookHandleToUrl('groups/myGroup'), 'https://www.facebook.com/groups/myGroup');
         });
     });
 
     describe('URL to handle extraction', () => {
-        it('should extract Facebook handle from URL', () => {
+        it('should extract regular Facebook handle from URL', () => {
             assert.equal(facebookUrlToHandle('https://www.facebook.com/myPage'), 'myPage');
-            assert.equal(facebookUrlToHandle('https://www.facebook.com/myPage/'), 'myPage/');
+            assert.equal(facebookUrlToHandle('https://www.facebook.com/myPage/'), 'myPage');
+            assert.equal(facebookUrlToHandle('https://fb.me/myPage'), 'myPage');
+            assert.equal(facebookUrlToHandle('https://fb.me/myPage/'), 'myPage');
+        });
+
+        it('should extract pages handle from URL', () => {
+            assert.equal(facebookUrlToHandle('https://www.facebook.com/pages/company/643146772483269'), 'pages/company/643146772483269');
+            assert.equal(facebookUrlToHandle('https://fb.me/pages/company/643146772483269'), 'pages/company/643146772483269');
+        });
+
+        it('should extract groups handle from URL', () => {
+            assert.equal(facebookUrlToHandle('https://www.facebook.com/groups/myGroup'), 'groups/myGroup');
+            assert.equal(facebookUrlToHandle('https://fb.me/groups/myGroup'), 'groups/myGroup');
+        });
+
+        it('should return null for invalid URLs', () => {
             assert.equal(facebookUrlToHandle('invalid-url'), null);
             assert.equal(facebookUrlToHandle('facebook.com/my\nPage'), null);
+            assert.equal(facebookUrlToHandle('https://twitter.com/user'), null);
         });
     });
 }); 

--- a/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/facebookUrls.test.ts
@@ -22,6 +22,8 @@ describe('Facebook URLs', () => {
             assert.equal(validateFacebookUrl('/myPage'), 'https://www.facebook.com/myPage');
             assert.equal(validateFacebookUrl('fb.me/myPage'), 'https://www.facebook.com/myPage');
             assert.equal(validateFacebookUrl('https://fb.me/myPage'), 'https://www.facebook.com/myPage');
+            assert.equal(validateFacebookUrl('  myPage  '), 'https://www.facebook.com/myPage');
+            assert.equal(validateFacebookUrl('@myPage'), 'https://www.facebook.com/myPage');
         });
 
         it('should format pages URLs correctly', () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2454/update-facebook-validation-with-more-specific-regex

- improves the regex for usernames based on fb docs (https://www.facebook.com/help/105399436216001/)
- makes sure different formats work, like regular usernames, groups, and pages
- adds a bit of a safety net so that currently-invalid usernames don't crash the page - users should have a chance to update
- make sure it works for both staff facebook links and the site facebook link