### PR TITLE
Fixed Admin stats-x redirect conditionals

### DIFF
--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -6,6 +6,7 @@ export default class HomeRoute extends AuthenticatedRoute {
     @inject config;
     @service feature;
     @service router;
+    @service session;
 
     beforeModel(transition) {
         super.beforeModel(...arguments);
@@ -14,8 +15,8 @@ export default class HomeRoute extends AuthenticatedRoute {
         if (transition.to?.queryParams?.firstStart === 'true') {
             return this.router.transitionTo('setup.done');
         }
-        
-        if (this.config.labs?.ui60 && this.feature.trafficAnalytics) {
+
+        if (this.config.stats && this.feature.trafficAnalytics && this.session.user?.isAdmin) {
             this.router.transitionTo('stats-x');
         } else {
             this.router.transitionTo('dashboard');

--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -22,10 +22,6 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
             return this.router.transitionTo('stats-x');
         }
 
-        if (this.config.labs?.ui60) {
-            return this.router.transitionTo('stats-x');
-        } else {
-            return this.router.transitionTo('dashboard');
-        }
+        return this.router.transitionTo('dashboard');
     }
 }


### PR DESCRIPTION
no issue

- in `home` we need to use the same conditional for the stats-x redirect as we use to redirect away from `stats-x` otherwise we can end up in an infinite loop
- in `setup.done` there were two different redirects to `stats-x`, removing the old `ui60` flag conditional means we don't have unexpected redirects to `stats-x` when we don't know if it's actually accessible
