### PR TITLE
Wired up Explore settings

### DIFF
--- a/apps/admin-x-design-system/src/global/form/Toggle.tsx
+++ b/apps/admin-x-design-system/src/global/form/Toggle.tsx
@@ -23,6 +23,7 @@ export interface ToggleProps {
     hint?: React.ReactNode;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     gap?: string;
+    testId?: string;
 }
 
 const Toggle: React.FC<ToggleProps> = ({
@@ -40,7 +41,8 @@ const Toggle: React.FC<ToggleProps> = ({
     disabled,
     name,
     onChange,
-    gap = 'gap-2'
+    gap = 'gap-2',
+    testId
 }) => {
     const id = useId();
 
@@ -109,7 +111,7 @@ const Toggle: React.FC<ToggleProps> = ({
                     'enabled:hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 enabled:group-hover:opacity-80',
                     sizeStyles,
                     direction === 'rtl' && ' order-2'
-                )} defaultChecked={checked} disabled={disabled} id={id} name={name} onCheckedChange={handleCheckedChange}>
+                )} data-testid={testId} defaultChecked={checked} disabled={disabled} id={id} name={name} onCheckedChange={handleCheckedChange}>
                     <TogglePrimitive.Thumb className={clsx(
                         thumbSizeStyles,
                         'block translate-x-0.5 rounded-full bg-white transition-transform duration-100 will-change-transform'

--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -31,7 +31,7 @@ export const useBrowseSettings = createQuery<SettingsResponseType>({
     dataType,
     path: '/settings/',
     defaultSearchParams: {
-        group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security,social_web'
+        group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security,social_web,explore'
     }
 });
 

--- a/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
@@ -1,0 +1,96 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests} from '../../utils/acceptance';
+import {mockApi, responseFixtures, toggleLabsFlag, updatedSettingsResponse} from '@tryghost/admin-x-framework/test/acceptance';
+
+test.describe('Ghost Explore', () => {
+    test.beforeEach(async () => {
+        toggleLabsFlag('ui60', true);
+    });
+
+    test('can join Ghost Explore', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'explore_ping', value: false},
+                        {key: 'explore_ping_growth', value: false}
+                    ]
+                }
+            },
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'explore_ping', value: true}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('explore');
+        await expect(section).toBeVisible();
+
+        // Main toggle should be off
+        const mainToggle = section.getByTestId('explore-toggle');
+        await expect(mainToggle).not.toBeChecked();
+
+        // Enable Ghost Explore
+        await mainToggle.click();
+
+        // Verify the API call to enable explore_ping
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [{key: 'explore_ping', value: true}]
+        });
+    });
+
+    test('can choose to share growth data', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'explore_ping', value: true},
+                        {key: 'explore_ping_growth', value: false}
+                    ]
+                }
+            },
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'explore_ping_growth', value: true}
+            ])}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('explore');
+        await expect(section).toBeVisible();
+
+        // Main toggle should be on
+        const mainToggle = section.getByTestId('explore-toggle');
+        await expect(mainToggle).toBeChecked();
+
+        // Preview should be visible
+        const preview = section.getByTestId('explore-preview');
+        await expect(preview).toBeVisible();
+        await expect(preview.getByText('Preview')).toBeVisible();
+        await expect(preview.getByText('Test Site')).toBeVisible();
+        await expect(preview.getByText('Thoughts, stories and ideas')).toBeVisible();
+        await expect(preview.getByText('test.com')).toBeVisible();
+
+        // Growth data toggle should be visible and off
+        const growthDataToggle = section.getByTestId('explore-growth-toggle');
+        await expect(growthDataToggle).toBeVisible();
+        await expect(growthDataToggle).not.toBeChecked();
+
+        // Turn off growth data sharing
+        await growthDataToggle.click();
+
+        // Verify the API call to disable explore_ping_growth
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [{key: 'explore_ping_growth', value: true}]
+        });
+    });
+});

--- a/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
@@ -85,7 +85,7 @@ test.describe('Ghost Explore', () => {
         await expect(growthDataToggle).toBeVisible();
         await expect(growthDataToggle).not.toBeChecked();
 
-        // Turn off growth data sharing
+        // Turn on growth data sharing
         await growthDataToggle.click();
 
         // Verify the API call to disable explore_ping_growth

--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -55,7 +55,7 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
     _loadSettings() {
         if (!this._loadingPromise) {
             this._loadingPromise = this.store
-                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,recommendations,security,social_web'})
+                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,recommendations,security,social_web,explore'})
                 .then((settings) => {
                     this._loadingPromise = null;
                     return settings;

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -64,8 +64,6 @@ const _ = require('lodash');
  * @property {boolean|null} social_web_enabled - Whether social web is enabled
  * @property {boolean|null} web_analytics_enabled - Whether web analytics is enabled
  * @property {boolean|null} web_analytics_configured - Whether web analytics is configured
- * @property {boolean|null} explore_ping - Whether Explore is enabled
- * @property {boolean|null} explore_ping_growth - Whether growth data is shared to Explore
  * @property {never} [x] - Prevent accessing undefined properties
  */
 

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -64,6 +64,8 @@ const _ = require('lodash');
  * @property {boolean|null} social_web_enabled - Whether social web is enabled
  * @property {boolean|null} web_analytics_enabled - Whether web analytics is enabled
  * @property {boolean|null} web_analytics_configured - Whether web analytics is configured
+ * @property {boolean|null} explore_ping - Whether Explore is enabled
+ * @property {boolean|null} explore_ping_growth - Whether growth data is shared to Explore
  * @property {never} [x] - Prevent accessing undefined properties
  */
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771

- Publishers can join the Ghost Explore directory by enabling the 'explore_ping' setting
- Additionally, they can choose to share their member count and other growth data by enabling 'explore_ping_growth' setting