### PR TITLE
Fixed e2e tests failing on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,9 +803,7 @@ jobs:
         image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        credentials: ${{ secrets.DOCKERHUB_USERNAME != '' && format('{{"username":"{0}","password":"{1}"}}', secrets.DOCKERHUB_USERNAME, secrets.DOCKERHUB_TOKEN) || null }}
         options: >-
           --health-cmd "curl -f http://localhost:7181/"
           --health-interval 2s
@@ -821,9 +819,7 @@ jobs:
           MYSQL_PASSWORD: ghost
         ports:
           - 3306:3306
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        credentials: ${{ secrets.DOCKERHUB_USERNAME != '' && format('{{"username":"{0}","password":"{1}"}}', secrets.DOCKERHUB_USERNAME, secrets.DOCKERHUB_TOKEN) || null }}
         options: >-
           --health-cmd "mysqladmin ping -h localhost"
           --health-interval 2s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,7 +803,6 @@ jobs:
         image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
-        credentials: ${{ secrets.DOCKERHUB_USERNAME != '' && format('{{"username":"{0}","password":"{1}"}}', secrets.DOCKERHUB_USERNAME, secrets.DOCKERHUB_TOKEN) || null }}
         options: >-
           --health-cmd "curl -f http://localhost:7181/"
           --health-interval 2s
@@ -819,7 +818,6 @@ jobs:
           MYSQL_PASSWORD: ghost
         ports:
           - 3306:3306
-        credentials: ${{ secrets.DOCKERHUB_USERNAME != '' && format('{{"username":"{0}","password":"{1}"}}', secrets.DOCKERHUB_USERNAME, secrets.DOCKERHUB_TOKEN) || null }}
         options: >-
           --health-cmd "mysqladmin ping -h localhost"
           --health-interval 2s


### PR DESCRIPTION
The e2e test suite should be able to run and pass when running on a PR raised from a fork — this is one of the main requirements of the test suite, since not being able to run our `e2e-browser` test suite from a fork (due to a similar issue with Stripe credentials) has been a pain for so long. 

I inadvertently broke this requirement when adding our Docker hub credentials to the e2e test job for pulling the `mysql` and `tinybird` images — now when running from a fork, the e2e tests will always fail.

This PR fixes this by not providing credentials for the Docker pulls at all. This opens up the potential to hit rate limits more frequently, but for the time being this is preferable to not allowing any PRs raised from a fork to pass CI. Planning to come up with a better solution here, but this should unblock PRs from forks for now.