### PR TITLE
Improved error handling in explore ping service

### DIFF
--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -88,17 +88,35 @@ describe('ExplorePingService', function () {
             });
         });
 
-        it('returns null for posts_first and posts_last if no posts', async function () {
+        it('returns null for post stats if no posts', async function () {
             postsStub.stats.getFirstPublishedPostDate.resolves(null);
             postsStub.stats.getMostRecentlyPublishedPostDate.resolves(null);
+            postsStub.stats.getTotalPostsPublished.resolves(null);
 
             const payload = await explorePingService.constructPayload();
             assert.equal(payload.posts_first, null);
             assert.equal(payload.posts_last, null);
+            assert.equal(payload.posts_total, null);
+        });
+
+        it('returns null for post stats if getTotalPostsPublished throws an error', async function () {
+            postsStub.stats.getTotalPostsPublished.rejects(new Error('Test error'));
+
+            const payload = await explorePingService.constructPayload();
+            assert.equal(payload.posts_total, null);
+            assert.equal(payload.posts_last, null);
+            assert.equal(payload.posts_first, null);
         });
 
         it('returns null for members_total if no members data available', async function () {
             membersStub.stats.getTotalMembers.resolves(null);
+
+            const payload = await explorePingService.constructPayload();
+            assert.equal(payload.members_total, null);
+        });
+
+        it('returns null for members_total if getTotalMembers throws an error', async function () {
+            membersStub.stats.getTotalMembers.rejects(new Error('Test error'));
 
             const payload = await explorePingService.constructPayload();
             assert.equal(payload.members_total, null);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore ref https://github.com/TryGhost/Ghost/pull/24360/files ref https://github.com/TryGhost/Ghost/commit/f97a4e0883f163e0deceb56c79c6cb41f791760e

- In trying to add the settings, it became clear this code needed improving first
- These changes ensure that post stats have the same error handling as member stats
- It also constructs the payload step-by-step which will make it cleaner when we add the settings
- Note: I accidentally committed adding the setting in https://github.com/TryGhost/Ghost/commit/f97a4e0883f163e0deceb56c79c6cb41f791760e I didn't mean to, so I'm removing it again, to add it cleanly in PR/24360


