### PR TITLE
Fixed position of member metric for latest post

### DIFF
--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -169,7 +169,9 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                     <div className={
                                         cn(
                                             metricClassName,
-                                            (!metricsToShow.showWebMetrics || !appSettings?.analytics.webAnalytics) && 'row-[2/3] col-[1/2]'
+
+                                            // Member metric is moved to the 2nd row in the grid if the post is email only or if web analytics is turned off, otherwise leave as is
+                                            (metricsToShow.showEmailMetrics && (!metricsToShow.showWebMetrics || !appSettings?.analytics.webAnalytics)) && 'row-[2/3] col-[1/2]'
                                         )
                                     } onClick={() => {
                                         navigate(`/posts/analytics/${latestPostStats.id}/growth`, {crossApp: true});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2455/fix-position-of-member-metric-on-latest-posts

- The member metric (ie. no. of new members the post generated) in the Latest post section on Analytics overview had to be positioned as the last item, if the post [has been sent as an email] and [there's no web analytics data (email-only post) or web analytics is turned off] — the reason for this is purely aesthetical: in this case it looks better if the member metric appears in the 2nd row of the grid. The current condition had not contained the first part ("has been sent as an email"), this PR added it.