### PR TITLE
Disabled settings editing for Stripe Connect when limit is enabled

### DIFF
--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -11,8 +11,7 @@ const EMAIL_KEYS = ['members_support_address'];
 const messages = {
     problemFindingSetting: 'Problem finding setting: {key}',
     accessCoreSettingFromExtReq: 'Attempted to access core setting from external request',
-    invalidEmail: 'Invalid email address',
-    stripeConnectDisabled: 'Stripe Connect is disabled on this plan'
+    invalidEmail: 'Invalid email address'
 };
 
 class SettingsBREADService {
@@ -197,9 +196,11 @@ class SettingsBREADService {
         }
 
         if (stripeConnectData) {
-            if (this.limitsService.isDisabled('limitStripeConnect')) {
+            try {
+                await this.limitsService.errorIfWouldGoOverLimit('limitStripeConnect');
+            } catch (error) {
                 throw new NoPermissionError({
-                    message: tpl(messages.stripeConnectDisabled)
+                    message: error.message
                 });
             }
 

--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -196,13 +196,7 @@ class SettingsBREADService {
         }
 
         if (stripeConnectData) {
-            try {
-                await this.limitsService.errorIfWouldGoOverLimit('limitStripeConnect');
-            } catch (error) {
-                throw new NoPermissionError({
-                    message: error.message
-                });
-            }
+            await this.limitsService.errorIfWouldGoOverLimit('limitStripeConnect');
 
             filteredSettings.push({
                 key: 'stripe_connect_publishable_key',

--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -197,7 +197,7 @@ class SettingsBREADService {
         }
 
         if (stripeConnectData) {
-            if (this.limitsService.isLimited('limitStripeConnect')) {
+            if (this.limitsService.isDisabled('limitStripeConnect')) {
                 throw new NoPermissionError({
                     message: tpl(messages.stripeConnectDisabled)
                 });

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -5,6 +5,7 @@
 const events = require('../../lib/common/events');
 const models = require('../../models');
 const labs = require('../../../shared/labs');
+const limits = require('../limits');
 const config = require('../../../shared/config');
 const adapterManager = require('../adapter-manager');
 const SettingsCache = require('../../../shared/settings-cache');
@@ -30,6 +31,7 @@ const getSettingsBREADServiceInstance = () => {
         SettingsModel: models.Settings,
         settingsCache: SettingsCache,
         labsService: labs,
+        limitsService: limits,
         mail,
         singleUseTokenProvider: new SingleUseTokenProvider({
             SingleUseTokenModel: models.SingleUseToken,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1221,6 +1221,418 @@ Object {
 }
 `;
 
+exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is not enabled 1: [body] 1`] = `
+Object {
+  "meta": Object {},
+  "settings": Array [
+    Object {
+      "key": "members_track_sources",
+      "value": true,
+    },
+    Object {
+      "key": "title",
+      "value": null,
+    },
+    Object {
+      "key": "description",
+      "value": "Thoughts, stories and ideas",
+    },
+    Object {
+      "key": "logo",
+      "value": "",
+    },
+    Object {
+      "key": "cover_image",
+      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    },
+    Object {
+      "key": "icon",
+      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
+    },
+    Object {
+      "key": "accent_color",
+      "value": "#FF1A75",
+    },
+    Object {
+      "key": "locale",
+      "value": "ua",
+    },
+    Object {
+      "key": "timezone",
+      "value": "Pacific/Auckland",
+    },
+    Object {
+      "key": "codeinjection_head",
+      "value": null,
+    },
+    Object {
+      "key": "codeinjection_foot",
+      "value": "",
+    },
+    Object {
+      "key": "facebook",
+      "value": "ghost",
+    },
+    Object {
+      "key": "twitter",
+      "value": "@ghost",
+    },
+    Object {
+      "key": "navigation",
+      "value": "[{\\"label\\":\\"label1\\"}]",
+    },
+    Object {
+      "key": "secondary_navigation",
+      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
+    },
+    Object {
+      "key": "meta_title",
+      "value": "SEO title",
+    },
+    Object {
+      "key": "meta_description",
+      "value": "SEO description",
+    },
+    Object {
+      "key": "og_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
+    },
+    Object {
+      "key": "og_title",
+      "value": "facebook title",
+    },
+    Object {
+      "key": "og_description",
+      "value": "facebook description",
+    },
+    Object {
+      "key": "twitter_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
+    },
+    Object {
+      "key": "twitter_title",
+      "value": "twitter title",
+    },
+    Object {
+      "key": "twitter_description",
+      "value": "twitter description",
+    },
+    Object {
+      "key": "active_theme",
+      "value": "source",
+    },
+    Object {
+      "key": "is_private",
+      "value": false,
+    },
+    Object {
+      "key": "password",
+      "value": "",
+    },
+    Object {
+      "key": "public_hash",
+      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
+    },
+    Object {
+      "key": "default_content_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "default_content_visibility_tiers",
+      "value": "[]",
+    },
+    Object {
+      "key": "members_signup_access",
+      "value": "all",
+    },
+    Object {
+      "key": "members_support_address",
+      "value": "support@example.com",
+    },
+    Object {
+      "key": "stripe_secret_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_publishable_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_plans",
+      "value": "[]",
+    },
+    Object {
+      "key": "stripe_connect_publishable_key",
+      "value": "pk_test_for_stripe",
+    },
+    Object {
+      "key": "stripe_connect_secret_key",
+      "value": "••••••••",
+    },
+    Object {
+      "key": "stripe_connect_livemode",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_display_name",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_account_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_monthly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_yearly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "portal_name",
+      "value": true,
+    },
+    Object {
+      "key": "portal_button",
+      "value": true,
+    },
+    Object {
+      "key": "portal_plans",
+      "value": "[\\"free\\"]",
+    },
+    Object {
+      "key": "portal_default_plan",
+      "value": "yearly",
+    },
+    Object {
+      "key": "portal_products",
+      "value": "[]",
+    },
+    Object {
+      "key": "portal_button_style",
+      "value": "icon-and-text",
+    },
+    Object {
+      "key": "portal_button_icon",
+      "value": null,
+    },
+    Object {
+      "key": "portal_button_signup_text",
+      "value": "Subscribe",
+    },
+    Object {
+      "key": "portal_signup_terms_html",
+      "value": null,
+    },
+    Object {
+      "key": "portal_signup_checkbox_required",
+      "value": false,
+    },
+    Object {
+      "key": "mailgun_domain",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_api_key",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
+      "value": true,
+    },
+    Object {
+      "key": "email_verification_required",
+      "value": false,
+    },
+    Object {
+      "key": "amp",
+      "value": false,
+    },
+    Object {
+      "key": "amp_gtag_id",
+      "value": null,
+    },
+    Object {
+      "key": "firstpromoter",
+      "value": false,
+    },
+    Object {
+      "key": "firstpromoter_id",
+      "value": null,
+    },
+    Object {
+      "key": "labs",
+      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
+    },
+    Object {
+      "key": "slack_url",
+      "value": "",
+    },
+    Object {
+      "key": "slack_username",
+      "value": "New Slack Username",
+    },
+    Object {
+      "key": "unsplash",
+      "value": false,
+    },
+    Object {
+      "key": "shared_views",
+      "value": "[]",
+    },
+    Object {
+      "key": "editor_default_email_recipients",
+      "value": "visibility",
+    },
+    Object {
+      "key": "editor_default_email_recipients_filter",
+      "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": "<p>Great news coming soon!</p>",
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
+      "key": "comments_enabled",
+      "value": "off",
+    },
+    Object {
+      "key": "outbound_link_tagging",
+      "value": true,
+    },
+    Object {
+      "key": "web_analytics",
+      "value": true,
+    },
+    Object {
+      "key": "pintura",
+      "value": true,
+    },
+    Object {
+      "key": "pintura_js_url",
+      "value": null,
+    },
+    Object {
+      "key": "pintura_css_url",
+      "value": null,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "500",
+    },
+    Object {
+      "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
+      "key": "members_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "members_invite_only",
+      "value": false,
+    },
+    Object {
+      "key": "allow_self_signup",
+      "value": true,
+    },
+    Object {
+      "key": "paid_members_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "firstpromoter_account",
+      "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "support@example.com",
+    },
+    Object {
+      "key": "all_blocked_email_domains",
+      "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
+  ],
+}
+`;
+
+exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is not enabled 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "4799",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is not enabled 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "4799",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Settings API Edit cannot edit Stripe settings when Stripe Connect limit is enabled 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1643,9 +1643,9 @@ Object {
       "ghostErrorCode": null,
       "help": null,
       "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Permission error, cannot edit setting.",
+      "message": "Host Limit error, cannot edit setting.",
       "property": null,
-      "type": "NoPermissionError",
+      "type": "HostLimitError",
     },
   ],
 }
@@ -1655,7 +1655,7 @@ exports[`Settings API Edit cannot edit Stripe settings when Stripe Connect limit
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "268",
+  "content-length": "265",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1638,7 +1638,7 @@ Object {
   "errors": Array [
     Object {
       "code": null,
-      "context": "Stripe Connect is disabled on this plan",
+      "context": "Upgrade to use limitStripeConnect feature.",
       "details": null,
       "ghostErrorCode": null,
       "help": null,
@@ -1655,7 +1655,7 @@ exports[`Settings API Edit cannot edit Stripe settings when Stripe Connect limit
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "265",
+  "content-length": "268",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1221,6 +1221,37 @@ Object {
 }
 `;
 
+exports[`Settings API Edit cannot edit Stripe settings when Stripe Connect limit is enabled 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Stripe Connect is disabled on this plan",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot edit setting.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Settings API Edit cannot edit Stripe settings when Stripe Connect limit is enabled 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "265",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Settings API Edit cannot edit uneditable settings 1: [body] 1`] = `
 Object {
   "meta": Object {},

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -346,7 +346,7 @@ describe('Settings API', function () {
         });
 
         it('cannot edit Stripe settings when Stripe Connect limit is enabled', async function () {
-            mockManager.mockLimitService('limitStripeConnect', {isLimited: true});
+            mockManager.mockLimitService('limitStripeConnect', {isLimited: true, isDisabled: () => true});
 
             const membersService = require('../../../core/server/services/members');
             sinon.stub(membersService.stripeConnect, 'getStripeConnectTokenData').returns(Promise.resolve({

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -347,7 +347,10 @@ describe('Settings API', function () {
         });
 
         it('can edit Stripe settings when Stripe Connect limit is not enabled', async function () {
-            mockManager.mockLimitService('limitStripeConnect', {isLimited: false, isDisabled: false});
+            mockManager.mockLimitService('limitStripeConnect', {
+                isLimited: false,
+                errorIfWouldGoOverLimit: false
+            });
 
             sinon.stub(membersService.stripeConnect, 'getStripeConnectTokenData').returns(Promise.resolve({
                 public_key: 'pk_test_for_stripe',
@@ -379,7 +382,10 @@ describe('Settings API', function () {
         });
 
         it('cannot edit Stripe settings when Stripe Connect limit is enabled', async function () {
-            mockManager.mockLimitService('limitStripeConnect', {isLimited: true, isDisabled: true});
+            mockManager.mockLimitService('limitStripeConnect', {
+                isLimited: true,
+                errorIfWouldGoOverLimit: true
+            });
 
             sinon.stub(membersService.stripeConnect, 'getStripeConnectTokenData').returns(Promise.resolve({
                 public_key: 'pk_test_123',

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -297,14 +297,14 @@ const mockLimitService = (limit, options) => {
 
     // If errorIfWouldGoOverLimit is true, reject with HostLimitError
     if (options.errorIfWouldGoOverLimit === true) {
-        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit, sinon.match.any).rejects(
+        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit).rejects(
             new errors.HostLimitError({
                 message: `Upgrade to use ${limit} feature.`
             })
         );
     } else {
         // Otherwise, resolve normally
-        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit, sinon.match.any).resolves();
+        mocks.limitService.errorIfWouldGoOverLimit.withArgs(limit).resolves();
     }
 };
 

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -274,6 +274,7 @@ const mockLimitService = (limit, options) => {
     if (!mocks.limitService) {
         mocks.limitService = {
             isLimited: sinon.stub(limitService, 'isLimited'),
+            isDisabled: sinon.stub(limitService, 'isDisabled'),
             checkWouldGoOverLimit: sinon.stub(limitService, 'checkWouldGoOverLimit'),
             errorIfWouldGoOverLimit: sinon.stub(limitService, 'errorIfWouldGoOverLimit'),
             originalLimits: limitService.limits || {},
@@ -282,6 +283,7 @@ const mockLimitService = (limit, options) => {
     }
 
     mocks.limitService.isLimited.withArgs(limit).returns(options.isLimited);
+    mocks.limitService.isDisabled.withArgs(limit).returns(options.isDisabled);
     mocks.limitService.checkWouldGoOverLimit.withArgs(limit).resolves(options.wouldGoOverLimit);
 
     // Mock the limits property for checking allowlist
@@ -316,6 +318,9 @@ const restoreLimitService = () => {
         }
         if (mocks.limitService.errorIfWouldGoOverLimit) {
             mocks.limitService.errorIfWouldGoOverLimit.restore();
+        }
+        if (mocks.limitService.isDisabled) {
+            mocks.limitService.isDisabled.restore();
         }
 
         // Remove any limits we mocked


### PR DESCRIPTION
ref [BAE-330](https://linear.app/ghost/issue/BAE-330/ghost-implement-server-side-limit-validations)

Prevent setting up Stripe Connect if the limit is active.