### PR TITLE
Added production config for new explore service

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -22,7 +22,8 @@ module.exports = {
             'pintura',
             'signupForm',
             'stats',
-            'security'
+            'security',
+            'exploreTestimonialsUrl'
         ];
 
         frame.response = {

--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -96,7 +96,7 @@ module.exports = class ExplorePingService {
             return;
         }
 
-        const exploreUrl = this.config.get('explore:url');
+        const exploreUrl = this.config.get('explore:update_url');
         if (!exploreUrl) {
             this.logging.warn('Explore URL not set');
             return;

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -25,6 +25,10 @@ module.exports = function getConfigProperties() {
         security: config.get('security')
     };
 
+    if (config.get('explore') && config.get('explore:testimonials_url')) {
+        configProperties.exploreTestimonialsUrl = config.get('explore:testimonials_url');
+    }
+
     // WIP tinybird stats feature - it's entirely config driven instead of using an alpha flag for now
     if (config.get('tinybird') && config.get('tinybird:stats')) {
         const statsConfig = config.get('tinybird:stats');

--- a/ghost/core/core/shared/config/env/config.production.json
+++ b/ghost/core/core/shared/config/env/config.production.json
@@ -17,5 +17,9 @@
             "enabled": true
         },
         "transports": ["file"]
+    },
+    "explore": {
+        "update_url": "https://explore.ghost.org/api/update",
+        "testimonials_url": "https://explore.ghost.org/api/testimonials"
     }
 }

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -28,7 +28,7 @@ describe('ExplorePingService', function () {
         };
 
         configStub.get.withArgs('url').returns('https://example.com');
-        configStub.get.withArgs('explore:url').returns('https://explore-api.ghost.org');
+        configStub.get.withArgs('explore:update_url').returns('https://explore.testing.com');
 
         labsStub = {
             isSet: sinon.stub().returns(true)
@@ -190,7 +190,7 @@ describe('ExplorePingService', function () {
         });
 
         it('does not ping if explore URL is not set', async function () {
-            configStub.get.withArgs('explore:url').returns(null);
+            configStub.get.withArgs('explore:update_url').returns(null);
 
             await explorePingService.ping();
 
@@ -213,6 +213,7 @@ describe('ExplorePingService', function () {
             await explorePingService.ping();
 
             assert.equal(requestStub.calledOnce, true);
+            assert.equal(requestStub.firstCall.args[0], 'https://explore.testing.com');
             const payload = await explorePingService.constructPayload();
             assert.equal(requestStub.firstCall.args[1].body, JSON.stringify(payload));
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- This adds two urls to config for explore to keep things simple - I didn't want to have a base URL and 2 paths - there's no need.
- - Note: this renames the update url from just url to update_url as I think that is easier to read and reason about vs `explore:url` and `explore:testimonals_url`. 
- The update url is only needed server side
- The testimonials url is only needed client side, and so is passed through the config API
- We only add this config in production, so that development and testing don't send pings

