### PR TITLE
Render block rate limit errors

### DIFF
--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -230,17 +230,25 @@ export class ActivityPubAPI {
             return null;
         }
 
-        const json = await response.json();
-
         if (!response.ok) {
+            let message: string;
+
+            try {
+                const json = await response.json();
+                message = json?.message || json?.error || 'Something went wrong, please try again.';
+            } catch {
+                message = 'Something went wrong, please try again.';
+            }
+
             const error = {
-                message: json?.message || json?.error || 'Unexpected Error',
+                message,
                 statusCode: response.status
             };
+
             throw error;
         }
 
-        return json;
+        return await response.json();
     }
 
     async blockDomain(domain: URL): Promise<boolean> {

--- a/apps/admin-x-activitypub/src/components/global/EmptyViewIndicator.tsx
+++ b/apps/admin-x-activitypub/src/components/global/EmptyViewIndicator.tsx
@@ -7,9 +7,9 @@ export const EmptyViewIcon: React.FC<{children?: ReactNode}> = ({children}) => {
     );
 };
 
-export const EmptyViewIndicator: React.FC<{children?: ReactNode}> = ({children}) => {
+export const EmptyViewIndicator: React.FC<{children?: ReactNode; className?: string}> = ({children, className}) => {
     return (
-        <div className='mx-auto mt-[24vh] flex max-w-[500px] flex-col items-center gap-5 text-center text-gray-700'>
+        <div className={`mx-auto mt-[24vh] flex max-w-[500px] flex-col items-center gap-5 text-center text-gray-700 ${className || ''}`}>
             {children}
         </div>
     );

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -1,6 +1,6 @@
 import Layout from '@components/layout/Layout';
+import {Button, H3, LucideIcon} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
-import {H3, LucideIcon} from '@tryghost/shade';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useRouteError} from 'react-router';
 
@@ -27,13 +27,31 @@ const Error = ({statusCode}: {statusCode?: number}) => {
 
     if (statusCode === 429) {
         return (
-            <div className="admin-x-container-error">
-                <div className="admin-x-error max-w-xl">
-                    <h1>Rate limit exceeded</h1>
-                    <p>You&apos;ve made too many requests. Please try again in a moment.</p>
-                    <p><a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></p>
-                </div>
-            </div>
+            <Layout>
+                <EmptyViewIndicator>
+                    <EmptyViewIcon><LucideIcon.TriangleAlert /></EmptyViewIcon>
+                    <H3 className='-mb-3'>Rate limit exceeded</H3>
+                    <div>You&apos;ve made too many requests. Please try again in a moment.</div>
+                    <Button asChild>
+                        <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                    </Button>
+                </EmptyViewIndicator>
+            </Layout>
+        );
+    }
+
+    if (statusCode === 403) {
+        return (
+            <Layout>
+                <EmptyViewIndicator>
+                    <EmptyViewIcon><LucideIcon.Ban /></EmptyViewIcon>
+                    <H3 className='-mb-3'>Account suspended</H3>
+                    <div>Your account has been suspended due to policy violations.</div>
+                    <Button asChild>
+                        <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                    </Button>
+                </EmptyViewIndicator>
+            </Layout>
         );
     }
 

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -1,5 +1,5 @@
 import Layout from '@components/layout/Layout';
-import {Button, H3, LucideIcon} from '@tryghost/shade';
+import {Button, H4, LucideIcon} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useRouteError} from 'react-router';
@@ -18,7 +18,7 @@ const Error = ({statusCode}: {statusCode?: number}) => {
             <Layout>
                 <EmptyViewIndicator>
                     <EmptyViewIcon><LucideIcon.SearchX /></EmptyViewIcon>
-                    <H3 className='-mb-3'>Oops, page not found!</H3>
+                    <H4 className='-mb-4'>Oops, page not found!</H4>
                     <div>We couldn&apos;t find the page you were looking for. It may have been moved, deleted, or never existed in the first place.</div>
                 </EmptyViewIndicator>
             </Layout>
@@ -30,7 +30,7 @@ const Error = ({statusCode}: {statusCode?: number}) => {
             <Layout>
                 <EmptyViewIndicator>
                     <EmptyViewIcon><LucideIcon.TriangleAlert /></EmptyViewIcon>
-                    <H3 className='-mb-3'>Rate limit exceeded</H3>
+                    <H4 className='-mb-4'>Rate limit exceeded</H4>
                     <div>You&apos;ve made too many requests. Please try again in a moment.</div>
                     <Button asChild>
                         <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
@@ -45,7 +45,7 @@ const Error = ({statusCode}: {statusCode?: number}) => {
             <Layout>
                 <EmptyViewIndicator>
                     <EmptyViewIcon><LucideIcon.Ban /></EmptyViewIcon>
-                    <H3 className='-mb-3'>Account suspended</H3>
+                    <H4 className='-mb-4'>Account suspended</H4>
                     <div>Your account has been suspended due to policy violations.</div>
                     <Button asChild>
                         <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -27,31 +27,27 @@ const Error = ({statusCode}: {statusCode?: number}) => {
 
     if (statusCode === 429) {
         return (
-            <Layout>
-                <EmptyViewIndicator>
-                    <EmptyViewIcon><LucideIcon.TriangleAlert /></EmptyViewIcon>
-                    <H4 className='-mb-4'>Rate limit exceeded</H4>
-                    <div>You&apos;ve made too many requests. Please try again in a moment.</div>
-                    <Button asChild>
-                        <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
-                    </Button>
-                </EmptyViewIndicator>
-            </Layout>
+            <EmptyViewIndicator className='mt-[50vh] -translate-y-1/2'>
+                <EmptyViewIcon><LucideIcon.TriangleAlert /></EmptyViewIcon>
+                <H4 className='-mb-4'>Rate limit exceeded</H4>
+                <div>You&apos;ve made too many requests. Please try again in a moment.</div>
+                <Button asChild>
+                    <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                </Button>
+            </EmptyViewIndicator>
         );
     }
 
     if (statusCode === 403) {
         return (
-            <Layout>
-                <EmptyViewIndicator>
-                    <EmptyViewIcon><LucideIcon.Ban /></EmptyViewIcon>
-                    <H4 className='-mb-4'>Account suspended</H4>
-                    <div>Your account has been suspended due to policy violations.</div>
-                    <Button asChild>
-                        <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
-                    </Button>
-                </EmptyViewIndicator>
-            </Layout>
+            <EmptyViewIndicator className='mt-[50vh] -translate-y-1/2'>
+                <EmptyViewIcon><LucideIcon.Ban /></EmptyViewIcon>
+                <H4 className='-mb-4'>Account suspended</H4>
+                <div>Your account has been suspended due to policy violations.</div>
+                <Button asChild>
+                    <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                </Button>
+            </EmptyViewIndicator>
         );
     }
 

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -4,8 +4,8 @@ import {H3, LucideIcon} from '@tryghost/shade';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useRouteError} from 'react-router';
 
-const Error = () => {
-    const error = useRouteError();
+const Error = ({statusCode}: {statusCode?: number}) => {
+    const routeError = useRouteError();
     const navigate = useNavigate();
 
     const toDashboard = (e: React.MouseEvent<HTMLElement>) => {
@@ -13,8 +13,8 @@ const Error = () => {
         navigate('/dashboard', {crossApp: true});
     };
 
-    return (
-        !error ? (
+    if (routeError) {
+        return (
             <Layout>
                 <EmptyViewIndicator>
                     <EmptyViewIcon><LucideIcon.SearchX /></EmptyViewIcon>
@@ -22,15 +22,29 @@ const Error = () => {
                     <div>We couldn&apos;t find the page you were looking for. It may have been moved, deleted, or never existed in the first place.</div>
                 </EmptyViewIndicator>
             </Layout>
-        ) : (
+        );
+    }
+
+    if (statusCode === 429) {
+        return (
             <div className="admin-x-container-error">
                 <div className="admin-x-error max-w-xl">
-                    <h1>Loading interrupted</h1>
-                    <p>They say life is a series of trials and tribulations. This moment right here? It&apos;s a tribulation. Our app was supposed to load, and yet here we are. Loadless. Click back to the dashboard to try again.</p>
-                    <a className='cursor-pointer text-green' onClick={toDashboard}>&larr; Back to the dashboard</a>
+                    <h1>Rate limit exceeded</h1>
+                    <p>You&apos;ve made too many requests. Please try again in a moment.</p>
+                    <p><a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a></p>
                 </div>
             </div>
-        )
+        );
+    }
+
+    return (
+        <div className="admin-x-container-error">
+            <div className="admin-x-error max-w-xl">
+                <h1>Loading interrupted</h1>
+                <p>They say life is a series of trials and tribulations. This moment right here? It&apos;s a tribulation. Our app was supposed to load, and yet here we are. Loadless. Click back to the dashboard to try again.</p>
+                <a className='cursor-pointer text-green' onClick={toDashboard}>&larr; Back to the dashboard</a>
+            </div>
+        </div>
     );
 };
 

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -1061,6 +1061,7 @@ export function useUnfollowMutationForUser(handle: string, onSuccess: () => void
             if (error.statusCode === 429) {
                 renderRateLimitError();
             }
+            onError();
         }
     });
 }
@@ -2340,7 +2341,7 @@ function useFilteredAccountsFromJSON(options: {
     }, [followingIds, blockedAccountIds, blockedDomains, excludeFollowing, excludeCurrentUser, currentUser]);
 
     const isLoading = isLoadingFollowing || isLoadingBlockedAccounts || isLoadingBlockedDomains || isLoadingCurrentUser;
-    
+
     // Track if we have finished loading all following data
     const isFollowingDataComplete = !isLoadingFollowing && !hasNextPage;
 

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -47,6 +47,20 @@ function createActivityPubAPI(handle: string, siteUrl: string) {
     );
 }
 
+function renderRateLimitError(
+    title = 'Rate limit exceeded',
+    description = 'You\'ve made too many requests. Please try again later.'
+) {
+    toast.error(title, {description});
+}
+
+function renderBlockedError(
+    title = 'Action failed',
+    description = 'This user has restricted who can interact with their account.'
+) {
+    toast.error(title, {description});
+}
+
 const QUERY_KEYS = {
     outbox: (handle: string) => ['outbox', handle],
     liked: (handle: string) => ['liked', handle],
@@ -559,9 +573,11 @@ export function useLikeMutationForUser(handle: string) {
             updateNotificationsLikedCache(queryClient, handle, id, false);
 
             if (error.statusCode === 403) {
-                toast.error('Action failed', {
-                    description: 'This user has restricted who can interact with their account.'
-                });
+                renderBlockedError();
+            }
+
+            if (error.statusCode === 429) {
+                renderRateLimitError();
             }
         }
     });
@@ -581,6 +597,11 @@ export function useUnlikeMutationForUser(handle: string) {
             updateLikeCache(queryClient, handle, id, false);
             updateLikeCacheOnce(queryClient, id, false);
             updateNotificationsLikedCache(queryClient, handle, id, false);
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -613,6 +634,11 @@ export function useBlockDomainMutationForUser(handle: string) {
                     };
                 }
             );
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -643,6 +669,11 @@ export function useUnblockDomainMutationForUser(handle: string) {
                     };
                 }
             );
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -674,6 +705,11 @@ export function useBlockMutationForUser(handle: string) {
             );
             queryClient.invalidateQueries({queryKey: QUERY_KEYS.feed});
             queryClient.invalidateQueries({queryKey: QUERY_KEYS.inbox});
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -701,6 +737,11 @@ export function useUnblockMutationForUser(handle: string) {
                     };
                 }
             );
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -806,9 +847,10 @@ export function useRepostMutationForUser(handle: string) {
             updateRepostCacheOnce(queryClient, id, false);
             updateNotificationsRepostCache(queryClient, handle, id, false);
             if (error.statusCode === 403) {
-                toast.error('Action failed', {
-                    description: 'This user has restricted who can interact with their account.'
-                });
+                renderBlockedError();
+            }
+            if (error.statusCode === 429) {
+                renderRateLimitError();
             }
         }
     });
@@ -828,6 +870,11 @@ export function useDerepostMutationForUser(handle: string) {
             updateRepostCache(queryClient, handle, id, false);
             updateRepostCacheOnce(queryClient, id, false);
             updateNotificationsRepostCache(queryClient, handle, id, false);
+        },
+        onError(error: {message: string, statusCode: number}) {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
         }
     });
 }
@@ -1010,7 +1057,11 @@ export function useUnfollowMutationForUser(handle: string, onSuccess: () => void
 
             onSuccess();
         },
-        onError
+        onError: (error: {message: string, statusCode: number}) => {
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
+        }
     });
 }
 
@@ -1176,10 +1227,12 @@ export function useFollowMutationForUser(handle: string, onSuccess: () => void, 
         onError(error: {message: string, statusCode: number}) {
             onError();
 
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
+
             if (error.statusCode === 403) {
-                toast.error('Action failed', {
-                    description: 'This user has restricted who can interact with their account.'
-                });
+                renderBlockedError();
             }
         }
     });
@@ -1368,10 +1421,13 @@ export function useReplyMutationForUser(handle: string, actorProps?: ActorProper
             // in the thread as this is handled locally in the ArticleModal component
 
             if (error.statusCode === 403) {
-                return toast.error('Action failed', {
-                    description: 'This user has restricted who can interact with their account.'
-                });
+                renderBlockedError();
             }
+
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
+
             toast.error('An error occurred while sending your reply.');
         }
     });
@@ -1419,13 +1475,17 @@ export function useNoteMutationForUser(handle: string, actorProps?: ActorPropert
             updateActivityInPaginatedCollection(queryClient, queryKeyOutbox, 'data', context?.id ?? '', () => activity);
             updateActivityInPaginatedCollection(queryClient, queryKeyPostsByAccount, 'posts', context?.id ?? '', () => activity);
         },
-        onError(error, _variables, context) {
+        onError(error: {message: string, statusCode: number}, _variables, context) {
             // eslint-disable-next-line no-console
             console.error(error);
 
             removeActivityFromPaginatedCollection(queryClient, queryKeyFeed, 'posts', context?.id ?? '');
             removeActivityFromPaginatedCollection(queryClient, queryKeyOutbox, 'data', context?.id ?? '');
             removeActivityFromPaginatedCollection(queryClient, queryKeyPostsByAccount, 'posts', context?.id ?? '');
+
+            if (error.statusCode === 429) {
+                renderRateLimitError();
+            }
 
             toast.error('An error occurred while posting your note.');
         }

--- a/apps/admin-x-activitypub/src/views/Feed/Feed.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Feed.tsx
@@ -1,5 +1,7 @@
+import Error from '@components/layout/Error';
 import FeedList from './components/FeedList';
 import React from 'react';
+import {isApiError} from '@src/api/activitypub';
 import {
     useFeedForUser,
     useUserDataForUser
@@ -7,13 +9,15 @@ import {
 
 const Feed: React.FC = () => {
     const {feedQuery} = useFeedForUser({enabled: true});
-
-    const feedQueryData = feedQuery;
-    const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQueryData;
+    const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQuery;
 
     const activities = (data?.pages.flatMap(page => page.posts) ?? Array.from({length: 5}, (_, index) => ({id: `placeholder-${index}`, object: {}})));
 
     const {data: user} = useUserDataForUser('index');
+
+    if (error && isApiError(error)) {
+        return <Error statusCode={error.statusCode}/>;
+    }
 
     return <FeedList
         activities={activities}

--- a/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
@@ -1,13 +1,19 @@
+import Error from '@components/layout/Error';
 import InboxList from './components/InboxList';
 import React from 'react';
+import {isApiError} from '@src/api/activitypub';
 import {useInboxForUser} from '@hooks/use-activity-pub-queries';
 
 const Inbox: React.FC = () => {
     const {inboxQuery} = useInboxForUser({enabled: true});
     const feedQueryData = inboxQuery;
-    const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQueryData;
+    const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQueryData;
 
     const activities = (data?.pages.flatMap(page => page.posts) ?? Array.from({length: 5}, (_, index) => ({id: `placeholder-${index}`, object: {}})));
+
+    if (error && isApiError(error)) {
+        return <Error statusCode={error.statusCode}/>;
+    }
 
     return <InboxList
         activities={activities}

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -1,9 +1,9 @@
 import React, {useEffect, useRef} from 'react';
+import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 
-import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
-
 import APAvatar from '@components/global/APAvatar';
+import Error from '@components/layout/Error';
 import FeedItemStats from '@components/feed/FeedItemStats';
 import NotificationItem from './components/NotificationItem';
 import Separator from '@components/global/Separator';
@@ -11,7 +11,7 @@ import Separator from '@components/global/Separator';
 import Layout from '@components/layout';
 import NotificationIcon from './components/NotificationIcon';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
-import {Notification} from '@src/api/activitypub';
+import {Notification, isApiError} from '@src/api/activitypub';
 import {handleProfileClick} from '@utils/handle-profile-click';
 import {renderFeedAttachment} from '@components/feed/FeedItem';
 import {renderTimestamp} from '@src/utils/render-timestamp';
@@ -192,7 +192,7 @@ const Notifications: React.FC = () => {
 
     const maxAvatars = 5;
 
-    const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useNotificationsForUser('index');
+    const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useNotificationsForUser('index');
 
     const notificationGroups = (
         data?.pages.flatMap((page) => {
@@ -257,6 +257,10 @@ const Notifications: React.FC = () => {
             break;
         }
     };
+
+    if (error && isApiError(error)) {
+        return <Error statusCode={error.statusCode}/>;
+    }
 
     return (
         <Layout>

--- a/apps/admin-x-activitypub/src/views/Preferences/Preferences.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/Preferences.tsx
@@ -1,11 +1,17 @@
+import Error from '@components/layout/Error';
 import Layout from '@components/layout';
 import Profile from './components/Profile';
 import React from 'react';
 import Settings from './components/Settings';
+import {isApiError} from '@src/api/activitypub';
 import {useAccountForUser} from '@hooks/use-activity-pub-queries';
 
 const Preferences: React.FC = () => {
-    const {data: account, isLoading: isLoadingAccount} = useAccountForUser('index', 'me');
+    const {data: account, isLoading: isLoadingAccount, error: accountError} = useAccountForUser('index', 'me');
+
+    if (accountError && isApiError(accountError)) {
+        return <Error statusCode={accountError.statusCode} />;
+    }
 
     return (
         <Layout>

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -1,9 +1,10 @@
 import ActorList from './components/ActorList';
+import Error from '@components/layout/Error';
 import Likes from './components/Likes';
 import Posts from './components/Posts';
 import ProfilePage from './components/ProfilePage';
 import React from 'react';
-import {Activity} from '@src/api/activitypub';
+import {Activity, isApiError} from '@src/api/activitypub';
 import {useAccountFollowsForUser, useAccountForUser, usePostsByAccount, usePostsLikedByAccount} from '@hooks/use-activity-pub-queries';
 import {useParams} from '@tryghost/admin-x-framework';
 
@@ -138,7 +139,11 @@ const FollowersTab: React.FC<{handle: string}> = ({handle}) => {
 const Profile: React.FC<ProfileProps> = ({}) => {
     const params = useParams();
 
-    const {data: account, isLoading: isLoadingAccount} = useAccountForUser('index', (params.handle || 'me'));
+    const {data: account, isLoading: isLoadingAccount, error: accountError} = useAccountForUser('index', (params.handle || 'me'));
+
+    if (accountError && isApiError(accountError)) {
+        return <Error statusCode={accountError.statusCode} />;
+    }
 
     const customFields = Object.keys(account?.customFields || {}).map((key) => {
         return {

--- a/apps/admin-x-activitypub/test/acceptance/feed.test.ts
+++ b/apps/admin-x-activitypub/test/acceptance/feed.test.ts
@@ -159,8 +159,8 @@ test.describe('Feed', async () => {
     });
 
     test('I can repost a note in my feed', async ({page}) => {
-        // Use the last post which has repostedByMe: false and no repostedBy
-        const lastPostFixture = feedFixture.posts[9]; // index 9 is the 10th post
+        // Use the first post which has repostedByMe: false and repostCount > 0 for better button visibility
+        const firstPostFixture = feedFixture.posts[0];
 
         const {lastApiRequests} = await mockApi({page, requests: {
             getFeed: {
@@ -170,7 +170,7 @@ test.describe('Feed', async () => {
             },
             repostPost: {
                 method: 'POST',
-                path: `/v1/actions/repost/${encodeURIComponent(lastPostFixture.id)}`,
+                path: `/v1/actions/repost/${encodeURIComponent(firstPostFixture.id)}`,
                 response: {}
             }
         }, options: {useActivityPub: true}});
@@ -185,14 +185,14 @@ test.describe('Feed', async () => {
         const feedItems = page.getByTestId('feed-item');
         await expect(feedItems).toHaveCount(10);
 
-        // Get the last post (10th item, index 9)
-        const lastPost = feedItems.nth(9);
+        // Get the first post
+        const firstPost = feedItems.first();
 
-        // Hover over the last post to make the repost button appear
-        await lastPost.hover();
+        // Hover over the first post to make the repost button appear
+        await firstPost.hover();
 
         // Click the repost button
-        const repostButton = lastPost.getByTestId('repost-button');
+        const repostButton = firstPost.getByTestId('repost-button');
         await expect(repostButton).toBeVisible();
         await repostButton.click();
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2261

- the infrastructure will return HTTP 429/empty body when a user is rate-limited, and HTTP 403/empty body when a user is blocked
- added support for non-json error responses
- added toast error for rate-limits, when the user is performing an action (e.g. liking a post)
- todo: add general error screen for rate-limits and blocks when reloading screens