### PR TITLE
Fixed posts-x redirect when analytics is not set up

### DIFF
--- a/ghost/admin/app/routes/posts-x.js
+++ b/ghost/admin/app/routes/posts-x.js
@@ -27,7 +27,7 @@ export default class PostsXRoute extends AuthenticatedRoute {
 
         // This ensures that we don't load this page if the stats config is not set
         if (!(this.config.stats && this.feature.trafficAnalytics)) {
-            return this.transitionTo('home');
+            return this.transitionTo('posts');
         }
     }
 }


### PR DESCRIPTION
no issue

- redirecting to `home` instead of the original `posts` route after a successful publish when the analytics feature is enabled but no config exists meant that the publish-success modal was never shown and therefore broke tests
- changed the redirect to `posts` so we show the original posts list which better matches expectations after trying to open a posts list route
