### PR TITLE
🐛 Fixed missing `lexical` field in post/page webhook payloads

### DIFF
--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -42,7 +42,7 @@ module.exports = (event, model) => {
             const frame = {options: {previous: true, context: {user: true}}};
 
             if (['posts', 'pages'].includes(docName)) {
-                frame.options.formats = ['mobiledoc', 'html', 'plaintext'];
+                frame.options.formats = ['lexical', 'mobiledoc', 'html', 'plaintext'];
                 frame.options.withRelated = ['tags', 'authors'];
             }
 

--- a/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
@@ -244,6 +244,7 @@ Object {
       "featured": false,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[{\\"children\\":[],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
       "mobiledoc": null,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "show_title_and_feature_image": true,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -246,6 +246,7 @@ Object {
       "featured": false,
       "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[{\\"children\\":[],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
       "mobiledoc": null,
       "published_at": null,
       "slug": "testing-post-deleted-webhook",


### PR DESCRIPTION
no issue

- webhook serializer has an explicit list of formats to include when building payloads but it was missing the `lexical` source format despite including the deprecated `mobiledoc` source format
