### PR TITLE
Fixed Ember Analytics routing bug with beta flags

### DIFF
--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -15,7 +15,7 @@ export default class HomeRoute extends AuthenticatedRoute {
             return this.router.transitionTo('setup.done');
         }
         
-        if (this.config.labs?.ui60 && this.feature.trafficAnalytics) {
+        if (this.config.labs?.ui60 || this.feature.trafficAnalytics) {
             this.router.transitionTo('stats-x');
         } else {
             this.router.transitionTo('dashboard');

--- a/ghost/admin/app/routes/stats-x.js
+++ b/ghost/admin/app/routes/stats-x.js
@@ -15,7 +15,7 @@ export default class StatsXRoute extends AuthenticatedRoute {
         }
 
         // This ensures that we don't load this page if the stats config is not set
-        if (!(this.config.stats && this.feature.trafficAnalytics)) {
+        if (!this.feature.trafficAnalytics) {
             return this.transitionTo('home');
         }
     }

--- a/ghost/admin/mirage/fixtures/configs.js
+++ b/ghost/admin/mirage/fixtures/configs.js
@@ -9,5 +9,18 @@ export default [{
     useGravatar: 'true',
     editor: {
         url: 'http://localhost:2368/editor.js'
-    }
+    },
+    tinybird: {
+        workspaceId: '1234567890',
+        adminToken: 'p.ey1234567890',
+        tracker: {
+            endpoint: 'https://api.tinybird.co/v0/events'
+        },
+        stats: {
+            endpoint: 'https://api.tinybird.co'
+        }
+    },
+    // Asset delivery configuration for stats component
+    statsFilename: 'stats.js',
+    statsHash: 'development'
 }];


### PR DESCRIPTION
no ref
- removed infinite loop when missing config
- fixed logging in routing to Analytics when `trafficAnalytics` flag OR `ui60` flag is enabled; previously required both which was incorrect

We should be routing users to Analytics when either the beta Analytics flag is enabled or the ui60 flag is enabled. We will be removing the config checks from Ember/Admin in another PR - this one needed to be removed for the regression test to pass.