### PR TITLE
Updated CI to use `mirror.gcr.io` for pulling docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,8 +824,24 @@ jobs:
 
       - name: Start E2E services
         run: |
+          echo "=== Starting network monitoring ==="
+          # Start tcpdump in background to monitor registry connections
+          sudo tcpdump -i any -n host mirror.gcr.io or host registry-1.docker.io or host index.docker.io > /tmp/registry_traffic.log 2>&1 &
+          TCPDUMP_PID=$!
+          
           echo "=== Pulling images with debug info ==="
           docker compose -f e2e/compose.e2e.yml pull
+          
+          echo "=== Stopping network monitoring ==="
+          sleep 2  # Let tcpdump capture any remaining packets
+          sudo kill $TCPDUMP_PID 2>/dev/null || true
+          
+          echo "=== Registry traffic analysis ==="
+          echo "Connections to mirror.gcr.io:"
+          grep "mirror.gcr.io" /tmp/registry_traffic.log || echo "No connections to mirror.gcr.io detected"
+          echo "Connections to Docker Hub:"
+          grep -E "(registry-1\.docker\.io|index\.docker\.io)" /tmp/registry_traffic.log || echo "No connections to Docker Hub detected"
+          
           echo "=== Inspecting pulled images ==="
           docker image inspect mysql:8.0 --format='{{.RepoDigests}}' || echo "MySQL image not found"
           docker image inspect tinybirdco/tinybird-local:latest --format='{{.RepoDigests}}' || echo "Tinybird image not found"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,7 +825,10 @@ jobs:
       - name: Start E2E services
         run: |
           echo "=== Pulling images with debug info ==="
-          DOCKER_BUILDKIT=0 docker compose -f e2e/compose.e2e.yml pull --verbose
+          docker compose -f e2e/compose.e2e.yml pull
+          echo "=== Inspecting pulled images ==="
+          docker image inspect mysql:8.0 --format='{{.RepoDigests}}' || echo "MySQL image not found"
+          docker image inspect tinybirdco/tinybird-local:latest --format='{{.RepoDigests}}' || echo "Tinybird image not found"
           echo "=== Starting services ==="
           docker compose -f e2e/compose.e2e.yml up -d
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,8 +819,8 @@ jobs:
           cat /etc/docker/daemon.json
           echo "=== Docker system info (Registry Mirrors) ==="
           docker system info | grep -A 3 "Registry Mirrors" || echo "No registry mirrors found in system info"
-          echo "=== Testing mirror connectivity ==="
-          curl -I https://mirror.gcr.io/v2/ || echo "Mirror connectivity test failed"
+          echo "=== Ensuring no Docker Hub authentication to avoid credential forwarding bug ==="
+          docker logout || echo "No Docker Hub login found"
 
       - name: Start E2E services
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
     name: E2E tests
     services:
       tinybird:
-        image: tinybirdco/tinybird-local:latest
+        image: ghcr.io/tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
         options: >-
@@ -810,7 +810,7 @@ jobs:
           --health-retries 5
           --health-start-period 30s
       mysql:
-        image: mysql:8.0
+        image: ghcr.io/mysql/mysql-server:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: ghost_testing
@@ -899,7 +899,7 @@ jobs:
           working-directory: ghost/core/core/server/data/tinybird
     services:
       tinybird:
-        image: tinybirdco/tinybird-local:latest
+        image: ghcr.io/tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,12 +818,12 @@ jobs:
           docker system info | grep -A 1 "Registry Mirrors"
 
       - name: Start E2E services
-        run: docker-compose -f e2e/compose.e2e.yml up -d
+        run: docker compose -f e2e/compose.e2e.yml up -d
         
       - name: Wait for services to be healthy
         run: |
           echo "Waiting for MySQL to be ready..."
-          timeout 60 bash -c 'until docker-compose -f e2e/compose.e2e.yml exec -T mysql mysqladmin ping -h localhost --silent; do sleep 2; done'
+          timeout 60 bash -c 'until docker compose -f e2e/compose.e2e.yml exec -T mysql mysqladmin ping -h localhost --silent; do sleep 2; done'
           echo "Waiting for Tinybird to be ready..."
           timeout 60 bash -c 'until curl -f http://localhost:7181/; do sleep 2; done'
 
@@ -882,7 +882,7 @@ jobs:
 
       - name: Stop E2E services
         if: always()
-        run: docker-compose -f e2e/compose.e2e.yml down
+        run: docker compose -f e2e/compose.e2e.yml down
 
   job_tinybird-tests:
     name: Tinybird Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
     name: E2E tests
     services:
       tinybird:
-        image: ghcr.io/tinybirdco/tinybird-local:latest
+        image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
         options: >-
@@ -899,7 +899,7 @@ jobs:
           working-directory: ghost/core/core/server/data/tinybird
     services:
       tinybird:
-        image: ghcr.io/tinybirdco/tinybird-local:latest
+        image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,7 +810,7 @@ jobs:
           --health-retries 5
           --health-start-period 30s
       mysql:
-        image: mysql:8.0
+        image: mirror.gcr.io/mysql/mysql-server:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: ghost_testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,15 +818,7 @@ jobs:
           docker logout || echo "No Docker Hub login found"
 
       - name: Start E2E services
-        run: docker compose -f e2e/compose.e2e.yml up -d
-        
-      - name: Wait for services to be healthy
-        run: |
-          echo "Waiting for MySQL to be ready..."
-          timeout 60 bash -c 'until docker compose -f e2e/compose.e2e.yml exec -T mysql mysqladmin ping -h localhost --silent; do sleep 2; done'
-          echo "Waiting for Tinybird to be ready..."
-          timeout 60 bash -c 'until curl -f http://localhost:7181/; do sleep 2; done'
-
+        run: docker compose -f e2e/compose.e2e.yml up -d --wait
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,10 +815,19 @@ jobs:
         run: |
           echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
-          docker system info | grep -A 1 "Registry Mirrors"
+          echo "=== Docker daemon configuration ==="
+          cat /etc/docker/daemon.json
+          echo "=== Docker system info (Registry Mirrors) ==="
+          docker system info | grep -A 3 "Registry Mirrors" || echo "No registry mirrors found in system info"
+          echo "=== Testing mirror connectivity ==="
+          curl -I https://mirror.gcr.io/v2/ || echo "Mirror connectivity test failed"
 
       - name: Start E2E services
-        run: docker compose -f e2e/compose.e2e.yml up -d
+        run: |
+          echo "=== Pulling images with debug info ==="
+          DOCKER_BUILDKIT=0 docker compose -f e2e/compose.e2e.yml pull --verbose
+          echo "=== Starting services ==="
+          docker compose -f e2e/compose.e2e.yml up -d
         
       - name: Wait for services to be healthy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
     name: E2E tests
     services:
       tinybird:
-        image: tinybirdco/tinybird-local:latest
+        image: mirror.gcr.io/tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
         options: >-
@@ -810,7 +810,7 @@ jobs:
           --health-retries 5
           --health-start-period 30s
       mysql:
-        image: ghcr.io/mysql/mysql-server:8.0
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: ghost_testing
@@ -899,7 +899,7 @@ jobs:
           working-directory: ghost/core/core/server/data/tinybird
     services:
       tinybird:
-        image: tinybirdco/tinybird-local:latest
+        image: mirror.gcr.io/tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,7 +894,7 @@ jobs:
           working-directory: ghost/core/core/server/data/tinybird
     services:
       tinybird:
-        image: mirror.gcr.io/tinybirdco/tinybird-local:latest
+        image: tinybirdco/tinybird-local:latest
         ports:
           - 7181:7181
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,7 +810,7 @@ jobs:
           --health-retries 5
           --health-start-period 30s
       mysql:
-        image: mirror.gcr.io/mysql/mysql-server:8.0
+        image: mirror.gcr.io/mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: ghost_testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,32 +798,6 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_any_code == 'true'
     name: E2E tests
-    services:
-      tinybird:
-        image: mirror.gcr.io/tinybirdco/tinybird-local:latest
-        ports:
-          - 7181:7181
-        options: >-
-          --health-cmd "curl -f http://localhost:7181/"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 5
-          --health-start-period 30s
-      mysql:
-        image: mirror.gcr.io/mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: ghost_testing
-          MYSQL_USER: ghost
-          MYSQL_PASSWORD: ghost
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -h localhost"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 5
-          --health-start-period 30s
     env:
       CI: true
       database__client: mysql
@@ -836,6 +810,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Configure Docker daemon for mirror.gcr.io
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker system info | grep -A 1 "Registry Mirrors"
+
+      - name: Start E2E services
+        run: docker-compose -f e2e/compose.e2e.yml up -d
+        
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for MySQL to be ready..."
+          timeout 60 bash -c 'until docker-compose -f e2e/compose.e2e.yml exec -T mysql mysqladmin ping -h localhost --silent; do sleep 2; done'
+          echo "Waiting for Tinybird to be ready..."
+          timeout 60 bash -c 'until curl -f http://localhost:7181/; do sleep 2; done'
+
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0
@@ -888,6 +879,10 @@ jobs:
           name: e2e-playwright-report
           path: e2e/test-results
           retention-days: 30
+
+      - name: Stop E2E services
+        if: always()
+        run: docker-compose -f e2e/compose.e2e.yml down
 
   job_tinybird-tests:
     name: Tinybird Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,23 +824,38 @@ jobs:
 
       - name: Start E2E services
         run: |
-          echo "=== Starting network monitoring ==="
-          # Start tcpdump in background to monitor registry connections
-          sudo tcpdump -i any -n host mirror.gcr.io or host registry-1.docker.io or host index.docker.io > /tmp/registry_traffic.log 2>&1 &
+          echo "=== Pre-pull image status ==="
+          docker images mysql:8.0 || echo "MySQL image not present"
+          docker images tinybirdco/tinybird-local:latest || echo "Tinybird image not present"
+          
+          echo "=== Force remove images to ensure fresh pull ==="
+          docker rmi mysql:8.0 tinybirdco/tinybird-local:latest 2>/dev/null || echo "Images not present to remove"
+          
+          echo "=== Starting enhanced network monitoring ==="
+          # Monitor HTTPS traffic to registries with more comprehensive logging
+          sudo tcpdump -i any -n -s 0 'host mirror.gcr.io or host registry-1.docker.io or host index.docker.io or host docker.io' > /tmp/registry_traffic.log 2>&1 &
           TCPDUMP_PID=$!
           
           echo "=== Pulling images with debug info ==="
           docker compose -f e2e/compose.e2e.yml pull
           
           echo "=== Stopping network monitoring ==="
-          sleep 2  # Let tcpdump capture any remaining packets
+          sleep 3  # Let tcpdump capture any remaining packets
           sudo kill $TCPDUMP_PID 2>/dev/null || true
           
           echo "=== Registry traffic analysis ==="
+          echo "All captured traffic:"
+          cat /tmp/registry_traffic.log | head -20 || echo "No traffic captured"
           echo "Connections to mirror.gcr.io:"
           grep "mirror.gcr.io" /tmp/registry_traffic.log || echo "No connections to mirror.gcr.io detected"
-          echo "Connections to Docker Hub:"
-          grep -E "(registry-1\.docker\.io|index\.docker\.io)" /tmp/registry_traffic.log || echo "No connections to Docker Hub detected"
+          echo "Connections to Docker registries:"
+          grep -E "(registry-1\.docker\.io|index\.docker\.io|docker\.io)" /tmp/registry_traffic.log || echo "No connections to Docker Hub detected"
+          
+          echo "=== Docker daemon logs ==="
+          echo "Recent daemon logs (last 50 lines):"
+          sudo journalctl -u docker.service --no-pager -n 50 || echo "Could not read daemon logs"
+          echo "Daemon logs mentioning registries:"
+          sudo journalctl -u docker.service --no-pager -n 100 | grep -i -E "(mirror|registry|pull)" || echo "No registry-related logs found"
           
           echo "=== Inspecting pulled images ==="
           docker image inspect mysql:8.0 --format='{{.RepoDigests}}' || echo "MySQL image not found"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,53 +815,10 @@ jobs:
         run: |
           echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
-          echo "=== Docker daemon configuration ==="
-          cat /etc/docker/daemon.json
-          echo "=== Docker system info (Registry Mirrors) ==="
-          docker system info | grep -A 3 "Registry Mirrors" || echo "No registry mirrors found in system info"
-          echo "=== Ensuring no Docker Hub authentication to avoid credential forwarding bug ==="
           docker logout || echo "No Docker Hub login found"
 
       - name: Start E2E services
-        run: |
-          echo "=== Pre-pull image status ==="
-          docker images mysql:8.0 || echo "MySQL image not present"
-          docker images tinybirdco/tinybird-local:latest || echo "Tinybird image not present"
-          
-          echo "=== Force remove images to ensure fresh pull ==="
-          docker rmi mysql:8.0 tinybirdco/tinybird-local:latest 2>/dev/null || echo "Images not present to remove"
-          
-          echo "=== Starting enhanced network monitoring ==="
-          # Monitor HTTPS traffic to registries with more comprehensive logging
-          sudo tcpdump -i any -n -s 0 'host mirror.gcr.io or host registry-1.docker.io or host index.docker.io or host docker.io' > /tmp/registry_traffic.log 2>&1 &
-          TCPDUMP_PID=$!
-          
-          echo "=== Pulling images with debug info ==="
-          docker compose -f e2e/compose.e2e.yml pull
-          
-          echo "=== Stopping network monitoring ==="
-          sleep 3  # Let tcpdump capture any remaining packets
-          sudo kill $TCPDUMP_PID 2>/dev/null || true
-          
-          echo "=== Registry traffic analysis ==="
-          echo "All captured traffic:"
-          cat /tmp/registry_traffic.log | head -20 || echo "No traffic captured"
-          echo "Connections to mirror.gcr.io:"
-          grep "mirror.gcr.io" /tmp/registry_traffic.log || echo "No connections to mirror.gcr.io detected"
-          echo "Connections to Docker registries:"
-          grep -E "(registry-1\.docker\.io|index\.docker\.io|docker\.io)" /tmp/registry_traffic.log || echo "No connections to Docker Hub detected"
-          
-          echo "=== Docker daemon logs ==="
-          echo "Recent daemon logs (last 50 lines):"
-          sudo journalctl -u docker.service --no-pager -n 50 || echo "Could not read daemon logs"
-          echo "Daemon logs mentioning registries:"
-          sudo journalctl -u docker.service --no-pager -n 100 | grep -i -E "(mirror|registry|pull)" || echo "No registry-related logs found"
-          
-          echo "=== Inspecting pulled images ==="
-          docker image inspect mysql:8.0 --format='{{.RepoDigests}}' || echo "MySQL image not found"
-          docker image inspect tinybirdco/tinybird-local:latest --format='{{.RepoDigests}}' || echo "Tinybird image not found"
-          echo "=== Starting services ==="
-          docker compose -f e2e/compose.e2e.yml up -d
+        run: docker compose -f e2e/compose.e2e.yml up -d
         
       - name: Wait for services to be healthy
         run: |

--- a/e2e/compose.e2e.yml
+++ b/e2e/compose.e2e.yml
@@ -1,0 +1,27 @@
+services:
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: ghost_testing
+      MYSQL_USER: ghost
+      MYSQL_PASSWORD: ghost
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  tinybird-local:
+    image: tinybirdco/tinybird-local:latest
+    ports:
+      - "7181:7181"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7181/"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+      start_period: 30s


### PR DESCRIPTION
As we're adding more containers to our CI workflow, we're increasingly at risk of hitting Docker Hub image pull rate limits. We've hit these sporadically in the past, and we've just added two more containers to the e2e test workflow. We've tried using our docker hub credentials to increase our limits, but this only works on PRs opened from TryGhost/Ghost, and fails on PRs opened from forks due to GHA's treatment of secrets on forks.

This gets around the Docker Hub rate limits by configuring `mirror.gcr.io`, a Docker Hub mirror maintained by Google, as a registry mirror. Not all images in Docker Hub are in the mirror, and they can go away unpredictably so we can't point directly to the fully qualified image name. Instead we need to configure the Docker Daemon to pull from the mirror if the image exists there, or fallback to Docker Hub otherwise.

As part of this change, I also had to switch to using docker compose rather than relying on Github Actions service containers, because we don't have any control over the Docker Daemon used for GHA services. This actually turned out to be faster anyways and it gives us more control + flexibility for adding new services in the future, so that's another small win here. 

This only updates the `job_e2e-tests` job — if this works well over the next little while, we can do the same thing for our other jobs that pull images from Docker Hub, and probably deprecate the `tryghost/mysql-setup` action in favor of this setup.