### PR TITLE
Fixed posts app not loading if tinybird config is undefined

### DIFF
--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -75,7 +75,10 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const site = useBrowseSite();
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
     const settings = useBrowseSettings();
-    const tinybirdTokenQuery = useTinybirdToken();
+    
+    // Only fetch Tinybird token if stats config is present
+    const hasStatsConfig = Boolean(config.data?.config?.stats);
+    const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
 
     // Initialize with all audiences selected (binary 111 = 7)
     const [audience, setAudience] = useState(7);
@@ -88,7 +91,8 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         }
     });
 
-    const requests = [config, site, settings, tinybirdTokenQuery];
+    // Only include tinybirdTokenQuery in requests if stats config is present
+    const requests = hasStatsConfig ? [config, site, settings, tinybirdTokenQuery] : [config, site, settings];
     const error = requests.map(request => request.error).find(Boolean);
     const isLoading = requests.some(request => request.isLoading);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2309/the-analytics-tab-does-not-load-with-ui60-enabled-and-no-tinybird
ref https://github.com/TryGhost/Ghost/commit/9ac63938febb1d0c2df8b2096c0689977b8002b2

Currently if you try to load the new post analytics app with an empty/missing `tinybird` configuration, the app will throw and error: it is trying to fetch a Tinybird token, but the required config isn't present so the request fails, and the app throws an error. Not having Tinybird config isn't a state that we'd anticipated in the new posts app yet, but now that the new posts app is becoming the default post analytics app in 6.0, we need to support it even if `tinybird` isn't configured. 

We already have the logic to conditionally display/hide parts of the UI if the configuration for tinybird is missing, but with the token error, we never reach that point. This commit fixes it (in the same way we fixed the same problem in the stats app) by checking if Tinybird config is set before making the token request. If there's no config, the `useTinybirdToken` call in the `GlobalDataProvider` will noop and return undefined, allowing the app to load successfully.