### PR TITLE
Removed `ui60` flag for Settings <> Admin navigation

### DIFF
--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -33,7 +33,7 @@ const MainContent: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 confirmIfDirty(isDirty, () => {
-                    navigateAway('/analytics');
+                    navigateAway('/');
                 });
             }
         };

--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -5,7 +5,6 @@ import Users from './components/settings/general/Users';
 import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {ReactNode, useEffect} from 'react';
 import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/users';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -25,8 +24,6 @@ const MainContent: React.FC = () => {
     const {currentUser} = useGlobalData();
     const {route, updateRoute, loadingModal} = useRouting();
     const {isDirty} = useGlobalDirtyState();
-    const {settings} = useGlobalData();
-    const [hasActivityPub] = getSettingValues(settings, ['social_web_enabled']) as [boolean];
 
     const navigateAway = (escLocation: string) => {
         window.location.hash = escLocation;
@@ -46,7 +43,7 @@ const MainContent: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isDirty, hasActivityPub, currentUser]);
+    }, [isDirty]);
 
     useEffect(() => {
         // resets any toasts that may have been left open on initial load

--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -4,7 +4,7 @@ import Sidebar from './components/Sidebar';
 import Users from './components/settings/general/Users';
 import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {ReactNode, useEffect} from 'react';
-import {canAccessSettings, hasAdminAccess, isEditorUser} from '@tryghost/admin-x-framework/api/users';
+import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/users';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
@@ -22,7 +22,7 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
 };
 
 const MainContent: React.FC = () => {
-    const {currentUser, config} = useGlobalData();
+    const {currentUser} = useGlobalData();
     const {route, updateRoute, loadingModal} = useRouting();
     const {isDirty} = useGlobalDirtyState();
     const {settings} = useGlobalData();
@@ -36,15 +36,7 @@ const MainContent: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
                 confirmIfDirty(isDirty, () => {
-                    if (config.labs.ui60) {
-                        navigateAway('/analytics');
-                    } else {
-                        if (hasActivityPub && hasAdminAccess(currentUser)) {
-                            navigateAway('/activitypub');
-                        } else {
-                            navigateAway('/dashboard');
-                        }
-                    }
+                    navigateAway('/analytics');
                 });
             }
         };
@@ -54,7 +46,7 @@ const MainContent: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isDirty, hasActivityPub, currentUser, config.labs.ui60]);
+    }, [isDirty, hasActivityPub, currentUser]);
 
     useEffect(() => {
         // resets any toasts that may have been left open on initial load

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -5,7 +5,7 @@ const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
 
     const navigateAway = () => {
-        window.location.hash = '/analytics';
+        window.location.hash = '/';
     };
 
     return (

--- a/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
+++ b/apps/admin-x-settings/src/components/ExitSettingsButton.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {hasAdminAccess} from '@tryghost/admin-x-framework/api/users';
-import {useGlobalData} from './providers/GlobalDataProvider';
 
 const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();
-    const {settings, currentUser, config} = useGlobalData();
-    const [hasActivityPub] = getSettingValues(settings, ['social_web_enabled']) as [boolean];
 
     const navigateAway = () => {
-        if (config.labs.ui60) {
-            window.location.hash = '/analytics';
-        } else {
-            window.location.hash = (hasActivityPub && hasAdminAccess(currentUser)) ? '/activitypub' : '/dashboard';
-        }
+        window.location.hash = '/analytics';
     };
 
     return (

--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -184,3 +184,7 @@ add|ember-template-lint|no-invalid-interactive|42|30|42|30|ffabb36d3b9e207aba8ff
 add|ember-template-lint|no-invalid-interactive|74|30|74|30|ffabb36d3b9e207aba8ff78ac29b648f2b314bb2|1749427200000|||app/components/gh-nav-menu/main.hbs
 add|ember-template-lint|no-unknown-arguments-for-builtin-components|76|32|76|32|571c3d774ed33480f528b54b323b23bfd7148eee|1749427200000|||app/components/gh-nav-menu/main.hbs
 remove|ember-template-lint|no-invalid-interactive|47|26|47|26|da9f7c0f319619ff98a53fd679c47841cfaa3c1d|1746489600000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|79|24|79|24|b8aae2daed1c14cf280800b3d282d11fb14851a4|1746489600000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-action|74|30|74|30|3b76c38861ddcdfaa277e272a1d27293c2659524|1749427200000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-invalid-interactive|74|30|74|30|ffabb36d3b9e207aba8ff78ac29b648f2b314bb2|1749427200000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|76|32|76|32|571c3d774ed33480f528b54b323b23bfd7148eee|1749427200000|||app/components/gh-nav-menu/main.hbs

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -26,7 +26,7 @@
         {{#unless this.session.user.isContributor}}
         <div class="gh-nav-top">
 
-            {{#if (and (feature "ui60") this.session.user.isAdmin)}}
+            {{#if this.session.user.isAdmin}}
                 <ul class="gh-nav-list gh-nav-main">
                     {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
                         <li class="relative">
@@ -56,59 +56,6 @@
                             <span>{{svg-jar "external"}}</span>
                         </a>
                     </li>
-                </ul>
-            {{else}}
-                <ul class="gh-nav-list gh-nav-main">
-                    {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
-                        <li class="relative gh-nav-list-ap">
-                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "ap-network"}} Network
-                                {{#unless this.notificationsCount.isLoading}}
-                                    {{#if (gt this.notificationsCount.count 0)}}
-                                        <span class="gh-nav-member-count">{{format-number this.notificationsCount.count}}</span>
-                                    {{/if}}
-                                {{/unless}}
-                            </LinkTo>
-                        </li>
-                    {{/if}}
-                    {{#if (and (gh-user-can-admin this.session.user) this.config.stats (feature "trafficAnalytics"))}}
-                        <li class="relative">
-                            <LinkTo @route="stats-x">{{svg-jar "graph-chart-up-arrow"}}Analytics</LinkTo>
-                        </li>
-                    {{/if}}
-                    {{#if (gh-user-can-admin this.session.user)}}
-                        <li class="relative gh-nav-list-home">
-                            <LinkTo @route="dashboard" @alt="Dashboard" data-test-nav="dashboard">
-                                {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
-                                    {{svg-jar "gauge"}}
-                                {{else}}
-                                    {{svg-jar "house"}}
-                                {{/if}}
-                                Dashboard
-                            </LinkTo>
-                        </li>
-                    {{/if}}
-                    <li class="relative">
-                        <span {{action "transitionToOrRefreshSite" on="click" }} class="{{if this.isOnSite "active"}}">
-                            <LinkTo @route="site" data-test-nav="site" @current-when={{this.isOnSite}}
-                                @preventDefault={{false}}>
-                                {{svg-jar "view-site"}} View site
-                            </LinkTo>
-                        </span>
-                        <a href="{{this.config.blogUrl}}/" class="gh-secondary-action" title="Open site in new tab"
-                            target="_blank" rel="noopener noreferrer">
-                            <span>{{svg-jar "external"}}</span>
-                        </a>
-                    </li>
-                    {{#if (gh-user-can-admin this.session.user)}}
-                        {{#if (not (and this.settings.socialWebEnabled this.session.user.isAdmin))}}
-                            <li class="relative">
-                                <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active" }} {{on "click" (fn
-                                    this.toggleExploreWindow "" )}} data-test-nav="explore">
-                                    {{svg-jar "globe-simple"}} Explore
-                                </a>
-                            </li>
-                        {{/if}}
-                    {{/if}}
                 </ul>
             {{/if}}
             <ul class="gh-nav-list gh-nav-manage">


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2317/remove-settings-related-ui60-flag

- Depending on the state of the `ui60` flag we redirected users to different pages when quitting Settings. Also we had different main navigation menus in Admin depending on the `ui60` flag. This PR removes the flag related to these behaviors and defaults to correct behavior in 6.0.