### PR TITLE
Removed `ui60` flag for Membership settings

### DIFF
--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -257,9 +257,6 @@ const Sidebar: React.FC = () => {
                     <SettingNavSection isVisible={checkVisible(Object.values(advancedSearchKeywords5x).flat())} title="Advanced">
                         <NavItem icon='modules-3' keywords={advancedSearchKeywords5x.integrations} navid='integrations' title="Integrations" onClick={handleSectionClick} />
                         <NavItem icon='download' keywords={advancedSearchKeywords5x.migrationtools} navid='migration' title="Import/Export" onClick={handleSectionClick} />
-                        {!ui60 &&
-                        <NavItem icon='block' keywords={advancedSearchKeywords5x.spamFilters} navid='spam-filters' title="Spam filters" onClick={handleSectionClick} />
-                        }
                         <NavItem icon='brackets' keywords={advancedSearchKeywords5x.codeInjection} navid='code-injection' title="Code injection" onClick={handleSectionClick} />
                         <NavItem icon='labs-flask' keywords={advancedSearchKeywords5x.labs} navid='labs' title="Labs" onClick={handleSectionClick} />
                         <NavItem icon='time-back' keywords={advancedSearchKeywords5x.history} navid='history' title="History" onClick={handleSectionClick} />

--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -17,7 +17,6 @@ import {searchKeywords as growthSearchKeywords} from './settings/growth/GrowthSe
 import {searchKeywords5x as growthSearchKeywords5x} from './settings/growth/GrowthSettings';
 
 import {searchKeywords as membershipSearchKeywords} from './settings/membership/MembershipSettings';
-import {searchKeywords5x as membershipSearchKeywords5x} from './settings/membership/MembershipSettings';
 
 import {searchKeywords as siteSearchKeywords} from './settings/site/SiteSettings';
 import {useGlobalData} from './providers/GlobalDataProvider';
@@ -96,7 +95,7 @@ const Sidebar: React.FC = () => {
         } else {
             if (!checkVisible(Object.values(generalSearchKeywords5x).flat()) &&
                 !checkVisible(Object.values(siteSearchKeywords).flat()) &&
-                !checkVisible(Object.values(membershipSearchKeywords5x).flat()) &&
+                !checkVisible(Object.values(membershipSearchKeywords).flat()) &&
                 !checkVisible(Object.values(growthSearchKeywords5x).flat()) &&
                 !checkVisible(Object.values(emailSearchKeywords).flat()) &&
                 !checkVisible(Object.values(advancedSearchKeywords).flat())) {
@@ -221,25 +220,15 @@ const Sidebar: React.FC = () => {
                 </SettingNavSection>
 
                 {/* Membership settings */}
-                {ui60 ?
-                    <SettingNavSection isVisible={checkVisible([...Object.values(membershipSearchKeywords).flat(), ...emailSearchKeywords.newslettersNavMenu])} title="Membership">
-                        <NavItem icon='key' keywords={membershipSearchKeywords.access} navid={['members', 'spam-filters']} title="Access" onClick={handleSectionClick} />
-                        <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
-                        <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
-                        {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
-                        <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
-                    </SettingNavSection>
-                    :
-                    <SettingNavSection isVisible={checkVisible(Object.values(membershipSearchKeywords5x).flat())} title="Membership">
-                        <NavItem icon='portal' keywords={membershipSearchKeywords5x.portal} navid='portal' title="Portal settings" onClick={handleSectionClick} />
-                        <NavItem icon='key' keywords={membershipSearchKeywords5x.access} navid='members' title="Access" onClick={handleSectionClick} />
-                        <NavItem icon='bills' keywords={membershipSearchKeywords5x.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
-                        <NavItem icon='baseline-chart' keywords={membershipSearchKeywords5x.analytics} navid='analytics' title="Analytics" onClick={handleSectionClick} />
-                    </SettingNavSection>
-                }
+                <SettingNavSection isVisible={checkVisible([...Object.values(membershipSearchKeywords).flat(), ...emailSearchKeywords.newslettersNavMenu])} title="Membership">
+                    <NavItem icon='key' keywords={membershipSearchKeywords.access} navid={['members', 'spam-filters']} title="Access" onClick={handleSectionClick} />
+                    <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
+                    <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
+                    {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
+                    <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
+                </SettingNavSection>
 
                 {/* Growth */}
-
                 {ui60 ?
                     <SettingNavSection isVisible={checkVisible(Object.values(growthSearchKeywords).flat())} title="Growth">
                         <NavItem icon='ap-network' keywords={growthSearchKeywords.network} navid='network' title="Network" onClick={handleSectionClick} />

--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -128,7 +128,6 @@ const Sidebar: React.FC = () => {
 
     const {settings, config} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
-    const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
 
     const handleSectionClick = (e?: React.MouseEvent<HTMLAnchorElement>) => {
@@ -244,19 +243,6 @@ const Sidebar: React.FC = () => {
                         {hasStripeEnabled && <NavItem icon='discount' keywords={growthSearchKeywords5x.offers} navid='offers' title="Offers" onClick={handleSectionClick} />}
                         {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={growthSearchKeywords5x.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     </SettingNavSection>
-                }
-
-                {!ui60 &&
-                <SettingNavSection isVisible={checkVisible(Object.values(emailSearchKeywords).flat())} title="Email newsletter">
-                    <NavItem icon='email-check' keywords={emailSearchKeywords.enableNewsletters} navid='enable-newsletters' title="Newsletter sending" onClick={handleSectionClick} />
-                    {newslettersEnabled !== 'disabled' && (
-                        <>
-                            <NavItem icon='recepients' keywords={emailSearchKeywords.defaultRecipients} navid='default-recipients' title="Default recipients" onClick={handleSectionClick} />
-                            <NavItem icon='email' keywords={emailSearchKeywords.newsletters} navid='newsletters' title="Newsletters" onClick={handleSectionClick} />
-                            {!config.mailgunIsConfigured && <NavItem icon='at-sign' keywords={emailSearchKeywords.mailgun} navid='mailgun' title="Mailgun settings" onClick={handleSectionClick} />}
-                        </>
-                    )}
-                </SettingNavSection>
                 }
 
                 {ui60 ?

--- a/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
@@ -6,7 +6,6 @@ import Labs from './Labs';
 import MigrationTools from './MigrationTools';
 import React from 'react';
 import SearchableSection from '../../SearchableSection';
-import SpamFilters from './SpamFilters';
 import useFeatureFlag from '../../../hooks/useFeatureFlag';
 
 export const searchKeywords5x = {
@@ -15,8 +14,7 @@ export const searchKeywords5x = {
     codeInjection: ['advanced', 'code injection', 'head', 'footer'],
     labs: ['advanced', 'labs', 'alpha', 'private', 'beta', 'flag', 'routes', 'redirect', 'translation', 'editor', 'portal'],
     history: ['advanced', 'history', 'log', 'events', 'user events', 'staff', 'audit', 'action'],
-    dangerzone: ['danger', 'danger zone', 'delete', 'content', 'delete all content', 'delete site'],
-    spamFilters: ['membership', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email']
+    dangerzone: ['danger', 'danger zone', 'delete', 'content', 'delete all content', 'delete site']
 };
 
 export const searchKeywords = {
@@ -36,7 +34,6 @@ const AdvancedSettings: React.FC = () => {
             <SearchableSection keywords={Object.values(searchKeywords5x).flat()} title='Advanced'>
                 <Integrations keywords={searchKeywords5x.integrations} />
                 <MigrationTools keywords={searchKeywords5x.migrationtools} />
-                <SpamFilters keywords={searchKeywords5x.spamFilters} />
                 <CodeInjection keywords={searchKeywords5x.codeInjection} />
                 <Labs keywords={searchKeywords5x.labs} />
                 <History keywords={searchKeywords5x.history} />

--- a/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
@@ -1,21 +1,12 @@
 import Access from './Access';
-import Analytics from './Analytics';
 import Portal from './Portal';
 import React from 'react';
 import SearchableSection from '../../SearchableSection';
 import SpamFilters from '../advanced/SpamFilters';
 import Tiers from './Tiers';
 import TipsAndDonations from '../growth/TipsAndDonations';
-import useFeatureFlag from '../../../hooks/useFeatureFlag';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
-
-export const searchKeywords5x = {
-    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address'],
-    access: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting'],
-    tiers: ['membership', 'tiers', 'payment', 'paid', 'stripe'],
-    analytics: ['membership', 'analytics', 'tracking', 'privacy', 'membership']
-};
 
 export const searchKeywords = {
     access: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email'],
@@ -28,18 +19,6 @@ const MembershipSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
-    const ui60 = useFeatureFlag('ui60');
-
-    if (!ui60) {
-        return (
-            <SearchableSection keywords={Object.values(searchKeywords5x).flat()} title='Membership'>
-                <Portal keywords={searchKeywords5x.portal} />
-                <Access keywords={searchKeywords5x.access} />
-                <Tiers keywords={searchKeywords5x.tiers} />
-                <Analytics keywords={searchKeywords5x.analytics} />
-            </SearchableSection>
-        );
-    }
 
     return (
         <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Membership'>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2208/settings-re-organization-for-60

- Removed `ui60` flag for the Membership section in settings for both in the navigation sidebar and in the settings content area. This also includes removing the separate "Newsletters" navigation group from the sidebar, as all newsletter settings have been merged under the "Membership" navigation group.