### PR TITLE
Updated Stripe Connect limit checks to allow access when already connected

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
@@ -33,7 +33,9 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const limiter = useLimiter();
 
     const openConnectModal = async () => {
-        if (limiter?.isLimited('limitStripeConnect')) {
+        // Allow Stripe despite the limit when it's already connected, so it's
+        // possible to disconnect or update the settings.
+        if (limiter?.isDisabled('limitStripeConnect') && !checkStripeEnabled(settings, config)) {
             try {
                 await limiter.errorIfWouldGoOverLimit('limitStripeConnect');
             } catch (error) {

--- a/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
@@ -260,6 +260,44 @@ test.describe('Tier settings', async () => {
         expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
     });
 
+    test('Allows access to Stripe Connect with limitStripeConnect and Stripe already set up', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            ...limitRequests,
+            browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
+            browseTiers: {method: 'GET', path: '/tiers/', response: responseFixtures.tiers},
+            browseConfig: {
+                ...globalDataRequests.browseConfig,
+                response: {
+                    config: {
+                        ...responseFixtures.config.config,
+                        hostSettings: {
+                            limits: {
+                                limitStripeConnect: {
+                                    disabled: true,
+                                    error: 'Your current plan doesn\'t support Stripe Connect.'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('tiers');
+
+        // Click on Stripe button (different text, as it's already connected)
+        await section.getByRole('button', {name: 'Connected to Stripe'}).click();
+
+        // Limit modal should not be visible
+        await expect(page.getByTestId('limit-modal')).not.toBeVisible();
+
+        // Stripe modal should be visible
+        await expect(page.getByTestId('stripe-modal')).toBeVisible();
+    });
+
     test('Shows limit modal when directly accessing stripe-connect route with limitStripeConnect', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,


### PR DESCRIPTION
closes [BAE-484](https://linear.app/ghost/issue/BAE-484/update-existing-stripe-limit-checks-to-check-current-stripe-connect)

When the `limitStripeConnect` limit is activated in the future, it would prevent users from accessing their Stripe settings even after successfully connecting. This would block users from disconnecting or managing their existing Stripe configuration. Updated the limit check to combine with `checkStripeEnabled()` to ensure users with existing Stripe connections can still access the settings. This prevents the UI from being blocked for users who have already connected Stripe, while still enforcing the limit for new connections.

Changed the limit check from `isLimited()` to `isDisabled()` and added the `isDisabled()` method to the limiter hook interface. This supports synchronous limit checking while maintaining the ability to retrieve error messages asynchronously through `errorIfWouldGoOverLimit()`.
