### PR TITLE
Moved theme and admin maxAge into config properly

### DIFF
--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -59,12 +59,10 @@ function forwardToExpressStatic(req, res, next) {
         return next();
     }
 
-    const configMaxAge = config.get('caching:theme:maxAge');
-
-    // @NOTE: the maxAge config passed below are in milliseconds and the config
-    //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
     express.static(themeEngine.getActive().path, {
-        maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : (365 * 24 * 60 * 60 * 1000) // Default to 1 year in ms
+        // @NOTE: the maxAge config passed below are in milliseconds and the config
+        //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
+        maxAge: config.get('caching:theme:maxAge') * 1000
     }
     )(req, res, next);
 }

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -19,16 +19,15 @@ module.exports = function setupAdminApp() {
     const adminApp = express('admin');
 
     // Admin assets
-    // @TODO ensure this gets a local 404 error handler
-    const configMaxAge = config.get('caching:admin:maxAge');
     // @NOTE: when we start working on HTTP/3 optimizations the immutable headers
     //        produced below should be split into separate 'Cache-Control' entry.
     //        For reference see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#validation_2
-    // @NOTE: the maxAge config passed below are in milliseconds and the config
-    //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
+
     adminApp.use('/assets', serveStatic(
         path.join(config.get('paths').adminAssets, 'assets'), {
-            maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : (365 * 24 * 60 * 60 * 1000), // Default to 1 year in ms
+            // @NOTE: the maxAge config passed below are in milliseconds and the config
+            //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
+            maxAge: config.get('caching:admin:maxAge') * 1000,
             immutable: true,
             fallthrough: false
         }

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -168,6 +168,12 @@
         },
         "commentsCountAPI": {
             "maxAge": 0
+        },
+        "admin": {
+            "maxAge": 31536000
+        },
+        "theme": {
+            "maxAge": 31536000
         }
     },
     "optimization": {


### PR DESCRIPTION
- This change doesn't have any affect on functionality it only moves the hardcoded maxAge into default config
- I think this simplifies the code and makes it easier to reason about 
- We could add a minimal cache for development, but not sure if that would interfere with theme development
- The multiplication by 1000 to get to milliseconds is kinda annoying but it is correct!

