### PR TITLE
Added custom cache-control maxAge rule to /p/ routes

### DIFF
--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -51,6 +51,11 @@ const getMiddleware = async (getFreeTier = async () => {
             return shared.middleware.cacheControl('private')(req, res, next);
         }
 
+        // CASE: Never cache preview routes
+        if (req.path?.startsWith('/p/')) {
+            return shared.middleware.cacheControl('public', {maxAge: 0})(req, res, next);
+        }
+
         // CASE: Cache member's content if this feature is enabled
         if (req.member && shouldCacheMembersContent) {
             // Set the 'cache-control' header to 'public'

--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -53,7 +53,7 @@ const getMiddleware = async (getFreeTier = async () => {
 
         // CASE: Never cache preview routes
         if (req.path?.startsWith('/p/')) {
-            return shared.middleware.cacheControl('public', {maxAge: 0})(req, res, next);
+            return shared.middleware.cacheControl('noCache')(req, res, next);
         }
 
         // CASE: Cache member's content if this feature is enabled

--- a/ghost/core/core/server/web/shared/middleware/cache-control.js
+++ b/ghost/core/core/server/web/shared/middleware/cache-control.js
@@ -9,7 +9,7 @@
 const isString = require('lodash/isString');
 
 /**
- * @param {'public'|'private'} profile Use "private" if you do not want caching
+ * @param {'public'|'private'|'noCache'} profile Use "private" if you do not want caching
  * @param {object} [options]
  * @param {number} [options.maxAge] The max-age in seconds to use when profile is "public"
  * @param {number} [options.staleWhileRevalidate] The stale-while-revalidate in seconds to use when profile is "public"
@@ -24,6 +24,7 @@ const cacheControl = (profile, options = {maxAge: 0}) => {
 
     const profiles = {
         public: publicOptions.filter(option => option).join(', '),
+        noCache: 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0',
         private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
     };
 

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -96,5 +96,20 @@ describe('Advanced URL Configurations', function () {
             await request.get('/welcome/amp/')
                 .expect(404);
         });
+
+        describe('Preview routes', function () {
+            before(async function () {
+                // NOTE: ideally we'd only insert the single draft post we want to test here
+                // but we don't have a way to do that just now and are already planning to
+                // replace the fixture system
+                await testUtils.fixtures.insertPostsAndTags();
+            });
+
+            it('should not cache preview routes', async function () {
+                await request.get('/blog/p/d52c42ae-2755-455c-80ec-70b2ec55c903/')
+                    .expect(200)
+                    .expect('Cache-Control', testUtils.cacheRules.public);
+            });
+        });
     });
 });

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -108,7 +108,7 @@ describe('Advanced URL Configurations', function () {
             it('should not cache preview routes', async function () {
                 await request.get('/blog/p/d52c42ae-2755-455c-80ec-70b2ec55c903/')
                     .expect(200)
-                    .expect('Cache-Control', testUtils.cacheRules.public);
+                    .expect('Cache-Control', testUtils.cacheRules.noCache);
             });
         });
     });

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -124,7 +124,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect('Content-Type', /text\/plain/)
             .expect(302)
             .expect('Location', /ghost\/#\/editor\/post\/\w+/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
+            .expect('Cache-Control', testUtils.cacheRules.noCache)
             .expect(assertCorrectFrontendHeaders);
     });
 
@@ -133,7 +133,7 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect('Content-Type', /text\/plain/)
             .expect(302)
             .expect('Location', /ghost\/#\/editor\/page\/\w+/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
+            .expect('Cache-Control', testUtils.cacheRules.noCache)
             .expect(assertCorrectFrontendHeaders);
     });
 

--- a/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
@@ -66,6 +66,14 @@ describe('frontendCaching', function () {
         assert.ok(res.set.calledWith({'X-Member-Cache-Tier': 'freeTierId'}));
     });
 
+    // Add test for path starting with /p/ resulting in public, max-age=0
+    it('should set cache control to public, max-age=0 if the path starts with /p/', function () {
+        req.path = '/p/test';
+        middleware(req, res, next);
+        assert.equal(res.set.callCount, 1);
+        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.public}));
+    });
+
     describe('calculateMemberTier', function () {
         it('should return null if the member has more than one active subscription', function () {
             const member = {

--- a/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
@@ -66,12 +66,11 @@ describe('frontendCaching', function () {
         assert.ok(res.set.calledWith({'X-Member-Cache-Tier': 'freeTierId'}));
     });
 
-    // Add test for path starting with /p/ resulting in public, max-age=0
-    it('should set cache control to public, max-age=0 if the path starts with /p/', function () {
+    it('should set cache control to no-cache if the path starts with /p/', function () {
         req.path = '/p/test';
         middleware(req, res, next);
         assert.equal(res.set.callCount, 1);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.public}));
+        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.noCache}));
     });
 
     describe('calculateMemberTier', function () {

--- a/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
@@ -54,6 +54,15 @@ describe('Cache-Control middleware', function () {
         });
     });
 
+    it('correctly sets the noCache profile headers', function (done) {
+        cacheControl('noCache')(null, res, function (a) {
+            should.not.exist(a);
+            res.set.calledOnce.should.be.true();
+            res.set.calledWith({'Cache-Control': 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'}).should.be.true();
+            done();
+        });
+    });
+
     it('will not set headers without a profile', function (done) {
         cacheControl()(null, res, function (a) {
             should.not.exist(a);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/24375/commits/c7af8c3a59e283c131f43dfa8b87f6a6f90065c1

- We want to make a change to our frontend cache defaults
- However, that change should not affect /p/ routes
- I thought about adding a caching:preview:maxAge config entry but I can't think of any reason why this should ever not be 0
- Therefore, it makes more sense for this to be fully hard-coded

