### PR TITLE
6.x Theme Asset Behaviour Changes

### DIFF
--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -59,10 +59,25 @@ function forwardToExpressStatic(req, res, next) {
         return next();
     }
 
+    // We allow robots.txt to fall through to the next middleware, so that we can return our default robots.txt
+    // We also allow sitemap.xml and sitemap-:resource.xml to fall through so that we can serve our defaults if they're not found in the theme
+    const fallthroughFiles = [
+        '/robots.txt',
+        '/sitemap.xml',
+        '/sitemap-posts.xml',
+        '/sitemap-pages.xml',
+        '/sitemap-tags.xml',
+        '/sitemap-authors.xml',
+        '/sitemap-users.xml',
+        '/sitemap.xsl'
+    ];
+    const fallthrough = fallthroughFiles.includes(req.path) ? true : false;
+
     express.static(themeEngine.getActive().path, {
         // @NOTE: the maxAge config passed below are in milliseconds and the config
         //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
-        maxAge: config.get('caching:theme:maxAge') * 1000
+        maxAge: config.get('caching:theme:maxAge') * 1000,
+        fallthrough
     }
     )(req, res, next);
 }

--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -69,6 +69,10 @@ function forwardToExpressStatic(req, res, next) {
 
 function staticTheme() {
     return function denyStatic(req, res, next) {
+        if (!path.extname(req.path)) {
+            return next();
+        }
+
         if (!isAllowedFile(req.path.toLowerCase()) && isDeniedFile(req.path.toLowerCase())) {
             return next();
         }

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -101,8 +101,8 @@ describe('Frontend Routing', function () {
             });
 
             it('Single post should sanitize double slashes when redirecting uppercase', function (done) {
-                request.get('///Google.com/')
-                    .expect('Location', '/google.com/')
+                request.get('///Google/')
+                    .expect('Location', '/google/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
                     .end(doEnd(done));

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -326,4 +326,132 @@ describe('staticTheme', function () {
             });
         });
     });
+
+    describe('fallthrough behavior', function () {
+        it('should set fallthrough to true for /robots.txt', function (done) {
+            req.path = '/robots.txt';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to true for /sitemap.xml', function (done) {
+            req.path = '/sitemap.xml';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to true for /sitemap-posts.xml', function (done) {
+            req.path = '/sitemap-posts.xml';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to false for other static files', function (done) {
+            req.path = '/style.css';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', false);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to false for nested files', function (done) {
+            req.path = '/assets/style.css';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', false);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to false for allowed special files like manifest.json', function (done) {
+            req.path = '/manifest.json';
+
+            staticTheme()(req, res, function next() {
+                // Specifically gets called twice
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                // Check that express static gets called with correct options
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', false);
+
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
closes: https://linear.app/ghost/issue/PROD-2214/return-404-from-frontends-assets-folder

These two commits go hand in hand.

If I try to add fallthrough:false to our theme assets to solve the above issue - the entire theme fails to render.

That's cos every single request goes through that middleware!

So, the [first commit](https://github.com/TryGhost/Ghost/commit/072e9d99db9bf190ec548a796bd13fc39f746a69) adds a line to correctly skip the middleware if the file doesn't have an extension,
This is potentially breaking if anyone was using this to render a file from their theme without an extension, but feels low-risk

The second commit then adds the fallthrough rule so we can not redirect missing assets and end on a 404 HTML page, but rather error immediately - with an exception for robots.txt
