### PR TITLE
Updated browser tests for new 6.x behavior

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -199,7 +199,6 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'publish+send'});
-            await closePublishFlow(sharedPage);
             await checkPostPublished(sharedPage, postData);
         });
 
@@ -231,7 +230,6 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPostDraft(sharedPage, postData);
             await publishPost(sharedPage, {type: 'send'});
-            await closePublishFlow(sharedPage);
             await checkPostNotPublished(sharedPage, postData);
         });
     });

--- a/ghost/core/test/e2e-browser/admin/reset-password.spec.js
+++ b/ghost/core/test/e2e-browser/admin/reset-password.spec.js
@@ -31,7 +31,7 @@ test.describe('Admin', () => {
             await sharedPage.getByRole('button', {name: 'Save new password'}).click();
 
             await sharedPage.waitForLoadState('networkidle');
-            await expect(sharedPage).toHaveURL(/\/ghost\/#\/dashboard/);
+            await expect(sharedPage).toHaveURL(/\/ghost\/#\/analytics/);
         });
 
         test.describe('2FA Reset Password', () => {
@@ -65,7 +65,7 @@ test.describe('Admin', () => {
                 await sharedPage.getByRole('button', {name: 'Save new password'}).click();
 
                 await sharedPage.waitForLoadState('networkidle');
-                await expect(sharedPage).toHaveURL(/\/ghost\/#\/dashboard/);
+                await expect(sharedPage).toHaveURL(/\/ghost\/#\/analytics/);
             });
         });
     });


### PR DESCRIPTION
There are a few places on the 6.x branch where we redirect to a different location than before, or redirect when we didn't previously. No functional changes here, just a couple fixes to browser tests.

- password reset tests: we previously checked for a redirect to `/dashboard`, but we now redirect to `/analytics`. This just updates the assertion in the browser test to `/analytics`
- publishing tests: when publishing a post with email (publish + email or email only), Ghost redirects to the post analytics for the post right away. The browser tests were timing out trying to close the publishing flow, but the app had already redirected away from it. This just removes this step from the tests so they can continue to check that the post is/is not published on the site.