### PR TITLE
Cleaned up Social Web (ActivityPub) labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/BetaFeatures.tsx
@@ -1,64 +1,20 @@
 import FeatureToggle from './FeatureToggle';
 import LabItem from './LabItem';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {Button, FileUpload, List, showToast} from '@tryghost/admin-x-design-system';
-import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {downloadRedirects, useUploadRedirects} from '@tryghost/admin-x-framework/api/redirects';
 import {downloadRoutes, useUploadRoutes} from '@tryghost/admin-x-framework/api/routes';
-import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
-import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const BetaFeatures: React.FC = () => {
-    const limiter = useLimiter();
     const {mutateAsync: uploadRedirects} = useUploadRedirects();
     const {mutateAsync: uploadRoutes} = useUploadRoutes();
     const handleError = useHandleError();
     const [redirectsUploading, setRedirectsUploading] = useState<boolean>(false);
     const [routesUploading, setRoutesUploading] = useState<boolean>(false);
-    const [limitSocialWeb, setLimitSocialWeb] = useState<boolean>(false);
-    const [socialWebLimitMessage, setSocialWebLimitMessage] = useState<string>('Please setup a custom domain to enable.');
-    const {config} = useGlobalData();
-    const isPro = !!config.hostSettings?.siteId;
-
-    useEffect(() => {
-        if (limiter?.isLimited('limitSocialWeb')) {
-            limiter.errorIfWouldGoOverLimit('limitSocialWeb').catch((error) => {
-                if (error instanceof HostLimitError) {
-                    const {subdir} = getGhostPaths();
-                    // ensure subdir is defined and not empty
-                    const hasSubdir = subdir?.length > 0;
-
-                    const socialWebNotAvailableMsg = hasSubdir ?
-                        'Not compatible with /subdirectory installations.' :
-                        'Please setup a custom domain to enable.';
-
-                    setSocialWebLimitMessage(socialWebNotAvailableMsg);
-                    setLimitSocialWeb(true);
-                } else {
-                    handleError(error);
-                }
-            });
-        }
-    }, [limiter, handleError]);
 
     return (
         <List titleSeparator={false}>
-            {isPro && (
-                <LabItem
-                    action={<FeatureToggle disabled={limitSocialWeb} flag="ActivityPub"/>}
-                    detail={
-                        <>
-                        Federate your site with ActivityPub to join the world&apos;s largest open network.
-                            {limitSocialWeb &&
-                                (<><br></br>{socialWebLimitMessage} </>)
-                            }
-                            &nbsp;
-                            <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
-                        </>
-                    }
-                    title='Social web (beta)' />
-            )}
             <LabItem
                 action={<FeatureToggle flag="superEditors" />}
                 detail={<>Allows newly-assigned editors to manage members and comments in addition to regular roles.</>}

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -234,12 +234,6 @@ class SettingsHelpers {
             return false;
         }
 
-        // Labs setting
-        if (!this.labs.isSet('ActivityPub')) {
-            debug('Social web is disabled in labs');
-            return false;
-        }
-
         // Ghost (Pro) limits
         if (this.limitService.isDisabled('limitSocialWeb')) {
             debug('Social web is not available for Ghost (Pro) sites without a custom domain, or hosted on a subdirectory');

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -27,7 +27,6 @@ const GA_FEATURES = [
     'announcementBar',
     'customFonts',
     'contentVisibility',
-    'ActivityPub',
     'trafficAnalytics',
     'ui60',
     'explore'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -9,7 +9,6 @@ Object {
     "enableDeveloperExperiments": false,
     "environment": StringMatching /\\^testing/,
     "labs": Object {
-      "ActivityPub": true,
       "additionalPaymentMethods": true,
       "announcementBar": true,
       "audienceFeedback": true,

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -257,7 +257,8 @@ describe('Settings Helpers', function () {
         const config = configUtils.config;
         let settingsCache;
         let urlUtils;
-        let labs;
+        let labs = {};
+
         beforeEach(function () {
             settingsCache = {
                 get: sinon.stub().withArgs('social_web').returns(true)
@@ -265,9 +266,6 @@ describe('Settings Helpers', function () {
             urlUtils = {
                 getSiteUrl: sinon.stub().returns('http://example.com/'),
                 getSubdir: sinon.stub().returns('')
-            };
-            labs = {
-                isSet: sinon.stub().withArgs('ActivityPub').returns(true)
             };
             limitService = {
                 isDisabled: sinon.stub().withArgs('limitSocialWeb').returns(undefined)
@@ -280,15 +278,6 @@ describe('Settings Helpers', function () {
 
         it('returns false when the UI setting is set to false', function () {
             settingsCache.get.withArgs('social_web').returns(false);
-
-            const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
-            const isEnabled = settingsHelpers.isSocialWebEnabled();
-
-            assert.equal(isEnabled, false);
-        });
-
-        it('returns false when the Labs setting is set to false', function () {
-            labs.isSet.withArgs('ActivityPub').returns(false);
 
             const settingsHelpers = new SettingsHelpers({settingsCache, config, urlUtils, labs, limitService});
             const isEnabled = settingsHelpers.isSocialWebEnabled();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2320

- Social web (ActivityPub) is moved to GA in Ghost 6.X
- this commit cleans up the flag from the codebase

