### PR TITLE
Added cacheRules utils to e2e-framework

### DIFF
--- a/ghost/core/test/e2e-server/1-options-requests.test.js
+++ b/ghost/core/test/e2e-server/1-options-requests.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert/strict');
-const {agentProvider, matchers} = require('../utils/e2e-framework');
+const {agentProvider, matchers, cacheRules} = require('../utils/e2e-framework');
 const {anyContentVersion} = matchers;
 const config = require('../../core/shared/config');
 
@@ -114,7 +114,7 @@ describe('OPTIONS requests', function () {
                 .set('origin', null)
                 .expect(200);
 
-            assert.equal(res.headers['cache-control'], 'public, max-age=0');
+            assert.equal(res.headers['cache-control'], cacheRules.public);
             assert.equal(res.headers.vary, 'Origin, Accept-Encoding');
             assert.equal(res.headers.allow, 'POST,GET,HEAD');
         });
@@ -125,7 +125,7 @@ describe('OPTIONS requests', function () {
                 .set('origin', 'https://otherdomain.tld/')
                 .expect(200);
 
-            assert.equal(res.headers['cache-control'], 'public, max-age=0');
+            assert.equal(res.headers['cache-control'], cacheRules.public);
             assert.equal(res.headers.vary, 'Origin, Accept-Encoding');
             assert.equal(res.headers.allow, 'POST,GET,HEAD');
         });

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -25,6 +25,7 @@ const crypto = require('crypto');
 const assert = require('assert/strict');
 
 const fixtureUtils = require('./fixture-utils');
+const cacheRules = require('./fixtures/cache-rules');
 const redirectsUtils = require('./redirects');
 const configUtils = require('./configUtils');
 const urlServiceUtils = require('./url-service-utils');
@@ -545,5 +546,6 @@ module.exports = {
     configUtils: require('./configUtils'),
     dbUtils: require('./db-utils'),
     urlUtils: require('./urlUtils'),
-    resetRateLimits
+    resetRateLimits,
+    cacheRules
 };


### PR DESCRIPTION
- This was the only place in tests where we have the cache rules hardcoded instead of using our cacheRules utility
- Added access to the cacheRules util through the "new" e2e-framework and use that instead so that futher changes to the cache rules don't require updates to the tests

