### PR TITLE
Removed beta flags from new Posts Analytics routing

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow.js
@@ -83,7 +83,7 @@ export default class PublishModalComponent extends Component {
             if (this.args.data.publishOptions.post.displayName !== 'page') {
                 if (this.args.data.publishOptions.post.hasEmail) {
                     // Route to beta analytics if trafficAnalytics feature flag is enabled
-                    if (this.feature.trafficAnalytics || this.feature.ui60) {
+                    if (this.feature.trafficAnalytics) {
                         this.router.transitionTo('posts-x', this.args.data.publishOptions.post.id);
                     } else {
                         this.router.transitionTo('posts.analytics', this.args.data.publishOptions.post.id);

--- a/ghost/admin/app/components/editor/modals/publish-flow.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow.js
@@ -82,12 +82,7 @@ export default class PublishModalComponent extends Component {
             }
             if (this.args.data.publishOptions.post.displayName !== 'page') {
                 if (this.args.data.publishOptions.post.hasEmail) {
-                    // Route to beta analytics if trafficAnalytics feature flag is enabled
-                    if (this.feature.trafficAnalytics) {
-                        this.router.transitionTo('posts-x', this.args.data.publishOptions.post.id);
-                    } else {
-                        this.router.transitionTo('posts.analytics', this.args.data.publishOptions.post.id);
-                    }
+                    this.router.transitionTo('posts-x', this.args.data.publishOptions.post.id);
                 } else {
                     this.router.transitionTo('posts');
                 }

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -296,8 +296,8 @@
         {{!-- Button column --}}
         {{#if @post.hasAnalyticsPage }}
             <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
-                <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
-                    {{svg-jar "stats" title="Go to Analytics Beta"}}
+                <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics" data-ignore-select>
+                    {{svg-jar "stats" title="Go to Analytics"}}
                 </span>
             </LinkTo>
         {{else}}

--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -259,14 +259,8 @@
 
     {{!-- Button column --}}
     {{#if @post.hasAnalyticsPage }}
-        {{#if (and (gh-user-can-admin this.session.user) (or (feature "trafficAnalytics") (feature "ui60")))}}
+        {{#if (gh-user-can-admin this.session.user)}}
         <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
-            <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics Beta" data-ignore-select>
-                {{svg-jar "stats" title="Go to Analytics Beta"}}
-            </span>
-        </LinkTo>
-        {{else}}
-        <LinkTo @route="posts.analytics" @model={{@post.id}} class="permalink gh-list-data gh-post-list-button" title="">
             <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics" data-ignore-select>
                 {{svg-jar "stats" title="Go to Analytics"}}
             </span>

--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -73,11 +73,6 @@
                             <li>
                                 <a class="view-browser" href="{{this.post.url}}" target="_blank" rel="noopener noreferrer">View in browser</a>
                             </li>
-                            {{#if (and (gh-user-can-admin this.session.user) (or (feature "trafficAnalytics") (feature "ui60")))}}
-                                <li>
-                                    <LinkTo class="edit-post" @route="posts-x" @model={{this.post.id}}>Switch to Analytics (beta)</LinkTo>
-                                </li>
-                            {{/if}}
                             <li>
                                 <button
                                     type="button"

--- a/ghost/admin/app/routes/posts-x.js
+++ b/ghost/admin/app/routes/posts-x.js
@@ -26,7 +26,7 @@ export default class PostsXRoute extends AuthenticatedRoute {
         }
 
         // ensure we don't load the app if flags aren't set
-        if (!this.feature.trafficAnalytics && !this.feature.ui60) {
+        if (!this.feature.trafficAnalytics) {
             // Redirect to the old post analytics route
             return this.transitionTo('posts.analytics', this.paramsFor('posts-x').post_id);
         }

--- a/ghost/admin/app/routes/posts-x.js
+++ b/ghost/admin/app/routes/posts-x.js
@@ -24,11 +24,5 @@ export default class PostsXRoute extends AuthenticatedRoute {
         } else if (!this.session.user.isAdmin) {
             return this.transitionTo('site');
         }
-
-        // ensure we don't load the app if flags aren't set
-        if (!this.feature.trafficAnalytics) {
-            // Redirect to the old post analytics route
-            return this.transitionTo('posts.analytics', this.paramsFor('posts-x').post_id);
-        }
     }
 }

--- a/ghost/admin/app/routes/posts/analytics.js
+++ b/ghost/admin/app/routes/posts/analytics.js
@@ -57,7 +57,7 @@ export default class Analytics extends AuthenticatedRoute {
             }
 
             // ensure we don't load the app if flags aren't set
-            if (!this.feature.trafficAnalytics || !this.feature.ui60) {
+            if (!this.feature.trafficAnalytics) {
                 return this.transitionTo('home');
             }
         }

--- a/ghost/admin/app/routes/posts/analytics.js
+++ b/ghost/admin/app/routes/posts/analytics.js
@@ -47,15 +47,6 @@ export default class Analytics extends AuthenticatedRoute {
         if (user.isContributor && !post.isDraft) {
             return this.replaceWith(returnRoute);
         }
-
-        if (this.routeName === 'posts.analytics.posts-x') {
-            // This is based on the logic for the dashboard
-            if (this.session.user.isContributor) {
-                return this.transitionTo('posts');
-            } else if (!this.session.user.isAdmin) {
-                return this.transitionTo('site');
-            }
-        }
     }
 
     serialize(model) {

--- a/ghost/admin/app/routes/posts/analytics.js
+++ b/ghost/admin/app/routes/posts/analytics.js
@@ -55,11 +55,6 @@ export default class Analytics extends AuthenticatedRoute {
             } else if (!this.session.user.isAdmin) {
                 return this.transitionTo('site');
             }
-
-            // ensure we don't load the app if flags aren't set
-            if (!this.feature.trafficAnalytics) {
-                return this.transitionTo('home');
-            }
         }
     }
 

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -17,16 +17,11 @@
                 >
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
-                            {{#if (and this.fromAnalytics (feature "trafficAnalytics"))}}
+                            {{#if this.fromAnalytics}}
                                 <a href="#{{this.fromAnalytics}}" class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}
                                     <span>Analytics</span>
                                 </a>
-                            {{else if this.fromAnalytics}}
-                                <LinkTo @route="posts.analytics" @model={{this.post}} class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
-                                    {{svg-jar "arrow-left"}}
-                                    <span>Analytics</span>
-                                </LinkTo>
                             {{else}}
                                 <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}} data-test-breadcrumb>
                                     {{svg-jar "arrow-left"}}

--- a/ghost/admin/app/templates/posts-x.hbs
+++ b/ghost/admin/app/templates/posts-x.hbs
@@ -1,3 +1,3 @@
-{{#if (or (feature "trafficAnalytics") (feature "ui60"))}}
+{{#if (feature "trafficAnalytics")}}
     <AdminX::Posts />
 {{/if}}

--- a/ghost/admin/app/templates/posts-x.hbs
+++ b/ghost/admin/app/templates/posts-x.hbs
@@ -1,3 +1,1 @@
-{{#if (feature "trafficAnalytics")}}
-    <AdminX::Posts />
-{{/if}}
+<AdminX::Posts />

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -159,14 +159,6 @@ describe('Acceptance: Analytics Navigation', function () {
             await expectPostAnalyticsRoute(post.id);
         });
 
-        it('allows access when only ui60 is enabled', async function () {
-            enableLabsFlag(this.server, 'ui60');
-
-            let post = this.server.create('post', {status: 'published'});
-            await visit(`/posts/analytics/beta/${post.id}`);
-            await expectPostAnalyticsRoute(post.id);
-        });
-
         it('redirects to old post analytics when both flags are disabled', async function () {
             let post = this.server.create('post', {status: 'published'});
             await visit(`/posts/analytics/beta/${post.id}`);

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -78,10 +78,6 @@ describe('Acceptance: Analytics Navigation', function () {
         expect(currentURL()).to.equal(`/posts/analytics/beta/${postId}`);
     }
     
-    async function expectOldPostAnalyticsRoute(postId) {
-        expect(currentURL()).to.equal(`/posts/analytics/${postId}`);
-    }
-    
     async function expectStatsAnalyticsRoute() {
         expect(currentURL()).to.equal('/analytics');
     }
@@ -142,33 +138,13 @@ describe('Acceptance: Analytics Navigation', function () {
     });
 
     describe('Posts-X route (/posts/analytics/beta/:post_id)', function () {
-        it('allows access when both trafficAnalytics and ui60 are enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
+        it('allows access', async function () {
             let post = this.server.create('post', {status: 'published'});
             await visit(`/posts/analytics/beta/${post.id}`);
             await expectPostAnalyticsRoute(post.id);
-        });
-
-        it('allows access when only trafficAnalytics is enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
-            let post = this.server.create('post', {status: 'published'});
-            await visit(`/posts/analytics/beta/${post.id}`);
-            await expectPostAnalyticsRoute(post.id);
-        });
-
-        it('redirects to old post analytics when both flags are disabled', async function () {
-            let post = this.server.create('post', {status: 'published'});
-            await visit(`/posts/analytics/beta/${post.id}`);
-            await expectOldPostAnalyticsRoute(post.id);
         });
 
         it('redirects contributors to posts', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
             updateUserRole(this.server, 'Contributor');
 
             let post = this.server.create('post', {status: 'published'});
@@ -223,22 +199,11 @@ describe('Acceptance: Analytics Navigation', function () {
 
     describe('Posts Index Navigation', function () {
         it('navigates to posts-x route when clicking on post analytics', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
             let post = createPostWithEmail(this.server);
 
             await visit('/posts');
             await clickPostAnalytics(post.id);
             await expectPostAnalyticsRoute(post.id);
-        });
-
-        it('navigates to old post analytics when clicking on post analytics', async function () {
-            let post = createPostWithEmail(this.server);
-
-            await visit('/posts');
-            await clickPostAnalytics(post.id);
-            await expectOldPostAnalyticsRoute(post.id);
         });
     });
 

--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -5,6 +5,7 @@ import {Response} from 'miragejs';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
 import {blur, click, currentRouteName, currentURL, fillIn, find, findAll, triggerEvent, typeIn, waitFor} from '@ember/test-helpers';
+import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {datepickerSelect} from 'ember-power-datepicker/test-support';
 import {editorSelector, pasteInEditor, titleSelector} from '../helpers/editor';
 import {enableLabsFlag} from '../helpers/labs-flag';
@@ -22,7 +23,12 @@ describe('Acceptance: Editor', function () {
     setupMirage(hooks);
 
     beforeEach(async function () {
+        mockAnalyticsApps();
         this.server.loadFixtures('configs');
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
     });
 
     it('redirects to signin when not authenticated', async function () {
@@ -601,7 +607,7 @@ describe('Acceptance: Editor', function () {
             });
 
             // visit the analytics page for the post
-            await visit(`/posts/analytics/${post.id}`);
+            await visit(`/posts/analytics/beta/${post.id}`);
             // now visit the editor for the same post
             await visit(`/editor/post/${post.id}`);
 
@@ -614,7 +620,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-breadcrumb]').getAttribute('href'),
                 'breadcrumb link'
-            ).to.equal(`/ghost/posts/analytics/${post.id}`);
+            ).to.equal(`#posts-x`);
         });
 
         it('does not render analytics breadcrumb for a new post', async function () {

--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -1,6 +1,7 @@
 import loginAsRole from '../../helpers/login-as-role';
 import moment from 'moment-timezone';
 import {blur, click, fillIn, find, findAll, waitFor} from '@ember/test-helpers';
+import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
 import {clickTrigger, removeMultipleOption, selectChoose} from 'ember-power-select/test-support/helpers';
 import {disableMailgun, enableMailgun} from '../../helpers/mailgun';
 import {disableMembers, enableMembers} from '../../helpers/members';
@@ -16,7 +17,12 @@ describe('Acceptance: Publish flow', function () {
     setupMirage(hooks);
 
     beforeEach(function () {
+        mockAnalyticsApps();
         this.server.loadFixtures();
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
     });
 
     it('has minimal features for contributors', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2321/
- removed conditional routing to/from the posts-x (new analytics) app
- removed routing to the Ember posts analytics page; this route is still present and will be cleaned up separately
- removed a couple references to trafficAnalytics/ui60/posts-x in the Ember analytics files
- removed unnecessary test cases for routing conditions
- updated existing tests

The intent is to remove the `trafficAnalytics` and `ui60` flags from the code base. We will be updating the actual routes in a separate PR; the intended end-state for this PR is that we remove any conditionals that direct to the old/new Analytics, and only point to the new.

There's still some references to the old (Ember) analytics in various areas of the code base (e.g. Dashboard, Debug page) that we will review separately.