### PR TITLE
Removed flags from Stats routing

### DIFF
--- a/ghost/admin/app/controllers/explore.js
+++ b/ghost/admin/app/controllers/explore.js
@@ -25,11 +25,7 @@ export default class ExploreController extends Controller {
             this.explore.sendRouteUpdate({path: '/explore'});
             this.router.transitionTo('/explore');
         } else {
-            if (this.config?.labs?.ui60) {
-                this.router.transitionTo('/stats-x');
-            } else {
-                this.router.transitionTo('/dashboard');
-            }
+            this.router.transitionTo('/stats-x');
         }
     }
 

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -18,7 +18,7 @@ export default class HomeRoute extends AuthenticatedRoute {
 
         if (this.session.user?.isAdmin) {
             this.router.transitionTo('stats-x');
-        } else if (this.session.user?.isContributor || this.session.user?.isAuthor) {
+        } else if (this.session.user?.isContributor) {
             this.router.transitionTo('posts');
         } else {
             this.router.transitionTo('site');

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -18,6 +18,10 @@ export default class HomeRoute extends AuthenticatedRoute {
 
         if (this.session.user?.isAdmin) {
             this.router.transitionTo('stats-x');
+        } else if (this.session.user?.isContributor || this.session.user?.isAuthor) {
+            this.router.transitionTo('posts');
+        } else {
+            this.router.transitionTo('site');
         }
     }
 }

--- a/ghost/admin/app/routes/home.js
+++ b/ghost/admin/app/routes/home.js
@@ -16,10 +16,8 @@ export default class HomeRoute extends AuthenticatedRoute {
             return this.router.transitionTo('setup.done');
         }
 
-        if ((this.feature.ui60 || this.feature.trafficAnalytics) && this.session.user?.isAdmin) {
+        if (this.session.user?.isAdmin) {
             this.router.transitionTo('stats-x');
-        } else {
-            this.router.transitionTo('dashboard');
         }
     }
 }

--- a/ghost/admin/app/routes/mentions.js
+++ b/ghost/admin/app/routes/mentions.js
@@ -25,11 +25,7 @@ export default class MentionsRoute extends AuthenticatedRoute {
     beforeModel() {
         super.beforeModel(...arguments);
         if (!this.feature.webmentions) {
-            if (this.config?.labs?.ui60) {
-                return this.transitionTo('stats-x');
-            } else {
-                return this.transitionTo('dashboard');
-            }
+            return this.transitionTo('analytics');
         }
     }
 

--- a/ghost/admin/app/routes/setup/done.js
+++ b/ghost/admin/app/routes/setup/done.js
@@ -17,11 +17,8 @@ export default class SetupFinishingTouchesRoute extends AuthenticatedRoute {
             this.onboarding.startChecklist();
         }
 
-        // Redirect to Analytics if trafficAnalytics or ui60 is enabled and user has access
-        if ((this.feature.trafficAnalytics || this.feature.ui60) && this.session.user?.isAdmin) {
+        if (this.session.user?.isAdmin) {
             return this.router.transitionTo('stats-x');
-        } else {
-            return this.router.transitionTo('dashboard');
         }
     }
 }

--- a/ghost/admin/app/routes/stats-x.js
+++ b/ghost/admin/app/routes/stats-x.js
@@ -13,9 +13,5 @@ export default class StatsXRoute extends AuthenticatedRoute {
         } else if (!this.session.user.isAdmin) {
             return this.transitionTo('site');
         }
-
-        if (!this.feature.trafficAnalytics && !this.feature.ui60) {
-            return this.transitionTo('home');
-        }
     }
 }

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -70,8 +70,6 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
-    @feature('ui60') ui60;
-    @feature('trafficAnalytics') trafficAnalytics;
 
     _user = null;
 

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -186,7 +186,7 @@ describe('Acceptance: Analytics Navigation', function () {
         it('redirects non-admin after signin based on role', async function () {
             await createUserAndSignIn(this.server, {role: 'Author', email: 'author@example.com'});
             
-            expect(currentURL()).to.equal('/site');
+            expect(currentURL()).to.equal('/');
             
             let analyticsLink = findAnalyticsNavLink();
             expect(analyticsLink).to.not.exist;

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -94,7 +94,7 @@ describe('Acceptance: Analytics Navigation', function () {
     });
 
     describe('Stats-X route (/analytics)', function () {
-        it('allows access when trafficAnalytics is enabled', async function () {
+        it('allows access', async function () {
             await visit('/analytics');
             await expectStatsAnalyticsRoute();
         });

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -3,7 +3,6 @@ import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentURL, fillIn} from '@ember/test-helpers';
-import {disableLabsFlag, enableLabsFlag} from '../helpers/labs-flag';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -88,10 +87,6 @@ describe('Acceptance: Analytics Navigation', function () {
         let role = this.server.create('role', {name: 'Administrator'});
         this.server.create('user', {id: '1', roles: [role]});
         await authenticateSession();
-        
-        // Disable all flags by default
-        disableLabsFlag(this.server, 'trafficAnalytics');
-        disableLabsFlag(this.server, 'ui60');
     });
 
     afterEach(function () {
@@ -100,27 +95,11 @@ describe('Acceptance: Analytics Navigation', function () {
 
     describe('Stats-X route (/analytics)', function () {
         it('allows access when trafficAnalytics is enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
             await visit('/analytics');
             await expectStatsAnalyticsRoute();
-        });
-
-        it('allows access when ui60 is enabled', async function () {
-            enableLabsFlag(this.server, 'ui60');
-
-            await visit('/analytics');
-            await expectStatsAnalyticsRoute();
-        });
-
-        it('redirects to dashboard when flags are disabled', async function () {
-            await visit('/analytics');
-            expect(currentURL()).to.equal('/dashboard');
         });
 
         it('redirects contributors to posts', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
             updateUserRole(this.server, 'Contributor');
 
             await visit('/analytics');
@@ -128,8 +107,6 @@ describe('Acceptance: Analytics Navigation', function () {
         });
 
         it('redirects non-admin users to site', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
             updateUserRole(this.server, 'Editor');
 
             await visit('/analytics');
@@ -154,20 +131,8 @@ describe('Acceptance: Analytics Navigation', function () {
     });
 
     describe('Navigation Menu', function () {
-        it('shows Analytics link when ui60 flag is enabled for admin', async function () {
-            enableLabsFlag(this.server, 'ui60');
-
-            await visit('/dashboard');
-            
-            let analyticsLink = findAnalyticsNavLink();
-            expect(analyticsLink).to.exist;
-            expect(analyticsLink.textContent).to.contain('Analytics');
-        });
-
-        it('shows Analytics link when only trafficAnalytics is enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
-            await visit('/dashboard');
+        it('shows Analytics link for admin users', async function () {
+            await visit('/site');
             
             let analyticsLink = findAnalyticsNavLink();
             expect(analyticsLink).to.exist;
@@ -175,9 +140,6 @@ describe('Acceptance: Analytics Navigation', function () {
         });
 
         it('hides Analytics link for non-admin users', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
             updateUserRole(this.server, 'Editor');
 
             await visit('/site');
@@ -187,10 +149,7 @@ describe('Acceptance: Analytics Navigation', function () {
         });
 
         it('navigates to Analytics when Analytics nav link is clicked', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
-            await visit('/dashboard');
+            await visit('/site');
             await click('.gh-nav-list a[href*="analytics"]');
             
             expect(currentURL()).to.equal('/analytics');
@@ -214,10 +173,7 @@ describe('Acceptance: Analytics Navigation', function () {
             });
         });
 
-        it('takes user to analytics after signin when flags are enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
+        it('takes user to analytics after signin', async function () {
             await createUserAndSignIn(this.server, {role: 'Administrator', email: 'test@example.com'});
             
             expect(currentURL()).to.equal('/analytics');
@@ -228,9 +184,6 @@ describe('Acceptance: Analytics Navigation', function () {
         });
 
         it('redirects non-admin after signin based on role', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
             await createUserAndSignIn(this.server, {role: 'Author', email: 'author@example.com'});
             
             expect(currentURL()).to.equal('/site');
@@ -241,10 +194,7 @@ describe('Acceptance: Analytics Navigation', function () {
     });
 
     describe('Setup Flow Navigation', function () {
-        it('shows Analytics after setup when flags are enabled', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-
+        it('shows Analytics after setup', async function () {
             await visit('/setup/done');
             
             expect(currentURL()).to.equal('/analytics');

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -186,7 +186,7 @@ describe('Acceptance: Analytics Navigation', function () {
         it('redirects non-admin after signin based on role', async function () {
             await createUserAndSignIn(this.server, {role: 'Author', email: 'author@example.com'});
             
-            expect(currentURL()).to.equal('/');
+            expect(currentURL()).to.equal('/posts');
             
             let analyticsLink = findAnalyticsNavLink();
             expect(analyticsLink).to.not.exist;

--- a/ghost/admin/tests/acceptance/analytics-navigation-test.js
+++ b/ghost/admin/tests/acceptance/analytics-navigation-test.js
@@ -186,7 +186,7 @@ describe('Acceptance: Analytics Navigation', function () {
         it('redirects non-admin after signin based on role', async function () {
             await createUserAndSignIn(this.server, {role: 'Author', email: 'author@example.com'});
             
-            expect(currentURL()).to.equal('/posts');
+            expect(currentURL()).to.equal('/site');
             
             let analyticsLink = findAnalyticsNavLink();
             expect(analyticsLink).to.not.exist;

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -3,6 +3,7 @@ import windowProxy from 'ghost-admin/utils/window-proxy';
 import {Response} from 'miragejs';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
+import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentRouteName, currentURL, fillIn, find, findAll, triggerKeyEvent, waitFor, waitUntil} from '@ember/test-helpers';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
@@ -60,7 +61,12 @@ describe('Acceptance: Authentication', function () {
     setupMirage(hooks);
 
     beforeEach(async function () {
+        mockAnalyticsApps();
         this.server.loadFixtures('configs');
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
     });
 
     describe('setup redirect', function () {
@@ -205,7 +211,7 @@ describe('Acceptance: Authentication', function () {
             await completeSignIn();
             expect(currentURL(), 'url after email+password submit').to.equal('/signin/verify');
             await completeVerification();
-            expect(currentURL()).to.equal('/dashboard');
+            expect(currentURL()).to.equal('/analytics');
         });
 
         it('handles 2fa code verification failure', async function () {
@@ -295,7 +301,7 @@ describe('Acceptance: Authentication', function () {
             // can correctly submit after failed attempts
             await fillIn(codeInput, '123456');
             await click(verifyButton);
-            expect(currentURL()).to.equal('/dashboard');
+            expect(currentURL()).to.equal('/analytics');
         });
 
         it('can resend verification code', async function () {

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -951,14 +951,20 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(visitorsText, 'visitor count column').to.not.exist;
             });
 
-            it('shows visitor count column when webAnalyticsEnabled is enabled', async function () {
+            it('shows visitor count column when webAnalyticsEnabled is enabled and trafficAnalytics feature is enabled', async function () {
                 // Enable webAnalyticsEnabled setting
                 this.server.db.settings.update({key: 'web_analytics_enabled'}, {value: 'true'});
 
+                // Enable trafficAnalytics feature flag
+                this.server.db.settings.update({key: 'labs'}, {value: JSON.stringify({trafficAnalytics: true})});
+
                 await visit('/posts');
 
+                // When both settings are enabled, the visitor count column container should exist
+                // even if it shows "—" without actual data
                 expect(find('.gh-post-list-metrics-container'), 'metrics container').to.exist;
 
+                // The page should load without errors when analytics are enabled
                 expect(currentURL(), 'current URL').to.equal('/posts');
             });
 
@@ -1022,25 +1028,6 @@ describe('Acceptance: Posts / Pages', function () {
 
                 // The page should load without errors
                 expect(currentURL(), 'current URL').to.equal('/posts');
-            });
-
-            it('shows different template based on trafficAnalytics feature flag', async function () {
-                // Test with trafficAnalytics disabled (standard template)
-                this.server.db.settings.update({key: 'labs'}, {value: JSON.stringify({trafficAnalytics: false})});
-
-                await visit('/posts');
-
-                // Standard template should not have enhanced analytics features
-                expect(find('.gh-post-list-analytics'), 'analytics template class').to.not.exist;
-
-                // Enable trafficAnalytics feature flag
-                this.server.db.settings.update({key: 'labs'}, {value: JSON.stringify({trafficAnalytics: true})});
-
-                await visit('/posts');
-
-                // Check that the enhanced template features are present
-                // The analytics template may not have the exact class name, so let's check for general presence
-                expect(findAll('.gh-posts-list-item').length, 'posts list items').to.be.greaterThan(0);
             });
         });
     });

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -951,20 +951,14 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(visitorsText, 'visitor count column').to.not.exist;
             });
 
-            it('shows visitor count column when webAnalyticsEnabled is enabled and trafficAnalytics feature is enabled', async function () {
+            it('shows visitor count column when webAnalyticsEnabled is enabled', async function () {
                 // Enable webAnalyticsEnabled setting
                 this.server.db.settings.update({key: 'web_analytics_enabled'}, {value: 'true'});
 
-                // Enable trafficAnalytics feature flag
-                this.server.db.settings.update({key: 'labs'}, {value: JSON.stringify({trafficAnalytics: true})});
-
                 await visit('/posts');
 
-                // When both settings are enabled, the visitor count column container should exist
-                // even if it shows "—" without actual data
                 expect(find('.gh-post-list-metrics-container'), 'metrics container').to.exist;
 
-                // The page should load without errors when analytics are enabled
                 expect(currentURL(), 'current URL').to.equal('/posts');
             });
 

--- a/ghost/admin/tests/acceptance/dashboard-test.js
+++ b/ghost/admin/tests/acceptance/dashboard-test.js
@@ -76,10 +76,5 @@ describe('Acceptance: Dashboard', function () {
             await visit('/dashboard');
             expect(currentURL()).to.equal('/dashboard');
         });
-
-        it('/ redirects to /dashboard', async function () {
-            await visit('/');
-            expect(currentURL()).to.equal('/dashboard');
-        });
     });
 });

--- a/ghost/admin/tests/acceptance/members-test.js
+++ b/ghost/admin/tests/acceptance/members-test.js
@@ -25,7 +25,7 @@ describe('Acceptance: Members Test', function () {
         await authenticateSession();
         await visit('/members');
 
-        expect(currentURL()).to.equal('/');
+        expect(currentURL()).to.equal('/site');
         expect(find('[data-test-nav="members"]'), 'sidebar link')
             .to.not.exist;
     });

--- a/ghost/admin/tests/acceptance/members-test.js
+++ b/ghost/admin/tests/acceptance/members-test.js
@@ -25,7 +25,7 @@ describe('Acceptance: Members Test', function () {
         await authenticateSession();
         await visit('/members');
 
-        expect(currentURL()).to.equal('/site');
+        expect(currentURL()).to.equal('/');
         expect(find('[data-test-nav="members"]'), 'sidebar link')
             .to.not.exist;
     });

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import sinon from 'sinon';
 import {authenticateSession} from 'ember-simple-auth/test-support';
 import {blur, click, currentURL, fillIn, find, findAll, focus} from '@ember/test-helpers';
+import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
 import {datepickerSelect} from 'ember-power-datepicker/test-support';
 import {enableNewsletters} from '../../helpers/newsletters';
 import {enablePaidMembers} from '../../helpers/members';
@@ -19,6 +20,8 @@ describe('Acceptance: Members filtering', function () {
     let clock;
 
     beforeEach(async function () {
+        mockAnalyticsApps();
+
         this.server.loadFixtures('configs');
         this.server.loadFixtures('settings');
         this.server.loadFixtures('newsletters');
@@ -33,6 +36,7 @@ describe('Acceptance: Members filtering', function () {
     });
 
     afterEach(function () {
+        cleanupMockAnalyticsApps();
         clock?.restore();
     });
 

--- a/ghost/admin/tests/acceptance/onboarding-test.js
+++ b/ghost/admin/tests/acceptance/onboarding-test.js
@@ -2,7 +2,6 @@ import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-sup
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentURL, find, visit} from '@ember/test-helpers';
 import {describe, it} from 'mocha';
-import {disableLabsFlag, enableLabsFlag} from '../helpers/labs-flag';
 import {enableMembers} from '../helpers/members';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
@@ -17,11 +16,17 @@ describe('Acceptance: Onboarding', function () {
     const skipOnboarding = '#ob-skip';
 
     beforeEach(async function () {
+        mockAnalyticsApps();
+
         this.server.loadFixtures('configs');
         this.server.loadFixtures('settings');
         this.server.loadFixtures('themes');
 
         enableMembers(this.server);
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
     });
 
     describe('checklist (owner)', function () {
@@ -32,40 +37,38 @@ describe('Acceptance: Onboarding', function () {
         });
 
         it('dashboard does not show checklist by default', async function () {
-            await visit('/dashboard');
-            expect(currentURL()).to.equal('/dashboard');
+            await visit('/analytics');
+            expect(currentURL()).to.equal('/analytics');
 
             // onboarding isn't shown
             expect(checklist()).to.not.exist;
-
-            // other default dashboard elements are visible
-            expect(find('[data-test-dashboard="header"]'), 'header').to.exist;
-            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.exist;
         });
 
         it('dashboard shows the checklist after accessing setup/done', async function () {
             await visit('/setup/done');
-            expect(currentURL()).to.equal('/dashboard');
+            expect(currentURL()).to.equal('/analytics');
 
             // main onboarding list is visible
             expect(checklist()).to.exist;
-
-            // other default dashboard elements get hidden
-            expect(find('[data-test-dashboard="header"]'), 'header').to.not.exist;
-            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.not.exist;
         });
 
         it('checklist is shown when members disabled', async function () {
             this.server.db.settings.update({membersSignupAccess: 'none'});
             await visit('/setup/done');
-            await visit('/dashboard');
+            await visit('/analytics');
 
             // onboarding is't shown
             expect(checklist()).to.exist;
+        });
 
-            // other default dashboard elements are not visible
-            expect(find('[data-test-dashboard="header"]'), 'header').to.not.exist;
-            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.not.exist;
+        it('checklist is hidden when completed', async function () {
+            await visit('/setup/done');
+            await visit('/analytics');
+
+            expect(checklist()).to.exist;
+
+            await click(skipOnboarding);
+            expect(checklist()).to.not.exist;
         });
     });
 
@@ -76,16 +79,12 @@ describe('Acceptance: Onboarding', function () {
             await authenticateSession();
         });
 
-        it('dashboard doesn\'t show the checklist', async function () {
-            await visit('/dashboard');
-            expect(currentURL()).to.equal('/dashboard');
+        it('analytics doesn\'t show the checklist', async function () {
+            await visit('/analytics');
+            expect(currentURL()).to.equal('/analytics');
 
             // onboarding isn't shown
             expect(checklist()).to.not.exist;
-
-            // other default dashboard elements are visible
-            expect(find('[data-test-dashboard="header"]'), 'header').to.exist;
-            expect(find('[data-test-dashboard="attribution"]'), 'attribution section').to.exist;
         });
     });
 
@@ -98,76 +97,6 @@ describe('Acceptance: Onboarding', function () {
         it('setup is redirected to signin', async function () {
             await visit('/setup/done');
             expect(currentURL()).to.equal('/signin');
-        });
-    });
-    
-    describe('onboarding with beta flags (owner)', function () {
-        beforeEach(async function () {
-            mockAnalyticsApps();
-            
-            // Create owner user and authenticate
-            let role = this.server.create('role', {name: 'Owner'});
-            this.server.create('user', {roles: [role], slug: 'owner'});
-            await authenticateSession();
-            
-            // Disable all flags by default
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-        });
-
-        afterEach(function () {
-            cleanupMockAnalyticsApps();
-        });
-
-        it('with no flags shows checklist on dashboard after setup/done', async function () {
-            await visit('/setup/done');
-            expect(currentURL()).to.equal('/dashboard');
-            expect(checklist()).to.exist;
-            
-            await click(skipOnboarding);
-            expect(checklist()).to.not.exist;
-            
-            expect(currentURL()).to.equal('/dashboard');
-        });
-
-        it('with trafficAnalytics flag shows checklist on analytics after setup/done', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            
-            await visit('/setup/done');
-            expect(currentURL()).to.equal('/analytics');
-            expect(checklist()).to.exist;
-            
-            await click(skipOnboarding);
-            expect(checklist()).to.not.exist;
-            
-            expect(currentURL()).to.equal('/analytics');
-        });
-
-        it('with ui60 flag shows checklist on analytics after setup/done', async function () {
-            enableLabsFlag(this.server, 'ui60');
-            
-            await visit('/setup/done');
-            expect(currentURL()).to.equal('/analytics');
-            expect(checklist()).to.exist;
-            
-            await click(skipOnboarding);
-            expect(checklist()).to.not.exist;
-            
-            expect(currentURL()).to.equal('/analytics');
-        });
-
-        it('with both flags shows checklist on analytics after setup/done', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-            
-            await visit('/setup/done');
-            expect(currentURL()).to.equal('/analytics');
-            expect(checklist()).to.exist;
-            
-            await click(skipOnboarding);
-            expect(checklist()).to.not.exist;
-            
-            expect(currentURL()).to.equal('/analytics');
         });
     });
 });

--- a/ghost/admin/tests/acceptance/setup-test.js
+++ b/ghost/admin/tests/acceptance/setup-test.js
@@ -3,7 +3,6 @@ import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
-import {disableLabsFlag, enableLabsFlag} from '../helpers/labs-flag';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -12,6 +11,14 @@ import {visit} from '../helpers/visit';
 describe('Acceptance: Setup', function () {
     let hooks = setupApplicationTest();
     setupMirage(hooks);
+
+    beforeEach(function () {
+        mockAnalyticsApps();
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
+    });
 
     // Helper function to setup the setup flow
     async function setupSetupFlow(server, {fillForm = true} = {}) {
@@ -115,7 +122,7 @@ describe('Acceptance: Setup', function () {
 
             // it redirects to the dashboard
             expect(currentURL(), 'url after submitting account details')
-                .to.equal('/dashboard');
+                .to.equal('/analytics');
         });
 
         it('handles validation errors in setup', async function () {
@@ -215,46 +222,6 @@ describe('Acceptance: Setup', function () {
 
         it('transitions to dashboard', async function () {
             await visit('/?firstStart=true');
-            expect(currentURL()).to.equal('/dashboard');
-        });
-    });
-    
-    describe('Success beta flags routing', function () {
-        beforeEach(function () {
-            mockAnalyticsApps();
-        });
-
-        afterEach(function () {
-            cleanupMockAnalyticsApps();
-        });
-
-        it('administrators with no flags redirects to dashboard', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSetupFlow(this.server);
-            await click('[data-test-button="setup"]');
-
-            expect(currentURL()).to.equal('/dashboard');
-        });
-
-        it('administrators with trafficAnalytics flag redirects to analytics', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSetupFlow(this.server);
-            await click('[data-test-button="setup"]');
-
-            expect(currentURL()).to.equal('/analytics');
-        });
-
-        it('administrators with ui60 flag redirects to analytics', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-            
-            await setupSetupFlow(this.server);
-            await click('[data-test-button="setup"]');
-
             expect(currentURL()).to.equal('/analytics');
         });
     });

--- a/ghost/admin/tests/acceptance/signin-test.js
+++ b/ghost/admin/tests/acceptance/signin-test.js
@@ -9,7 +9,6 @@ import {
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
-import {disableLabsFlag, enableLabsFlag} from '../helpers/labs-flag';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -68,6 +67,7 @@ describe('Acceptance: Signin', function () {
         await authenticateSession();
         await visit('/signin');
 
+        // With analytics mocks, authors get redirected to home first, then to site
         expect(currentURL(), 'current url').to.equal('/site');
     });
 
@@ -130,33 +130,8 @@ describe('Acceptance: Signin', function () {
         });
 
         it('submits successfully', async function () {
-            invalidateSession();
-
-            await visit('/signin');
-            expect(currentURL(), 'current url').to.equal('/signin');
-
-            await fillIn('[name="identification"]', 'test@example.com');
-            await fillIn('[name="password"]', 'thisissupersafe');
-            await click('[data-test-button="sign-in"]');
-            expect(currentURL(), 'currentURL').to.equal('/dashboard');
-        });
-
-        it('submits successfully with traffic analytics enabled', async function () {
-            // Mock the asset delivery config for stats component (comes from Admin config, not Ghost backend [fixture] config)
-            config.statsFilename = 'stats.js';
-            config.statsHash = 'development';
+            mockAnalyticsApps();
             
-            // Mock the stats component to prevent actual loading
-            // The component expects an object with AdminXApp property
-            window['@tryghost/stats'] = {
-                AdminXApp: function MockStatsComponent() {
-                    return <div data-test-stats-component>Mock Stats Component</div>;
-                }
-            };
-            
-            this.server.loadFixtures('configs');
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
             invalidateSession();
 
             await visit('/signin');
@@ -166,77 +141,8 @@ describe('Acceptance: Signin', function () {
             await fillIn('[name="password"]', 'thisissupersafe');
             await click('[data-test-button="sign-in"]');
             expect(currentURL(), 'currentURL').to.equal('/analytics');
-            expect(find('[data-test-stats-component]')).to.exist;
-        });
-    });
-
-    describe('Success beta flags routing', function () {
-        beforeEach(function () {
-            mockAnalyticsApps();
-        });
-
-        afterEach(function () {
+            
             cleanupMockAnalyticsApps();
-        });
-
-        it('administrators with no flags redirects to dashboard', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Administrator'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/dashboard');
-        });
-
-        it('administrators with trafficAnalytics flag redirects to analytics', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Administrator'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/analytics');
-        });
-
-        it('administrators with ui60 flag redirects to analytics', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Administrator'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/analytics');
-        });
-
-        it('non-admins with no flags redirects to site', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Author'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/site');
-        });
-
-        it('non-admins with trafficAnalytics flag redirects to site', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Author'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/site');
-        });
-
-        it('non-admins with ui60 flag redirects to site', async function () {
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            enableLabsFlag(this.server, 'ui60');
-            
-            await setupSigninFlow(this.server, {role: 'Author'});
-            await click('[data-test-button="sign-in"]');
-
-            expect(currentURL()).to.equal('/site');
         });
     });
 });

--- a/ghost/admin/tests/acceptance/signin-test.js
+++ b/ghost/admin/tests/acceptance/signin-test.js
@@ -1,12 +1,10 @@
-import config from 'ghost-admin/config/environment';
 import {Response} from 'miragejs';
-import {
-    afterEach,
+import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
+import {    
     beforeEach,
     describe,
     it
 } from 'mocha';
-import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {click, currentURL, fillIn, find, findAll} from '@ember/test-helpers';
 import {expect} from 'chai';
@@ -17,48 +15,6 @@ import {visit} from '../helpers/visit';
 describe('Acceptance: Signin', function () {
     let hooks = setupApplicationTest();
     setupMirage(hooks);
-
-    // Helper function to setup signin flow
-    async function setupSigninFlow(server, {role = 'Administrator', fillForm = true} = {}) {
-        // Ensure fixtures are loaded
-        if (!server.schema.configs.all().length) {
-            server.loadFixtures('configs');
-        }
-        if (!server.schema.settings.all().length) {
-            server.loadFixtures('settings');
-        }
-        
-        let roleObj = server.create('role', {name: role});
-        server.create('user', {roles: [roleObj], slug: 'test-user'});
-
-        server.post('/session', function (schema, {requestBody}) {
-            let {
-                username,
-                password
-            } = JSON.parse(requestBody);
-
-            expect(username).to.equal('test@example.com');
-
-            if (password === 'thisissupersafe') {
-                return new Response(201);
-            } else {
-                return new Response(401, {}, {
-                    errors: [{
-                        type: 'UnauthorizedError',
-                        message: 'Invalid Password'
-                    }]
-                });
-            }
-        });
-
-        await invalidateSession();
-        await visit('/signin');
-
-        if (fillForm) {
-            await fillIn('[name="identification"]', 'test@example.com');
-            await fillIn('[name="password"]', 'thisissupersafe');
-        }
-    }
 
     it('redirects if already authenticated', async function () {
         let role = this.server.create('role', {name: 'Author'});

--- a/ghost/admin/tests/acceptance/signin-test.js
+++ b/ghost/admin/tests/acceptance/signin-test.js
@@ -16,6 +16,54 @@ describe('Acceptance: Signin', function () {
     let hooks = setupApplicationTest();
     setupMirage(hooks);
 
+    beforeEach(function () {
+        mockAnalyticsApps();
+    });
+
+    afterEach(function () {
+        cleanupMockAnalyticsApps();
+    });
+
+    async function setupSigninFlow(server, {role = 'Administrator', fillForm = true} = {}) {
+        if (!server.schema.configs.all().length) {
+            server.loadFixtures('configs');
+        }
+        if (!server.schema.settings.all().length) {
+            server.loadFixtures('settings');
+        }
+
+        let roleObj = server.create('role', {name: role});
+        server.create('user', {roles: [roleObj], slug: 'test-user'});
+
+        server.post('/session', function (schema, {requestBody}) {
+            let {
+                username,
+                password
+            } = JSON.parse(requestBody);
+
+            expect(username).to.equal('test@example.com');
+
+            if (password === 'thisissupersafe') {
+                return new Response(201);
+            } else {
+                return new Response(401, {}, {
+                    errors: [{
+                        type: 'UnauthorizedError',
+                        message: 'Invalid Password'
+                    }]
+                });
+            }
+        });
+
+        await invalidateSession();
+        await visit('/signin');
+
+        if (fillForm) {
+            await fillIn('[name="identification"]', 'test@example.com');
+            await fillIn('[name="password"]', 'thisissupersafe');
+        }
+    }
+
     it('redirects if already authenticated', async function () {
         let role = this.server.create('role', {name: 'Author'});
         this.server.create('user', {roles: [role], slug: 'test-user'});
@@ -99,6 +147,29 @@ describe('Acceptance: Signin', function () {
             expect(currentURL(), 'currentURL').to.equal('/analytics');
             
             cleanupMockAnalyticsApps();
+        });
+    });
+
+    describe('success routing', function () {
+        it('redirects admin user to analytics', async function () {
+            await setupSigninFlow(this.server, {role: 'Administrator'});
+            await click('[data-test-button="sign-in"]');
+
+            expect(currentURL()).to.equal('/analytics');
+        });
+
+        it('redirects contributor user to posts', async function () {
+            await setupSigninFlow(this.server, {role: 'Contributor'});
+            await click('[data-test-button="sign-in"]');
+
+            expect(currentURL()).to.equal('/posts');
+        });
+
+        it('redirects author user to site', async function () {
+            await setupSigninFlow(this.server, {role: 'Author'});
+            await click('[data-test-button="sign-in"]');
+
+            expect(currentURL()).to.equal('/site');
         });
     });
 });

--- a/ghost/admin/tests/acceptance/signup-test.js
+++ b/ghost/admin/tests/acceptance/signup-test.js
@@ -1,8 +1,6 @@
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {blur, click, currentRouteName, fillIn, find, focus} from '@ember/test-helpers';
-import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../helpers/mock-analytics-apps';
 import {describe, it} from 'mocha';
-import {disableLabsFlag, enableLabsFlag} from '../helpers/labs-flag';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
@@ -181,46 +179,6 @@ describe('Acceptance: Signup', function () {
         await click('[data-test-button="signup"]');
 
         expect(currentRouteName()).to.equal('site');
-    });
-
-    describe('Sign up success routing', function () {
-        beforeEach(function () {
-            mockAnalyticsApps();
-            disableLabsFlag(this.server, 'trafficAnalytics');
-            disableLabsFlag(this.server, 'ui60');
-        });
-
-        afterEach(function () {
-            cleanupMockAnalyticsApps();
-        });
-
-        it('signup with author user redirects to site with no flags', async function () {
-            await setupSignupFlow(this.server);
-            await click('[data-test-button="signup"]');
-
-            // Non-admin users go to site regardless of flags
-            expect(currentRouteName()).to.equal('site');
-        });
-
-        it('signup with author user redirects to site with ui60 flag', async function () {
-            enableLabsFlag(this.server, 'ui60');
-
-            await setupSignupFlow(this.server);
-            await click('[data-test-button="signup"]');
-
-            // Non-admin users go to site regardless of flags
-            expect(currentRouteName()).to.equal('site');
-        });
-
-        it('signup with author user redirects to site with trafficAnalytics flag', async function () {
-            enableLabsFlag(this.server, 'trafficAnalytics');
-
-            await setupSignupFlow(this.server);
-            await click('[data-test-button="signup"]');
-
-            // Non-admin users go to site regardless of flags
-            expect(currentRouteName()).to.equal('site');
-        });
     });
 
     it('redirects if already logged in', async function () {

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -26,14 +26,10 @@ describe('Unit: Service: post-analytics', function () {
             webAnalyticsEnabled: true,
             membersTrackSources: true
         };
-        const featureStub = {
-            trafficAnalytics: true
-        };
 
         service.ajax = {request: ajaxStub};
         service.ghostPaths = ghostPathsStub;
         service.settings = settingsStub;
-        service.feature = featureStub;
     });
 
     afterEach(function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2321/
- removed trafficAnalytics and ui60 flags from Ember routing logic; this means we are using Analytics in lieu of Dashboard and Dashboard is unlisted
- updated Ember acceptance tests; removed flag use and added Analytics mocks where necessary
- Dashboard is still directly navigable to