### PR TITLE
Fixed locations tab showing in analytics when web analytics is disabled

### DIFF
--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -79,9 +79,11 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                         navigate('/growth/');
                     }}>Growth</PageMenuItem>
 
-                    <PageMenuItem value="/locations/" onClick={() => {
-                        navigate('/locations/');
-                    }}>Locations</PageMenuItem>
+                    {appSettings?.analytics.webAnalytics && (
+                        <PageMenuItem value="/locations/" onClick={() => {
+                            navigate('/locations/');
+                        }}>Locations</PageMenuItem>
+                    )}
                 </PageMenu>
                 <NavbarActions>
                     {children}


### PR DESCRIPTION
https://linear.app/ghost/issue/PROD-2304/locations-tab-should-be-hidden-when-web-analytics-is-turned-off

Currently the "Locations" tab in the analytics view is still showing in the header when web analytics is disabled (either by the user, or plan limit, or missing configuration). This tab only includes data from Tinybird, and it redirects to the Overview tab if you try to select it with web analytics disabled. This commit hides the link as well.