### PR TITLE
Re-added social accounts back to explore payload

### DIFF
--- a/ghost/core/core/server/services/explore-ping/ExplorePingService.js
+++ b/ghost/core/core/server/services/explore-ping/ExplorePingService.js
@@ -33,7 +33,9 @@ module.exports = class ExplorePingService {
             ghost: this.ghostVersion.full,
             site_uuid: this.settingsCache.get('site_uuid'),
             url: this.config.get('url'),
-            theme: this.settingsCache.get('active_theme')
+            theme: this.settingsCache.get('active_theme'),
+            facebook: this.settingsCache.get('facebook'),
+            twitter: this.settingsCache.get('twitter')
         };
 
         try {

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -23,8 +23,8 @@ describe('ExplorePingService', function () {
         settingsCacheStub.get.withArgs('active_theme').returns('alto');
         settingsCacheStub.get.withArgs('explore_ping').returns(true);
         settingsCacheStub.get.withArgs('explore_ping_growth').returns(false);
-        settingsCacheStub.get.withArgs('facebook').returns('https://facebook.com/example');
-        settingsCacheStub.get.withArgs('twitter').returns('https://twitter.com/example');
+        settingsCacheStub.get.withArgs('facebook').returns('my-profile');
+        settingsCacheStub.get.withArgs('twitter').returns('my-handle');
 
         configStub = {
             get: sinon.stub()
@@ -88,8 +88,8 @@ describe('ExplorePingService', function () {
                 site_uuid: '123e4567-e89b-12d3-a456-426614174000',
                 url: 'https://example.com',
                 theme: 'alto',
-                facebook: 'https://facebook.com/example',
-                twitter: 'https://twitter.com/example',
+                facebook: 'my-profile',
+                twitter: 'my-handle',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z'
@@ -130,8 +130,8 @@ describe('ExplorePingService', function () {
                 site_uuid: '123e4567-e89b-12d3-a456-426614174000',
                 url: 'https://example.com',
                 theme: 'alto',
-                facebook: 'https://facebook.com/example',
-                twitter: 'https://twitter.com/example',
+                facebook: 'my-profile',
+                twitter: 'my-handle',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z',

--- a/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/ExplorePingService.test.js
@@ -23,6 +23,8 @@ describe('ExplorePingService', function () {
         settingsCacheStub.get.withArgs('active_theme').returns('alto');
         settingsCacheStub.get.withArgs('explore_ping').returns(true);
         settingsCacheStub.get.withArgs('explore_ping_growth').returns(false);
+        settingsCacheStub.get.withArgs('facebook').returns('https://facebook.com/example');
+        settingsCacheStub.get.withArgs('twitter').returns('https://twitter.com/example');
 
         configStub = {
             get: sinon.stub()
@@ -86,6 +88,8 @@ describe('ExplorePingService', function () {
                 site_uuid: '123e4567-e89b-12d3-a456-426614174000',
                 url: 'https://example.com',
                 theme: 'alto',
+                facebook: 'https://facebook.com/example',
+                twitter: 'https://twitter.com/example',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z'
@@ -126,6 +130,8 @@ describe('ExplorePingService', function () {
                 site_uuid: '123e4567-e89b-12d3-a456-426614174000',
                 url: 'https://example.com',
                 theme: 'alto',
+                facebook: 'https://facebook.com/example',
+                twitter: 'https://twitter.com/example',
                 posts_total: 100,
                 posts_last: '2023-01-01T00:00:00.000Z',
                 posts_first: '2020-01-01T00:00:00.000Z',


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1771/push-support-for-ghost-explore

- The payload for explore was simplified because most properties could be gotten from the public site endpoint
- But social accounts  are not available there yet
- Adding these back to explore, in lieu of adding them to the site endpoint, maybe when we add the other socials
- For now, this seems like a simpler change as it feels weird adding "twitter" to an endpont and documenting it, but we haven't entirely decided what to do about that because x is a weird property name

