### PR TITLE
🔒 Prevented homograph attacks with punycode domains on member signin

### DIFF
--- a/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
+++ b/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
@@ -1,0 +1,31 @@
+const punycode = require('punycode/');
+
+/**
+ * Normalizes email addresses by converting Unicode domains to ASCII (punycode)
+ * This prevents homograph attacks where Unicode characters are used to spoof
+ * domains
+ *
+ * @param {string} email The email address to normalize
+ * @returns {string} The normalized email address
+ * @throws {Error} When punycode conversion fails
+ */
+function normalizeEmail(email) {
+    if (!email || typeof email !== 'string') {
+        return null;
+    }
+
+    const atIndex = email.lastIndexOf('@');
+
+    if (atIndex === -1) {
+        return email;
+    }
+
+    const localPart = email.substring(0, atIndex);
+    const domainPart = email.substring(atIndex + 1);
+
+    const asciiDomain = punycode.toASCII(domainPart);
+
+    return `${localPart}@${asciiDomain}`;
+}
+
+module.exports = normalizeEmail;

--- a/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`sendMagicLink Homograph attack prevention should prevent homograph attacks by normalizing unicode domains 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "No member exists with this e-mail address. Please sign up first.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
 exports[`sendMagicLink Throws an error when logging in to a email that does not exist (invite only) 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
@@ -1,0 +1,53 @@
+const should = require('should');
+const normalizeEmail = require('../../../../../../../core/server/services/members/members-api/utils/normalize-email');
+
+describe('normalizeEmail', function () {
+    it('should normalize unicode domains to punycode', function () {
+        normalizeEmail('test@еxample.com').should.equal('test@xn--xample-2of.com');
+        normalizeEmail('user@tëst.org').should.equal('user@xn--tst-jma.org');
+        normalizeEmail('foo@bär.baz').should.equal('foo@xn--br-via.baz');
+    });
+
+    it('should preserve ASCII domains unchanged', function () {
+        normalizeEmail('user@example.com').should.equal('user@example.com');
+        normalizeEmail('admin@test.org').should.equal('admin@test.org');
+        normalizeEmail('foo@bar.baz').should.equal('foo@bar.baz');
+    });
+
+    it('should preserve unicode in the local part of the email', function () {
+        normalizeEmail('üser@example.com').should.equal('üser@example.com');
+        normalizeEmail('tëst@test.org').should.equal('tëst@test.org');
+        normalizeEmail('用户@example.com').should.equal('用户@example.com');
+    });
+
+    it('should handle already punycoded domains', function () {
+        normalizeEmail('test@xn--tst-jma.com').should.equal('test@xn--tst-jma.com');
+        normalizeEmail('user@xn--br-via.baz').should.equal('user@xn--br-via.baz');
+    });
+
+    it('should preserve the case of the email address', function () {
+        normalizeEmail('User@Example.COM').should.equal('User@Example.COM');
+        normalizeEmail('Admin@TEST.org').should.equal('Admin@TEST.org');
+    });
+
+    it('should handle edge cases gracefully', function () {
+        should.not.exist(normalizeEmail(null));
+        should.not.exist(normalizeEmail(undefined));
+        should.not.exist(normalizeEmail(''));
+        normalizeEmail('invalid-email').should.equal('invalid-email');
+        normalizeEmail('@example.com').should.equal('@example.com');
+        normalizeEmail('user@').should.equal('user@');
+    });
+
+    it('should handle non-string inputs', function () {
+        should.not.exist(normalizeEmail(123));
+        should.not.exist(normalizeEmail({}));
+        should.not.exist(normalizeEmail([]));
+        should.not.exist(normalizeEmail(true));
+    });
+
+    it('should handle multiple @ symbols by using the last one', function () {
+        normalizeEmail('user@name@example.com').should.equal('user@name@example.com');
+        normalizeEmail('user@name@tëst.com').should.equal('user@name@xn--tst-jma.com');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2462

Added normalization to email addresses for member signup / signin to prevent homograph attacks with punycode domains. This change should be backwards compatible with existing members using emails with unicode characters