### PR TITLE
Fix: Empty results while searching some keywords in /settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/email-settings.tsx
@@ -11,22 +11,28 @@ export const searchKeywords = {
     enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
     newsletters: ['newsletters', 'emails', 'design', 'customization'],
     defaultRecipients: ['newsletters', 'default recipients', 'emails'],
-    mailgun: ['mailgun', 'emails', 'newsletters'],
-    newslettersNavMenu: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'mailgun', 'tips', 'donations', 'one time', 'payment']
+    mailgun: ['mailgun', 'emails', 'newsletters']
 };
 
 const EmailSettings: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
+    const hasNewslettersEnabled = newslettersEnabled !== 'disabled';
+    const hasMailgun = hasNewslettersEnabled && !config.mailgunIsConfigured;
+    const visibleSearchKeywords = [
+        searchKeywords.enableNewsletters,
+        ...(hasNewslettersEnabled ? [searchKeywords.defaultRecipients, searchKeywords.newsletters] : []),
+        ...(hasMailgun ? [searchKeywords.mailgun] : [])
+    ].flat();
 
     return (
-        <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Newsletters'>
+        <SearchableSection keywords={visibleSearchKeywords} title='Newsletters'>
             <EnableNewsletters keywords={searchKeywords.enableNewsletters} />
-            {newslettersEnabled !== 'disabled' && (
+            {hasNewslettersEnabled && (
                 <>
                     <DefaultRecipients keywords={searchKeywords.defaultRecipients} />
                     <Newsletters keywords={searchKeywords.newsletters} />
-                    {!config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
+                    {hasMailgun && <MailGun keywords={searchKeywords.mailgun} />}
                 </>
             )}
         </SearchableSection>

--- a/apps/admin-x-settings/src/components/settings/email/emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/emails.tsx
@@ -21,8 +21,7 @@ export const searchKeywords = {
     enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
     emails: ['emails', 'newsletters', 'automation emails', 'transactional', 'design', 'customization', 'automations', 'welcome'],
     defaultRecipients: ['newsletters', 'default recipients', 'emails'],
-    mailgun: ['mailgun', 'emails', 'newsletters'],
-    emailsNavMenu: ['emails', 'newsletters', 'automation emails', 'transactional', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off', 'design', 'customization', 'default recipients', 'mailgun', 'automations', 'welcome']
+    mailgun: ['mailgun', 'emails', 'newsletters']
 };
 
 const TransactionalTabContent: React.FC = () => {
@@ -184,13 +183,20 @@ const Emails: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [newslettersEnabled] = getSettingValues(settings, ['editor_default_email_recipients']) as [string];
     const hasNewslettersEnabled = newslettersEnabled !== 'disabled';
+    const hasMailgun = hasNewslettersEnabled && !config.mailgunIsConfigured;
+    const visibleSearchKeywords = [
+        searchKeywords.enableNewsletters,
+        ...(hasNewslettersEnabled ? [searchKeywords.defaultRecipients] : []),
+        searchKeywords.emails,
+        ...(hasMailgun ? [searchKeywords.mailgun] : [])
+    ].flat();
 
     return (
-        <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Email'>
+        <SearchableSection keywords={visibleSearchKeywords} title='Email'>
             <EnableNewsletters keywords={searchKeywords.enableNewsletters} />
             {hasNewslettersEnabled && <DefaultRecipients keywords={searchKeywords.defaultRecipients} />}
             <EmailsGroup keywords={searchKeywords.emails} newslettersEnabled={hasNewslettersEnabled} />
-            {hasNewslettersEnabled && !config.mailgunIsConfigured && <MailGun keywords={searchKeywords.mailgun} />}
+            {hasMailgun && <MailGun keywords={searchKeywords.mailgun} />}
         </SearchableSection>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/general-settings.tsx
@@ -16,7 +16,7 @@ export const searchKeywords = {
     users: ['general', 'users and permissions', 'roles', 'staff', 'invite people', 'contributors', 'editors', 'authors', 'administrators'],
     metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card', 'llms', 'ai', 'ai search engines', 'llm'],
     socialAccounts: ['general', 'social accounts', 'facebook', 'twitter', 'threads', 'bluesky', 'mastodon', 'tiktok', 'youtube', 'instagram', 'linkedin', 'structured data', 'rich cards'],
-    analytics: ['membership', 'analytics', 'tracking', 'privacy', 'membership']
+    analytics: ['general', 'analytics', 'tracking', 'privacy', 'membership']
 };
 
 const GeneralSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/growth/growth-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/growth-settings.tsx
@@ -19,9 +19,16 @@ export const searchKeywords = {
 const GrowthSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
+    const visibleSearchKeywords = [
+        searchKeywords.network,
+        searchKeywords.explore,
+        searchKeywords.recommendations,
+        searchKeywords.embedSignupForm,
+        ...(hasStripeEnabled ? [searchKeywords.offers] : [])
+    ].flat();
 
     return (
-        <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Growth'>
+        <SearchableSection keywords={visibleSearchKeywords} title='Growth'>
             <Network keywords={searchKeywords.network} />
             <Explore keywords={searchKeywords.explore} />
             <Recommendations keywords={searchKeywords.recommendations} />

--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -17,7 +17,7 @@ export const searchKeywords = {
     portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address'],
     giftSubscriptions: ['membership', 'gift', 'gifts', 'gift subscriptions', 'present', 'share', 'shareable link'],
     memberEmails: ['membership', 'signup', 'welcome email', 'welcome emails', 'email', 'new user', 'new member', 'account'],
-    tips: ['growth', 'tips', 'donations', 'one time', 'payment']
+    tips: ['membership', 'tips', 'donations', 'one time', 'payment']
 };
 
 const MembershipSettings: React.FC = () => {
@@ -31,7 +31,7 @@ const MembershipSettings: React.FC = () => {
         searchKeywords.portal,
         ...(paidMembersEnabled ? [searchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [searchKeywords.memberEmails]),
-        searchKeywords.tips
+        ...(hasTipsAndDonations && hasStripeEnabled ? [searchKeywords.tips] : [])
     ].flat();
 
     return (

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -55,20 +55,36 @@ const Sidebar: React.FC = () => {
     const searchInputRef = useRef<HTMLInputElement | null>(null);
     const {isAnyTextFieldFocused} = useFocusContext();
     const {settings, config} = useGlobalData();
-    const [hasTipsAndDonations, isPrivate, paidMembersEnabled] = getSettingValues(settings, ['donations_enabled', 'is_private', 'paid_members_enabled']) as [string, boolean, boolean];
+    const [hasTipsAndDonations, isPrivate, paidMembersEnabled, newslettersEnabled] = getSettingValues(settings, ['donations_enabled', 'is_private', 'paid_members_enabled', 'editor_default_email_recipients']) as [boolean, boolean, boolean, string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
     const hasAutomations = useFeatureFlag('automations');
+    const hasNewslettersEnabled = newslettersEnabled !== 'disabled';
+    const mailgunIsConfigured = Boolean(config.mailgunIsConfigured);
+    const hasMailgun = hasNewslettersEnabled && !mailgunIsConfigured;
     const visibleMembershipSearchKeywords = React.useMemo(() => [
         membershipSearchKeywords.access,
         membershipSearchKeywords.tiers,
         membershipSearchKeywords.portal,
         ...(paidMembersEnabled ? [membershipSearchKeywords.giftSubscriptions] : []),
         ...(hasAutomations ? [] : [membershipSearchKeywords.memberEmails]),
-        membershipSearchKeywords.tips
-    ].flat(), [hasAutomations, paidMembersEnabled]);
-    const visibleEmailSearchKeywords = React.useMemo(() => (
-        Object.values(hasAutomations ? emailsSearchKeywords : emailSearchKeywords).flat()
-    ), [hasAutomations]);
+        ...(hasTipsAndDonations && hasStripeEnabled ? [membershipSearchKeywords.tips] : [])
+    ].flat(), [hasStripeEnabled, hasTipsAndDonations, paidMembersEnabled, hasAutomations]);
+    const visibleEmailSearchKeywords = React.useMemo(() => {
+        const keywords = hasAutomations ? emailsSearchKeywords : emailSearchKeywords;
+        return [
+            keywords.enableNewsletters,
+            ...(hasNewslettersEnabled ? [keywords.defaultRecipients] : []),
+            ...(hasAutomations ? [emailsSearchKeywords.emails] : (hasNewslettersEnabled ? [emailSearchKeywords.newsletters] : [])),
+            ...(hasMailgun ? [keywords.mailgun] : [])
+        ].flat();
+    }, [hasAutomations, hasNewslettersEnabled, hasMailgun]);
+    const visibleGrowthSearchKeywords = React.useMemo(() => [
+        growthSearchKeywords.network,
+        growthSearchKeywords.explore,
+        growthSearchKeywords.recommendations,
+        growthSearchKeywords.embedSignupForm,
+        ...(hasStripeEnabled ? [growthSearchKeywords.offers] : [])
+    ].flat(), [hasStripeEnabled]);
 
     // Focus in on search field when pressing "/"
     useEffect(() => {
@@ -101,15 +117,14 @@ const Sidebar: React.FC = () => {
     useEffect(() => {
         if (!checkVisible(Object.values(generalSearchKeywords).flat()) &&
             !checkVisible(Object.values(siteSearchKeywords).flat()) &&
-            !checkVisible(visibleMembershipSearchKeywords) &&
-            !checkVisible(Object.values(growthSearchKeywords).flat()) &&
-            !checkVisible(visibleEmailSearchKeywords) &&
+            !checkVisible([...visibleMembershipSearchKeywords, ...visibleEmailSearchKeywords]) &&
+            !checkVisible(visibleGrowthSearchKeywords) &&
             !checkVisible(Object.values(advancedSearchKeywords).flat())) {
             setNoResult(true);
         } else {
             setNoResult(false);
         }
-    }, [checkVisible, setNoResult, filter, visibleEmailSearchKeywords, visibleMembershipSearchKeywords]);
+    }, [checkVisible, setNoResult, filter, visibleEmailSearchKeywords, visibleMembershipSearchKeywords, visibleGrowthSearchKeywords]);
 
     useEffect(() => {
         const searchInput = searchInputRef.current;
@@ -208,7 +223,7 @@ const Sidebar: React.FC = () => {
                 </SettingNavSection>
 
                 {/* Membership settings */}
-                <SettingNavSection isVisible={checkVisible([...visibleMembershipSearchKeywords, ...(hasAutomations ? emailsSearchKeywords.emailsNavMenu : emailSearchKeywords.newslettersNavMenu)])} title="Membership">
+                <SettingNavSection isVisible={checkVisible([...visibleMembershipSearchKeywords, ...visibleEmailSearchKeywords])} title="Membership">
                     <NavItem
                         icon='key'
                         keywords={membershipSearchKeywords.access}
@@ -227,13 +242,13 @@ const Sidebar: React.FC = () => {
                     {!hasAutomations && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />}
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     {hasAutomations
-                        ? <NavItem icon='email' keywords={emailsSearchKeywords.emailsNavMenu} navid={['enable-newsletters', 'default-recipients', 'emails', 'mailgun']} title="Email" onClick={handleSectionClick} />
-                        : <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
+                        ? <NavItem icon='email' keywords={visibleEmailSearchKeywords} navid={['enable-newsletters', 'default-recipients', 'emails', 'mailgun']} title="Email" onClick={handleSectionClick} />
+                        : <NavItem icon='email' keywords={visibleEmailSearchKeywords} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
                     }
                 </SettingNavSection>
 
                 {/* Growth */}
-                <SettingNavSection isVisible={checkVisible(Object.values(growthSearchKeywords).flat())} title="Growth">
+                <SettingNavSection isVisible={checkVisible(visibleGrowthSearchKeywords)} title="Growth">
                     <NavItem icon='ap-network' keywords={growthSearchKeywords.network} navid='network' title="Network" onClick={handleSectionClick} />
                     <NavItem icon='globe-simple' keywords={growthSearchKeywords.explore} navid='explore' title="Ghost Explore" onClick={handleSectionClick} />
                     <NavItem icon='heart' keywords={growthSearchKeywords.recommendations} navid='recommendations' title="Recommendations" onClick={handleSectionClick} />

--- a/apps/admin-x-settings/test/unit/components/settings/search-keywords.test.ts
+++ b/apps/admin-x-settings/test/unit/components/settings/search-keywords.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert/strict';
+import {searchKeywords as emailSearchKeywords} from '@src/components/settings/email/email-settings';
+import {searchKeywords as emailsSearchKeywords} from '@src/components/settings/email/emails';
+import {searchKeywords as generalSearchKeywords} from '@src/components/settings/general/general-settings';
+import {searchKeywords as membershipSearchKeywords} from '@src/components/settings/membership/membership-settings';
+
+const includes = (keywords: string[], term: string) => keywords.some(keyword => keyword.toLowerCase().includes(term.toLowerCase()));
+
+describe('settings search keywords', function () {
+    it('analytics keywords include "general" and do not duplicate "membership"', function () {
+        const analytics = generalSearchKeywords.analytics;
+        assert.equal(analytics.includes('general'), true);
+        assert.equal(analytics.filter(keyword => keyword === 'membership').length, 1);
+    });
+
+    it('tips keywords map to the membership section, not growth', function () {
+        assert.equal(membershipSearchKeywords.tips.includes('membership'), true);
+        assert.equal(membershipSearchKeywords.tips.includes('growth'), false);
+    });
+
+    it('email keyword sets do not expose tips/donations payment terms', function () {
+        for (const keywords of [...Object.values(emailSearchKeywords), ...Object.values(emailsSearchKeywords)]) {
+            assert.equal(includes(keywords, 'tips'), false);
+            assert.equal(includes(keywords, 'donations'), false);
+            assert.equal(includes(keywords, 'one time'), false);
+            assert.equal(includes(keywords, 'payment'), false);
+        }
+    });
+
+    it('email keyword sets no longer expose stale nav-menu aggregates', function () {
+        assert.equal('newslettersNavMenu' in emailSearchKeywords, false);
+        assert.equal('emailsNavMenu' in emailsSearchKeywords, false);
+    });
+});


### PR DESCRIPTION
This PR fixes a bunch of issues in the search feature in `/settings`, and also refactors the code for improved readability and reuse. The issue is tracked in https://github.com/TryGhost/Ghost/issues/24458.

Here are the issues fixed:

### 1. Empty results under "Email newsletters" when searching for "one time" or "payment".

#### In 5.X and 6.0-alpha
| BEFORE | AFTER |
| ---- | ---- |
| <img width="1111" height="814" alt="Screenshot 2025-07-21 at 7 54 39 PM" src="https://github.com/user-attachments/assets/9a80f2c5-c0dc-400a-aea0-8d4f59561c85" /> | <img width="1221" height="624" alt="Screenshot 2025-07-21 at 7 55 12 PM" src="https://github.com/user-attachments/assets/cec57c47-7ec4-4db1-8d4a-609ec15895aa" />
| <img width="917" height="396" alt="Screenshot 2025-07-21 at 7 54 44 PM" src="https://github.com/user-attachments/assets/5d8cbb34-ddfe-4653-b622-854cfa6faec2" /> | <img width="908" height="345" alt="Screenshot 2025-07-21 at 7 55 05 PM" src="https://github.com/user-attachments/assets/911d9f90-49b1-4fd8-a320-15e582e19928" />

**Notes**

* The [newslettersNavMenu](https://github.com/TryGhost/Ghost/blob/b0d3b343746f79460007ec9adbdb37724d913a81/apps/admin-x-settings/src/components/settings/email/EmailSettings.tsx#L15) key was introduced in https://github.com/TryGhost/Ghost/pull/24299, presumably for the upcoming 6.0 release, to map all email newsletter keywords to the "Newsletter" menu item in 6.0. `newslettersNavMenu` includes "one time" and "payment" keywords, and it doesn't appear to be necessary here. 
* After removing one time" and "payment" keywords from `newslettersNavMenu`, what's left is a concatenation of all keywords under the other email newsletter submenu items. It makes sense to programmatically do the concatenation, so that manual/unforced errors can be avoided in the future (example: if a new keyword is added under, say, `defaultRecipients`, then it's not apparent that the same keyword also needs to be added under `newslettersNavMenu`). The refactored concatenation is implemented [here](https://github.com/TryGhost/Ghost/pull/24461/files#diff-cc3d16deb8d2989b5cb53cbc7261b2876f693b13be0857bc828bcd251a8a4ff0).

### 2. Incorrect mapping of keyword to nav item section

* In [this line](https://github.com/TryGhost/Ghost/blob/245847713a428f2a96fa243cbec81d49f7a8c465/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx#L15), the `tips` feature has "growth" in the keywords array, instead of "memberships".
* In [this line](https://github.com/TryGhost/Ghost/blob/245847713a428f2a96fa243cbec81d49f7a8c465/apps/admin-x-settings/src/components/settings/general/GeneralSettings.tsx#L21), the `analytics` feature has "membership" in the keyword array which is repeated twice in the array - the first value should be "growth".


### 3. Empty results when searching for "tips", "offer", "mailgun"

Feature like Tips & Donations, Offers, and Mailgun are not available on all accounts. So, searching for "tips" on an account not eligible for the feature can lead to empty results because the keyword mapping still exists. Here are some examples of this bug:

| Version | Bug |
| ---- | ---- |
| 5.X | <img width="810" height="205" alt="Screenshot 2025-07-21 at 8 25 43 PM" src="https://github.com/user-attachments/assets/fd68de66-0dc3-4cdf-8220-97a32a2098ee" /> |
| 6.0-alpha | <img width="715" height="309" alt="Screenshot 2025-07-21 at 8 24 48 PM" src="https://github.com/user-attachments/assets/abccb2d8-2282-40b7-ad8f-b8e9404cb10c" /> |
| Ghost Pro trial | <img width="812" height="242" alt="Screenshot 2025-07-21 at 8 26 02 PM" src="https://github.com/user-attachments/assets/353e0210-5487-49ba-a603-117ae76a058a" /> |

This PR conditionally includes the keywords in the search array, only if the account is eligible for that feature. This way, searching for "tips" on an account that does not have this feature enabled will lead to correctly displaying that the feature is not available.

#### After

<img width="1249" height="436" alt="Screenshot 2025-07-21 at 7 05 02 PM" src="https://github.com/user-attachments/assets/099abd5a-9bc2-4dee-a10e-1cf1972fb41e" />

**If the Tips feature is enabled, then the search results will correctly display that feature:**

**5.X**

<img width="1168" height="545" alt="Screenshot 2025-07-21 at 7 04 14 PM" src="https://github.com/user-attachments/assets/82f33b77-1b71-465f-8258-9d3857a2daca" />

**6.0-alpha**
<img width="952" height="373" alt="Screenshot 2025-07-21 at 8 34 49 PM" src="https://github.com/user-attachments/assets/b8c28f55-58af-4b7f-abd4-8968ac5448e7" />

### Testing Instructions

1. Go to `/settings`
2. On a ~5.X setup~ 6.X setup, search the following terms and verify that the appropriate setting is displayed, if the feature exists. Otherwise, the "no results" message should be displayed. Search keywords to be used:
    - mailgun
    - tips (check with and without the feature enabled)
    - offers (check with and without the feature enabled)
    - 
3. On a 6.X setup (~enable it via the Labs setting~), verify that searching for any of the keywords [here](https://github.com/TryGhost/Ghost/blob/main/apps/admin-x-settings/src/components/settings/email/EmailSettings.tsx#L11-L14) displays the "newsletters" menu item under Memberships.
