### PR TITLE
Change authentication for self-service migrations to send API key instead of JWT

### DIFF
--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -1,6 +1,5 @@
 import Service, {inject as service} from '@ember/service';
 import config from 'ghost-admin/config/environment';
-import {SignJWT} from 'jose';
 import {tracked} from '@glimmer/tracking';
 
 export default class MigrateService extends Service {

--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -77,13 +77,13 @@ export default class MigrateService extends Service {
         return url;
     }
 
-    // Sends a route update to a child route in the BMA, because we can't control
+    // Sends a route update to a child route in the migrate app, because we can't control
     // navigating to it otherwise
     sendRouteUpdate(route) {
         this.getMigrateIframe().contentWindow.postMessage({
             query: 'routeUpdate',
             response: route
-        }, '*');
+        }, this.migrateUrl);
     }
 
     // Controls migrate window modal visibility and sync of the URL visible in browser

--- a/ghost/admin/app/services/migrate.js
+++ b/ghost/admin/app/services/migrate.js
@@ -28,49 +28,26 @@ export default class MigrateService extends Service {
         return url;
     }
 
-    async apiToken() {
-        // TODO: Getting the token can be improved
+    async apiKey() {
         const ghostIntegrationsUrl = this.ghostPaths.url.api('integrations') + '?include=api_keys';
         return this.ajax.request(ghostIntegrationsUrl).then(async (response) => {
             const ssmIntegration = response.integrations.find(r => r.slug === 'self-serve-migration');
 
             const key = ssmIntegration.api_keys[0].secret;
-            const [id, secret] = key.split(':');
 
-            function hexToBytes(hex) {
-                let bytes = [];
-                for (let c = 0; c < hex.length; c += 2) {
-                    bytes.push(parseInt(hex.substr(c, 2), 16));
-                }
-                return new Uint8Array(bytes);
-            }
-
-            const encodedSecret = hexToBytes(secret);
-
-            const token = await new SignJWT({})
-                .setProtectedHeader({
-                    alg: 'HS256',
-                    typ: 'JWT',
-                    kid: id
-                })
-                .setIssuedAt()
-                .setExpirationTime('24h')
-                .setAudience('/admin/')
-                .sign(encodedSecret);
-
-            return token;
+            return key;
         }).catch((error) => {
             throw error;
         });
     }
 
     async postMessagePayload() {
-        const theToken = await this.apiToken();
+        const theKey = await this.apiKey();
         const theOwner = await this.billing.getOwnerUser();
 
         let payload = {
             apiUrl: this.apiUrl,
-            apiToken: theToken,
+            apiKey: theKey,
             stripe: this.isStripeConnected,
             ghostVersion: this.ghostVersion,
             ownerEmail: theOwner.email

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -175,7 +175,6 @@
   },
   "dependencies": {
     "i18n-iso-countries": "7.14.0",
-    "jose": "4.15.9",
     "lru-cache": "6.0.0",
     "path-browserify": "1.0.1",
     "webpack": "5.100.2"

--- a/ghost/admin/tests/unit/services/migrate-test.js
+++ b/ghost/admin/tests/unit/services/migrate-test.js
@@ -26,7 +26,7 @@ describe('Unit: Service: migrate', function () {
     });
 
     it('can generate valid payload', async function () {
-        sinon.stub(migrateService, 'apiToken').resolves('test-token');
+        sinon.stub(migrateService, 'apiKey').resolves('abcd:1234');
 
         this.owner.register('service:billing', Service.extend({
             getOwnerUser: () => {
@@ -38,10 +38,10 @@ describe('Unit: Service: migrate', function () {
 
         let payload = await migrateService.postMessagePayload();
 
-        expect(payload).to.be.an('object').that.has.all.keys('apiUrl', 'apiToken', 'stripe', 'ghostVersion', 'ownerEmail');
+        expect(payload).to.be.an('object').that.has.all.keys('apiUrl', 'apiKey', 'stripe', 'ghostVersion', 'ownerEmail');
         expect(isValidUrl(payload.apiUrl)).to.be.true;
         expect(payload.apiUrl.endsWith('/ghost')).to.be.true;
-        expect(payload.apiToken).to.equal('test-token');
+        expect(payload.apiKey).to.equal('abcd:1234');
         expect(payload.stripe).to.be.false;
         expect(payload.ghostVersion).to.be.string;
         expect(payload.ownerEmail).to.equal('name@example.com');

--- a/yarn.lock
+++ b/yarn.lock
@@ -21858,7 +21858,7 @@ jiti@^1.18.2, jiti@^1.21.6:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-jose@4.15.9, jose@^4.15.4:
+jose@^4.15.4:
   version "4.15.9"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
   integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==


### PR DESCRIPTION
ref https://linear.app/ghost/issue/CON-372/change-ghost-self-service-migrations-app-auth

- The self-service migrations app is currently authenticated with a JWT, but the expire time for these is capped at 5 minutes in the [Admin API key auth service](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/services/auth/api-key/admin.js)
- I wasn't aware of this in #24119, making that change ineffective
- The API key used to make the JWT is already available to privileged users of Ghost Admin
- This commit changes the migrate service to send the API key rather than a JWT (and handling that in the self-service app) yields the same result, allowing migrations more time to process, improving the end result
- It also removes the now-unused `jose` dependency 
