### PR TITLE
Fix: “Spam filters” section not shown when searching for “spam” in Settings

### DIFF
--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -99,7 +99,7 @@ const Sidebar: React.FC = () => {
                 !checkVisible(Object.values(membershipSearchKeywords5x).flat()) &&
                 !checkVisible(Object.values(growthSearchKeywords5x).flat()) &&
                 !checkVisible(Object.values(emailSearchKeywords).flat()) &&
-                !checkVisible(Object.values(advancedSearchKeywords).flat())) {
+                !checkVisible(Object.values(advancedSearchKeywords5x).flat())) {
                 setNoResult(true);
             } else {
                 setNoResult(false);
@@ -282,9 +282,7 @@ const Sidebar: React.FC = () => {
                     <SettingNavSection isVisible={checkVisible(Object.values(advancedSearchKeywords5x).flat())} title="Advanced">
                         <NavItem icon='modules-3' keywords={advancedSearchKeywords5x.integrations} navid='integrations' title="Integrations" onClick={handleSectionClick} />
                         <NavItem icon='download' keywords={advancedSearchKeywords5x.migrationtools} navid='migration' title="Import/Export" onClick={handleSectionClick} />
-                        {!ui60 &&
                         <NavItem icon='block' keywords={advancedSearchKeywords5x.spamFilters} navid='spam-filters' title="Spam filters" onClick={handleSectionClick} />
-                        }
                         <NavItem icon='brackets' keywords={advancedSearchKeywords5x.codeInjection} navid='code-injection' title="Code injection" onClick={handleSectionClick} />
                         <NavItem icon='labs-flask' keywords={advancedSearchKeywords5x.labs} navid='labs' title="Labs" onClick={handleSectionClick} />
                         <NavItem icon='time-back' keywords={advancedSearchKeywords5x.history} navid='history' title="History" onClick={handleSectionClick} />


### PR DESCRIPTION
This PR fixes an issue where searching for "spam" in the /settings page does not surface the "Spam filters" section.

The root cause was that the updated 5.x keyword list for Advanced Settings (introduced in [#24299](https://github.com/TryGhost/Ghost/pull/24299)) was not being used when checking section visibility against the search query.

Fix: This PR ensures that the correct keyword version is used during search matching, so that sections like "Spam filters" are properly shown when relevant keywords are searched.

Fixes: [#24464](https://github.com/TryGhost/Ghost/issues/24464)

**Note**

This PR also refactors and removes away a redundant check for `ui60` while checking for eligibility to display the "Spam filters" section. 

### Before
<img width="50%"  alt="Screenshot 2025-07-21 at 2 27 48 PM" src="https://github.com/user-attachments/assets/ae436de3-e9b5-4a39-ad5f-efaee8744558" />

### After 

<img width="50%" alt="Screenshot 2025-07-21 at 11 08 20 PM" src="https://github.com/user-attachments/assets/194da106-08d0-4318-bcb7-be63e0cda340" />

### Testing Instructions

1. In `/settings`, search for "spam". 
2. The "Spam filters" section should be visible in the filtered settings results.
