### PR TITLE
🐛 Fixed notification sent when commenting or replying on own post

### DIFF
--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -43,6 +43,11 @@ class CommentsServiceEmails {
                 continue;
             }
 
+            // Don't send a notification if you comment or reply as a member to your own post
+            if (author.get('email') === member.get('email')) {
+                continue;
+            }
+
             const to = author.get('email');
             const subject = '💬 New comment on your post: ' + post.get('title');
 

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -158,6 +158,92 @@ Object {
 }
 `;
 
+exports[`Comments API When authenticated as post author does NOT notify post author when they comment on their own post 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a comment",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API When authenticated as post author does NOT notify post author when they comment on their own post 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "399",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Encoding",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\//,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API When authenticated as post author does NOT notify post author when they reply to a comment on their own post 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "Reply from post author",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API When authenticated as post author does NOT notify post author when they reply to a comment on their own post 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "404",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Encoding",
+  "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated Browsing comments does not return the member unsubscribe_url 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -163,10 +163,12 @@ Object {
   "comments": Array [
     Object {
       "count": Object {
+        "direct_replies": 0,
         "likes": Any<Number>,
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "This is a comment",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -180,6 +182,8 @@ Object {
         "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
       "replies": Array [],
       "status": "published",
     },
@@ -189,13 +193,14 @@ Object {
 
 exports[`Comments API When authenticated as post author does NOT notify post author when they comment on their own post 2: [headers] 1`] = `
 Object {
-  "access-control-allow-origin": "*",
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "399",
+  "content-length": "467",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
-  "vary": "Accept-Encoding",
+  "vary": "Origin, Accept-Encoding",
   "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\//,
   "x-powered-by": "Express",
 }
@@ -206,10 +211,12 @@ Object {
   "comments": Array [
     Object {
       "count": Object {
+        "direct_replies": 0,
         "likes": Any<Number>,
         "replies": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "disliked": false,
       "edited_at": null,
       "html": "Reply from post author",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -223,6 +230,8 @@ Object {
         "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
+      "parent_id": Nullable<StringMatching>,
+      "pinned": Any<Boolean>,
       "replies": Array [],
       "status": "published",
     },
@@ -232,13 +241,14 @@ Object {
 
 exports[`Comments API When authenticated as post author does NOT notify post author when they reply to a comment on their own post 2: [headers] 1`] = `
 Object {
-  "access-control-allow-origin": "*",
+  "access-control-allow-credentials": "true",
+  "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "404",
+  "content-length": "494",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
-  "vary": "Accept-Encoding",
+  "vary": "Origin, Accept-Encoding",
   "x-cache-invalidate": StringMatching /\\\\/api\\\\/members\\\\/comments\\\\/post\\\\/\\[0-9a-f\\]\\{24\\}\\\\/, \\\\/api\\\\/members\\\\/comments\\\\/\\[0-9a-f\\]\\{24\\}\\\\/replies\\\\//,
   "x-powered-by": "Express",
 }

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -2242,7 +2242,6 @@ describe('Comments API', function () {
     });
 
     describe('When authenticated as post author', function () {
-
         let getStub;
 
         before(async function () {
@@ -2293,7 +2292,6 @@ describe('Comments API', function () {
                 to: fixtureManager.get('members', 1).email
             });
         });
-
     });
 
     describe('when commenting disabled', function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -2241,13 +2241,12 @@ describe('Comments API', function () {
         });
     });
 
-    describe('When authenticated as post author', async function () {
+    describe('When authenticated as post author', function () {
 
         let getStub;
 
         before(async function () {
             await membersAgent.loginAs(postAuthorEmail);
-            const postAuthor = await models.Member.findOne({email: postAuthorEmail}, {require: true});
         });
 
         beforeEach(function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -2241,6 +2241,62 @@ describe('Comments API', function () {
         });
     });
 
+    describe('When authenticated as post author', async function () {
+
+        let getStub;
+
+        before(async function () {
+            await membersAgent.loginAs(postAuthorEmail);
+            const postAuthor = await models.Member.findOne({email: postAuthorEmail}, {require: true});
+        });
+
+        beforeEach(function () {
+            getStub = sinon.stub(settingsCache, 'get');
+            getStub.callsFake((key, options) => {
+                if (key === 'comments_enabled') {
+                    return 'all';
+                }
+                return getStub.wrappedMethod.call(settingsCache, key, options);
+            });
+        });
+
+        afterEach(async function () {
+            sinon.restore();
+        });
+
+        it('does NOT notify post author when they comment on their own post', async function () {
+            await testPostComment({
+                post_id: postId,
+                html: 'This is a comment'
+            });
+
+            // Post author should NOT receive a notification for their own comment
+            emailMockReceiver.assertSentEmailCount(0);
+        });
+
+        it('does NOT notify post author when they reply to a comment on their own post', async function () {
+            // Create a parent comment from another member
+            const parentComment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 1).id
+            });
+
+            // Post author replies
+            await testPostComment({
+                post_id: postId,
+                parent_id: parentComment.get('id'),
+                html: 'Reply from post author'
+            });
+
+            // Post author should NOT receive a notification for their own reply
+            emailMockReceiver.assertSentEmailCount(1); // Only the parent comment author is notified
+            mockManager.assert.sentEmail({
+                subject: '↪️ New reply to your comment on Ghost',
+                to: fixtureManager.get('members', 1).email
+            });
+        });
+
+    });
+
     describe('when commenting disabled', function () {
         beforeEach(async function () {
             await membersAgent.loginAs('member@example.com');

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -2242,24 +2242,18 @@ describe('Comments API', function () {
     });
 
     describe('When authenticated as post author', function () {
-        let getStub;
-
         before(async function () {
             await membersAgent.loginAs(postAuthorEmail);
         });
 
         beforeEach(function () {
-            getStub = sinon.stub(settingsCache, 'get');
+            const getStub = sinon.stub(settingsCache, 'get');
             getStub.callsFake((key, options) => {
                 if (key === 'comments_enabled') {
                     return 'all';
                 }
                 return getStub.wrappedMethod.call(settingsCache, key, options);
             });
-        });
-
-        afterEach(async function () {
-            sinon.restore();
         });
 
         it('does NOT notify post author when they comment on their own post', async function () {

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -180,6 +180,16 @@ describe('Comments Service: CommentsServiceEmails', function () {
             assert.equal(templateData.postUrl, POST_URL_FOR_COMMENT);
         });
 
+        it('notifyPostAuthors: skips an author whose email matches the commenting member', async function () {
+            const {instance, comment, renderStub} = buildHarness({
+                authors: [makeAuthor({email: 'reader@example.com', slug: 'author'})]
+            });
+
+            await instance.notifyPostAuthors(comment);
+
+            sinon.assert.notCalled(renderStub);
+        });
+
         // notifyParentCommentAuthor is intentionally not exercised here: the
         // function reaches into emailService.renderer.createUnsubscribeUrl,
         // which is only populated after the email-service module is


### PR DESCRIPTION
fixes: https://github.com/TryGhost/Ghost/issues/24441 

By comparing the identity of the post's author and the commenter, we prevent email notifications from being sent to the post's author if they comment or reply to a comment on their own post. As Staff users and Members are two separate entities, the email address is used for the comparison.
