### PR TITLE
Added demo data override for posts and stats apps

### DIFF
--- a/apps/admin-x-framework/src/hooks/useFakeData.ts
+++ b/apps/admin-x-framework/src/hooks/useFakeData.ts
@@ -1,0 +1,42 @@
+import {useMemo, useState} from 'react';
+import {createFakeDataProvider} from '../utils/fake-data';
+import type {FakeDataConfig} from '../providers/FrameworkProvider';
+
+/**
+ * Reads the fake data preference from localStorage with SSR safety
+ */
+function getFakeDataEnabled(): boolean {
+    try {
+        return localStorage.getItem('ghost-fake-data') === 'true';
+    } catch {
+        // Fallback for SSR or when localStorage is unavailable
+        return false;
+    }
+}
+
+/**
+ * Creates a complete fake data configuration object
+ */
+function createFakeDataConfig(enabled: boolean): FakeDataConfig | undefined {
+    if (!enabled) {
+        return undefined;
+    }
+    return {
+        enabled: true,
+        dataProvider: createFakeDataProvider()
+    };
+}
+
+/**
+ * Custom hook to manage fake data state and configuration
+ * Reads from localStorage synchronously to avoid race conditions with API requests
+ */
+export function useFakeData(): FakeDataConfig | undefined {
+    // Manage fake data state internally - read from localStorage synchronously to avoid race condition
+    const [enabled] = useState(() => getFakeDataEnabled());
+
+    // Create fake data config when enabled
+    const fakeDataConfig = useMemo(() => createFakeDataConfig(enabled), [enabled]);
+
+    return fakeDataConfig;
+}

--- a/apps/admin-x-framework/src/hooks/useFakeTinybirdData.ts
+++ b/apps/admin-x-framework/src/hooks/useFakeTinybirdData.ts
@@ -1,0 +1,75 @@
+import {useState, useEffect, useMemo} from 'react';
+import {createTinybirdFakeDataProvider} from '../utils/fake-data';
+import type {FakeDataConfig} from '../providers/FrameworkProvider';
+
+interface TinybirdResponse {
+    data: Array<Record<string, unknown>>;
+    meta?: unknown;
+}
+
+interface UseFakeTinybirdDataOptions {
+    fakeDataConfig?: FakeDataConfig;
+    enabled: boolean;
+    endpoint: string;
+    params: Record<string, string>;
+}
+
+/**
+ * Custom hook to handle fake Tinybird data fetching
+ * Separated from useTinybirdQuery for cleaner code organization
+ */
+export function useFakeTinybirdData({fakeDataConfig, enabled, endpoint, params}: UseFakeTinybirdDataOptions) {
+    const hasFakeData = fakeDataConfig?.enabled || false;
+    
+    const [fakeData, setFakeData] = useState<TinybirdResponse | null>(null);
+    const [fakeLoading, setFakeLoading] = useState(false);
+    const [fakeError, setFakeError] = useState<Error | null>(null);
+
+    // Create fake data provider
+    const fakeDataProvider = useMemo(() => {
+        return hasFakeData ? createTinybirdFakeDataProvider() : null;
+    }, [hasFakeData]);
+
+    // Only memoize params if fake data is enabled to avoid unnecessary JSON.stringify
+    const stableParams = useMemo(() => {
+        return hasFakeData ? JSON.stringify(params) : '';
+    }, [hasFakeData, params]);
+
+    // Handle fake data fetching
+    useEffect(() => {
+        if (fakeDataProvider && enabled && endpoint) {
+            setFakeLoading(true);
+            setFakeError(null);
+            
+            fakeDataProvider(endpoint)
+                .then((result) => {
+                    if (result && typeof result === 'object' && 'data' in result) {
+                        setFakeData({
+                            data: (result as {data: Array<Record<string, unknown>>}).data,
+                            meta: undefined // Tinybird fake data doesn't include meta
+                        });
+                    } else {
+                        setFakeData(null);
+                    }
+                })
+                .catch((err) => {
+                    setFakeError(err instanceof Error ? err : new Error('Fake data provider failed'));
+                    setFakeData(null);
+                })
+                .finally(() => {
+                    setFakeLoading(false);
+                });
+        } else {
+            setFakeData(null);
+            setFakeLoading(false);
+            setFakeError(null);
+        }
+    }, [fakeDataProvider, enabled, endpoint, stableParams]);
+
+    return {
+        fakeData,
+        fakeLoading,
+        fakeError,
+        hasFakeData
+    };
+}

--- a/apps/admin-x-framework/src/hooks/useFakeTinybirdData.ts
+++ b/apps/admin-x-framework/src/hooks/useFakeTinybirdData.ts
@@ -41,7 +41,11 @@ export function useFakeTinybirdData({fakeDataConfig, enabled, endpoint, params}:
             setFakeLoading(true);
             setFakeError(null);
             
-            fakeDataProvider(endpoint)
+            // Build endpoint with query params for proper filtering
+            const endpointWithParams = new URLSearchParams(params).toString();
+            const fullEndpoint = endpointWithParams ? `${endpoint}?${endpointWithParams}` : endpoint;
+            
+            fakeDataProvider(fullEndpoint)
                 .then((result) => {
                     if (result && typeof result === 'object' && 'data' in result) {
                         setFakeData({

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -23,6 +23,9 @@ export {getSymbol} from './utils/currency';
 // Stats utilities
 export {getStatEndpointUrl, getToken} from './utils/stats-config';
 
+// Fake data utilities (for demo/development)
+export {clearFakeDataCache, getFakeDataCacheStats, testRealPostFetching} from './utils/fake-data';
+
 // Post utilities
 export type {Post} from './api/posts';
 export {hasBeenEmailed} from './utils/post-utils';

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -24,7 +24,7 @@ export {getSymbol} from './utils/currency';
 export {getStatEndpointUrl, getToken} from './utils/stats-config';
 
 // Fake data utilities (for demo/development)
-export {clearFakeDataCache, getFakeDataCacheStats, testRealPostFetching} from './utils/fake-data';
+export {clearFakeDataCache, getFakeDataCacheStats, testRealPostFetching, showMasterAnalytics} from './utils/fake-data';
 
 // Post utilities
 export type {Post} from './api/posts';

--- a/apps/admin-x-framework/src/providers/FrameworkProvider.tsx
+++ b/apps/admin-x-framework/src/providers/FrameworkProvider.tsx
@@ -3,6 +3,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {ReactNode, createContext, useContext, useMemo} from 'react';
 import queryClient from '../utils/queryClient';
 import {ExternalLink} from './RoutingProvider';
+import {useFakeData} from '../hooks/useFakeData';
 
 // Stats-specific configuration
 export interface StatsConfig {
@@ -14,6 +15,11 @@ export interface StatsConfig {
         endpoint?: string;
         token?: string;
     };
+}
+
+export interface FakeDataConfig {
+    enabled: boolean;
+    dataProvider?: (endpoint: string, options?: RequestInit) => Promise<unknown>;
 }
 
 export interface FrameworkProviderProps {
@@ -43,7 +49,9 @@ export interface FrameworkProviderProps {
 
 export type TopLevelFrameworkProps = Omit<FrameworkProviderProps, 'children'>;
 
-export type FrameworkContextType = Omit<FrameworkProviderProps, 'children'>;
+export type FrameworkContextType = Omit<FrameworkProviderProps, 'children'> & {
+    fakeDataConfig?: FakeDataConfig;
+};
 
 const FrameworkContext = createContext<FrameworkContextType>({
     ghostVersion: '',
@@ -62,6 +70,8 @@ const FrameworkContext = createContext<FrameworkContextType>({
 });
 
 export function FrameworkProvider({children, queryClientOptions, ...props}: FrameworkProviderProps) {
+    const fakeDataConfig = useFakeData();
+
     const client = useMemo(() => {
         if (!queryClientOptions) {
             return queryClient;
@@ -85,7 +95,7 @@ export function FrameworkProvider({children, queryClientOptions, ...props}: Fram
     return (
         <SentryErrorBoundary>
             <QueryClientProvider client={client}>
-                <FrameworkContext.Provider value={props}>
+                <FrameworkContext.Provider value={{...props, fakeDataConfig}}>
                     {children}
                 </FrameworkContext.Provider>
             </QueryClientProvider>

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -79,11 +79,151 @@ function generateMrrHistory() {
 }
 
 /**
+ * Generates fake active visitors data for Tinybird
+ */
+function generateActiveVisitors() {
+    const activeVisitors = 15 + Math.floor(Math.random() * 85); // 15-100 active visitors
+    return {
+        data: [{
+            active_visitors: activeVisitors
+        }]
+    };
+}
+
+/**
+ * Generates fake top pages data for Tinybird
+ */
+function generateTopPages() {
+    const pages = [
+        {pathname: '/', hits: 450 + Math.floor(Math.random() * 200)},
+        {pathname: '/about', hits: 180 + Math.floor(Math.random() * 100)},
+        {pathname: '/pricing', hits: 120 + Math.floor(Math.random() * 80)},
+        {pathname: '/blog', hits: 200 + Math.floor(Math.random() * 150)},
+        {pathname: '/contact', hits: 90 + Math.floor(Math.random() * 60)},
+        {pathname: '/features', hits: 160 + Math.floor(Math.random() * 90)},
+        {pathname: '/docs', hits: 110 + Math.floor(Math.random() * 70)}
+    ];
+    
+    // Sort by hits and take top 5
+    pages.sort((a, b) => b.hits - a.hits);
+    
+    return {
+        data: pages.slice(0, 5)
+    };
+}
+
+/**
+ * Generates fake top sources data for Tinybird matching BaseSourceData interface
+ */
+function generateTopSources() {
+    const sources = [
+        {
+            source: 'Direct', 
+            visits: 320 + Math.floor(Math.random() * 180),
+            free_members: Math.floor(Math.random() * 10),
+            paid_members: Math.floor(Math.random() * 5),
+            mrr: Math.floor(Math.random() * 100)
+        },
+        {
+            source: 'Google', 
+            visits: 280 + Math.floor(Math.random() * 120),
+            free_members: Math.floor(Math.random() * 8),
+            paid_members: Math.floor(Math.random() * 4),
+            mrr: Math.floor(Math.random() * 80)
+        },
+        {
+            source: 'Twitter', 
+            visits: 150 + Math.floor(Math.random() * 100),
+            free_members: Math.floor(Math.random() * 6),
+            paid_members: Math.floor(Math.random() * 3),
+            mrr: Math.floor(Math.random() * 60)
+        },
+        {
+            source: 'LinkedIn', 
+            visits: 90 + Math.floor(Math.random() * 60),
+            free_members: Math.floor(Math.random() * 4),
+            paid_members: Math.floor(Math.random() * 2),
+            mrr: Math.floor(Math.random() * 40)
+        },
+        {
+            source: 'Facebook', 
+            visits: 70 + Math.floor(Math.random() * 50),
+            free_members: Math.floor(Math.random() * 3),
+            paid_members: Math.floor(Math.random() * 1),
+            mrr: Math.floor(Math.random() * 30)
+        },
+        {
+            source: 'Reddit', 
+            visits: 45 + Math.floor(Math.random() * 40),
+            free_members: Math.floor(Math.random() * 2),
+            paid_members: 0,
+            mrr: 0
+        }
+    ];
+    
+    // Sort by visits
+    sources.sort((a, b) => b.visits - a.visits);
+    
+    return {
+        data: sources
+    };
+}
+
+/**
+ * Generates fake KPIs data for Tinybird with proper field names and multiple dates
+ */
+function generateKpis() {
+    const data = [];
+    const now = new Date();
+    
+    // Generate 31 days of data (matching the real API response)
+    for (let i = 30; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        
+        const visits = Math.floor(Math.random() * 10) + 10; // 10-20 visits
+        const pageviews = visits + Math.floor(Math.random() * visits * 10); // More pageviews than visits
+        const bounceRate = Math.random(); // 0-1 (0-100%)
+        const avgSessionSec = Math.random() * 3000; // 0-3000 seconds
+        
+        data.push({
+            date: date.toISOString().split('T')[0],
+            visits,
+            pageviews,
+            bounce_rate: Number(bounceRate.toFixed(2)),
+            avg_session_sec: Number(avgSessionSec.toFixed(2))
+        });
+    }
+    
+    return {
+        meta: [
+            {name: 'date', type: 'Date'},
+            {name: 'visits', type: 'UInt64'},
+            {name: 'pageviews', type: 'UInt64'},
+            {name: 'bounce_rate', type: 'Float64'},
+            {name: 'avg_session_sec', type: 'Float64'}
+        ],
+        data,
+        rows: data.length,
+        statistics: {
+            elapsed: 0.02 + Math.random() * 0.01,
+            rows_read: Math.floor(Math.random() * 50000) + 10000,
+            bytes_read: Math.floor(Math.random() * 3000000) + 1000000
+        }
+    };
+}
+
+/**
  * Fake data fixture generators for development and demo purposes
  */
 export const fakeDataFixtures = {
     memberCountHistory: generateMemberCountHistory,
-    mrrHistory: generateMrrHistory
+    mrrHistory: generateMrrHistory,
+    // Tinybird endpoints
+    activeVisitors: generateActiveVisitors,
+    topPages: generateTopPages,
+    topSources: generateTopSources,
+    kpis: generateKpis
 };
 
 /**
@@ -109,6 +249,34 @@ export function createFakeDataProvider() {
         // Check if we have fake data for this endpoint
         if (pathname in endpointMap) {
             return endpointMap[pathname]();
+        }
+        
+        // Return undefined to fall back to real API
+        return undefined;
+    };
+}
+
+/**
+ * Creates a fake data provider specifically for Tinybird endpoints
+ * Maps Tinybird endpoint names to fixture data generators
+ */
+export function createTinybirdFakeDataProvider() {
+    const tinybirdEndpointMap: Record<string, () => unknown> = {
+        api_active_visitors: fakeDataFixtures.activeVisitors,
+        api_top_pages: fakeDataFixtures.topPages,
+        api_top_sources: fakeDataFixtures.topSources,
+        api_kpis: fakeDataFixtures.kpis
+    };
+
+    return async (endpoint: string): Promise<unknown> => {
+        // Add a small delay to simulate network request
+        await new Promise<void>((resolve) => {
+            setTimeout(() => resolve(), 100 + Math.random() * 200);
+        });
+        
+        // Check if we have fake data for this Tinybird endpoint
+        if (endpoint in tinybirdEndpointMap) {
+            return tinybirdEndpointMap[endpoint]();
         }
         
         // Return undefined to fall back to real API

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -626,7 +626,7 @@ function generateNewsletterClickStats() {
 async function fetchRealPosts(limit = 10): Promise<Record<string, unknown>[]> {
     try {
         // Try to fetch real posts from the Ghost API
-        const response = await fetch(`/ghost/api/admin/posts/?limit=${limit}&fields=id,uuid,slug,title,published_at,feature_image,status,authors&formats=`, {
+        const response = await fetch(`/ghost/api/admin/posts/?limit=${limit}&fields=id,uuid,slug,title,published_at,feature_image,status&include=authors`, {
             headers: {
                 Accept: 'application/json',
                 'Content-Type': 'application/json'

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -107,6 +107,11 @@ function initializeMasterAnalytics(): void {
     for (let i = 30; i >= 0; i--) {
         const date = new Date();
         date.setDate(date.getDate() - i);
+        // Validate the date is valid
+        if (isNaN(date.getTime())) {
+            // Skip invalid dates
+            continue;
+        }
         const dayOfWeek = date.getDay();
         
         // Base traffic with weekly pattern (lower on weekends)
@@ -468,6 +473,10 @@ function generateMemberCountHistory() {
     for (let i = 29; i >= 0; i--) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
+        // Validate the date is valid
+        if (isNaN(date.getTime())) {
+            continue;
+        }
         
         // Simulate realistic growth with some randomness
         const paidGrowth = Math.floor(Math.random() * 4); // 0-3 new paid members per day
@@ -512,6 +521,10 @@ function generateMrrHistory() {
     for (let i = 29; i >= 0; i--) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
+        // Validate the date is valid
+        if (isNaN(date.getTime())) {
+            continue;
+        }
         
         // Simulate MRR growth with some volatility
         const growth = Math.floor(Math.random() * 100) - 10; // -10 to +90 change
@@ -794,6 +807,10 @@ async function generateNewsletterBasicStats() {
         const post = realPosts[i];
         const sendDate = new Date(now);
         sendDate.setDate(sendDate.getDate() - (i * 7 + Math.floor(Math.random() * 3))); // Weekly-ish sends
+        // Validate the date is valid
+        if (isNaN(sendDate.getTime())) {
+            continue;
+        }
         
         const sentTo = 800 + Math.floor(Math.random() * 400);
         const openRate = 0.25 + Math.random() * 0.35; // 25-60% open rate
@@ -941,6 +958,10 @@ function generateSubscriberCount() {
     for (let i = 29; i >= 0; i--) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
+        // Validate the date is valid
+        if (isNaN(date.getTime())) {
+            continue;
+        }
         
         // Simulate realistic growth with some churn
         const newSubs = Math.floor(Math.random() * 20) + 5; // 5-25 new subscribers per day
@@ -1011,7 +1032,12 @@ async function fetchRealPosts(limit = 10): Promise<Record<string, unknown>[]> {
         uuid: `fallback-uuid-${i + 1}`,
         slug: `amazing-blog-post-title-${i + 1}`,
         title: `Amazing Blog Post Title ${i + 1}`,
-        published_at: new Date(Date.now() - Math.floor(Math.random() * 90) * 24 * 60 * 60 * 1000).toISOString(),
+        published_at: (() => {
+            const daysAgo = Math.floor(Math.random() * 90);
+            const pubDate = new Date();
+            pubDate.setDate(pubDate.getDate() - daysAgo);
+            return isNaN(pubDate.getTime()) ? new Date().toISOString() : pubDate.toISOString();
+        })(),
         feature_image: `https://images.unsplash.com/photo-${1500000000 + i}?w=800&h=600`,
         status: 'published',
         authors: i % 3 === 0 ? [{name: 'John Doe'}, {name: 'Jane Smith'}] : [{name: 'John Doe'}]
@@ -1554,6 +1580,12 @@ export function createTinybirdFakeDataProvider() {
                         const publicationDate = new Date();
                         publicationDate.setDate(publicationDate.getDate() - daysAgo);
                         
+                        // Validate the publication date
+                        if (isNaN(publicationDate.getTime())) {
+                            // Fall back to 7 days ago if date is invalid
+                            publicationDate.setTime(Date.now() - (7 * 24 * 60 * 60 * 1000));
+                        }
+                        
                         // Filter to only show data from publication date onwards
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         filteredByDate = kpiData.data.filter((item: any) => {
@@ -1564,7 +1596,7 @@ export function createTinybirdFakeDataProvider() {
                         console.log('📅 Implicit date filtering for post:', {
                             postUuid,
                             daysAgo,
-                            publicationDate: publicationDate.toISOString().split('T')[0],
+                            publicationDate: isNaN(publicationDate.getTime()) ? 'Invalid Date' : publicationDate.toISOString().split('T')[0],
                             filteredDays: filteredByDate.length
                         });
                     }

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -1,4 +1,125 @@
 /**
+ * Simple in-memory cache for fake data to ensure consistency during a session
+ */
+interface CacheEntry {
+    data: unknown;
+    timestamp: number;
+}
+
+class FakeDataCache {
+    private cache = new Map<string, CacheEntry>();
+    private readonly TTL = 30 * 60 * 1000; // 30 minutes TTL
+
+    get(key: string): unknown | undefined {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            return undefined;
+        }
+
+        // Check if entry has expired
+        if (Date.now() - entry.timestamp > this.TTL) {
+            this.cache.delete(key);
+            return undefined;
+        }
+
+        return entry.data;
+    }
+
+    set(key: string, data: unknown): void {
+        this.cache.set(key, {
+            data,
+            timestamp: Date.now()
+        });
+    }
+
+    clear(): void {
+        this.cache.clear();
+    }
+}
+
+// Global cache instance
+const fakeDataCache = new FakeDataCache();
+
+/**
+ * Wrapper function to add caching to fake data generators
+ */
+function withCache<T>(key: string, generator: () => T): T {
+    const cached = fakeDataCache.get(key) as T;
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const data = generator();
+    fakeDataCache.set(key, data);
+    return data;
+}
+
+/**
+ * Async wrapper function to add caching to async fake data generators
+ */
+async function withAsyncCache<T>(key: string, generator: () => Promise<T>): Promise<T> {
+    const cached = fakeDataCache.get(key) as T;
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const data = await generator();
+    fakeDataCache.set(key, data);
+    return data;
+}
+
+/**
+ * Enhanced cache wrapper for dynamic endpoints with parameters
+ */
+function withDynamicCache<T>(baseKey: string, params: string, generator: () => T): T {
+    const key = `${baseKey}:${params}`;
+    return withCache(key, generator);
+}
+
+/**
+ * Clear the fake data cache (useful for testing or forcing refresh)
+ * Usage in browser console: window.clearFakeDataCache()
+ */
+export function clearFakeDataCache(): void {
+    fakeDataCache.clear();
+}
+
+/**
+ * Get cache stats for debugging
+ */
+export function getFakeDataCacheStats(): {size: number; keys: string[]} {
+    const cache = (fakeDataCache as any).cache;
+    return {
+        size: cache.size,
+        keys: Array.from(cache.keys())
+    };
+}
+
+/**
+ * Test function to verify real post fetching works
+ * Usage in browser console: window.testRealPostFetching()
+ */
+export async function testRealPostFetching(): Promise<void> {
+    console.log('Testing real post fetching...');
+    try {
+        const posts = await fetchRealPosts(5);
+        console.log('Fetched posts:', posts);
+        console.log(`Successfully fetched ${posts.length} posts`);
+        
+        if (posts.length > 0) {
+            console.log('Sample post:', {
+                id: posts[0].id,
+                title: posts[0].title,
+                slug: posts[0].slug,
+                hasFeatureImage: !!posts[0].feature_image
+            });
+        }
+    } catch (error) {
+        console.error('Failed to test real post fetching:', error);
+    }
+}
+
+/**
  * Generates fake member count history data with realistic growth patterns
  */
 function generateMemberCountHistory() {
@@ -214,16 +335,305 @@ function generateKpis() {
 }
 
 /**
+ * Generates fake top locations data for Tinybird
+ */
+function generateTopLocations() {
+    const locations = [
+        {location: 'United States', visits: 450 + Math.floor(Math.random() * 200)},
+        {location: 'United Kingdom', visits: 180 + Math.floor(Math.random() * 100)},
+        {location: 'Canada', visits: 120 + Math.floor(Math.random() * 80)},
+        {location: 'Germany', visits: 100 + Math.floor(Math.random() * 60)},
+        {location: 'Australia', visits: 85 + Math.floor(Math.random() * 50)},
+        {location: 'France', visits: 75 + Math.floor(Math.random() * 40)},
+        {location: 'Netherlands', visits: 65 + Math.floor(Math.random() * 35)},
+        {location: 'India', visits: 60 + Math.floor(Math.random() * 30)},
+        {location: 'Brazil', visits: 55 + Math.floor(Math.random() * 25)},
+        {location: 'Japan', visits: 50 + Math.floor(Math.random() * 20)}
+    ];
+    
+    // Sort by visits and take top 8
+    locations.sort((a, b) => b.visits - a.visits);
+    
+    return {
+        data: locations.slice(0, 8)
+    };
+}
+
+/**
+ * Generates fake post referrers data for Ghost Admin API
+ */
+function generatePostReferrers() {
+    const stats = [
+        {
+            source: 'Direct',
+            referrer_url: null,
+            free_members: 25 + Math.floor(Math.random() * 15),
+            paid_members: 8 + Math.floor(Math.random() * 7),
+            mrr: (15 + Math.floor(Math.random() * 20)) * 100 // in cents
+        },
+        {
+            source: 'Google',
+            referrer_url: 'https://www.google.com/',
+            free_members: 18 + Math.floor(Math.random() * 12),
+            paid_members: 5 + Math.floor(Math.random() * 5),
+            mrr: (10 + Math.floor(Math.random() * 15)) * 100
+        },
+        {
+            source: 'Twitter',
+            referrer_url: 'https://twitter.com/',
+            free_members: 12 + Math.floor(Math.random() * 8),
+            paid_members: 3 + Math.floor(Math.random() * 3),
+            mrr: (5 + Math.floor(Math.random() * 10)) * 100
+        },
+        {
+            source: 'Facebook',
+            referrer_url: 'https://www.facebook.com/',
+            free_members: 8 + Math.floor(Math.random() * 6),
+            paid_members: 2 + Math.floor(Math.random() * 2),
+            mrr: (3 + Math.floor(Math.random() * 7)) * 100
+        },
+        {
+            source: 'LinkedIn',
+            referrer_url: 'https://www.linkedin.com/',
+            free_members: 6 + Math.floor(Math.random() * 4),
+            paid_members: 1 + Math.floor(Math.random() * 2),
+            mrr: (2 + Math.floor(Math.random() * 5)) * 100
+        }
+    ];
+    
+    return {
+        stats,
+        meta: {}
+    };
+}
+
+/**
+ * Generates fake post growth data for Ghost Admin API
+ */
+function generatePostGrowth() {
+    const stats = [{
+        post_id: 'fake-post-id',
+        free_members: 45 + Math.floor(Math.random() * 25),
+        paid_members: 12 + Math.floor(Math.random() * 8),
+        mrr: (25 + Math.floor(Math.random() * 35)) * 100 // in cents
+    }];
+    
+    return {
+        stats,
+        meta: {}
+    };
+}
+
+/**
+ * Generates fake newsletter basic stats for Ghost Admin API
+ */
+function generateNewsletterBasicStats() {
+    const stats = [];
+    const now = new Date();
+    
+    // Generate 5 recent newsletter sends
+    for (let i = 0; i < 5; i++) {
+        const sendDate = new Date(now);
+        sendDate.setDate(sendDate.getDate() - (i * 7 + Math.floor(Math.random() * 3))); // Weekly-ish sends
+        
+        const sentTo = 800 + Math.floor(Math.random() * 400);
+        const openRate = 0.25 + Math.random() * 0.35; // 25-60% open rate
+        const totalOpens = Math.floor(sentTo * openRate);
+        
+        stats.push({
+            post_id: `newsletter-post-${i + 1}`,
+            post_title: `Newsletter ${i + 1}: Weekly Update`,
+            send_date: sendDate.toISOString(),
+            sent_to: sentTo,
+            total_opens: totalOpens,
+            open_rate: Number(openRate.toFixed(3)),
+            total_clicks: Math.floor(totalOpens * (0.1 + Math.random() * 0.2)), // 10-30% of opens click
+            click_rate: Number((0.02 + Math.random() * 0.08).toFixed(3)) // 2-10% overall click rate
+        });
+    }
+    
+    return {
+        stats,
+        meta: {}
+    };
+}
+
+/**
+ * Generates fake newsletter click stats for Ghost Admin API
+ */
+function generateNewsletterClickStats() {
+    const stats = [];
+    const now = new Date();
+    
+    // Generate 5 recent newsletter sends with click data
+    for (let i = 0; i < 5; i++) {
+        const sendDate = new Date(now);
+        sendDate.setDate(sendDate.getDate() - (i * 7 + Math.floor(Math.random() * 3)));
+        
+        const sentTo = 800 + Math.floor(Math.random() * 400);
+        const clickRate = 0.02 + Math.random() * 0.08; // 2-10% click rate
+        const totalClicks = Math.floor(sentTo * clickRate);
+        
+        stats.push({
+            post_id: `newsletter-post-${i + 1}`,
+            post_title: `Newsletter ${i + 1}: Weekly Update`,
+            send_date: sendDate.toISOString(),
+            sent_to: sentTo,
+            total_opens: Math.floor(sentTo * (0.25 + Math.random() * 0.35)),
+            open_rate: Number((0.25 + Math.random() * 0.35).toFixed(3)),
+            total_clicks: totalClicks,
+            click_rate: Number(clickRate.toFixed(3))
+        });
+    }
+    
+    return {
+        stats,
+        meta: {}
+    };
+}
+
+/**
+ * Fetches real posts from Ghost API for more authentic fake data
+ */
+async function fetchRealPosts(limit = 10): Promise<any[]> {
+    try {
+        // Try to fetch real posts from the Ghost API
+        const response = await fetch(`/ghost/api/admin/posts/?limit=${limit}&fields=id,uuid,slug,title,published_at,feature_image,status,authors&formats=`, {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        
+        if (response.ok) {
+            const data = await response.json();
+            const posts = data.posts || [];
+            
+            // Filter out any posts without titles (just in case)
+            return posts.filter((post: any) => post.title && post.title.trim().length > 0);
+        } else {
+            console.warn('Ghost API returned non-OK status:', response.status, response.statusText);
+        }
+    } catch (error) {
+        // Fall back to fake posts if API fails
+        console.warn('Failed to fetch real posts, using fake data:', error);
+    }
+    
+    // Fallback fake posts if API is not available
+    return Array.from({length: limit}, (_, i) => ({
+        id: `fallback-post-${i + 1}`,
+        uuid: `fallback-uuid-${i + 1}`,
+        slug: `amazing-blog-post-title-${i + 1}`,
+        title: `Amazing Blog Post Title ${i + 1}`,
+        published_at: new Date(Date.now() - Math.floor(Math.random() * 90) * 24 * 60 * 60 * 1000).toISOString(),
+        feature_image: `https://images.unsplash.com/photo-${1500000000 + i}?w=800&h=600`,
+        status: 'published',
+        authors: i % 3 === 0 ? [{name: 'John Doe'}, {name: 'Jane Smith'}] : [{name: 'John Doe'}]
+    }));
+}
+
+/**
+ * Generates fake top posts views data using real post data with fake analytics
+ */
+async function generateTopPostsViews() {
+    // Fetch real posts from the API
+    const realPosts = await fetchRealPosts(10);
+    
+    const stats = realPosts.map((post, i) => {
+        const views = 500 - (i * 30) + Math.floor(Math.random() * 100); // Decreasing views with some randomness
+        const members = Math.floor(views * (0.05 + Math.random() * 0.15)); // 5-20% conversion to members
+        const sentCount = Math.random() > 0.3 ? 800 + Math.floor(Math.random() * 400) : null; // 70% were sent as newsletters
+        const openedCount = sentCount ? Math.floor(sentCount * (0.25 + Math.random() * 0.35)) : null;
+        
+        // Format authors - handle both array and string formats
+        let authorsString = 'John Doe';
+        if (post.authors && Array.isArray(post.authors)) {
+            authorsString = post.authors.map((author: any) => author.name).join(', ');
+        } else if (typeof post.authors === 'string') {
+            authorsString = post.authors;
+        }
+        
+        return {
+            post_id: post.id,
+            title: post.title,
+            published_at: post.published_at,
+            feature_image: post.feature_image || `https://images.unsplash.com/photo-${1500000000 + i}?w=800&h=600`,
+            status: post.status || 'published',
+            authors: authorsString,
+            views,
+            sent_count: sentCount,
+            opened_count: openedCount,
+            open_rate: openedCount && sentCount ? Number((openedCount / sentCount).toFixed(3)) : null,
+            clicked_count: openedCount ? Math.floor(openedCount * (0.1 + Math.random() * 0.2)) : 0,
+            click_rate: openedCount && sentCount ? Number((Math.floor(openedCount * (0.1 + Math.random() * 0.2)) / sentCount).toFixed(3)) : null,
+            members,
+            free_members: Math.floor(members * 0.7),
+            paid_members: Math.floor(members * 0.3)
+        };
+    });
+    
+    return {
+        stats
+    };
+}
+
+/**
+ * Generates fake top content data using real post data with fake analytics
+ */
+async function generateTopContent() {
+    // Fetch real posts for more authentic content
+    const realPosts = await fetchRealPosts(15);
+    
+    const stats = realPosts.map((post, i) => {
+        const visits = 400 - (i * 20) + Math.floor(Math.random() * 50); // Decreasing visits with randomness
+        
+        // Create a realistic pathname from the post slug or title
+        let pathname = '/';
+        if (post.slug) {
+            pathname = `/${post.slug}/`;
+        } else if (post.title) {
+            pathname = `/${post.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}/`;
+        } else {
+            pathname = `/post-${i + 1}/`;
+        }
+        
+        return {
+            pathname,
+            visits,
+            title: post.title,
+            post_uuid: post.uuid || post.id,
+            post_id: post.id,
+            post_type: 'post',
+            url_exists: true
+        };
+    });
+    
+    return {
+        stats,
+        meta: {}
+    };
+}
+
+/**
  * Fake data fixture generators for development and demo purposes
+ * All generators are wrapped with caching to ensure consistent data during a session
  */
 export const fakeDataFixtures = {
-    memberCountHistory: generateMemberCountHistory,
-    mrrHistory: generateMrrHistory,
+    memberCountHistory: () => withCache('memberCountHistory', generateMemberCountHistory),
+    mrrHistory: () => withCache('mrrHistory', generateMrrHistory),
     // Tinybird endpoints
-    activeVisitors: generateActiveVisitors,
-    topPages: generateTopPages,
-    topSources: generateTopSources,
-    kpis: generateKpis
+    activeVisitors: () => withCache('activeVisitors', generateActiveVisitors),
+    topPages: () => withCache('topPages', generateTopPages),
+    topSources: () => withCache('topSources', generateTopSources),
+    topLocations: () => withCache('topLocations', generateTopLocations),
+    kpis: () => withCache('kpis', generateKpis),
+    // Ghost Admin API endpoints
+    postReferrers: () => withCache('postReferrers', generatePostReferrers),
+    postGrowth: () => withCache('postGrowth', generatePostGrowth),
+    newsletterBasicStats: () => withCache('newsletterBasicStats', generateNewsletterBasicStats),
+    newsletterClickStats: () => withCache('newsletterClickStats', generateNewsletterClickStats),
+    topPostsViews: () => withAsyncCache('topPostsViews', generateTopPostsViews),
+    topContent: () => withAsyncCache('topContent', generateTopContent)
 };
 
 /**
@@ -233,7 +643,11 @@ export const fakeDataFixtures = {
 export function createFakeDataProvider() {
     const endpointMap: Record<string, () => unknown> = {
         '/ghost/api/admin/stats/member_count/': fakeDataFixtures.memberCountHistory,
-        '/ghost/api/admin/stats/mrr/': fakeDataFixtures.mrrHistory
+        '/ghost/api/admin/stats/mrr/': fakeDataFixtures.mrrHistory,
+        '/ghost/api/admin/stats/newsletter-basic-stats/': fakeDataFixtures.newsletterBasicStats,
+        '/ghost/api/admin/stats/newsletter-click-stats/': fakeDataFixtures.newsletterClickStats,
+        '/ghost/api/admin/stats/top-posts-views/': fakeDataFixtures.topPostsViews,
+        '/ghost/api/admin/stats/top-content/': fakeDataFixtures.topContent
     };
 
     return async (endpoint: string): Promise<unknown> => {
@@ -246,9 +660,29 @@ export function createFakeDataProvider() {
             setTimeout(() => resolve(), 100 + Math.random() * 200);
         });
         
-        // Check if we have fake data for this endpoint
+        // Check for exact matches first
         if (pathname in endpointMap) {
-            return endpointMap[pathname]();
+            const result = endpointMap[pathname]();
+            
+            // Handle both sync and async fixture functions
+            if (result instanceof Promise) {
+                return await result;
+            }
+            
+            return result;
+        }
+        
+        // Check for dynamic post-specific endpoints
+        const referrersMatch = pathname.match(/^\/ghost\/api\/admin\/stats\/posts\/([^/]+)\/top-referrers$/);
+        if (referrersMatch) {
+            const postId = referrersMatch[1];
+            return withDynamicCache(`postReferrers`, postId, generatePostReferrers);
+        }
+        
+        const growthMatch = pathname.match(/^\/ghost\/api\/admin\/stats\/posts\/([^/]+)\/growth$/);
+        if (growthMatch) {
+            const postId = growthMatch[1];
+            return withDynamicCache(`postGrowth`, postId, generatePostGrowth);
         }
         
         // Return undefined to fall back to real API
@@ -265,6 +699,7 @@ export function createTinybirdFakeDataProvider() {
         api_active_visitors: fakeDataFixtures.activeVisitors,
         api_top_pages: fakeDataFixtures.topPages,
         api_top_sources: fakeDataFixtures.topSources,
+        api_top_locations: fakeDataFixtures.topLocations,
         api_kpis: fakeDataFixtures.kpis
     };
 
@@ -274,7 +709,7 @@ export function createTinybirdFakeDataProvider() {
             setTimeout(() => resolve(), 100 + Math.random() * 200);
         });
         
-        // Check if we have fake data for this Tinybird endpoint
+        // Check if we have fake data for this Tinybird endpoint  
         if (endpoint in tinybirdEndpointMap) {
             return tinybirdEndpointMap[endpoint]();
         }

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -1559,13 +1559,13 @@ export function createTinybirdFakeDataProvider() {
                 const kpiData = data as any;
                 if (kpiData.data && Array.isArray(kpiData.data)) {
                     // eslint-disable-next-line no-console
-                    console.log('[FakeData] Site-wide KPI date range inputs:', { dateFrom, dateTo });
+                    console.log('[FakeData] Site-wide KPI date range inputs:', {dateFrom, dateTo});
                     const fromDate = dateFrom ? new Date(dateFrom) : new Date('2000-01-01');
                     const toDate = dateTo ? new Date(dateTo) : new Date();
                     
                     if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
                         // eslint-disable-next-line no-console
-                        console.error('[FakeData] Invalid date range:', { dateFrom, dateTo, fromDate, toDate });
+                        console.error('[FakeData] Invalid date range:', {dateFrom, dateTo, fromDate, toDate});
                     }
                     
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/admin-x-framework/src/utils/fake-data.ts
+++ b/apps/admin-x-framework/src/utils/fake-data.ts
@@ -1,0 +1,148 @@
+/**
+ * Generates fake member count history data with realistic growth patterns
+ */
+function generateMemberCountHistory() {
+    const stats = [];
+    const now = new Date();
+    let paid = 85 + Math.floor(Math.random() * 20); // Start between 85-105
+    let free = 450 + Math.floor(Math.random() * 100); // Start between 450-550
+    let comped = 5 + Math.floor(Math.random() * 5); // Start between 5-10
+    
+    // Generate 30 days of data
+    for (let i = 29; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        
+        // Simulate realistic growth with some randomness
+        const paidGrowth = Math.floor(Math.random() * 4); // 0-3 new paid members per day
+        const freeGrowth = Math.floor(Math.random() * 15) + 5; // 5-20 new free members per day
+        const compedGrowth = Math.random() < 0.3 ? 1 : 0; // 30% chance of 1 comped member
+        
+        paid += paidGrowth;
+        free += freeGrowth;
+        comped += compedGrowth;
+        
+        stats.push({
+            date: date.toISOString().split('T')[0],
+            paid,
+            free,
+            comped,
+            paid_subscribed: paidGrowth,
+            paid_canceled: Math.random() < 0.1 ? 1 : 0 // 10% chance of cancellation
+        });
+    }
+    
+    return {
+        stats,
+        meta: {
+            totals: {
+                paid,
+                free,
+                comped
+            }
+        }
+    };
+}
+
+/**
+ * Generates fake MRR history data with realistic revenue growth
+ */
+function generateMrrHistory() {
+    const stats = [];
+    const now = new Date();
+    let mrr = 2500 + Math.floor(Math.random() * 1000); // Start between $2500-$3500
+    
+    // Generate 30 days of data
+    for (let i = 29; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        
+        // Simulate MRR growth with some volatility
+        const growth = Math.floor(Math.random() * 100) - 10; // -10 to +90 change
+        mrr = Math.max(1000, mrr + growth); // Don't go below $1000
+        
+        stats.push({
+            date: date.toISOString().split('T')[0],
+            mrr,
+            currency: 'USD'
+        });
+    }
+    
+    return {
+        stats,
+        meta: {
+            totals: {
+                mrr
+            }
+        }
+    };
+}
+
+/**
+ * Fake data fixture generators for development and demo purposes
+ */
+export const fakeDataFixtures = {
+    memberCountHistory: generateMemberCountHistory,
+    mrrHistory: generateMrrHistory
+};
+
+/**
+ * Creates a fake data provider function that can be used with FrameworkProvider
+ * Maps endpoint URLs to fixture data generators
+ */
+export function createFakeDataProvider() {
+    const endpointMap: Record<string, () => unknown> = {
+        '/ghost/api/admin/stats/member_count/': fakeDataFixtures.memberCountHistory,
+        '/ghost/api/admin/stats/mrr/': fakeDataFixtures.mrrHistory
+    };
+
+    return async (endpoint: string): Promise<unknown> => {
+        // Extract the pathname from the endpoint URL
+        const url = new URL(endpoint, 'http://localhost');
+        const pathname = url.pathname;
+        
+        // Add a small delay to simulate network request
+        await new Promise<void>((resolve) => {
+            setTimeout(() => resolve(), 100 + Math.random() * 200);
+        });
+        
+        // Check if we have fake data for this endpoint
+        if (pathname in endpointMap) {
+            return endpointMap[pathname]();
+        }
+        
+        // Return undefined to fall back to real API
+        return undefined;
+    };
+}
+
+/**
+ * Attempts to intercept a request and return fake data if available
+ * Returns undefined if fake data is not enabled or not available for this endpoint
+ */
+export async function tryInterceptWithFakeData<T = unknown>(
+    fakeDataConfig: {enabled: boolean; dataProvider?: (endpoint: string, options?: RequestInit) => Promise<unknown>} | undefined,
+    requestEndpoint: string,
+    requestOptions: RequestInit
+): Promise<T | undefined> {
+    // Check if fake data is enabled and should intercept this request
+    if (fakeDataConfig?.enabled && fakeDataConfig.dataProvider) {
+        try {
+            const fakeResponse = await fakeDataConfig.dataProvider(requestEndpoint.toString(), {
+                headers: {...requestOptions.headers},
+                ...requestOptions
+            });
+            if (fakeResponse !== undefined) {
+                return fakeResponse as T;
+            }
+        } catch (error) {
+            // Fall through to real API if fake data provider fails
+            if (import.meta.env.MODE === 'development') {
+                // eslint-disable-next-line no-console
+                console.warn('Fake data provider failed, falling back to real API:', error);
+            }
+        }
+    }
+    
+    return undefined;
+}

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -18,7 +18,6 @@ const Overview: React.FC = () => {
     const navigate = useNavigate();
     const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId} = useGlobalData();
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
-    const {startDate, endDate, timezone} = getRangeDates(STATS_RANGES.ALL_TIME.value);
     const {appSettings} = useAppContext();
     const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
 
@@ -33,13 +32,13 @@ const Overview: React.FC = () => {
 
     const {startDate: chartStartDate, endDate: chartEndDate, timezone: chartTimezone} = getRangeDates(chartRange);
 
-    // KPI params for overview data
+    // KPI params for overview data - use the same date range as chart
     const params = useMemo(() => {
         const baseParams = {
             site_uuid: statsConfig?.id || '',
-            date_from: formatQueryDate(startDate),
-            date_to: formatQueryDate(endDate),
-            timezone: timezone,
+            date_from: formatQueryDate(chartStartDate),
+            date_to: formatQueryDate(chartEndDate),
+            timezone: chartTimezone,
             post_uuid: ''
         };
 
@@ -51,7 +50,7 @@ const Overview: React.FC = () => {
         }
 
         return baseParams;
-    }, [isPostLoading, post, statsConfig?.id, startDate, endDate, timezone]);
+    }, [isPostLoading, post, statsConfig?.id, chartStartDate, chartEndDate, chartTimezone]);
 
     // Chart params for chart data
     const chartParams = useMemo(() => {

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -26,8 +26,13 @@ const Overview: React.FC = () => {
         if (!post?.published_at) {
             return STATS_RANGES.ALL_TIME.value; // Fallback if no publication date
         }
-        const calculatedRange = getRangeForStartDate(post.published_at);
-        return calculatedRange;
+        try {
+            const calculatedRange = getRangeForStartDate(post.published_at);
+            return calculatedRange || STATS_RANGES.ALL_TIME.value;
+        } catch (error) {
+            console.error('Error calculating range for post:', error);
+            return STATS_RANGES.ALL_TIME.value;
+        }
     }, [post?.published_at]);
 
     const {startDate: chartStartDate, endDate: chartEndDate, timezone: chartTimezone} = getRangeDates(chartRange);
@@ -36,9 +41,9 @@ const Overview: React.FC = () => {
     const params = useMemo(() => {
         const baseParams = {
             site_uuid: statsConfig?.id || '',
-            date_from: formatQueryDate(chartStartDate),
-            date_to: formatQueryDate(chartEndDate),
-            timezone: chartTimezone,
+            date_from: chartStartDate ? formatQueryDate(chartStartDate) : '',
+            date_to: chartEndDate ? formatQueryDate(chartEndDate) : '',
+            timezone: chartTimezone || 'UTC',
             post_uuid: ''
         };
 
@@ -56,9 +61,9 @@ const Overview: React.FC = () => {
     const chartParams = useMemo(() => {
         const baseParams = {
             site_uuid: statsConfig?.id || '',
-            date_from: formatQueryDate(chartStartDate),
-            date_to: formatQueryDate(chartEndDate),
-            timezone: chartTimezone,
+            date_from: chartStartDate ? formatQueryDate(chartStartDate) : '',
+            date_to: chartEndDate ? formatQueryDate(chartEndDate) : '',
+            timezone: chartTimezone || 'UTC',
             post_uuid: ''
         };
 

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -30,6 +30,7 @@ const Overview: React.FC = () => {
             const calculatedRange = getRangeForStartDate(post.published_at);
             return calculatedRange || STATS_RANGES.ALL_TIME.value;
         } catch (error) {
+            // eslint-disable-next-line no-console
             console.error('Error calculating range for post:', error);
             return STATS_RANGES.ALL_TIME.value;
         }

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -187,7 +187,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
 
 export const useGrowthStats = (range: number) => {
     // Calculate date range using Shade's timezone-aware getRangeDates
-    const {startDate, endDate} = useMemo(() => getRangeDates(range), [range]);
+    const {startDate, endDate} = useMemo(() => getRangeDates(range || 30), [range]);
     const dateFrom = formatQueryDate(startDate);
 
     // Fetch member count history from API

--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -23,7 +23,7 @@ export const useNewsletterStatsWithRange = (range?: number, order?: TopNewslette
     const currentOrder = order ?? 'date desc'; // Default to date descending
 
     // Calculate date strings using the helper, memoize for stability
-    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
+    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange || 30), [currentRange]);
 
     // Build search params
     const searchParams = useMemo(() => {
@@ -69,7 +69,7 @@ export const useSubscriberCountWithRange = (range?: number, newsletterId?: strin
     const currentRange = range ?? 30;
 
     // Calculate date strings using the helper, memoize for stability
-    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
+    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange || 30), [currentRange]);
 
     // Build search params
     const searchParams = useMemo(() => {
@@ -124,7 +124,7 @@ export const useNewsletterBasicStatsWithRange = (range?: number, order?: TopNews
     const currentOrder = order ?? 'date desc'; // Default to date descending
 
     // Calculate date strings using the helper, memoize for stability
-    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
+    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange || 30), [currentRange]);
 
     // Build search params
     const searchParams = useMemo(() => {

--- a/apps/stats/src/hooks/useTopPostsStatsWithRange.ts
+++ b/apps/stats/src/hooks/useTopPostsStatsWithRange.ts
@@ -24,7 +24,7 @@ export const useTopPostsStatsWithRange = (range?: number, order?: TopPostsOrder,
     const currentOrder = order ?? 'mrr desc'; // Default to MRR descending
 
     // Calculate date strings using the helper, memoize for stability
-    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange), [currentRange]);
+    const {startDate, endDate} = useMemo(() => getRangeDates(currentRange || 30), [currentRange]);
 
     // Construct searchParams including the order and post_type parameters
     const searchParams = useMemo(() => {

--- a/apps/stats/src/hooks/useTopSourcesGrowth.ts
+++ b/apps/stats/src/hooks/useTopSourcesGrowth.ts
@@ -5,7 +5,7 @@ import {useTopSourcesGrowth as useTopSourcesGrowthAPI} from '@tryghost/admin-x-f
 
 export const useTopSourcesGrowth = (range: number, orderBy: string = 'signups desc', limit: number = 50) => {
     const {audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
+    const {startDate, endDate, timezone} = getRangeDates(range || 30);
 
     const searchParams: Record<string, string> = {
         date_from: formatQueryDate(startDate),

--- a/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
@@ -84,7 +84,7 @@ const GrowthKPIs: React.FC<{
             }];
         }
 
-        const {startDate, endDate} = getRangeDates(dateRange);
+        const {startDate, endDate} = getRangeDates(dateRange || 30);
         const dateSpan = moment(endDate).diff(moment(startDate), 'days');
         const strategy = determineAggregationStrategy(dateRange, dateSpan, 'sum');
 

--- a/apps/stats/src/views/Stats/Locations/Locations.tsx
+++ b/apps/stats/src/views/Stats/Locations/Locations.tsx
@@ -56,7 +56,7 @@ interface ProcessedLocationData {
 
 const Locations:React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
+    const {startDate, endDate, timezone} = getRangeDates(range || 30);
     const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
     const ITEMS_PER_PAGE = 10;
     const {appSettings} = useAppContext();

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -294,7 +294,7 @@ const Newsletters: React.FC = () => {
     const subscribersData = useMemo(() => {
         if (!subscriberStatsData?.stats?.[0]?.deltas || subscriberStatsData.stats[0].deltas.length === 0) {
             // When there's no data, create zero points for each day spanning the range
-            const {startDate, endDate} = getRangeDates(range);
+            const {startDate, endDate} = getRangeDates(range || 30);
 
             const dailyData = [];
             const currentDate = new Date(startDate);

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -65,8 +65,8 @@ type GrowthChartDataItem = {
 const Overview: React.FC = () => {
     const {appSettings} = useAppContext();
     const {statsConfig, isLoading: isConfigLoading, range, audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
-    const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
+    const {startDate, endDate, timezone} = getRangeDates(range || 30); // Default to 30 days if range is undefined
+    const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range || 30);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -49,7 +49,7 @@ export const KPI_METRICS: Record<string, KpiMetric> = {
 
 const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
+    const {startDate, endDate, timezone} = getRangeDates(range || 30);
     const {appSettings} = useAppContext();
 
     // Get site URL and icon for domain comparison and Direct traffic favicon

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -90,7 +90,7 @@ interface TopContentProps {
 
 const TopContent: React.FC<TopContentProps> = ({range}) => {
     const {audience} = useGlobalData();
-    const {startDate, endDate, timezone} = getRangeDates(range);
+    const {startDate, endDate, timezone} = getRangeDates(range || 30);
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
 
     // Prepare query parameters based on selected content type


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2301/generate-fake-data-for-the-marketing-site-for-screenshots

❌ Not planning to merge this, this is just some hacky stuff we can deploy to staging on a test site.

The goal here is to enable a "demo data mode" for the posts and stats apps. There are fundamentally two different approaches to doing this, as I see it:
- Seeding a site's actual databases (MySQL + Tinybird) with generated raw data
- Intercepting the API requests and returning fake aggregated data

This PR opts for the latter approach, as it offers a few benefits over the former (albeit with tradeoffs):
- Data freshness — we can generate the data on demand, so it will always be fresh
- Convenience — the fake data mode can be enabled/disabled all in the browser, without any ad-hoc scripting or knowledge of code.
- Simplicity — generating realistic looking aggregated data (as returned by the API endpoints) feels like a lighter lift than generating all the data and relationships required to return the same aggregated data

How it works:
- The "fake data" mode is enabled by setting the `ghost-fake-data` key in localStorage to `'true'`. There's no UI toggle (yet) — for now this can be accomplished in the browser console with `localStorage.setItem('ghost-fake-data', 'true');`
- When "fake data" is enabled, we intercept API requests to Ghost's Admin API and Tinybird's endpoints at the framework level, and inject fake data into the responses. Doing this at the framework level avoids making any code changes to the apps themselves, makes the same pattern available in all the other admin-x-* apps, and just generally feels cleaner than overriding the responses in ~15 custom hooks individually
- Each endpoint that we choose to intercept uses a generator function for the response data, so we can dynamically generate the fake data with timestamps that make sense, some randomness, etc.

This isn't fully implemented for all required endpoints yet, but I wanted to share for early feedback on the approach before going too much further with this.