### PR TITLE
Updated post list analytics metric conditions

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -167,28 +167,36 @@
             {{!-- Visitor count column (only when web analytics is enabled) --}}
             {{#if this.settings.webAnalyticsEnabled}}
                 {{#if @post.isPublished}}
-                    {{#if this.hasVisitorData}}
-                        <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">
-                            <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
-                                <h3>Web traffic</h3>
-                                <div class="metrics">
-                                    <div class="metric">
-                                        <div class="data">
-                                            {{svg-jar "analytics-visitors"}}
-                                            Unique visitors
-                                        </div>
-                                        <span>{{format-number this.visitorCount}}</span>
+                    <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">
+                        <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
+                            <h3>Web traffic</h3>
+                            <div class="metrics">
+                                <div class="metric">
+                                    <div class="data">
+                                        {{svg-jar "analytics-visitors"}}
+                                        Unique visitors
                                     </div>
+                                    <span>
+                                        {{#if this.hasVisitorData}}
+                                            {{format-number this.visitorCount}}
+                                        {{else}}
+                                            0
+                                        {{/if}}
+                                    </span>
                                 </div>
                             </div>
-                            <div class="gh-post-list-analytics-metric" data-test-analytics-visitors>
-                                {{svg-jar "analytics-visitors" class="gh-list-analytics-icon"}}
-                                <span class="gh-content-email-stats-value">
+                        </div>
+                        <div class="gh-post-list-analytics-metric" data-test-analytics-visitors>
+                            {{svg-jar "analytics-visitors" class="gh-list-analytics-icon"}}
+                            <span class="gh-content-email-stats-value">
+                                {{#if this.hasVisitorData}}
                                     {{abbreviate-number this.visitorCount}}
-                                </span>
-                            </div>
-                        </LinkTo>
-                    {{/if}}
+                                {{else}}
+                                    0
+                                {{/if}}
+                            </span>
+                        </div>
+                    </LinkTo>
                 {{/if}}
             {{/if}}
 
@@ -260,35 +268,49 @@
             {{!-- Member conversions column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
             {{#if this.settings.membersTrackSources}}
                 {{#if @post.isPublished}}
-                    {{#if this.hasMemberData}}
-                        <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">
-                        <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
-                            <h3>New members</h3>
-                            <div class="metrics">
-                                <div class="metric">
-                                    <div class="data">
-                                        {{svg-jar "analytics-free-members"}}
-                                        Free
-                                    </div>
-                                    <span>{{format-number this.memberCounts.free}}</span>
+                    <LinkTo @route="posts-x" @model={{@post.id}} class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">
+                    <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
+                        <h3>New members</h3>
+                        <div class="metrics">
+                            <div class="metric">
+                                <div class="data">
+                                    {{svg-jar "analytics-free-members"}}
+                                    Free
                                 </div>
-                                <div class="metric">
-                                    <div class="data">
-                                        {{svg-jar "analytics-paid-members"}}
-                                        Paid
-                                    </div>
-                                    <span>{{format-number this.memberCounts.paid}}</span>
-                                </div>
-                            </div>
-                        </div>
-                            <div class="gh-post-list-analytics-metric" data-test-analytics-member-conversions>
-                                {{svg-jar "analytics-members" class="gh-list-analytics-icon"}}
-                                <span class="gh-content-email-stats-value">
-                                    {{format-number this.totalMemberConversions}}
+                                <span>
+                                    {{#if this.hasMemberData}}
+                                        {{format-number this.memberCounts.free}}
+                                    {{else}}
+                                        0
+                                    {{/if}}
                                 </span>
                             </div>
-                        </LinkTo>
-                    {{/if}}
+                            <div class="metric">
+                                <div class="data">
+                                    {{svg-jar "analytics-paid-members"}}
+                                    Paid
+                                </div>
+                                <span>
+                                    {{#if this.hasMemberData}}
+                                        {{format-number this.memberCounts.paid}}
+                                    {{else}}
+                                        0
+                                    {{/if}}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                        <div class="gh-post-list-analytics-metric" data-test-analytics-member-conversions>
+                            {{svg-jar "analytics-members" class="gh-list-analytics-icon"}}
+                            <span class="gh-content-email-stats-value">
+                                {{#if this.hasMemberData}}
+                                    {{format-number this.totalMemberConversions}}
+                                {{else}}
+                                    0
+                                {{/if}}
+                            </span>
+                        </div>
+                    </LinkTo>
                 {{/if}}
             {{/if}}
         </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2448/update-post-list-metric-conditions

Currently post list metrics (web visitors, no. of members etc.) are displayed with conditions that are not appropriate and inconsistent with the new Traffic Analytics.

Here are the issues that should be fixed:

**Web visitors**

- Should be shown if web analytics is turned on, regardless if there's data
- Current condition: it's only shown if there is visitor data

**Member data**

- Should be shown if member tracking is turned on, regardless if there's data
- Current condition: it's show only if there's member related data

<img width="3430" height="2372" alt="CleanShot 2025-07-22 at 11 54 07@2x" src="https://github.com/user-attachments/assets/634de86f-5959-4940-8ebe-e3f9a534c559" />
