### PR TITLE
Refined loading indicator for post stats overview

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -3,7 +3,7 @@ import NewsletterOverview from './components/NewsletterOverview';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import WebOverview from './components/WebOverview';
-import {Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
+import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, LucideIcon, Skeleton, formatNumber, formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade';
 import {KPI_METRICS} from '../Web/components/Kpis';
 import {KpiDataItem} from '@src/utils/kpi-helpers';
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
@@ -128,6 +128,13 @@ const Overview: React.FC = () => {
             navigate(`/analytics/beta/${postId}/growth`);
         }
     }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId]);
+
+    // First we have to wait for the post to be loaded to determine what sections (web, newsletter etc.) should be displayed
+    if (isPostLoading) {
+        return (
+            <BarChartLoadingIndicator />
+        );
+    }
 
     return (
         <>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2174/investigate-web-analytics-flash-on-email-only-posts

- The current loading indicator setup of the post analytics overview shows all sections with separate, dedicated loading indicators. However it's only possible to determine which sections should be shown only once the post data is loaded. For email-only posts this could result in showing the web section for a splitsecond and then immediately removing it, causing an unwanted flash on the UI. To overcome this problem, this PR adds a loading indicator that's shown on the whole page until the post data is loaded, resulting in showing only relevant sections without the flash.