### PR TITLE
Used site_uuid over site_url in Explore testimonials

### DIFF
--- a/apps/admin-x-framework/src/api/site.ts
+++ b/apps/admin-x-framework/src/api/site.ts
@@ -13,6 +13,7 @@ export type SiteData = {
     url: string;
     locale: string;
     version: string;
+    site_uuid: string;
 };
 
 export interface SiteResponseType {

--- a/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
@@ -19,7 +19,7 @@ const TestimonialsModal = NiceModal.create(() => {
 
     const exploreTestimonialsUrl = config.exploreTestimonialsUrl as string;
 
-    const siteUrl = siteData.url.replace(/\/$/, '');
+    const siteUuid = siteData.site_uuid;
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const staffUserName = currentUser.name;
     const staffUserEmail = currentUser.email;
@@ -33,10 +33,8 @@ const TestimonialsModal = NiceModal.create(() => {
         },
         onSave: async (): Promise<void> => {
             const payload = {
-                site_url: siteUrl,
-                staff_user_name: staffUserName,
+                ghost_uuid: siteUuid,
                 staff_user_email: staffUserEmail,
-                staff_user_role: staffUserRole,
                 content: formState.content,
                 prev_platform: formState.prev_platform
             };

--- a/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
@@ -19,7 +19,7 @@ const TestimonialsModal = NiceModal.create(() => {
 
     const exploreTestimonialsUrl = config.exploreTestimonialsUrl as string;
 
-    const siteUrl = siteData.url;
+    const siteUrl = siteData.url.replace(/\/$/, '');
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
     const staffUserName = currentUser.name;
     const staffUserEmail = currentUser.email;

--- a/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
@@ -167,7 +167,7 @@ test.describe('Ghost Explore', () => {
 
         // Verify the API request was made with correct payload
         expect(testimonialRequestBody).toEqual({
-            site_url: 'http://test.com/',
+            site_url: 'http://test.com',
             staff_user_name: 'Owner User',
             staff_user_email: 'owner@test.com',
             staff_user_role: 'Owner',

--- a/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
@@ -114,6 +114,16 @@ test.describe('Ghost Explore', () => {
                         {key: 'explore_ping_growth', value: true}
                     ]
                 }
+            },
+            browseSite: {
+                ...globalDataRequests.browseSite,
+                response: {
+                    ...responseFixtures.site,
+                    site: {
+                        ...responseFixtures.site.site,
+                        site_uuid: '9a604cf9-4c27-4a05-9991-be9974a764c5'
+                    }
+                }
             }
         }});
 
@@ -167,10 +177,8 @@ test.describe('Ghost Explore', () => {
 
         // Verify the API request was made with correct payload
         expect(testimonialRequestBody).toEqual({
-            site_url: 'http://test.com',
-            staff_user_name: 'Owner User',
+            ghost_uuid: '9a604cf9-4c27-4a05-9991-be9974a764c5',
             staff_user_email: 'owner@test.com',
-            staff_user_role: 'Owner',
             content: 'I love Ghost!',
             prev_platform: 'wordpress'
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771

- Explore testimonials API has been updated to accept a site uuid over a site url
- The staff name/role fields have also been dropped

