### PR TITLE
Wired up member count in Explore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
               - 'apps/admin-x-settings/**'
               - 'apps/admin-x-design-system/**'
               - 'apps/admin-x-framework/**'
+              - 'apps/shade/**'
             admin-x-activitypub:
               - *shared
               - 'apps/shade/**'

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -49,6 +49,7 @@
     "@testing-library/react": "14.3.1",
     "@tryghost/admin-x-design-system": "0.0.0",
     "@tryghost/admin-x-framework": "0.0.0",
+    "@tryghost/shade": "0.0.0",
     "@tryghost/custom-fonts": "1.0.2",
     "@types/react": "18.3.23",
     "@types/react-dom": "18.3.7",

--- a/apps/admin-x-settings/src/components/settings/growth/Explore.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/Explore.tsx
@@ -1,10 +1,12 @@
 import FakeLogo from '../../../assets/images/explore-default-logo.png';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import SettingImg from '../../../assets/images/ghost-explore.png';
 import TopLevelGroup from '../../TopLevelGroup';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {Button, Icon, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
+import {abbreviateNumber} from '@tryghost/shade';
+import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -14,6 +16,21 @@ const Explore: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: editSettings} = useEditSettings();
     const handleError = useHandleError();
     const {updateRoute} = useRouting();
+
+    // Get members count
+    const {refetch: fetchMembers} = useBrowseMembers({
+        searchParams: {limit: '1'}
+    });
+    const [membersCount, setMembersCount] = useState(0);
+    useEffect(() => {
+        const fetchMemberCount = async () => {
+            const {data: members} = await fetchMembers();
+            const count = members?.meta?.pagination?.total || 0;
+            setMembersCount(count);
+        };
+
+        fetchMemberCount();
+    }, [fetchMembers]);
 
     const [accentColor, icon] = getSettingValues<string>(settings, ['accent_color', 'icon']);
     const {localSettings, siteData} = useSettingGroup();
@@ -89,8 +106,8 @@ const Explore: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         <a className='group mt-8 flex h-6 w-full items-center justify-between gap-5 hover:cursor-pointer' href={url} rel="noopener noreferrer" target="_blank">
                             <span className='text-sm font-semibold'>{siteDomain}</span>
                             {shareGrowthData ?
-                                <span className='rounded-sm bg-black px-2 py-0.5 text-xs font-semibold text-white'>
-                                    12k members
+                                <span className='rounded-sm bg-black px-2 py-0.5 text-xs font-semibold text-white' data-testid='explore-members-count'>
+                                    {abbreviateNumber(membersCount)}&nbsp;members
                                 </span>
                                 :
                                 <span className='flex size-5 items-center justify-center rounded-full border border-black text-black group-hover:bg-black group-hover:text-white'>

--- a/apps/admin-x-settings/src/components/settings/growth/Explore.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/Explore.tsx
@@ -107,7 +107,7 @@ const Explore: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             <span className='text-sm font-semibold'>{siteDomain}</span>
                             {shareGrowthData ?
                                 <span className='rounded-sm bg-black px-2 py-0.5 text-xs font-semibold text-white' data-testid='explore-members-count'>
-                                    {abbreviateNumber(membersCount)}&nbsp;members
+                                    {abbreviateNumber(membersCount)}&nbsp;{membersCount === 1 ? 'member' : 'members'}
                                 </span>
                                 :
                                 <span className='flex size-5 items-center justify-center rounded-full border border-black text-black group-hover:bg-black group-hover:text-white'>

--- a/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
+++ b/apps/admin-x-settings/test/acceptance/growth/explore.test.ts
@@ -39,7 +39,7 @@ test.describe('Ghost Explore', () => {
         });
     });
 
-    test('can choose to share growth data', async ({page}) => {
+    test('can share growth data with Ghost Explore', async ({page}) => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             browseSettings: {
@@ -67,26 +67,77 @@ test.describe('Ghost Explore', () => {
         const mainToggle = section.getByTestId('explore-toggle');
         await expect(mainToggle).toBeChecked();
 
-        // Preview should be visible
-        const preview = section.getByTestId('explore-preview');
-        await expect(preview).toBeVisible();
-        await expect(preview.getByText('Preview')).toBeVisible();
-        await expect(preview.getByText('Test Site')).toBeVisible();
-        await expect(preview.getByText('Thoughts, stories and ideas')).toBeVisible();
-        await expect(preview.getByText('test.com')).toBeVisible();
-
-        // Growth data toggle should be visible and off
+        // Growth data toggle should be off
         const growthDataToggle = section.getByTestId('explore-growth-toggle');
-        await expect(growthDataToggle).toBeVisible();
         await expect(growthDataToggle).not.toBeChecked();
 
-        // Turn on growth data sharing
+        // Enable growth data sharing
         await growthDataToggle.click();
 
-        // Verify the API call to disable explore_ping_growth
+        // Verify the API call to enable explore_ping_growth
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [{key: 'explore_ping_growth', value: true}]
         });
+    });
+
+    test('renders a preview with members count', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {
+                ...globalDataRequests.browseSettings,
+                response: {
+                    ...responseFixtures.settings,
+                    settings: [
+                        ...responseFixtures.settings.settings,
+                        {key: 'explore_ping', value: true},
+                        {key: 'explore_ping_growth', value: true}
+                    ]
+                }
+            },
+            browseMembers: {
+                method: 'GET',
+                path: '/members/?limit=1',
+                response: {
+                    members: [{
+                        id: '0000000086b42a93546b7315',
+                        uuid: '7e0ae12f-2a44-4117-b825-2c78a1e73260',
+                        email: 'emilylangworth278258@example.com',
+                        name: 'Emily Langworth'
+                    }],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 1,
+                            pages: 1000,
+                            total: 1000,
+                            next: 2,
+                            prev: null
+                        }
+                    }
+                }
+            }
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('explore');
+        await expect(section).toBeVisible();
+
+        // Check that the preview is rendered correctly
+        const preview = section.getByTestId('explore-preview');
+        await expect(preview).toBeVisible();
+
+        // Check site title
+        await expect(preview.getByText('Test Site')).toBeVisible();
+
+        // Check site description
+        await expect(preview.getByText('Thoughts, stories and ideas')).toBeVisible();
+
+        // Check site URL (domain)
+        await expect(preview.getByText('test.com')).toBeVisible();
+
+        // Check members count
+        await expect(preview.getByText('1k members')).toBeVisible();
     });
 
     test('can send a testimonial', async ({page}) => {
@@ -142,6 +193,10 @@ test.describe('Ghost Explore', () => {
         const modal = page.getByTestId('explore-testimonials-modal');
         await expect(modal).toBeVisible();
         await expect(modal.getByText('Send a testimonial')).toBeVisible();
+
+        // Check that the staff user name, staff user role and site title are rendered
+        await expect(modal.getByText('By Owner User')).toBeVisible();
+        await expect(modal.getByText('Owner — Test Site')).toBeVisible();
 
         // Try to submit with empty content
         const submitButton = modal.getByRole('button', {name: 'Send testimonial'});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771

- if growth data sharing is enabled, show a preview with the site's members count
- member count above 1000 are rendered are abbreviated, e.g. `1.2k` for `1210` members

<img width="1270" height="1050" alt="CleanShot 2025-07-22 at 19 23 19@2x" src="https://github.com/user-attachments/assets/3b332522-5d93-4118-ab09-436ec9b3d275" />


