### PR TITLE
Migrated Tinybird payload from JSON field to String field

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -6,9 +6,12 @@ SCHEMA >
     `session_id` String `json:$.session_id`,
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
-    `payload` JSON(max_dynamic_types=4, max_dynamic_paths=32) `json:$.payload`,
+    `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
+
+FORWARD_QUERY >
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -8,9 +8,12 @@ SCHEMA >
     `session_id` String `json:$.session_id`,
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
-    `payload` JSON(max_dynamic_types=4, max_dynamic_paths=32) `json:$.payload`,
+    `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
+
+FORWARD_QUERY >
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -5,20 +5,20 @@ SQL >
         action,
         version,
         coalesce(session_id, '0') as session_id,
-        toString(payload.locale) as locale,
-        toString(payload.location) as location,
+        JSONExtractString(payload, 'locale') as locale,
+        JSONExtractString(payload, 'location') as location,
         case
-            when isNull(payload.referrerSource) then toString(payload.meta.referrerSource)
-            else toString(payload.referrerSource)
+            when JSONExtractString(payload, 'referrerSource') = '' then JSONExtractString(payload, 'meta', 'referrerSource')
+            else JSONExtractString(payload, 'referrerSource')
         end as referrer,
-        toString(payload.pathname) as pathname,
-        toString(payload.href) as href,
+        JSONExtractString(payload, 'pathname') as pathname,
+        JSONExtractString(payload, 'href') as href,
         site_uuid,
-        toString(payload.member_uuid) as member_uuid,
-        toString(payload.member_status) as member_status,
-        toString(payload.post_uuid) as post_uuid,
-        toString(payload.post_type) as post_type,
-        lower(toString(getSubcolumn(payload,'user-agent'))) as user_agent
+        JSONExtractString(payload, 'member_uuid') as member_uuid,
+        JSONExtractString(payload, 'member_status') as member_status,
+        JSONExtractString(payload, 'post_uuid') as post_uuid,
+        JSONExtractString(payload, 'post_type') as post_type,
+        lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2271/figure-out-a-path-forward-with-tinybird-for-the-experimental-json-data

Our Tinybird workspace currently uses a JSON field type for the `payload` in our main datasource. This JSON field is a beta feature that isn't _quite_ ready for production yet, so for now we need to migrate back to storing the payload in a String field.

Luckily, this change only impacts two important files:
- `analytics_events.datasource` — our main datasource
- `mv_hits.pipe` — pipe that feeds our main materialized view

All of our other pipes and endpoints read from the `mv_hits` materialized view, rather than reading from the `analytics_events` datasource directly, which means there are no required changes to any of our other pipes/endpoints.

Testing this change:
- [x] This change should deploy successfully to Tinybird, starting with a fresh/empty workspace (clear local workspace with `tb local remove`)
- [x] This change should deploy successfully to Tinybird, starting with the existing workspace/schema (checkout main, deploy to tb local, checkout this branch, deploy to tb local)
- [x] Existing Tinybird endpoint tests should all pass without modification
- [x] The full Ghost -> Analytics Service -> Tinybird -> Ghost Admin event ingestion and querying flow should work after the migration
- [x] No existing data should be lost/corrupted/duplicated in the course of the migration/deployment (checkout main, deploy to tb local, add some events, checkout this branch, deploy to tb local)
- [x] Querying the `mv_hits.pipe` before and after should return exactly the same results (`tb sql 'select * from mv_hits;'`)
- [x] An event recorded before the migration in the mv_hits materialized view should exactly match the same event recorded after the migration, except for the timestamp (including the full ingestion flow with the analytics service)
- [x] There should be no downtime during the deployment process — events recorded continuously through the migration should continue to be ingested and seamlessly populate the mv_hits materialized view without dropping or corrupting any events (technically this isn't critical/blocking yet since we're still in beta, but it's a good stress test on our deployment process)

Note: this also changes the `analytics_events_test.datasource` to match, but this datasource is not used at all in production, so testing this is not a concern.