### PR TITLE
Created data factory framework for E2E test package

### DIFF
--- a/e2e/data-factory/.env.example
+++ b/e2e/data-factory/.env.example
@@ -1,0 +1,10 @@
+# Ghost Database Configuration
+GHOST_DB_HOST=localhost
+GHOST_DB_PORT=3306
+GHOST_DB_USER=root
+GHOST_DB_PASSWORD=root
+GHOST_DB_NAME=ghost
+
+# Tinybird Configuration
+TINYBIRD_HOST=http://localhost:7181/v0/events
+TINYBIRD_TOKEN=test-token-here

--- a/e2e/data-factory/README.md
+++ b/e2e/data-factory/README.md
@@ -83,12 +83,19 @@ const customFactory = new DataFactory({
 
 ## Available Methods
 
+### Factory Pattern
+All factories implement a build/create pattern:
+- `build()` - Build an object without persisting it
+- `create()` - Build and persist an object
+
 ### Ghost Plugin (`factory.ghost`)
 - `createPost()` - Create a draft post
 - `createPublishedPost()` - Create a published post
 - `createDraftPost()` - Create a draft post explicitly
 - `createScheduledPost()` - Create a scheduled post
 - `posts` - Direct access to post factory
+  - `posts.build()` - Build a post without saving
+  - `posts.create()` - Build and save a post
 - `getStats()` - Get creation statistics
 - `getDatabase()` - Access the shared database connection
 
@@ -99,6 +106,8 @@ const customFactory = new DataFactory({
 - `createNewSession()` - Create a new session ID
 - `createSessionHits()` - Create multiple hits for a session
 - `pageHits` - Direct access to page hit factory
+  - `pageHits.build()` - Build a page hit without sending
+  - `pageHits.create()` - Build and send a page hit
 - `getStats()` - Get analytics statistics
 - `isInitialized()` - Check if Tinybird is ready
 
@@ -175,6 +184,23 @@ yarn test:types
 ```
 
 ## Example Tests
+
+### Build vs Create Pattern
+```typescript
+test('build vs create', async ({factory}) => {
+    // Build: creates object without persisting
+    const draftPost = factory.ghost.posts.build({
+        title: 'Draft Version'
+    });
+    // Post has all fields but isn't saved to database
+    
+    // Create: builds and persists object
+    const savedPost = await factory.ghost.posts.create({
+        title: 'Saved Version'
+    });
+    // Post is saved to database and tracked for cleanup
+});
+```
 
 ### Basic Usage
 ```typescript

--- a/e2e/data-factory/README.md
+++ b/e2e/data-factory/README.md
@@ -1,0 +1,221 @@
+# Data Factory
+
+Plugin-based test data factory for Ghost and Tinybird with a clean, extensible architecture.
+
+## Features
+
+- **Plugin Architecture**: Modular design allows custom combinations of factories
+- **Shared Dependencies**: Ghost factories share database connections, Tinybird factories share HTTP clients
+- **Type Safe**: Full TypeScript support with proper typing
+- **Auto Cleanup**: Automatic cleanup of test data after each test
+- **Clean API**: Intuitive plugin-based API with no legacy cruft
+
+## Setup
+
+1. Copy `.env.example` to `.env` and configure:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edit `.env` with your database and Tinybird settings.
+
+## Usage
+
+### Basic Example
+
+```typescript
+import {test, expect} from '@e2e/data-factory';
+
+test('create content', async ({factory}) => {
+    // Access plugins through factory
+    const post = await factory.ghost.createPublishedPost({
+        title: 'Hello World'
+    });
+    
+    await factory.tinybird.createPageHitsForPost(post.uuid, 100);
+    
+    expect(post.status).toBe('published');
+});
+```
+
+### Destructured Plugin Access (Recommended)
+
+```typescript
+// Use only what you need
+test('ghost only', async ({ghost}) => {
+    const post = await ghost.createPublishedPost({
+        title: 'Test Post'
+    });
+    expect(post.status).toBe('published');
+});
+
+test('analytics', async ({tinybird, ghost}) => {
+    const post = await ghost.createPost();
+    await tinybird.createPageHitsForPost(post.uuid, 50);
+});
+
+test('both plugins', async ({ghost, tinybird}) => {
+    const post = await ghost.createPublishedPost();
+    await tinybird.createPageHit({
+        post_uuid: post.uuid
+    });
+});
+```
+
+### Custom Plugin Configuration
+
+```typescript
+import {DataFactory, GhostPlugin, TinybirdPlugin} from '@e2e/data-factory';
+
+// Ghost only
+const ghostFactory = new DataFactory({
+    plugins: [new GhostPlugin()]
+});
+
+// Custom database
+const customFactory = new DataFactory({
+    plugins: [
+        new GhostPlugin({database: myDatabase}),
+        new TinybirdPlugin({httpClient: myHttpClient})
+    ]
+});
+```
+
+## Available Methods
+
+### Ghost Plugin (`factory.ghost`)
+- `createPost()` - Create a draft post
+- `createPublishedPost()` - Create a published post
+- `createDraftPost()` - Create a draft post explicitly
+- `createScheduledPost()` - Create a scheduled post
+- `posts` - Direct access to post factory
+- `getStats()` - Get creation statistics
+- `getDatabase()` - Access the shared database connection
+
+### Tinybird Plugin (`factory.tinybird`)
+- `createPageHit()` - Create a single page hit
+- `createPageHits()` - Create multiple page hits
+- `createPageHitsForPost()` - Create page hits for a specific post
+- `createNewSession()` - Create a new session ID
+- `createSessionHits()` - Create multiple hits for a session
+- `pageHits` - Direct access to page hit factory
+- `getStats()` - Get analytics statistics
+- `isInitialized()` - Check if Tinybird is ready
+
+## Environment Variables
+
+### Ghost Database
+- `GHOST_DB_HOST` - Database host (default: localhost)
+- `GHOST_DB_PORT` - Database port (default: 3306)
+- `GHOST_DB_USER` - Database user (default: root)
+- `GHOST_DB_PASSWORD` - Database password (default: root)
+- `GHOST_DB_NAME` - Database name (default: ghost)
+
+### Tinybird
+- `TINYBIRD_HOST` - Tinybird API endpoint
+- `TINYBIRD_TOKEN` - Tinybird authentication token
+
+## Architecture
+
+### Plugin-Based Design
+
+The data factory uses a plugin architecture where each data source (Ghost, Tinybird) is a self-contained plugin:
+
+- **Ghost Plugin**: Manages all Ghost-related factories and shares a database connection between them
+- **Tinybird Plugin**: Manages all analytics factories and shares an HTTP client between them
+- **DataFactory**: Coordinates plugins and handles cross-plugin dependencies
+
+```
+data-factory/
+├── ghost/
+│   ├── posts/            # Post factory
+│   ├── ghost-plugin.ts   # Ghost plugin coordinator
+│   ├── config.ts         # Ghost configuration
+│   └── database.ts       # Database utilities
+├── tinybird/
+│   ├── page-hits/        # Page hit factory
+│   ├── tinybird-plugin.ts # Tinybird plugin coordinator
+│   └── config.ts         # Tinybird configuration
+├── plugin.ts             # Plugin interfaces
+├── data-factory.ts       # Main coordinator
+├── test-fixtures.ts      # Playwright integration
+└── index.ts             # Public exports
+```
+
+### Plugin Benefits
+
+1. **Dependency Isolation**: Each plugin owns its dependencies (Ghost owns Knex, Tinybird owns HTTP client)
+2. **Modular Composition**: Use only the plugins you need
+3. **Easy Extension**: Add new plugins without modifying core code
+4. **Shared Resources**: Related factories share connections/clients efficiently
+
+## Key Features
+
+- **Automatic cleanup**: Each test gets its own factory instance with automatic cleanup
+- **Simple configuration**: Just use `.env` file
+- **Type safe**: Full TypeScript support
+- **Test isolation**: Each test's data is isolated
+
+## Example Tests
+
+### Basic Usage
+```typescript
+import {test, expect} from '@e2e/data-factory';
+
+test('blog with analytics', async ({factory}) => {
+    // Create content
+    const post = await factory.ghost.createPublishedPost({
+        title: 'Popular Article',
+        featured: true
+    });
+    
+    // Generate traffic
+    await factory.tinybird.createPageHitsForPost(post.uuid, 1000);
+    
+    // Check stats
+    const stats = factory.ghost.getStats();
+    expect(stats.posts).toBe(1);
+    
+    // Cleanup happens automatically!
+});
+```
+
+### Multi-Session Analytics
+```typescript
+test('track multiple user sessions', async ({factory}) => {
+    const post = await factory.ghost.createPublishedPost();
+    
+    // Session 1: New visitor from Google
+    const session1 = factory.tinybird.createNewSession();
+    await factory.tinybird.createSessionHits(session1, 3, {
+        post_uuid: post.uuid,
+        referrer: 'https://google.com',
+        member_status: 'undefined'
+    });
+    
+    // Session 2: Returning paid member
+    const session2 = factory.tinybird.createNewSession();
+    await factory.tinybird.createSessionHits(session2, 5, {
+        post_uuid: post.uuid,
+        member_status: 'paid'
+    });
+    
+    // Session 3: User journey
+    const session3 = factory.tinybird.createNewSession();
+    await factory.tinybird.pageHits.create({
+        session_id: session3,
+        pathname: '/',
+        referrer: 'https://twitter.com'
+    });
+    await factory.tinybird.pageHits.create({
+        session_id: session3,
+        pathname: `/posts/${post.slug}`,
+        post_uuid: post.uuid
+    });
+    
+    // Check stats
+    const pageHitStats = factory.tinybird.pageHits.getStats();
+    expect(pageHitStats.sessions).toBe(3);
+    expect(pageHitStats.events).toBe(10);
+});
+```

--- a/e2e/data-factory/README.md
+++ b/e2e/data-factory/README.md
@@ -24,7 +24,7 @@ Plugin-based test data factory for Ghost and Tinybird with a clean, extensible a
 ### Basic Example
 
 ```typescript
-import {test, expect} from '@e2e/data-factory';
+import {test, expect} from './data-factory';
 
 test('create content', async ({factory}) => {
     // Access plugins through factory
@@ -65,7 +65,7 @@ test('both plugins', async ({ghost, tinybird}) => {
 ### Custom Plugin Configuration
 
 ```typescript
-import {DataFactory, GhostPlugin, TinybirdPlugin} from '@e2e/data-factory';
+import {DataFactory, GhostPlugin, TinybirdPlugin} from './data-factory';
 
 // Ghost only
 const ghostFactory = new DataFactory({
@@ -127,18 +127,22 @@ The data factory uses a plugin architecture where each data source (Ghost, Tinyb
 
 ```
 data-factory/
-├── ghost/
-│   ├── posts/            # Post factory
-│   ├── ghost-plugin.ts   # Ghost plugin coordinator
-│   ├── config.ts         # Ghost configuration
-│   └── database.ts       # Database utilities
-├── tinybird/
-│   ├── page-hits/        # Page hit factory
-│   ├── tinybird-plugin.ts # Tinybird plugin coordinator
-│   └── config.ts         # Tinybird configuration
-├── plugin.ts             # Plugin interfaces
+├── plugins/
+│   ├── base-plugin.ts    # Base plugin class
+│   ├── ghost/
+│   │   ├── posts/        # Post factory
+│   │   ├── ghost-plugin.ts # Ghost plugin coordinator
+│   │   ├── config.ts     # Ghost configuration
+│   │   └── database.ts   # Database utilities
+│   └── tinybird/
+│       ├── page-hits/    # Page hit factory
+│       ├── tinybird-plugin.ts # Tinybird plugin coordinator
+│       ├── config.ts     # Tinybird configuration
+│       └── interfaces.ts # HTTP client interfaces
+├── base-factory.ts       # Base factory class
 ├── data-factory.ts       # Main coordinator
 ├── test-fixtures.ts      # Playwright integration
+├── tests/                # Test suite
 └── index.ts             # Public exports
 ```
 
@@ -152,15 +156,29 @@ data-factory/
 ## Key Features
 
 - **Automatic cleanup**: Each test gets its own factory instance with automatic cleanup
+- **Session-based tracking**: Tinybird tracks sessions for bulk cleanup instead of aggressive truncation
 - **Simple configuration**: Just use `.env` file
 - **Type safe**: Full TypeScript support
 - **Test isolation**: Each test's data is isolated
+
+## Running Tests
+
+```bash
+# Run all data factory tests
+yarn test:factory
+
+# Run linter (includes data-factory directory)
+yarn lint
+
+# Type checking
+yarn test:types
+```
 
 ## Example Tests
 
 ### Basic Usage
 ```typescript
-import {test, expect} from '@e2e/data-factory';
+import {test, expect} from './data-factory';
 
 test('blog with analytics', async ({factory}) => {
     // Create content

--- a/e2e/data-factory/base-factory.ts
+++ b/e2e/data-factory/base-factory.ts
@@ -1,15 +1,28 @@
+import type {PersistenceAdapter} from './persistence/types';
+
 export abstract class Factory<TOptions = unknown, TResult = unknown> {
     abstract name: string;
+    abstract entityType: string; // Used for persistence routing
+    
+    private persistence?: PersistenceAdapter;
+    private trackingEnabled = true;
+    protected createdEntities = new Map<string, TResult>();
     
     /**
      * Set up any necessary resources (database connections, etc.)
+     * Override this method if your factory needs initialization
      */
-    abstract setup(): Promise<void>;
+    async setup(): Promise<void> {
+        // Default implementation - no setup needed
+    }
     
     /**
-     * Clean up resources and created data
+     * Factory-specific cleanup (override if needed)
+     * Called after entities are cleaned up
      */
-    abstract destroy(): Promise<void>;
+    async destroy(): Promise<void> {
+        // Default implementation - no cleanup needed
+    }
     
     /**
      * Build an object without persisting it
@@ -17,7 +30,73 @@ export abstract class Factory<TOptions = unknown, TResult = unknown> {
     abstract build(options?: TOptions): TResult | Promise<TResult>;
     
     /**
+     * Inject persistence adapter
+     */
+    setPersistence(adapter: PersistenceAdapter): void {
+        this.persistence = adapter;
+    }
+    
+    /**
+     * Control entity tracking for cleanup
+     */
+    setTracking(enabled: boolean): void {
+        this.trackingEnabled = enabled;
+    }
+    
+    /**
      * Build and persist an object
      */
-    abstract create(options?: TOptions): Promise<TResult>;
+    async create(options?: TOptions): Promise<TResult> {
+        if (!this.persistence) {
+            throw new Error(`No persistence adapter configured for ${this.name} factory`);
+        }
+        
+        // Build the entity
+        const entity = await Promise.resolve(this.build(options));
+        
+        // Persist using the adapter
+        const persisted = await this.persistence.insert(this.entityType, entity);
+        
+        // Track for cleanup if enabled
+        if (this.trackingEnabled) {
+            const id = this.extractId(persisted);
+            if (id) {
+                this.createdEntities.set(id, persisted);
+            }
+        }
+        
+        return persisted;
+    }
+    
+    /**
+     * Clean up all created entities
+     */
+    async cleanup(): Promise<void> {
+        if (!this.persistence || this.createdEntities.size === 0) {
+            return;
+        }
+        
+        const ids = Array.from(this.createdEntities.keys());
+        await this.persistence.deleteMany(this.entityType, ids);
+        this.createdEntities.clear();
+        
+        // Call factory-specific cleanup
+        await this.destroy();
+    }
+    
+    /**
+     * Extract ID from entity (override if needed)
+     */
+    protected extractId(entity: TResult): string | undefined {
+        const e = entity as Record<string, unknown>;
+        const id = e.id || e.uuid;
+        return typeof id === 'string' ? id : undefined;
+    }
+    
+    /**
+     * Get all created entities
+     */
+    getCreatedEntities(): TResult[] {
+        return Array.from(this.createdEntities.values());
+    }
 }

--- a/e2e/data-factory/base-factory.ts
+++ b/e2e/data-factory/base-factory.ts
@@ -1,0 +1,27 @@
+export abstract class Factory {
+    abstract name: string;
+    
+    abstract setup(): Promise<void>;
+    abstract destroy(): Promise<void>;
+    
+    protected generateId(): string {
+        return Date.now().toString(16) + Math.random().toString(16).substring(2, 10);
+    }
+    
+    protected generateUuid(): string {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+    
+    protected generateSlug(text: string): string {
+        return text.toLowerCase()
+            .trim()
+            .replace(/[^a-z0-9\s-]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-+|-+$/g, '');
+    }
+}

--- a/e2e/data-factory/base-factory.ts
+++ b/e2e/data-factory/base-factory.ts
@@ -1,3 +1,5 @@
+import {v4 as uuid} from 'uuid';
+
 export abstract class Factory {
     abstract name: string;
     
@@ -9,11 +11,7 @@ export abstract class Factory {
     }
     
     protected generateUuid(): string {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-            const r = Math.random() * 16 | 0;
-            const v = c === 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
+        return uuid();
     }
     
     protected generateSlug(text: string): string {

--- a/e2e/data-factory/base-factory.ts
+++ b/e2e/data-factory/base-factory.ts
@@ -1,25 +1,23 @@
-import {v4 as uuid} from 'uuid';
-
-export abstract class Factory {
+export abstract class Factory<TOptions = unknown, TResult = unknown> {
     abstract name: string;
     
+    /**
+     * Set up any necessary resources (database connections, etc.)
+     */
     abstract setup(): Promise<void>;
+    
+    /**
+     * Clean up resources and created data
+     */
     abstract destroy(): Promise<void>;
     
-    protected generateId(): string {
-        return Date.now().toString(16) + Math.random().toString(16).substring(2, 10);
-    }
+    /**
+     * Build an object without persisting it
+     */
+    abstract build(options?: TOptions): TResult | Promise<TResult>;
     
-    protected generateUuid(): string {
-        return uuid();
-    }
-    
-    protected generateSlug(text: string): string {
-        return text.toLowerCase()
-            .trim()
-            .replace(/[^a-z0-9\s-]/g, '')
-            .replace(/\s+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-+|-+$/g, '');
-    }
+    /**
+     * Build and persist an object
+     */
+    abstract create(options?: TOptions): Promise<TResult>;
 }

--- a/e2e/data-factory/data-factory.ts
+++ b/e2e/data-factory/data-factory.ts
@@ -1,0 +1,98 @@
+import type {DataFactoryPlugin} from './plugins/base-plugin';
+import {GhostPlugin} from './plugins/ghost/ghost-plugin';
+import {TinybirdPlugin} from './plugins/tinybird/tinybird-plugin';
+import {getSiteUuid} from './plugins/ghost/database';
+
+export interface DataFactoryOptions {
+    plugins?: DataFactoryPlugin[];
+}
+
+/**
+ * Data factory that coordinates plugins for creating test data.
+ * Each test gets its own instance for proper isolation.
+ */
+export class DataFactory {
+    private plugins = new Map<string, DataFactoryPlugin>();
+    private isDestroyed = false;
+    
+    constructor(options: DataFactoryOptions = {}) {
+        const plugins = options.plugins ?? [
+            new GhostPlugin(),
+            new TinybirdPlugin()
+        ];
+        
+        // Register all plugins
+        plugins.forEach(plugin => this.register(plugin));
+    }
+    
+    register<T extends DataFactoryPlugin>(plugin: T): T {
+        this.plugins.set(plugin.name, plugin);
+        return plugin;
+    }
+    
+    getPlugin<T extends DataFactoryPlugin>(name: string): T | undefined {
+        return this.plugins.get(name) as T;
+    }
+    
+    async initialize(): Promise<void> {
+        // Setup all plugins
+        for (const plugin of this.plugins.values()) {
+            await plugin.setup();
+        }
+        
+        // Handle cross-plugin initialization
+        await this.initializeCrossPluginDependencies();
+    }
+    
+    /**
+     * Initialize Tinybird with Ghost's site UUID if both plugins are present
+     */
+    private async initializeCrossPluginDependencies(): Promise<void> {
+        const ghost = this.getPlugin<GhostPlugin>('ghost');
+        const tinybird = this.getPlugin<TinybirdPlugin>('tinybird');
+        
+        // Initialize Tinybird with Ghost's site UUID if both plugins are present
+        if (ghost && tinybird && !tinybird.isInitialized()) {
+            const siteUuid = await getSiteUuid(ghost.getDatabase());
+            if (siteUuid) {
+                await tinybird.initializeWithSiteUuid(siteUuid);
+            }
+        }
+    }
+    
+    // *
+    // Convenience getters for tests, allow for direct access to plugins
+    //  e.g. test({ghost}) => ghost.createPost()
+    //   vs. test({factory}) => factory.ghost.createPost()
+    // *
+    get ghost(): GhostPlugin {
+        const plugin = this.getPlugin<GhostPlugin>('ghost');
+        if (!plugin) {
+            throw new Error('Ghost plugin not registered');
+        }
+        return plugin;
+    }
+    
+    get tinybird(): TinybirdPlugin {
+        const plugin = this.getPlugin<TinybirdPlugin>('tinybird');
+        if (!plugin) {
+            throw new Error('Tinybird plugin not registered');
+        }
+        return plugin;
+    }
+    
+    async cleanup(): Promise<void> {
+        if (this.isDestroyed) {
+            return;
+        }
+        
+        // Destroy all plugins in reverse order
+        const plugins = Array.from(this.plugins.values()).reverse();
+        for (const plugin of plugins) {
+            await plugin.destroy();
+        }
+        
+        this.plugins.clear();
+        this.isDestroyed = true;
+    }
+}

--- a/e2e/data-factory/index.ts
+++ b/e2e/data-factory/index.ts
@@ -1,0 +1,14 @@
+// Test fixtures with automatic cleanup and helpers
+export {test, expect} from './test-fixtures';
+
+// Direct factory access for advanced usage
+export {DataFactory} from './data-factory';
+
+// Plugin exports for custom setups
+export {DataFactoryPlugin, BasePlugin} from './plugins/base-plugin';
+export {GhostPlugin} from './plugins/ghost/ghost-plugin';
+export {TinybirdPlugin} from './plugins/tinybird/tinybird-plugin';
+
+// Type exports
+export type {PostOptions, PostResult} from './plugins/ghost/posts/types';
+export type {PageHitOptions, PageHitResult} from './plugins/tinybird/page-hits/types';

--- a/e2e/data-factory/persistence/entity-registry.ts
+++ b/e2e/data-factory/persistence/entity-registry.ts
@@ -1,0 +1,31 @@
+import type {EntityRegistry, EntityMetadata} from './types';
+
+/**
+ * Default implementation of entity registry with sensible defaults
+ */
+export class DefaultEntityRegistry implements EntityRegistry {
+    private metadata = new Map<string, EntityMetadata>();
+    
+    register(entityType: string, metadata: EntityMetadata): void {
+        this.metadata.set(entityType, metadata);
+    }
+    
+    getMetadata(entityType: string): EntityMetadata {
+        const meta = this.metadata.get(entityType);
+        if (!meta) {
+            // Sensible defaults - entity type maps to table name
+            return {
+                tableName: entityType,
+                primaryKey: 'id'
+            };
+        }
+        return meta;
+    }
+    
+    // Helper method to register multiple entities at once
+    registerMany(entities: Record<string, EntityMetadata>): void {
+        Object.entries(entities).forEach(([entityType, metadata]) => {
+            this.register(entityType, metadata);
+        });
+    }
+}

--- a/e2e/data-factory/persistence/index.ts
+++ b/e2e/data-factory/persistence/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './knex-adapter';
+export * from './entity-registry';

--- a/e2e/data-factory/persistence/knex-adapter.ts
+++ b/e2e/data-factory/persistence/knex-adapter.ts
@@ -1,0 +1,94 @@
+import type {Knex} from 'knex';
+import type {PersistenceAdapter, EntityRegistry} from './types';
+
+/**
+ * Knex-based persistence adapter for direct database access
+ */
+export class KnexPersistenceAdapter implements PersistenceAdapter {
+    constructor(
+        private db: Knex,
+        private registry: EntityRegistry
+    ) {}
+    
+    async insert<T>(entityType: string, data: T): Promise<T> {
+        const {tableName} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        await this.db(tableName).insert(data);
+        return data;
+    }
+    
+    async update<T>(entityType: string, id: string, data: Partial<T>): Promise<T> {
+        const {tableName, primaryKey = 'id'} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        await this.db(tableName)
+            .where(primaryKey, id)
+            .update(data);
+        
+        const updated = await this.findById<T>(entityType, id);
+        if (!updated) {
+            throw new Error(`Entity not found after update: ${entityType}/${id}`);
+        }
+        
+        return updated;
+    }
+    
+    async delete(entityType: string, id: string): Promise<void> {
+        const {tableName, primaryKey = 'id'} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        await this.db(tableName)
+            .where(primaryKey, id)
+            .del();
+    }
+    
+    async deleteMany(entityType: string, ids: string[]): Promise<void> {
+        if (ids.length === 0) {
+            return;
+        }
+        
+        const {tableName, primaryKey = 'id'} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        await this.db(tableName)
+            .whereIn(primaryKey, ids)
+            .del();
+    }
+    
+    async findById<T>(entityType: string, id: string): Promise<T | null> {
+        const {tableName, primaryKey = 'id'} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        const result = await this.db(tableName)
+            .where(primaryKey, id)
+            .first();
+        
+        return result || null;
+    }
+    
+    async findMany<T>(entityType: string, query?: Record<string, unknown>): Promise<T[]> {
+        const {tableName} = this.registry.getMetadata(entityType);
+        if (!tableName) {
+            throw new Error(`No table configured for entity type: ${entityType}`);
+        }
+        
+        let queryBuilder = this.db(tableName);
+        
+        if (query) {
+            queryBuilder = queryBuilder.where(query);
+        }
+        
+        return await queryBuilder.select();
+    }
+}

--- a/e2e/data-factory/persistence/tinybird-adapter.ts
+++ b/e2e/data-factory/persistence/tinybird-adapter.ts
@@ -1,0 +1,142 @@
+import type {PersistenceAdapter, EntityRegistry} from './types';
+import type {TinybirdConfig, HttpClient} from '../plugins/tinybird/interfaces';
+import {FetchHttpClient} from '../plugins/tinybird/interfaces';
+
+/**
+ * Tinybird-based persistence adapter for API access
+ */
+export class TinybirdPersistenceAdapter implements PersistenceAdapter {
+    private httpClient: HttpClient;
+    
+    constructor(
+        private config: TinybirdConfig,
+        private registry: EntityRegistry,
+        httpClient?: HttpClient
+    ) {
+        this.httpClient = httpClient ?? new FetchHttpClient();
+    }
+    
+    async insert<T>(entityType: string, data: T): Promise<T> {
+        const {endpoint} = this.registry.getMetadata(entityType);
+        if (!endpoint) {
+            throw new Error(`No endpoint configured for entity type: ${entityType}`);
+        }
+        
+        // For Tinybird, we send to the events API
+        const url = `${this.config.host}${endpoint}`;
+        
+        try {
+            const response = await this.httpClient.fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${this.config.token}`,
+                    'x-site-uuid': (data as Record<string, unknown> & {payload?: {site_uuid?: string}}).payload?.site_uuid || ''
+                },
+                body: JSON.stringify(data)
+            });
+            
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Tinybird request failed: ${response.status} - ${text}`);
+            }
+            
+            return data;
+        } catch (error) {
+            // Log the error for debugging
+            // eslint-disable-next-line no-console
+            console.warn('Tinybird error:', error instanceof Error ? error.message : String(error));
+            
+            // For e2e tests, we should actually fail if Tinybird is not available
+            // This ensures tests are meaningful
+            throw error;
+        }
+    }
+    
+    async update<T>(_entityType: string, _id: string, _data: Partial<T>): Promise<T> {
+        void _entityType;
+        void _id;
+        void _data;
+        throw new Error('Update not supported for Tinybird events');
+    }
+    
+    async delete(entityType: string, id: string): Promise<void> {
+        const {primaryKey = 'session_id'} = this.registry.getMetadata(entityType);
+        
+        // Use Tinybird SQL endpoint to delete
+        const sqlUrl = `${this.config.host}/v0/sql`;
+        const query = `DELETE FROM ${entityType} WHERE ${primaryKey} = '${id}'`;
+        
+        try {
+            const response = await this.httpClient.fetch(sqlUrl, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${this.config.token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({q: query})
+            });
+            
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Failed to delete event: ${response.status} - ${text}`);
+            }
+        } catch (error) {
+            // For e2e tests, we should actually fail if Tinybird is not available
+            // This ensures tests are meaningful
+            throw error;
+        }
+    }
+    
+    async deleteMany(entityType: string, ids: string[]): Promise<void> {
+        if (ids.length === 0) {
+            return;
+        }
+        
+        const {primaryKey = 'session_id'} = this.registry.getMetadata(entityType);
+        
+        // Delete in batches using SQL endpoint
+        const batchSize = 100;
+        for (let i = 0; i < ids.length; i += batchSize) {
+            const batch = ids.slice(i, i + batchSize);
+            const idList = batch.map(id => `'${id}'`).join(',');
+            
+            const sqlUrl = `${this.config.host}/v0/sql`;
+            const query = `DELETE FROM ${entityType} WHERE ${primaryKey} IN (${idList})`;
+            
+            try {
+                const response = await this.httpClient.fetch(sqlUrl, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${this.config.token}`,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({q: query})
+                });
+                
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(`Failed to delete events: ${response.status} - ${text}`);
+                }
+            } catch (error) {
+                // For e2e tests, we should actually fail if Tinybird is not available
+                // This ensures tests are meaningful
+                throw error;
+            }
+        }
+    }
+    
+    async findById<T>(_entityType: string, _id: string): Promise<T | null> {
+        void _entityType;
+        void _id;
+        // Tinybird doesn't support individual event retrieval in the same way
+        throw new Error('FindById not supported for Tinybird events');
+    }
+    
+    async findMany<T>(_entityType: string, _query?: Record<string, unknown>): Promise<T[]> {
+        void _entityType;
+        void _query;
+        // Tinybird queries would use their SQL API, not implemented for now
+        throw new Error('FindMany not supported for Tinybird events');
+    }
+}

--- a/e2e/data-factory/persistence/types.ts
+++ b/e2e/data-factory/persistence/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Core persistence adapter interface
+ */
+export interface PersistenceAdapter {
+    insert<T>(entityType: string, data: T): Promise<T>;
+    update<T>(entityType: string, id: string, data: Partial<T>): Promise<T>;
+    delete(entityType: string, id: string): Promise<void>;
+    deleteMany(entityType: string, ids: string[]): Promise<void>;
+    findById<T>(entityType: string, id: string): Promise<T | null>;
+    findMany<T>(entityType: string, query?: Record<string, unknown>): Promise<T[]>;
+}
+
+/**
+ * Entity metadata for routing
+ */
+export interface EntityMetadata {
+    tableName?: string; // For database adapters
+    endpoint?: string; // For API adapters
+    primaryKey?: string; // Default: 'id'
+}
+
+/**
+ * Registry for entity configurations
+ */
+export interface EntityRegistry {
+    register(entityType: string, metadata: EntityMetadata): void;
+    getMetadata(entityType: string): EntityMetadata;
+}

--- a/e2e/data-factory/playwright.config.mjs
+++ b/e2e/data-factory/playwright.config.mjs
@@ -1,0 +1,17 @@
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+    timeout: 30 * 1000,
+    expect: {
+        timeout: 10000
+    },
+    retries: 0,
+    workers: 1,
+    reporter: process.env.CI ? [['list', {printSteps: true}], ['html']] : [['list', {printSteps: true}]],
+    use: {
+        trace: 'retain-on-failure',
+        browserName: 'chromium'
+    },
+    testDir: './tests'
+};
+
+export default config;

--- a/e2e/data-factory/plugins/base-plugin.ts
+++ b/e2e/data-factory/plugins/base-plugin.ts
@@ -1,0 +1,26 @@
+/**
+ * Base interface for all data factory plugins
+ */
+export interface DataFactoryPlugin {
+    readonly name: string;
+    
+    /**
+     * Initialize the plugin and its factories
+     */
+    setup(): Promise<void>;
+    
+    /**
+     * Clean up all resources and created data
+     */
+    destroy(): Promise<void>;
+}
+
+/**
+ * Base class for plugins that provides common functionality
+ */
+export abstract class BasePlugin implements DataFactoryPlugin {
+    abstract readonly name: string;
+    
+    abstract setup(): Promise<void>;
+    abstract destroy(): Promise<void>;
+}

--- a/e2e/data-factory/plugins/base-plugin.ts
+++ b/e2e/data-factory/plugins/base-plugin.ts
@@ -1,3 +1,6 @@
+import type {Factory} from '../base-factory';
+import type {PersistenceAdapter} from '../persistence/types';
+
 /**
  * Base interface for all data factory plugins
  */
@@ -20,7 +23,56 @@ export interface DataFactoryPlugin {
  */
 export abstract class BasePlugin implements DataFactoryPlugin {
     abstract readonly name: string;
+    protected persistence?: PersistenceAdapter;
+    protected factories = new Map<string, Factory<unknown, unknown>>();
     
     abstract setup(): Promise<void>;
-    abstract destroy(): Promise<void>;
+    
+    /**
+     * Set persistence adapter for all factories
+     */
+    setPersistenceAdapter(adapter: PersistenceAdapter): void {
+        this.persistence = adapter;
+        
+        // Apply to all registered factories
+        for (const factory of this.factories.values()) {
+            factory.setPersistence(adapter);
+        }
+    }
+    
+    /**
+     * Register a factory with the plugin
+     */
+    protected registerFactory<T extends Factory<unknown, unknown>>(factory: T): T {
+        this.factories.set(factory.name, factory);
+        
+        // Apply current persistence if available
+        if (this.persistence) {
+            factory.setPersistence(this.persistence);
+        }
+        
+        return factory;
+    }
+    
+    /**
+     * Clean up all factories
+     */
+    async destroy(): Promise<void> {
+        await Promise.all(
+            Array.from(this.factories.values()).map(factory => factory.cleanup())
+        );
+    }
+    
+    /**
+     * Get statistics from all factories
+     */
+    getStats(): Record<string, number> {
+        const stats: Record<string, number> = {};
+        
+        for (const [name, factory] of this.factories) {
+            stats[name] = factory.getCreatedEntities().length;
+        }
+        
+        return stats;
+    }
 }

--- a/e2e/data-factory/plugins/ghost/config.ts
+++ b/e2e/data-factory/plugins/ghost/config.ts
@@ -1,0 +1,12 @@
+/**
+ * Simple Ghost configuration from environment variables.
+ */
+export function getGhostConfig() {
+    return {
+        host: process.env.GHOST_DB_HOST || 'localhost',
+        port: parseInt(process.env.GHOST_DB_PORT || '3306'),
+        user: process.env.GHOST_DB_USER || 'root',
+        password: process.env.GHOST_DB_PASSWORD || 'root',
+        database: process.env.GHOST_DB_NAME || 'ghost'
+    };
+}

--- a/e2e/data-factory/plugins/ghost/database.ts
+++ b/e2e/data-factory/plugins/ghost/database.ts
@@ -1,0 +1,31 @@
+import knex, {Knex} from 'knex';
+import {getGhostConfig} from './config';
+
+/**
+ * Simple database connection for Ghost.
+ */
+export function createDatabase(): Knex {
+    const config = getGhostConfig();
+    return knex({
+        client: 'mysql2',
+        connection: {
+            ...config,
+            charset: 'utf8mb4'
+        },
+        pool: {min: 0, max: 5}
+    });
+}
+
+/**
+ * Get site UUID from Ghost settings
+ */
+export async function getSiteUuid(db: Knex): Promise<string | null> {
+    try {
+        const result = await db('settings')
+            .where('key', 'site_uuid')
+            .first();
+        return result?.value || null;
+    } catch {
+        return null;
+    }
+}

--- a/e2e/data-factory/plugins/ghost/ghost-plugin.ts
+++ b/e2e/data-factory/plugins/ghost/ghost-plugin.ts
@@ -32,20 +32,23 @@ export class GhostPlugin extends BasePlugin {
         if (options.persistence) {
             this.setPersistenceAdapter(options.persistence);
         } else {
-            // Create default Knex persistence adapter
-            const registry = new DefaultEntityRegistry();
-            registry.registerMany({
-                posts: {tableName: 'posts'},
-                users: {tableName: 'users'},
-                tags: {tableName: 'tags'}
-            });
-            
-            const adapter = new KnexPersistenceAdapter(this.db, registry);
-            this.setPersistenceAdapter(adapter);
+            this.setPersistenceAdapter(this.createDefaultPersistence());
         }
         
         // Create and register factories
         this.postFactory = this.registerFactory(new PostFactory());
+    }
+    
+    /**
+     * Creates the default persistence adapter for Ghost
+     */
+    private createDefaultPersistence(): PersistenceAdapter {
+        const registry = new DefaultEntityRegistry();
+        registry.register('posts', {
+            tableName: 'posts'
+        });
+        
+        return new KnexPersistenceAdapter(this.db, registry);
     }
     
     async setup(): Promise<void> {

--- a/e2e/data-factory/plugins/ghost/ghost-plugin.ts
+++ b/e2e/data-factory/plugins/ghost/ghost-plugin.ts
@@ -1,0 +1,128 @@
+import type {Knex} from 'knex';
+import {BasePlugin} from '../base-plugin';
+import {createDatabase} from './database';
+import {PostFactory} from './posts/post-factory';
+import type {PostOptions, PostResult} from './posts/types';
+
+export interface GhostPluginOptions {
+    database?: Knex;
+}
+
+/**
+ * Ghost plugin that coordinates all Ghost-related factories
+ * and shares the database connection between them
+ */
+export class GhostPlugin extends BasePlugin {
+    readonly name = 'ghost';
+    
+    private db: Knex;
+    private postFactory: PostFactory;
+    
+    constructor(options: GhostPluginOptions = {}) {
+        super();
+        // All Ghost factories share this database connection
+        this.db = options.database ?? createDatabase();
+        
+        // Initialize factories with shared database
+        this.postFactory = new PostFactory(this.db);
+    }
+    
+    async setup(): Promise<void> {
+        await this.postFactory.setup();
+    }
+    
+    async destroy(): Promise<void> {
+        await this.postFactory.destroy();        
+        await this.db.destroy();
+    }
+    
+    /**
+     * Get the shared database connection for cross-plugin operations or custom queries
+     */
+    getDatabase(): Knex {
+        return this.db;
+    }
+    
+    // Allows for ghost.posts.create() syntax
+    get posts(): PostFactory {
+        return this.postFactory;
+    }
+    
+    // *
+    // Convenience methods
+    // *
+    async createPost(options?: PostOptions): Promise<PostResult> {
+        return this.postFactory.create(options);
+    }
+    
+    async createPublishedPost(options?: PostOptions): Promise<PostResult> {
+        return this.postFactory.create({
+            status: 'published',
+            published_at: options?.published_at || new Date(),
+            ...options
+        });
+    }
+    
+    async createDraftPost(options?: PostOptions): Promise<PostResult> {
+        return this.postFactory.create({
+            status: 'draft',
+            published_at: null,
+            ...options
+        });
+    }
+    
+    async createScheduledPost(publishDate: Date, options?: PostOptions): Promise<PostResult> {
+        return this.postFactory.create({
+            status: 'scheduled',
+            published_at: publishDate,
+            ...options
+        });
+    }
+    
+    /**
+     * Mixed composition methods - these will coordinate multiple factories
+     * once we have tags, users, etc.
+     */
+    
+    // Future: When we have tags
+    // async createPostWithTags(
+    //     postOptions?: PostOptions, 
+    //     tagNames: string[] = ['default-tag']
+    // ): Promise<{post: PostResult; tags: TagResult[]}> {
+    //     const post = await this.createPost(postOptions);
+    //     const tags = await Promise.all(
+    //         tagNames.map(name => this.tagFactory.create({name}))
+    //     );
+    //     
+    //     // Create relationships
+    //     await this.db('posts_tags').insert(
+    //         tags.map(tag => ({
+    //             post_id: post.id,
+    //             tag_id: tag.id
+    //         }))
+    //     );
+    //     
+    //     return {post, tags};
+    // }
+    
+    // Future: When we have users/authors
+    // async createAuthorWithPosts(
+    //     authorOptions?: UserOptions,
+    //     postCount = 3
+    // ): Promise<{author: UserResult; posts: PostResult[]}> {
+    //     const author = await this.userFactory.create(authorOptions);
+    //     const posts = await Promise.all(
+    //         Array(postCount).fill(null).map(() => 
+    //             this.createPost({author_id: author.id})
+    //         )
+    //     );
+    //     
+    //     return {author, posts};
+    // }
+    
+    getStats(): {posts: number} {
+        return {
+            posts: this.postFactory.getCreatedCount()
+        };
+    }
+}

--- a/e2e/data-factory/plugins/ghost/ghost-plugin.ts
+++ b/e2e/data-factory/plugins/ghost/ghost-plugin.ts
@@ -57,25 +57,25 @@ export class GhostPlugin extends BasePlugin {
     
     async createPublishedPost(options?: PostOptions): Promise<PostResult> {
         return this.postFactory.create({
+            ...options,
             status: 'published',
-            published_at: options?.published_at || new Date(),
-            ...options
+            published_at: options?.published_at || new Date()
         });
     }
     
     async createDraftPost(options?: PostOptions): Promise<PostResult> {
         return this.postFactory.create({
+            ...options,
             status: 'draft',
-            published_at: null,
-            ...options
+            published_at: null
         });
     }
     
     async createScheduledPost(publishDate: Date, options?: PostOptions): Promise<PostResult> {
         return this.postFactory.create({
+            ...options,
             status: 'scheduled',
-            published_at: publishDate,
-            ...options
+            published_at: publishDate
         });
     }
     

--- a/e2e/data-factory/plugins/ghost/posts/post-factory.ts
+++ b/e2e/data-factory/plugins/ghost/posts/post-factory.ts
@@ -1,0 +1,102 @@
+import {Factory} from '../../../base-factory';
+import {faker} from '@faker-js/faker';
+import type {PostOptions, PostResult} from './types';
+import type {Knex} from 'knex';
+
+/**
+ * Simple factory for creating Ghost posts.
+ */
+export class PostFactory extends Factory {
+    name = 'post';
+    private createdPostIds: Set<string> = new Set();
+    
+    constructor(private db: Knex) {
+        super();
+    }
+    
+    async setup(): Promise<void> {
+        // Any post-specific initialization
+    }
+    
+    async destroy(): Promise<void> {
+        await this.clearCreated();
+    }
+    
+    async create(options: PostOptions = {}): Promise<PostResult> {
+        const now = new Date();
+        const title = options.title || faker.lorem.sentence();
+        const content = faker.lorem.paragraphs(3);
+        
+        // Generate mobiledoc format
+        const mobiledoc = {
+            version: '0.3.1',
+            atoms: [],
+            cards: [],
+            markups: [],
+            sections: [[1, 'p', [[0, [], 0, content]]]],
+            ghostVersion: '5.0'
+        };
+        
+        // Create defaults object
+        const defaults = {
+            id: this.generateId(),
+            uuid: this.generateUuid(),
+            title: title,
+            slug: options.slug || this.generateSlug(title) + '-' + Date.now().toString(16),
+            mobiledoc: JSON.stringify(mobiledoc),
+            lexical: null,
+            html: `<p>${content}</p>`,
+            comment_id: this.generateId(),
+            plaintext: content,
+            feature_image: `https://picsum.photos/800/600?random=${Math.random()}`,
+            featured: faker.datatype.boolean(),
+            type: 'post',
+            status: 'draft',
+            locale: null,
+            visibility: 'public',
+            email_recipient_filter: 'none',
+            created_at: now,
+            updated_at: now,
+            published_at: null,
+            custom_excerpt: faker.lorem.paragraph(),
+            codeinjection_head: null,
+            codeinjection_foot: null,
+            custom_template: null,
+            canonical_url: null,
+            newsletter_id: null,
+            show_title_and_feature_image: true
+        };
+        
+        // Merge with user options, handling special cases
+        const post: PostResult = {
+            ...defaults,
+            ...options,
+            // Handle published_at logic - if status is published but no published_at is set, use current time
+            published_at: options.status === 'published' && !options.published_at ? now : (options.published_at || defaults.published_at)
+        } as PostResult;
+        
+        await this.db('posts').insert(post);
+        
+        // Track created post for cleanup
+        this.createdPostIds.add(post.id);
+        
+        return post;
+    }
+    
+    /**
+     * Clear all posts created by this factory instance
+     */
+    async clearCreated(): Promise<void> {
+        if (this.createdPostIds.size > 0) {
+            await this.db('posts').whereIn('id', Array.from(this.createdPostIds)).delete();
+            this.createdPostIds.clear();
+        }
+    }
+    
+    /**
+     * Get the count of posts created by this factory
+     */
+    getCreatedCount(): number {
+        return this.createdPostIds.size;
+    }
+}

--- a/e2e/data-factory/plugins/ghost/posts/post-factory.ts
+++ b/e2e/data-factory/plugins/ghost/posts/post-factory.ts
@@ -2,25 +2,16 @@ import {Factory} from '../../../base-factory';
 import {faker} from '@faker-js/faker';
 import {generateId, generateUuid, generateSlug} from '../../../utils';
 import type {PostOptions, PostResult} from './types';
-import type {Knex} from 'knex';
 
 /**
  * Simple factory for creating Ghost posts.
  */
 export class PostFactory extends Factory<PostOptions, PostResult> {
     name = 'post';
-    private createdPostIds: Set<string> = new Set();
+    entityType = 'posts'; // Maps to 'posts' table
     
-    constructor(private db: Knex) {
+    constructor() {
         super();
-    }
-    
-    async setup(): Promise<void> {
-        // Any post-specific initialization
-    }
-    
-    async destroy(): Promise<void> {
-        await this.clearCreated();
     }
     
     build(options: PostOptions = {}): PostResult {
@@ -77,33 +68,5 @@ export class PostFactory extends Factory<PostOptions, PostResult> {
         } as PostResult;
         
         return post;
-    }
-    
-    async create(options: PostOptions = {}): Promise<PostResult> {
-        const post = this.build(options);
-        
-        await this.db('posts').insert(post);
-        
-        // Track created post for cleanup
-        this.createdPostIds.add(post.id);
-        
-        return post;
-    }
-    
-    /**
-     * Clear all posts created by this factory instance
-     */
-    async clearCreated(): Promise<void> {
-        if (this.createdPostIds.size > 0) {
-            await this.db('posts').whereIn('id', Array.from(this.createdPostIds)).delete();
-            this.createdPostIds.clear();
-        }
-    }
-    
-    /**
-     * Get the count of posts created by this factory
-     */
-    getCreatedCount(): number {
-        return this.createdPostIds.size;
     }
 }

--- a/e2e/data-factory/plugins/ghost/posts/types.ts
+++ b/e2e/data-factory/plugins/ghost/posts/types.ts
@@ -1,0 +1,63 @@
+// Ghost Post Options based on the Ghost schema
+export interface PostOptions {
+    id?: string;
+    uuid?: string;
+    title?: string;
+    slug?: string;
+    mobiledoc?: string | null;
+    lexical?: string | null;
+    html?: string | null;
+    comment_id?: string | null;
+    plaintext?: string | null;
+    feature_image?: string | null;
+    featured?: boolean;
+    type?: 'post' | 'page';
+    status?: 'published' | 'draft' | 'scheduled' | 'sent';
+    locale?: string | null;
+    visibility?: string;
+    email_recipient_filter?: string;
+    created_at?: Date;
+    created_by?: string;
+    updated_at?: Date;
+    updated_by?: string;
+    published_at?: Date | null;
+    published_by?: string | null;
+    custom_excerpt?: string | null;
+    codeinjection_head?: string | null;
+    codeinjection_foot?: string | null;
+    custom_template?: string | null;
+    canonical_url?: string | null;
+    newsletter_id?: string | null;
+    show_title_and_feature_image?: boolean;
+}
+
+// Return type for created posts
+export type PostResult = PostOptions & {
+    id: string;
+    uuid: string;
+    title: string;
+    slug: string;
+    status: PostOptions['status'];
+    type: PostOptions['type'];
+    created_at: Date;
+    updated_at: Date;
+    mobiledoc: string | null;
+    lexical: string | null;
+    html: string | null;
+    comment_id: string | null;
+    plaintext: string | null;
+    feature_image: string | null;
+    locale: string | null;
+    visibility: string;
+    email_recipient_filter: string;
+    created_by?: string;
+    updated_by?: string;
+    custom_excerpt: string | null;
+    codeinjection_head: string | null;
+    codeinjection_foot: string | null;
+    custom_template: string | null;
+    canonical_url: string | null;
+    newsletter_id: string | null;
+    show_title_and_feature_image: boolean;
+    featured: boolean;
+};

--- a/e2e/data-factory/plugins/tinybird/check-availability.ts
+++ b/e2e/data-factory/plugins/tinybird/check-availability.ts
@@ -1,0 +1,24 @@
+import {getTinybirdConfig} from './config';
+import {FetchHttpClient} from './interfaces';
+
+/**
+ * Check if Tinybird service is available
+ */
+export async function isTinybirdAvailable(): Promise<boolean> {
+    try {
+        const config = getTinybirdConfig();
+        const httpClient = new FetchHttpClient();
+        
+        // Try to hit the Tinybird endpoint
+        const response = await httpClient.fetch(`${config.host}/v0/pipes`, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${config.token}`
+            }
+        });
+        
+        return response.ok;
+    } catch (error) {
+        return false;
+    }
+}

--- a/e2e/data-factory/plugins/tinybird/config.ts
+++ b/e2e/data-factory/plugins/tinybird/config.ts
@@ -1,0 +1,9 @@
+/**
+ * Simple Tinybird configuration from environment variables.
+ */
+export function getTinybirdConfig() {
+    return {
+        host: process.env.TINYBIRD_HOST || 'http://localhost:7181/v0/events',
+        token: process.env.TINYBIRD_TOKEN || 'test-token'
+    };
+}

--- a/e2e/data-factory/plugins/tinybird/interfaces.ts
+++ b/e2e/data-factory/plugins/tinybird/interfaces.ts
@@ -1,0 +1,17 @@
+// HTTP client interface for dependency injection
+export interface HttpClient {
+    fetch(url: string, options?: RequestInit): Promise<Response>;
+}
+
+// Default implementation using global fetch
+export class FetchHttpClient implements HttpClient {
+    async fetch(url: string, options?: RequestInit): Promise<Response> {
+        return fetch(url, options);
+    }
+}
+
+// Tinybird configuration
+export interface TinybirdConfig {
+    host: string;
+    token: string;
+}

--- a/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
+++ b/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
@@ -1,0 +1,221 @@
+import {Factory} from '../../../base-factory';
+import {faker} from '@faker-js/faker';
+import {v4 as uuid} from 'uuid';
+import type {PageHitOptions, PageHitResult} from './types';
+import type {TinybirdConfig, HttpClient} from '../interfaces';
+import {FetchHttpClient} from '../interfaces';
+
+export class PageHitFactory extends Factory {
+    name = 'pageHit';
+    private httpClient: HttpClient;
+    private createdSessionIds = new Set<string>();
+    private createdEventIds = new Set<string>();
+    
+    constructor(
+        private siteUuid: string,
+        private config: TinybirdConfig,
+        httpClient?: HttpClient
+    ) {
+        super();
+        this.httpClient = httpClient ?? new FetchHttpClient();
+    }
+    
+    async setup(): Promise<void> {
+        // No setup needed for page hits - Tinybird is a separate service
+    }
+    
+    async destroy(): Promise<void> {
+        // Clean up all tracked sessions
+        if (this.createdSessionIds.size > 0) {
+            await this.deleteBySessionIds(Array.from(this.createdSessionIds));
+            this.createdSessionIds.clear();
+            this.createdEventIds.clear();
+        }
+    }
+    
+    /**
+     * Create and send a page hit event to Tinybird
+     */
+    async create(options?: PageHitOptions): Promise<PageHitResult> {
+        const timestamp = options?.timestamp || new Date();
+        const pathname = options?.pathname || '/';
+        
+        // Generate new session_id if not provided
+        const sessionId = options?.session_id || uuid();
+        
+        // Track the session
+        this.createdSessionIds.add(sessionId);
+        
+        // Build the event
+        const event: PageHitResult = {
+            timestamp: timestamp.toISOString().replace('T', ' ').slice(0, -1),
+            action: 'page_hit',
+            version: '1',
+            session_id: sessionId,
+            payload: {
+                site_uuid: this.siteUuid,
+                member_uuid: options?.member_uuid || 'undefined',
+                member_status: options?.member_status || 'undefined',
+                post_uuid: options?.post_uuid || 'undefined',
+                pathname: pathname,
+                referrer: options?.referrer || '',
+                'user-agent': options?.user_agent || faker.internet.userAgent(),
+                locale: options?.locale || 'en-US',
+                location: options?.location || 'US',
+                href: `https://example.com${pathname}`,
+                event_id: uuid(),
+                meta: {}
+            }
+        };
+        
+        // Add referrer source if we have a referrer
+        if (options?.referrer) {
+            event.payload.meta.referrerSource = this.getReferrerSource(options.referrer);
+        }
+        
+        // Track event ID
+        this.createdEventIds.add(event.payload.event_id);
+        
+        // Send to Tinybird
+        await this.sendToTinybird(event);
+        
+        return event;
+    }
+    
+    /**
+     * Send event to Tinybird via HTTP POST
+     */
+    private async sendToTinybird(event: PageHitResult): Promise<void> {
+        // Default to analytics_events data source
+        const datasource = 'analytics_events';
+        const url = `${this.config.host}?name=${datasource}&token=${this.config.token}`;
+        
+        try {
+            const response = await this.httpClient.fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-site-uuid': this.siteUuid
+                },
+                body: JSON.stringify(event)
+            });
+            
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Tinybird request failed: ${response.status} - ${text}`);
+            }
+        } catch (error) {
+            // Log the error for debugging
+            // eslint-disable-next-line no-console
+            console.warn('Tinybird error:', error instanceof Error ? error.message : String(error));
+            // eslint-disable-next-line no-console
+            console.warn('URL:', url);
+            
+            // For e2e tests, we might want to continue even if Tinybird is not available
+            if (process.env.FAIL_ON_TINYBIRD_ERROR === 'true') {
+                throw error;
+            }
+            // Continue if Tinybird is not available in test environment
+        }
+    }
+    
+    /**
+     * Parse referrer source from URL
+     */
+    private getReferrerSource(referrer: string): string {
+        const sourceMap: Record<string, string> = {
+            'news.google.com': 'Google News',
+            'google.com': 'Google',
+            'duckduckgo.com': 'DuckDuckGo',
+            'bing.com': 'Bing',
+            'reddit.com': 'Reddit',
+            'go.bsky.app': 'Bluesky',
+            't.co': 'Twitter',
+            'facebook.com': 'Facebook'
+        };
+        
+        // Check domains in order (more specific first)
+        for (const [domain, source] of Object.entries(sourceMap)) {
+            if (referrer.includes(domain)) {
+                return source;
+            }
+        }
+        
+        return new URL(referrer).hostname;
+    }
+    
+    /**
+     * Create multiple hits for the same session
+     */
+    async createSessionHits(sessionId: string, count: number, options?: Omit<PageHitOptions, 'session_id'>): Promise<PageHitResult[]> {
+        const hits: PageHitResult[] = [];
+        for (let i = 0; i < count; i++) {
+            const hit = await this.create({
+                ...options,
+                session_id: sessionId
+            });
+            hits.push(hit);
+        }
+        return hits;
+    }
+    
+    /**
+     * Create a new session and return its ID for reuse
+     */
+    createNewSession(): string {
+        const sessionId = uuid();
+        this.createdSessionIds.add(sessionId);
+        return sessionId;
+    }
+    
+    /**
+     * Get statistics about created data
+     */
+    getStats(): { sessions: number; events: number } {
+        return {
+            sessions: this.createdSessionIds.size,
+            events: this.createdEventIds.size
+        };
+    }
+    
+    private async deleteBySessionIds(sessionIds: string[]): Promise<void> {
+        // Delete in batches if there are many sessions
+        const batchSize = 100;
+        for (let i = 0; i < sessionIds.length; i += batchSize) {
+            const batch = sessionIds.slice(i, i + batchSize);
+            await this.deleteBatch(batch);
+        }
+    }
+    
+    private async deleteBatch(sessionIds: string[]): Promise<void> {
+        const url = `${this.config.host}/v0/datasources/analytics_events/delete`;
+        
+        // Create SQL IN clause for multiple session IDs
+        const sessionIdList = sessionIds.map(id => `'${id}'`).join(',');
+        
+        try {
+            const response = await this.httpClient.fetch(url, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${this.config.token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    condition: `session_id IN (${sessionIdList})`
+                })
+            });
+            
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Failed to delete events: ${response.status} - ${text}`);
+            }
+        } catch (error) {
+            if (process.env.FAIL_ON_TINYBIRD_ERROR === 'true') {
+                throw error;
+            }
+            // Log but continue if cleanup fails
+            // eslint-disable-next-line no-console
+            console.warn('Failed to clean up Tinybird events:', error);
+        }
+    }
+}

--- a/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
+++ b/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
@@ -88,13 +88,14 @@ export class PageHitFactory extends Factory {
     private async sendToTinybird(event: PageHitResult): Promise<void> {
         // Default to analytics_events data source
         const datasource = 'analytics_events';
-        const url = `${this.config.host}?name=${datasource}&token=${this.config.token}`;
+        const url = `${this.config.host}?name=${datasource}`;
         
         try {
             const response = await this.httpClient.fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    Authorization: `Bearer ${this.config.token}`,
                     'x-site-uuid': this.siteUuid
                 },
                 body: JSON.stringify(event)
@@ -105,7 +106,7 @@ export class PageHitFactory extends Factory {
                 throw new Error(`Tinybird request failed: ${response.status} - ${text}`);
             }
         } catch (error) {
-            // Log the error for debugging
+            // Log the error for debugging (without exposing the token)
             // eslint-disable-next-line no-console
             console.warn('Tinybird error:', error instanceof Error ? error.message : String(error));
             // eslint-disable-next-line no-console

--- a/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
+++ b/e2e/data-factory/plugins/tinybird/page-hits/page-hit-factory.ts
@@ -20,10 +20,6 @@ export class PageHitFactory extends Factory<PageHitOptions, PageHitResult> {
         this.httpClient = httpClient ?? new FetchHttpClient();
     }
     
-    async setup(): Promise<void> {
-        // No setup needed for page hits - Tinybird is a separate service
-    }
-    
     async destroy(): Promise<void> {
         // Clean up all tracked sessions
         if (this.createdSessionIds.size > 0) {

--- a/e2e/data-factory/plugins/tinybird/page-hits/types.ts
+++ b/e2e/data-factory/plugins/tinybird/page-hits/types.ts
@@ -1,0 +1,37 @@
+// Tinybird Page Hit Options
+export interface PageHitOptions {
+    timestamp?: Date;
+    session_id?: string;
+    post_uuid?: string;
+    member_uuid?: string;
+    member_status?: 'free' | 'paid' | 'comped' | 'undefined';
+    pathname?: string;
+    referrer?: string;
+    user_agent?: string;
+    locale?: string;
+    location?: string;
+}
+
+// Tinybird Page Hit Result
+export interface PageHitResult {
+    timestamp: string;
+    action: 'page_hit';
+    version: '1';
+    session_id: string;
+    payload: {
+        site_uuid: string;
+        member_uuid: string;
+        member_status: string;
+        post_uuid: string;
+        pathname: string;
+        referrer: string;
+        'user-agent': string;
+        locale: string;
+        location: string;
+        href: string;
+        event_id: string;
+        meta: {
+            referrerSource?: string;
+        };
+    };
+}

--- a/e2e/data-factory/plugins/tinybird/page-hits/types.ts
+++ b/e2e/data-factory/plugins/tinybird/page-hits/types.ts
@@ -29,7 +29,6 @@ export interface PageHitResult {
         locale: string;
         location: string;
         href: string;
-        event_id: string;
         meta: {
             referrerSource?: string;
         };

--- a/e2e/data-factory/plugins/tinybird/tinybird-plugin.ts
+++ b/e2e/data-factory/plugins/tinybird/tinybird-plugin.ts
@@ -1,0 +1,101 @@
+import {BasePlugin} from '../base-plugin';
+import {PageHitFactory} from './page-hits/page-hit-factory';
+import {getTinybirdConfig} from './config';
+import type {TinybirdConfig, HttpClient} from './interfaces';
+import {FetchHttpClient} from './interfaces';
+import type {PageHitOptions, PageHitResult} from './page-hits/types';
+
+export interface TinybirdPluginOptions {
+    httpClient?: HttpClient;
+    config?: TinybirdConfig;
+}
+
+/**
+ * Tinybird plugin that coordinates all analytics-related factories
+ * and shares the HTTP client between them
+ */
+export class TinybirdPlugin extends BasePlugin {
+    readonly name = 'tinybird';
+    
+    private httpClient: HttpClient;
+    private config: TinybirdConfig;
+    private pageHitFactory?: PageHitFactory;
+    
+    constructor(options: TinybirdPluginOptions = {}) {
+        super();
+        // All Tinybird factories share these dependencies
+        this.httpClient = options.httpClient ?? new FetchHttpClient();
+        this.config = options.config ?? getTinybirdConfig();
+    }
+    
+    async setup(): Promise<void> {
+        // Tinybird factories are initialized on demand via initializeWithSiteUuid()
+    }
+    
+    async destroy(): Promise<void> {
+        if (this.pageHitFactory) {
+            await this.pageHitFactory.destroy();
+        }
+    }
+    
+    /**
+     * Must be called before using any Tinybird functionality
+     */
+    async initializeWithSiteUuid(siteUuid: string): Promise<void> {
+        this.pageHitFactory = new PageHitFactory(siteUuid, this.config, this.httpClient);
+        await this.pageHitFactory.setup();
+    }
+    
+    isInitialized(): boolean {
+        return !!this.pageHitFactory;
+    }
+    
+    get pageHits(): PageHitFactory {
+        if (!this.pageHitFactory) {
+            throw new Error('Tinybird not initialized. Call initializeWithSiteUuid() first or ensure Ghost has a site_uuid.');
+        }
+        return this.pageHitFactory;
+    }
+    
+    async createPageHit(options?: PageHitOptions): Promise<PageHitResult> {
+        return this.pageHits.create(options);
+    }
+    
+    async createPageHits(count: number, options?: PageHitOptions): Promise<PageHitResult[]> {
+        const hits: PageHitResult[] = [];
+        for (let i = 0; i < count; i++) {
+            hits.push(await this.createPageHit(options));
+        }
+        return hits;
+    }
+    
+    async createPageHitsForPost(postUuid: string, count: number, options?: PageHitOptions): Promise<PageHitResult[]> {
+        return this.createPageHits(count, {
+            post_uuid: postUuid,
+            ...options
+        });
+    }
+    
+    // *
+    // Convenience methods
+    // *
+    createNewSession(): string {
+        return this.pageHits.createNewSession();
+    }
+    
+    async createSessionHits(
+        sessionId: string, 
+        count: number, 
+        options?: Omit<PageHitOptions, 'session_id'>
+    ): Promise<PageHitResult[]> {
+        return this.pageHits.createSessionHits(sessionId, count, options);
+    }
+    
+    getStats(): {sessions: number; events: number} {
+        if (!this.pageHitFactory) {
+            return {sessions: 0, events: 0};
+        }
+        
+        return this.pageHitFactory.getStats();
+    }
+}

--- a/e2e/data-factory/test-fixtures.ts
+++ b/e2e/data-factory/test-fixtures.ts
@@ -1,0 +1,38 @@
+import {test as base} from '@playwright/test';
+import {DataFactory} from './data-factory';
+import {GhostPlugin} from './plugins/ghost/ghost-plugin';
+import {TinybirdPlugin} from './plugins/tinybird/tinybird-plugin';
+
+/**
+ * Extended Playwright test context with data factory integration.
+ * Provides automatic cleanup through a single factory instance.
+ * 
+ * Usage:
+ * - test({factory}) - Full factory access
+ * - test({ghost, tinybird}) - Direct plugin access
+ * - test({ghost}) - Just Ghost plugin
+ * - test({tinybird}) - Just Tinybird plugin
+ */
+export const test = base.extend<{
+    factory: DataFactory;
+    ghost: GhostPlugin;
+    tinybird: TinybirdPlugin;
+}>({
+    factory: async ({}, use) => {
+        const factory = new DataFactory();
+        await factory.initialize();
+        await use(factory);
+        await factory.cleanup();
+    },
+    
+    ghost: async ({factory}, use) => {
+        await use(factory.ghost);
+    },
+    
+    tinybird: async ({factory}, use) => {
+        await use(factory.tinybird);
+    }
+});
+
+// Re-export expect for convenience
+export {expect} from '@playwright/test';

--- a/e2e/data-factory/tests/example.test.ts
+++ b/e2e/data-factory/tests/example.test.ts
@@ -1,0 +1,71 @@
+import {test, expect} from '../test-fixtures';
+
+test.describe('Data Factory Examples', () => {
+    test('create a simple published post', async ({factory}) => {
+        const post = await factory.ghost.createPublishedPost({
+            title: 'Hello World',
+            custom_excerpt: 'This is my first post'
+        });
+        
+        expect(post.title).toBe('Hello World');
+        expect(post.status).toBe('published');
+        expect(post.published_at).toBeDefined();
+    });
+    
+    test('create post with analytics', async ({ghost, tinybird}) => {
+        const post = await ghost.createPublishedPost({
+            title: 'Popular Article',
+            featured: true
+        });
+        
+        // Generate 100 page views
+        const hits = await tinybird.createPageHitsForPost(post.uuid, 100, {
+            member_status: 'free',
+            pathname: `/posts/${post.slug}`
+        });
+        
+        expect(hits).toHaveLength(100);
+        expect(hits[0].payload.post_uuid).toBe(post.uuid);
+    });
+    
+    test('multi-session analytics example', async ({ghost, tinybird}) => {
+        const post = await ghost.createPublishedPost({
+            title: 'Popular Post',
+            featured: true
+        });
+        
+        // Session 1: New visitor from Google
+        const session1 = tinybird.createNewSession();
+        await tinybird.createSessionHits(session1, 3, {
+            post_uuid: post.uuid,
+            referrer: 'https://google.com',
+            member_status: 'undefined'
+        });
+        
+        // Session 2: Returning paid member
+        const session2 = tinybird.createNewSession();
+        await tinybird.createSessionHits(session2, 5, {
+            post_uuid: post.uuid,
+            member_status: 'paid'
+        });
+        
+        // Session 3: Free member browsing
+        const session3 = tinybird.createNewSession();
+        await tinybird.createPageHit({
+            session_id: session3,
+            pathname: '/',
+            referrer: 'https://twitter.com'
+        });
+        await tinybird.createPageHit({
+            session_id: session3,
+            pathname: `/posts/${post.slug}`,
+            post_uuid: post.uuid,
+            member_status: 'free'
+        });
+        
+        // Check page hit stats
+        const pageHitStats = tinybird.getStats();
+        expect(pageHitStats.sessions).toBe(3);
+        expect(pageHitStats.events).toBe(10); // 3 + 5 + 2
+    });
+});

--- a/e2e/data-factory/tests/unit/base-factory.test.ts
+++ b/e2e/data-factory/tests/unit/base-factory.test.ts
@@ -1,0 +1,100 @@
+import {test, expect} from '@playwright/test';
+import {Factory} from '../../base-factory';
+
+// Concrete implementation of Factory for testing
+class TestFactory extends Factory {
+    name = 'test';
+    
+    async setup(): Promise<void> {
+        // Mock setup
+    }
+    
+    async destroy(): Promise<void> {
+        // Mock destroy
+    }
+    
+    // Expose protected methods for testing
+    public testGenerateId(): string {
+        return this.generateId();
+    }
+    
+    public testGenerateUuid(): string {
+        return this.generateUuid();
+    }
+    
+    public testGenerateSlug(text: string): string {
+        return this.generateSlug(text);
+    }
+}
+
+test.describe('Base Factory', () => {
+    let factory: TestFactory;
+    
+    test.beforeEach(() => {
+        factory = new TestFactory();
+    });
+    
+    test('should have a name property', () => {
+        expect(factory.name).toBe('test');
+    });
+    
+    test('should generate unique IDs', () => {
+        const id1 = factory.testGenerateId();
+        const id2 = factory.testGenerateId();
+        
+        expect(id1).toBeTruthy();
+        expect(id2).toBeTruthy();
+        expect(id1).not.toBe(id2);
+        expect(typeof id1).toBe('string');
+        expect(typeof id2).toBe('string');
+    });
+    
+    test('should generate valid UUIDs', () => {
+        const uuid1 = factory.testGenerateUuid();
+        const uuid2 = factory.testGenerateUuid();
+        
+        // UUID format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+        
+        expect(uuid1).toMatch(uuidRegex);
+        expect(uuid2).toMatch(uuidRegex);
+        expect(uuid1).not.toBe(uuid2);
+    });
+    
+    test('should generate slugs from text', () => {
+        const testCases = [
+            {input: 'Hello World', expected: 'hello-world'},
+            {input: 'This Is A Test!', expected: 'this-is-a-test'},
+            {input: 'Multiple   Spaces', expected: 'multiple-spaces'},
+            {input: '  Leading and trailing spaces  ', expected: 'leading-and-trailing-spaces'},
+            {input: 'Special @#$% Characters!', expected: 'special-characters'},
+            {input: 'numbers-123-and-456', expected: 'numbers-123-and-456'},
+            {input: 'Multiple---Dashes', expected: 'multiple-dashes'}
+        ];
+        
+        testCases.forEach(({input, expected}) => {
+            const result = factory.testGenerateSlug(input);
+            expect(result).toBe(expected);
+        });
+    });
+    
+    test('should handle empty string in slug generation', () => {
+        const result = factory.testGenerateSlug('');
+        expect(result).toBe('');
+    });
+    
+    test('should handle special characters in slug generation', () => {
+        const result = factory.testGenerateSlug('Café & Restaurant');
+        expect(result).toBe('caf-restaurant');
+    });
+    
+    test('should implement setup method', async () => {
+        // Should not throw
+        await expect(factory.setup()).resolves.toBeUndefined();
+    });
+    
+    test('should implement destroy method', async () => {
+        // Should not throw
+        await expect(factory.destroy()).resolves.toBeUndefined();
+    });
+});

--- a/e2e/data-factory/tests/unit/build-create-pattern.test.ts
+++ b/e2e/data-factory/tests/unit/build-create-pattern.test.ts
@@ -1,0 +1,88 @@
+import {test, expect} from '@playwright/test';
+import {DataFactory} from '../../data-factory';
+
+test.describe('Build/Create Pattern', () => {
+    let factory: DataFactory;
+    
+    test.beforeEach(async () => {
+        factory = new DataFactory();
+        await factory.initialize();
+    });
+    
+    test.afterEach(async () => {
+        await factory.cleanup();
+    });
+    
+    test('should build a post without persisting', async () => {
+        // Build creates the object but doesn't save it
+        const post = factory.ghost.posts.build({
+            title: 'Test Build Pattern',
+            status: 'draft'
+        });
+        
+        // Post should have all required fields
+        expect(post.id).toBeTruthy();
+        expect(post.uuid).toBeTruthy();
+        expect(post.title).toBe('Test Build Pattern');
+        expect(post.status).toBe('draft');
+        expect(post.slug).toContain('test-build-pattern');
+        
+        // Post should not be tracked for cleanup (not persisted)
+        const stats = factory.ghost.getStats();
+        expect(stats.posts).toBe(0);
+    });
+    
+    test('should create a post and persist it', async () => {
+        // Create builds and persists the object
+        const post = await factory.ghost.posts.create({
+            title: 'Test Create Pattern',
+            status: 'published'
+        });
+        
+        // Post should have all fields
+        expect(post.id).toBeTruthy();
+        expect(post.title).toBe('Test Create Pattern');
+        expect(post.status).toBe('published');
+        
+        // Post should be tracked for cleanup
+        const stats = factory.ghost.getStats();
+        expect(stats.posts).toBe(1);
+    });
+    
+    test('should build page hits without sending', () => {
+        // Build creates the event but doesn't send it
+        const hit = factory.tinybird.pageHits.build({
+            pathname: '/about',
+            referrer: 'https://google.com'
+        });
+        
+        // Hit should have all required fields
+        expect(hit.session_id).toBeTruthy();
+        expect(hit.payload.pathname).toBe('/about');
+        expect(hit.payload.referrer).toBe('https://google.com');
+        expect(hit.payload.meta.referrerSource).toBe('Google');
+        
+        // Hit should not be tracked
+        const stats = factory.tinybird.getStats();
+        expect(stats.sessions).toBe(0);
+        expect(stats.events).toBe(0);
+    });
+    
+    test('should create page hits and send them', async () => {
+        // Create builds and sends the event
+        const hit = await factory.tinybird.pageHits.create({
+            pathname: '/contact',
+            member_status: 'free'
+        });
+        
+        // Hit should have all fields
+        expect(hit.session_id).toBeTruthy();
+        expect(hit.payload.pathname).toBe('/contact');
+        expect(hit.payload.member_status).toBe('free');
+        
+        // Hit should be tracked
+        const stats = factory.tinybird.getStats();
+        expect(stats.sessions).toBe(1);
+        expect(stats.events).toBe(1);
+    });
+});

--- a/e2e/data-factory/tests/unit/data-factory.test.ts
+++ b/e2e/data-factory/tests/unit/data-factory.test.ts
@@ -1,0 +1,156 @@
+import {test, expect} from '@playwright/test';
+import {DataFactory, GhostPlugin, TinybirdPlugin, BasePlugin} from '../../index';
+
+test.describe('DataFactory', () => {
+    test('should initialize with default plugins', async () => {
+        const factory = new DataFactory();
+        
+        expect(factory.ghost).toBeDefined();
+        expect(factory.tinybird).toBeDefined();
+        
+        await factory.initialize();
+        await factory.cleanup();
+    });
+    
+    test('should accept custom plugin configurations', async () => {
+        const factory = new DataFactory({
+            plugins: [new GhostPlugin()]
+        });
+        
+        expect(factory.ghost).toBeDefined();
+        expect(() => factory.tinybird).toThrow();
+        
+        await factory.initialize();
+        await factory.cleanup();
+    });
+    
+    test('should handle empty plugin array', async () => {
+        const factory = new DataFactory({plugins: []});
+        
+        expect(() => factory.ghost).toThrow('Ghost plugin not registered');
+        expect(() => factory.tinybird).toThrow('Tinybird plugin not registered');
+        
+        await factory.initialize();
+        await factory.cleanup();
+    });
+    
+    test('should initialize cross-plugin dependencies', async () => {
+        // This test would need a real database with site_uuid
+        // For now, we'll test the mechanism exists
+        const factory = new DataFactory();
+        await factory.initialize();
+        
+        // The initialization should have attempted to get site UUID
+        // and initialize Tinybird if available
+        expect(factory.tinybird).toBeDefined();
+        
+        await factory.cleanup();
+    });
+    
+    test('should register plugins dynamically', async () => {
+        const factory = new DataFactory({plugins: []});
+        
+        const ghost = new GhostPlugin();
+        factory.register(ghost);
+        
+        expect(factory.getPlugin('ghost')).toBe(ghost);
+        expect(factory.ghost).toBe(ghost);
+        
+        await factory.initialize();
+        await factory.cleanup();
+    });
+    
+    test('should handle custom database configuration', async () => {
+        // Create a mock database object
+        const customDb = {
+            select: () => customDb,
+            from: () => customDb,
+            where: () => customDb,
+            first: () => Promise.resolve(null),
+            insert: () => customDb,
+            update: () => customDb,
+            del: () => customDb,
+            destroy: () => Promise.resolve()
+        } as unknown as ReturnType<typeof import('knex').default>;
+        
+        const factory = new DataFactory({
+            plugins: [
+                new GhostPlugin({database: customDb})
+            ]
+        });
+        
+        await factory.initialize();
+        
+        // Should use the custom database
+        expect(factory.ghost.getDatabase()).toBe(customDb);
+        
+        await factory.cleanup();
+    });
+    
+    test('should prevent double initialization', async () => {
+        const factory = new DataFactory();
+        
+        await factory.initialize();
+        
+        // Second initialization should work (idempotent)
+        await expect(factory.initialize()).resolves.toBeUndefined();
+        
+        await factory.cleanup();
+    });
+    
+    test('should clean up in correct order', async () => {
+        const cleanupOrder: string[] = [];
+        
+        class TrackedGhostPlugin extends GhostPlugin {
+            async destroy() {
+                cleanupOrder.push('ghost');
+                await super.destroy();
+            }
+        }
+        
+        class TrackedTinybirdPlugin extends TinybirdPlugin {
+            async destroy() {
+                cleanupOrder.push('tinybird');
+                await super.destroy();
+            }
+        }
+        
+        const factory = new DataFactory({
+            plugins: [
+                new TrackedGhostPlugin(),
+                new TrackedTinybirdPlugin()
+            ]
+        });
+        
+        await factory.initialize();
+        await factory.cleanup();
+        
+        // Should destroy in reverse order of registration
+        expect(cleanupOrder).toEqual(['tinybird', 'ghost']);
+    });
+    
+    test('should handle plugin errors gracefully', async () => {
+        class BrokenPlugin extends BasePlugin {
+            readonly name = 'broken';
+            
+            async setup() {
+                throw new Error('Setup failed');
+            }
+            
+            async destroy() {
+                throw new Error('Destroy failed');
+            }
+        }
+        
+        const factory = new DataFactory({
+            plugins: [new BrokenPlugin()]
+        });
+        
+        // Setup error should propagate
+        await expect(factory.initialize()).rejects.toThrow('Setup failed');
+        
+        // But cleanup should still work
+        await expect(factory.cleanup()).rejects.toThrow('Destroy failed');
+    });
+});
+

--- a/e2e/data-factory/tests/unit/ghost-plugin.test.ts
+++ b/e2e/data-factory/tests/unit/ghost-plugin.test.ts
@@ -1,0 +1,135 @@
+import {test, expect} from '../../test-fixtures';
+
+test.describe('Ghost Plugin', () => {
+    test('should create a draft post by default', async ({ghost}) => {
+        const post = await ghost.createPost();
+        
+        expect(post.id).toBeTruthy();
+        expect(post.uuid).toBeTruthy();
+        expect(post.title).toBeTruthy();
+        expect(post.slug).toBeTruthy();
+        expect(post.status).toBe('draft');
+        expect(post.type).toBe('post');
+        expect(post.visibility).toBe('public');
+        expect(post.published_at).toBeNull();
+    });
+    
+    test('should create a published post with timestamp', async ({ghost}) => {
+        const before = new Date();
+        const post = await ghost.createPublishedPost({
+            title: 'Published Post'
+        });
+        const after = new Date();
+        
+        expect(post.status).toBe('published');
+        expect(post.title).toBe('Published Post');
+        expect(post.published_at).toBeTruthy();
+        
+        const publishedAt = new Date(post.published_at!);
+        expect(publishedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+        expect(publishedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+    
+    test('should create a scheduled post', async ({ghost}) => {
+        const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const post = await ghost.createScheduledPost(futureDate, {
+            title: 'Future Post'
+        });
+        
+        expect(post.status).toBe('scheduled');
+        expect(post.published_at).toBeTruthy();
+        expect(new Date(post.published_at!).getTime()).toBe(futureDate.getTime());
+    });
+    
+    test('should generate proper slugs', async ({ghost}) => {
+        const testCases = [
+            {title: 'Simple Title', expectedSlug: 'simple-title'},
+            {title: 'Title With Numbers 123', expectedSlug: 'title-with-numbers-123'},
+            {title: 'Special Characters!@#$%', expectedSlug: 'special-characters'},
+            {title: '   Spaces   Everywhere   ', expectedSlug: 'spaces-everywhere'}
+        ];
+        
+        for (const {title, expectedSlug} of testCases) {
+            const post = await ghost.createPost({title});
+            expect(post.slug).toMatch(new RegExp(`^${expectedSlug}-[0-9a-f]+$`));
+        }
+    });
+    
+    test('should handle custom post properties', async ({ghost}) => {
+        const post = await ghost.createPost({
+            title: 'Custom Post',
+            custom_excerpt: 'This is a custom excerpt',
+            featured: true,
+            visibility: 'members',
+            type: 'page',
+            locale: 'es'
+        });
+        
+        expect(post.custom_excerpt).toBe('This is a custom excerpt');
+        expect(post.featured).toBe(true);
+        expect(post.visibility).toBe('members');
+        expect(post.type).toBe('page');
+        expect(post.locale).toBe('es');
+    });
+    
+    test('should track created posts for cleanup', async ({ghost}) => {
+        const initialStats = ghost.getStats();
+        
+        await ghost.createPost({title: 'Post 1'});
+        await ghost.createPost({title: 'Post 2'});
+        await ghost.createPublishedPost({title: 'Post 3'});
+        
+        const finalStats = ghost.getStats();
+        expect(finalStats.posts).toBe(initialStats.posts + 3);
+    });
+    
+    test('should provide direct factory access', async ({ghost}) => {
+        const post = await ghost.posts.create({
+            title: 'Direct Factory Post',
+            status: 'published',
+            featured: true
+        });
+        
+        expect(post.title).toBe('Direct Factory Post');
+        expect(post.status).toBe('published');
+        expect(post.featured).toBe(true);
+    });
+    
+    test('should generate valid mobiledoc format', async ({ghost}) => {
+        const post = await ghost.createPost({
+            title: 'Mobiledoc Test'
+        });
+        
+        expect(post.mobiledoc).toBeTruthy();
+        const mobiledoc = JSON.parse(post.mobiledoc);
+        
+        expect(mobiledoc.version).toBe('0.3.1');
+        expect(mobiledoc.atoms).toEqual([]);
+        expect(mobiledoc.cards).toEqual([]);
+        expect(mobiledoc.markups).toEqual([]);
+        expect(mobiledoc.sections).toHaveLength(1);
+        expect(mobiledoc.sections[0][0]).toBe(1); // Section type
+        expect(mobiledoc.sections[0][1]).toBe('p'); // Tag name
+        expect(mobiledoc.sections[0][2][0][2]).toBe(0); // Markup ref
+        expect(typeof mobiledoc.sections[0][2][0][3]).toBe('string'); // Content exists
+    });
+    
+    test('should handle concurrent post creation', async ({ghost}) => {
+        const titles = Array.from({length: 10}, (_, i) => `Concurrent Post ${i}`);
+        
+        const posts = await Promise.all(
+            titles.map(title => ghost.createPost({title}))
+        );
+        
+        expect(posts).toHaveLength(10);
+        
+        // Check all posts have unique IDs
+        const ids = new Set(posts.map(p => p.id));
+        expect(ids.size).toBe(10);
+        
+        // Check all titles are correct
+        posts.forEach((post, i) => {
+            expect(post.title).toBe(`Concurrent Post ${i}`);
+        });
+    });
+});

--- a/e2e/data-factory/tests/unit/persistence-architecture.test.ts
+++ b/e2e/data-factory/tests/unit/persistence-architecture.test.ts
@@ -1,0 +1,144 @@
+import {test, expect} from '@playwright/test';
+import {GhostPlugin} from '../../plugins/ghost/ghost-plugin';
+import {PostFactory} from '../../plugins/ghost/posts/post-factory';
+import type {PersistenceAdapter} from '../../persistence/types';
+
+// Mock persistence adapter for testing
+class MockPersistenceAdapter implements PersistenceAdapter {
+    private storage = new Map<string, unknown[]>();
+    private lastInserted: unknown = null;
+    
+    async insert<T>(entityType: string, data: T): Promise<T> {
+        if (!this.storage.has(entityType)) {
+            this.storage.set(entityType, []);
+        }
+        this.storage.get(entityType)!.push(data);
+        this.lastInserted = data;
+        return data;
+    }
+    
+    async update<T>(_entityType: string, _id: string, _data: Partial<T>): Promise<T> {
+        void _entityType;
+        void _id;
+        void _data;
+        throw new Error('Not implemented');
+    }
+    
+    async delete(entityType: string, id: string): Promise<void> {
+        const entities = this.storage.get(entityType) || [];
+        const index = entities.findIndex(e => (e as Record<string, unknown>).id === id);
+        if (index >= 0) {
+            entities.splice(index, 1);
+        }
+    }
+    
+    async deleteMany(entityType: string, ids: string[]): Promise<void> {
+        const entities = this.storage.get(entityType) || [];
+        this.storage.set(entityType, entities.filter(e => !ids.includes((e as Record<string, unknown>).id as string)));
+    }
+    
+    async findById<T>(entityType: string, id: string): Promise<T | null> {
+        const entities = this.storage.get(entityType) || [];
+        return entities.find(e => (e as Record<string, unknown>).id === id) as T || null;
+    }
+    
+    async findMany<T>(entityType: string, _query?: Record<string, unknown>): Promise<T[]> {
+        void _query;
+        return (this.storage.get(entityType) || []) as T[];
+    }
+    
+    getLastInserted() {
+        return this.lastInserted;
+    }
+    
+    getAll(entityType: string) {
+        return this.storage.get(entityType) || [];
+    }
+}
+
+test.describe('Persistence Architecture', () => {
+    test('factory should work with injected persistence', async () => {
+        const mockAdapter = new MockPersistenceAdapter();
+        const factory = new PostFactory();
+        factory.setPersistence(mockAdapter);
+        
+        // Build doesn't use persistence
+        const built = factory.build({title: 'Built Post'});
+        expect(built.title).toBe('Built Post');
+        expect(mockAdapter.getLastInserted()).toBeNull();
+        
+        // Create uses persistence
+        const created = await factory.create({title: 'Created Post'});
+        expect(created.title).toBe('Created Post');
+        expect(mockAdapter.getLastInserted()).toEqual(created);
+        
+        // Should be tracked for cleanup
+        expect(factory.getCreatedEntities()).toHaveLength(1);
+    });
+    
+    test('plugin should configure persistence for all factories', async () => {
+        const mockAdapter = new MockPersistenceAdapter();
+        const plugin = new GhostPlugin({persistence: mockAdapter});
+        
+        // Create a post through the plugin
+        await plugin.createPublishedPost({title: 'Test Post'});
+        
+        // Should be in mock storage
+        const stored = mockAdapter.getAll('posts');
+        expect(stored).toHaveLength(1);
+        expect((stored[0] as Record<string, unknown>).title).toBe('Test Post');
+        expect((stored[0] as Record<string, unknown>).status).toBe('published');
+    });
+    
+    test('cleanup should use persistence adapter', async () => {
+        const mockAdapter = new MockPersistenceAdapter();
+        const plugin = new GhostPlugin({persistence: mockAdapter});
+        
+        // Create multiple posts
+        await plugin.createPost({title: 'Post 1'});
+        await plugin.createPost({title: 'Post 2'});
+        await plugin.createPost({title: 'Post 3'});
+        
+        // Should have 3 posts
+        expect(mockAdapter.getAll('posts')).toHaveLength(3);
+        
+        // Clean up
+        await plugin.destroy();
+        
+        // Should be empty
+        expect(mockAdapter.getAll('posts')).toHaveLength(0);
+    });
+    
+    test('switching persistence adapters', async () => {
+        // Start with one adapter
+        const adapter1 = new MockPersistenceAdapter();
+        const plugin = new GhostPlugin({persistence: adapter1});
+        
+        await plugin.createPost({title: 'Post in Adapter 1'});
+        expect(adapter1.getAll('posts')).toHaveLength(1);
+        
+        // Switch to another adapter
+        const adapter2 = new MockPersistenceAdapter();
+        plugin.setPersistenceAdapter(adapter2);
+        
+        await plugin.createPost({title: 'Post in Adapter 2'});
+        
+        // First adapter still has its post
+        expect(adapter1.getAll('posts')).toHaveLength(1);
+        
+        // Second adapter has the new post
+        expect(adapter2.getAll('posts')).toHaveLength(1);
+        expect((adapter2.getAll('posts')[0] as Record<string, unknown>).title).toBe('Post in Adapter 2');
+    });
+    
+    test('factory without persistence should throw', async () => {
+        const factory = new PostFactory();
+        
+        // Build should work
+        expect(() => factory.build({title: 'Test'})).not.toThrow();
+        
+        // Create should throw
+        await expect(factory.create({title: 'Test'}))
+            .rejects.toThrow('No persistence adapter configured');
+    });
+});

--- a/e2e/data-factory/tests/unit/plugin-system.test.ts
+++ b/e2e/data-factory/tests/unit/plugin-system.test.ts
@@ -1,0 +1,124 @@
+import {test, expect} from '@playwright/test';
+import {DataFactory, GhostPlugin, BasePlugin} from '../../index';
+
+// Test plugin for testing the plugin system
+class TestPlugin extends BasePlugin {
+    readonly name = 'test';
+    setupCalled = false;
+    destroyCalled = false;
+    
+    async setup(): Promise<void> {
+        this.setupCalled = true;
+    }
+    
+    async destroy(): Promise<void> {
+        this.destroyCalled = true;
+    }
+}
+
+test.describe('Plugin System', () => {
+    test('should initialize with default plugins', async () => {
+        const factory = new DataFactory();
+        await factory.initialize();
+        
+        expect(factory.ghost).toBeDefined();
+        expect(factory.tinybird).toBeDefined();
+        
+        await factory.cleanup();
+    });
+    
+    test('should register custom plugins', async () => {
+        const testPlugin = new TestPlugin();
+        const factory = new DataFactory({
+            plugins: [testPlugin]
+        });
+        
+        expect(factory.getPlugin('test')).toBe(testPlugin);
+        
+        await factory.initialize();
+        expect(testPlugin.setupCalled).toBe(true);
+        
+        await factory.cleanup();
+        expect(testPlugin.destroyCalled).toBe(true);
+    });
+    
+    test('should throw error for missing plugins', () => {
+        const factory = new DataFactory({plugins: []});
+        
+        expect(() => factory.ghost).toThrow('Ghost plugin not registered');
+        expect(() => factory.tinybird).toThrow('Tinybird plugin not registered');
+    });
+    
+    test('should handle mixed plugin configurations', async () => {
+        const testPlugin = new TestPlugin();
+        const factory = new DataFactory({
+            plugins: [
+                new GhostPlugin(),
+                testPlugin
+            ]
+        });
+        
+        await factory.initialize();
+        
+        expect(factory.ghost).toBeDefined();
+        expect(() => factory.tinybird).toThrow('Tinybird plugin not registered');
+        expect(factory.getPlugin('test')).toBe(testPlugin);
+        
+        await factory.cleanup();
+    });
+    
+    test('should prevent double cleanup', async () => {
+        const factory = new DataFactory();
+        await factory.initialize();
+        
+        await factory.cleanup();
+        
+        // Second cleanup should not throw
+        await expect(factory.cleanup()).resolves.toBeUndefined();
+    });
+    
+    test('should handle plugin initialization errors gracefully', async () => {
+        class ErrorPlugin extends BasePlugin {
+            readonly name = 'error';
+            async setup(): Promise<void> {
+                throw new Error('Setup failed');
+            }
+            async destroy(): Promise<void> {}
+        }
+        
+        const factory = new DataFactory({
+            plugins: [new ErrorPlugin()]
+        });
+        
+        await expect(factory.initialize()).rejects.toThrow('Setup failed');
+    });
+    
+    test('should clean up plugins in reverse order', async () => {
+        const order: string[] = [];
+        
+        class Plugin1 extends BasePlugin {
+            readonly name = 'plugin1';
+            async setup(): Promise<void> {}
+            async destroy(): Promise<void> {
+                order.push('plugin1');
+            }
+        }
+        
+        class Plugin2 extends BasePlugin {
+            readonly name = 'plugin2';
+            async setup(): Promise<void> {}
+            async destroy(): Promise<void> {
+                order.push('plugin2');
+            }
+        }
+        
+        const factory = new DataFactory({
+            plugins: [new Plugin1(), new Plugin2()]
+        });
+        
+        await factory.initialize();
+        await factory.cleanup();
+        
+        expect(order).toEqual(['plugin2', 'plugin1']);
+    });
+});

--- a/e2e/data-factory/tests/unit/tinybird-plugin.test.ts
+++ b/e2e/data-factory/tests/unit/tinybird-plugin.test.ts
@@ -1,0 +1,156 @@
+import {test, expect} from '../../test-fixtures';
+
+test.describe('Tinybird Plugin', () => {
+    test('should create a page hit with defaults', async ({tinybird}) => {
+        const hit = await tinybird.createPageHit();
+        
+        expect(hit.timestamp).toBeTruthy();
+        expect(hit.action).toBe('page_hit');
+        expect(hit.version).toBe('1');
+        expect(hit.session_id).toBeTruthy();
+        expect(hit.payload.site_uuid).toBeTruthy();
+        expect(hit.payload.pathname).toBe('/');
+        expect(hit.payload.member_status).toBe('undefined');
+        expect(hit.payload['user-agent']).toBeTruthy();
+        expect(hit.payload.event_id).toBeTruthy();
+    });
+    
+    test('should create page hit with custom options', async ({tinybird, ghost}) => {
+        const post = await ghost.createPost();
+        
+        const hit = await tinybird.createPageHit({
+            post_uuid: post.uuid,
+            pathname: `/posts/${post.slug}`,
+            member_status: 'paid',
+            referrer: 'https://google.com',
+            locale: 'fr-FR',
+            location: 'FR'
+        });
+        
+        expect(hit.payload.post_uuid).toBe(post.uuid);
+        expect(hit.payload.pathname).toBe(`/posts/${post.slug}`);
+        expect(hit.payload.member_status).toBe('paid');
+        expect(hit.payload.referrer).toBe('https://google.com');
+        expect(hit.payload.locale).toBe('fr-FR');
+        expect(hit.payload.location).toBe('FR');
+        expect(hit.payload.meta.referrerSource).toBe('Google');
+    });
+    
+    test('should parse referrer sources correctly', async ({tinybird}) => {
+        const testCases = [
+            {referrer: 'https://google.com/search', expected: 'Google'},
+            {referrer: 'https://news.google.com', expected: 'Google News'},
+            {referrer: 'https://duckduckgo.com', expected: 'DuckDuckGo'},
+            {referrer: 'https://bing.com', expected: 'Bing'},
+            {referrer: 'https://reddit.com/r/ghost', expected: 'Reddit'},
+            {referrer: 'https://go.bsky.app', expected: 'Bluesky'},
+            {referrer: 'https://t.co/abc123', expected: 'Twitter'},
+            {referrer: 'https://facebook.com', expected: 'Facebook'},
+            {referrer: 'https://example.com', expected: 'example.com'}
+        ];
+        
+        for (const {referrer, expected} of testCases) {
+            const hit = await tinybird.createPageHit({referrer});
+            expect(hit.payload.meta.referrerSource).toBe(expected);
+        }
+    });
+    
+    test('should create multiple page hits', async ({tinybird, ghost}) => {
+        const post = await ghost.createPost();
+        const hits = await tinybird.createPageHits(5, {
+            post_uuid: post.uuid
+        });
+        
+        expect(hits).toHaveLength(5);
+        hits.forEach((hit) => {
+            expect(hit.payload.post_uuid).toBe(post.uuid);
+        });
+    });
+    
+    test('should create page hits for a specific post', async ({tinybird, ghost}) => {
+        const post = await ghost.createPublishedPost();
+        const hits = await tinybird.createPageHitsForPost(post.uuid, 10, {
+            member_status: 'free'
+        });
+        
+        expect(hits).toHaveLength(10);
+        hits.forEach((hit) => {
+            expect(hit.payload.post_uuid).toBe(post.uuid);
+            expect(hit.payload.member_status).toBe('free');
+        });
+    });
+    
+    test('should manage sessions correctly', async ({tinybird}) => {
+        // Create new session
+        const session1 = tinybird.createNewSession();
+        expect(session1).toBeTruthy();
+        expect(typeof session1).toBe('string');
+        
+        // Create another session
+        const session2 = tinybird.createNewSession();
+        expect(session2).not.toBe(session1);
+        
+        // Create hits with specific session
+        const hits = await tinybird.createSessionHits(session1, 3, {
+            pathname: '/about'
+        });
+        
+        expect(hits).toHaveLength(3);
+        hits.forEach((hit) => {
+            expect(hit.session_id).toBe(session1);
+            expect(hit.payload.pathname).toBe('/about');
+        });
+    });
+    
+    test('should track sessions for cleanup', async ({tinybird}) => {
+        const initialStats = tinybird.getStats();
+        
+        // Create hits with auto-generated sessions
+        await tinybird.createPageHit();
+        await tinybird.createPageHit();
+        
+        // Create hits with manual sessions
+        const session = tinybird.createNewSession();
+        await tinybird.createSessionHits(session, 3);
+        
+        const finalStats = tinybird.getStats();
+        expect(finalStats.sessions).toBe(initialStats.sessions + 3); // 2 auto + 1 manual
+        expect(finalStats.events).toBe(initialStats.events + 5);
+    });
+    
+    test('should format timestamps correctly', async ({tinybird}) => {
+        const customDate = new Date('2024-01-15T10:30:45.123Z');
+        const hit = await tinybird.createPageHit({
+            timestamp: customDate
+        });
+        
+        // Tinybird expects format: "2024-01-15 10:30:45.123"
+        expect(hit.timestamp).toBe('2024-01-15 10:30:45.123');
+    });
+    
+    test('should generate proper href URLs', async ({tinybird}) => {
+        const testCases = [
+            {pathname: '/', expected: 'https://example.com/'},
+            {pathname: '/about', expected: 'https://example.com/about'},
+            {pathname: '/posts/my-post', expected: 'https://example.com/posts/my-post'}
+        ];
+        
+        for (const {pathname, expected} of testCases) {
+            const hit = await tinybird.createPageHit({pathname});
+            expect(hit.payload.href).toBe(expected);
+        }
+    });
+    
+    test('should allow custom session IDs in page hits', async ({tinybird}) => {
+        const customSessionId = 'test-session-123';
+        const hit = await tinybird.createPageHit({
+            session_id: customSessionId
+        });
+        
+        expect(hit.session_id).toBe(customSessionId);
+        
+        // Should still track the session
+        const stats = tinybird.getStats();
+        expect(stats.sessions).toBeGreaterThan(0);
+    });
+});

--- a/e2e/data-factory/tests/unit/tinybird-plugin.test.ts
+++ b/e2e/data-factory/tests/unit/tinybird-plugin.test.ts
@@ -1,6 +1,22 @@
 import {test, expect} from '../../test-fixtures';
+import {isTinybirdAvailable} from '../../plugins/tinybird/check-availability';
 
 test.describe('Tinybird Plugin', () => {
+    let tinybirdAvailable = false;
+    
+    test.beforeAll(async () => {
+        tinybirdAvailable = await isTinybirdAvailable();
+        if (!tinybirdAvailable) {
+            // eslint-disable-next-line no-console
+            console.warn('⚠️  Tinybird is not available. Tinybird tests will be skipped. Run `tb local` to enable these tests.');
+        }
+    });
+    
+    test.beforeEach(async ({}, testInfo) => {
+        if (!tinybirdAvailable) {
+            testInfo.skip();
+        }
+    });
     test('should create a page hit with defaults', async ({tinybird}) => {
         const hit = await tinybird.createPageHit();
         
@@ -12,7 +28,6 @@ test.describe('Tinybird Plugin', () => {
         expect(hit.payload.pathname).toBe('/');
         expect(hit.payload.member_status).toBe('undefined');
         expect(hit.payload['user-agent']).toBeTruthy();
-        expect(hit.payload.event_id).toBeTruthy();
     });
     
     test('should create page hit with custom options', async ({tinybird, ghost}) => {

--- a/e2e/data-factory/tests/unit/utils.test.ts
+++ b/e2e/data-factory/tests/unit/utils.test.ts
@@ -1,46 +1,10 @@
 import {test, expect} from '@playwright/test';
-import {Factory} from '../../base-factory';
+import {generateId, generateUuid, generateSlug} from '../../utils';
 
-// Concrete implementation of Factory for testing
-class TestFactory extends Factory {
-    name = 'test';
-    
-    async setup(): Promise<void> {
-        // Mock setup
-    }
-    
-    async destroy(): Promise<void> {
-        // Mock destroy
-    }
-    
-    // Expose protected methods for testing
-    public testGenerateId(): string {
-        return this.generateId();
-    }
-    
-    public testGenerateUuid(): string {
-        return this.generateUuid();
-    }
-    
-    public testGenerateSlug(text: string): string {
-        return this.generateSlug(text);
-    }
-}
-
-test.describe('Base Factory', () => {
-    let factory: TestFactory;
-    
-    test.beforeEach(() => {
-        factory = new TestFactory();
-    });
-    
-    test('should have a name property', () => {
-        expect(factory.name).toBe('test');
-    });
-    
+test.describe('Utils', () => {
     test('should generate unique IDs', () => {
-        const id1 = factory.testGenerateId();
-        const id2 = factory.testGenerateId();
+        const id1 = generateId();
+        const id2 = generateId();
         
         expect(id1).toBeTruthy();
         expect(id2).toBeTruthy();
@@ -50,8 +14,8 @@ test.describe('Base Factory', () => {
     });
     
     test('should generate valid UUIDs', () => {
-        const uuid1 = factory.testGenerateUuid();
-        const uuid2 = factory.testGenerateUuid();
+        const uuid1 = generateUuid();
+        const uuid2 = generateUuid();
         
         // UUID format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
         const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -73,28 +37,18 @@ test.describe('Base Factory', () => {
         ];
         
         testCases.forEach(({input, expected}) => {
-            const result = factory.testGenerateSlug(input);
+            const result = generateSlug(input);
             expect(result).toBe(expected);
         });
     });
     
     test('should handle empty string in slug generation', () => {
-        const result = factory.testGenerateSlug('');
+        const result = generateSlug('');
         expect(result).toBe('');
     });
     
     test('should handle special characters in slug generation', () => {
-        const result = factory.testGenerateSlug('Café & Restaurant');
+        const result = generateSlug('Café & Restaurant');
         expect(result).toBe('caf-restaurant');
-    });
-    
-    test('should implement setup method', async () => {
-        // Should not throw
-        await expect(factory.setup()).resolves.toBeUndefined();
-    });
-    
-    test('should implement destroy method', async () => {
-        // Should not throw
-        await expect(factory.destroy()).resolves.toBeUndefined();
     });
 });

--- a/e2e/data-factory/tsconfig.json
+++ b/e2e/data-factory/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./build",
+      "rootDir": "."
+    },
+    "include": [
+      "**/*.ts"
+    ],
+    "exclude": [
+      "build/**/*"
+    ]
+  }

--- a/e2e/data-factory/utils.ts
+++ b/e2e/data-factory/utils.ts
@@ -1,0 +1,27 @@
+import {v4 as uuid} from 'uuid';
+
+/**
+ * Generate a unique ID using timestamp and random string
+ */
+export function generateId(): string {
+    return Date.now().toString(16) + Math.random().toString(16).substring(2, 10);
+}
+
+/**
+ * Generate a UUID v4
+ */
+export function generateUuid(): string {
+    return uuid();
+}
+
+/**
+ * Generate a URL-safe slug from text
+ */
+export function generateSlug(text: string): string {
+    return text.toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,8 +12,9 @@
     "build:ts": "tsc",
     "prepare": "tsc",
     "test": "playwright test",
+    "test:factory": "playwright test --config=data-factory/playwright.config.mjs",
     "test:types": "tsc --noEmit",
-    "lint": "eslint helpers --ext .ts --cache"
+    "lint": "eslint helpers data-factory --ext .ts --cache"
   },
   "files": [
     "build"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2327/

This PR introduces a new plugin-based test data factory for our E2E test suite. I've started with demonstrating two very basic implementations:
- Ghost plugin with Post factory
- Tinybird plugin with PageHit factory

The core concept is to have a plugin-based architecture that allows a custom mix of factories that the test writer can choose without needing to boot absolutely everything, while also providing a simple interface for test writing. We'll demonstrate the use with some simplistic tests for the Analytics apps, which is why I've started with Posts and Page Hits.

The goal for all of this is simple tests. See the `examples.test.ts` file, where use is as simple as:
```
test('create a post with views', async ({ghost,tinybird}) => {
    const post = await ghost.createPublishedPost();
    const hits = await tinybird.createPageHitsForPost(post, 100, {member_status: 'free'});   
    // navigate and assert
});
```
And the framework cleans up the created data after each test.

Major decision points:
- [ ] Plugin-based design; this helps isolate dependencies and allows for varied compositions (e.g. testing Analytics should look different from testing ActivityPub)
- [ ] Factories are simple and only handle `create()` and cleanup tracking; it's an open question if they should handle convenience functions or if those should live in the plugin, which has cross-factory knowledge (allowing `createPostWithTags`). This allows them to be (safely) tightly coupled to their own schema/type.
- [ ] `Factory`, `BasePlugin` classes help define behavior/structure
- [ ] `DataFactory` is the coordinator for the various plugins
- [ ] `test-fixtures` demonstrates how to easily integrate with Playwright/test runners to manage instantiation and cleanup

We have some serious concerns related to parallelization and shared Ghost dbs, which is not designed to be multi-site (multi-tenant) like Tinybird, which we can look in to later. Through use of `test.concurrent` we can be clever in our test design to allow for tests to run successfully both in parallel and in isolation.