### PR TITLE
Fixed placeholder not being shown in Explore testimonials

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
@@ -35,11 +35,12 @@ const TestimonialsModal = NiceModal.create(() => {
             prev_platform: ''
         },
         onSave: async (): Promise<void> => {
+            const prevPlatform = ['none', 'other', ''].includes(formState.prev_platform) ? undefined : formState.prev_platform;
             const payload = {
                 ghost_uuid: siteUuid,
                 staff_user_email: staffUserEmail,
                 content: formState.content,
-                prev_platform: formState.prev_platform
+                prev_platform: prevPlatform
             };
 
             if (!exploreTestimonialsUrl) {

--- a/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
@@ -79,7 +79,7 @@ const TestimonialsModal = NiceModal.create(() => {
     });
 
     const migratedFromOptions: Array<{value: string; label: string;}> = [
-        {value: '', label: 'None - This is a new site'},
+        {value: 'none', label: 'None - This is a new site'},
         {value: 'substack', label: 'Substack'},
         {value: 'beehiiv', label: 'Beehiiv'},
         {value: 'wordpress', label: 'Wordpress'},

--- a/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore/TestimonialsModal.tsx
@@ -65,6 +65,7 @@ const TestimonialsModal = NiceModal.create(() => {
                 type: 'success'
             });
 
+            updateRoute('explore');
             modal.remove();
         },
         onSaveError: handleError,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1771

- the 'None - this is a new site' option was being rendered as default instead of the placeholder
- also: don't send `prev_platform` if the user has selected none, other or hasn't selected anything
