### PR TITLE
🐛 Require newsletter_id when email_segments is used

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -156,7 +156,9 @@ const controller = {
         options: [
             'include',
             'formats',
-            'source'
+            'source',
+            'email_segment',
+            'newsletter'
         ],
         validation: {
             options: {

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/posts.js
@@ -52,15 +52,26 @@ const validateSingleContentSource = async function (frame) {
     }
 };
 
+const validateEmailSegmentWithNewsletter = async function (frame) {
+    if (frame.options.email_segment && !frame.options.newsletter) {
+        return Promise.reject(new ValidationError({
+            message: 'The email_segment parameter requires the newsletter parameter to be set',
+            property: 'email_segment'
+        }));
+    }
+};
+
 module.exports = {
     async add(apiConfig, frame) {
         await jsonSchema.validate(...arguments);
         await validateVisibility(frame);
         await validateSingleContentSource(frame);
+        await validateEmailSegmentWithNewsletter(frame);
     },
     async edit(apiConfig, frame) {
         await jsonSchema.validate(...arguments);
         await validateVisibility(frame);
         await validateSingleContentSource(frame);
+        await validateEmailSegmentWithNewsletter(frame);
     }
 };

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -384,6 +384,48 @@ describe('Posts API', function () {
                 });
         });
 
+        it('Errors when email_segment is set without newsletter parameter', async function () {
+            const post = {
+                title: 'Email segment without newsletter test',
+                status: 'draft'
+            };
+
+            await agent
+                .post('/posts/?email_segment=status:free')
+                .body({posts: [post]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+
+        it('Can create a post with email_segment when newsletter is also provided', async function () {
+            const post = {
+                title: 'Email segment with newsletter test',
+                status: 'draft'
+            };
+
+            // Note: Using a valid newsletter slug from test fixtures
+            await agent
+                .post('/posts/?email_segment=status:free&newsletter=daily-newsletter')
+                .body({posts: [post]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    posts: [Object.assign({}, matchPostShallowIncludes, {published_at: null})]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('posts')
+                });
+        });
+
         // update when updating a scheduled post
     });
 


### PR DESCRIPTION
This keeps the app from getting to an invalid state where it
appears to set to send to email but it's not actually going anyway.

Fixes #24490

## QA Log

- Added automated test
- Confirmed it failed
- Added code
- Confirmed test passed
