### PR TITLE
Fix: What's New modal footer visibility in dark mode

### DIFF
--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -518,6 +518,10 @@ input:focus,
     background: color-mod(var(--white) l(+2%));
 }
 
+.gh-whatsnew-modal-footer {
+    background: color-mod(var(--white) l(-1%));
+}
+
 .seo-preview-title {
     color: color-mod(#1e0fbe l(+25%));
 }


### PR DESCRIPTION
This PR fixes visibility issues in the What's New modal's footer section when viewed in dark mode. The issue is described in https://github.com/TryGhost/Ghost/issues/24497.

| BEFORE | AFTER |
| ---- | ---- |
| <img width="747" height="834" alt="Screenshot 2025-07-25 at 3 53 27 PM" src="https://github.com/user-attachments/assets/09b2107f-7ab4-4fc2-bb8e-d3ddcc2f9d20" /> |  <img width="815" height="896" alt="Screenshot 2025-07-25 at 3 54 27 PM" src="https://github.com/user-attachments/assets/e08f2f93-b273-444e-bc09-ad4c9f5ebc62" /> |

### Testing Instructions

1. In your Ghost admin, open the What's New modal ([screenshot](https://cloudup.com/c0NPlMsO61L)).
2. Verify that the modal's footer background colour matches dark mode, and that the button text is visible.