### PR TITLE
🎨 Added event field to webhook payloads

### DIFF
--- a/ghost/core/core/server/services/webhooks/webhook-trigger.js
+++ b/ghost/core/core/server/services/webhooks/webhook-trigger.js
@@ -113,7 +113,10 @@ class WebhookTrigger {
         debug(`${hooks.models.length} webhooks found for ${event}.`);
 
         for (const webhook of hooks.models) {
-            const hookPayload = await this.payload(webhook.get('event'), model);
+            const hookPayload = {
+                event: webhook.get('event'),
+                ...await this.payload(webhook.get('event'), model)
+            };
 
             const reqPayload = JSON.stringify(hookPayload);
             const url = webhook.get('target_url');

--- a/ghost/core/test/e2e-server/__snapshots__/click-tracking.test.js.snap
+++ b/ghost/core/test/e2e-server/__snapshots__/click-tracking.test.js.snap
@@ -13,6 +13,7 @@ Object {
 
 exports[`Click Tracking Full test 2: [body] 1`] = `
 Object {
+  "event": "member.edited",
   "member": Object {
     "current": Object {
       "avatar_image": null,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/members.test.js.snap
@@ -13,6 +13,7 @@ Object {
 
 exports[`member.* events member.added event is triggered 2: [body] 1`] = `
 Object {
+  "event": "member.added",
   "member": Object {
     "current": Object {
       "avatar_image": null,
@@ -68,6 +69,7 @@ Object {
 
 exports[`member.* events member.deleted event is triggered 2: [body] 1`] = `
 Object {
+  "event": "member.deleted",
   "member": Object {
     "current": Object {},
     "previous": Object {
@@ -116,6 +118,7 @@ Object {
 
 exports[`member.* events member.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "member.edited",
   "member": Object {
     "current": Object {
       "avatar_image": null,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
@@ -13,6 +13,7 @@ Object {
 
 exports[`page.* events page.added event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.added",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -185,6 +186,7 @@ Object {
 
 exports[`page.* events page.deleted event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.deleted",
   "page": Object {
     "current": Object {},
     "previous": Object {
@@ -274,6 +276,7 @@ Object {
 
 exports[`page.* events page.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.edited",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -512,6 +515,7 @@ Object {
 
 exports[`page.* events page.published event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.published",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -750,6 +754,7 @@ Object {
 
 exports[`page.* events page.published.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.published.edited",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -987,6 +992,7 @@ Object {
 
 exports[`page.* events page.rescheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.rescheduled",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -1224,6 +1230,7 @@ Object {
 
 exports[`page.* events page.scheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.scheduled",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -1462,6 +1469,7 @@ Object {
 
 exports[`page.* events page.tag.attached event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.tag.attached",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -1744,6 +1752,7 @@ Object {
 
 exports[`page.* events page.tag.detached event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.tag.detached",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -1966,6 +1975,7 @@ Object {
 
 exports[`page.* events page.unpublished event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.unpublished",
   "page": Object {
     "current": Object {
       "authors": Array [
@@ -2203,6 +2213,7 @@ Object {
 
 exports[`page.* events page.unscheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "page.unscheduled",
   "page": Object {
     "current": Object {
       "authors": Array [

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -13,6 +13,7 @@ Object {
 
 exports[`post.* events post.added event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.added",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -187,6 +188,7 @@ Object {
 
 exports[`post.* events post.deleted event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.deleted",
   "post": Object {
     "current": Object {},
     "previous": Object {
@@ -275,6 +277,7 @@ Object {
 
 exports[`post.* events post.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.edited",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -513,6 +516,7 @@ Object {
 
 exports[`post.* events post.published event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.published",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -774,6 +778,7 @@ Object {
 
 exports[`post.* events post.published.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.published.edited",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -1012,6 +1017,7 @@ Object {
 
 exports[`post.* events post.rescheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.rescheduled",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -1250,6 +1256,7 @@ Object {
 
 exports[`post.* events post.scheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.scheduled",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -1489,6 +1496,7 @@ Object {
 
 exports[`post.* events post.tag.attached event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.tag.attached",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -1794,6 +1802,7 @@ Object {
 
 exports[`post.* events post.tag.detached event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.tag.detached",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -2039,6 +2048,7 @@ Object {
 
 exports[`post.* events post.unpublished event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.unpublished",
   "post": Object {
     "current": Object {
       "authors": Array [
@@ -2299,6 +2309,7 @@ Object {
 
 exports[`post.* events post.unscheduled event is triggered 2: [body] 1`] = `
 Object {
+  "event": "post.unscheduled",
   "post": Object {
     "current": Object {
       "authors": Array [

--- a/ghost/core/test/e2e-webhooks/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/site.test.js.snap
@@ -11,7 +11,11 @@ Object {
 }
 `;
 
-exports[`site.* events site.changed event is triggered 2: [body] 1`] = `Object {}`;
+exports[`site.* events site.changed event is triggered 2: [body] 1`] = `
+Object {
+  "event": "site.changed",
+}
+`;
 
 exports[`site.* events site.changed event is triggered, custom integrations are limited but we have an internal webhook 1: [headers] 1`] = `
 Object {
@@ -24,4 +28,8 @@ Object {
 }
 `;
 
-exports[`site.* events site.changed event is triggered, custom integrations are limited but we have an internal webhook 2: [body] 1`] = `Object {}`;
+exports[`site.* events site.changed event is triggered, custom integrations are limited but we have an internal webhook 2: [body] 1`] = `
+Object {
+  "event": "site.changed",
+}
+`;

--- a/ghost/core/test/e2e-webhooks/__snapshots__/tags.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/tags.test.js.snap
@@ -13,6 +13,7 @@ Object {
 
 exports[`tag.* events tag.added event is triggered 2: [body] 1`] = `
 Object {
+  "event": "tag.added",
   "tag": Object {
     "current": Object {
       "accent_color": null,
@@ -55,6 +56,7 @@ Object {
 
 exports[`tag.* events tag.deleted event is triggered 2: [body] 1`] = `
 Object {
+  "event": "tag.deleted",
   "tag": Object {
     "current": Object {},
     "previous": Object {
@@ -96,6 +98,7 @@ Object {
 
 exports[`tag.* events tag.edited event is triggered 2: [body] 1`] = `
 Object {
+  "event": "tag.edited",
   "tag": Object {
     "current": Object {
       "accent_color": null,

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -135,9 +135,13 @@ describe('Webhook Service', function () {
             sinon.assert.called(payload);
             sinon.assert.called(request);
             assert.equal(request.args[0][0], WEBHOOK_TARGET_URL);
-            assert.equal(request.args[0][1].body, '{"data":[1]}');
+            const reqBody = JSON.parse(request.args[0][1].body);
+            assert.deepEqual(reqBody, {
+                event: WEBHOOK_EVENT,
+                data: [1]
+            });
             assert.deepEqual(Object.keys(request.args[0][1].headers), ['Content-Length', 'Content-Type', 'Content-Version']);
-            assert.equal(request.args[0][1].headers['Content-Length'], 12);
+            assert.equal(request.args[0][1].headers['Content-Length'], 33);
             assert.equal(request.args[0][1].headers['Content-Type'], 'application/json');
             assert.match(request.args[0][1].headers['Content-Version'], /v\d+\.\d+/);
         });
@@ -201,12 +205,42 @@ describe('Webhook Service', function () {
             sinon.assert.called(payload);
             sinon.assert.called(request);
             assert.equal(request.args[0][0], WEBHOOK_TARGET_URL);
-
-            const expectedHeader = `sha256=${crypto.createHmac('sha256', WEBHOOK_SECRET).update(`{"data":[1]}${ts}`).digest('hex')}, t=${ts}`;
+            const expectedPayload = JSON.stringify({
+                event: WEBHOOK_EVENT,
+                data: [1]
+            });
+            const expectedHeader = `sha256=${crypto.createHmac('sha256', WEBHOOK_SECRET).update(`${expectedPayload}${ts}`).digest('hex')}, t=${ts}`;
             const header = request.args[0][1].headers[SIGNATURE_HEADER];
             assert.equal(expectedHeader, header);
 
             clock.restore();
+        });
+        it('includes the event name in the JSON payload', async function () {
+            const webhookModel = {
+                get: sinon.stub()
+            };
+
+            webhookModel.get
+                .withArgs('event').returns(WEBHOOK_EVENT)
+                .withArgs('target_url').returns(WEBHOOK_TARGET_URL)
+                .withArgs('secret').returns('');
+
+            models.Webhook.findAllByEvent
+                .withArgs(WEBHOOK_EVENT, {context: {internal: true}})
+                .resolves({models: [webhookModel]});
+
+            const postModel = sinon.stub();
+
+            payload
+                .withArgs(WEBHOOK_EVENT, postModel)
+                .resolves({data: [1]});
+
+            await webhookTrigger.trigger(WEBHOOK_EVENT, postModel);
+
+            const reqBody = request.args[0][1].body;
+            const parsed = JSON.parse(reqBody);
+
+            assert.equal(parsed.event, WEBHOOK_EVENT);
         });
     });
 

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -141,7 +141,7 @@ describe('Webhook Service', function () {
                 data: [1]
             });
             assert.deepEqual(Object.keys(request.args[0][1].headers), ['Content-Length', 'Content-Type', 'Content-Version']);
-            assert.equal(request.args[0][1].headers['Content-Length'], 33);
+            assert.equal(request.args[0][1].headers['Content-Length'], Buffer.byteLength(request.args[0][1].body));
             assert.equal(request.args[0][1].headers['Content-Type'], 'application/json');
             assert.match(request.args[0][1].headers['Content-Version'], /v\d+\.\d+/);
         });
@@ -215,6 +215,7 @@ describe('Webhook Service', function () {
 
             clock.restore();
         });
+
         it('includes the event name in the JSON payload', async function () {
             const webhookModel = {
                 get: sinon.stub()


### PR DESCRIPTION
Webhooks now include an `event` field like "post.published" in the body. This change was made to improve the developer experience when handling incoming webhooks. Without the `event` field in the payload, downstream systems had to infer the event from the request URL or set up separate endpoints per event. By explicitly including the event type, we make it easier to handle webhooks generically and reduce boilerplate for consumers.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
