### PR TITLE
Fix: Mobile and Tablet UI issues on `/members`

### DIFF
--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -5,10 +5,6 @@
     --member-import-table-border: var(--whitegrey-d1);
 }
 
-.view-container  {
-    overflow-x: hidden;
-}
-
 /* Members avatar
 /* ----------------------------------------- */
 .gh-member-gravatar {
@@ -79,6 +75,10 @@
 @media (max-width: 1100px) {
     .members-list {
         border-bottom: none
+    }
+
+    .view-container.members-list-container  {
+        overflow-x: hidden;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -368,7 +368,7 @@ p.gh-members-list-email {
     min-width: 120px;
 }
 
-@media (max-width: 440px) {
+@media (max-width: 480px) {
     .gh-members-list-row .gh-list-data:first-child {
         width: 160px;
         min-width: 160px;

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -373,7 +373,6 @@ p.gh-members-list-email {
         width: 160px;
         min-width: 160px;
         max-width: 160px;
-        overflow-x: hidden;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -5,6 +5,10 @@
     --member-import-table-border: var(--whitegrey-d1);
 }
 
+.view-container  {
+    overflow-x: hidden;
+}
+
 /* Members avatar
 /* ----------------------------------------- */
 .gh-member-gravatar {
@@ -364,6 +368,15 @@ p.gh-members-list-email {
     min-width: 120px;
 }
 
+@media (max-width: 440px) {
+    .gh-members-list-row .gh-list-data:first-child {
+        width: 160px;
+        min-width: 160px;
+        max-width: 160px;
+        overflow-x: hidden;
+    }
+}
+
 @media (max-width: 1100px) {
     .gh-members-chart-summary-data {
         font-size: 2.8rem;
@@ -381,11 +394,6 @@ p.gh-members-list-email {
     .gh-list-with-helpsection {
         margin-left: 0;
         margin-right: 0;
-    }
-
-    .gh-members-list-row .gh-list-data:first-child {
-        min-width: 280px;
-        overflow-x: hidden;
     }
 
     .gh-members-list-email,

--- a/ghost/admin/app/templates/members.hbs
+++ b/ghost/admin/app/templates/members.hbs
@@ -127,7 +127,7 @@
             <GhLoadingSpinner />
         </div>
     {{else}}
-        <section class="view-container {{if (or (not this.members) (lt this.members.length 6)) "members-list-container-stretch"}}">
+        <section class="view-container members-list-container {{if (or (not this.members) (lt this.members.length 6)) "members-list-container-stretch"}}">
             {{#if this.members}}
                 <div class="gh-list-scrolling {{if (lt this.members.length 6) "gh-list-with-helpsection"}}" data-test-table="members">
                     <table class="gh-list">


### PR DESCRIPTION
This PR resolves mobile and tablet UI bugs on the `/members` page. More specifically, the following issues are fixed (tracked in https://github.com/TryGhost/Ghost/issues/24501):

* On mobile screens, the member details page occupied most of the available width, leaving little space for the rest of the columns.
* On tablet screens, there was a visual overlap of columns when scrolling horizontally. 

### Changes

1. Apply a fixed width for the member details column on mobile screens, leaving adequate space for the rest of the columns.

| BEFORE | AFTER |
| ---- | ---- |
| ![m2](https://github.com/user-attachments/assets/d55967ae-a8f0-4ca4-8682-1546bed79e06) | ![m1](https://github.com/user-attachments/assets/aafd9893-ef65-43b5-b10e-c28475952306)

2. Hide overflow on tablet screens

| BEFORE | AFTER |
| ---- | ---- |
| <img width="812" height="863" alt="Screenshot 2025-07-26 at 6 01 04 PM" src="https://github.com/user-attachments/assets/37ebf4bf-051f-446d-a48d-44d0b3ea6a64" /> | <img width="778" height="709" alt="Screenshot 2025-07-26 at 6 55 12 PM" src="https://github.com/user-attachments/assets/83192424-d60a-4bc2-bd1e-4848eb7623f1" />
