### PR TITLE
Fix: Mobile view nav menu is not visible in `/pro` and `/explore`

### DIFF
--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -52,3 +52,9 @@
     transition: all 0.2s ease-in-out;
     top: 25px;
 }
+
+@media (max-width: 500px) {
+    .gh-billing {
+        z-index: 1;
+    }
+}

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -55,6 +55,6 @@
 
 @media (max-width: 500px) {
     .gh-billing {
-        z-index: 1;
+        z-index: 801;
     }
 }

--- a/ghost/admin/app/styles/layouts/billing.css
+++ b/ghost/admin/app/styles/layouts/billing.css
@@ -55,6 +55,6 @@
 
 @media (max-width: 500px) {
     .gh-billing {
-        z-index: 801;
+        z-index: var(--z-index-iframe-mobile);
     }
 }

--- a/ghost/admin/app/styles/layouts/explore.css
+++ b/ghost/admin/app/styles/layouts/explore.css
@@ -239,4 +239,8 @@
     .explore-permissions > div span svg {
         width: 1.8rem;
     }
+
+    .gh-explore {
+        z-index: 1;
+    }
 }

--- a/ghost/admin/app/styles/layouts/explore.css
+++ b/ghost/admin/app/styles/layouts/explore.css
@@ -241,6 +241,6 @@
     }
 
     .gh-explore {
-        z-index: 1;
+        z-index: 801;
     }
 }

--- a/ghost/admin/app/styles/layouts/explore.css
+++ b/ghost/admin/app/styles/layouts/explore.css
@@ -241,6 +241,6 @@
     }
 
     .gh-explore {
-        z-index: 801;
+        z-index: var(--z-index-iframe-mobile);
     }
 }

--- a/ghost/admin/app/styles/patterns/global.css
+++ b/ghost/admin/app/styles/patterns/global.css
@@ -219,6 +219,9 @@
     --input-bg-color: var(--white);
     --input-border-color: var(--whitegrey-d1);
     --input-border: var(--input-border-color) 1px solid;
+
+    /* Z-index values */
+    --z-index-iframe-mobile: 801;
 }
 
 /* Colour classes


### PR DESCRIPTION
This PR fixes an issue where the nav drawer was not visible on mobile viewports in the `/explore` and `/pro` routes due to a z-index issue. 

Both `/explore` and `/pro` render content inside an iframe. On mobile, the nav drawer (triggered via the footer hamburger menu) appeared hidden because it was rendered underneath the iframe.

This resolves [#24507](https://github.com/TryGhost/Ghost/issues/24507).

### Changes made

This PR sets the `z-index` of the iframe’s content area to `801`.

This value is:

* Higher than the mobile footer nav (`z-index: 800`) → ensures iframe content stays above the footer.
https://github.com/TryGhost/Ghost/blob/3c327c1d3d7f53329c3d716c1cff4095a2a83440/ghost/admin/app/styles/layouts/main.css#L1091

* Lower than the sidebar nav drawer (`z-index: 1000`) → ensures the nav drawer renders on top.https://github.com/TryGhost/Ghost/blob/3c327c1d3d7f53329c3d716c1cff4095a2a83440/ghost/admin/app/styles/layouts/main.css#L999

This preserves expected behavior:
* Content remains scrollable when nav is closed
* Nav drawer overlays the content when opened

> **NOTE**: The example.com domain seen in the /pro screenshots is a placeholder used for local development. On production, the real Ghost(Pro) billing page will be shown.

| BEFORE | AFTER |
| --- | --- |
| ![pro1](https://github.com/user-attachments/assets/3c132db5-c3bc-4e9f-b025-3b8402b01d5a) | ![profix2](https://github.com/user-attachments/assets/b559952e-a1a8-4807-bc97-ac1d68977f39) 
| ![pro2](https://github.com/user-attachments/assets/c9d3e15d-4fa9-4408-a85f-6086b32d440a) | ![profix1](https://github.com/user-attachments/assets/0a378d15-5996-4e42-8216-6c08bb05395d)


### Testing Instructions

#### /explore

* Open Ghost Admin on a mobile viewport (via DevTools or a mobile device).
* In Ghost 6.x, manually enter `/explore` in the address bar.
* Verify that you are able to scroll the iframed content area.
* Tap the hamburger menu in the footer.
* The nav drawer should now appear over the content.

### /pro

Since the `/pro` route isn't active in local development by default, you’ll need to simulate it by temporarily modifying a few lines:

1. Modify the iframe URL in [gh-billing-iframe.js](https://github.com/TryGhost/Ghost/blob/3c327c1d3d7f53329c3d716c1cff4095a2a83440/ghost/admin/app/components/gh-billing-iframe.js#L26):
```diff
-this.billing.getBillingIframe().src = this.billing.getIframeURL();
+this.billing.getBillingIframe().src = 'https://example.com'; // Test URL for billing iframe
```

2. Force-enable billing in [application.js](https://github.com/TryGhost/Ghost/blob/3c327c1d3d7f53329c3d716c1cff4095a2a83440/ghost/admin/app/controllers/application.js#L21):

```diff
-return this.config.hostSettings?.billing?.enabled;
+return true; // Force show billing for testing
```
3. Now open Ghost Admin on a mobile viewport and navigate to /pro.

4. Tap the hamburger menu in the footer.

5. The nav drawer should appear correctly above the iframe content.
6. Another way to test this is to log in to a Ghost pro account and use devtools to modify the z-index to be the same as that defined in this PR. Verify on the `/pro` path that the nav drawer is visible and that the content area is scrollable. Here's a video walkthrough on how to test this:



https://github.com/user-attachments/assets/b8856666-4a45-4183-b21f-70e31574d2b1


 