### PR TITLE
Fix: On Mobile, `X` button on user profile modal does not work

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -329,9 +329,6 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         setSelectedTab(newTabId);
     };
 
-    // Override the default "×" icon.
-    const topRightContent: React.ReactNode = <></>;
-
     return (
         <Modal
             afterClose={navigateOnClose}
@@ -345,7 +342,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             size={canAccessSettings(currentUser) ? 'md' : 'bleed'}
             stickyFooter={true}
             testId='user-detail-modal'
-            topRightContent={topRightContent}
+            topRightContent={<></>}
             width={canAccessSettings(currentUser) ? 600 : 'full'}
             onOk={async () => {
                 await (handleSave({fakeWhenUnchanged: true}));

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -342,7 +342,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             size={canAccessSettings(currentUser) ? 'md' : 'bleed'}
             stickyFooter={true}
             testId='user-detail-modal'
-            topRightContent={<></>}
+            topRightContent={<></>} // override the default "×" icon.
             width={canAccessSettings(currentUser) ? 600 : 'full'}
             onOk={async () => {
                 await (handleSave({fakeWhenUnchanged: true}));

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -329,6 +329,8 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         setSelectedTab(newTabId);
     };
 
+    const topRightContent = <span></span>; // render an empty header section for the modal.
+
     return (
         <Modal
             afterClose={navigateOnClose}
@@ -342,6 +344,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             size={canAccessSettings(currentUser) ? 'md' : 'bleed'}
             stickyFooter={true}
             testId='user-detail-modal'
+            topRightContent={topRightContent}
             width={canAccessSettings(currentUser) ? 600 : 'full'}
             onOk={async () => {
                 await (handleSave({fakeWhenUnchanged: true}));

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -329,7 +329,8 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         setSelectedTab(newTabId);
     };
 
-    const topRightContent = <span></span>; // render an empty header section for the modal.
+    // Override the default "×" icon.
+    const topRightContent: React.ReactNode = <></>;
 
     return (
         <Modal

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -337,12 +337,12 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             buttonsDisabled={okProps.disabled}
             cancelLabel='Close'
             dirty={saveState === 'unsaved'}
+            hideXOnMobile={true}
             okColor={okProps.color}
             okLabel={okProps.label || 'Save'}
             size={canAccessSettings(currentUser) ? 'md' : 'bleed'}
             stickyFooter={true}
             testId='user-detail-modal'
-            topRightContent={<></>} // override the default "×" icon.
             width={canAccessSettings(currentUser) ? 600 : 'full'}
             onOk={async () => {
                 await (handleSave({fakeWhenUnchanged: true}));


### PR DESCRIPTION
On mobile viewports, the close (`×`) icon is unresponsive. It also seems redundant, as the modal already provides a "Close" button in the footer. 

This PR fixes the issue by removing the `X` button from the header section of the modal, thereby removing the redundancy. Users can close the modal using the "Close" button in the footer. This fixes one of the issues described in https://github.com/TryGhost/Ghost/issues/24509.

| BEFORE | AFTER 
| ---- | ---
| <video src="https://github.com/user-attachments/assets/61bb40d9-a785-4214-8f7d-67d3ecb97320" /> | <img width="305" height="637" alt="Screenshot 2025-07-27 at 12 18 42 PM" src="https://github.com/user-attachments/assets/ec2c2e59-4001-4d46-8192-9b359c0f8f3b" />

### Testing Instructions

1. Open Ghost Admin in a mobile viewport (DevTools or actual device).
2. Click on "Your profile" ([screenshot](https://cloudup.com/cxziBYfeJGC)).
3. In the profile modal, verify that it does not have the `X` button.