### PR TITLE
Fix: Newsletter performance layout alignment and mobile responsiveness

### DIFF
--- a/apps/posts/src/hooks/usePostSuccessModal.ts
+++ b/apps/posts/src/hooks/usePostSuccessModal.ts
@@ -149,7 +149,7 @@ export const usePostSuccessModal = () => {
             author: getAuthorsText(post.authors),
             onClose: handleClose
         };
-    }, [post, isModalOpen, postCount, site?.title]);
+    }, [post, isModalOpen, postCount, site?.title, site?.icon]);
 
     useEffect(() => {
         const checkForPublishedPost = () => {

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -20,7 +20,6 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
 
     useEffect(() => {
         const handleResize = () => {
-            console.log('vp: ' + getIsSmallViewport());
             setIsSmallViewport(getIsSmallViewport());
         };
 

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -15,12 +15,12 @@ interface NewsletterOverviewProps {
 const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewsletterStatsLoading, isWebShown}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
-    const isSmallViewport = () => Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 600;
-    const [isMobile, setIsMobile] = useState(() => isSmallViewport());
+    const getIsSmallViewport = () => Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 600;
+    const [isSmallViewport, setIsSmallViewport] = useState(() => getIsSmallViewport());
 
     useEffect(() => {
         const handleResize = () => {
-            setIsMobile(isSmallViewport());
+            setIsSmallViewport(getIsSmallViewport());
         };
 
         window.addEventListener('resize', handleResize);
@@ -77,7 +77,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         }
     } satisfies ChartConfig;
 
-    const fullWidth = !isMobile && (post.email_only || !isWebShown);
+    const fullWidth = !isSmallViewport && (post.email_only || !isWebShown);
 
     return (
         <Card className={`group/datalist overflow-hidden ${fullWidth && 'col-span-2'}`}>
@@ -147,7 +147,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                         {!fullWidth && <Separator />}
                         <div className={fullWidth ? '' : 'pt-3'}>
                             <div className={`flex items-center justify-between gap-3 ${fullWidth ? 'pb-3' : 'py-3'}`}>
-                                <span className='text-muted-foreground font-medium'>Top clicked links in this email</span>
+                                <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
                                 <HTable>Members</HTable>
                             </div>
 
@@ -164,7 +164,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                                     }} />
                                                     <DataListItemContent>
                                                         <div className="flex items-center space-x-2 overflow-hidden">
-                                                            <LucideIcon.Link className='text-muted-foreground shrink-0' size={16} strokeWidth={1.5} />
+                                                            <LucideIcon.Link className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />
                                                             <a className="block truncate font-medium hover:underline"
                                                                 href={link.link.to}
                                                                 rel="noreferrer"
@@ -184,7 +184,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                     </DataListBody>
                                 </DataList>
                                 :
-                                <div className='text-gray-700 py-20 text-center text-sm'>
+                                <div className='text-center text-gray-700 py-20 text-sm'>
                                     You have no links in your post.
                                 </div>
                             }

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -60,7 +60,8 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         }
     } satisfies ChartConfig;
 
-    const fullWidth = post.email_only || !isWebShown;
+    const isMobile = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 480;
+    const fullWidth = !isMobile && (post.email_only || !isWebShown);
 
     return (
         <Card className={`group/datalist overflow-hidden ${fullWidth && 'col-span-2'}`}>
@@ -112,23 +113,24 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                 </div>
 
                             </KpiCardHeader>
+                            {!fullWidth && <Separator />}
+                            <div className='mx-auto my-6 h-[240px]'>
+                                <NewsletterRadialChart
+                                    className='pointer-events-none aspect-square h-[240px]'
+                                    config={commonChartConfig}
+                                    data={commonChartData}
+                                    tooltip={false}
+                                />
+                            </div>
                         </div>
-                        {!fullWidth && <Separator />}
-                        <div className='mx-auto my-6 h-[240px]'>
-                            <NewsletterRadialChart
-                                className='pointer-events-none aspect-square h-[240px]'
-                                config={commonChartConfig}
-                                data={commonChartData}
-                                tooltip={false}
-                            />
-                        </div>
+
                     </div>
 
                     <div className={`${fullWidth && 'pl-6'}`}>
                         {!fullWidth && <Separator />}
                         <div className={fullWidth ? '' : 'pt-3'}>
                             <div className={`flex items-center justify-between gap-3 ${fullWidth ? 'pb-3' : 'py-3'}`}>
-                                <span className='font-medium text-muted-foreground'>Top clicked links in this email</span>
+                                <span className='text-muted-foreground font-medium'>Top clicked links in this email</span>
                                 <HTable>Members</HTable>
                             </div>
 

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -77,7 +77,6 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         }
     } satisfies ChartConfig;
 
-    
     const fullWidth = !isMobile && (post.email_only || !isWebShown);
 
     return (
@@ -165,7 +164,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                                     }} />
                                                     <DataListItemContent>
                                                         <div className="flex items-center space-x-2 overflow-hidden">
-                                                            <LucideIcon.Link className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />
+                                                            <LucideIcon.Link className='text-muted-foreground shrink-0' size={16} strokeWidth={1.5} />
                                                             <a className="block truncate font-medium hover:underline"
                                                                 href={link.link.to}
                                                                 rel="noreferrer"
@@ -185,7 +184,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                     </DataListBody>
                                 </DataList>
                                 :
-                                <div className='py-20 text-center text-sm text-gray-700'>
+                                <div className='text-gray-700 py-20 text-center text-sm'>
                                     You have no links in your post.
                                 </div>
                             }

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, ChartConfig, DataList, DataListBar, DataListBody, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue, LucideIcon, Separator, formatNumber, formatPercentage} from '@tryghost/shade';
 import {NewsletterRadialChart, NewsletterRadialChartData} from '../../Newsletter/components/NewsLetterRadialChart';
 import {Post} from '@tryghost/admin-x-framework/api/posts';
@@ -15,6 +15,23 @@ interface NewsletterOverviewProps {
 const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewsletterStatsLoading, isWebShown}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
+    const isSmallViewport = () => Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 600;
+    const [isMobile, setIsMobile] = useState(() => isSmallViewport());
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(isSmallViewport());
+        };
+
+        window.addEventListener('resize', handleResize);
+
+        // Call once to make sure state is in sync on mount
+        handleResize();
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, []);
 
     // Calculate stats from post data
     const stats = useMemo(() => {
@@ -60,7 +77,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
         }
     } satisfies ChartConfig;
 
-    const isMobile = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 480;
+    
     const fullWidth = !isMobile && (post.email_only || !isWebShown);
 
     return (
@@ -113,7 +130,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                 </div>
 
                             </KpiCardHeader>
-                            {!fullWidth && <Separator />}
+                            {!fullWidth && <Separator className="col-span-2" />}
                             <div className='mx-auto my-6 h-[240px]'>
                                 <NewsletterRadialChart
                                     className='pointer-events-none aspect-square h-[240px]'
@@ -122,6 +139,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                     tooltip={false}
                                 />
                             </div>
+                            
                         </div>
 
                     </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -15,11 +15,12 @@ interface NewsletterOverviewProps {
 const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewsletterStatsLoading, isWebShown}) => {
     const {postId} = useParams();
     const navigate = useNavigate();
-    const getIsSmallViewport = () => Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) < 600;
+    const getIsSmallViewport = () => window.matchMedia('(max-width: 600px)').matches;
     const [isSmallViewport, setIsSmallViewport] = useState(() => getIsSmallViewport());
 
     useEffect(() => {
         const handleResize = () => {
+            console.log('vp: ' + getIsSmallViewport());
             setIsSmallViewport(getIsSmallViewport());
         };
 

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -184,7 +184,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                                     </DataListBody>
                                 </DataList>
                                 :
-                                <div className='text-center text-gray-700 py-20 text-sm'>
+                                <div className='py-20 text-center text-sm text-gray-700'>
                                     You have no links in your post.
                                 </div>
                             }


### PR DESCRIPTION
This PR fixes two UI issues in the post analytics view, improving both layout alignment and responsiveness.

### 1.  Align chart with metrics in the "Newsletter performance" section

Previously, the radial chart was center-aligned within its own container, while the “Open rate” and “Click rate” titles were left-aligned in a separate container. This created a visually misaligned layout. 

**Fix**: The radial chart now shares a parent container with the metrics, ensuring consistent alignment and a more balanced layout.
Notice in the "Before" section below, the radial chart is aligned under "Click rate", whereas in "After", the radial chart is more towards the centre between "Open rate" and "Click rate" sections.

| BEFORE | AFTER 
| ---- | ----
| <img width="1379" height="523" alt="Screenshot 2025-07-27 at 7 20 02 PM" src="https://github.com/user-attachments/assets/193bb653-d035-4f4f-9107-10d362698779" /> | <img width="1390" height="551" alt="Screenshot 2025-07-27 at 7 18 29 PM" src="https://github.com/user-attachments/assets/5a29fb54-7821-4448-adc1-cc5ef6705a11" />

### Improve mobile responsiveness

On smaller viewports, the radial chart and the “Top clicked links” section overlapped, reducing readability. This is tracked in [#24509](https://github.com/TryGhost/Ghost/issues/24509).

**Fix**: The layout now stacks correctly on mobile, preventing overlap and maintaining readability.

| BEFORE | AFTER
| ---- | ----
| <img width="321" height="566" alt="Screenshot 2025-07-27 at 12 33 51 PM" src="https://github.com/user-attachments/assets/707bb4d9-9582-4928-9efe-dc8934c59363" /> | <img width="356" height="737" alt="Screenshot 2025-07-27 at 7 44 12 PM" src="https://github.com/user-attachments/assets/e3ec51a6-fdbf-4a56-920e-2cbb4e1f7181" />

**Fluid resize**

https://github.com/user-attachments/assets/d05d05bb-4c6b-4960-825d-cce5f21ea795

### Testing Instructions

1. In your local repo, run the following command to generate dummy stats in `/ghost/core`
```
node index.js generate-data --clear-database --quantities members:10,tags:20,posts:10
```

2. Go to `/posts` and click on a post that has analytics data, so that you're now on `/posts/analytics/`.
3. Verify that the UI for the radial chart in the Overview section matches the scenarios shown in the description.

