### PR TITLE
Fixed duplicate tags and missing post count in tags list

### DIFF
--- a/ghost/admin/app/components/tags/list-item.hbs
+++ b/ghost/admin/app/components/tags/list-item.hbs
@@ -20,7 +20,7 @@
         </LinkTo>
     {{else}}
         <LinkTo @route="tag" @model={{@tag}} class="gh-list-data gh-tag-list-posts-count gh-list-cellwidth-10" title="Edit tag">
-            <span class="nowrap f8 midlightgrey">{{gh-pluralize @tag.count.posts "post"}}</span>
+            <span class="nowrap f8 midlightgrey">0 posts</span>
         </LinkTo>
     {{/if}}
 

--- a/ghost/admin/app/components/tags/list-item.hbs
+++ b/ghost/admin/app/components/tags/list-item.hbs
@@ -20,7 +20,7 @@
         </LinkTo>
     {{else}}
         <LinkTo @route="tag" @model={{@tag}} class="gh-list-data gh-tag-list-posts-count gh-list-cellwidth-10" title="Edit tag">
-            <span class="nowrap f8 midlightgrey">0 posts</span>
+            <span class="nowrap f8 midlightgrey" data-test-tag-count>0 posts</span>
         </LinkTo>
     {{/if}}
 

--- a/ghost/admin/app/controllers/tag.js
+++ b/ghost/admin/app/controllers/tag.js
@@ -45,10 +45,12 @@ export default class TagController extends Controller {
             if (tag.get('errors').length !== 0) {
                 return;
             }
+            const wasNew = tag.isNew;
             yield tag.save();
 
-            this.tagsManager.tagsScreenInfinityModel?.pushObjects([tag]);
-
+            if (wasNew) {
+                this.tagsManager.tagsScreenInfinityModel?.pushObjects([tag]);
+            }
             // replace 'new' route with 'tag' route
             this.replaceRoute('tag', tag);
 

--- a/ghost/admin/app/controllers/tags.js
+++ b/ghost/admin/app/controllers/tags.js
@@ -16,8 +16,8 @@ export default class TagsController extends Controller {
     }
 
     get filteredTags() {
-        // new tags are preemptively added to tagsScreenInfinityModel,
-        // but if the user hasn't fetched them on /tags yet they'll show up twice
+        // new tags are preemptively added to the client-side tagsScreenInfinityModel,
+        // but if the new tag is included in a later pagination request it will end up duplicated
         // this makes sure each tag only shows up once
         const tagMap = new Map();
         

--- a/ghost/admin/app/controllers/tags.js
+++ b/ghost/admin/app/controllers/tags.js
@@ -16,9 +16,18 @@ export default class TagsController extends Controller {
     }
 
     get filteredTags() {
-        return this.tags.filter((tag) => {
-            return (!tag.isNew && !tag.isDestroyed && !tag.isDestroying && !tag.isDeleted && (!this.type || tag.visibility === this.type));
+        // new tags are preemptively added to tagsScreenInfinityModel,
+        // but if the user hasn't fetched them on /tags yet they'll show up twice
+        // this makes sure each tag only shows up once
+        const tagMap = new Map();
+        
+        this.tags.forEach((tag) => {
+            if (!tag.isNew && !tag.isDestroyed && !tag.isDestroying && !tag.isDeleted && (!this.type || tag.visibility === this.type)) {
+                tagMap.set(tag.id, tag);
+            }
         });
+        
+        return [...tagMap.values()];
     }
 
     get sortedTags() {

--- a/ghost/admin/app/templates/tags-loading.hbs
+++ b/ghost/admin/app/templates/tags-loading.hbs
@@ -2,7 +2,7 @@
     <GhCanvasHeader class="gh-canvas-header sticky">
         <h2 class="gh-canvas-title" data-test-screen-title>Tags</h2>
         <section class="view-actions">
-            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary"><span>New tag</span></LinkTo>
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary" data-test-button="new-tag"><span>New tag</span></LinkTo>
         </section>
     </GhCanvasHeader>
 

--- a/ghost/admin/app/templates/tags.hbs
+++ b/ghost/admin/app/templates/tags.hbs
@@ -6,7 +6,7 @@
                 <button class="gh-btn {{if (eq this.type "public") "gh-btn-group-selected"}}" type="button" {{action "changeType" "public"}} data-test-tags-nav="public" data-test-active={{eq this.type "public"}}><span>Public tags</span></button>
                 <button class="gh-btn {{if (eq this.type "internal") "gh-btn-group-selected"}}" type="button" {{action "changeType" "internal"}} data-test-tags-nav="internal" data-test-active={{eq this.type "internal"}}><span>Internal tags</span></button>
             </div>
-            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary"><span>New tag</span></LinkTo>
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary" data-test-button="new-tag"><span>New tag</span></LinkTo>
         </section>
     </GhCanvasHeader>
 

--- a/ghost/admin/tests/acceptance/tags-test.js
+++ b/ghost/admin/tests/acceptance/tags-test.js
@@ -85,6 +85,24 @@ describe('Acceptance: Tags', function () {
             expect(findAll('[data-test-tag]'), 'internal tag list count').to.have.length(2);
         });
 
+        it('can add tags', async function () {
+            await visit('tags');
+            expect(findAll('[data-test-tag]')).to.have.length(0);
+
+            await click('[data-test-button="new-tag"]');
+
+            expect(currentURL()).to.equal('/tags/new');
+
+            await fillIn('[data-test-input="tag-name"]', 'New tag name');
+            await fillIn('[data-test-input="tag-slug"]', 'new-tag-slug');
+            await click('[data-test-button="save"]');
+            await click('[data-test-link="tags-back"]');
+
+            expect(findAll('[data-test-tag]')).to.have.length(1);
+            expect(find('[data-test-tag] [data-test-tag-name]')).to.have.trimmed.text('New tag name');
+            expect(find('[data-test-tag] [data-test-tag-slug]')).to.have.trimmed.text('new-tag-slug');
+        });
+        
         it('can edit tags', async function () {
             const tag = this.server.create('tag', {name: 'To be edited', slug: 'to-be-edited'});
 

--- a/ghost/admin/tests/acceptance/tags-test.js
+++ b/ghost/admin/tests/acceptance/tags-test.js
@@ -115,6 +115,24 @@ describe('Acceptance: Tags', function () {
             expect(tagListItem.querySelector('[data-test-tag-slug]')).to.have.trimmed.text('new-tag-slug');
         });
 
+        it('does not create duplicates when editing a tag', async function () {
+            const tag = this.server.create('tag', {name: 'To be edited', slug: 'to-be-edited'});
+
+            await visit('tags');
+            
+            // Verify we start with one tag
+            expect(findAll('[data-test-tag]')).to.have.length(1);
+
+            await click(`[data-test-tag="${tag.id}"] [data-test-tag-name]`);
+            await fillIn('[data-test-input="tag-name"]', 'Edited Tag Name');
+            await click('[data-test-button="save"]');
+            await click('[data-test-link="tags-back"]');
+
+            // Verify we still have only one tag after editing (no duplicates)
+            expect(findAll('[data-test-tag]')).to.have.length(1);
+            expect(find('[data-test-tag] [data-test-tag-name]')).to.have.trimmed.text('Edited Tag Name');
+        });
+
         it('can delete tags', async function () {
             const tag = this.server.create('tag', {name: 'To be edited', slug: 'to-be-edited'});
             this.server.create('post', {tags: [tag]});

--- a/ghost/admin/tests/acceptance/tags-test.js
+++ b/ghost/admin/tests/acceptance/tags-test.js
@@ -101,6 +101,7 @@ describe('Acceptance: Tags', function () {
             expect(findAll('[data-test-tag]')).to.have.length(1);
             expect(find('[data-test-tag] [data-test-tag-name]')).to.have.trimmed.text('New tag name');
             expect(find('[data-test-tag] [data-test-tag-slug]')).to.have.trimmed.text('new-tag-slug');
+            expect(find('[data-test-tag] [data-test-tag-count]')).to.have.trimmed.text('0 posts');
         });
         
         it('can edit tags', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2478

- fixes an issue where a copy of a tag would get added to the list on /tags on save. Ember already updates items automatically, this change makes it so only new tags are added on save
- also fixes an issue where a new tag would say "posts" instead of "0 posts"

to see the issue:
- on `main`, edit a tag and then click back to /tags. You'll see the tag listed twice. It'll increase every time you edit that tag.
- create a tag, notice it just says "posts"

to see the fix:
- on this branch, create and edit tags. if you have 100+ tags, make some at the beginning and end of the list.
- tags get created and updated correctly, and only show in the list once.