### PR TITLE
🐛 Fixed duplicate tag in list after tag edit

### DIFF
--- a/ghost/admin/app/controllers/tag.js
+++ b/ghost/admin/app/controllers/tag.js
@@ -39,7 +39,8 @@ export default class TagController extends Controller {
 
     @task({drop: true})
     *saveTask() {
-        let {tag} = this;
+        const {tag} = this;
+        const {isNew} = tag;
 
         try {
             if (tag.get('errors').length !== 0) {
@@ -47,7 +48,9 @@ export default class TagController extends Controller {
             }
             yield tag.save();
 
-            this.tagsManager.tagsScreenInfinityModel?.pushObjects([tag]);
+            if (isNew) {
+                this.tagsManager.tagsScreenInfinityModel?.pushObjects([tag]);
+            }
 
             // replace 'new' route with 'tag' route
             this.replaceRoute('tag', tag);

--- a/ghost/admin/app/templates/tags-loading.hbs
+++ b/ghost/admin/app/templates/tags-loading.hbs
@@ -2,7 +2,7 @@
     <GhCanvasHeader class="gh-canvas-header sticky">
         <h2 class="gh-canvas-title" data-test-screen-title>Tags</h2>
         <section class="view-actions">
-            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary"><span>New tag</span></LinkTo>
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary" data-test-button="new-tag"><span>New tag</span></LinkTo>
         </section>
     </GhCanvasHeader>
 

--- a/ghost/admin/app/templates/tags.hbs
+++ b/ghost/admin/app/templates/tags.hbs
@@ -6,7 +6,7 @@
                 <button class="gh-btn {{if (eq this.type "public") "gh-btn-group-selected"}}" type="button" {{action "changeType" "public"}} data-test-tags-nav="public" data-test-active={{eq this.type "public"}}><span>Public tags</span></button>
                 <button class="gh-btn {{if (eq this.type "internal") "gh-btn-group-selected"}}" type="button" {{action "changeType" "internal"}} data-test-tags-nav="internal" data-test-active={{eq this.type "internal"}}><span>Internal tags</span></button>
             </div>
-            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary"><span>New tag</span></LinkTo>
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-primary" data-test-button="new-tag"><span>New tag</span></LinkTo>
         </section>
     </GhCanvasHeader>
 

--- a/ghost/admin/tests/acceptance/tags-test.js
+++ b/ghost/admin/tests/acceptance/tags-test.js
@@ -85,6 +85,24 @@ describe('Acceptance: Tags', function () {
             expect(findAll('[data-test-tag]'), 'internal tag list count').to.have.length(2);
         });
 
+        it('can add tags', async function () {
+            await visit('tags');
+            expect(findAll('[data-test-tag]')).to.have.length(0);
+
+            await click('[data-test-button="new-tag"]');
+
+            expect(currentURL()).to.equal('/tags/new');
+
+            await fillIn('[data-test-input="tag-name"]', 'New tag name');
+            await fillIn('[data-test-input="tag-slug"]', 'new-tag-slug');
+            await click('[data-test-button="save"]');
+            await click('[data-test-link="tags-back"]');
+
+            expect(findAll('[data-test-tag]')).to.have.length(1);
+            expect(find('[data-test-tag] [data-test-tag-name]')).to.have.trimmed.text('New tag name');
+            expect(find('[data-test-tag] [data-test-tag-slug]')).to.have.trimmed.text('new-tag-slug');
+        });
+
         it('can edit tags', async function () {
             const tag = this.server.create('tag', {name: 'To be edited', slug: 'to-be-edited'});
 
@@ -109,6 +127,9 @@ describe('Acceptance: Tags', function () {
             expect(savedTag.slug, 'saved tag slug').to.equal('new-tag-slug');
 
             await click('[data-test-link="tags-back"]');
+
+            // there should not be any duplicate entries
+            expect(findAll('[data-test-tag]')).to.have.length(1, 'edited tag was duplicated in list');
 
             const tagListItem = find('[data-test-tag]');
             expect(tagListItem.querySelector('[data-test-tag-name]')).to.have.trimmed.text('New tag name');


### PR DESCRIPTION
closes https://linear.app/ghost/issue/ENG-2478

- adds conditional so we only push a tag onto the tags list after save when it's a new tag, for edits we can rely on Ember auto-updating
