### PR TITLE
Fixed toast color mode inconsistency

### DIFF
--- a/apps/shade/src/components/ui/sonner.tsx
+++ b/apps/shade/src/components/ui/sonner.tsx
@@ -1,26 +1,19 @@
-import {useTheme} from 'next-themes';
 import {Toaster as Sonner} from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({...props}: ToasterProps) => {
-    const {theme = 'system'} = useTheme();
-
     return (
         <Sonner
             className="toaster group"
-            theme={theme as ToasterProps['theme']}
-            toastOptions={{
-                classNames: {
-                    toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-                    description: 'group-[.toast]:text-muted-foreground',
-                    actionButton:
-            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-                    cancelButton:
-            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'
-                }
-            }}
+            style={
+                {
+                    '--normal-bg': 'hsl(var(--background))',
+                    '--normal-text': 'hsl(var(--foreground))',
+                    '--normal-border': 'hsl(var(--border))'
+                } as React.CSSProperties
+            }
+            theme="light" // Always force light to prevent browser override
             {...props}
         />
     );


### PR DESCRIPTION
ref PROD-2346

- Prevented browser settings from overriding toast appearance
- Ensured Sonner toast library respects application's color mode settings
- Fixed issue where toasts appeared in dark mode while app was in light mode