### PR TITLE
Added word break for long handles in profile share widget in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
@@ -129,8 +129,7 @@ const ProfileCard: React.FC<ProfileCardProps> = memo(({
                         background: accentColor ? `linear-gradient(to top right, ${hexToRgba(backgroundColor === 'accent' ? '#ffffff' : accentColor, backgroundColor === 'dark' ? 0.12 : 0.04)}, ${hexToRgba(backgroundColor === 'accent' ? '#ffffff' : accentColor, backgroundColor === 'dark' ? 0.48 : 0.16)})` : undefined
                     }}
                 >
-                    {/* {account?.handle} */}
-                    @verylonghandlelolwhydidyoudothis@main.ghost.org
+                    {account?.handle}
                 </div>
             </div>
         </div>

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Profile.tsx
@@ -122,14 +122,15 @@ const ProfileCard: React.FC<ProfileCardProps> = memo(({
                 <H2 className={`${isScreenshot && 'tracking-normal'}`} style={{color: textColor}}>{!isLoading ? account?.name : <Skeleton className='w-32' />}</H2>
                 <span className={`mt-1.5 leading-7 ${isScreenshot && 'tracking-normal'}`} style={{color: textColor}}>{!isLoading ? 'Available on Ghost, Flipboard, Threads, Bluesky, Mastodon, or wherever you get your social web feeds.' : <Skeleton className='w-28' />}</span>
                 <div
-                    className={`mt-auto flex max-h-[60px] min-h-12 w-full items-center justify-center rounded-full border px-4 py-2 font-medium leading-7 ${isScreenshot && 'tracking-normal'}`}
+                    className={`mt-auto flex max-h-[60px] min-h-12 w-full items-center justify-center break-all rounded-full border px-4 py-2 font-medium leading-7 ${isScreenshot && 'tracking-normal'}`}
                     style={{
                         color: backgroundColor !== 'light' ? '#fff' : accentColor,
                         borderColor: accentColor ? hexToRgba(backgroundColor === 'accent' ? '#ffffff' : accentColor, backgroundColor !== 'light' ? 0.7 : 0.2) : undefined,
                         background: accentColor ? `linear-gradient(to top right, ${hexToRgba(backgroundColor === 'accent' ? '#ffffff' : accentColor, backgroundColor === 'dark' ? 0.12 : 0.04)}, ${hexToRgba(backgroundColor === 'accent' ? '#ffffff' : accentColor, backgroundColor === 'dark' ? 0.48 : 0.16)})` : undefined
                     }}
                 >
-                    {account?.handle}
+                    {/* {account?.handle} */}
+                    @verylonghandlelolwhydidyoudothis@main.ghost.org
                 </div>
             </div>
         </div>


### PR DESCRIPTION
ref PROD-2343

- Implemented text wrapping for lengthy usernames in profile share widget
- Ensured profile information remains visible regardless of handle length