### PR TITLE
Fixed order of averages on Newsletters tab

### DIFF
--- a/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
+++ b/apps/stats/src/hooks/useNewsletterStatsWithRange.ts
@@ -6,7 +6,7 @@ import {useNewsletterBasicStats, useNewsletterClickStats, useNewsletterStats, us
 /**
  * Represents the possible fields to order top newsletters by.
  */
-export type TopNewslettersOrder = 'date desc' | 'open_rate desc' | 'click_rate desc' | 'sent_to desc';
+export type TopNewslettersOrder = 'date asc' | 'date desc' | 'open_rate desc' | 'click_rate desc' | 'sent_to desc';
 
 /**
  * Hook to fetch Newsletter Stats, handling the conversion from a numeric range

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -350,7 +350,7 @@ const Newsletters: React.FC = () => {
             open_rate: stat.open_rate,
             total_clicks: stat.total_clicks || 0,
             click_rate: stat.click_rate || 0
-        }));
+        })).sort((a, b) => new Date(a.send_date).getTime() - new Date(b.send_date).getTime());
     }, [newsletterStatsData]);
 
     // Separate loading states for different sections

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -250,7 +250,7 @@ const Newsletters: React.FC = () => {
     // and to calculate averages - using the same data source as the table for consistency
     const {data: newsletterStatsData, isLoading: isNewsletterStatsLoading, isClicksLoading} = useNewsletterStatsWithRangeSplit(
         range,
-        'date desc',
+        'date asc',
         selectedNewsletterId || undefined,
         shouldFetchStats || false
     );
@@ -350,7 +350,7 @@ const Newsletters: React.FC = () => {
             open_rate: stat.open_rate,
             total_clicks: stat.total_clicks || 0,
             click_rate: stat.click_rate || 0
-        })).sort((a, b) => new Date(a.send_date).getTime() - new Date(b.send_date).getTime());
+        }));
     }, [newsletterStatsData]);
 
     // Separate loading states for different sections


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2483/analytics-newsletters-graph-shows-data-from-newest-to-oldest-instead

- The order of newsletters on the Newsletters / Avg. open rate and Avg. click rate tabs were by date descending
