### PR TITLE
Fixed minor UI bugs in Analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -454,7 +454,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                                                             {title}
                                                                         </a>
                                                                         {edited && (
-                                                                            <span className='text-xs text-gray-500'>(edited)</span>
+                                                                            <span className='ml-1 text-gray-500'>(edited)</span>
                                                                         )}
                                                                     </>
                                                                 )}

--- a/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/LatestPost.tsx
@@ -104,8 +104,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 <div className='mt-0.5 text-sm text-muted-foreground'>
                                     {latestPostStats.authors && latestPostStats.authors.length > 0 && (
                                         <div>
-                                            By {latestPostStats.authors.map(author => author.name).join(', ')} &ndash;
-                                            {formatDisplayDate(latestPostStats.published_at)}
+                                            By {latestPostStats.authors.map(author => author.name).join(', ')} &ndash; {formatDisplayDate(latestPostStats.published_at)}
                                         </div>
                                     )}
                                     <div className='mt-0.5'>

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -394,7 +394,7 @@
 
 .gh-post-list-feature-image-placeholder {
     position: relative;
-    height: 100%;
+    height: auto;
     width: 100%;
     opacity: 0.5;
     display: flex;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2465/overview-empty-space-missing-before-date-for-post-date-in-latest
ref https://linear.app/ghost/issue/PROD-2334/newsletter-link-edited-text-is-tightly-spaced

- Added space before newsletter link "(edited)" link
- Added missing space for post date in latest post on Analytics overview
- Fixed buggy aspect ratio of post placeholder image in post list in Safari