### PR TITLE
Skipped set/drop nullable migration queries when not necessary

### DIFF
--- a/ghost/core/test/integration/migrations/nullable-utils.test.js
+++ b/ghost/core/test/integration/migrations/nullable-utils.test.js
@@ -1,0 +1,340 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../utils');
+const dbUtils = require('../../utils/db-utils');
+const logging = require('@tryghost/logging');
+
+const utils = require('../../../core/server/data/migrations/utils');
+const db = require('../../../core/server/data/db');
+
+describe('Migrations - schema utils', function () {
+    const tableName = 'test_nullable_integration';
+
+    before(async function () {
+        await testUtils.startGhost();
+    });
+
+    beforeEach(async function () {
+        // Clean up any existing test tables first
+        const knex = db.knex;
+        
+        if (await knex.schema.hasTable(tableName)) {
+            await knex.schema.dropTable(tableName);
+        }
+        if (await knex.schema.hasTable('test_foreign_table')) {
+            await knex.schema.dropTable('test_foreign_table');
+        }
+
+        // Create a second table for foreign key testing first
+        await knex.schema.createTable('test_foreign_table', function (table) {
+            table.increments('id');
+            table.string('name');
+        });
+
+        await knex.schema.createTable(tableName, function (table) {
+            table.increments('id');
+            table.string('nullable_col').nullable();
+            table.string('not_nullable_col').notNullable();
+            table.string('mixed_col').notNullable();
+            table.string('with_default').notNullable().defaultTo('default');
+            table.integer('foreign_key_col').unsigned();
+        });
+
+        // Note: We're not adding actual foreign key constraints in these tests
+        // because MySQL has limitations with modifying columns that have foreign keys,
+        // even with foreign_key_checks disabled. The tests verify that the 
+        // disableForeignKeyChecks option is properly passed through to the migration.
+
+        // Insert test data
+        await knex('test_foreign_table').insert({id: 1, name: 'test'});
+        await knex(tableName).insert({
+            nullable_col: 'test',
+            not_nullable_col: 'required',
+            mixed_col: 'data',
+            with_default: 'custom',
+            foreign_key_col: 1
+        });
+    });
+
+    afterEach(async function () {
+        const knex = db.knex;
+
+        // Drop tables in correct order due to foreign key constraints
+        if (await knex.schema.hasTable(tableName)) {
+            if (dbUtils.isMySQL()) {
+                try {
+                    // Get all foreign keys for the table
+                    const fks = await knex.raw(`
+                        SELECT CONSTRAINT_NAME 
+                        FROM information_schema.TABLE_CONSTRAINTS 
+                        WHERE TABLE_SCHEMA = DATABASE() 
+                        AND TABLE_NAME = ? 
+                        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+                    `, [tableName]);
+                    
+                    // Drop each foreign key
+                    for (const fk of fks[0]) {
+                        await knex.raw(`ALTER TABLE ?? DROP FOREIGN KEY ??`, [tableName, fk.CONSTRAINT_NAME]);
+                    }
+                } catch (err) {
+                    // Foreign keys might not exist, continue
+                }
+            }
+            await knex.schema.dropTable(tableName);
+        }
+
+        if (await knex.schema.hasTable('test_foreign_table')) {
+            await knex.schema.dropTable('test_foreign_table');
+        }
+
+        sinon.restore();
+    });
+
+    async function isColumnNullable(table, column) {
+        const knex = db.knex;
+        
+        if (dbUtils.isSQLite()) {
+            const response = await knex.raw('PRAGMA table_info(??)', [table]);
+            const columnInfo = response.find(col => col.name === column);
+            return columnInfo && columnInfo.notnull === 0;
+        } else {
+            const response = await knex.raw('SHOW COLUMNS FROM ??', [table]);
+            const columnInfo = response[0].find(col => col.Field === column);
+            return columnInfo && columnInfo.Null === 'YES';
+        }
+    }
+
+    async function isColumnNotNullable(table, column) {
+        const knex = db.knex;
+        
+        if (dbUtils.isSQLite()) {
+            const response = await knex.raw('PRAGMA table_info(??)', [table]);
+            const columnInfo = response.find(col => col.name === column);
+            return columnInfo && columnInfo.notnull === 1;
+        } else {
+            const response = await knex.raw('SHOW COLUMNS FROM ??', [table]);
+            const columnInfo = response[0].find(col => col.Field === column);
+            return columnInfo && columnInfo.Null === 'NO';
+        }
+    }
+
+    describe('createSetNullableMigration', function () {
+        it('Sets a not-nullable column to nullable', async function () {
+            const migration = utils.createSetNullableMigration(tableName, 'not_nullable_col');
+
+            // Verify initial state
+            const isNotNullableInitial = await isColumnNotNullable(tableName, 'not_nullable_col');
+            should.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
+
+            // Run up migration
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            // Verify column is now nullable
+            const isNullableAfter = await isColumnNullable(tableName, 'not_nullable_col');
+            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+
+            // Run down migration with foreign key checks disabled
+            const transactingDown = await db.knex.transaction();
+            await migration.down({transacting: transactingDown});
+            await transactingDown.commit();
+
+            // Verify column is not nullable again
+            const isNotNullableAfterDown = await isColumnNotNullable(tableName, 'not_nullable_col');
+            should.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
+        });
+
+        it('Skips setting nullable when column is already nullable', async function () {
+            const migration = utils.createSetNullableMigration(tableName, 'nullable_col');
+            const logSpy = sinon.spy(logging, 'warn');
+
+            // Verify initial state
+            const isNullableInitial = await isColumnNullable(tableName, 'nullable_col');
+            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+
+            // Run up migration
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            should.ok(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+
+            // Column should still be nullable
+            const isNullableAfter = await isColumnNullable(tableName, 'nullable_col');
+            should.equal(isNullableAfter, true, 'Column should still be nullable');
+        });
+
+        it('Handles disableForeignKeyChecks option in down migration', async function () {
+            // This test verifies that the disableForeignKeyChecks option works correctly
+            const migration = utils.createSetNullableMigration(tableName, 'mixed_col', {
+                disableForeignKeyChecks: true
+            });
+
+            // Run up migration first
+            const transactingUp = await db.knex.transaction();
+            await migration.up({transacting: transactingUp});
+            await transactingUp.commit();
+
+            // Verify column is nullable
+            const isNullableAfter = await isColumnNullable(tableName, 'mixed_col');
+            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+
+            // Run down migration with foreign key checks disabled
+            const transactingDown = await db.knex.transaction();
+            await migration.down({transacting: transactingDown});
+            await transactingDown.commit();
+
+            // Verify column is not nullable again
+            const isNotNullableAfterDown = await isColumnNotNullable(tableName, 'mixed_col');
+            should.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
+            
+            // The test passes if no errors were thrown
+            // The disableForeignKeyChecks option is being used internally
+        });
+    });
+
+    describe('createDropNullableMigration', function () {
+        it('Drops nullable from a nullable column', async function () {
+            const migration = utils.createDropNullableMigration(tableName, 'nullable_col');
+
+            // Verify initial state
+            const isNullableInitial = await isColumnNullable(tableName, 'nullable_col');
+            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+
+            // Run up migration
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            // Verify column is now not nullable
+            const isNotNullableAfter = await isColumnNotNullable(tableName, 'nullable_col');
+            should.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
+
+            // Run down migration
+            const transactingDown = await db.knex.transaction();
+            await migration.down({transacting: transactingDown});
+            await transactingDown.commit();
+
+            // Verify column is nullable again
+            const isNullableAfterDown = await isColumnNullable(tableName, 'nullable_col');
+            should.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
+        });
+
+        it('Skips dropping nullable when column is already not nullable', async function () {
+            const migration = utils.createDropNullableMigration(tableName, 'not_nullable_col');
+            const logSpy = sinon.spy(logging, 'warn');
+
+            // Verify initial state
+            const isNotNullableInitial = await isColumnNotNullable(tableName, 'not_nullable_col');
+            should.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
+
+            // Run up migration
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            should.ok(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+
+            // Column should still be not nullable
+            const isNotNullableAfter = await isColumnNotNullable(tableName, 'not_nullable_col');
+            should.equal(isNotNullableAfter, true, 'Column should still be not nullable');
+        });
+
+        it('Handles disableForeignKeyChecks option when dropping nullable', async function () {
+            // This test verifies that the disableForeignKeyChecks option works correctly
+            const testColumn = 'nullable_col';
+            const migration = utils.createDropNullableMigration(tableName, testColumn, {
+                disableForeignKeyChecks: true
+            });
+
+            // Verify column is initially nullable
+            const isNullableInitial = await isColumnNullable(tableName, testColumn);
+            should.equal(isNullableInitial, true, 'Column should be nullable before test');
+
+            // Run up migration with foreign key checks disabled
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            // Verify column is not nullable
+            const isNotNullableAfter = await isColumnNotNullable(tableName, testColumn);
+            should.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
+            
+            // The test passes if no errors were thrown
+            // The disableForeignKeyChecks option is being used internally
+        });
+    });
+
+    describe('Database-specific edge cases', function () {
+        it('Handles columns with default values correctly', async function () {
+            // Test with a column that has a default value
+            const migration = utils.createDropNullableMigration(tableName, 'with_default');
+
+            // First make it nullable
+            const setNullableMigration = utils.createSetNullableMigration(tableName, 'with_default');
+            const transactingSetup = await db.knex.transaction();
+            await setNullableMigration.up({transacting: transactingSetup});
+            await transactingSetup.commit();
+
+            // Run drop nullable migration
+            const transacting = await db.knex.transaction();
+            await migration.up({transacting});
+            await transacting.commit();
+
+            // Verify column is not nullable and still has its default
+            const isNotNullable = await isColumnNotNullable(tableName, 'with_default');
+            should.equal(isNotNullable, true, 'Column should be not nullable');
+            
+            // Verify default value is preserved (MySQL-specific check)
+            if (dbUtils.isMySQL()) {
+                const response = await db.knex.raw('SHOW COLUMNS FROM ??', [tableName]);
+                const columnInfo = response[0].find(col => col.Field === 'with_default');
+                should.equal(columnInfo.Default, 'default', 'Column should still have its default value');
+            }
+        });
+
+        it('Handles non-existent table errors', async function () {
+            const migration = utils.createSetNullableMigration('non_existent_table', 'some_column');
+            const logWarnSpy = sinon.spy(logging, 'warn');
+
+            let transacting;
+            let errorThrown = false;
+            let errorMessage = '';
+            try {
+                transacting = await db.knex.transaction();
+                await migration.up({transacting});
+                await transacting.commit();
+            } catch (error) {
+                errorThrown = true;
+                errorMessage = error.message;
+                // Expected to fail when actually trying to alter the non-existent table
+                if (transacting && !transacting.isCompleted()) {
+                    await transacting.rollback();
+                }
+            }
+            
+            // The behavior differs between databases:
+            // - MySQL: SHOW COLUMNS will throw an error for non-existent table, logging a warning
+            // - SQLite: PRAGMA table_info returns empty result, no error until ALTER TABLE
+            
+            if (dbUtils.isMySQL()) {
+                // MySQL should log a warning when checking nullable status fails
+                should.ok(logWarnSpy.calledWith(sinon.match('Could not check nullable status')), 
+                    'MySQL should log warning about checking nullable status');
+            }
+            
+            // Both databases should eventually fail when trying to ALTER the non-existent table
+            should.ok(errorThrown, 'Should throw an error when trying to alter non-existent table');
+            
+            // The error message varies between databases and Knex versions
+            // SQLite might give a Knex internal error or a 'no such table' error
+            // MySQL should give a 'table does not exist' error
+            const isExpectedError = errorMessage.match(/no such table|does not exist|doesn't exist|Table .* not found/i) ||
+                                  errorMessage.includes('Cannot read properties of undefined') ||
+                                  errorMessage.includes('SQLITE_ERROR');
+            
+            should.ok(isExpectedError, `Error should be related to missing table, but was: ${errorMessage}`);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -702,3 +702,168 @@ describe('migrations/utils/settings', function () {
         });
     });
 });
+
+async function setupNullableTestDb() {
+    const knex = Knex({
+        client: 'sqlite3',
+        connection: {
+            filename: ':memory:'
+        },
+        useNullAsDefault: true
+    });
+
+    // Create test table with mixed nullable/not-nullable columns
+    await knex.raw(`
+        CREATE TABLE test_nullable_migration (
+            id INTEGER PRIMARY KEY,
+            nullable_col TEXT NULL,
+            not_nullable_col TEXT NOT NULL,
+            mixed_col TEXT NOT NULL
+        );
+    `);
+
+    // Insert test data
+    await knex('test_nullable_migration').insert({
+        id: 1,
+        nullable_col: 'test',
+        not_nullable_col: 'required',
+        mixed_col: 'data'
+    });
+
+    return knex;
+}
+
+// Helper function to check column nullable status for SQLite
+async function checkColumnNullable(table, column, knex) {
+    const response = await knex.raw(`PRAGMA table_info("${table}")`);
+    const columnInfo = response.find(col => col.name === column);
+    return columnInfo ? columnInfo.notnull === 0 : null;
+}
+
+describe('migrations/utils/schema nullable functions', function () {
+    describe('createSetNullableMigration', function () {
+        it('Sets a not-nullable column to nullable', async function () {
+            const knex = await setupNullableTestDb();
+            
+            const migration = utils.createSetNullableMigration('test_nullable_migration', 'not_nullable_col');
+
+            should.ok(migration.config.transaction, 'createSetNullableMigration creates a transactional migration');
+
+            // Verify initial state - column should be not nullable
+            const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+            should.equal(isNullableInitial, false, 'Column should initially be not nullable');
+
+            const runDownMigration = await runUpMigration(knex, migration);
+
+            // Verify column is now nullable
+            const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+
+            // Test down migration
+            await runDownMigration();
+            const isNullableAfterDown = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+            should.equal(isNullableAfterDown, false, 'Column should be not nullable after down migration');
+
+            await knex.destroy();
+        });
+
+        it('Skips setting nullable when column is already nullable', async function () {
+            const knex = await setupNullableTestDb();
+
+            const migration = utils.createSetNullableMigration('test_nullable_migration', 'nullable_col');
+
+            // Verify initial state - column should already be nullable
+            const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+
+            // Spy on logging to verify skip message
+            const logSpy = sinon.spy(require('@tryghost/logging'), 'warn');
+
+            try {
+                const runDownMigration = await runUpMigration(knex, migration);
+
+                should.ok(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+
+                // Column should still be nullable
+                const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+                should.equal(isNullableAfter, true, 'Column should still be nullable');
+
+                await runDownMigration();
+            } finally {
+                logSpy.restore();
+                
+                await knex.destroy();
+            }
+        });
+    });
+
+    describe('createDropNullableMigration', function () {
+        it('Drops nullable from a nullable column', async function () {
+            const knex = await setupNullableTestDb();
+
+            const migration = utils.createDropNullableMigration('test_nullable_migration', 'nullable_col');
+
+            should.ok(migration.config.transaction, 'createDropNullableMigration creates a transactional migration');
+
+            // Verify initial state - column should be nullable
+            const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+
+            const runDownMigration = await runUpMigration(knex, migration);
+
+            // Verify column is now not nullable
+            const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+            should.equal(isNotNullableAfter, false, 'Column should be not nullable after up migration');
+
+            // Test down migration (should set back to nullable)
+            await runDownMigration();
+            const isNullableAfterDown = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+            should.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
+
+            await knex.destroy();
+        });
+
+        it('Skips dropping nullable when column is already not nullable', async function () {
+            const knex = await setupNullableTestDb();
+
+            const migration = utils.createDropNullableMigration('test_nullable_migration', 'not_nullable_col');
+
+            // Verify initial state - column should already be not nullable
+            const isNotNullableInitial = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+            should.equal(isNotNullableInitial, false, 'Column should initially be not nullable');
+
+            // Spy on logging to verify skip message
+            const logSpy = sinon.spy(require('@tryghost/logging'), 'warn');
+
+            try {
+                const runDownMigration = await runUpMigration(knex, migration);
+
+                should.ok(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+
+                // Column should still be not nullable
+                const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+                should.equal(isNotNullableAfter, false, 'Column should still be not nullable');
+
+                await runDownMigration();
+            } finally {
+                logSpy.restore();
+                
+                await knex.destroy();
+            }
+        });
+    });
+
+    describe('helper functions', function () {
+        it('Nullable status detection works correctly', async function () {
+            const knex = await setupNullableTestDb();
+
+            const nullableResult = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
+            const notNullableResult = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
+
+            should.equal(nullableResult, true, 'Should identify nullable column correctly');
+            should.equal(notNullableResult, false, 'Should identify not nullable column correctly');
+
+            await knex.destroy();
+        });
+    });
+});

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 
 const utils = require('../../../../../core/server/data/migrations/utils');
 
@@ -735,7 +736,7 @@ async function setupNullableTestDb() {
 
 // Helper function to check column nullable status for SQLite
 async function checkColumnNullable(table, column, knex) {
-    const response = await knex.raw(`PRAGMA table_info("${table}")`);
+    const response = await knex.raw(`PRAGMA table_info(??)`, [table]);
     const columnInfo = response.find(col => col.name === column);
     return columnInfo ? columnInfo.notnull === 0 : null;
 }
@@ -744,7 +745,7 @@ describe('migrations/utils/schema nullable functions', function () {
     describe('createSetNullableMigration', function () {
         it('Sets a not-nullable column to nullable', async function () {
             const knex = await setupNullableTestDb();
-            
+
             const migration = utils.createSetNullableMigration('test_nullable_migration', 'not_nullable_col');
 
             should.ok(migration.config.transaction, 'createSetNullableMigration creates a transactional migration');
@@ -777,7 +778,7 @@ describe('migrations/utils/schema nullable functions', function () {
             should.equal(isNullableInitial, true, 'Column should initially be nullable');
 
             // Spy on logging to verify skip message
-            const logSpy = sinon.spy(require('@tryghost/logging'), 'warn');
+            const logSpy = sinon.spy(logging, 'warn');
 
             try {
                 const runDownMigration = await runUpMigration(knex, migration);
@@ -791,7 +792,7 @@ describe('migrations/utils/schema nullable functions', function () {
                 await runDownMigration();
             } finally {
                 logSpy.restore();
-                
+
                 await knex.destroy();
             }
         });
@@ -847,7 +848,7 @@ describe('migrations/utils/schema nullable functions', function () {
                 await runDownMigration();
             } finally {
                 logSpy.restore();
-                
+
                 await knex.destroy();
             }
         });


### PR DESCRIPTION
no issue

- added pre-condition checks to `createDropNullableMigration` and `createSetNullableMigration` migration utils that skips expensive `ALTER TABLE` queries when the database is already in the correct state
