### PR TITLE
Fixed member growth source of Direct showing as a link

### DIFF
--- a/apps/admin-x-framework/src/utils/source-utils.ts
+++ b/apps/admin-x-framework/src/utils/source-utils.ts
@@ -202,6 +202,11 @@ export const getFaviconDomain = (source: string | number | undefined, siteUrl?: 
     if (!source || typeof source !== 'string') {
         return {domain: null, isDirectTraffic: false};
     }
+    
+    // Handle 'Direct' source explicitly
+    if (source === 'Direct') {
+        return {domain: null, isDirectTraffic: true};
+    }
 
     // Extract site domain for comparison
     const siteDomain = siteUrl ? extractDomain(siteUrl) : null;

--- a/apps/admin-x-framework/test/unit/utils/source-utils.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/source-utils.test.ts
@@ -259,6 +259,17 @@ describe('source-utils', () => {
                 isDirectTraffic: false
             });
         });
+
+        it('handles Direct source explicitly', () => {
+            expect(getFaviconDomain('Direct')).toEqual({
+                domain: null,
+                isDirectTraffic: true
+            });
+            expect(getFaviconDomain('Direct', 'https://example.com')).toEqual({
+                domain: null,
+                isDirectTraffic: true
+            });
+        });
     });
 
     describe('processSources', () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2336/
- 'Direct' should not link; we handle this in other components, and needed to add handling here to prevent dead/broken links

__Testing__
- [x] Publish a post and sign up a new member through direct navigation. Go to Post Analytics > Growth an ensure Direct is not a link.