### PR TITLE
Prevented stats script from loading within iframes

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -151,6 +151,11 @@ function getWebmentionDiscoveryLink() {
 }
 
 function getTinybirdTrackerScript(dataRoot) {
+    const preview = dataRoot?.context?.includes('preview');
+    if (preview) {
+        return '';
+    }
+
     const src = getAssetUrl('public/ghost-stats.min.js', false);
 
     const env = config.get('env');

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -151,11 +151,6 @@ function getWebmentionDiscoveryLink() {
 }
 
 function getTinybirdTrackerScript(dataRoot) {
-    const preview = dataRoot?.context?.includes('preview');
-    if (preview) {
-        return '';
-    }
-
     const src = getAssetUrl('public/ghost-stats.min.js', false);
 
     const env = config.get('env');

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -212,7 +212,6 @@ export class GhostStats {
 
         // Skip if page is loaded in an iframe (admin preview, embeds, etc.)
         if (this.browser.window && this.browser.window.self !== this.browser.window.top) {
-            console.log('Ghost Stats: Skipping initialization in iframe');
             return false;
         }
 

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -210,6 +210,12 @@ export class GhostStats {
             return false;
         }
 
+        // Skip if page is loaded in an iframe (admin preview, embeds, etc.)
+        if (this.browser.window && this.browser.window.self !== this.browser.window.top) {
+            console.log('Ghost Stats: Skipping initialization in iframe');
+            return false;
+        }
+
         // Initialize configuration
         const configInitialized = this.initConfig();
         if (!configInitialized) {

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1476,16 +1476,6 @@ describe('{{ghost_head}} helper', function () {
             rendered.should.match(/data-datasource="analytics_events"/);
         });
 
-        it('does not include tracker script when preview is set', async function () {
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                locals: {
-                    context: ['preview', 'post']
-                }
-            }));
-
-            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js"/);
-        });
-
         it('uses the provided host/endpoint from config', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
@@ -1537,17 +1527,6 @@ describe('{{ghost_head}} helper', function () {
             }));
 
             rendered.should.not.match(/data-token=/);
-        });
-
-        it('does not include tracker script in preview context', async function () {
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                locals: {
-                    relativeUrl: '/',
-                    context: ['preview', 'home', 'index'],
-                    safeVersion: '4.3'
-                }
-            }));
-            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
         });
     });
     describe('respects values from excludes: ', function () {

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1476,6 +1476,16 @@ describe('{{ghost_head}} helper', function () {
             rendered.should.match(/data-datasource="analytics_events"/);
         });
 
+        it('does not include tracker script when preview is set', async function () {
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    context: ['preview', 'post']
+                }
+            }));
+
+            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js"/);
+        });
+
         it('uses the provided host/endpoint from config', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
@@ -1529,6 +1539,18 @@ describe('{{ghost_head}} helper', function () {
             rendered.should.not.match(/data-token=/);
         });
     });
+
+    it('does not include tracker script in preview context', async function () {
+        const rendered = await testGhostHead(testUtils.createHbsResponse({
+            locals: {
+                relativeUrl: '/',
+                context: ['preview', 'home', 'index'],
+                safeVersion: '4.3'
+            }
+        }));
+        rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+    });
+
     describe('respects values from excludes: ', function () {
         it('when excludes is empty', async function () {
             getStub.withArgs('members_enabled').returns(true);

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1538,17 +1538,17 @@ describe('{{ghost_head}} helper', function () {
 
             rendered.should.not.match(/data-token=/);
         });
-    });
 
-    it('does not include tracker script in preview context', async function () {
-        const rendered = await testGhostHead(testUtils.createHbsResponse({
-            locals: {
-                relativeUrl: '/',
-                context: ['preview', 'home', 'index'],
-                safeVersion: '4.3'
-            }
-        }));
-        rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+        it('does not include tracker script in preview context', async function () {
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['preview', 'home', 'index'],
+                    safeVersion: '4.3'
+                }
+            }));
+            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+        });    
     });
 
     describe('respects values from excludes: ', function () {

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -490,7 +490,7 @@ describe('ghost-stats.js', function () {
             const originalSelf = mockWindow.self;
             const originalTop = mockWindow.top;
             mockWindow.self = mockWindow;
-            mockWindow.top = { different: 'window' }; // Different from self
+            mockWindow.top = {different: 'window'}; // Different from self
             
             expect(ghostStats.init()).to.be.false;
             expect(mockWindow.Tinybird).to.not.exist;

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -481,6 +481,39 @@ describe('ghost-stats.js', function () {
             mockWindow.Cypress = undefined;
         });
 
+        it('should skip initialization when in an iframe', function () {
+            // Configure with valid settings
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            
+            // Simulate being in an iframe (window.self !== window.top)
+            const originalSelf = mockWindow.self;
+            const originalTop = mockWindow.top;
+            mockWindow.self = mockWindow;
+            mockWindow.top = { different: 'window' }; // Different from self
+            
+            expect(ghostStats.init()).to.be.false;
+            expect(mockWindow.Tinybird).to.not.exist;
+            
+            // Restore original values
+            mockWindow.self = originalSelf;
+            mockWindow.top = originalTop;
+        });
+
+        it('should initialize when NOT in an iframe', function () {
+            // Configure with valid settings
+            mockDocument.currentScript.getAttribute.withArgs('data-host').returns('https://test.com');
+            mockDocument.currentScript.getAttribute.withArgs('data-token').returns('test-token');
+            
+            // Simulate NOT being in an iframe (window.self === window.top)
+            mockWindow.self = mockWindow;
+            mockWindow.top = mockWindow; // Same as self
+            
+            expect(ghostStats.init()).to.be.true;
+            expect(mockWindow.Tinybird).to.exist;
+            expect(typeof mockWindow.Tinybird.trackEvent).to.equal('function');
+        });
+
         it('should handle missing configuration gracefully', function () {
             expect(ghostStats.init()).to.be.false;
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2338/

We previously had handling for post preview, but navigation past that first view was still loading ghost_head, and any query param/middleware solutions were ephemeral as well.

It's common practice to prevent loading of stats scripts within iframes for a variety of reasons, and this is a far simpler and more robust implementation.

__Testing__
- [ ] Clicking around in Admin > Site does not make a network request to web_analytics. 
- [ ] Click around in Editor > Preview does not make a network request to web_analytics.