### PR TITLE
Fixed visitor count percentages in top content component

### DIFF
--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -120,6 +120,7 @@ const Web: React.FC = () => {
                 <div className='flex min-h-[460px] grid-cols-2 flex-col gap-8 lg:grid'>
                     <TopContent
                         range={range}
+                        totalVisitors={totalVisitors}
                     />
                     <SourcesCard
                         data={sourcesData as SourcesData[] | null}

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -86,9 +86,10 @@ const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, d
 
 interface TopContentProps {
     range: number;
+    totalVisitors: number;
 }
 
-const TopContent: React.FC<TopContentProps> = ({range}) => {
+const TopContent: React.FC<TopContentProps> = ({range, totalVisitors}) => {
     const {audience} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
@@ -128,20 +129,17 @@ const TopContent: React.FC<TopContentProps> = ({range}) => {
             return null;
         }
 
-        // Calculate total visits for the filtered dataset
-        const filteredTotalVisits = data.reduce((sum, item) => sum + Number(item.visits), 0);
-
         return data.map(item => ({
             pathname: item.pathname,
             title: item.title || item.pathname,
             visits: item.visits,
-            percentage: filteredTotalVisits > 0 ? (Number(item.visits) / filteredTotalVisits) : 0,
+            percentage: totalVisitors > 0 ? (Number(item.visits) / totalVisitors) : 0,
             post_uuid: item.post_uuid,
             post_id: item.post_id,
             post_type: item.post_type,
             url_exists: item.url_exists
         }));
-    }, [topContentData]);
+    }, [topContentData, totalVisitors]);
 
     const topContent = transformedData?.slice(0, 10) || [];
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2468/
- percentages correctly updated to calculate based on total visit count, not total count of content visits

__Testing__
- [ ] Analytics > Web > Top content entries should show a % with {rowVisitorCount}/{totalSiteVisitorCount}. The total site visitor count should be the same as what is shown above in the KPI.