### PR TITLE
Disabled Renovate automerge for code-freeze

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,6 +98,12 @@
                 "/^css/"
             ],
             "enabled": false
+        },
+
+        // Disable automerge for all packages during code freeze
+        {
+            "matchPackageNames": ["*"],
+            "automerge": false
         }
     ]
 }


### PR DESCRIPTION
no issue

- we're switching to code freeze whilst preparing and testing for Ghost 6.x
- having Renovate automerging increases our rate of change so this is intended to temporarily disable it until we're out of code freeze
  - PRs will still be created and can be merged manually if needed
