### PR TITLE
Fixed Instagram username validation logic to accept usernames that end with underscore ("_")

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/instagram.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/instagram.ts
@@ -30,7 +30,7 @@ export function validateInstagramUrl(newUrl: string) {
 
     // Validate username: alphanumeric, underscore, period, 1–30 chars, no leading/trailing/consecutive periods
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9]$/) ||
+        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length > 30
     ) {
@@ -60,7 +60,7 @@ export const instagramHandleToUrl = (handle: string) => {
 
     // Validate username: alphanumeric, underscore, period, 1–30 chars, no leading/trailing/consecutive periods
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9]$/) ||
+        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length > 30
     ) {

--- a/apps/admin-x-settings/test/unit/utils/instagramUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/instagramUrls.test.ts
@@ -13,6 +13,7 @@ describe('Instagram URL validation', () => {
         assert.equal(validateInstagramUrl('instagram.com/john_smith_123'), 'https://www.instagram.com/john_smith_123');
         assert.equal(validateInstagramUrl('@johnsmith'), 'https://www.instagram.com/johnsmith');
         assert.equal(validateInstagramUrl('johnsmith'), 'https://www.instagram.com/johnsmith');
+        assert.equal(validateInstagramUrl('john_smith_'), 'https://www.instagram.com/john_smith_');
     });
 
     it('should reject URLs from other domains', () => {


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
This change updates the validation logic used by admin-x-settings, to allow for instagram usernames that end in underscore. This is a valid username pattern - I ran into this bug when trying to add [@primaryfocus_](https://www.instagram.com/primaryfocus_) to an author's profile on a Ghost.org hosted site

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
