### PR TITLE
Fixed config handling crashing stats/posts apps when empty strings

### DIFF
--- a/apps/admin-x-framework/src/hooks/useTinybirdToken.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdToken.ts
@@ -11,16 +11,23 @@ export interface UseTinybirdTokenOptions {
     enabled?: boolean;
 }
 
+// Track if we've already logged the warning to avoid spamming the console
+let hasLoggedConfigWarning = false;
+
 export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTinybirdTokenResult => {
     const {enabled = true} = options;
     const tinybirdQuery = getTinybirdToken({enabled});
 
     const apiToken = tinybirdQuery.data?.tinybird?.token;
     
-    // If we have a successful response but invalid token, create a validation error
-    let error = tinybirdQuery.error as Error | null;
-    if (!tinybirdQuery.error && tinybirdQuery.data && (!apiToken || typeof apiToken !== 'string')) {
-        error = new Error('Invalid token received from API: token must be a non-empty string');
+    // Only treat actual API errors as errors, not null/undefined tokens
+    // A null token just means Tinybird is not configured, which is valid
+    const error = tinybirdQuery.error as Error | null;
+    
+    // Log a warning ONCE if we got a response but no valid token (likely misconfiguration)
+    if (!tinybirdQuery.isLoading && enabled && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
+        console.warn('Tinybird analytics: No valid token received. Check your Tinybird configuration (workspaceId and adminToken must be non-empty strings).');
+        hasLoggedConfigWarning = true;
     }
     
     return {

--- a/apps/admin-x-framework/src/hooks/useTinybirdToken.ts
+++ b/apps/admin-x-framework/src/hooks/useTinybirdToken.ts
@@ -26,6 +26,7 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
     
     // Log a warning ONCE if we got a response but no valid token (likely misconfiguration)
     if (!tinybirdQuery.isLoading && enabled && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
+        // eslint-disable-next-line no-console
         console.warn('Tinybird analytics: No valid token received. Check your Tinybird configuration (workspaceId and adminToken must be non-empty strings).');
         hasLoggedConfigWarning = true;
     }

--- a/apps/admin-x-framework/test/unit/hooks/useTinybirdToken.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/useTinybirdToken.test.tsx
@@ -98,7 +98,7 @@ describe('useTinybirdToken', () => {
         expect(mockGetTinybirdToken.mock.calls[0]).toEqual([{enabled: true}]);
     });
 
-    it('creates validation error for invalid token types', () => {
+    it('returns undefined for invalid token types without throwing error', () => {
         mockGetTinybirdToken.mockReturnValue({
             data: {tinybird: {token: 123}}, // number instead of string
             isLoading: false,
@@ -109,9 +109,7 @@ describe('useTinybirdToken', () => {
         const {result} = renderHook(() => useTinybirdToken(), {wrapper});
 
         expect(result.current.token).toBeUndefined();
-        expect(result.current.error).toEqual(
-            new Error('Invalid token received from API: token must be a non-empty string')
-        );
+        expect(result.current.error).toBe(null);
     });
 
     it('passes through API errors', () => {

--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -91,13 +91,16 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         }
     });
 
-    // Only include tinybirdTokenQuery errors if it's a real error (not just missing token)
-    const requests = [config, site, settings];
-    if (hasStatsConfig && tinybirdTokenQuery.error) {
-        requests.push(tinybirdTokenQuery);
-    }
-    const error = requests.map(request => request.error).find(Boolean);
-    const isLoading = [config, site, settings, tinybirdTokenQuery].some(request => request.isLoading);
+    // Check for errors in the ghost requests
+    const ghostRequests = [config, site, settings];
+    const ghostError = ghostRequests.map(request => request.error).find(Boolean);
+    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
+    const error = ghostError || tinybirdError;
+    
+    // Check loading states
+    const isGhostLoading = ghostRequests.some(request => request.isLoading);
+    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
+    const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {
         throw error;

--- a/apps/posts/src/providers/PostAnalyticsContext.tsx
+++ b/apps/posts/src/providers/PostAnalyticsContext.tsx
@@ -91,10 +91,13 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         }
     });
 
-    // Only include tinybirdTokenQuery in requests if stats config is present
-    const requests = hasStatsConfig ? [config, site, settings, tinybirdTokenQuery] : [config, site, settings];
+    // Only include tinybirdTokenQuery errors if it's a real error (not just missing token)
+    const requests = [config, site, settings];
+    if (hasStatsConfig && tinybirdTokenQuery.error) {
+        requests.push(tinybirdTokenQuery);
+    }
     const error = requests.map(request => request.error).find(Boolean);
-    const isLoading = requests.some(request => request.isLoading);
+    const isLoading = [config, site, settings, tinybirdTokenQuery].some(request => request.isLoading);
 
     if (error) {
         throw error;

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -46,10 +46,13 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const [audience, setAudience] = useState(7);
     const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
-    // Only include tinybirdTokenQuery in requests if stats config is present
-    const requests = hasStatsConfig ? [config, settings, site, tinybirdTokenQuery] : [config, settings, site];
+    // Only include tinybirdTokenQuery errors if it's a real error (not just missing token)
+    const requests = [config, settings, site];
+    if (hasStatsConfig && tinybirdTokenQuery.error) {
+        requests.push(tinybirdTokenQuery);
+    }
     const error = requests.map(request => request.error).find(Boolean);
-    const isLoading = requests.some(request => request.isLoading);
+    const isLoading = [config, settings, site, tinybirdTokenQuery].some(request => request.isLoading);
 
     if (error) {
         throw error;

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -46,13 +46,16 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const [audience, setAudience] = useState(7);
     const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
-    // Only include tinybirdTokenQuery errors if it's a real error (not just missing token)
-    const requests = [config, settings, site];
-    if (hasStatsConfig && tinybirdTokenQuery.error) {
-        requests.push(tinybirdTokenQuery);
-    }
-    const error = requests.map(request => request.error).find(Boolean);
-    const isLoading = [config, settings, site, tinybirdTokenQuery].some(request => request.isLoading);
+    // Check for errors in the main requests
+    const ghostRequests = [config, settings, site];
+    const ghostError = ghostRequests.map(request => request.error).find(Boolean);
+    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
+    const error = ghostError || tinybirdError;
+    
+    // Check loading states
+    const isGhostLoading = ghostRequests.some(request => request.isLoading);
+    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
+    const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {
         throw error;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2355/
- log console.warn instead of fatal error when config is inappropriate to fetch token (empty string)

The frontend apps require workspaceId and adminToken to be set in Ghost's config:tinybird block. When set to an empty string, they were causing the app to crash due to the response from the API. This has been updated to handle it more gracefully by logging a console warn statement and not crash the apps. The user can still see a CTA in the Settings > Analytics block that their config is incorrect.

__Testing__
- [ ] Analytics loads web data with a valid config.
- [ ] Analytics loads w/ missing config; missing web data, shows console.warn, shows CTA in Settings > Analytics.
- [ ] Analytics loads w/ empty string config (workspaceId, adminToken, + various combinations); missing web data, shows console.warn, shows CTA in Settings > Analytics.