### PR TITLE
Fixed ?ref being dropped by stats script attribution with direct navigation

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -1,5 +1,5 @@
 import { getCountryForTimezone } from 'countries-and-timezones';
-import { parseReferrer } from '../utils/url-attribution';
+import { getReferrer, parseReferrer } from '../utils/url-attribution';
 import { processPayload } from '../utils/privacy';
 import { BrowserService } from './browser-service';
 
@@ -161,13 +161,16 @@ export class GhostStats {
         const navigator = this.browser.getNavigator();
         const location = this.browser.getLocation();
 
+        const referrerData = parseReferrer(location?.href);
+        referrerData.url = getReferrer(location?.href) || referrerData.url; // ensure the referrer.url is set for parsing
+
         // Wait a bit for SPA routers
         this.browser.setTimeout(() => {
             this.trackEvent('page_hit', {
                 'user-agent': navigator?.userAgent,
                 locale,
                 location: country,
-                parsedReferrer: parseReferrer(location?.href), // this sends an object with source, medium, and url
+                parsedReferrer: referrerData,
                 pathname: location?.pathname,
                 href: location?.href,
             });

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -558,25 +558,6 @@ describe('ghost-stats.js', function () {
             ghostStats.initConfig();
         });
 
-        it('should parse standard Reddit referrer correctly', function () {
-            mockDocument.referrer = 'https://www.reddit.com/r/ghost/comments/123/test';
-            mockWindow.location.href = 'https://example.com/test';
-            
-            ghostStats.trackPageHit();
-            
-            const timeoutCallback = mockWindow.setTimeout.firstCall.args[0];
-            timeoutCallback();
-            
-            const payload = JSON.parse(mockFetch.firstCall.args[1].body);
-            const innerPayload = JSON.parse(payload.payload);
-            
-            expect(innerPayload.parsedReferrer).to.deep.equal({
-                source: 'Reddit',
-                medium: 'social',
-                url: 'https://www.reddit.com/r/ghost/comments/123/test'
-            });
-        });
-
         it('should parse query string referrer parameters', function () {
             mockDocument.referrer = '';
             mockWindow.location.href = 'https://example.com/test?ref=ghost-newsletter&utm_source=twitter&utm_medium=social';
@@ -591,22 +572,6 @@ describe('ghost-stats.js', function () {
             
             expect(innerPayload.parsedReferrer.source).to.equal('ghost-newsletter');
             expect(innerPayload.parsedReferrer.medium).to.equal('social');
-        });
-
-        it('should handle portal hash URLs with referrer parameters', function () {
-            mockDocument.referrer = '';
-            mockWindow.location.href = 'https://example.com/#/portal?ref=footer&source=blog';
-            
-            ghostStats.trackPageHit();
-            
-            const timeoutCallback = mockWindow.setTimeout.firstCall.args[0];
-            timeoutCallback();
-            
-            const payload = JSON.parse(mockFetch.firstCall.args[1].body);
-            const innerPayload = JSON.parse(payload.payload);
-            
-            expect(innerPayload.parsedReferrer.source).to.equal('footer');
-            expect(innerPayload.parsedReferrer.url).to.be.null;
         });
 
         it('should preserve document referrer when getReferrer returns null', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2354/
ref https://github.com/TryGhost/Ghost/commit/9e048cc4c62489dad616598a10b4284763afe100
- direct navigation to a ghost site with a ?ref, ?source, ?utm_source query param is now appropriately associated with the referrer (previously mistreated as direct)

When we removed the referrer fallback in the above commit within our Tinybird pipes, we inadvertently removed fallback behavior previously in the `ghost-stats` script that is critical for handling `?ref` and related url params, whose behavior should match the `member-attribution` script.

`member-attribution` has [fallback behavior](https://github.com/TryGhost/Ghost/blob/c1465feb65863102e20876b9ae5502763d3161a7/ghost/core/core/frontend/src/member-attribution/member-attribution.js#L97) that ensures the `referrer.url` field is always populated - this is critical for the `referrer-parser` lib to [conduct](https://github.com/TryGhost/SDK/blob/b5c29510af8c1af9a11f593f91f5834ebf821594/packages/referrer-parser/lib/ReferrerParser.ts#L60) its parsing. While this isn't particularly intuitive, a fuller redesign of all this is out of scope, as the `member-attribution` parsing logic was mere centralized in TryGhost/SDK to be used by `ghost-stats`, and a more appropriate solution would be to rebuild it such that it makes sense to be used in multiple areas of the code base.

In short, we need to ensure we set `referrer.url`, and we should be using `getReferrer` for this. This is a difficult piece to catch in tests because the code is now split (`ghost-stats` script in TryGhost/Ghost, `referrer-parser` lib in TryGhost/SDK, and the traffic analytics/page hit parsing logic in TryGhost/TrafficAnalytics. We need true e2e tests to have good coverage over this part of the code base (which is a WIP).

__Testing__
- [ ] Execute page hits including `?ref=google` and related sources. Ensure those show up in Analytics > Web > Sources.
- [ ] We'll want to move this build onto staging and test site newsletters, which is difficult to do locally w/ localhost. Send a newsletter from Site 1 that links to Site 2. Click and follow the traffic.