### PR TITLE
Fixed web data appropriately adjusting post publish date for tz

### DIFF
--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -66,7 +66,7 @@ export {useSimplePagination} from './hooks/use-simple-pagination';
 
 // Utils
 export * from '@/lib/utils';
-export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatTimestamp, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, getYRangeWithMinPadding, getYRangeWithLargePadding, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars, getRangeForStartDate, formatMemberName, getMemberInitials, stringToHslColor, abbreviateNumber} from '@/lib/utils';
+export {cn, debounce, kebabToPascalCase, formatUrl, formatQueryDate, formatTimestamp, formatNumber, formatDuration, formatPercentage, formatDisplayDate, isValidDomain, getYRange, getYRangeWithMinPadding, getYRangeWithLargePadding, calculateYAxisWidth, getRangeDates, getCountryFlag, sanitizeChartData, formatDisplayDateWithRange, centsToDollars, getRangeForStartDate, formatMemberName, getMemberInitials, stringToHslColor, abbreviateNumber, getUserTimezone, getTzMoment} from '@/lib/utils';
 
 export {default as ShadeApp} from './ShadeApp';
 export type {ShadeAppProps} from './ShadeApp';

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -292,6 +292,23 @@ export const centsToDollars = (value: number) => {
     return Math.round(value / 100);
 };
 
+/* Date/Time helpers
+/* -------------------------------------------------------------------------- */
+
+// Get user's timezone
+export const getUserTimezone = (): string => {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+};
+
+// Get timezone-aware moment instance
+export const getTzMoment = (date?: string | Date | Moment, timezone?: string): Moment => {
+    const tz = timezone || getUserTimezone();
+    if (date) {
+        return moment.tz(date, tz);
+    }
+    return moment().tz(tz);
+};
+
 /* Chart formatters
 /* -------------------------------------------------------------------------- */
 
@@ -415,10 +432,9 @@ export const calculateYAxisWidth = (ticks: number[], formatter: (value: number) 
 
 // Get range for date
 export const getRangeForStartDate = (startDate: string) => {
-    const publishedDate = new Date(startDate);
-    const today = new Date();
-    const diffInTime = today.getTime() - publishedDate.getTime();
-    const diffInDays = Math.ceil(diffInTime / (1000 * 3600 * 24));
+    const publishedDate = getTzMoment(startDate).startOf('day');
+    const today = getTzMoment().endOf('day');
+    const diffInDays = today.diff(publishedDate, 'days') + 1;
 
     // Ensure minimum of 1 day to avoid issues with same-day publications
     return Math.max(diffInDays, 1);
@@ -426,16 +442,16 @@ export const getRangeForStartDate = (startDate: string) => {
 
 //Return today and startdate for charts
 export const getRangeDates = (range: number) => {
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const endDate = moment().tz(timezone).endOf('day');
+    const timezone = getUserTimezone();
+    const endDate = getTzMoment().endOf('day');
     let startDate;
 
     if (range === -1) {
         // Year to date - use January 1st of current year
-        startDate = moment().tz(timezone).startOf('year');
+        startDate = getTzMoment().startOf('year');
     } else {
         // Regular range calculation
-        startDate = moment().tz(timezone).subtract(range - 1, 'days').startOf('day');
+        startDate = getTzMoment().subtract(range - 1, 'days').startOf('day');
     }
 
     return {startDate, endDate, timezone};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2249
- added tz handling to `getRangeForStartDate` util used by Post Analytics

When published near an end of day UTC, it was possible users in different timezones would see inconsistent behavior in Post Analytics components, and might cut off real data because of it. Post Analytics > Overview > charts were impacted, as well as the Web tab charts.

Before the fix:
- A post published at 2025-01-28T23:00:00Z (11pm UTC)
- User in NYC (UTC-5): Sees it as Jan 28, 6pm → calculates days from Jan 28
- User in Berlin (UTC+1): Sees it as Jan 29, 12am → calculates days from Jan 29
- Result: Different users see different "days since publication" counts

After the fix:
- Same post published at 2025-01-28T23:00:00Z
- Both users' browsers convert to their local timezone consistently
- Both calculate days from the start of the publication day in their timezone
- Result: All users see the same relative day count

__Testing__
Note the above. If you create a post and edit the db to set the `published_at` time close to a day threshold, you can use Chrome devtools > More tools > Sensors (or set system tz) to mock your tz. Basically, make sure the chart starts with an appropriate date for the local tz.

In plain language:
- [ ] Post Analytics charts should use the appropriate start date for the local tz. If the post was published yesterday w/r to the tz, we should show through today (>1 day).

<img width="806" height="1312" alt="CleanShot 2025-07-29 at 16 28 37@2x" src="https://github.com/user-attachments/assets/abd7dc55-9064-4dbf-a086-4fdfe2e6a458" />
