### PR TITLE
Fixed handling for 'Today' lookback with Analytics kpis

### DIFF
--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -160,21 +160,40 @@ export const formatQueryDate = (date: Moment) => {
 
 // Format date for UI, result is in the formate of `12 Jun 2025`
 export const formatDisplayDate = (dateString: string): string => {
+    // Check if this is a datetime string (contains time) or just a date
+    const hasTime = dateString.includes(':');
+    
     const date = new Date(dateString);
     const today = new Date();
-    const isToday = date.toISOString().slice(0, 10) === today.toISOString().slice(0, 10);
-    const isCurrentYear = date.getUTCFullYear() === today.getUTCFullYear();
-
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const day = date.getUTCDate();
-    const month = months[date.getUTCMonth()];
-    const year = date.getUTCFullYear();
-
-    if (isToday) {
-        return `${day} ${month}`;
+    
+    let day, month, year, isToday, isCurrentYear;
+    
+    if (hasTime && !dateString.includes('T') && !dateString.includes('Z')) {
+        // This is a localized datetime string like "2025-07-29 19:00:00"
+        // Use local date methods to avoid timezone conversion
+        day = date.getDate();
+        month = date.getMonth();
+        year = date.getFullYear();
+        isToday = date.toDateString() === today.toDateString();
+        isCurrentYear = year === today.getFullYear();
+    } else {
+        // This is either a date-only string or an ISO format with timezone
+        // Use UTC methods as before
+        day = date.getUTCDate();
+        month = date.getUTCMonth();
+        year = date.getUTCFullYear();
+        isToday = date.toISOString().slice(0, 10) === today.toISOString().slice(0, 10);
+        isCurrentYear = year === today.getUTCFullYear();
     }
 
-    return isCurrentYear ? `${day} ${month}` : `${day} ${month} ${year}`;
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const monthName = months[month];
+
+    if (isToday) {
+        return `${day} ${monthName}`;
+    }
+
+    return isCurrentYear ? `${day} ${monthName}` : `${day} ${monthName} ${year}`;
 };
 
 // Helper function to format timestamp

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -7,40 +7,41 @@ SQL >
         {% set _single_day = defined(date_from) and day_diff(date_from, date_to) == 0 %}
         with
             {% if defined(date_from) %}
-                toStartOfDay(
-                    toDate(
-                        {{
-                            Date(
-                                date_from,
-                                description="Starting day for filtering a date range",
-                                required=False,
-                            )
-                        }}
-                    )
+                toDateTime(
+                    {{
+                        Date(
+                            date_from,
+                            description="Starting day for filtering a date range (in site timezone)",
+                            required=False,
+                        )
+                    }},
+                    {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}
                 ) as start,
-            {% else %} toStartOfDay(timestampAdd(today(), interval -7 day)) as start,
+            {% else %} toDateTime(timestampAdd(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}), interval -7 day)) as start,
             {% end %}
             {% if defined(date_to) %}
-                toStartOfDay(
-                    toDate(
+                timestampAdd(
+                    toDateTime(
                         {{
                             Date(
                                 date_to,
-                                description="Finishing day for filtering a date range",
+                                description="Finishing day for filtering a date range (in site timezone)",
                                 required=False,
                             )
-                        }}
-                    )
+                        }},
+                        {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}
+                    ),
+                    interval 1 day
                 ) as end
-            {% else %} toStartOfDay(today()) as end
+            {% else %} timestampAdd(toStartOfDay(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})), interval 1 day) as end
             {% end %}
         {% if _single_day %}
             select
                 arrayJoin(
                     arrayMap(
-                        x -> toDateTime(toString(toDateTime(x)), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}),
+                        x -> toDateTime(x, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}),
                         range(
-                            toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                            toUInt32(start), toUInt32(end), 3600
                         )
                     )
                 ) as date
@@ -48,8 +49,8 @@ SQL >
             select
                 arrayJoin(
                     arrayMap(
-                        x -> toDate(x),
-                        range(toUInt32(start), toUInt32(timestampAdd(end, interval 1 day)), 24 * 3600)
+                        x -> toDate(toDateTime(x, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})),
+                        range(toUInt32(start), toUInt32(end), 24 * 3600)
                     )
                 ) as date
         {% end %}
@@ -62,12 +63,13 @@ DESCRIPTION >
 SQL >
 
     %
+        
         select
             site_uuid,
             {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                toStartOfHour(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                toStartOfHour(toTimezone(first_pageview, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) as date,
             {% else %}
-                toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                toDate(toTimezone(first_pageview, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) as date,
             {% end %}
             session_id,
             pageviews,
@@ -78,11 +80,15 @@ SQL >
                 on fs.session_id = sd.session_id
         where
             site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-            {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
+            {% if defined(date_from) %}
+                and first_pageview >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
             {% else %}
-                {% if defined(date_from) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
-                {% if defined(date_to) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
+                and first_pageview >= toDateTime(timestampAdd(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}), interval -7 day))
+            {% end %}
+            {% if defined(date_to) %}
+                and first_pageview < timestampAdd(toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}), interval 1 day)
+            {% else %}
+                and first_pageview < timestampAdd(toStartOfDay(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})), interval 1 day)
             {% end %}
 
 
@@ -111,27 +117,32 @@ DESCRIPTION >
 SQL >
 
     %
+            
             select
                 {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                    toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                    toStartOfHour(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) as date,
                 {% else %}
-                    toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
+                    toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) as date,
                 {% end %}
                 count() pageviews
             from timeseries a
             inner join _mv_hits h on
                 {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                    a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                    a.date = toStartOfHour(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}))
                 {% else %}
-                    a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
+                    a.date = toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}))
                 {% end %}
             where
                 site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-                {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
-                    and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) = {{ Date(date_from) }}
+                {% if defined(date_from) %}
+                    and timestamp >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
                 {% else %}
-                    {% if defined(date_from) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
-                    {% if defined(date_to) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
+                    and timestamp >= toDateTime(timestampAdd(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}), interval -7 day))
+                {% end %}
+                {% if defined(date_to) %}
+                    and timestamp < timestampAdd(toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}), interval 1 day)
+                {% else %}
+                    and timestamp < timestampAdd(toStartOfDay(now({{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})), interval 1 day)
                 {% end %}
                 {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
                 {% if defined(device) %} and device = {{ String(device, description="Device to filter on", required=False) }} {% end %}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2243/
- api_kpis wasn't appropriately handling timezones, and now returns localized data that doesn't allow gaps
- formatDisplayDate was assuming UTC returned data when parsing timestamps, which was incorrectly adjusting the data returns from the API

Ideally we would handle UTC data across the board, but we need a serious rethink of how we handle startDate and endDate. This appears to handle the case of 'Today' in Analytics > Overview, Analytics > Web, and Post Analytics > Overview/Web.