### PR TITLE
Fixed incorrect error message for non-existent profiles in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -141,7 +141,7 @@ const Profile: React.FC<ProfileProps> = ({}) => {
 
     const {data: account, isLoading: isLoadingAccount, error: accountError} = useAccountForUser('index', (params.handle || 'me'));
 
-    if (accountError && isApiError(accountError)) {
+    if (accountError && isApiError(accountError) && accountError.statusCode !== 404) {
         return <Error statusCode={accountError.statusCode} />;
     }
 


### PR DESCRIPTION
ref PROD-2349

- Restored specific "Profile not found" message for non-existent profiles
- Fixed regression caused by recent rate-limit and blocked error handling
- Prevented generic error box from overriding the profile-specific message