### PR TITLE
Fixed handling for 'Today' lookback with Analytics kpis

### DIFF
--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -160,21 +160,40 @@ export const formatQueryDate = (date: Moment) => {
 
 // Format date for UI, result is in the formate of `12 Jun 2025`
 export const formatDisplayDate = (dateString: string): string => {
+    // Check if this is a datetime string (contains time) or just a date
+    const hasTime = dateString.includes(':');
+    
     const date = new Date(dateString);
     const today = new Date();
-    const isToday = date.toISOString().slice(0, 10) === today.toISOString().slice(0, 10);
-    const isCurrentYear = date.getUTCFullYear() === today.getUTCFullYear();
-
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const day = date.getUTCDate();
-    const month = months[date.getUTCMonth()];
-    const year = date.getUTCFullYear();
-
-    if (isToday) {
-        return `${day} ${month}`;
+    
+    let day, month, year, isToday, isCurrentYear;
+    
+    if (hasTime && !dateString.includes('T') && !dateString.includes('Z')) {
+        // This is a localized datetime string like "2025-07-29 19:00:00"
+        // Use local date methods to avoid timezone conversion
+        day = date.getDate();
+        month = date.getMonth();
+        year = date.getFullYear();
+        isToday = date.toDateString() === today.toDateString();
+        isCurrentYear = year === today.getFullYear();
+    } else {
+        // This is either a date-only string or an ISO format with timezone
+        // Use UTC methods as before
+        day = date.getUTCDate();
+        month = date.getUTCMonth();
+        year = date.getUTCFullYear();
+        isToday = date.toISOString().slice(0, 10) === today.toISOString().slice(0, 10);
+        isCurrentYear = year === today.getUTCFullYear();
     }
 
-    return isCurrentYear ? `${day} ${month}` : `${day} ${month} ${year}`;
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const monthName = months[month];
+
+    if (isToday) {
+        return `${day} ${monthName}`;
+    }
+
+    return isCurrentYear ? `${day} ${monthName}` : `${day} ${monthName} ${year}`;
 };
 
 // Helper function to format timestamp

--- a/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
@@ -234,7 +234,7 @@ const GrowthKPIs: React.FC<{
                 const todayData = subscriptionData.find(item => item.date === today);
 
                 return [{
-                    date: formatDisplayDateWithRange(new Date(today), range),
+                    date: formatDisplayDateWithRange(today, range),
                     new: todayData?.signups || 0,
                     cancelled: -(todayData?.cancellations || 0) // Negative for the stacked bar chart
                 }];
@@ -270,10 +270,8 @@ const GrowthKPIs: React.FC<{
             const filledData = fillMissingDataPoints(combinedData, range);
 
             return filledData.map((item) => {
-                const date = new Date(item.date);
-
                 return {
-                    date: formatDisplayDateWithRange(date, range),
+                    date: formatDisplayDateWithRange(item.date, range),
                     new: item.signups || 0,
                     cancelled: -(item.cancellations || 0) // Negative for the stacked bar chart
                 };
@@ -290,7 +288,7 @@ const GrowthKPIs: React.FC<{
                 const todayData = allChartData.find(item => item.date === today);
 
                 return [{
-                    date: formatDisplayDateWithRange(new Date(today), range),
+                    date: formatDisplayDateWithRange(today, range),
                     new: todayData?.paid_subscribed || 0,
                     cancelled: -(todayData?.paid_canceled || 0) // Negative for the stacked bar chart
                 }];
@@ -299,10 +297,8 @@ const GrowthKPIs: React.FC<{
             const sanitizedData = sanitizeChartData(allChartData, range, 'paid', 'exact');
 
             return sanitizedData.map((item) => {
-                const date = new Date(item.date);
-
                 return {
-                    date: formatDisplayDateWithRange(date, range),
+                    date: formatDisplayDateWithRange(item.date, range),
                     new: item.paid_subscribed || 0,
                     cancelled: -(item.paid_canceled || 0) // Negative for the stacked bar chart
                 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2243/
- formatDisplayDate was assuming UTC returned data when parsing timestamps, which was incorrectly adjusting the data returns from the API

Ideally we would handle UTC data across the board, but we need a serious rethink of how we handle startDate and endDate. This appears to handle the case of 'Today' in Analytics > Overview, Analytics > Web, and Post Analytics > Overview/Web.