### PR TITLE
Fixed domain blocking UI update and labeling in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -622,7 +622,7 @@ export function useBlockDomainMutationForUser(handle: string) {
                 return;
             }
             queryClient.setQueryData(
-                QUERY_KEYS.account(handle),
+                QUERY_KEYS.account(data.handle),
                 (currentAccount?: Account) => {
                     if (!currentAccount) {
                         return currentAccount;
@@ -659,7 +659,7 @@ export function useUnblockDomainMutationForUser(handle: string) {
                 return;
             }
             queryClient.setQueryData(
-                QUERY_KEYS.account(handle),
+                QUERY_KEYS.account(data.handle),
                 (currentAccount?: Account) => {
                     if (!currentAccount) {
                         return currentAccount;

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -128,7 +128,9 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                 }
                                 setDialogOpen(true);
                             }}>
-                                {isBlocked || isDomainBlocked ? 'Unblock' : 'Block'} user
+                                {isBlocked || isDomainBlocked ? 'Unblock' : 'Block'}
+                                {` `}
+                                {!isBlocked && isDomainBlocked ? 'domain' : 'user'}
                             </Button>
                         </PopoverClose>
                     </div>

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfileMenu.tsx
@@ -128,9 +128,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                 }
                                 setDialogOpen(true);
                             }}>
-                                {isBlocked || isDomainBlocked ? 'Unblock' : 'Block'}
-                                {` `}
-                                {!isBlocked && isDomainBlocked ? 'domain' : 'user'}
+                                {isBlocked ? 'Unblock user' : isDomainBlocked ? 'Unblock domain' : 'Block user'}
                             </Button>
                         </PopoverClose>
                     </div>


### PR DESCRIPTION
ref PROD-2348

- Corrected query key for domain block/unblock mutations to properly update UI
- Fixed UI not reflecting blocking changes despite successful backend operations
- Changed profile menu item from "Unblock user" to "Unblock domain" when only domain is blocked