### PR TITLE
Fix: Timezone dropdown label now includes DST-aware GMT offsets

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/time-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/time-zone.tsx
@@ -1,10 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import timezoneData from '@tryghost/timezone-data';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {Select, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getLocalTime} from '../../../utils/helpers';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {timezoneDataWithGMTOffset} from '@tryghost/timezone-data';
 
 interface TimezoneDataDropdownOption {
     name: string;
@@ -47,7 +47,7 @@ const TimeZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const [publicationTimezone] = getSettingValues(localSettings, ['timezone']) as string[];
 
-    const timezoneOptions: Array<{value: string; label: string}> = timezoneData.map((tzOption: TimezoneDataDropdownOption) => {
+    const timezoneOptions: Array<{value: string; label: string}> = timezoneDataWithGMTOffset().map((tzOption: TimezoneDataDropdownOption) => {
         return {
             value: tzOption.name,
             label: tzOption.label

--- a/apps/admin-x-settings/test/acceptance/general/time-zone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/time-zone.test.ts
@@ -17,12 +17,12 @@ test.describe('Time zone settings', async () => {
 
         await expect(select).toBeVisible();
 
-        await chooseOptionInSelect(select, '(GMT -9:00) Alaska');
+        await chooseOptionInSelect(select, 'Alaska');
 
         await section.getByRole('button', {name: 'Save'}).click();
 
         await expect(select).toBeVisible();
-        await expect(select).toContainText('(GMT -9:00) Alaska');
+        await expect(select).toContainText('Alaska');
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/ghost/admin/app/instance-initializers/config.js
+++ b/ghost/admin/app/instance-initializers/config.js
@@ -1,12 +1,12 @@
-import timezoneData from '@tryghost/timezone-data';
 import {TrackedObject} from 'tracked-built-ins';
+import {timezoneDataWithGMTOffset} from '@tryghost/timezone-data';
 
 export function initialize(applicationInstance) {
     const config = new TrackedObject({});
 
     Object.defineProperty(config, 'availableTimezones', {
         get() {
-            return timezoneData;
+            return timezoneDataWithGMTOffset();
         },
         enumerable: true
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ catalogs:
       specifier: 0.3.4
       version: 0.3.4
     '@tryghost/timezone-data':
-      specifier: 0.5.0
-      version: 0.5.0
+      specifier: 1.0.0
+      version: 1.0.0
     '@types/express':
       specifier: 4.17.25
       version: 4.17.25
@@ -980,7 +980,7 @@ importers:
         version: 0.3.4
       '@tryghost/timezone-data':
         specifier: 'catalog:'
-        version: 0.5.0
+        version: 1.0.0
       '@uiw/react-codemirror':
         specifier: 4.25.10
         version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.2)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.0)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2016,7 +2016,7 @@ importers:
         version: 0.3.4
       '@tryghost/timezone-data':
         specifier: 'catalog:'
-        version: 0.5.0
+        version: 1.0.0
       animejs:
         specifier: 3.2.2
         version: 3.2.2
@@ -8852,8 +8852,9 @@ packages:
   '@tryghost/string@0.3.4':
     resolution: {integrity: sha512-eI8B3lEgfv8RQFbQnP7H4KnlhrDkqrh+lAcNLXHyUAoqb5MwqlrHAIAQZxpl5CLW9agBJ8w1UO7ZrcseHEL8Ww==}
 
-  '@tryghost/timezone-data@0.5.0':
-    resolution: {integrity: sha512-TvEHhSfBhCi5MMYEUOgW96y3eQh2sai/8dvTww6244BNEoDv/LAJPl0J2NPfY+chxU3gCanX+W+bWY2kRX+NxQ==}
+  '@tryghost/timezone-data@1.0.0':
+    resolution: {integrity: sha512-A9483jAxE13ivnHdLK1kQYRaQYW+BcrKz33Nkdb59erNXiJYoaWx0HBAQoXKlySvrVX+wvVd9g1LzF44LgqidQ==}
+    engines: {node: '>=18.0.0'}
 
   '@tryghost/tpl@0.1.40':
     resolution: {integrity: sha512-8w94lbNxXptRCIS8pe/IHjzgVFLxljxXx8+UQLO8NRFKraoEXthkPjAphN2MXKp1UGtj5ldh4Ye4D82bUWceOw==}
@@ -29102,7 +29103,7 @@ snapshots:
     dependencies:
       unidecode: 1.1.0
 
-  '@tryghost/timezone-data@0.5.0': {}
+  '@tryghost/timezone-data@1.0.0': {}
 
   '@tryghost/tpl@0.1.40':
     dependencies:
@@ -30135,7 +30136,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   '@tryghost/nql': 0.12.11
   '@tryghost/nql-lang': 0.6.5
   '@tryghost/string': 0.3.4
-  '@tryghost/timezone-data': 0.5.0
+  '@tryghost/timezone-data': 1.0.0
   '@types/express': 4.17.25
   '@types/html-minifier': ^4.0.6
   '@types/jest': 29.5.14


### PR DESCRIPTION
## Description

This PR addresses https://github.com/TryGhost/Ghost/issues/24559, where the timezone dropdown on the `/settings/timezone` page displayed static GMT offsets that did not account for Daylight Saving Time (DST).

## What’s Changed

* The timezone dropdown now uses the `timezoneDataWithGMTOffset()` function, which dynamically prepends each label with the current, DST-adjusted GMT offset.
* The `timezoneDataWithGMTOffset()` implementation is introduced in [TryGhost/SDK#584](https://github.com/TryGhost/SDK/pull/584).
* Timezone entries are now sorted by current GMT offset, ensuring that the sort order remains in ascending order of GMT offset.

### BEFORE

The dropdown displayed incorrect static offsets. For example, when GMT time was 03:55, Amsterdam (which was in GMT+2 due to DST) was shown as GMT+1:

https://github.com/user-attachments/assets/bda82422-844f-41d4-b99e-50e0ec8ea188

### AFTER

The offsets now correctly reflect DST adjustments (e.g., Amsterdam is shown as GMT+2 when appropriate). Also, entries are sorted based on current offsets, placing GMT+0 entries like Azores alongside others in the same zone.

https://github.com/user-attachments/assets/96dd75a4-c3b9-466f-b372-174c0f049f34


## 🚨Note on Failing Tests

Unit tests are currently failing because this PR depends on changes in the `@tryghost/timezone-data` package introduced in [TryGhost/SDK#584](https://github.com/TryGhost/SDK/pull/584), which has not yet been published to npm.
Once the SDK changes are released and the package is updated, the tests in this PR should pass without further modifications.

In the meantime, you can verify that the tests pass locally by running in the Ghost repo (after linking the modified SDK package as described in the testing instructions below).

## Testing Instructions

This PR depends on [TryGhost/SDK#584](https://github.com/TryGhost/SDK/pull/584), which must be built and linked locally:

1. **Setup the SDK package:**
```
git clone https://github.com/TryGhost/SDK.git
cd SDK
yarn
cd packages/timezone-data
yarn build
yarn link
```

2. **Link the SDK package in Ghost:**
```
cd path/to/ghost
yarn link "@tryghost/timezone-data"
```

3. **Test the dropdown:**

* Navigate to `/settings/timezone`.
* Open the timezone dropdown.
* Confirm that each option reflects the correct current GMT offset, including DST.
* Verify that the list is sorted by GMT offset.

4. **Ensure tests pass locally**
```
cd apps/admin-x-settings/test
PLAYWRIGHT_REPORTER=list yarn test:acceptance test/acceptance/general/timeZone.test.ts
```
```
cd ghost/admin/tests 
yarn test 1 --filter="config-manager"
```
