### PR TITLE
Updated links in Admin for Analytics and Network

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/Network.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/Network.tsx
@@ -74,7 +74,7 @@ const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             <div className='flex w-full gap-1.5 rounded-md border border-grey-200 bg-grey-75 p-3 text-sm dark:border-grey-900 dark:bg-grey-925'>
                                 <Icon name='info' size={16} />
                                 <div className='-mt-0.5'>
-                                You need to configure a supported custom domain to use this feature. <a className='text-green' href="https://ghost.org/docs" rel="noopener noreferrer" target="_blank">Help &rarr;</a>
+                                You need to configure a supported custom domain to use this feature. <a className='text-green' href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Help &rarr;</a>
                                 </div>
                             </div>
                     }

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -68,7 +68,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     <div className='mb-5 rounded-md border border-grey-200 bg-grey-50 px-4 py-2.5 text-sm dark:border-grey-900 dark:bg-grey-925'>
                         <span className='flex items-start gap-2'>
                             <span>
-                                Web analytics in Ghost is powered by <a className='text-green' href="https://tinybird.co" rel="noopener noreferrer" target='_blank'>Tinybird</a> and requires configuration to start collecting data. <a className='text-green' href="https://ghost.org/docs/" rel="noopener noreferrer" target='_blank'>Get started &rarr;</a>
+                                Web analytics in Ghost is powered by <a className='text-green' href="https://tinybird.co" rel="noopener noreferrer" target='_blank'>Tinybird</a> and requires configuration to start collecting data. <a className='text-green' href="https://docs.ghost.org/install/docker#tinybird-integration" rel="noopener noreferrer" target='_blank'>Get started &rarr;</a>
                             </span>
                         </span>
                     </div>

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -221,7 +221,7 @@ const Overview: React.FC = () => {
                     <HelpCard
                         description='Find out how to review the performance of your content and get the most out of post analytics in Ghost.'
                         title='Understanding analytics in Ghost'
-                        url='https://ghost.org/help/post-analytics/'>
+                        url='https://ghost.org/help/native-analytics'>
                         <div className='flex h-18 w-[100px] min-w-[100px] items-center justify-center rounded-md bg-gradient-to-tr from-[#14B8FF]/20 to-[#00BBA7]/20 p-4 opacity-80 transition-all group-hover/card:opacity-100'>
                             <LucideIcon.ChartColumnIncreasing className='text-[#00BBA7]' size={20} strokeWidth={1.5} />
                         </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2086/update-the-dashboard-to-native-analytics

- The link for the "Understanding analytics in Ghost" banner on the Analytics overview was pointing to the old URL.
- The link for "Get started" for self-hosters in Settings / Analytics was pointing to docs home instead of the specific article.
- The "Help" link in Settings / Network was incorrectly pointing to ghost.org/docs