### PR TITLE
Fixed Analytics > Newsletters chart loading

### DIFF
--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -85,7 +85,7 @@ const NewsletterTableRows: React.FC<{
                                 </div>
                             </TableCell>
                             <TableCell className="whitespace-nowrap text-sm">
-                                {formatDisplayDate(new Date(post.send_date))}
+                                {formatDisplayDate(post.send_date)}
                             </TableCell>
                             <TableCell className='text-right font-mono text-sm'>
                                 {formatNumber(post.sent_to)}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2493/
ref https://github.com/TryGhost/Ghost/commit/31932c50f775ffce600512e3d36bacaa5113ddc0
- formatDisplayDate was being called with a Date object instead of date string

We updated date formatting to ingest localized dates as localized dates and UTC dates as UTC dates, however we introduced a string function that broke the call when used with a Date object instead of date string. The previous implementation did not have this trouble. I would've expected the Typescript build to fail here - I will have to look in to that.