### PR TITLE
Fixed top sources not deduplicating free->paid conversions

### DIFF
--- a/ghost/core/core/server/services/stats/ReferrersStatsService.js
+++ b/ghost/core/core/server/services/stats/ReferrersStatsService.js
@@ -250,51 +250,6 @@ class ReferrersStatsService {
         return rows;
     }
 
-    /**
-     * Fetch paid conversion sources with date range
-     * @param {string} startDate 
-     * @param {string} endDate 
-     * @returns {Promise<PaidConversionsCountStatDate[]>}
-     **/
-    async fetchPaidConversionSourcesWithRange(startDate, endDate) {
-        const knex = this.knex;
-        const startDateTime = moment.utc(startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss');
-        const endDateTime = moment.utc(endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss');
-        
-        const rows = await knex('members_subscription_created_events')
-            .select(knex.raw(`DATE(created_at) as date`))
-            .select(knex.raw(`COUNT(*) as paid_conversions`))
-            .select(knex.raw(`referrer_source as source`))
-            .where('created_at', '>=', startDateTime)
-            .where('created_at', '<=', endDateTime)
-            .groupBy('date', 'referrer_source')
-            .orderBy('date');
-
-        return rows;
-    }
-
-    /**
-     * Fetch signup sources with date range
-     * @param {string} startDate 
-     * @param {string} endDate 
-     * @returns {Promise<SignupCountStatDate[]>}
-     **/
-    async fetchSignupSourcesWithRange(startDate, endDate) {
-        const knex = this.knex;
-        const startDateTime = moment.utc(startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss');
-        const endDateTime = moment.utc(endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss');
-        
-        const rows = await knex('members_created_events')
-            .select(knex.raw(`DATE(created_at) as date`))
-            .select(knex.raw(`COUNT(*) as signups`))
-            .select(knex.raw(`referrer_source as source`))
-            .where('created_at', '>=', startDateTime)
-            .where('created_at', '<=', endDateTime)
-            .groupBy('date', 'referrer_source')
-            .orderBy('date');
-
-        return rows;
-    }
 
     /**
      * Fetch MRR sources with date range
@@ -327,6 +282,76 @@ class ReferrersStatsService {
     }
 
     /**
+     * Fetch deduplicated member counts by source with date range
+     * Returns both free signups (excluding those who converted) and paid conversions
+     * @param {string} startDate 
+     * @param {string} endDate 
+     * @returns {Promise<{source: string, signups: number, paid_conversions: number}[]>}
+     **/
+    async fetchMemberCountsBySource(startDate, endDate) {
+        const knex = this.knex;
+        const startDateTime = moment.utc(startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss');
+        const endDateTime = moment.utc(endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss');
+        
+        // Query 1: Free members who haven't converted to paid within the same time window
+        const freeSignupsQuery = knex('members_created_events as mce')
+            .select('mce.referrer_source as source')
+            .select(knex.raw('COUNT(DISTINCT mce.member_id) as signups'))
+            .leftJoin('members_subscription_created_events as msce', function () {
+                this.on('mce.member_id', '=', 'msce.member_id')
+                    // Only join if the conversion happened within the same time window
+                    .andOn('msce.created_at', '>=', knex.raw('?', [startDateTime]))
+                    .andOn('msce.created_at', '<=', knex.raw('?', [endDateTime]));
+            })
+            .where('mce.created_at', '>=', startDateTime)
+            .where('mce.created_at', '<=', endDateTime)
+            .whereNull('msce.id')
+            .groupBy('mce.referrer_source');
+
+        // Query 2: Paid conversions
+        const paidConversionsQuery = knex('members_subscription_created_events as msce')
+            .select('msce.referrer_source as source')
+            .select(knex.raw('COUNT(DISTINCT msce.member_id) as paid_conversions'))
+            .where('msce.created_at', '>=', startDateTime)
+            .where('msce.created_at', '<=', endDateTime)
+            .groupBy('msce.referrer_source');
+
+        // Execute both queries in parallel
+        const [freeResults, paidResults] = await Promise.all([
+            freeSignupsQuery,
+            paidConversionsQuery
+        ]);
+
+        // Combine results by source
+        const sourceMap = new Map();
+        
+        // Add free signups
+        freeResults.forEach((row) => {
+            sourceMap.set(row.source, {
+                source: row.source,
+                signups: parseInt(row.signups) || 0,
+                paid_conversions: 0
+            });
+        });
+        
+        // Add paid conversions
+        paidResults.forEach((row) => {
+            const existing = sourceMap.get(row.source);
+            if (existing) {
+                existing.paid_conversions = parseInt(row.paid_conversions) || 0;
+            } else {
+                sourceMap.set(row.source, {
+                    source: row.source,
+                    signups: 0,
+                    paid_conversions: parseInt(row.paid_conversions) || 0
+                });
+            }
+        });
+
+        return Array.from(sourceMap.values());
+    }
+
+    /**
      * Return aggregated attribution sources for a date range, grouped by source only (not by date)
      * This is used for "Top Sources" tables that need server-side sorting
      * @param {string} startDate - Start date in YYYY-MM-DD format
@@ -336,35 +361,47 @@ class ReferrersStatsService {
      * @returns {Promise<{data: AttributionCountStatWithMrr[], meta: {}}>}
      */
     async getTopSourcesWithRange(startDate, endDate, orderBy = 'signups desc', limit = 50) {
-        const paidConversionEntries = await this.fetchPaidConversionSourcesWithRange(startDate, endDate);
-        const signupEntries = await this.fetchSignupSourcesWithRange(startDate, endDate);
-        const mrrEntries = await this.fetchMrrSourcesWithRange(startDate, endDate);
+        // Get deduplicated member counts and MRR data in parallel
+        const [memberCounts, mrrEntries] = await Promise.all([
+            this.fetchMemberCountsBySource(startDate, endDate),
+            this.fetchMrrSourcesWithRange(startDate, endDate)
+        ]);
 
         // Aggregate by source (not by date + source)
         const sourceMap = new Map();
 
-        // Add signup data
-        signupEntries.forEach((entry) => {
+        // Add member counts (both signups and paid conversions)
+        memberCounts.forEach((entry) => {
             const source = normalizeSource(entry.source);
-            const existing = sourceMap.get(source) || {source, signups: 0, paid_conversions: 0, mrr: 0};
-            existing.signups += entry.signups;
-            sourceMap.set(source, existing);
-        });
-
-        // Add paid conversion data
-        paidConversionEntries.forEach((entry) => {
-            const source = normalizeSource(entry.source);
-            const existing = sourceMap.get(source) || {source, signups: 0, paid_conversions: 0, mrr: 0};
-            existing.paid_conversions += entry.paid_conversions;
-            sourceMap.set(source, existing);
+            const existing = sourceMap.get(source);
+            if (existing) {
+                // Aggregate if the normalized source already exists (e.g., multiple null/empty values)
+                existing.signups += entry.signups;
+                existing.paid_conversions += entry.paid_conversions;
+            } else {
+                sourceMap.set(source, {
+                    source,
+                    signups: entry.signups,
+                    paid_conversions: entry.paid_conversions,
+                    mrr: 0
+                });
+            }
         });
 
         // Add MRR data
         mrrEntries.forEach((entry) => {
             const source = normalizeSource(entry.source);
-            const existing = sourceMap.get(source) || {source, signups: 0, paid_conversions: 0, mrr: 0};
-            existing.mrr += entry.mrr;
-            sourceMap.set(source, existing);
+            const existing = sourceMap.get(source);
+            if (existing) {
+                existing.mrr += entry.mrr;
+            } else {
+                sourceMap.set(source, {
+                    source,
+                    signups: 0,
+                    paid_conversions: 0,
+                    mrr: entry.mrr
+                });
+            }
         });
 
         // Convert to array and sort

--- a/ghost/core/core/server/services/stats/ReferrersStatsService.js
+++ b/ghost/core/core/server/services/stats/ReferrersStatsService.js
@@ -250,7 +250,6 @@ class ReferrersStatsService {
         return rows;
     }
 
-
     /**
      * Fetch MRR sources with date range
      * @param {string} startDate 

--- a/ghost/core/test/unit/server/services/stats/referrers.test.js
+++ b/ghost/core/test/unit/server/services/stats/referrers.test.js
@@ -18,15 +18,25 @@ describe('ReferrersStatsService', function () {
             });
 
             await db.schema.createTable('members_created_events', function (table) {
+                table.string('member_id');
                 table.string('referrer_source');
                 table.string('referrer_medium');
                 table.string('referrer_url');
                 table.date('created_at');
             });
             await db.schema.createTable('members_subscription_created_events', function (table) {
+                table.string('id');
+                table.string('member_id');
+                table.string('subscription_id');
                 table.string('referrer_source');
                 table.string('referrer_medium');
                 table.string('referrer_url');
+                table.date('created_at');
+            });
+            await db.schema.createTable('members_paid_subscription_events', function (table) {
+                table.string('member_id');
+                table.string('subscription_id');
+                table.integer('mrr_delta');
                 table.date('created_at');
             });
         });
@@ -45,6 +55,7 @@ describe('ReferrersStatsService', function () {
                 const day = startDate.plus({days: index}).toISODate();
                 if (index > 0) {
                     signupInsert.push({
+                        member_id: `member_${index}`,
                         referrer_source: sources[index],
                         referrer_medium: null,
                         referrer_url: null,
@@ -53,6 +64,9 @@ describe('ReferrersStatsService', function () {
                 }
 
                 paidInsert.push({
+                    id: `sub_event_${index}`,
+                    member_id: `member_${index}`,
+                    subscription_id: `sub_${index}`,
                     referrer_source: sources[index],
                     referrer_medium: null,
                     referrer_url: null,
@@ -63,12 +77,14 @@ describe('ReferrersStatsService', function () {
             // Insert null referrer data for signups
             signupInsert.push(...[
                 {
+                    member_id: 'member_null_1',
                     referrer_source: null,
                     referrer_medium: null,
                     referrer_url: null,
                     created_at: startDate.plus({days: sources.length}).toISODate()
                 },
                 {
+                    member_id: 'member_null_2',
                     referrer_source: null,
                     referrer_medium: null,
                     referrer_url: null,
@@ -79,12 +95,18 @@ describe('ReferrersStatsService', function () {
             // Insert null referrer data for paid conversions
             paidInsert.push(...[
                 {
+                    id: 'sub_event_null_1',
+                    member_id: 'member_null_1',
+                    subscription_id: 'sub_null_1',
                     referrer_source: null,
                     referrer_medium: null,
                     referrer_url: null,
                     created_at: startDate.plus({days: sources.length}).toISODate()
                 },
                 {
+                    id: 'sub_event_null_2',
+                    member_id: 'member_null_2',
+                    subscription_id: 'sub_null_2',
                     referrer_source: null,
                     referrer_medium: null,
                     referrer_url: null,
@@ -132,6 +154,251 @@ describe('ReferrersStatsService', function () {
 
             assert(nullReferrerCounts.signups === 2);
             assert(nullReferrerCounts.paid_conversions === 2);
+        });
+    });
+
+    describe('getTopSourcesWithRange', function () {
+        /** @type {import('knex').Knex} */
+        let db;
+        let stats;
+
+        beforeEach(async function () {
+            db = knex({
+                client: 'sqlite3',
+                useNullAsDefault: true,
+                connection: {
+                    filename: ':memory:'
+                }
+            });
+
+            await db.schema.createTable('members_created_events', function (table) {
+                table.string('member_id');
+                table.string('referrer_source');
+                table.date('created_at');
+            });
+            
+            await db.schema.createTable('members_subscription_created_events', function (table) {
+                table.string('id');
+                table.string('member_id');
+                table.string('subscription_id');
+                table.string('referrer_source');
+                table.date('created_at');
+            });
+            
+            await db.schema.createTable('members_paid_subscription_events', function (table) {
+                table.string('member_id');
+                table.string('subscription_id');
+                table.integer('mrr_delta');
+                table.date('created_at');
+            });
+
+            stats = new ReferrersStatsService({knex: db});
+        });
+
+        afterEach(async function () {
+            await db.destroy();
+        });
+
+        it('should properly deduplicate members who converted from free to paid', async function () {
+            const testDate = '2024-01-15';
+            
+            // Insert 3 member signups for Google
+            await db('members_created_events').insert([
+                {member_id: 'member_1', referrer_source: 'Google', created_at: testDate},
+                {member_id: 'member_2', referrer_source: 'Google', created_at: testDate},
+                {member_id: 'member_3', referrer_source: 'Google', created_at: testDate}
+            ]);
+
+            // 1 member converts to paid in the same time window
+            await db('members_subscription_created_events').insert([
+                {id: 'sub_1', member_id: 'member_1', subscription_id: 'sub_1', referrer_source: 'Google', created_at: testDate}
+            ]);
+
+            // 1 member converts to paid after the time window (in February)
+            await db('members_subscription_created_events').insert([
+                {id: 'sub_2', member_id: 'member_2', subscription_id: 'sub_2', referrer_source: 'Google', created_at: '2024-02-15'}
+            ]);
+
+            // Query for January
+            const result = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+            const googleStats = result.data.find(s => s.source === 'Google');
+
+            // Expected: 2 signups (member_2 who converted later + member_3 who stayed free)
+            // member_1 is excluded from signups because they converted in the same window
+            // 1 paid conversion (member_1 who converted in January)
+            assert.equal(googleStats.signups, 2, 'Google should have 2 signups (excluding only member who converted in same window)');
+            assert.equal(googleStats.paid_conversions, 1, 'Google should have 1 paid conversion in January');
+            
+            // Query for February to see member_2's conversion
+            const febResult = await stats.getTopSourcesWithRange('2024-02-01', '2024-02-28');
+            const febGoogleStats = febResult.data.find(s => s.source === 'Google');
+            assert(febGoogleStats, 'Google stats should exist in February results');
+            assert.equal(febGoogleStats.paid_conversions, 1, 'Google should have 1 paid conversion in February');
+        });
+
+        it('should aggregate MRR data correctly', async function () {
+            const testDate = '2024-01-15';
+            
+            // Insert paid conversions
+            await db('members_subscription_created_events').insert([
+                {id: 'sub_1', member_id: 'paid_1', subscription_id: 'sub_1', referrer_source: 'Google', created_at: testDate},
+                {id: 'sub_2', member_id: 'paid_2', subscription_id: 'sub_2', referrer_source: 'Google', created_at: testDate},
+                {id: 'sub_3', member_id: 'paid_3', subscription_id: 'sub_3', referrer_source: 'Twitter', created_at: testDate}
+            ]);
+
+            // Insert MRR events
+            await db('members_paid_subscription_events').insert([
+                {member_id: 'paid_1', subscription_id: 'sub_1', mrr_delta: 500, created_at: testDate},
+                {member_id: 'paid_2', subscription_id: 'sub_2', mrr_delta: 1000, created_at: testDate},
+                {member_id: 'paid_3', subscription_id: 'sub_3', mrr_delta: 750, created_at: testDate}
+            ]);
+
+            const result = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+
+            const googleStats = result.data.find(s => s.source === 'Google');
+            const twitterStats = result.data.find(s => s.source === 'Twitter');
+
+            assert.equal(googleStats.mrr, 1500, 'Google should have total MRR of 1500');
+            assert.equal(twitterStats.mrr, 750, 'Twitter should have total MRR of 750');
+        });
+
+        it('should respect date range filters', async function () {
+            // Insert events across different dates
+            await db('members_created_events').insert([
+                {member_id: 'jan_1', referrer_source: 'Google', created_at: '2024-01-15'},
+                {member_id: 'jan_2', referrer_source: 'Google', created_at: '2024-01-20'},
+                {member_id: 'feb_1', referrer_source: 'Google', created_at: '2024-02-15'},
+                {member_id: 'feb_2', referrer_source: 'Google', created_at: '2024-02-20'}
+            ]);
+
+            const janResult = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+            const febResult = await stats.getTopSourcesWithRange('2024-02-01', '2024-02-28');
+
+            const janGoogle = janResult.data.find(s => s.source === 'Google');
+            const febGoogle = febResult.data.find(s => s.source === 'Google');
+
+            assert.equal(janGoogle.signups, 2, 'January should have 2 signups');
+            assert.equal(febGoogle.signups, 2, 'February should have 2 signups');
+        });
+
+        it('should handle Direct traffic normalization', async function () {
+            const testDate = '2024-01-15';
+            
+            await db('members_created_events').insert([
+                {member_id: 'direct_1', referrer_source: null, created_at: testDate},
+                {member_id: 'direct_2', referrer_source: '', created_at: testDate},
+                {member_id: 'direct_3', referrer_source: null, created_at: testDate}
+            ]);
+
+            const result = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+            const directStats = result.data.find(s => s.source === 'Direct');
+
+            // The normalization happens in the service layer
+            // Both null and empty string should be normalized to 'Direct'
+            assert(directStats, 'Direct stats should exist');
+            
+            // We expect 3 signups total: 2 nulls + 1 empty string
+            assert.equal(directStats.signups, 3, 'Should have 3 Direct signups');
+        });
+
+        it('should sort results correctly', async function () {
+            const testDate = '2024-01-15';
+            
+            await db('members_created_events').insert([
+                // Twitter: 3 signups
+                {member_id: 't1', referrer_source: 'Twitter', created_at: testDate},
+                {member_id: 't2', referrer_source: 'Twitter', created_at: testDate},
+                {member_id: 't3', referrer_source: 'Twitter', created_at: testDate},
+                // Google: 1 signup
+                {member_id: 'g1', referrer_source: 'Google', created_at: testDate},
+                // Facebook: 2 signups
+                {member_id: 'f1', referrer_source: 'Facebook', created_at: testDate},
+                {member_id: 'f2', referrer_source: 'Facebook', created_at: testDate}
+            ]);
+
+            // Test different sort orders
+            const signupsResult = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31', 'signups desc');
+            assert.equal(signupsResult.data[0].source, 'Twitter', 'Twitter should be first when sorted by signups');
+            assert.equal(signupsResult.data[1].source, 'Facebook', 'Facebook should be second');
+            assert.equal(signupsResult.data[2].source, 'Google', 'Google should be third');
+
+            const sourceResult = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31', 'source desc');
+            assert.equal(sourceResult.data[0].source, 'Twitter', 'Sources should be sorted alphabetically descending');
+        });
+
+        it('should respect limit parameter', async function () {
+            const testDate = '2024-01-15';
+            
+            // Insert signups for multiple sources
+            const sources = ['Google', 'Twitter', 'Facebook', 'Reddit', 'LinkedIn'];
+            const inserts = [];
+            sources.forEach((source, idx) => {
+                inserts.push({
+                    member_id: `member_${idx}`,
+                    referrer_source: source,
+                    created_at: testDate
+                });
+            });
+            await db('members_created_events').insert(inserts);
+
+            const result = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31', 'signups desc', 3);
+            assert.equal(result.data.length, 3, 'Should return only 3 results when limit is 3');
+        });
+
+        it('should handle members with same source converting on different dates', async function () {
+            // Member signs up free in January
+            await db('members_created_events').insert([
+                {member_id: 'member_1', referrer_source: 'Google', created_at: '2024-01-15'}
+            ]);
+
+            // Same member converts to paid in February
+            await db('members_subscription_created_events').insert([
+                {id: 'sub_1', member_id: 'member_1', subscription_id: 'sub_1', referrer_source: 'Google', created_at: '2024-02-15'}
+            ]);
+
+            // Query for January - should see the signup (no conversion in same window)
+            const janResult = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+            const janGoogle = janResult.data.find(s => s.source === 'Google');
+            assert(janGoogle, 'Google stats should exist in January results');
+            assert.equal(janGoogle.signups, 1, 'January should count this member as signup (conversion happened later)');
+            assert.equal(janGoogle.paid_conversions, 0, 'January should have no paid conversions');
+
+            // Query for February - should see the paid conversion
+            const febResult = await stats.getTopSourcesWithRange('2024-02-01', '2024-02-28');
+            const febGoogle = febResult.data.find(s => s.source === 'Google');
+            assert(febGoogle, 'Google stats should exist in February results');
+            assert.equal(febGoogle.signups, 0, 'February should have no signups');
+            assert.equal(febGoogle.paid_conversions, 1, 'February should have 1 paid conversion');
+        });
+
+        it('should handle members who sign up and convert with different sources', async function () {
+            const testDate = '2024-01-15';
+            
+            // Member signs up via Google
+            await db('members_created_events').insert([
+                {member_id: 'member_1', referrer_source: 'Google', created_at: testDate}
+            ]);
+
+            // Same member converts to paid via Twitter (different attribution) in same window
+            await db('members_subscription_created_events').insert([
+                {id: 'sub_1', member_id: 'member_1', subscription_id: 'sub_1', referrer_source: 'Twitter', created_at: testDate}
+            ]);
+
+            const result = await stats.getTopSourcesWithRange('2024-01-01', '2024-01-31');
+            
+            const googleStats = result.data.find(s => s.source === 'Google');
+            const twitterStats = result.data.find(s => s.source === 'Twitter');
+
+            // Google might not exist in results since member converted via different source
+            if (googleStats) {
+                assert.equal(googleStats.signups, 0, 'Google should have 0 signups (member converted in same window)');
+                assert.equal(googleStats.paid_conversions, 0, 'Google should have 0 paid conversions');
+            }
+            
+            // Twitter should exist and show the paid conversion
+            assert(twitterStats, 'Twitter stats should exist');
+            assert.equal(twitterStats.signups, 0, 'Twitter should have 0 signups');
+            assert.equal(twitterStats.paid_conversions, 1, 'Twitter should have 1 paid conversion');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2496/analytics-growth-top-sources-sources-free-members-is-not-showing
- in other places (post stats) we 'deduplicate' member counts where a free signup also includes a paid conversion in the same time frame; this was not handled in Sources
- added unit test coverage to describe cases/behavior

We've defined member attribution in the Analytics apps as only counting a free signup if the user didn't also sign up as a paid member in the same timeframe. This makes it a bit easier to reason about your total member count when looking at the free/paid split.

__Testing__
- [ ] Publish a post.
- [ ] Sign up a free member on it.
- [ ] Check Analytics > Growth to see the free signup.
- [ ] With the same post, upgrade to paid (may need to enable Stripe). 
- [ ] Check Analytics > Growth to see the free signup disappear and paid signup appear.