### PR TITLE
Fixed stats endpoints inconsistently handling timezone

### DIFF
--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -533,12 +533,7 @@ const controller = {
             };
         },
         async query(frame) {
-            return await statsService.api.getTopSourcesWithRange(
-                frame.options.date_from, 
-                frame.options.date_to, 
-                frame.options.order || 'free_members desc',
-                frame.options.limit || 50
-            );
+            return await statsService.api.getTopSourcesWithRange(frame.options);
         }
     }
 

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -678,10 +678,6 @@ class PostsStatsService {
         return subquery;
     }
 
-
-
-
-
     /**
      * Get newsletter stats for sent or published posts with a specific newsletter_id
      *

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -4,6 +4,8 @@ const urlUtils = require('../../../shared/url-utils');
 
 // Import source normalization from ReferrersStatsService
 const {normalizeSource} = require('./ReferrersStatsService');
+// Import centralized date utilities
+const {getDateBoundaries, applyDateFilter} = require('./utils/date-utils');
 
 /**
  * @typedef {Object} StatsServiceOptions
@@ -21,6 +23,7 @@ const {normalizeSource} = require('./ReferrersStatsService');
  * @property {number} [limit=20] - Maximum number of results to return
  * @property {string} [date_from] - Start date filter in YYYY-MM-DD format
  * @property {string} [date_to] - End date filter in YYYY-MM-DD format
+ * @property {string} [timezone='UTC'] - optional timezone for date interpretation
  * @property {string} [post_type] - Filter by post type ('post', 'page')
  */
 
@@ -99,6 +102,7 @@ class PostsStatsService {
             const limitRaw = Number.parseInt(String(options.limit ?? 20), 10);
             const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20;
             const [orderField, orderDirection = 'desc'] = order.split(' ');
+            const {dateFrom, dateTo} = getDateBoundaries(options);
 
             if (!['free_members', 'paid_members', 'mrr'].includes(orderField)) {
                 throw new errors.BadRequestError({
@@ -142,27 +146,13 @@ class PostsStatsService {
                             const subquery1 = this.select('attribution_url', 'attribution_type', 'attribution_id')
                                 .from('members_created_events')
                                 .whereNotNull('attribution_url');
-                            if (options.date_from || options.date_to) {
-                                if (options.date_from) {
-                                    subquery1.where('created_at', '>=', options.date_from);
-                                }
-                                if (options.date_to) {
-                                    subquery1.where('created_at', '<=', options.date_to + ' 23:59:59');
-                                }
-                            }
+                            applyDateFilter(subquery1, dateFrom, dateTo, 'created_at');
                             
                             subquery1.union(function () {
                                 const subquery2 = this.select('attribution_url', 'attribution_type', 'attribution_id')
                                     .from('members_subscription_created_events')
                                     .whereNotNull('attribution_url');
-                                if (options.date_from || options.date_to) {
-                                    if (options.date_from) {
-                                        subquery2.where('created_at', '>=', options.date_from);
-                                    }
-                                    if (options.date_to) {
-                                        subquery2.where('created_at', '<=', options.date_to + ' 23:59:59');
-                                    }
-                                }
+                                applyDateFilter(subquery2, dateFrom, dateTo, 'created_at');
                             })
                                 .as('combined');
                         })
@@ -462,6 +452,7 @@ class PostsStatsService {
         const selectField = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id as post_id';
         const groupByField = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id';
         const joinCondition = groupByUrl ? 'mce.attribution_url' : 'mce.attribution_id';
+        const {dateFrom, dateTo} = getDateBoundaries(options);
         
         let subquery = knex('members_created_events as mce')
             .select(selectField)
@@ -507,7 +498,7 @@ class PostsStatsService {
             }
         }
 
-        this._applyDateFilter(subquery, options, 'mce.created_at');
+        applyDateFilter(subquery, dateFrom, dateTo, 'mce.created_at');
         return subquery;
     }
 
@@ -523,6 +514,7 @@ class PostsStatsService {
         const knex = this.knex;
         const selectField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id as post_id';
         const groupByField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id';
+        const {dateFrom, dateTo} = getDateBoundaries(options);
         
         let subquery = knex('members_subscription_created_events as msce')
             .select(selectField)
@@ -551,7 +543,7 @@ class PostsStatsService {
             }
         }
 
-        this._applyDateFilter(subquery, options, 'msce.created_at');
+        applyDateFilter(subquery, dateFrom, dateTo, 'msce.created_at');
         return subquery;
     }
 
@@ -566,6 +558,7 @@ class PostsStatsService {
     _buildMrrSubquery(options, groupByUrl = false) {
         const selectField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id as post_id';
         const groupByField = groupByUrl ? 'msce.attribution_url' : 'msce.attribution_id';
+        const {dateFrom, dateTo} = getDateBoundaries(options);
         
         let subquery = this.knex('members_subscription_created_events as msce')
             .select(selectField)
@@ -599,7 +592,7 @@ class PostsStatsService {
             }
         }
 
-        this._applyDateFilter(subquery, options, 'msce.created_at');
+        applyDateFilter(subquery, dateFrom, dateTo, 'msce.created_at');
         return subquery;
     }
 
@@ -615,6 +608,7 @@ class PostsStatsService {
      */
     _buildFreeReferrersSubquery(postId, options) {
         const knex = this.knex;
+        const {dateFrom, dateTo} = getDateBoundaries(options);
 
         // Simpler approach mirroring _buildFreeMembersSubquery
         let subquery = knex('members_created_events as mce')
@@ -631,7 +625,7 @@ class PostsStatsService {
             .whereNull('msce.id') // Keep only signups where no matching paid conversion (same post/referrer) exists
             .groupBy('mce.referrer_source');
 
-        this._applyDateFilter(subquery, options, 'mce.created_at'); // Filter based on signup time
+        applyDateFilter(subquery, dateFrom, dateTo, 'mce.created_at');
         return subquery;
     }
 
@@ -645,6 +639,7 @@ class PostsStatsService {
     */
     _buildPaidReferrersSubquery(postId, options) {
         const knex = this.knex;
+        const {dateFrom, dateTo} = getDateBoundaries(options);
         let subquery = knex('members_subscription_created_events as msce')
             .select('msce.referrer_source as source')
             .countDistinct('msce.member_id as paid_members')
@@ -652,8 +647,7 @@ class PostsStatsService {
             .where('msce.attribution_type', 'post')
             .groupBy('msce.referrer_source');
 
-        // Apply date filter to the paid conversion event timestamp
-        this._applyDateFilter(subquery, options, 'msce.created_at');
+        applyDateFilter(subquery, dateFrom, dateTo, 'msce.created_at');
         return subquery;
     }
 
@@ -667,6 +661,7 @@ class PostsStatsService {
      */
     _buildMrrReferrersSubquery(postId, options) {
         const knex = this.knex;
+        const {dateFrom, dateTo} = getDateBoundaries(options);
         let subquery = knex('members_subscription_created_events as msce')
             .select('msce.referrer_source as source')
             .sum('mpse.mrr_delta as mrr')
@@ -679,50 +674,13 @@ class PostsStatsService {
             .where('msce.attribution_type', 'post')
             .groupBy('msce.referrer_source');
 
-        // Apply date filter to the paid conversion event timestamp
-        this._applyDateFilter(subquery, options, 'msce.created_at');
+        applyDateFilter(subquery, dateFrom, dateTo, 'msce.created_at');
         return subquery;
     }
 
-    /**
-     * Apply date filters to a query builder instance
-     * @private
-     * @param {import('knex').Knex.QueryBuilder} query
-     * @param {StatsServiceOptions} options
-     * @param {string} dateColumn - The date column to filter on
-     */
-    _applyDateFilter(query, options, dateColumn) {
-        // Note: Timezone handling might require converting dates before querying,
-        // depending on how created_at is stored (UTC assumed here).
-        if (options.date_from) {
-            try {
-                // Attempt to parse and validate the date
-                const fromDate = new Date(options.date_from);
-                if (!isNaN(fromDate.getTime())) {
-                    query.where(dateColumn, '>=', fromDate);
-                } else {
-                    logging.warn(`Invalid date_from format: ${options.date_from}. Skipping filter.`);
-                }
-            } catch (e) {
-                logging.warn(`Error parsing date_from: ${options.date_from}. Skipping filter.`);
-            }
-        }
-        if (options.date_to) {
-            try {
-                const toDate = new Date(options.date_to);
-                if (!isNaN(toDate.getTime())) {
-                    // Include the whole day for the 'to' date by setting to end of day
-                    const endOfDay = new Date(toDate);
-                    endOfDay.setHours(23, 59, 59, 999);
-                    query.where(dateColumn, '<=', endOfDay);
-                } else {
-                    logging.warn(`Invalid date_to format: ${options.date_to}. Skipping filter.`);
-                }
-            } catch (e) {
-                logging.warn(`Error parsing date_to: ${options.date_to}. Skipping filter.`);
-            }
-        }
-    }
+
+
+
 
     /**
      * Get newsletter stats for sent or published posts with a specific newsletter_id
@@ -733,6 +691,7 @@ class PostsStatsService {
      * @param {number|string} [options.limit=20] - Maximum number of results to return
      * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
      * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<{data: NewsletterStatResult[]}>} The newsletter stats for sent/published posts with the specified newsletter_id
      */
     async getNewsletterStats(newsletterId, options = {}) {
@@ -740,6 +699,7 @@ class PostsStatsService {
             const order = options.order || 'date desc';
             const limitRaw = Number.parseInt(String(options.limit ?? 20), 10);
             const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20;
+            const {dateFrom, dateTo} = getDateBoundaries(options);
 
             // Parse order field and direction
             let [orderField, orderDirection = 'desc'] = order.split(' ');
@@ -764,19 +724,6 @@ class PostsStatsService {
                 throw new errors.BadRequestError({
                     message: `Invalid order direction: ${orderDirection}`
                 });
-            }
-
-            // Build date filters if provided
-            let dateFilter = this.knex.raw('1=1');
-            if (options.date_from) {
-                dateFilter = this.knex.raw(`p.published_at >= ?`, [options.date_from]);
-            }
-            if (options.date_to) {
-                // Make date_to inclusive of the entire day by adding 23:59:59
-                const endOfDay = options.date_to + ' 23:59:59';
-                dateFilter = options.date_from
-                    ? this.knex.raw(`p.published_at >= ? AND p.published_at <= ?`, [options.date_from, endOfDay])
-                    : this.knex.raw(`p.published_at <= ?`, [endOfDay]);
             }
 
             // Subquery to count clicks from members_click_events
@@ -806,10 +753,11 @@ class PostsStatsService {
                 .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
                 .where('p.newsletter_id', newsletterId)
                 .whereIn('p.status', ['sent', 'published'])
-                // Show all newsletters that were sent, even if no email record exists or has 0 engagement
-                .whereRaw(dateFilter)
                 .orderBy(orderFieldMap[orderField], orderDirection)
                 .limit(limit);
+
+            // Apply centralized date filtering
+            applyDateFilter(query, dateFrom, dateTo, 'p.published_at');
 
             const results = await query;
 
@@ -829,6 +777,7 @@ class PostsStatsService {
      * @param {number} [options.limit] - Number of results to return (default: 20)
      * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
      * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<{data: Array}>} The newsletter basic stats (with click data when ordering by click_rate)
      */
     async getNewsletterBasicStats(newsletterId, options = {}) {
@@ -836,6 +785,7 @@ class PostsStatsService {
             const order = options.order || 'date desc';
             const limitRaw = Number.parseInt(String(options.limit ?? 20), 10);
             const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20;
+            const {dateFrom, dateTo} = getDateBoundaries(options);
 
             // Parse order field and direction
             let [orderField, orderDirection = 'desc'] = order.split(' ');
@@ -860,19 +810,6 @@ class PostsStatsService {
                 throw new errors.BadRequestError({
                     message: `Invalid order direction: ${orderDirection}`
                 });
-            }
-
-            // Build date filters if provided
-            let dateFilter = this.knex.raw('1=1');
-            if (options.date_from) {
-                dateFilter = this.knex.raw(`p.published_at >= ?`, [options.date_from]);
-            }
-            if (options.date_to) {
-                // Make date_to inclusive of the entire day by adding 23:59:59
-                const endOfDay = options.date_to + ' 23:59:59';
-                dateFilter = options.date_from
-                    ? this.knex.raw(`p.published_at >= ? AND p.published_at <= ?`, [options.date_from, endOfDay])
-                    : this.knex.raw(`p.published_at <= ?`, [endOfDay]);
             }
 
             let query;
@@ -906,10 +843,11 @@ class PostsStatsService {
                     .leftJoin(clicksSubquery, 'p.id', 'clicks.post_id')
                     .where('p.newsletter_id', newsletterId)
                     .whereIn('p.status', ['sent', 'published'])
-                    // Show all newsletters that were sent, even if no email record exists or has 0 engagement
-                    .whereRaw(dateFilter)
                     .orderBy(orderFieldMap[orderField], orderDirection)
                     .limit(limit);
+                    
+                // Apply centralized date filtering
+                applyDateFilter(query, dateFrom, dateTo, 'p.published_at');
             } else {
                 // Build the query without click data for better performance
                 query = this.knex
@@ -925,10 +863,11 @@ class PostsStatsService {
                     .leftJoin('emails as e', 'p.id', 'e.post_id')
                     .where('p.newsletter_id', newsletterId)
                     .whereIn('p.status', ['sent', 'published'])
-                    // Show all newsletters that were sent, even if no email record exists or has 0 engagement
-                    .whereRaw(dateFilter)
                     .orderBy(orderFieldMap[orderField], orderDirection)
                     .limit(limit);
+                    
+                // Apply centralized date filtering
+                applyDateFilter(query, dateFrom, dateTo, 'p.published_at');
             }
 
             const results = await query;
@@ -996,6 +935,7 @@ class PostsStatsService {
      * @param {Object} options - Query options
      * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
      * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<{data: Array<{total: number, deltas: Array<{date: string, value: number}>}>}>} The newsletter subscriber stats
      */
     async getNewsletterSubscriberStats(newsletterId, options = {}) {
@@ -1055,8 +995,15 @@ class PostsStatsService {
     /**
      * Optimized query to get newsletter subscriber deltas
      * @private
+     * @param {string} newsletterId - ID of the newsletter to get subscriber deltas for
+     * @param {Object} options - Query options
+     * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
+     * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      */
     async _getNewsletterSubscriberDeltas(newsletterId, options = {}) {
+        const {dateFrom, dateTo} = getDateBoundaries(options);
+        
         // Build optimized deltas query - avoid expensive JOIN
         let deltasQuery = this.knex('members_subscribe_events as mse')
             .select(
@@ -1073,13 +1020,8 @@ class PostsStatsService {
             .groupByRaw('DATE(mse.created_at)')
             .orderBy('date', 'asc');
 
-        // Apply date filters early to reduce dataset
-        if (options.date_from) {
-            deltasQuery.where('mse.created_at', '>=', options.date_from);
-        }
-        if (options.date_to) {
-            deltasQuery.where('mse.created_at', '<=', `${options.date_to} 23:59:59`);
-        }
+        // Apply timezone-aware date filters
+        applyDateFilter(deltasQuery, dateFrom, dateTo, 'mse.created_at');
 
         return await deltasQuery;
     }
@@ -1369,12 +1311,17 @@ class PostsStatsService {
      * @private
      * @param {string[]} postIds - Array of post IDs to get attribution counts for
      * @param {Object} options - Date filter options
+     * @param {string} [options.date_from] - Start date in YYYY-MM-DD format
+     * @param {string} [options.date_to] - End date in YYYY-MM-DD format
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<Array<{post_id: string, free_members: number, paid_members: number}>>}
      */
     async _getMemberAttributionCounts(postIds, options = {}) {
         if (!postIds.length) {
             return [];
         }
+
+        const {dateFrom, dateTo} = getDateBoundaries(options);
 
         try {
             // Build free members query (modeled after _buildFreeMembersSubquery)
@@ -1393,7 +1340,7 @@ class PostsStatsService {
                 .groupBy('mce.attribution_id');
 
             // Apply date filter to free members query
-            this._applyDateFilter(freeMembersQuery, options, 'mce.created_at');
+            applyDateFilter(freeMembersQuery, dateFrom, dateTo, 'mce.created_at');
 
             // Build paid members query (modeled after _buildPaidMembersSubquery)
             // Members whose paid conversion was attributed to this post
@@ -1405,7 +1352,7 @@ class PostsStatsService {
                 .groupBy('msce.attribution_id');
 
             // Apply date filter to paid members query
-            this._applyDateFilter(paidMembersQuery, options, 'msce.created_at');
+            applyDateFilter(paidMembersQuery, dateFrom, dateTo, 'msce.created_at');
 
             // Execute both queries
             const [freeResults, paidResults] = await Promise.all([

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -123,6 +123,7 @@ class StatsService {
      * @param {number} [options.limit=20] - Max number of results to return
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<{data: import('./PostsStatsService').NewsletterStatResult[]}>}
      */
     async getNewsletterStats(options = {}) {
@@ -146,6 +147,7 @@ class StatsService {
      * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @returns {Promise<{data: import('./PostsStatsService').NewsletterSubscriberStats[]}>}
      */
     async getNewsletterSubscriberStats(options = {}) {
@@ -190,6 +192,7 @@ class StatsService {
      * @param {string} [options.newsletter_id] - ID of the specific newsletter to get stats for
      * @param {string} [options.order='published_at desc'] - Order field and direction
      * @param {number} [options.limit=20] - Max number of results to return
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
      * @param {string} [options.date_from] - Start date filter in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date filter in YYYY-MM-DD format
      * @returns {Promise<{data: import('./PostsStatsService').NewsletterStatResult[]}>}
@@ -229,8 +232,16 @@ class StatsService {
         return result;
     }
 
-    async getTopSourcesWithRange(startDate, endDate, orderBy, limit) {
-        return this.referrers.getTopSourcesWithRange(startDate, endDate, orderBy, limit);
+    /**
+     * @param {Object} options
+     * @param {string} [options.date_from] - Start date in YYYY-MM-DD format
+     * @param {string} [options.date_to] - End date in YYYY-MM-DD format
+     * @param {string} [options.timezone] - Timezone to use for date interpretation
+     * @param {string} [options.orderBy='signups desc'] - Sort order: 'signups desc', 'paid_conversions desc', 'mrr desc', 'source desc'
+     * @param {number} [options.limit=50] - Maximum number of sources to return
+     */
+    async getTopSourcesWithRange(options = {}) {
+        return this.referrers.getTopSourcesWithRange(options);
     }
 
     /**

--- a/ghost/core/core/server/services/stats/utils/date-utils.js
+++ b/ghost/core/core/server/services/stats/utils/date-utils.js
@@ -1,0 +1,37 @@
+const moment = require('moment-timezone');
+
+/**
+ * Get processed date boundaries with timezone support
+ * @param {Object} options - Options containing date and timezone info
+ * @param {string} [options.date_from] - Start date in YYYY-MM-DD format
+ * @param {string} [options.date_to] - End date in YYYY-MM-DD format
+ * @param {string} [options.timezone='UTC'] - Timezone for date interpretation
+ * @returns {{dateFrom: string|null, dateTo: string|null}} Processed dates in ISO format
+ */
+function getDateBoundaries(options) {
+    const timezone = options.timezone || 'UTC';
+    const dateFrom = options.date_from ? moment.tz(options.date_from, timezone).utc().startOf('day').toISOString() : null;
+    const dateTo = options.date_to ? moment.tz(options.date_to, timezone).utc().endOf('day').toISOString() : null;
+    return {dateFrom, dateTo};
+}
+
+/**
+ * Apply date filters to a query builder instance
+ * @param {import('knex').Knex.QueryBuilder} query - The query builder to apply filters to
+ * @param {string|null} dateFrom - Start date in ISO format
+ * @param {string|null} dateTo - End date in ISO format
+ * @param {string} dateColumn - The date column to filter on
+ */
+function applyDateFilter(query, dateFrom, dateTo, dateColumn) {
+    if (dateFrom) {
+        query.where(dateColumn, '>=', dateFrom);
+    }
+    if (dateTo) {
+        query.where(dateColumn, '<=', dateTo);
+    }
+}
+
+module.exports = {
+    getDateBoundaries,
+    applyDateFilter
+};

--- a/ghost/core/core/server/services/stats/utils/date-utils.js
+++ b/ghost/core/core/server/services/stats/utils/date-utils.js
@@ -10,8 +10,8 @@ const moment = require('moment-timezone');
  */
 function getDateBoundaries(options) {
     const timezone = options.timezone || 'UTC';
-    const dateFrom = options.date_from ? moment.tz(options.date_from, timezone).utc().startOf('day').toISOString() : null;
-    const dateTo = options.date_to ? moment.tz(options.date_to, timezone).utc().endOf('day').toISOString() : null;
+    const dateFrom = options.date_from ? moment.tz(options.date_from, timezone).startOf('day').utc().toISOString() : null;
+    const dateTo = options.date_to ? moment.tz(options.date_to, timezone).endOf('day').utc().toISOString() : null;
     return {dateFrom, dateTo};
 }
 

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -1,5 +1,6 @@
 const knex = require('knex').default;
 const assert = require('assert/strict');
+const moment = require('moment-timezone');
 const PostsStatsService = require('../../../../../core/server/services/stats/PostsStatsService');
 
 /**
@@ -81,7 +82,7 @@ describe('PostsStatsService', function () {
             attribution_url: `/${postId.replace('post', 'post-')}/`,
             referrer_source: referrerSource,
             referrer_url: referrerSource ? `https://${referrerSource}` : null,
-            created_at: createdAt,
+            created_at: moment(createdAt).utc().format('YYYY-MM-DD HH:mm:ss'),
             source: 'member'
         });
     }
@@ -100,7 +101,7 @@ describe('PostsStatsService', function () {
             attribution_url: `/${postId.replace('post', 'post-')}/`,
             referrer_source: referrerSource,
             referrer_url: referrerSource ? `https://${referrerSource}` : null,
-            created_at: createdAt
+            created_at: moment(createdAt).utc().format('YYYY-MM-DD HH:mm:ss')
         });
 
         await db('members_paid_subscription_events').insert({
@@ -108,7 +109,7 @@ describe('PostsStatsService', function () {
             member_id: memberId,
             subscription_id: subscriptionId,
             mrr_delta: mrr,
-            created_at: createdAt
+            created_at: moment(createdAt).utc().format('YYYY-MM-DD HH:mm:ss')
         });
     }
 
@@ -155,7 +156,7 @@ describe('PostsStatsService', function () {
             id: clickEventId,
             member_id: memberId,
             redirect_id: redirectId,
-            created_at: createdAt
+            created_at: moment(createdAt).utc().format('YYYY-MM-DD HH:mm:ss')
         });
     }
 
@@ -417,8 +418,9 @@ describe('PostsStatsService', function () {
             await _createFreeSignupEvent('post2', 'member_future', 'referrer_future', thirtyDaysAgo);
 
             const lastFifteenDaysResult = await service.getTopPosts({
-                date_from: fifteenDaysAgo,
-                date_to: new Date()
+                date_from: moment(fifteenDaysAgo).format('YYYY-MM-DD'),
+                date_to: moment().format('YYYY-MM-DD'),
+                timezone: 'UTC'
             });
 
             // Only post1 should be returned since post2 has no events in the date range
@@ -428,8 +430,9 @@ describe('PostsStatsService', function () {
 
             // Test filtering to include both dates
             const lastThirtyDaysResult = await service.getTopPosts({
-                date_from: sixtyDaysAgo,
-                date_to: new Date()
+                date_from: moment(sixtyDaysAgo).format('YYYY-MM-DD'),
+                date_to: moment().format('YYYY-MM-DD'),
+                timezone: 'UTC'
             });
 
             // Both posts should be returned
@@ -585,8 +588,9 @@ describe('PostsStatsService', function () {
             await _createFreeSignupEvent('post1', 'member_future', 'referrer_future', thirtyDaysAgo);
 
             const lastFifteenDaysResult = await service.getReferrersForPost('post1', {
-                date_from: fifteenDaysAgo,
-                date_to: new Date()
+                date_from: moment(fifteenDaysAgo).format('YYYY-MM-DD'),
+                date_to: moment().format('YYYY-MM-DD'),
+                timezone: 'UTC'
             });
 
             // Make sure we have the result for referrer_past
@@ -596,8 +600,9 @@ describe('PostsStatsService', function () {
 
             // Test filtering to include both dates
             const lastThirtyDaysResult = await service.getReferrersForPost('post1', {
-                date_from: sixtyDaysAgo,
-                date_to: new Date()
+                date_from: moment(sixtyDaysAgo).format('YYYY-MM-DD'),
+                date_to: moment().format('YYYY-MM-DD'),
+                timezone: 'UTC'
             });
 
             // Make sure we have results for both referrers


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2373/
- more declarative about passing timezone with date_from and date_to in stats endpoint options
- centralized date calculations and date filter application to knex query objects; this allows us to cleanly handle timezone adjustments if someone is on the day before/after UTC's current date

__The Problem__
We do not consistently handle date translations w/r to timezones. We pass the `date_from`, `date_to`, and `timezone` options to Tinybird, which does handle timezone translations, and passes the data back in a localized format. We __do not__ currently do that with Ghost data.

__Solution__
For the moment, we'll centralize utils for translating `date_from` and `date_to` to UTC dates based on the provided `timezone`, and clean up the endpoints by using a centralized filter, ensuring we're applying the date filtering in the same way everywhere.

Ideally, we'll set standards around endpoints always being in UTC, and letting the caller handle the conversion, which feels more appropriate (the client knows its timezone, why does the server need to know it?).