### PR TITLE
Fixed monobundle script failing to copy missing PRIVACY.md file

### DIFF
--- a/ghost/core/monobundle.js
+++ b/ghost/core/monobundle.js
@@ -165,7 +165,6 @@ function getWorkspaces(from) {
     const filesToCopy = [
         'README.md',
         'LICENSE',
-        'PRIVACY.md',
         'yarn.lock'
     ];
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/eba8c4d0f5ea74ca8671fbfcca593788e830b08a
ref https://github.com/TryGhost/Ghost-Moya/actions/runs/16660745091/job/47157061575#step:14:792

The ref'd commit removed the PRIVACY.md file, but there is a step in the monobundle.js script (part of the docker build process) which tries to copy the PRIVACY.md file, which is now failing. This fixes that.