### PR TITLE
Fix race condition in Unsplash search that causes mixed results

### DIFF
--- a/ghost/admin/app/services/unsplash.js
+++ b/ghost/admin/app/services/unsplash.js
@@ -118,8 +118,8 @@ export default Service.extend({
     }).restartable(),
 
     _addPhotosFromResponse(response, searchTermAtRequest) {
-        // If this is a search result, only apply it if the search term still matches
-        // This prevents race conditions where old search results overwrite new ones
+        // If a search term was provided at the time of the request,
+        // we only want to add photos if the search term matches the current one.
         if (searchTermAtRequest && searchTermAtRequest !== this.searchTerm) {
             return;
         }

--- a/ghost/admin/app/services/unsplash.js
+++ b/ghost/admin/app/services/unsplash.js
@@ -111,12 +111,19 @@ export default Service.extend({
 
     _search: task(function* (term) {
         yield timeout(DEBOUNCE_MS);
+        const searchTermAtRequest = term;
 
         let url = `${API_URL}/search/photos?query=${term}&per_page=30`;
-        yield this._makeRequest(url);
+        yield this._makeRequest(url, {searchTermAtRequest});
     }).restartable(),
 
-    _addPhotosFromResponse(response) {
+    _addPhotosFromResponse(response, searchTermAtRequest) {
+        // If this is a search result, only apply it if the search term still matches
+        // This prevents race conditions where old search results overwrite new ones
+        if (searchTermAtRequest && searchTermAtRequest !== this.searchTerm) {
+            return;
+        }
+
         let photos = response.results || response;
 
         photos.forEach(photo => this._addPhoto(photo));
@@ -191,7 +198,7 @@ export default Service.extend({
             .then(response => this._checkStatus(response))
             .then(response => this._extractPagination(response))
             .then(response => response.json())
-            .then(response => this._addPhotosFromResponse(response))
+            .then(response => this._addPhotosFromResponse(response, options.searchTermAtRequest))
             .catch(() => {
                 // if the error text isn't already set then we've get a connection error from `fetch`
                 if (!options.ignoreErrors && !this.error) {

--- a/ghost/admin/app/services/unsplash.js
+++ b/ghost/admin/app/services/unsplash.js
@@ -111,10 +111,9 @@ export default Service.extend({
 
     _search: task(function* (term) {
         yield timeout(DEBOUNCE_MS);
-        const searchTermAtRequest = term;
 
         let url = `${API_URL}/search/photos?query=${term}&per_page=30`;
-        yield this._makeRequest(url, {searchTermAtRequest});
+        yield this._makeRequest(url, {searchTermAtRequest: term});
     }).restartable(),
 
     _addPhotosFromResponse(response, searchTermAtRequest) {
@@ -196,7 +195,7 @@ export default Service.extend({
 
         return fetch(url, {headers})
             .then(response => this._checkStatus(response))
-            .then(response => this._extractPagination(response))
+            .then(response => this._extractPagination(response, options.searchTermAtRequest))
             .then(response => response.json())
             .then(response => this._addPhotosFromResponse(response, options.searchTermAtRequest))
             .catch(() => {
@@ -240,7 +239,11 @@ export default Service.extend({
         });
     },
 
-    _extractPagination(response) {
+    _extractPagination(response, searchTermAtRequest) {
+        if (searchTermAtRequest && searchTermAtRequest !== this.searchTerm) {
+            return response;
+        }
+
         let pagination = {};
         let linkRegex = new RegExp('<(.*)>; rel="(.*)"');
         let {link: links} = response.headers.map;

--- a/ghost/admin/tests/unit/services/unsplash-test.js
+++ b/ghost/admin/tests/unit/services/unsplash-test.js
@@ -27,6 +27,49 @@ describe('Unit: Service: unsplash', function () {
         it('can load next page of search results');
         it('clears photos when starting new search');
         it('loads new when query is cleared');
+
+        it('discards responses that no longer match the current search term', async function () {
+            server.get('https://api.unsplash.com/photos', function () {
+                return [200, {'Content-Type': 'application/json'}, JSON.stringify([])];
+            });
+            server.get('https://api.unsplash.com/search/photos', function () {
+                return [200, {
+                    'Content-Type': 'application/json',
+                    Link: '<https://api.unsplash.com/search/photos?query=cat&page=2>; rel="next"'
+                }, JSON.stringify({results: [{id: 'cat-photo', width: 100, height: 100}]})];
+            });
+
+            let service = this.owner.lookup('service:unsplash');
+            await settled();
+
+            // response for "cat" arrives after the term has changed to "dog"
+            service.set('searchTerm', 'dog');
+            await service._makeRequest('https://api.unsplash.com/search/photos?query=cat', {searchTermAtRequest: 'cat'});
+
+            expect(service.photos.length).to.equal(0);
+            expect(service._pagination.next).to.not.exist;
+        });
+
+        it('adds photos and pagination when the response matches the current search term', async function () {
+            server.get('https://api.unsplash.com/photos', function () {
+                return [200, {'Content-Type': 'application/json'}, JSON.stringify([])];
+            });
+            server.get('https://api.unsplash.com/search/photos', function () {
+                return [200, {
+                    'Content-Type': 'application/json',
+                    Link: '<https://api.unsplash.com/search/photos?query=cat&page=2>; rel="next"'
+                }, JSON.stringify({results: [{id: 'cat-photo', width: 100, height: 100}]})];
+            });
+
+            let service = this.owner.lookup('service:unsplash');
+            await settled();
+
+            service.set('searchTerm', 'cat');
+            await service._makeRequest('https://api.unsplash.com/search/photos?query=cat', {searchTermAtRequest: 'cat'});
+
+            expect(service.photos.length).to.equal(1);
+            expect(service._pagination.next).to.exist;
+        });
     });
 
     describe('columns', function () {


### PR DESCRIPTION
This PR fixes a race condition in the Unsplash search flow where results from an intermediate search term (e.g., "germ") may appear alongside the final term (e.g., "germany") when users pause briefly while typing. 

Fixes: https://github.com/TryGhost/Ghost/issues/24584

### Root cause

The race condition occurs due to the combination of:

1. A debounce in `_search()` delaying API calls.

2. The `updateSearch()` method triggering a UI [reset](https://github.com/TryGhost/Ghost/blob/b5dedb0bc2c3cece0dfcf09860fa67a4488060f9/ghost/admin/app/services/unsplash.js#L63) too early, before `this.photos` is populated.

3. No mechanism to discard results from outdated search terms.

I could consistently reproduce results on a ~50Mbps connection:

* Type "germany" with a brief ~1s pause after "m".
* "germ" triggers a search.
* Before that request completes, the user continues typing to "germany", triggering a new search.
* Since both API calls resolve asynchronously, the results from "germ" are populated, followed by the results from "germany" being appended to the previous results, leading to incorrect UI state.

### Changes made

The fix adds validation to ensure that search results are only applied if the returned term matches the current user input. Each `_makeRequest()` call captures the term at the time it was made, and the response handler checks if it still matches the latest search term. If not, the results are discarded.

### Before

* Typing "Germany" with a brief pause shows results for "Germ" at the top.
* Network requests shows search fired for both "germ" and "germany".


https://github.com/user-attachments/assets/02dacebd-4fb2-4f7e-89d2-11e4179aba23


### After

* Typing "Germany" with a brief pause at "Germ" discards the old search results, ensuring that the relevant result for "Germany" appears at the top.
* Network requests shows search fired for both "germ" and "germany". The fix ensures that only the results for "germany" are included in the results.


https://github.com/user-attachments/assets/7a4efe45-842f-46d5-a17c-04b49f355beb



### Testing Instructions

1. Throttle your network to ~50Mbps.
2. Open the editor for either a post or page.
3. Click on "Add feature image".
4. In the Unsplash search bar, type a term slowly with a pause in the middle (e.g., "para" → pause → "chute").
5. Ensure that only results for the final input (e.g., "parachute") are shown.
6. Try with other terms and varying pause durations to confirm consistent behaviour.
7. Ensure that other behaviours (such as lazy loading paginated content in Unsplash results) remain unaffected.