### PR TITLE
Fix mobile tap behavior on Unsplash images

### DIFF
--- a/ghost/admin/app/components/gh-unsplash-photo.js
+++ b/ghost/admin/app/components/gh-unsplash-photo.js
@@ -41,6 +41,10 @@ export default class GhUnsplashPhoto extends Component {
         this.height = this.width * this.args.photo.ratio;
     }
 
+    get isTouchDevice() {
+        return window.matchMedia('(pointer: coarse)').matches;
+    }
+
     @action
     select(event) {
         event.preventDefault();
@@ -51,6 +55,13 @@ export default class GhUnsplashPhoto extends Component {
     @action
     zoom(event) {
         const {target} = event;
+
+        // Prevent zooming on touch devices
+        if (this.isTouchDevice) {
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
 
         // only zoom when it wasn't one of the child links clicked
         if (!target.matches('a') && target.closest('a').classList.contains('gh-unsplash-photo')) {

--- a/ghost/admin/app/components/gh-unsplash-photo.js
+++ b/ghost/admin/app/components/gh-unsplash-photo.js
@@ -7,6 +7,13 @@ export default class GhUnsplashPhoto extends Component {
     @tracked height = 0;
     @tracked width = 1200;
 
+    // Overlay button selectors for touch device handling
+    static OVERLAY_BUTTON_SELECTORS = [
+        '.gh-unsplash-button-likes',
+        '.gh-unsplash-button-download',
+        '.gh-unsplash-photo-author'
+    ];
+
     get style() {
         return htmlSafe(this.args.zoomed ? 'width: auto; margin: 0;' : '');
     }
@@ -55,9 +62,7 @@ export default class GhUnsplashPhoto extends Component {
     @action
     zoom(event) {
         const {target} = event;
-        const isOverlayButtonClick = target.closest('.gh-unsplash-button-likes') || 
-                                   target.closest('.gh-unsplash-button-download') ||
-                                   target.closest('.gh-unsplash-photo-author');
+        const isOverlayButtonClick = GhUnsplashPhoto.OVERLAY_BUTTON_SELECTORS.some(selector => target.closest(selector));                           
 
         if (this.isTouchDevice && isOverlayButtonClick) {
             return;

--- a/ghost/admin/app/components/gh-unsplash-photo.js
+++ b/ghost/admin/app/components/gh-unsplash-photo.js
@@ -48,10 +48,6 @@ export default class GhUnsplashPhoto extends Component {
         this.height = this.width * this.args.photo.ratio;
     }
 
-    get isTouchDevice() {
-        return window.matchMedia('(pointer: coarse)').matches;
-    }
-
     @action
     select(event) {
         event.preventDefault();
@@ -62,13 +58,16 @@ export default class GhUnsplashPhoto extends Component {
     @action
     zoom(event) {
         const {target} = event;
-        const isOverlayButtonClick = GhUnsplashPhoto.OVERLAY_BUTTON_SELECTORS.some(selector => target.closest(selector));                           
+        const isOverlayButtonClick = GhUnsplashPhoto.OVERLAY_BUTTON_SELECTORS.some(selector => target.closest(selector));
+        const isMobileViewport = window.matchMedia('(max-width: 540px)').matches;
+        const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+        const shouldNotZoom = isMobileViewport || isTouchDevice;
 
-        if (this.isTouchDevice && isOverlayButtonClick) {
+        if (shouldNotZoom && isOverlayButtonClick) {
             return;
         }
 
-        if (this.isTouchDevice) {
+        if (shouldNotZoom) {
             event.stopPropagation();
             event.preventDefault();
             return;

--- a/ghost/admin/app/components/gh-unsplash-photo.js
+++ b/ghost/admin/app/components/gh-unsplash-photo.js
@@ -55,8 +55,14 @@ export default class GhUnsplashPhoto extends Component {
     @action
     zoom(event) {
         const {target} = event;
+        const isOverlayButtonClick = target.closest('.gh-unsplash-button-likes') || 
+                                   target.closest('.gh-unsplash-button-download') ||
+                                   target.closest('.gh-unsplash-photo-author');
 
-        // Prevent zooming on touch devices
+        if (this.isTouchDevice && isOverlayButtonClick) {
+            return;
+        }
+
         if (this.isTouchDevice) {
             event.stopPropagation();
             event.preventDefault();

--- a/ghost/admin/app/styles/components/unsplash.css
+++ b/ghost/admin/app/styles/components/unsplash.css
@@ -131,6 +131,12 @@
     cursor: zoom-in;
 }
 
+@media (max-width: 540px) {
+    .gh-unsplash-photo {
+        cursor: default;
+    }
+}
+
 .gh-unsplash-photo-container > img {
     position: absolute;
     display: block;

--- a/ghost/admin/app/styles/components/unsplash.css
+++ b/ghost/admin/app/styles/components/unsplash.css
@@ -131,7 +131,7 @@
     cursor: zoom-in;
 }
 
-@media (max-width: 540px) {
+@media (pointer: coarse) {
     .gh-unsplash-photo {
         cursor: default;
     }


### PR DESCRIPTION
### Summary
This PR disables the zoom-on-tap behavior for Unsplash images in mobile viewports. Instead of zooming (which doesn't work well on mobile viewports), tapping now reveals the action buttons (e.g. “Insert” and “❤️”), making the interaction more intuitive for touch users.

### Why this change?

* Zooming into an image in small viewports results in awkward aspect ratios.
* Tapping should surface actionable UI (buttons), not an unhelpful zoom state.
* On touch devices, hover-only buttons remain interactive even when invisible, resulting in confusing behaviour. For example, tapping the bottom-right corner of an image can trigger the “Insert” action, even though the button isn’t visible when the image first loads.


 This fixes https://github.com/TryGhost/Ghost/issues/24585.

### Behaviour before

Tapping an image:

* Zooms in without improving clarity
* Randomly triggers invisible hover-only buttons
* In tablet screens, no hover actions visible on zoom

| Mobile | Tablet
| ---- | ----
| <video src="https://github.com/user-attachments/assets/7c090fc3-8c91-4c3e-8d6f-dbb84652e998" /> | <video src="https://github.com/user-attachments/assets/a61446b5-0e95-453b-b344-2115a292bee1" />



### Behaviour after

This PR handles touch devices and non-touch browser resized windows correctly. 

#### In touch-enabled devices, tapping an image:

* No longer zooms in
* Consistently reveals visible action buttons
* Enables predictable interactions

| Mobile | Tablet
| ---- | ----
| <video src="https://github.com/user-attachments/assets/4742f18e-7d93-4c87-9262-47d4524accc5" /> | <video src="https://github.com/user-attachments/assets/ad34c96f-9269-4285-af49-2dd5b388f517" /> 

#### In non-touch devices, for example a desktop browser resized to a small viewport:

* The tap-to-zoom behaviour is retained up to a max-width of 540px.
* If the browser window is resized to a width below 540px, then the tap-to-zoom is disabled. Mouse hover over the images will reveal the action buttons.


https://github.com/user-attachments/assets/f4abaa13-dd67-4094-a04d-869052eb3136




### Testing instructions

1. Open ghost admin on a mobile viewport.
2. In `/posts`, create a new post and click on "Add a feature image".
3. Use Chrome devtools to simulate a mobile. Click on an image in the search result, and verify that it doesn't open the zoomed in content.
4. Verify that clicking on an image reveals the action buttons, and that each of the action buttons work as expected.
5. Search for images, and verify that the action buttons work on the search results.
6. Now use your desktop browser (not mobile simulated) and resize your browser window to smaller viewports. As you resize, verify that the mouse hover action reveals the action buttons, and clicking on an image zooms in, up to a max-width of 540px. Below 540px width, mouse hover will reveal the action buttons but the images will no longer zoom on click.

