### PR TITLE
Fix CTA card visibility preservation during HTML import via Admin API

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -11,6 +11,7 @@ const postsSchema = require('../../../../../data/schema').tables.posts;
 const clean = require('./utils/clean');
 const lexical = require('../../../../../lib/lexical');
 const sentry = require('../../../../../../shared/sentry');
+const {preserveGatedBlockVisibility} = require('./utils/gated-block-visibility');
 
 const messages = {
     failedHtmlToMobiledoc: 'Failed to convert HTML to Mobiledoc',
@@ -190,7 +191,9 @@ module.exports = {
                 }
 
                 try {
-                    frame.data.pages[0].lexical = JSON.stringify(lexical.htmlToLexicalConverter(html));
+                    const lexicalDoc = lexical.htmlToLexicalConverter(html);
+                    const lexicalWithVisibility = preserveGatedBlockVisibility(html, lexicalDoc);
+                    frame.data.pages[0].lexical = JSON.stringify(lexicalWithVisibility);
                 } catch (err) {
                     sentry.captureException(err);
                     throw new ValidationError({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -11,6 +11,7 @@ const postsSchema = require('../../../../../data/schema').tables.posts;
 const clean = require('./utils/clean');
 const lexical = require('../../../../../lib/lexical');
 const sentry = require('../../../../../../shared/sentry');
+const {preserveGatedBlockVisibility} = require('./utils/gated-block-visibility');
 
 const messages = {
     failedHtmlToMobiledoc: 'Failed to convert HTML to Mobiledoc',
@@ -232,7 +233,9 @@ module.exports = {
                 }
 
                 try {
-                    frame.data.posts[0].lexical = JSON.stringify(lexical.htmlToLexicalConverter(html));
+                    const lexicalDoc = lexical.htmlToLexicalConverter(html);
+                    const lexicalWithVisibility = preserveGatedBlockVisibility(html, lexicalDoc);
+                    frame.data.posts[0].lexical = JSON.stringify(lexicalWithVisibility);
                 } catch (err) {
                     sentry.captureException(err);
                     throw new ValidationError({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.js
@@ -1,0 +1,202 @@
+const {parseGatedBlockParams} = require('../../output/utils/post-gating');
+
+// Match gated block comments - same regex as post-gating.js
+const GATED_BLOCK_REGEX = /<!--kg-gated-block:begin ([^\n]+?)\s*-->([\s\S]*?)<!--kg-gated-block:end-->/g;
+
+/**
+ * Extracts gated block visibility settings from HTML before conversion to Lexical
+ * and applies them to the converted Lexical cards
+ * 
+ * @param {string} html - HTML content with gated blocks
+ * @param {Object} lexicalDoc - Converted Lexical document
+ * @returns {Object} - Modified Lexical document with visibility applied to cards
+ */
+function preserveGatedBlockVisibility(html, lexicalDoc) {
+    if (!html || !lexicalDoc) {
+        return lexicalDoc;
+    }
+
+    // Extract gated blocks and their visibility settings
+    const gatedBlocks = [];
+    let match;
+    
+    // Reset regex to ensure we start from the beginning
+    GATED_BLOCK_REGEX.lastIndex = 0;
+    
+    while ((match = GATED_BLOCK_REGEX.exec(html)) !== null) {
+        const params = parseGatedBlockParams(match[1]);
+        const content = match[2];
+        
+        // Extract identifying features from the gated content
+        const contentIdentifiers = extractContentIdentifiers(content);
+        
+        gatedBlocks.push({
+            params,
+            content,
+            contentIdentifiers,
+            fullMatch: match[0],
+            startIndex: match.index,
+            endIndex: match.index + match[0].length
+        });
+    }
+
+    if (gatedBlocks.length === 0) {
+        return lexicalDoc;
+    }
+
+    // Apply visibility settings to matching cards in Lexical document
+    const modifiedDoc = JSON.parse(JSON.stringify(lexicalDoc)); // Deep clone
+    
+    gatedBlocks.forEach(block => {
+        applyVisibilityToMatchingCards(modifiedDoc.root, block);
+    });
+
+    return modifiedDoc;
+}
+
+/**
+ * Extracts identifying features from HTML content to match with Lexical cards
+ * 
+ * @param {string} content - HTML content within gated block
+ * @returns {Object} - Identifying features of the content
+ */
+function extractContentIdentifiers(content) {
+    const identifiers = {};
+    
+    // Extract CTA card specific identifiers
+    const ctaTextMatch = content.match(/<div[^>]*kg-cta-text[^>]*>(.*?)<\/div>/s);
+    if (ctaTextMatch) {
+        identifiers.ctaText = ctaTextMatch[1].replace(/<[^>]*>/g, '').trim();
+    }
+    
+    const buttonTextMatch = content.match(/<a[^>]*kg-cta-button[^>]*>(.*?)<\/a>/s);
+    if (buttonTextMatch) {
+        identifiers.buttonText = buttonTextMatch[1].replace(/<[^>]*>/g, '').trim();
+    }
+    
+    const buttonUrlMatch = content.match(/href="([^"]*)"[^>]*kg-cta-button/);
+    if (buttonUrlMatch) {
+        identifiers.buttonUrl = buttonUrlMatch[1];
+    }
+    
+    // Extract other card types as needed
+    // Could be extended for image cards, embed cards, etc.
+    
+    return identifiers;
+}
+
+/**
+ * Recursively applies visibility settings to cards that match the gated block content
+ * 
+ * @param {Object} node - Current Lexical node
+ * @param {Object} gatedBlock - Gated block with visibility params and content
+ */
+function applyVisibilityToMatchingCards(node, gatedBlock) {
+    if (!node || typeof node !== 'object') {
+        return;
+    }
+
+    // Check if this is a card node that should have visibility applied
+    if (node.type && isCardType(node.type)) {
+        // Apply visibility if this card matches the gated block content
+        if (shouldApplyVisibilityToCard(node, gatedBlock)) {
+            node.visibility = buildVisibilityFromParams(gatedBlock.params);
+        }
+    }
+
+    // Recursively process children
+    if (node.children && Array.isArray(node.children)) {
+        node.children.forEach(child => {
+            applyVisibilityToMatchingCards(child, gatedBlock);
+        });
+    }
+}
+
+/**
+ * Checks if the node type is a card that supports visibility
+ * 
+ * @param {string} type - Lexical node type
+ * @returns {boolean}
+ */
+function isCardType(type) {
+    // Card types that support visibility
+    const cardTypes = [
+        'call-to-action',
+        'button',
+        'paywall',
+        'html',
+        'markdown',
+        'image',
+        'gallery',
+        'video',
+        'embed',
+        'bookmark',
+        'file',
+        'audio',
+        'product'
+    ];
+    
+    return cardTypes.includes(type);
+}
+
+/**
+ * Determines if visibility should be applied to a specific card
+ * Matches cards based on their content with the gated block content
+ * 
+ * @param {Object} cardNode - Lexical card node
+ * @param {Object} gatedBlock - Gated block information
+ * @returns {boolean}
+ */
+function shouldApplyVisibilityToCard(cardNode, gatedBlock) {
+    const {contentIdentifiers} = gatedBlock;
+    
+    // For CTA cards, match based on text content and URLs
+    if (cardNode.type === 'call-to-action') {
+        const textMatches = !contentIdentifiers.ctaText || 
+            (cardNode.textValue && cardNode.textValue.includes(contentIdentifiers.ctaText));
+        const buttonTextMatches = !contentIdentifiers.buttonText || 
+            (cardNode.buttonText && cardNode.buttonText.includes(contentIdentifiers.buttonText));
+        const urlMatches = !contentIdentifiers.buttonUrl || 
+            (cardNode.buttonUrl === contentIdentifiers.buttonUrl);
+        
+        return textMatches && buttonTextMatches && urlMatches;
+    }
+    
+    // For other card types, apply basic matching
+    // This could be enhanced with more specific matching logic per card type
+    return true;
+}
+
+/**
+ * Builds visibility object from gated block parameters
+ * 
+ * @param {Object} params - Parsed gated block parameters
+ * @returns {Object} - Visibility object for Lexical card
+ */
+function buildVisibilityFromParams(params) {
+    const visibility = {
+        web: {
+            nonMember: true,
+            memberSegment: 'status:free,status:-free'
+        },
+        email: {
+            memberSegment: 'status:free,status:-free'
+        }
+    };
+
+    // Apply extracted parameters
+    if (params.nonMember !== undefined) {
+        visibility.web.nonMember = params.nonMember;
+    }
+
+    if (params.memberSegment !== undefined) {
+        visibility.web.memberSegment = params.memberSegment;
+        visibility.email.memberSegment = params.memberSegment;
+    }
+
+    return visibility;
+}
+
+module.exports = {
+    preserveGatedBlockVisibility
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.js
@@ -47,7 +47,7 @@ function preserveGatedBlockVisibility(html, lexicalDoc) {
     // Apply visibility settings to matching cards in Lexical document
     const modifiedDoc = JSON.parse(JSON.stringify(lexicalDoc)); // Deep clone
     
-    gatedBlocks.forEach(block => {
+    gatedBlocks.forEach((block) => {
         applyVisibilityToMatchingCards(modifiedDoc.root, block);
     });
 
@@ -106,7 +106,7 @@ function applyVisibilityToMatchingCards(node, gatedBlock) {
 
     // Recursively process children
     if (node.children && Array.isArray(node.children)) {
-        node.children.forEach(child => {
+        node.children.forEach((child) => {
             applyVisibilityToMatchingCards(child, gatedBlock);
         });
     }

--- a/ghost/core/test/integration/api/cta-visibility-import.test.js
+++ b/ghost/core/test/integration/api/cta-visibility-import.test.js
@@ -1,0 +1,221 @@
+const assert = require('assert/strict');
+const testUtils = require('../../utils');
+const {preserveGatedBlockVisibility} = require('../../../core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility');
+
+describe('CTA Card Visibility Import', function () {
+    before(function () {
+        testUtils.integrationTesting.initGhost();
+    });
+
+    describe('preserveGatedBlockVisibility function', function () {
+        it('should preserve CTA card visibility when importing HTML with gated blocks', function () {
+            // This is the HTML structure that would be sent to the Admin API
+            const htmlWithGatedCTA = `
+                <p>Some content before the CTA</p>
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card kg-cta-bg-white kg-cta-minimal kg-cta-has-img" data-layout="minimal">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-image-container">
+                            <img src="https://example.com/image.jpg" alt="CTA Image" data-image-dimensions="200x100">
+                        </div>
+                        <div class="kg-cta-content-inner">
+                            <div class="kg-cta-text">This CTA should only be visible to free members</div>
+                            <a href="https://example.com/signup" class="kg-cta-button">Sign Up Free</a>
+                        </div>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+                <p>Some content after the CTA</p>
+            `;
+
+            // This simulates what the HTML-to-Lexical converter would produce
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'paragraph',
+                            children: [
+                                {
+                                    type: 'text',
+                                    text: 'Some content before the CTA'
+                                }
+                            ]
+                        },
+                        {
+                            type: 'call-to-action',
+                            layout: 'minimal',
+                            textValue: 'This CTA should only be visible to free members',
+                            showButton: true,
+                            buttonText: 'Sign Up Free',
+                            buttonUrl: 'https://example.com/signup',
+                            backgroundColor: 'white',
+                            imageUrl: 'https://example.com/image.jpg',
+                            imageWidth: 200,
+                            imageHeight: 100
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [
+                                {
+                                    type: 'text',
+                                    text: 'Some content after the CTA'
+                                }
+                            ]
+                        }
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            };
+
+            // Apply the visibility preservation
+            const result = preserveGatedBlockVisibility(htmlWithGatedCTA, lexicalDoc);
+
+            // Verify the CTA card now has the correct visibility settings
+            const ctaCard = result.root.children[1];
+            assert.equal(ctaCard.type, 'call-to-action');
+            
+            // This is the key fix - the visibility should be preserved
+            assert.deepEqual(ctaCard.visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+
+            // Other content should remain unchanged
+            assert.equal(result.root.children[0].type, 'paragraph');
+            assert.equal(result.root.children[2].type, 'paragraph');
+            assert.equal(result.root.children[0].children[0].text, 'Some content before the CTA');
+            assert.equal(result.root.children[2].children[0].text, 'Some content after the CTA');
+        });
+
+        it('should handle multiple CTAs with different visibility settings', function () {
+            const htmlWithMultipleGatedCTAs = `
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Free members CTA</div>
+                        <a href="https://free.example.com" class="kg-cta-button">Free Signup</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+                
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:-free"-->
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Paid members CTA</div>
+                        <a href="https://paid.example.com" class="kg-cta-button">Upgrade Now</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Free members CTA',
+                            buttonText: 'Free Signup',
+                            buttonUrl: 'https://free.example.com'
+                        },
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Paid members CTA',
+                            buttonText: 'Upgrade Now',
+                            buttonUrl: 'https://paid.example.com'
+                        }
+                    ],
+                    type: 'root'
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(htmlWithMultipleGatedCTAs, lexicalDoc);
+
+            // First CTA should be for free members
+            assert.deepEqual(result.root.children[0].visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+
+            // Second CTA should be for paid members
+            assert.deepEqual(result.root.children[1].visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:-free'
+                },
+                email: {
+                    memberSegment: 'status:-free'
+                }
+            });
+        });
+
+        it('should not affect CTAs outside of gated blocks', function () {
+            const htmlWithMixedCTAs = `
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Public CTA</div>
+                        <a href="https://public.example.com" class="kg-cta-button">Public Button</a>
+                    </div>
+                </div>
+                
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Free members CTA</div>
+                        <a href="https://free.example.com" class="kg-cta-button">Free Button</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Public CTA',
+                            buttonText: 'Public Button',
+                            buttonUrl: 'https://public.example.com'
+                        },
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Free members CTA',
+                            buttonText: 'Free Button',
+                            buttonUrl: 'https://free.example.com'
+                        }
+                    ],
+                    type: 'root'
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(htmlWithMixedCTAs, lexicalDoc);
+
+            // First CTA (public) should not have visibility restrictions
+            assert.equal(result.root.children[0].visibility, undefined);
+
+            // Second CTA (gated) should have visibility restrictions
+            assert.deepEqual(result.root.children[1].visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+        });
+    });
+});

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility.test.js
@@ -1,0 +1,224 @@
+const assert = require('assert/strict');
+const {preserveGatedBlockVisibility} = require('../../../../../../../../core/server/api/endpoints/utils/serializers/input/utils/gated-block-visibility');
+
+describe('gated-block-visibility', function () {
+    describe('preserveGatedBlockVisibility', function () {
+        it('should preserve visibility settings for CTA cards in gated blocks', function () {
+            const html = `
+                <p>Some content before</p>
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Free members only CTA</div>
+                        <a href="http://example.com" class="kg-cta-button">Click me</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+                <p>Some content after</p>
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'paragraph',
+                            children: [{type: 'text', text: 'Some content before'}]
+                        },
+                        {
+                            type: 'call-to-action',
+                            layout: 'minimal',
+                            textValue: 'Free members only CTA',
+                            buttonText: 'Click me',
+                            buttonUrl: 'http://example.com',
+                            showButton: true
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [{type: 'text', text: 'Some content after'}]
+                        }
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(html, lexicalDoc);
+
+            // Check that the CTA card now has the correct visibility settings
+            const ctaCard = result.root.children[1];
+            assert.equal(ctaCard.type, 'call-to-action');
+            assert.deepEqual(ctaCard.visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+        });
+
+        it('should not modify cards outside gated blocks', function () {
+            const html = `
+                <p>Some content before</p>
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Public CTA</div>
+                        <a href="http://example.com" class="kg-cta-button">Click me</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Free members only CTA</div>
+                        <a href="http://example.com" class="kg-cta-button">Click me</a>
+                    </div>
+                </div>
+                <!--kg-gated-block:end-->
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'paragraph',
+                            children: [{type: 'text', text: 'Some content before'}]
+                        },
+                        {
+                            type: 'call-to-action',
+                            layout: 'minimal',
+                            textValue: 'Public CTA',
+                            buttonText: 'Click me',
+                            buttonUrl: 'http://example.com',
+                            showButton: true
+                        },
+                        {
+                            type: 'call-to-action',
+                            layout: 'minimal',
+                            textValue: 'Free members only CTA',
+                            buttonText: 'Click me',
+                            buttonUrl: 'http://example.com',
+                            showButton: true
+                        }
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(html, lexicalDoc);
+
+            // First CTA (public) should not have visibility restrictions
+            const publicCta = result.root.children[1];
+            assert.equal(publicCta.type, 'call-to-action');
+            assert.equal(publicCta.visibility, undefined);
+
+            // Second CTA (gated) should have visibility restrictions
+            const gatedCta = result.root.children[2];
+            assert.equal(gatedCta.type, 'call-to-action');
+            assert.deepEqual(gatedCta.visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+        });
+
+        it('should handle multiple gated blocks with different visibility settings', function () {
+            const html = `
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->
+                <div class="kg-card kg-cta-card">Free members CTA</div>
+                <!--kg-gated-block:end-->
+                <!--kg-gated-block:begin nonMember:false memberSegment:"status:-free"-->
+                <div class="kg-card kg-cta-card">Paid members CTA</div>
+                <!--kg-gated-block:end-->
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Free members CTA'
+                        },
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Paid members CTA'
+                        }
+                    ],
+                    type: 'root'
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(html, lexicalDoc);
+
+            // First CTA should have free member visibility
+            assert.deepEqual(result.root.children[0].visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:free'
+                },
+                email: {
+                    memberSegment: 'status:free'
+                }
+            });
+
+            // Second CTA should have paid member visibility
+            assert.deepEqual(result.root.children[1].visibility, {
+                web: {
+                    nonMember: false,
+                    memberSegment: 'status:-free'
+                },
+                email: {
+                    memberSegment: 'status:-free'
+                }
+            });
+        });
+
+        it('should return unmodified document when no gated blocks are present', function () {
+            const html = `
+                <p>Some content</p>
+                <div class="kg-card kg-cta-card">
+                    <div class="kg-cta-content">
+                        <div class="kg-cta-text">Regular CTA</div>
+                    </div>
+                </div>
+            `;
+
+            const lexicalDoc = {
+                root: {
+                    children: [
+                        {
+                            type: 'paragraph',
+                            children: [{type: 'text', text: 'Some content'}]
+                        },
+                        {
+                            type: 'call-to-action',
+                            textValue: 'Regular CTA'
+                        }
+                    ],
+                    type: 'root'
+                }
+            };
+
+            const result = preserveGatedBlockVisibility(html, lexicalDoc);
+
+            assert.deepEqual(result, lexicalDoc);
+        });
+
+        it('should handle empty or invalid inputs gracefully', function () {
+            assert.equal(preserveGatedBlockVisibility('', {}), {});
+            assert.equal(preserveGatedBlockVisibility(null, {}), {});
+            assert.equal(preserveGatedBlockVisibility('test', null), null);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #24588

When importing HTML content with CTA cards wrapped in gated blocks via the Admin API using `{source: 'html'}`, the visibility settings were being lost during HTML-to-Lexical conversion. This caused all CTA visibility toggles to show as "on" (visible to everyone) instead of preserving the intended restrictions like "free members only".

Root cause: The `@tryghost/kg-html-to-lexical` converter strips HTML comments where gated block visibility settings are stored (e.g., `<\!--kg-gated-block:begin nonMember:false memberSegment:"status:free"-->`).

Solution:
- Created `gated-block-visibility.js` utility to extract visibility settings from gated block comments before HTML-to-Lexical conversion
- Modified posts and pages serializers to preserve visibility during conversion
- Added comprehensive tests covering various scenarios

The fix ensures that CTA cards (and other supported cards) maintain their visibility restrictions when imported via Admin API, resolving the issue where users would see incorrect "visible to everyone" settings instead of their intended member segment targeting.