### PR TITLE
Fixed paid members showing up in post list

### DIFF
--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -165,26 +165,19 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                 }}>
                                                     <PostListTooltip
                                                         className='left-auto right-0 translate-x-0'
-                                                        metrics={
-                                                            appSettings?.paidMembersEnabled ?
-
-                                                                [{
-                                                                    icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                    label: 'Free members',
-                                                                    metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
-                                                                },
-                                                                {
-                                                                    icon: <LucideIcon.CreditCard className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                    label: 'Paid members',
-                                                                    metric: post.paid_members > 0 ? `+${formatNumber(post.paid_members)}` : '0'
-                                                                }]
-                                                                :
-                                                                [{
-                                                                    icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                    label: 'Free members',
-                                                                    metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
-                                                                }]
-                                                        }
+                                                        metrics={[
+                                                            {
+                                                                icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
+                                                                label: 'Free members',
+                                                                metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
+                                                            },
+                                                            // Only show paid members if paid members are enabled
+                                                            ...(appSettings?.paidMembersEnabled ? [{
+                                                                icon: <LucideIcon.CreditCard className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
+                                                                label: 'Paid members',
+                                                                metric: post.paid_members > 0 ? `+${formatNumber(post.paid_members)}` : '0'
+                                                            }] : [])
+                                                        ]}
                                                         title='New members'
                                                     />
                                                     <div className={metricClass}>

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -168,13 +168,13 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                         metrics={[
                                                             {
                                                                 icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                label: 'Free members',
+                                                                label: 'Free',
                                                                 metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
                                                             },
                                                             // Only show paid members if paid members are enabled
                                                             ...(appSettings?.paidMembersEnabled ? [{
                                                                 icon: <LucideIcon.CreditCard className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                label: 'Paid members',
+                                                                label: 'Paid',
                                                                 metric: post.paid_members > 0 ? `+${formatNumber(post.paid_members)}` : '0'
                                                             }] : [])
                                                         ]}

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -165,18 +165,26 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                 }}>
                                                     <PostListTooltip
                                                         className='left-auto right-0 translate-x-0'
-                                                        metrics={[
-                                                            {
-                                                                icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                label: 'Free members',
-                                                                metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
-                                                            },
-                                                            {
-                                                                icon: <LucideIcon.CreditCard className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
-                                                                label: 'Paid members',
-                                                                metric: post.paid_members > 0 ? `+${formatNumber(post.paid_members)}` : '0'
-                                                            }
-                                                        ]}
+                                                        metrics={
+                                                            appSettings?.paidMembersEnabled ?
+
+                                                                [{
+                                                                    icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
+                                                                    label: 'Free members',
+                                                                    metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
+                                                                },
+                                                                {
+                                                                    icon: <LucideIcon.CreditCard className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
+                                                                    label: 'Paid members',
+                                                                    metric: post.paid_members > 0 ? `+${formatNumber(post.paid_members)}` : '0'
+                                                                }]
+                                                                :
+                                                                [{
+                                                                    icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
+                                                                    label: 'Free members',
+                                                                    metric: post.free_members > 0 ? `+${formatNumber(post.free_members)}` : '0'
+                                                                }]
+                                                        }
                                                         title='New members'
                                                     />
                                                     <div className={metricClass}>

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -285,19 +285,21 @@
                                     {{/if}}
                                 </span>
                             </div>
-                            <div class="metric">
-                                <div class="data">
-                                    {{svg-jar "analytics-paid-members"}}
-                                    Paid
+                            {{#if this.membersUtils.paidMembersEnabled}}
+                                <div class="metric">
+                                    <div class="data">
+                                        {{svg-jar "analytics-paid-members"}}
+                                        Paid
+                                    </div>
+                                    <span>
+                                        {{#if this.hasMemberData}}
+                                            {{format-number this.memberCounts.paid}}
+                                        {{else}}
+                                            0
+                                        {{/if}}
+                                    </span>
                                 </div>
-                                <span>
-                                    {{#if this.hasMemberData}}
-                                        {{format-number this.memberCounts.paid}}
-                                    {{else}}
-                                        0
-                                    {{/if}}
-                                </span>
-                            </div>
+                            {{/if}}
                         </div>
                     </div>
                         <div class="gh-post-list-analytics-metric" data-test-analytics-member-conversions>

--- a/ghost/admin/app/components/posts-list/list-item-analytics.js
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.js
@@ -7,6 +7,7 @@ import {tracked} from '@glimmer/tracking';
 
 export default class PostsListItemClicks extends Component {
     @service feature;
+    @service membersUtils;
     @service session;
     @service settings;
     @service postAnalytics;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2377/analytics-growth-top-content-sources-shows-paid-related-columns

- In the main post list and Analytics top post list stats popup, paid membership related columns are displayed in the Top Sources table even though paid membership is turned off for the publication.