### PR TITLE
Fixed members header disappearing during list load

### DIFF
--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -98,6 +98,10 @@
     margin: 0 -48px;
 }
 
+.members-header .gh-canvas-header-content {
+    z-index: 1; /* Ensure the header content is above loading spinner */
+}
+
 .members-header .view-actions input.gh-members-list-searchfield {
     min-width: 220px;
     padding-left: 32px;
@@ -658,9 +662,9 @@ p.gh-members-list-email {
 
 
 .gh-members-help-card:hover {
-    box-shadow: 
-        0 0 1px rgba(0,0,0,.12), 
-        0 1px 6px rgba(0,0,0,.03), 
+    box-shadow:
+        0 0 1px rgba(0,0,0,.12),
+        0 1px 6px rgba(0,0,0,.03),
         0 8px 10px -8px rgba(0,0,0,.1);
     transition: all 0.15s ease-in-out;
 }


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2391/

- the members list uses `<GhLoadingSpinner />` which creates an element that covers it's parent in order to position in the middle, however it also has a white background so will cover anything that isn't sitting above it in the stacking context, this was resulting in the search and filter disappearing each time you made a change whilst the list refreshes
- added `z-index` to the header content so it has it's own stacking context and sits above the loading spinner
