### PR TITLE
Fixed ghost_head erroring on missing context

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -171,7 +171,7 @@ function getTinybirdTrackerScript(dataRoot) {
     const tbParams = _.map({
         site_uuid: settingsCache.get('site_uuid'),
         post_uuid: dataRoot.post?.uuid,
-        post_type: dataRoot.context.includes('post') ? 'post' : dataRoot.context.includes('page') ? 'page' : null,
+        post_type: dataRoot?.context?.includes('post') ? 'post' : dataRoot?.context?.includes('page') ? 'page' : null,
         member_uuid: dataRoot.member?.uuid,
         member_status: dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -171,7 +171,7 @@ function getTinybirdTrackerScript(dataRoot) {
     const tbParams = _.map({
         site_uuid: settingsCache.get('site_uuid'),
         post_uuid: dataRoot.post?.uuid,
-        post_type: dataRoot?.context?.includes('post') ? 'post' : dataRoot?.context?.includes('page') ? 'page' : null,
+        post_type: dataRoot.context?.includes('post') ? 'post' : dataRoot.context?.includes('page') ? 'page' : null,
         member_uuid: dataRoot.member?.uuid,
         member_status: dataRoot.member?.status
     }, (value, key) => `tb_${key}="${value}"`).join(' ');


### PR DESCRIPTION
ref https://ghost.slack.com/archives/CJBJ3MZFD/p1754319214934039?thread_ts=1754317131.975229&cid=CJBJ3MZFD

If the context prop was not set on dataRoot, it was possible for ghost_head to error loading and serve a 422, rather than failing to serve the page.