### PR TITLE
Fixed posts list newsletter analytics hover logic

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -265,7 +265,7 @@
                         <div class="gh-post-list-analytics-metric" data-test-analytics-sent>
                             {{svg-jar "analytics-sent" class="gh-list-analytics-icon"}}
                             <span class="gh-content-email-stats-value">
-                                {{format-number @post.email.emailCount}}
+                                {{abbreviate-number @post.email.emailCount}}
                             </span>
                         </div>
                     </LinkTo>

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -200,11 +200,12 @@
                 {{/if}}
             {{/if}}
 
+            {{#if @post.email}}
             <div class="gh-post-analytics-email-metrics gh-post-list-analytics-tt-container">
                 <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
                     <h3>Newsletter performance</h3>
                     <div class="metrics">
-                        {{#if @post.email}}
+                        {{!-- Always show sent count --}}
                         <div class="metric">
                             <div class="data">
                                 {{svg-jar "analytics-sent"}}
@@ -212,7 +213,8 @@
                             </div>
                             <span>{{format-number @post.email.emailCount}}</span>
                         </div>
-                        {{/if}}
+                        {{!-- Show opens when enabled --}}
+                        {{#if @post.showEmailOpenAnalytics}}
                         <div class="metric">
                             <div class="data">
                                 {{svg-jar "analytics-opens"}}
@@ -220,6 +222,9 @@
                             </div>
                             <span>{{format-number @post.email.openedCount}}</span>
                         </div>
+                        {{/if}}
+                        {{!-- Show clicks when enabled --}}
+                        {{#if @post.showEmailClickAnalytics}}
                         <div class="metric">
                             <div class="data">
                                 {{svg-jar "analytics-clicks"}}
@@ -227,10 +232,11 @@
                             </div>
                             <span>{{format-number @post.count.clicks}}</span>
                         </div>
+                        {{/if}}
                     </div>
                 </div>
-                {{!-- Opened / Signups column --}}
-                {{#if (and @post.showEmailOpenAnalytics @post.showEmailClickAnalytics) }}
+                {{!-- Opens column --}}
+                {{#if @post.showEmailOpenAnalytics}}
                     <LinkTo @route="posts-x.posts-x" @models={{array @post.id "newsletter"}} class="permalink gh-list-data gh-post-list-metrics">
                         <div class="gh-post-list-analytics-metric" data-test-analytics-opens>
                             {{svg-jar "analytics-opens" class="gh-list-analytics-icon"}}
@@ -241,8 +247,8 @@
                     </LinkTo>
                 {{/if}}
 
-                {{!-- Clicked / Conversions column --}}
-                {{#if @post.showEmailClickAnalytics }}
+                {{!-- Clicks column --}}
+                {{#if @post.showEmailClickAnalytics}}
                     <LinkTo @route="posts-x.posts-x" @models={{array @post.id "newsletter"}} class="permalink gh-list-data gh-post-list-metrics">
                         <div class="gh-post-list-analytics-metric" data-test-analytics-clicks>
                             {{svg-jar "analytics-clicks" class="gh-list-analytics-icon"}}
@@ -251,19 +257,21 @@
                             </span>
                         </div>
                     </LinkTo>
-                {{else}}
-                    {{#if @post.showEmailOpenAnalytics }}
-                        <LinkTo @route="posts-x.posts-x" @models={{array @post.id "newsletter"}} class="permalink gh-list-data gh-post-list-metrics">
-                            <div class="gh-post-list-analytics-metric" data-test-analytics-opens>
-                                {{svg-jar "analytics-opens" class="gh-list-analytics-icon"}}
-                                <span class="gh-content-email-stats-value">
-                                        {{@post.email.openRate}}%
-                                </span>
-                            </div>
-                        </LinkTo>
-                    {{/if}}
+                {{/if}}
+
+                {{!-- Sent column (only when both clicks and opens are disabled) --}}
+                {{#if (and (not @post.showEmailClickAnalytics) (not @post.showEmailOpenAnalytics))}}
+                    <LinkTo @route="posts-x.posts-x" @models={{array @post.id "newsletter"}} class="permalink gh-list-data gh-post-list-metrics">
+                        <div class="gh-post-list-analytics-metric" data-test-analytics-sent>
+                            {{svg-jar "analytics-sent" class="gh-list-analytics-icon"}}
+                            <span class="gh-content-email-stats-value">
+                                {{format-number @post.email.emailCount}}
+                            </span>
+                        </div>
+                    </LinkTo>
                 {{/if}}
             </div>
+            {{/if}}
 
             {{!-- Member conversions column (only show for published posts when traffic analytics is enabled AND web analytics is enabled) --}}
             {{#if this.settings.membersTrackSources}}

--- a/ghost/admin/mirage/serializers/post.js
+++ b/ghost/admin/mirage/serializers/post.js
@@ -12,6 +12,7 @@ export default BaseSerializer.extend({
         includes.add('tags');
         includes.add('authors');
         includes.add('tiers');
+        includes.add('email');
 
         // clean up some things that mirage doesn't understand
         includes.delete('authorsRoles');

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -1080,7 +1080,7 @@ describe('Acceptance: Posts / Pages', function () {
                 
                 // Verify sent column appears with proper formatting
                 expect(find('[data-test-analytics-sent]'), 'sent column').to.exist;
-                expect(find('[data-test-analytics-sent] .gh-content-email-stats-value').textContent.trim()).to.equal('15,000');
+                expect(find('[data-test-analytics-sent] .gh-content-email-stats-value').textContent.trim()).to.equal('15k');
                 expect(find('[data-test-analytics-opens]'), 'opens column when disabled').to.not.exist;
                 expect(find('[data-test-analytics-clicks]'), 'clicks column when disabled').to.not.exist;
             });

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -1002,6 +1002,89 @@ describe('Acceptance: Posts / Pages', function () {
                 expect(currentURL(), 'current URL').to.equal('/posts');
             });
         });
+
+        describe('newsletter analytics display logic', function () {
+            // Note: These tests verify the template logic we implemented.
+            // The showEmailOpenAnalytics and showEmailClickAnalytics are computed
+            // properties that depend on multiple conditions:
+            // - hasBeenEmailed
+            // - user is not contributor
+            // - settings.membersSignupAccess !== 'none'
+            // - email.trackOpens/trackClicks
+            // - settings.emailTrackOpens/emailTrackClicks
+            // 
+            // For full integration testing, these would need to be set up properly
+            // in the test environment, but that's beyond the scope of this template change.
+
+            beforeEach(async function () {
+                let adminRole = this.server.create('role', {name: 'Administrator'});
+                this.server.create('user', {roles: [adminRole]});
+
+                await authenticateSession();
+            });
+
+            it('shows/hides email analytics section based on post.email', async function () {
+                // Create a post with email data
+                let email1 = this.server.create('email', {
+                    emailCount: 1500
+                });
+                
+                this.server.create('post', {
+                    status: 'published',
+                    hasBeenEmailed: true,
+                    email: email1
+                });
+
+                // Create a post without email data
+                this.server.create('post', {
+                    status: 'published',
+                    hasBeenEmailed: false,
+                    email: null
+                });
+
+                await visit('/posts');
+                
+                let postElements = findAll('.gh-posts-list-item');
+                expect(postElements.length).to.equal(2);
+                
+                // First post should show email analytics section
+                let firstPost = postElements[0];
+                let emailSection = firstPost.querySelector('.gh-post-analytics-email-metrics');
+                expect(emailSection, 'email analytics section for post with email').to.exist;
+                
+                // Second post should not show email analytics section
+                let secondPost = postElements[1];
+                let noEmailSection = secondPost.querySelector('.gh-post-analytics-email-metrics');
+                expect(noEmailSection, 'email analytics section for post without email').to.not.exist;
+            });
+
+            it('displays newsletter columns based on email tracking settings', async function () {
+                // Test 1: When both tracking options are disabled, show sent column
+                let email1 = this.server.create('email', {
+                    emailCount: 15000,
+                    trackOpens: false,
+                    trackClicks: false
+                });
+                
+                // Create post that would show sent column
+                this.server.create('post', {
+                    status: 'published',
+                    hasBeenEmailed: true,
+                    email: email1,
+                    // Override computed properties for testing
+                    showEmailOpenAnalytics: false,
+                    showEmailClickAnalytics: false
+                });
+
+                await visit('/posts');
+                
+                // Verify sent column appears with proper formatting
+                expect(find('[data-test-analytics-sent]'), 'sent column').to.exist;
+                expect(find('[data-test-analytics-sent] .gh-content-email-stats-value').textContent.trim()).to.equal('15,000');
+                expect(find('[data-test-analytics-opens]'), 'opens column when disabled').to.not.exist;
+                expect(find('[data-test-analytics-clicks]'), 'clicks column when disabled').to.not.exist;
+            });
+        });
     });
 
     // NOTE: Because the pages list is (at this point in time) a thin extension of the posts list, we should not need to duplicate all of the tests.


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2386/post-newsletter-analytics-hover-doesnt-respect-one-flag-disabled
- updated show/hide logic to respect settings for clicks/opens
 - added fallback to sent when both clicks+opens disabled

 W/r to the issue, this fixes the logic in the Posts List component. I'll tackle the Top Posts updates separately.

 The logic is as follows, for posts with email data:
 - Show clicks column if click tracking enabled
 - Show open column is open tracking enabled
 - Show sent column if open tracking and click tracking are disabled

 Tooltip behavior should respect the settings as well:
 - Sent always shown
 - Clicks shown if click tracking enabled
 - Opens shown if open tracking enabled

 The idea here is that Sent data should always be shown, and the other two should only be shown if the corresponding setting is enabled. There's some slight differences here with number of columns vs. Top Posts which is why I'm separating it out, as that component has less horizontal space to work with.