### PR TITLE
Fixed newsletter metric display in Analytics > Top Posts

### DIFF
--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -180,7 +180,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                                 return (
                                                                     <>
                                                                         <LucideIcon.Send className='text-muted-foreground group-hover:text-foreground' size={16} strokeWidth={1.5} />
-                                                                        {formatNumber(post.sent_count || 0)}
+                                                                        {abbreviateNumber(post.sent_count || 0)}
                                                                     </>
                                                                 );
                                                             }

--- a/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/TopPosts.tsx
@@ -63,7 +63,8 @@ const TopPosts: React.FC<TopPostsProps> = ({
 
     // Show open rate if newsletters are enabled and email tracking is enabled
     const showWebAnalytics = appSettings?.analytics.webAnalytics;
-    const showOpenRate = appSettings?.newslettersEnabled && appSettings?.analytics.emailTrackOpens;
+    const showClickTracking = appSettings?.analytics.emailTrackClicks;
+    const showOpenTracking = appSettings?.analytics.emailTrackOpens;
 
     const metricClass = 'flex items-center justify-end gap-1 rounded-md px-2 py-1 font-mono text-gray-800 hover:bg-muted-foreground/10 group-hover:text-foreground';
 
@@ -126,7 +127,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     </div>
                                                 </div>
                                             }
-                                            {showOpenRate && post.sent_count !== null &&
+                                            {post.sent_count !== null &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' onClick={(e) => {
                                                     e.stopPropagation();
                                                     navigate(`/posts/analytics/${post.post_id}/newsletter`, {crossApp: true});
@@ -134,27 +135,56 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     <PostListTooltip
                                                         className={`${!appSettings?.analytics.membersTrackSources ? 'left-auto right-0 translate-x-0' : ''}`}
                                                         metrics={[
+                                                            // Always show sent
                                                             {
                                                                 icon: <LucideIcon.Send className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
                                                                 label: 'Sent',
                                                                 metric: formatNumber(post.sent_count || 0)
                                                             },
-                                                            {
+                                                            // Only show opens if open tracking is enabled
+                                                            ...(showOpenTracking ? [{
                                                                 icon: <LucideIcon.MailOpen className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
                                                                 label: 'Opens',
                                                                 metric: formatNumber(post.opened_count || 0)
-                                                            },
-                                                            {
+                                                            }] : []),
+                                                            // Only show clicks if click tracking is enabled
+                                                            ...(showClickTracking ? [{
                                                                 icon: <LucideIcon.MousePointer className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,
                                                                 label: 'Clicks',
                                                                 metric: formatNumber(post.clicked_count || 0)
-                                                            }
+                                                            }] : [])
                                                         ]}
                                                         title='Newsletter performance'
                                                     />
                                                     <div className={metricClass}>
-                                                        <LucideIcon.MailOpen className='text-muted-foreground group-hover:text-foreground' size={16} strokeWidth={1.5} />
-                                                        {post.open_rate ? `${Math.round(post.open_rate)}%` : <>0</>}
+                                                        {(() => {
+                                                            // If clicks and opens are enabled, show open rate %
+                                                            // If clicks are disabled but opens enabled, show open rate %
+                                                            if (showOpenTracking) {
+                                                                return (
+                                                                    <>
+                                                                        <LucideIcon.MailOpen className='text-muted-foreground group-hover:text-foreground' size={16} strokeWidth={1.5} />
+                                                                        {post.open_rate ? `${Math.round(post.open_rate)}%` : '0%'}
+                                                                    </>
+                                                                );
+                                                            } else if (showClickTracking) {
+                                                                // If open rate is disabled but clicks enabled, show click rate %
+                                                                return (
+                                                                    <>
+                                                                        <LucideIcon.MousePointer className='text-muted-foreground group-hover:text-foreground' size={16} strokeWidth={1.5} />
+                                                                        {post.click_rate ? `${Math.round(post.click_rate)}%` : '0%'}
+                                                                    </>
+                                                                );
+                                                            } else {
+                                                                // If both are disabled, show sent count
+                                                                return (
+                                                                    <>
+                                                                        <LucideIcon.Send className='text-muted-foreground group-hover:text-foreground' size={16} strokeWidth={1.5} />
+                                                                        {formatNumber(post.sent_count || 0)}
+                                                                    </>
+                                                                );
+                                                            }
+                                                        })()}
                                                     </div>
                                                 </div>
                                             }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2386/post-newsletter-analytics-hover-doesnt-respect-one-flag-disabled ref https://github.com/TryGhost/Ghost/pull/24599
- updated display logic in Top Posts

Building on the other PR (see ref), this updates the Newsletter analytics column in the Top Posts component. Logic is very similar to the Posts List column, except there's one fewer column in Top Posts, as there's less horizontal space here.

Column display:
- Hidden if no post email data
- Show open rate if open rate tracking enabled
- Show click rate if open rate tracking disabled *and* click rate tracking enabled
- Show sent count if open rate tracking and click rate tracking are disabled

Tooltip:
- Always display Sent count
- Display click count if click tracking enabled
- Display open rate if open rate enabled