### PR TITLE
Fixed profile navigation and data consistency issues in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -3,7 +3,7 @@ import Error from '@components/layout/Error';
 import Likes from './components/Likes';
 import Posts from './components/Posts';
 import ProfilePage from './components/ProfilePage';
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Activity, isApiError} from '@src/api/activitypub';
 import {useAccountFollowsForUser, useAccountForUser, usePostsByAccount, usePostsLikedByAccount} from '@hooks/use-activity-pub-queries';
 import {useParams} from '@tryghost/admin-x-framework';
@@ -139,7 +139,11 @@ const FollowersTab: React.FC<{handle: string}> = ({handle}) => {
 const Profile: React.FC<ProfileProps> = ({}) => {
     const params = useParams();
 
-    const {data: account, isLoading: isLoadingAccount, error: accountError} = useAccountForUser('index', (params.handle || 'me'));
+    const {data: account, isLoading: isLoadingAccount, error: accountError, refetch} = useAccountForUser('index', (params.handle || 'me'));
+
+    useEffect(() => {
+        refetch();
+    }, [params.handle, refetch]);
 
     if (accountError && isApiError(accountError) && accountError.statusCode !== 404) {
         return <Error statusCode={accountError.statusCode} />;

--- a/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -218,7 +218,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                     onClick={toggleExpand}
                                 >{isExpanded ? 'Show less' : 'Show all'}</Button>}
                             </div>)}
-                            <Tabs className='mt-5' defaultValue='posts' variant='underline'>
+                            <Tabs key={params.handle || account?.handle || 'current-user'} className='mt-5' defaultValue='posts' variant='underline'>
                                 <TabsList>
                                     <TabsTrigger value="posts">Posts</TabsTrigger>
                                     {!params.handle && <TabsTrigger value="likes">


### PR DESCRIPTION
ref PROD-2409

- Resolved data staleness by refetching profile information when navigating between profiles
- Reset tab selection to "Posts" when visiting a new profile
- Ensured followers, following counts, descriptions, and images are always current