### PR TITLE
Improved typography and layout of trend tooltips

### DIFF
--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -205,7 +205,7 @@ const KpiCardHeaderValue: React.FC<KpiCardValueProps> = ({value, diffDirection, 
                         <TrendingDown className='!size-[12px]' size={14} strokeWidth={2} />
                     }
                     {diffTooltip &&
-                        <div className='pointer-events-none absolute inset-x-0 top-0 z-50 -translate-y-full rounded-sm bg-background px-3 py-2 text-sm text-foreground opacity-0 shadow-md transition-all group-hover/diff:translate-y-[calc(-100%-8px)] group-hover/diff:opacity-100'>
+                        <div className='pointer-events-none absolute inset-x-0 top-0 z-50 w-full max-w-[240px] -translate-y-full text-pretty rounded-sm bg-background px-3 py-2 text-sm text-foreground opacity-0 shadow-md transition-all group-hover/diff:translate-y-[calc(-100%-8px)] group-hover/diff:opacity-100'>
                             {diffTooltip}
                         </div>
                     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2456/add-max-width-and-text-pretty-to-tooltips-on-overview

- The tooltip over the trend values in Analytics overview KPIs were too wide (covering the "View more" button) and it could have widows in certain cases. This PR sets a max width for the tooltip.
