### PR TITLE
Updated ActivityPub default error screen to redirect to the new homepage

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -8,9 +8,9 @@ const Error = ({statusCode}: {statusCode?: number}) => {
     const routeError = useRouteError();
     const navigate = useNavigate();
 
-    const toDashboard = (e: React.MouseEvent<HTMLElement>) => {
+    const toAnalytics = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        navigate('/dashboard', {crossApp: true});
+        navigate('/analytics', {crossApp: true});
     };
 
     if (routeError) {
@@ -56,7 +56,7 @@ const Error = ({statusCode}: {statusCode?: number}) => {
             <div className="admin-x-error max-w-xl">
                 <h1>Loading interrupted</h1>
                 <p>They say life is a series of trials and tribulations. This moment right here? It&apos;s a tribulation. Our app was supposed to load, and yet here we are. Loadless. Click back to the dashboard to try again.</p>
-                <a className='cursor-pointer text-green' onClick={toDashboard}>&larr; Back to the dashboard</a>
+                <a className='cursor-pointer text-green' onClick={toAnalytics}>&larr; Back to the homepage</a>
             </div>
         </div>
     );


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2414/activitypub-error-page-links-to-dashboard

- in Ghost 6.0, the new Admin homepage is /analytics, as opposed to the previous /dashboard
