### PR TITLE
Added clickthrough from post analytics to members

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -74,12 +74,14 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                 <div className='flex flex-col md:grid md:grid-cols-3 md:items-stretch'>
                                     <KpiCard className='grow'>
                                         <KpiCardMoreButton onClick={() => {
-                                            navigate(`/members?filterParam=signup:'${postId}'%2Bconversion:-'${postId}'`, {crossApp: true});
+                                            const filterParam = encodeURIComponent(`signup:'${postId}'+conversion:-'${postId}'`);
+                                            navigate(`/members?filterParam=${filterParam}`, {crossApp: true});
                                         }}>
                                             View members &rarr;
                                         </KpiCardMoreButton>
                                         <KpiCardLabel onClick={() => {
-                                            navigate(`/members?filterParam=signup:'${postId}'%2Bconversion:-'${postId}'`, {crossApp: true});
+                                            const filterParam = encodeURIComponent(`signup:'${postId}'+conversion:-'${postId}'`);
+                                            navigate(`/members?filterParam=${filterParam}`, {crossApp: true});
                                         }}>
                                             <LucideIcon.User strokeWidth={1.5} />
                                             Free members
@@ -92,12 +94,14 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     <>
                                         <KpiCard className='grow'>
                                             <KpiCardMoreButton onClick={() => {
-                                                navigate(`/members?filterParam=conversion:'${postId}'`, {crossApp: true});
+                                                const filterParam = encodeURIComponent(`conversion:'${postId}'`);
+                                                navigate(`/members?filterParam=${filterParam}`, {crossApp: true});
                                             }}>
                                                 View members &rarr;
                                             </KpiCardMoreButton>
                                             <KpiCardLabel onClick={() => {
-                                                navigate(`/members?filterParam=conversion:'${postId}'`, {crossApp: true});
+                                                const filterParam = encodeURIComponent(`conversion:'${postId}'`);
+                                                navigate(`/members?filterParam=${filterParam}`, {crossApp: true});
                                             }}>
                                                 <LucideIcon.WalletCards strokeWidth={1.5} />
                                                 Paid members

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -1,9 +1,9 @@
 import GrowthSources from './components/GrowthSources';
-import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components/KpiCard';
+import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardMoreButton, KpiCardValue} from '../components/KpiCard';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import React from 'react';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
+import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/App';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useNavigate, useParams} from '@tryghost/admin-x-framework';
@@ -72,11 +72,15 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                             </CardHeader>
                             <CardContent className='p-0'>
                                 <div className='flex flex-col md:grid md:grid-cols-3 md:items-stretch'>
-                                    <KpiCard className='group relative grow'>
-                                        <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                                            navigate(`/members?filterParam=signup:[${postId}]`, {crossApp: true});
-                                        }}>View members &rarr;</Button>
-                                        <KpiCardLabel>
+                                    <KpiCard className='grow'>
+                                        <KpiCardMoreButton onClick={() => {
+                                            navigate(`/members?filterParam=signup:'${postId}'%2Bconversion:-'${postId}'`, {crossApp: true});
+                                        }}>
+                                            View members &rarr;
+                                        </KpiCardMoreButton>
+                                        <KpiCardLabel onClick={() => {
+                                            navigate(`/members?filterParam=signup:'${postId}'%2Bconversion:-'${postId}'`, {crossApp: true});
+                                        }}>
                                             <LucideIcon.User strokeWidth={1.5} />
                                             Free members
                                         </KpiCardLabel>
@@ -86,13 +90,17 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     </KpiCard>
                                     {appSettings?.paidMembersEnabled &&
                                     <>
-                                        <KpiCard className='group relative grow'>
-                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                        <KpiCard className='grow'>
+                                            <KpiCardMoreButton onClick={() => {
                                                 navigate(`/members?filterParam=conversion:[${postId}]`, {crossApp: true});
-                                            }}>View members &rarr;</Button>
-                                            <KpiCardLabel>
+                                            }}>
+                                                View members &rarr;
+                                            </KpiCardMoreButton>
+                                            <KpiCardLabel onClick={() => {
+                                                navigate(`/members?filterParam=conversion:[${postId}]`, {crossApp: true});
+                                            }}>
                                                 <LucideIcon.WalletCards strokeWidth={1.5} />
-                                            Paid members
+                                                Paid members
                                             </KpiCardLabel>
                                             <KpiCardContent>
                                                 <KpiCardValue>{formatNumber(totals?.paid_members || 0)}</KpiCardValue>
@@ -101,7 +109,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                         <KpiCard className='grow'>
                                             <KpiCardLabel>
                                                 <LucideIcon.Coins strokeWidth={1.5} />
-                                            MRR
+                                                MRR
                                             </KpiCardLabel>
                                             <KpiCardContent>
                                                 <KpiCardValue>+{currencySymbol}{centsToDollars(totals?.mrr || 0)}</KpiCardValue>

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -3,10 +3,10 @@ import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import React from 'react';
-import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/App';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
-import {useParams} from '@tryghost/admin-x-framework';
+import {useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 
 export const centsToDollars = (value : number) => {
@@ -20,6 +20,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {postId} = useParams();
     const {stats: postReferrers, totals, isLoading, currencySymbol} = usePostReferrers(postId || '');
     const {appSettings} = useAppContext();
+    const navigate = useNavigate();
 
     // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;
@@ -71,7 +72,10 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                             </CardHeader>
                             <CardContent className='p-0'>
                                 <div className='flex flex-col md:grid md:grid-cols-3 md:items-stretch'>
-                                    <KpiCard className='grow'>
+                                    <KpiCard className='group relative grow'>
+                                        <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                            navigate(`/members?filterParam=signup:[${postId}]`, {crossApp: true});
+                                        }}>View members &rarr;</Button>
                                         <KpiCardLabel>
                                             <LucideIcon.User strokeWidth={1.5} />
                                             Free members
@@ -82,7 +86,10 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     </KpiCard>
                                     {appSettings?.paidMembersEnabled &&
                                     <>
-                                        <KpiCard className='grow'>
+                                        <KpiCard className='group relative grow'>
+                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                                navigate(`/members?filterParam=conversion:[${postId}]`, {crossApp: true});
+                                            }}>View members &rarr;</Button>
                                             <KpiCardLabel>
                                                 <LucideIcon.WalletCards strokeWidth={1.5} />
                                             Paid members

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -92,12 +92,12 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                     <>
                                         <KpiCard className='grow'>
                                             <KpiCardMoreButton onClick={() => {
-                                                navigate(`/members?filterParam=conversion:[${postId}]`, {crossApp: true});
+                                                navigate(`/members?filterParam=conversion:'${postId}'`, {crossApp: true});
                                             }}>
                                                 View members &rarr;
                                             </KpiCardMoreButton>
                                             <KpiCardLabel onClick={() => {
-                                                navigate(`/members?filterParam=conversion:[${postId}]`, {crossApp: true});
+                                                navigate(`/members?filterParam=conversion:'${postId}'`, {crossApp: true});
                                             }}>
                                                 <LucideIcon.WalletCards strokeWidth={1.5} />
                                                 Paid members

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -1,6 +1,6 @@
 // import AudienceSelect from './components/AudienceSelect';
 import Feedback from './components/Feedback';
-import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components/KpiCard';
+import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardMoreButton, KpiCardValue} from '../components/KpiCard';
 import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, ChartConfig, DataList, DataListBar, DataListBody, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, Input, LucideIcon, Separator, SimplePagination, SimplePaginationNavigation, SimplePaginationNextButton, SimplePaginationPreviousButton, SkeletonTable, formatNumber, formatPercentage, useSimplePagination} from '@tryghost/shade';
@@ -281,11 +281,15 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                             :
                             <CardContent className='p-0'>
                                 <div className={`grid ${chartHeaderClass} items-stretch border-b`}>
-                                    <KpiCard className='group relative grow p-3 md:px-6 md:py-5'>
-                                        <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                    <KpiCard className='group relative isolate grow p-3 md:px-6 md:py-5'>
+                                        <KpiCardMoreButton onClick={() => {
                                             navigate(`/members?filterParam=emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
-                                        }}>View members &rarr;</Button>
-                                        <KpiCardLabel>
+                                        }}>
+                                            View members &rarr;
+                                        </KpiCardMoreButton>
+                                        <KpiCardLabel onClick={() => {
+                                            navigate(`/members?filterParam=emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                        }}>
                                             <div className='ml-0.5 size-[9px] rounded-full bg-chart-purple !text-sm opacity-50 lg:text-base'></div>
                                     Sent
                                         </KpiCardLabel>
@@ -295,13 +299,17 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                     </KpiCard>
 
                                     {emailTrackOpensEnabled &&
-                                        <KpiCard className='group relative grow p-3 md:px-6 md:py-5'>
-                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                        <KpiCard className='p-3 md:px-6 md:py-5'>
+                                            <KpiCardMoreButton onClick={() => {
                                                 navigate(`/members?filterParam=opened_emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
-                                            }}>View members &rarr;</Button>
-                                            <KpiCardLabel>
+                                            }}>
+                                                View members &rarr;
+                                            </KpiCardMoreButton>
+                                            <KpiCardLabel onClick={() => {
+                                                navigate(`/members?filterParam=opened_emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            }}>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-blue !text-sm opacity-50 lg:text-base'></div>
-                                        Opened
+                                                Opened
                                             </KpiCardLabel>
                                             <KpiCardContent>
                                                 <KpiCardValue className='text-xl leading-none sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.opened)}</KpiCardValue>
@@ -310,13 +318,17 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                     }
 
                                     {emailTrackClicksEnabled &&
-                                        <KpiCard className='group relative grow  p-3 md:px-6 md:py-5'>
-                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                        <KpiCard className='group relative isolate grow p-3 md:px-6 md:py-5'>
+                                            <KpiCardMoreButton onClick={() => {
                                                 navigate(`/members?filterParam=clicked_links.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
-                                            }}>View members &rarr;</Button>
-                                            <KpiCardLabel>
+                                            }}>
+                                                View members &rarr;
+                                            </KpiCardMoreButton>
+                                            <KpiCardLabel onClick={() => {
+                                                navigate(`/members?filterParam=clicked_links.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            }}>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-teal !text-sm opacity-50 lg:text-base'></div>
-                                        Clicked
+                                                Clicked
                                             </KpiCardLabel>
                                             <KpiCardContent>
                                                 <KpiCardValue className='text-xl leading-none sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.clicked)}</KpiCardValue>

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -283,12 +283,20 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                 <div className={`grid ${chartHeaderClass} items-stretch border-b`}>
                                     <KpiCard className='group relative isolate grow p-3 md:px-6 md:py-5'>
                                         <KpiCardMoreButton onClick={() => {
-                                            navigate(`/members?filterParam=emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            const params = new URLSearchParams({
+                                                filterParam: `emails.post_id:${postId}`,
+                                                postAnalytics: postId
+                                            });
+                                            navigate(`/members?${params.toString()}`, {crossApp: true});
                                         }}>
                                             View members &rarr;
                                         </KpiCardMoreButton>
                                         <KpiCardLabel onClick={() => {
-                                            navigate(`/members?filterParam=emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            const params = new URLSearchParams({
+                                                filterParam: `emails.post_id:${postId}`,
+                                                postAnalytics: postId
+                                            });
+                                            navigate(`/members?${params.toString()}`, {crossApp: true});
                                         }}>
                                             <div className='ml-0.5 size-[9px] rounded-full bg-chart-purple !text-sm opacity-50 lg:text-base'></div>
                                     Sent
@@ -301,12 +309,20 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                     {emailTrackOpensEnabled &&
                                         <KpiCard className='p-3 md:px-6 md:py-5'>
                                             <KpiCardMoreButton onClick={() => {
-                                                navigate(`/members?filterParam=opened_emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                                const params = new URLSearchParams({
+                                                    filterParam: `opened_emails.post_id:${postId}`,
+                                                    postAnalytics: postId
+                                                });
+                                                navigate(`/members?${params.toString()}`, {crossApp: true});
                                             }}>
                                                 View members &rarr;
                                             </KpiCardMoreButton>
                                             <KpiCardLabel onClick={() => {
-                                                navigate(`/members?filterParam=opened_emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                                const params = new URLSearchParams({
+                                                    filterParam: `opened_emails.post_id:${postId}`,
+                                                    postAnalytics: postId
+                                                });
+                                                navigate(`/members?${params.toString()}`, {crossApp: true});
                                             }}>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-blue !text-sm opacity-50 lg:text-base'></div>
                                                 Opened
@@ -320,12 +336,20 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                     {emailTrackClicksEnabled &&
                                         <KpiCard className='group relative isolate grow p-3 md:px-6 md:py-5'>
                                             <KpiCardMoreButton onClick={() => {
-                                                navigate(`/members?filterParam=clicked_links.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                                const params = new URLSearchParams({
+                                                    filterParam: `clicked_links.post_id:${postId}`,
+                                                    postAnalytics: postId
+                                                });
+                                                navigate(`/members?${params.toString()}`, {crossApp: true});
                                             }}>
                                                 View members &rarr;
                                             </KpiCardMoreButton>
                                             <KpiCardLabel onClick={() => {
-                                                navigate(`/members?filterParam=clicked_links.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                                const params = new URLSearchParams({
+                                                    filterParam: `clicked_links.post_id:${postId}`,
+                                                    postAnalytics: postId
+                                                });
+                                                navigate(`/members?${params.toString()}`, {crossApp: true});
                                             }}>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-teal !text-sm opacity-50 lg:text-base'></div>
                                                 Clicked

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -281,41 +281,45 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                             :
                             <CardContent className='p-0'>
                                 <div className={`grid ${chartHeaderClass} items-stretch border-b`}>
-                                    <KpiCard className='relative grow p-3 md:p-6'>
-                                        {/* <FunnelArrow /> */}
+                                    <KpiCard className='group relative grow p-3 md:px-6 md:py-5'>
+                                        <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                            navigate(`/members?filterParam=emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                        }}>View members &rarr;</Button>
                                         <KpiCardLabel>
                                             <div className='ml-0.5 size-[9px] rounded-full bg-chart-purple !text-sm opacity-50 lg:text-base'></div>
-                                            {/* <LucideIcon.Send strokeWidth={1.5} /> */}
                                     Sent
                                         </KpiCardLabel>
                                         <KpiCardContent>
-                                            <KpiCardValue className='text-xl sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.sent)}</KpiCardValue>
+                                            <KpiCardValue className='text-xl leading-none sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.sent)}</KpiCardValue>
                                         </KpiCardContent>
                                     </KpiCard>
 
                                     {emailTrackOpensEnabled &&
-                                        <KpiCard className='relative grow p-3 md:p-6'>
-                                            {/* <FunnelArrow /> */}
+                                        <KpiCard className='group relative grow p-3 md:px-6 md:py-5'>
+                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                                navigate(`/members?filterParam=opened_emails.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            }}>View members &rarr;</Button>
                                             <KpiCardLabel>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-blue !text-sm opacity-50 lg:text-base'></div>
-                                                {/* <LucideIcon.Eye strokeWidth={1.5} /> */}
                                         Opened
                                             </KpiCardLabel>
                                             <KpiCardContent>
-                                                <KpiCardValue className='text-xl sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.opened)}</KpiCardValue>
+                                                <KpiCardValue className='text-xl leading-none sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.opened)}</KpiCardValue>
                                             </KpiCardContent>
                                         </KpiCard>
                                     }
 
                                     {emailTrackClicksEnabled &&
-                                        <KpiCard className='relative grow p-3 md:p-6'>
+                                        <KpiCard className='group relative grow  p-3 md:px-6 md:py-5'>
+                                            <Button className='absolute right-6 translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                                navigate(`/members?filterParam=clicked_links.post_id:${postId}&postAnalytics=${postId}`, {crossApp: true});
+                                            }}>View members &rarr;</Button>
                                             <KpiCardLabel>
                                                 <div className='ml-0.5 size-[9px] rounded-full bg-chart-teal !text-sm opacity-50 lg:text-base'></div>
-                                                {/* <LucideIcon.MousePointer strokeWidth={1.5} /> */}
                                         Clicked
                                             </KpiCardLabel>
                                             <KpiCardContent>
-                                                <KpiCardValue className='text-xl sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.clicked)}</KpiCardValue>
+                                                <KpiCardValue className='text-xl leading-none sm:text-2xl md:text-[2.6rem]'>{formatNumber(stats.clicked)}</KpiCardValue>
                                             </KpiCardContent>
                                         </KpiCard>
                                     }

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {cn} from '@tryghost/shade';
+import {Button, cn} from '@tryghost/shade';
 
 export const KpiCardContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
@@ -11,7 +11,11 @@ export const KpiCardContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
 
 export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <div className={cn('[&_svg]:size-4 flex items-center gap-1.5 text-base h-[22px] font-medium transition-all', className)} {...props}>
+        <div className={
+            cn('[&_svg]:size-4 flex items-center gap-1.5 text-base h-[22px] font-medium transition-all',
+                className,
+                props.onClick && 'hover:cursor-pointer hover:text-black'
+            )} {...props}>
             {children}
         </div>
     );
@@ -25,12 +29,20 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
     );
 };
 
+export const KpiCardMoreButton: React.FC<React.HTMLAttributes<HTMLButtonElement>> = ({children, className, ...props}) => {
+    return (
+        <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 md:!visible md:!block', className)} size='sm' variant='outline' {...props}>
+            {children}
+        </Button>
+    );
+};
+
 const KpiCard: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
         <div
             className={
                 cn(
-                    'group flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all text-muted-foreground',
+                    'group relative isolate flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all text-muted-foreground',
                     props.onClick ? 'hover:bg-accent/50 hover:text-foreground cursor-pointer' : 'cursor-auto',
                     className
                 )}

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -29,7 +29,7 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
     );
 };
 
-export const KpiCardMoreButton: React.FC<React.HTMLAttributes<HTMLButtonElement>> = ({children, className, ...props}) => {
+export const KpiCardMoreButton: React.FC<React.ComponentProps<typeof Button>> = ({children, className, ...props}) => {
     return (
         <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 md:!visible md:!block', className)} size='sm' variant='outline' {...props}>
             {children}

--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -25,20 +25,19 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
     );
 };
 
-const KpiCard: React.FC<React.HTMLAttributes<HTMLButtonElement>> = ({children, className, ...props}) => {
+const KpiCard: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <button
+        <div
             className={
                 cn(
                     'group flex flex-col border-r border-border last:border-none items-start gap-2 px-6 py-5 transition-all text-muted-foreground',
-                    props.onClick ? 'hover:bg-accent/50 hover:text-foreground' : 'cursor-auto',
+                    props.onClick ? 'hover:bg-accent/50 hover:text-foreground cursor-pointer' : 'cursor-auto',
                     className
                 )}
-            type='button'
             {...props}
         >
             {children}
-        </button>
+        </div>
     );
 };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2353/add-links-to-filter-members-by-opens-clicks-from-post-newsletter-page

- Customers were missing the ability to filter members who received, clicked or opened emails + who signed up, directly from the post analytics Newsletter & Growth tabs.