### PR TITLE
Re-enabled Renovate automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,12 +98,6 @@
                 "/^css/"
             ],
             "enabled": false
-        },
-
-        // Disable automerge for all packages during code freeze
-        {
-            "matchPackageNames": ["*"],
-            "automerge": false
         }
     ]
 }


### PR DESCRIPTION
reverts commit 239d6c0cb947eb9e6343472c9a241c359a329ae3.

- code-freeze for the 6.0 major is over, we can allow renovate to automatically merge passing PRs again
