### PR TITLE
🐛 Fixed ActivityPub `/ghost/api/admin/site/` access with separated admin setup

### DIFF
--- a/ghost/core/core/frontend/web/middleware/redirect-ghost-to-admin.js
+++ b/ghost/core/core/frontend/web/middleware/redirect-ghost-to-admin.js
@@ -2,10 +2,10 @@ const express = require('../../../shared/express');
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 
-const adminRedirect = (path) => {
-    return function doRedirect(req, res) {
-        return urlUtils.redirectToAdmin(301, res, path);
-    };
+// Extract the core redirect logic for easier testing
+const handleAdminRedirect = function (req, res) {
+    const adminPath = req.path.replace(/^\/ghost/, '') || '/';
+    return urlUtils.redirectToAdmin(301, res, adminPath);
 };
 
 // redirect to /ghost to the admin
@@ -13,8 +13,11 @@ module.exports = function redirectGhostToAdmin() {
     const router = express.Router('redirect-ghost-to-admin');
 
     if (config.get('admin:redirects')) {
-        router.get(/^\/ghost\/?$/, adminRedirect('/'));
+        router.get(/^\/ghost(\/.*)?\/?$/, handleAdminRedirect);
     }
 
     return router;
 };
+
+// Export the core logic for testing
+module.exports.handleAdminRedirect = handleAdminRedirect;

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -130,10 +130,10 @@ describe('Advanced URL Configurations', function () {
                     .expect('Location', 'http://localhost:9999/blog/ghost/');
             });
 
-            it('/blog/ghost/api/settings/site/ should redirect to external admin API route', async function () {
-                await request.get('/blog/ghost/api/settings/site/')
+            it('/blog/ghost/api/admin/site/ should redirect to external admin API route', async function () {
+                await request.get('/blog/ghost/api/admin/site/')
                     .expect(301)
-                    .expect('Location', 'http://localhost:9999/blog/ghost/api/settings/site/');
+                    .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/site/');
             });
         });
     });

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -98,50 +98,47 @@ describe('Advanced URL Configurations', function () {
                     .expect('Cache-Control', testUtils.cacheRules.noCache);
             });
         });
+    });
 
-        describe('/ghost/ redirects with separate admin', function () {
-            before(async function () {
-                // TODO: fix urlUtils.restore to be async and await configUtils.restore
-                urlUtils.restore(); // this also restores configUtils so needs to happen first
-                await configUtils.restore(); // urlUtils.restore() doesn't await configUtils.restore() despite it being a Promise
-                configUtils.set('url', 'http://localhost/blog/');
-                configUtils.set('admin:redirects', true);
-                configUtils.set('admin:url', 'http://localhost:9999/');
-                urlUtils.stubUrlUtilsFromConfig();
-                await testUtils.startGhost();
-                request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
-            });
+    describe('Subdirectory config: /ghost/ redirects with separate admin', function () {
+        before(async function () {
+            await urlUtils.restore();
+            configUtils.set('url', 'http://localhost/blog/');
+            configUtils.set('admin:redirects', true);
+            configUtils.set('admin:url', 'http://localhost:9999/');
+            urlUtils.stubUrlUtilsFromConfig();
+            await testUtils.startGhost();
+            request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
+        });
 
-            after(async function () {
-                await configUtils.restore();
-                await testUtils.startGhost();
-                request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
-            });
+        after(async function () {
+            await configUtils.restore();
+            await testUtils.startGhost();
+            request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
+        });
 
-            it('/blog/ghost should redirect to external admin SPA', async function () {
-                await request.get('/blog/ghost')
-                    .expect(301)
-                    .expect('Location', 'http://localhost:9999/blog/ghost/');
-            });
+        it('/blog/ghost should redirect to external admin SPA', async function () {
+            await request.get('/blog/ghost')
+                .expect(301)
+                .expect('Location', 'http://localhost:9999/blog/ghost/');
+        });
 
-            it('/blog/ghost/ should redirect to external admin SPA', async function () {
-                await request.get('/blog/ghost/')
-                    .expect(301)
-                    .expect('Location', 'http://localhost:9999/blog/ghost/');
-            });
+        it('/blog/ghost/ should redirect to external admin SPA', async function () {
+            await request.get('/blog/ghost/')
+                .expect(301)
+                .expect('Location', 'http://localhost:9999/blog/ghost/');
+        });
 
-            it('/blog/ghost/api/admin/posts/ should redirect to external admin API route', async function () {
-                await request.get('/blog/ghost/api/admin/posts/')
-                    .expect(301)
-                    .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/posts/');
-            });
+        it('/blog/ghost/api/admin/posts/ should redirect to external admin API route', async function () {
+            await request.get('/blog/ghost/api/admin/posts/')
+                .expect(301)
+                .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/posts/');
+        });
 
-            // NOTE: this uses middleware.publicAdminApi which has an explicit redirect outside of normal vhost setup
-            it('/blog/ghost/api/admin/site/ should redirect to external admin API route', async function () {
-                await request.get('/blog/ghost/api/admin/site/')
-                    .expect(301)
-                    .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/site/');
-            });
+        it('/blog/ghost/api/admin/site/ should redirect to external admin API route', async function () {
+            await request.get('/blog/ghost/api/admin/site/')
+                .expect(301)
+                .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/site/');
         });
     });
 });

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -105,7 +105,7 @@ describe('Advanced URL Configurations', function () {
             await urlUtils.restore();
             configUtils.set('url', 'http://localhost/blog/');
             configUtils.set('admin:redirects', true);
-            configUtils.set('admin:url', 'http://localhost:9999/');
+            configUtils.set('admin:url', 'http://admin.localhost/');
             urlUtils.stubUrlUtilsFromConfig();
             await testUtils.startGhost();
             request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));
@@ -120,25 +120,25 @@ describe('Advanced URL Configurations', function () {
         it('/blog/ghost should redirect to external admin SPA', async function () {
             await request.get('/blog/ghost')
                 .expect(301)
-                .expect('Location', 'http://localhost:9999/blog/ghost/');
+                .expect('Location', 'http://admin.localhost/blog/ghost/');
         });
 
         it('/blog/ghost/ should redirect to external admin SPA', async function () {
             await request.get('/blog/ghost/')
                 .expect(301)
-                .expect('Location', 'http://localhost:9999/blog/ghost/');
+                .expect('Location', 'http://admin.localhost/blog/ghost/');
         });
 
         it('/blog/ghost/api/admin/posts/ should redirect to external admin API route', async function () {
             await request.get('/blog/ghost/api/admin/posts/')
                 .expect(301)
-                .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/posts/');
+                .expect('Location', 'http://admin.localhost/blog/ghost/api/admin/posts/');
         });
 
         it('/blog/ghost/api/admin/site/ should redirect to external admin API route', async function () {
             await request.get('/blog/ghost/api/admin/site/')
                 .expect(301)
-                .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/site/');
+                .expect('Location', 'http://admin.localhost/blog/ghost/api/admin/site/');
         });
     });
 });

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -30,7 +30,7 @@ describe('Advanced URL Configurations', function () {
 
         after(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
             mockManager.restore();
         });
 
@@ -102,7 +102,6 @@ describe('Advanced URL Configurations', function () {
 
     describe('Subdirectory config: /ghost/ redirects with separate admin', function () {
         before(async function () {
-            await urlUtils.restore();
             configUtils.set('url', 'http://localhost/blog/');
             configUtils.set('admin:redirects', true);
             configUtils.set('admin:url', 'http://admin.localhost/');
@@ -112,6 +111,7 @@ describe('Advanced URL Configurations', function () {
         });
 
         after(async function () {
+            await urlUtils.restore();
             await configUtils.restore();
             await testUtils.startGhost();
             request = supertest.agent(configUtils.config.get('server:host') + ':' + configUtils.config.get('server:port'));

--- a/ghost/core/test/e2e-frontend/advanced_url_config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced_url_config.test.js
@@ -130,6 +130,13 @@ describe('Advanced URL Configurations', function () {
                     .expect('Location', 'http://localhost:9999/blog/ghost/');
             });
 
+            it('/blog/ghost/api/admin/posts/ should redirect to external admin API route', async function () {
+                await request.get('/blog/ghost/api/admin/posts/')
+                    .expect(301)
+                    .expect('Location', 'http://localhost:9999/blog/ghost/api/admin/posts/');
+            });
+
+            // NOTE: this uses middleware.publicAdminApi which has an explicit redirect outside of normal vhost setup
             it('/blog/ghost/api/admin/site/ should redirect to external admin API route', async function () {
                 await request.get('/blog/ghost/api/admin/site/')
                     .expect(301)

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -184,6 +184,77 @@ describe('Default Frontend routing', function () {
         });
     });
 
+    describe('/ghost/ redirects', function () {
+        describe('with separate admin and admin:redirects=false', function () {
+            before(async function () {
+                configUtils.set('admin:redirects', false);
+                configUtils.set('admin:url', 'http://localhost:9999');
+
+                await testUtils.startGhost();
+                request = supertest.agent(configUtils.config.get('url'));
+            });
+
+            after(async function () {
+                await configUtils.restore();
+
+                await testUtils.startGhost();
+                request = supertest.agent(configUtils.config.get('url'));
+            });
+
+            it('/ghost/ should NOT redirect', async function () {
+                await request.get('/ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
+                    .expect(404)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+
+            it('/ghost/api/settings/site/ should NOT redirect', async function () {
+                await request.get('/ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
+                    .expect(404)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+        });
+
+        describe('with separate admin and admin:redirects=true', function () {
+            before(async function () {
+                configUtils.set('admin:redirects', true);
+                configUtils.set('admin:url', 'http://localhost:9999');
+
+                await testUtils.startGhost();
+                request = supertest.agent(configUtils.config.get('url'));
+            });
+
+            after(async function () {
+                await configUtils.restore();
+
+                await testUtils.startGhost();
+                request = supertest.agent(configUtils.config.get('url'));
+            });
+
+            it('/ghost should redirect to external admin SPA', async function () {
+                await request.get('/ghost')
+                    .expect('Location', 'http://localhost:9999/ghost/')
+                    .expect(301)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+
+            it('/ghost/ should redirect to external admin SPA', async function () {
+                await request.get('/ghost/')
+                    .expect('Location', 'http://localhost:9999/ghost/')
+                    .expect(301)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+
+            it('/ghost/api/settings/site/ should redirect to external admin API route', async function () {
+                await request.get('/ghost/api/settings/site/')
+                    .expect('Location', 'http://localhost:9999/ghost/api/settings/site/')
+                    .expect(301)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+        });
+    });
+
     describe('AMP post', function () {
         // AMP is no longer supported as of v6.0, so we only check the case in which it's disabled
         describe('AMP Disabled', function () {

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -209,7 +209,7 @@ describe('Default Frontend routing', function () {
             });
 
             it('/ghost/api/settings/site/ should NOT redirect', async function () {
-                await request.get('/ghost/')
+                await request.get('/ghost/api/settings/site/')
                     .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(assertCorrectFrontendHeaders);

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -246,9 +246,16 @@ describe('Default Frontend routing', function () {
                     .expect(assertCorrectFrontendHeaders);
             });
 
-            it('/ghost/api/settings/site/ should redirect to external admin API route', async function () {
-                await request.get('/ghost/api/settings/site/')
-                    .expect('Location', 'http://localhost:9999/ghost/api/settings/site/')
+            it('/ghost/api/admin/site/ (known path) should redirect to external admin API route', async function () {
+                await request.get('/ghost/api/admin/site/')
+                    .expect('Location', 'http://localhost:9999/ghost/api/admin/site/')
+                    .expect(301)
+                    .expect(assertCorrectFrontendHeaders);
+            });
+
+            it('/ghost/api/new-endpoint/ (unknown path) should redirect to external admin API route', async function () {
+                await request.get('/ghost/api/new-endpoint/')
+                    .expect('Location', 'http://localhost:9999/ghost/api/new-endpoint/')
                     .expect(301)
                     .expect(assertCorrectFrontendHeaders);
             });

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -202,6 +202,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     response.statusCode.should.eql(301);
+                    response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
 
@@ -216,6 +217,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     response.statusCode.should.eql(301);
+                    response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
 

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -191,7 +191,7 @@ describe('Integration - Web - vhosts', function () {
                 });
         });
 
-        it('404s the api on configured url', function () {
+        it('redirects the api on configured url', function () {
             const req = {
                 secure: false,
                 method: 'GET',
@@ -201,11 +201,11 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    response.statusCode.should.eql(301);
                 });
         });
 
-        it('404s the api on localhost', function () {
+        it('redirects the api on localhost', function () {
             const req = {
                 secure: false,
                 method: 'GET',
@@ -215,7 +215,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    response.statusCode.should.eql(301);
                 });
         });
 
@@ -305,6 +305,20 @@ describe('Integration - Web - vhosts', function () {
                 secure: false,
                 method: 'GET',
                 url: '/ghost/',
+                host: 'example.com'
+            };
+
+            return localUtils.mockExpress.invoke(app, req)
+                .then(function (response) {
+                    response.statusCode.should.eql(404);
+                });
+        });
+
+        it('404s the api on configured url', function () {
+            const req = {
+                secure: false,
+                method: 'GET',
+                url: `${ADMIN_API_URL}/site/`,
                 host: 'example.com'
             };
 

--- a/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
@@ -1,0 +1,89 @@
+const should = require('should');
+const sinon = require('sinon');
+const redirectGhostToAdmin = require('../../../../../core/frontend/web/middleware/redirect-ghost-to-admin');
+const {handleAdminRedirect} = require('../../../../../core/frontend/web/middleware/redirect-ghost-to-admin');
+const configUtils = require('../../../../utils/configUtils');
+const urlUtils = require('../../../../../core/shared/url-utils');
+
+describe('Redirect Ghost To Admin', function () {
+    let req;
+    let res;
+    let redirectToAdminStub;
+
+    beforeEach(function () {
+        req = {
+            path: ''
+        };
+        res = {
+            redirect: sinon.spy()
+        };
+
+        redirectToAdminStub = sinon.stub(urlUtils, 'redirectToAdmin');
+    });
+
+    afterEach(async function () {
+        sinon.restore();
+        await configUtils.restore();
+    });
+
+    // Helper function to test redirect behavior
+    const expectPathCallsRedirectToAdminWith = (inputPath, expectedAdminPath) => {
+        req.path = inputPath;
+        handleAdminRedirect(req, res);
+        redirectToAdminStub.calledOnce.should.be.true();
+        redirectToAdminStub.calledWith(301, res, expectedAdminPath).should.be.true();
+    };
+
+    describe('handleAdminRedirect function', function () {
+        it('should redirect /ghost (no trailing slash) to admin root', function () {
+            expectPathCallsRedirectToAdminWith('/ghost', '/');
+        });
+
+        it('should redirect /ghost/ to admin root', function () {
+            expectPathCallsRedirectToAdminWith('/ghost/', '/');
+        });
+
+        it('should redirect /ghost/api/admin/site/ to admin API', function () {
+            expectPathCallsRedirectToAdminWith('/ghost/api/admin/site/', '/api/admin/site/');
+        });
+    });
+
+    describe('redirectGhostToAdmin middleware', function () {
+        it('should return router with no routes when admin:redirects is disabled', function () {
+            configUtils.set({admin: {redirects: false}});
+
+            const router = redirectGhostToAdmin();
+
+            // When disabled, no ghost redirect routes should be added
+            const ghostRoutes = router.stack.filter(layer => layer.regexp.source.includes('ghost'));
+            ghostRoutes.should.have.length(0);
+        });
+
+        it('should add admin redirect route when admin:redirects is enabled', function () {
+            configUtils.set({admin: {redirects: true}});
+
+            const router = redirectGhostToAdmin();
+
+            // Find the ghost redirect route
+            const ghostRoute = router.stack.find(layer => layer.regexp.source.includes('ghost'));
+            ghostRoute.should.not.be.undefined();
+        });
+
+        it('admin redirect route should match the correct regex pattern', function () {
+            configUtils.set({admin: {redirects: true}});
+
+            const router = redirectGhostToAdmin();
+            const route = router.stack.find(layer => layer.regexp.source.includes('ghost'));
+
+            // Test that the regex matches the expected paths
+            route.regexp.test('/ghost').should.be.true();
+            route.regexp.test('/ghost/').should.be.true();
+            route.regexp.test('/ghost/api/admin/site/').should.be.true();
+
+            // Test that it doesn't match unrelated paths
+            route.regexp.test('/admin').should.be.false();
+            route.regexp.test('/.ghost/').should.be.false();
+            route.regexp.test('/tag/ghost/').should.be.false();
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2429/

- ActivityPub assumes it can fetch `{site url}/ghost/api/admin/site/` but for self-hosters with separated front-end/admin domain setups that endpoint would 404 because `/ghost/*` routes are only served by the admin app which lives at `{admin url}/ghost/`
- updated the `redirectGhostToAdmin` middleware used by the frontend app so it now redirects `{site}/ghost/*` instead of just `{site}/ghost/`, fixing the 404 that ActivityPub was receiving when hitting the front-end
