### PR TITLE
Fixed Amazon link card display issues

### DIFF
--- a/ghost/core/core/server/services/oembed/AmazonOEmbedProvider.js
+++ b/ghost/core/core/server/services/oembed/AmazonOEmbedProvider.js
@@ -1,0 +1,201 @@
+const logging = require('@tryghost/logging');
+const cheerio = require('cheerio');
+
+/**
+ * @typedef {import('./oembed').ICustomProvider} ICustomProvider
+ * @typedef {import('./oembed').IExternalRequest} IExternalRequest
+ */
+
+// Matches Amazon product URLs from various Amazon domains
+const AMAZON_PRODUCT_PATH_REGEX = /\/(dp|gp\/product|exec\/obidos\/ASIN|o\/ASIN|gp\/aw\/d)\/([A-Z0-9]{10})/i;
+// Matches Amazon short URLs (amzn.to)
+const AMAZON_SHORT_URL_REGEX = /^\/([A-Z0-9]{10})/i;
+
+/**
+ * @implements ICustomProvider
+ */
+class AmazonOEmbedProvider {
+    /**
+     * @param {object} dependencies
+     */
+    constructor(dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    /**
+     * @param {URL} url
+     * @returns {Promise<boolean>}
+     */
+    async canSupportRequest(url) {
+        // Check if it's an Amazon domain
+        const amazonDomains = [
+            'amazon.com',
+            'amazon.co.uk',
+            'amazon.ca',
+            'amazon.de',
+            'amazon.fr',
+            'amazon.es',
+            'amazon.it',
+            'amazon.co.jp',
+            'amazon.com.br',
+            'amazon.com.mx',
+            'amazon.in',
+            'amazon.com.au',
+            'amzn.to', // Short URL
+            'amzn.com'
+        ];
+
+        const isAmazonDomain = amazonDomains.some(domain => 
+            url.host === domain || url.host === `www.${domain}`
+        );
+
+        if (!isAmazonDomain) {
+            return false;
+        }
+
+        // Check if it's a product page or a short URL
+        if (url.host === 'amzn.to' || url.host === 'amzn.com') {
+            return AMAZON_SHORT_URL_REGEX.test(url.pathname);
+        }
+        
+        return AMAZON_PRODUCT_PATH_REGEX.test(url.pathname);
+    }
+
+    /**
+     * Extract clean product data from Amazon HTML
+     * @param {string} html
+     * @param {URL} url
+     * @returns {object}
+     */
+    extractProductData(html, url) {
+        const $ = cheerio.load(html);
+        
+        // Extract product title - Amazon uses different selectors
+        let title = $('#productTitle').text().trim() ||
+                   $('h1#title').text().trim() ||
+                   $('meta[property="og:title"]').attr('content') ||
+                   $('meta[name="title"]').attr('content') ||
+                   $('title').text().trim();
+
+        // Clean up the title (remove "Amazon.com: " prefix if present)
+        if (title) {
+            title = title.replace(/^Amazon(\.[a-z]+)?:\s*/i, '').trim();
+        }
+
+        // Extract description - use feature bullets or product description
+        let description = '';
+        
+        // Try to get feature bullets first
+        const features = [];
+        $('#feature-bullets li span.a-list-item').each((i, el) => {
+            const text = $(el).text().trim();
+            if (text && !text.includes('Make sure this fits')) {
+                features.push(text);
+            }
+        });
+        
+        if (features.length > 0) {
+            description = features.slice(0, 3).join(' • ');
+        } else {
+            // Fallback to meta description
+            description = $('meta[property="og:description"]').attr('content') ||
+                         $('meta[name="description"]').attr('content') ||
+                         '';
+        }
+
+        // Extract product image
+        let image = $('meta[property="og:image"]').attr('content') ||
+                   $('#landingImage').attr('src') ||
+                   $('#imgBlkFront').attr('src') ||
+                   $('#main-image').attr('src') ||
+                   $('.image-container img').first().attr('src');
+
+        // Extract price if available
+        let price = $('.a-price-whole').first().text().trim() ||
+                   $('span.a-price').first().text().trim() ||
+                   '';
+
+        // Extract author/brand
+        let author = $('#bylineInfo').text().trim() ||
+                    $('.by-line a').first().text().trim() ||
+                    $('#brand').text().trim() ||
+                    '';
+        
+        if (author) {
+            author = author.replace(/^(by|Brand:)\s*/i, '').trim();
+        }
+
+        // Build a proper description if we only have title
+        if (!description && title) {
+            description = `View product details for ${title} on Amazon`;
+        }
+
+        return {
+            title: title || 'Amazon Product',
+            description: description,
+            image: image,
+            author: author,
+            price: price,
+            url: url.href
+        };
+    }
+
+    /**
+     * @param {URL} url
+     * @param {IExternalRequest} externalRequest
+     *
+     * @returns {Promise<object>}
+     */
+    async getOEmbedData(url, externalRequest) {
+        try {
+            // Fetch the Amazon product page
+            const response = await externalRequest(url.href, {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+                    'Accept-Language': 'en-US,en;q=0.5',
+                    'Accept-Encoding': 'gzip, deflate, br',
+                    'DNT': '1',
+                    'Connection': 'keep-alive',
+                    'Upgrade-Insecure-Requests': '1'
+                },
+                timeout: 5000,
+                followRedirect: true
+            });
+
+            const productData = this.extractProductData(response.body, url);
+
+            // Return in bookmark format since Amazon doesn't provide oEmbed
+            return {
+                version: '1.0',
+                type: 'bookmark',
+                url: url.href,
+                metadata: {
+                    title: productData.title,
+                    description: productData.description,
+                    author: productData.author,
+                    publisher: 'Amazon',
+                    thumbnail: productData.image,
+                    icon: 'https://www.amazon.com/favicon.ico'
+                }
+            };
+        } catch (err) {
+            logging.error('Failed to fetch Amazon product data', err);
+            
+            // Return a basic bookmark with minimal data
+            return {
+                version: '1.0',
+                type: 'bookmark',
+                url: url.href,
+                metadata: {
+                    title: 'Amazon Product',
+                    description: 'View this product on Amazon',
+                    publisher: 'Amazon',
+                    icon: 'https://www.amazon.com/favicon.ico'
+                }
+            };
+        }
+    }
+}
+
+module.exports = AmazonOEmbedProvider;

--- a/ghost/core/core/server/services/oembed/service.js
+++ b/ghost/core/core/server/services/oembed/service.js
@@ -19,7 +19,13 @@ const twitter = new Twitter({
     }
 });
 
+const Amazon = require('./AmazonOEmbedProvider');
+const amazon = new Amazon({
+    config: {}
+});
+
 oembed.registerProvider(nft);
 oembed.registerProvider(twitter);
+oembed.registerProvider(amazon);
 
 module.exports = oembed;

--- a/ghost/core/test/unit/server/services/oembed/amazon-oembed.test.js
+++ b/ghost/core/test/unit/server/services/oembed/amazon-oembed.test.js
@@ -1,0 +1,174 @@
+const assert = require('assert/strict');
+const sinon = require('sinon');
+const nock = require('nock');
+
+const AmazonOEmbedProvider = require('../../../../../core/server/services/oembed/AmazonOEmbedProvider');
+
+describe('AmazonOEmbedProvider', function () {
+    let provider;
+    let externalRequest;
+
+    beforeEach(function () {
+        externalRequest = sinon.stub();
+        provider = new AmazonOEmbedProvider({config: {}});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        nock.cleanAll();
+    });
+
+    describe('canSupportRequest', function () {
+        it('should return true for Amazon product URLs', async function () {
+            const tests = [
+                'https://www.amazon.com/Harry-Potter-Sorcerers-Stone-Book/dp/B017V4IMVQ/',
+                'https://www.amazon.com/dp/B017V4IMVQ',
+                'https://amazon.com/gp/product/B017V4IMVQ',
+                'https://www.amazon.co.uk/dp/B017V4IMVQ',
+                'https://www.amazon.de/dp/B017V4IMVQ',
+                'https://www.amazon.co.jp/dp/B017V4IMVQ',
+                'https://amzn.to/B017V4IMVQ'
+            ];
+
+            for (const testUrl of tests) {
+                const url = new URL(testUrl);
+                const result = await provider.canSupportRequest(url);
+                assert.equal(result, true, `Should support ${testUrl}`);
+            }
+        });
+
+        it('should return false for non-Amazon URLs', async function () {
+            const tests = [
+                'https://www.example.com/product',
+                'https://www.youtube.com/watch?v=123',
+                'https://twitter.com/status/123'
+            ];
+
+            for (const testUrl of tests) {
+                const url = new URL(testUrl);
+                const result = await provider.canSupportRequest(url);
+                assert.equal(result, false, `Should not support ${testUrl}`);
+            }
+        });
+
+        it('should return false for non-product Amazon URLs', async function () {
+            const tests = [
+                'https://www.amazon.com/',
+                'https://www.amazon.com/s?k=books',
+                'https://www.amazon.com/gp/help/customer/display.html'
+            ];
+
+            for (const testUrl of tests) {
+                const url = new URL(testUrl);
+                const result = await provider.canSupportRequest(url);
+                assert.equal(result, false, `Should not support ${testUrl}`);
+            }
+        });
+    });
+
+    describe('extractProductData', function () {
+        it('should extract product data from Amazon HTML', function () {
+            const html = `
+                <html>
+                    <head>
+                        <title>Amazon.com: Harry Potter and the Sorcerer's Stone</title>
+                        <meta property="og:title" content="Harry Potter and the Sorcerer's Stone" />
+                        <meta property="og:description" content="A wonderful book about a wizard" />
+                        <meta property="og:image" content="https://example.com/image.jpg" />
+                    </head>
+                    <body>
+                        <h1 id="productTitle">Harry Potter and the Sorcerer's Stone</h1>
+                        <div id="bylineInfo">by J.K. Rowling</div>
+                        <div id="feature-bullets">
+                            <ul>
+                                <li><span class="a-list-item">First feature</span></li>
+                                <li><span class="a-list-item">Second feature</span></li>
+                            </ul>
+                        </div>
+                        <span class="a-price-whole">19.99</span>
+                    </body>
+                </html>
+            `;
+
+            const url = new URL('https://www.amazon.com/dp/B017V4IMVQ');
+            const data = provider.extractProductData(html, url);
+
+            assert.equal(data.title, 'Harry Potter and the Sorcerer\'s Stone');
+            assert.equal(data.description, 'First feature • Second feature');
+            assert.equal(data.author, 'J.K. Rowling');
+            assert.equal(data.image, 'https://example.com/image.jpg');
+            assert.equal(data.price, '19.99');
+        });
+
+        it('should handle missing data gracefully', function () {
+            const html = '<html><head><title>Amazon Product</title></head><body></body></html>';
+            const url = new URL('https://www.amazon.com/dp/B017V4IMVQ');
+            const data = provider.extractProductData(html, url);
+
+            assert.equal(data.title, 'Amazon Product');
+            assert.ok(data.description);
+            assert.equal(data.url, 'https://www.amazon.com/dp/B017V4IMVQ');
+        });
+
+        it('should clean Amazon prefix from title', function () {
+            const html = `
+                <html>
+                    <head>
+                        <title>Amazon.com: Product Title Here</title>
+                    </head>
+                </html>
+            `;
+
+            const url = new URL('https://www.amazon.com/dp/B017V4IMVQ');
+            const data = provider.extractProductData(html, url);
+
+            assert.equal(data.title, 'Product Title Here');
+        });
+    });
+
+    describe('getOEmbedData', function () {
+        it('should return bookmark data for Amazon product', async function () {
+            const html = `
+                <html>
+                    <head>
+                        <title>Harry Potter Book</title>
+                        <meta property="og:image" content="https://example.com/book.jpg" />
+                    </head>
+                    <body>
+                        <h1 id="productTitle">Harry Potter and the Sorcerer's Stone</h1>
+                        <div id="bylineInfo">by J.K. Rowling</div>
+                    </body>
+                </html>
+            `;
+
+            externalRequest.resolves({
+                body: html,
+                headers: {'content-type': 'text/html'}
+            });
+
+            const url = new URL('https://www.amazon.com/dp/B017V4IMVQ');
+            const result = await provider.getOEmbedData(url, externalRequest);
+
+            assert.equal(result.type, 'bookmark');
+            assert.equal(result.version, '1.0');
+            assert.equal(result.url, 'https://www.amazon.com/dp/B017V4IMVQ');
+            assert.equal(result.metadata.title, 'Harry Potter and the Sorcerer\'s Stone');
+            assert.equal(result.metadata.author, 'J.K. Rowling');
+            assert.equal(result.metadata.publisher, 'Amazon');
+            assert.equal(result.metadata.thumbnail, 'https://example.com/book.jpg');
+            assert.equal(result.metadata.icon, 'https://www.amazon.com/favicon.ico');
+        });
+
+        it('should return fallback data on error', async function () {
+            externalRequest.rejects(new Error('Network error'));
+
+            const url = new URL('https://www.amazon.com/dp/B017V4IMVQ');
+            const result = await provider.getOEmbedData(url, externalRequest);
+
+            assert.equal(result.type, 'bookmark');
+            assert.equal(result.version, '1.0');
+            assert.equal(result.metadata.title, 'Amazon Product');
+            assert.equal(result.metadata.publisher, 'Amazon');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
  Fixed Amazon product link cards not displaying correctly - images were missing and title/description showed duplicate content.

  ## Issue
  Fixes #22417

  ## Problem
  - Amazon product links were not displaying images in link cards
  - Title and description contained identical content
  - Generic metascraper wasn't properly extracting Amazon product metadata

  ## Solution
  - Created custom `AmazonOEmbedProvider` to handle Amazon product URLs specifically
  - Properly extracts product title, description, image, author/brand, and price
  - Supports all major Amazon domains and short URLs (amzn.to)
  - Returns properly formatted bookmark metadata

  ## Testing
  - Added comprehensive unit tests covering various Amazon URL formats
  - All 8 new tests pass
  - Existing OEmbed tests continue to pass