### PR TITLE
Improved 403 error handling with specific messages in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -195,6 +195,7 @@ export interface PaginatedPostsResponse {
 export type ApiError = {
     message: string;
     statusCode: number;
+    code?: string;
 };
 
 export const isApiError = (error: unknown): error is ApiError => {
@@ -258,6 +259,10 @@ export class ActivityPubAPI {
 
                 if (errorMessage) {
                     error.message = errorMessage;
+                }
+
+                if (json.code) {
+                    error.code = json.code;
                 }
             } catch {
                 // Leave the default message

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -4,7 +4,7 @@ import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyVie
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useRouteError} from 'react-router';
 
-const Error = ({statusCode}: {statusCode?: number}) => {
+const Error = ({statusCode, errorCode}: {statusCode?: number, errorCode?: string}) => {
     const routeError = useRouteError();
     const navigate = useNavigate();
 
@@ -39,6 +39,21 @@ const Error = ({statusCode}: {statusCode?: number}) => {
     }
 
     if (statusCode === 403) {
+        // API-related 403 errors (ROLE_MISSING, SITE_MISSING) indicate misconfiguration
+        if (errorCode === 'ROLE_MISSING' || errorCode === 'SITE_MISSING') {
+            return (
+                <EmptyViewIndicator className='mt-[50vh] -translate-y-1/2'>
+                    <EmptyViewIcon><LucideIcon.Settings /></EmptyViewIcon>
+                    <H4 className='-mb-4'>Site not configured correctly</H4>
+                    <div>This feature can&apos;t be used because the site isn&apos;t set up correctly. If you manage this site, check your settings or server logs, or contact support.</div>
+                    <Button asChild>
+                        <a href="https://ghost.org/help/social-web/" rel="noopener noreferrer" target="_blank">Learn more &rarr;</a>
+                    </Button>
+                </EmptyViewIndicator>
+            );
+        }
+
+        // Infrastructure-level 403 errors (account suspended)
         return (
             <EmptyViewIndicator className='mt-[50vh] -translate-y-1/2'>
                 <EmptyViewIcon><LucideIcon.Ban /></EmptyViewIcon>

--- a/apps/admin-x-activitypub/src/views/Feed/Feed.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Feed.tsx
@@ -16,7 +16,7 @@ const Feed: React.FC = () => {
     const {data: user} = useUserDataForUser('index');
 
     if (error && isApiError(error)) {
-        return <Error statusCode={error.statusCode}/>;
+        return <Error errorCode={error.code} statusCode={error.statusCode}/>;
     }
 
     return <FeedList

--- a/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/Inbox.tsx
@@ -12,7 +12,7 @@ const Inbox: React.FC = () => {
     const activities = (data?.pages.flatMap(page => page.posts) ?? Array.from({length: 5}, (_, index) => ({id: `placeholder-${index}`, object: {}})));
 
     if (error && isApiError(error)) {
-        return <Error statusCode={error.statusCode}/>;
+        return <Error errorCode={error.code} statusCode={error.statusCode}/>;
     }
 
     return <InboxList

--- a/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/admin-x-activitypub/src/views/Notifications/Notifications.tsx
@@ -259,7 +259,7 @@ const Notifications: React.FC = () => {
     };
 
     if (error && isApiError(error)) {
-        return <Error statusCode={error.statusCode}/>;
+        return <Error errorCode={error.code} statusCode={error.statusCode}/>;
     }
 
     return (

--- a/apps/admin-x-activitypub/src/views/Preferences/Preferences.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/Preferences.tsx
@@ -10,7 +10,7 @@ const Preferences: React.FC = () => {
     const {data: account, isLoading: isLoadingAccount, error: accountError} = useAccountForUser('index', 'me');
 
     if (accountError && isApiError(accountError)) {
-        return <Error statusCode={accountError.statusCode} />;
+        return <Error errorCode={accountError.code} statusCode={accountError.statusCode} />;
     }
 
     return (

--- a/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/Profile.tsx
@@ -146,7 +146,7 @@ const Profile: React.FC<ProfileProps> = ({}) => {
     }, [params.handle, refetch]);
 
     if (accountError && isApiError(accountError) && accountError.statusCode !== 404) {
-        return <Error statusCode={accountError.statusCode} />;
+        return <Error errorCode={accountError.code} statusCode={accountError.statusCode} />;
     }
 
     const customFields = Object.keys(account?.customFields || {}).map((key) => {


### PR DESCRIPTION
ref PROD-2402

- Distinguished between different causes of 403 errors
- Removed misleading "account suspended" message for non-infrastructure 403s
- Added specific error messages for site configuration issues