### PR TITLE
Revert "Fixed members header disappearing during list load"

### DIFF
--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -98,10 +98,6 @@
     margin: 0 -48px;
 }
 
-.members-header .gh-canvas-header-content {
-    z-index: 1; /* Ensure the header content is above loading spinner */
-}
-
 .members-header .view-actions input.gh-members-list-searchfield {
     min-width: 220px;
     padding-left: 32px;
@@ -662,9 +658,9 @@ p.gh-members-list-email {
 
 
 .gh-members-help-card:hover {
-    box-shadow:
-        0 0 1px rgba(0,0,0,.12),
-        0 1px 6px rgba(0,0,0,.03),
+    box-shadow: 
+        0 0 1px rgba(0,0,0,.12), 
+        0 1px 6px rgba(0,0,0,.03), 
         0 8px 10px -8px rgba(0,0,0,.1);
     transition: all 0.15s ease-in-out;
 }


### PR DESCRIPTION
This reverts commit 78c143c9574ec6c377a16b0b17514767ef59bce0.

- broke members filter browser test that wasn't caught in PR
