### PR TITLE
Fixed `urlUtils.restore()` async behavior

### DIFF
--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -89,7 +89,7 @@ describe('Admin Routing', function () {
         });
 
         after(async function () {
-            urlUtils.restore();
+            await urlUtils.restore();
             await configUtils.restore();
         });
 

--- a/ghost/core/test/integration/services/q-email-addresses.test.js
+++ b/ghost/core/test/integration/services/q-email-addresses.test.js
@@ -137,7 +137,7 @@ describe('Email addresses', function () {
 
     afterEach(async function () {
         await configUtils.restore();
-        urlUtils.restore();
+        await urlUtils.restore();
         mockManager.restore();
     });
 

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -18,7 +18,7 @@ describe('api/endpoints/content/posts', function () {
 
     afterEach(async function () {
         await configUtils.restore();
-        urlUtils.restore();
+        await urlUtils.restore();
     });
 
     const validKey = localUtils.getValidKey();

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -44,7 +44,7 @@ describe('Frontend behavior tests', function () {
 
         after(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
             sinon.restore();
         });
 
@@ -256,7 +256,7 @@ describe('Frontend behavior tests', function () {
         });
 
         after(async function () {
-            urlUtils.restore();
+            await urlUtils.restore();
             await configUtils.restore();
         });
 
@@ -363,7 +363,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -468,7 +468,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -521,7 +521,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -613,7 +613,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -689,7 +689,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -836,7 +836,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -941,7 +941,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
                 sinon.restore();
             });
 
@@ -999,7 +999,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -1050,7 +1050,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
                 sinon.restore();
             });
 
@@ -1225,7 +1225,7 @@ describe('Frontend behavior tests', function () {
 
             afterEach(async function () {
                 await configUtils.restore();
-                urlUtils.restore();
+                await urlUtils.restore();
             });
 
             after(function () {
@@ -1456,7 +1456,7 @@ describe('Frontend behavior tests', function () {
 
         afterEach(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
         });
 
         after(function () {

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -17,7 +17,7 @@ describe('Integration - Web - vhosts', function () {
 
     after(async function () {
         await configUtils.restore();
-        urlUtils.restore();
+        await urlUtils.restore();
         sinon.restore();
     });
 
@@ -37,7 +37,7 @@ describe('Integration - Web - vhosts', function () {
 
         after(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
             sinon.restore();
         });
 
@@ -144,7 +144,7 @@ describe('Integration - Web - vhosts', function () {
 
         after(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
             sinon.restore();
         });
 
@@ -296,7 +296,7 @@ describe('Integration - Web - vhosts', function () {
 
         after(async function () {
             await configUtils.restore();
-            urlUtils.restore();
+            await urlUtils.restore();
             sinon.restore();
         });
 

--- a/ghost/core/test/unit/server/services/members/config.test.js
+++ b/ghost/core/test/unit/server/services/members/config.test.js
@@ -61,7 +61,7 @@ describe('Members - config', function () {
 
     afterEach(async function () {
         await configUtils.restore();
-        urlUtils.restore();
+        await urlUtils.restore();
         sinon.restore();
     });
 

--- a/ghost/core/test/unit/server/services/newsletters/service.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/service.test.js
@@ -81,6 +81,10 @@ describe('NewslettersService', function () {
         mockManager.restore();
     });
 
+    after(async function () {
+        await urlUtils.restore();
+    });
+
     describe('read', function () {
         let findOneStub;
         beforeEach(function () {

--- a/ghost/core/test/utils/urlUtils.js
+++ b/ghost/core/test/utils/urlUtils.js
@@ -50,10 +50,10 @@ const stubUrlUtilsFromConfig = () => {
     return stubUrlUtils(options, defaultSandbox);
 };
 
-const restore = () => {
+const restore = async () => {
     defaultSandbox.restore();
     // eslint-disable-next-line no-console
-    configUtils.restore().catch(console.error);
+    await configUtils.restore().catch(console.error);
 };
 
 module.exports.stubUrlUtilsFromConfig = stubUrlUtilsFromConfig;


### PR DESCRIPTION
no issue

- the `urlUtils.restore()` test util calls `configUtils.restore()` which returns a promise but it was not awaiting or returning it meaning tests that stubbed `urlUtils` multiple times would have very confusing/incorrect test behaviour if the timing was just right
- changed `urlUtils.restore()` to be an async method that correctly awaits the config restore and updated all uses to match
- added missing `urlUtils.restore()` to the newsletters service unit test that was found after it was preventing a new unit test in a different PR from passing because it caused a double-wrapped stub
