### PR TITLE
🐛 Fixed preview route for published post bypassing redirect to post URL

### DIFF
--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -19,6 +19,7 @@ const _addMemberContextToFrame = async (frame) => {
     // only set apiType when given a member_status to preserve backwards compatibility
     // where we used to serve "Admin API" content with no gating for all previews
     frame.apiType = 'content';
+    frame.isPreview = true;
 
     frame.original ??= {};
     frame.original.context ??= {};

--- a/ghost/core/core/server/api/endpoints/utils/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/index.js
@@ -40,5 +40,14 @@ module.exports = {
      */
     isInternal: (frame) => {
         return frame.options.context && frame.options.context.internal;
+    },
+
+    /**
+     * @description Returns true if the request is a preview request.
+     * @param {import('@tryghost/api-framework').Frame} frame
+     * @returns {boolean}
+     */
+    isPreview: (frame) => {
+        return frame.isPreview === true;
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
@@ -82,7 +82,9 @@ const post = (attrs, frame) => {
     const fields = frame && frame.original && frame.original.query && frame.original.query.fields || null;
 
     if (localUtils.isContentAPI(frame)) {
-        delete attrs.status;
+        if (!localUtils.isPreview(frame)) {
+            delete attrs.status;
+        }
         delete attrs.email_only;
         delete attrs.newsletter;
         delete attrs.email_segment;

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -145,6 +145,14 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(assertCorrectFrontendHeaders);
     });
 
+    it('should redirect published posts to their live url with ?member_status=paid', async function () {
+        await request.get('/p/2ac6b4f6-e1f3-406c-9247-c94a0496d39d/?member_status=paid')
+            .expect(301)
+            .expect('Location', '/short-and-sweet/')
+            .expect('Cache-Control', testUtils.cacheRules.year)
+            .expect(assertCorrectFrontendHeaders);
+    });
+
     it('should render scheduled email-only posts', async function () {
         const scheduledEmail = await testUtils.fixtures.insertPosts([{
             title: 'test newsletter',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2506/its-possible-to-bypass-paywall-on-a-post-by-constructing-a-preview

There was a bug in the post preview route that bypassed the normal redirect to the published post. The preview route should only be accessible for posts that are not published. This was caused by the post's status being stripped in some cases, which bypassed the logic to redirect to the published post's normal URL, and instead allowed the preview content to render in its entirety.

