### PR TITLE
Updated ghost-cli tests to update from latest v5 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,7 +980,7 @@ jobs:
       - name: Latest v5 Release
         run: |
           DIR=$(mktemp -d)
-          ghost install v5 local -d $DIR
+          ghost install v5 --local -d $DIR
           ghost update -d $DIR --archive $(pwd)/ghost/core/ghost.tgz
 
       - name: Print debug logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,10 +977,10 @@ jobs:
           DIR=$(mktemp -d)
           ghost install local -d $DIR --archive $(pwd)/ghost/core/ghost.tgz
 
-      - name: Latest Release
+      - name: Latest v5 Release
         run: |
           DIR=$(mktemp -d)
-          ghost install local -d $DIR
+          ghost install v5 local -d $DIR
           ghost update -d $DIR --archive $(pwd)/ghost/core/ghost.tgz
 
       - name: Print debug logs


### PR DESCRIPTION
The `ghost-cli` tests on the v5 branch are failing because they are trying to upgrade from the "Latest release" (which is now v6) to the current version — this is effectively now a downgrade on the `5.x` branch, so the tests fail.

This changes it to attempt an upgrade from the latest public v5 release to the current commit.