### PR TITLE
🐛 Fixed issue with header images in Outlook

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -27,6 +27,11 @@ const features: Feature[] = [{
     title: 'Explore',
     description: 'Enables keeping in touch with the new Explore API',
     flag: 'explore'
+},
+{
+    title: 'Outlook header card image',
+    description: 'Enables header card images styled for Outlook',
+    flag: 'emailHeaderCardOutlook'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -125,7 +125,7 @@ function emailTemplate(nodeData, options) {
                     <!--[if mso]>
                     <td class="kg-header-card-content" style="${hasImageNoSplit ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
                     <![endif]-->
-                    <!--[if !mso]><!-- -->
+                    <!--[if !mso]><!-->
                     <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">
                     <!--<![endif]-->
                     ${hasImageNoSplit ? `

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -86,7 +86,9 @@ function emailTemplate(nodeData, options) {
     });
 
     const hasDarkBg = nodeData.textColor?.toLowerCase() === '#ffffff';
-
+    const hasContainAndSplit = nodeData.backgroundSize === 'contain' && nodeData.layout === 'split';
+    const hasImageNoSplit = nodeData.backgroundImageSrc && nodeData.layout !== 'split';
+    
     return (
         `
         <div class="kg-header-card kg-v2${hasDarkBg ? ' kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
@@ -119,19 +121,21 @@ function emailTemplate(nodeData, options) {
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
-                <!--[if mso]>
-                <td class="kg-header-card-content" style="${nodeData.layout !== 'split' ? 'padding: 0;' : 'padding: 40px;'}${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
-                <![endif]-->
-                <!--[if !mso]><!-- -->
-                <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
-                <!--<![endif]-->
-                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
-                <!--[if mso]>
-                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
-                    <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
-                    <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
-                <![endif]-->
-                ` : ''}
+                    ${labs.isSet('emailHeaderCardOutlook') ? `
+                    <!--[if mso]>
+                    <td class="kg-header-card-content" style="${nodeData.layout !== 'split' ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
+                    <![endif]-->
+                    <!--[if !mso]><!-- -->
+                    <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">
+                    <!--<![endif]-->
+                    ${hasImageNoSplit ? `
+                    <!--[if mso]>
+                    <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
+                        <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
+                        <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
+                    <![endif]-->
+                    ` : ''}
+                    ` : `<td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">`}
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                                 <td align="${nodeData.alignment}">
@@ -151,15 +155,13 @@ function emailTemplate(nodeData, options) {
                                 ` : ''}
                             </tr>
                         </table>
-                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
+                ${labs.isSet('emailHeaderCardOutlook') && hasImageNoSplit ? `
                 <!--[if mso]>
                     </v:textbox>
                 </v:rect>
                 <![endif]-->
                 ` : ''}
-                    <!--[if mso]></td><![endif]-->
-                    <!--[if !mso]><!-- --></td><!--<![endif]-->
-
+                    </td>
                 </tr>
             </table>
         </div>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -175,14 +175,14 @@ function emailTemplate(nodeData, options) {
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
                         <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image" bgcolor="${nodeData.backgroundColor}" align="center">
-                            ${generateMSOSplitHeaderImage(nodeData)}
+                            ${generateMSOSplitHeaderImage(nodeData) /* mso-only img, no shared markup */}
                         </td>
                     </tr>
                 </table>
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
-                    ${generateMSOContentWrapper(nodeData)}
+                    ${generateMSOContentWrapper(nodeData) /* creates correct opening td tag for any platform */}
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                                 <td align="${nodeData.alignment}">
@@ -202,7 +202,7 @@ function emailTemplate(nodeData, options) {
                                 ` : ''}
                             </tr>
                         </table>
-                ${generateMSOContentClosing(nodeData)}
+                ${generateMSOContentClosing(nodeData) /* mso-only closing tags, no shared markup */}
                     </td>
                 </tr>
             </table>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -91,7 +91,7 @@ function emailTemplate(nodeData, options) {
     
     return (
         `
-        <div class="kg-header-card kg-v2${hasDarkBg ? ' kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+        <div class="kg-header-card kg-v2 ${hasDarkBg ? 'kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
             ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
@@ -123,7 +123,7 @@ function emailTemplate(nodeData, options) {
                 <tr>
                     ${labs.isSet('emailHeaderCardOutlook') ? `
                     <!--[if mso]>
-                    <td class="kg-header-card-content" style="${nodeData.layout !== 'split' ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
+                    <td class="kg-header-card-content" style="${hasImageNoSplit ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
                     <![endif]-->
                     <!--[if !mso]><!-- -->
                     <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -90,12 +90,26 @@ function emailTemplate(nodeData, options) {
         `
         <div class="kg-header-card kg-v2${hasDarkBg ? ' kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
             ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
-                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
-                        <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image"></td>
+                        <td align="center" class="kg-header-card-image" style="padding:0; mso-padding-alt:0;">
+                        <!--[if gte mso 9]>
+                        <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"
+                                style="width:${nodeData.backgroundImageWidth || 600}px;height:${nodeData.backgroundImageHeight || 320}px;">
+                            <v:fill type="frame" src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" />
+                            <v:textbox inset="0,0,0,0">
+                        <![endif]-->
+                
+                        <div style="${splitImageStyle}; background-repeat:no-repeat; width:100%; max-width:${nodeData.backgroundImageWidth || 600}px; height:${nodeData.backgroundImageHeight || 320}px;"></div>
+                
+                        <!--[if gte mso 9]>
+                            </v:textbox>
+                        </v:rect>
+                        <![endif]-->
+                        </td>
                     </tr>
                 </table>
-            ` : ''}
+          ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
                     <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -94,7 +94,7 @@ function emailTemplate(nodeData, options) {
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
                         <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image">
-                            ${labs.isSet('emailHeaderCardOutlook') && `
+                            ${labs.isSet('emailHeaderCardOutlook') ? `
                             <!--[if mso]>
                                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" 
                                 style="width:600px;height:320px;">
@@ -103,20 +103,20 @@ function emailTemplate(nodeData, options) {
                                     </v:textbox>
                                 </v:rect>
                             <![endif]-->
-                            `}
+                            ` : ''}
                         </td>
                     </tr>
                 </table>
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
-                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc && `
+                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
                 <!--[if mso]>
                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
                     <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
                     <v:textbox inset="0,24pt,0,24pt" style="mso-fit-shape-to-text:true;">
                 <![endif]-->
-                `}
+                ` : ''}
                     <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
@@ -138,12 +138,12 @@ function emailTemplate(nodeData, options) {
                             </tr>
                         </table>
                     </td>
-                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc && `
+                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
                 <!--[if mso]>
                     </v:textbox>
                 </v:rect>
                 <![endif]-->
-                `}
+                ` : ''}
                 </tr>
             </table>
         </div>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -106,7 +106,6 @@ function emailTemplate(nodeData, options) {
                 </table>
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
-
                 <tr>
                 ${nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
                 <!--[if mso]>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -79,13 +79,8 @@ function generateMSOSplitHeaderImage(nodeData) {
     if (backgroundSize === 'contain') {
         return `
             <!--[if mso]>
-                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" stroke="false"
-                style="width:600px;height:320px;">
-                    <v:fill type="frame"
-                            aspect="atmost"
-                            size="225pt,120pt"
-                            src="${backgroundImageSrc}"
-                            color="${backgroundColor}" />
+                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" stroke="false" style="width:600px;height:320px;">
+                    <v:fill type="frame" aspect="atmost" size="225pt,120pt" src="${backgroundImageSrc}" color="${backgroundColor}" />
                     <v:textbox inset="0,0,0,0">
                     </v:textbox>
                 </v:rect>
@@ -94,8 +89,7 @@ function generateMSOSplitHeaderImage(nodeData) {
     } else {
         return `
             <!--[if mso]>
-                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" 
-                style="width:600px;height:320px;">
+                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;height:320px;">
                     <v:fill type="frame" aspect="atleast" src="${backgroundImageSrc}" color="${backgroundColor}" />
                     <v:textbox inset="0,0,0,0">
                     </v:textbox>
@@ -126,12 +120,7 @@ function generateMSOContentWrapper(nodeData) {
     const msoImageVML = hasImageNoSplit ? `
                     <!--[if mso]>
                         <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
-                            <v:fill 
-                                src="${backgroundImageSrc}" 
-                                color="${backgroundColor}" 
-                                type="frame" 
-                                aspect="atleast" 
-                                focusposition="0.5,0.5" />
+                            <v:fill src="${backgroundImageSrc}" color="${backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
                             <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
                     <![endif]-->
                     ` : '';

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -81,11 +81,11 @@ function generateMSOSplitHeaderImage(nodeData) {
             <!--[if mso]>
                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" stroke="false"
                 style="width:600px;height:320px;">
-                <v:fill type="frame"
-                        aspect="atmost"
-                        size="225pt,120pt"
-                        src="${backgroundImageSrc}"
-                        color="${backgroundColor}" />
+                    <v:fill type="frame"
+                            aspect="atmost"
+                            size="225pt,120pt"
+                            src="${backgroundImageSrc}"
+                            color="${backgroundColor}" />
                     <v:textbox inset="0,0,0,0">
                     </v:textbox>
                 </v:rect>
@@ -117,17 +117,22 @@ function generateMSOContentWrapper(nodeData) {
     // Outlook clients will return the first td, all other clients will return the second td
     const msoOpenTag = `
                     <!--[if mso]>
-                    <td class="kg-header-card-content" style="${hasImageNoSplit ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
+                        <td class="kg-header-card-content" style="${hasImageNoSplit ? 'padding: 0;' : 'padding: 40px;'}${hasContainAndSplit ? 'padding-top: 0;' : ''}">
                     <![endif]-->
                     <!--[if !mso]><!-->
-                    <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">
+                        <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">
                     <!--<![endif]-->`;
 
     const msoImageVML = hasImageNoSplit ? `
                     <!--[if mso]>
-                    <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
-                        <v:fill src="${backgroundImageSrc}" color="${backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
-                        <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
+                        <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
+                            <v:fill 
+                                src="${backgroundImageSrc}" 
+                                color="${backgroundColor}" 
+                                type="frame" 
+                                aspect="atleast" 
+                                focusposition="0.5,0.5" />
+                            <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
                     <![endif]-->
                     ` : '';
 

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -93,12 +93,21 @@ function emailTemplate(nodeData, options) {
             ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
-                        <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image">
+                        <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image" bgcolor="${nodeData.backgroundColor}" align="center">
                             ${labs.isSet('emailHeaderCardOutlook') ? `
                             <!--[if mso]>
+                                ${nodeData.backgroundSize === 'contain' ? `<v:rect xmlns:v="urn:schemas-microsoft-com:vml"  stroke="false"
+                                style="width:600px;height:320px;">
+                                <v:fill type="frame"
+                                        aspect="atmost"
+                                        size="225pt,120pt"
+                                        src="${nodeData.backgroundImageSrc}"
+                                        color="${nodeData.backgroundColor}" />` : `
+                                
                                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" 
                                 style="width:600px;height:320px;">
                                     <v:fill type="frame" aspect="atleast" src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" />
+                                    `}
                                     <v:textbox inset="0,0,0,0">
                                     </v:textbox>
                                 </v:rect>
@@ -110,14 +119,19 @@ function emailTemplate(nodeData, options) {
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
+                <!--[if mso]>
+                <td class="kg-header-card-content" style="${nodeData.layout !== 'split' ? 'padding: 0;' : 'padding: 40px;'}${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
+                <![endif]-->
+                <!--[if !mso]><!-- -->
+                <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
+                <!--<![endif]-->
                 ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
                 <!--[if mso]>
                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
                     <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
-                    <v:textbox inset="0,24pt,0,24pt" style="mso-fit-shape-to-text:true;">
+                    <v:textbox inset="30pt,30pt,30pt,30pt" style="mso-fit-shape-to-text:true;">
                 <![endif]-->
                 ` : ''}
-                    <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                                 <td align="${nodeData.alignment}">
@@ -137,13 +151,15 @@ function emailTemplate(nodeData, options) {
                                 ` : ''}
                             </tr>
                         </table>
-                    </td>
                 ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
                 <!--[if mso]>
                     </v:textbox>
                 </v:rect>
                 <![endif]-->
                 ` : ''}
+                    <!--[if mso]></td><![endif]-->
+                    <!--[if !mso]><!-- --></td><!--<![endif]-->
+
                 </tr>
             </table>
         </div>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -90,28 +90,31 @@ function emailTemplate(nodeData, options) {
         `
         <div class="kg-header-card kg-v2${hasDarkBg ? ' kg-header-card-dark-bg' : 'kg-header-card-light-bg'}" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
             ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
-                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
-                        <td align="center" class="kg-header-card-image" style="padding:0; mso-padding-alt:0;">
-                        <!--[if gte mso 9]>
-                        <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"
-                                style="width:${nodeData.backgroundImageWidth || 600}px;height:${nodeData.backgroundImageHeight || 320}px;">
-                            <v:fill type="frame" src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" />
-                            <v:textbox inset="0,0,0,0">
-                        <![endif]-->
-                
-                        <div style="${splitImageStyle}; background-repeat:no-repeat; width:100%; max-width:${nodeData.backgroundImageWidth || 600}px; height:${nodeData.backgroundImageHeight || 320}px;"></div>
-                
-                        <!--[if gte mso 9]>
-                            </v:textbox>
-                        </v:rect>
-                        <![endif]-->
+                        <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image">
+                            <!--[if mso]>
+                                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" 
+                                style="width:600px;height:320px;">
+                                    <v:fill type="frame" aspect="atleast" src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" />
+                                    <v:textbox inset="0,0,0,0">
+                                    </v:textbox>
+                                </v:rect>
+                            <![endif]-->
                         </td>
                     </tr>
                 </table>
-          ` : ''}
+            ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+
                 <tr>
+                ${nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
+                <!--[if mso]>
+                <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
+                    <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
+                    <v:textbox inset="0,24pt,0,24pt" style="mso-fit-shape-to-text:true;">
+                <![endif]-->
+                ` : ''}
                     <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
@@ -132,7 +135,13 @@ function emailTemplate(nodeData, options) {
                                 ` : ''}
                             </tr>
                         </table>
-                    </td>
+                        </td>
+                ${nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
+                <!--[if mso]>
+                    </v:textbox>
+                </v:rect>
+                <![endif]-->
+                ` : ''}
                 </tr>
             </table>
         </div>

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -115,7 +115,8 @@ function generateMSOContentWrapper(nodeData) {
                     <![endif]-->
                     <!--[if !mso]><!-->
                         <td class="kg-header-card-content" style="${hasContainAndSplit ? 'padding-top: 0;' : ''}">
-                    <!--<![endif]-->`;
+                    <!--<![endif]-->
+                    `;
 
     const msoImageVML = hasImageNoSplit ? `
                     <!--[if mso]>
@@ -135,13 +136,12 @@ function generateMSOContentClosing(nodeData) {
         return '';
     }
 
-    // spacing here maintains proper markup indentation
     return `
-                <!--[if mso]>
-                    </v:textbox>
-                </v:rect>
-                <![endif]-->
-                `;
+        <!--[if mso]>
+            </v:textbox>
+        </v:rect>
+        <![endif]-->
+        `;
 }
 
 function emailTemplate(nodeData, options) {

--- a/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/header-v2-renderer.js
@@ -2,6 +2,7 @@ const {renderEmailButton} = require('../render-partials/email-button');
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {slugify} = require('../render-utils/slugify');
 const {getSrcsetAttribute} = require('../render-utils/srcset-attribute');
+const labs = require('../../../../shared/labs');
 
 // TODO: nodeData.buttonTextColor should be calculated on the fly here rather than hardcoded by the editor
 
@@ -93,6 +94,7 @@ function emailTemplate(nodeData, options) {
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
                         <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image">
+                            ${labs.isSet('emailHeaderCardOutlook') && `
                             <!--[if mso]>
                                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" 
                                 style="width:600px;height:320px;">
@@ -101,19 +103,20 @@ function emailTemplate(nodeData, options) {
                                     </v:textbox>
                                 </v:rect>
                             <![endif]-->
+                            `}
                         </td>
                     </tr>
                 </table>
             ` : ''}
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
                 <tr>
-                ${nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
+                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc && `
                 <!--[if mso]>
                 <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;">
                     <v:fill src="${nodeData.backgroundImageSrc}" color="${nodeData.backgroundColor}" type="frame" aspect="atleast" focusposition="0.5,0.5" />
                     <v:textbox inset="0,24pt,0,24pt" style="mso-fit-shape-to-text:true;">
                 <![endif]-->
-                ` : ''}
+                `}
                     <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
@@ -134,13 +137,13 @@ function emailTemplate(nodeData, options) {
                                 ` : ''}
                             </tr>
                         </table>
-                        </td>
-                ${nodeData.layout !== 'split' && nodeData.backgroundImageSrc ? `
+                    </td>
+                ${labs.isSet('emailHeaderCardOutlook') && nodeData.layout !== 'split' && nodeData.backgroundImageSrc && `
                 <!--[if mso]>
                     </v:textbox>
                 </v:rect>
                 <![endif]-->
-                ` : ''}
+                `}
                 </tr>
             </table>
         </div>

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -46,7 +46,8 @@ const PRIVATE_FEATURES = [
     'urlCache',
     'lexicalIndicators',
     'contentVisibilityAlpha',
-    'emailCustomization'
+    'emailCustomization',
+    'emailHeaderCardOutlook'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -17,6 +17,7 @@ Object {
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,
+      "emailHeaderCardOutlook": true,
       "explore": true,
       "i18n": true,
       "importMemberTier": true,

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -2302,7 +2302,6 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
-                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -2319,8 +2318,8 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                 
                             </tr>
                         </tbody></table>
-                    </td>
                 
+                    </td>
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -2752,7 +2751,6 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
 
 
 
@@ -3737,7 +3735,6 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
-                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -3754,8 +3751,8 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                 
                             </tr>
                         </tbody></table>
-                    </td>
                 
+                    </td>
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -4193,7 +4190,6 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
 
 
 
@@ -5164,7 +5160,6 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
-                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -5181,8 +5176,8 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                 
                             </tr>
                         </tbody></table>
-                    </td>
                 
+                    </td>
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -5614,7 +5609,6 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
 
 
 
@@ -6599,7 +6593,6 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
-                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -6616,8 +6609,8 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                 
                             </tr>
                         </tbody></table>
-                    </td>
                 
+                    </td>
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -7055,7 +7048,6 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
 
 
 

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -2803,6 +2803,7 @@ This header renders properly in all email clients!
 
 
 
+
  
 
 
@@ -4222,6 +4223,7 @@ Good news everyone!
 
 
 This header renders properly in all email clients!
+
 
 
 
@@ -5663,6 +5665,7 @@ This header renders properly in all email clients!
 
 
 
+
  
 
 
@@ -7082,6 +7085,7 @@ Good news everyone!
 
 
 This header renders properly in all email clients!
+
 
 
 

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -2302,6 +2302,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
+                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -2319,6 +2320,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                             </tr>
                         </tbody></table>
                     </td>
+                
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -2750,6 +2752,7 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -3733,6 +3736,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
+                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -3750,6 +3754,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                             </tr>
                         </tbody></table>
                     </td>
+                
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -4187,6 +4192,7 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -5156,6 +5162,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
+                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -5173,6 +5180,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                             </tr>
                         </tbody></table>
                     </td>
+                
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -5604,6 +5612,7 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -6587,6 +6596,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
             
             <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #FFFFFF; text-align: center; background-color: #000000;\\" align=\\"center\\" bgcolor=\\"#000000\\">
                 <tbody><tr>
+                
                     <td class=\\"kg-header-card-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 40px;\\" valign=\\"top\\">
                         <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                             <tbody><tr>
@@ -6604,6 +6614,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                             </tr>
                         </tbody></table>
                     </td>
+                
                 </tr>
             </tbody></table>
         </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
@@ -7041,6 +7052,7 @@ with Ghost
 
 
 Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2437

- When using a header card with an image in an email, the images weren't rendering in Outlook
- This PR adds Outlook-specific styling so those images will render
- Tried it out with both an img tag and vml. vml was more reliable in being able to create properly-sized images, both standalone and background.

[This blog post](https://www.hteumeuleu.com/2021/background-properties-in-vml/) is a good primer on vml.

below shows the different header variations as they appear in Outlook after the fix, with the feature flag on. 

Note: I'm not sure what's causing the lack of space between some of the cards, but it seems to be only on Outlook desktop. I'm going to check and make sure there's not a missing closing tag somewhere or something - but if it's not that, I might address this in a follow up. but I'd imagine it's unlikely an email would be designed anything like this anyway.

<img width="200" height="992" alt="Screenshot 2025-08-18 at 10 40 08 AM" src="https://github.com/user-attachments/assets/d66c4ad5-7b1a-4c7b-a599-96e99129d9ad" />

This is with the feature flag off:
<img width="200" height="991" alt="Screenshot 2025-08-18 at 11 54 25 AM" src="https://github.com/user-attachments/assets/4568f463-fdab-44c6-a5ec-dfb9bbb9810e" />
