### PR TITLE
Configured CI to run on any release branch or major version branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
       - 'v[0-9]+.*'
-      - '5.x'
-      - '6.x'
+      - '[0-9]+.x'
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'v5.*'
+      - 'v[0-9]+.*'
       - '5.x'
       - '6.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
+    # Ref: GHA Filter pattern syntax: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
+    # Run on pushes to main, release branches, and previous/future major version branches
     branches:
       - main
-      - 'v[0-9]+.*'
-      - '[0-9]+.x'
+      - 'v[0-9]+.*' # Matches any release branch, e.g. v6.0.3, v12.1.0
+      - '[0-9]+.x' # Matches any major version branch, e.g. 5.x, 23.x
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
When pushing to any release branch, we need to run our CI workflow, because the release job ensures the checks have passed before cutting the release (by default). This future proofs the branch pattern to work for any arbitrary release branch, regardless of the major version.

For previous major versions, we'll release straight from the major version branch (i.e. `5.x`) so we also need CI to run on those branches.

Note: Technically it doesn't strictly enforce semver on the release branch pattern since it just looks at the prefix, but that should be fine.