### PR TITLE
Added support for top-level `yarn test:browser --ui`

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -41,9 +41,18 @@ const availableAppFlags = {
     https: 'Serve apps using HTTPS',
     offline: 'Run in offline mode (no Stripe webhooks will be forwarded)'
 }
-const DASH_DASH_ARGS = process.argv.filter(a => a.startsWith('--')).map(a => a.slice(2));
+
+// Split args on '--' separator to separate app flags from pass-through args
+const doubleDashIndex = process.argv.lastIndexOf('--');
+const devArgs = doubleDashIndex === -1 ? process.argv : process.argv.slice(0, doubleDashIndex);
+const passThroughArgs = doubleDashIndex === -1 ? [] : process.argv.slice(doubleDashIndex + 1);
+
+const DASH_DASH_ARGS = devArgs.filter(a => a.startsWith('--')).map(a => a.slice(2));
 const ENV_ARGS = process.env.GHOST_DEV_APP_FLAGS?.split(',') || [];
 const GHOST_APP_FLAGS = [...ENV_ARGS, ...DASH_DASH_ARGS].filter(flag => flag.trim().length > 0);
+
+// Format pass-through args for command usage
+const PASS_THROUGH_FLAGS = passThroughArgs.join(' ');
 
 function showAvailableAppFlags() {
     console.log(chalk.blue('App flags can be enabled by setting the GHOST_DEV_APP_FLAGS environment variable to a comma separated list of flags.'));
@@ -95,7 +104,7 @@ const COMMAND_ADMIN = {
 
 const COMMAND_BROWSERTESTS = {
     name: 'browser-tests',
-    command: 'nx run ghost:test:browser',
+    command: `nx run ghost:test:browser${PASS_THROUGH_FLAGS ? ` -- ${PASS_THROUGH_FLAGS}`: ''}`,
     prefixColor: 'blue',
     env: {}
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
     "test:unit": "nx run-many -t test:unit",
-    "test:browser": "node .github/scripts/dev.js --browser-tests --all",
+    "test:browser": "node .github/scripts/dev.js --browser-tests --all --",
     "test:e2e": "yarn workspace @tryghost/e2e test",
     "main": "yarn main:monorepo && yarn main:submodules",
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",


### PR DESCRIPTION
no issue

- previously it wasn't possible to pass additional arguments through to `yarn test:browser` meaning playwright args like `--ui` and `--headed` were unusable
- by splitting the args across a `--` separator we can separate Ghost app commands from the pass through args, then use those pass through args in the internal call to `ghost:test:browser`
- we can't use a `--` separator directly on the command line because `yarn` will strip it out when building the script command so we also need a trailing `--` in the package.json script so the command now works like `yarn test:browser --ui` as if you were calling the Ghost test script or playwright directly
