### PR TITLE
Updated e2e-browser tests readme

### DIFF
--- a/apps/portal/README.md
+++ b/apps/portal/README.md
@@ -55,12 +55,11 @@ yarn test
 
 ### Ghost e2e browser tests
 
-Portal is primarily tested via Ghost's e2e browser tests. In order to test against your local changes rather than the last published package on npm you need to have the local portal build being served and to configure Ghost to use the local URL.
+Portal is primarily tested via Ghost's e2e browser tests, see [our Playwright docs](https://ghost.notion.site/Playwright-Tests-b49ccb6e2b4a40f1a4f8df5261391218) for more details.
 
-1. Run `yarn dev` in `ghost/apps/portal` to serve the local portal build on http://localhost:4175/portal.min.js
-2. Run the Ghost e2e tests in `ghost/core`, providing an ENV variable to override the portal URL:
+1. Run the Ghost e2e tests in the top-level of the monorepo, providing ENV variables for Stripe:
    ```
-   portal__url=http://localhost:4175/portal.min.js STRIPE_ACCOUNT_ID=acct_xxx STRIPE_PUBLISHABLE_KEY=pk_test_xxx STRIPE_SECRET_KEY=sk_test_xxx yarn test:browser:portal
+   STRIPE_ACCOUNT_ID=acct_xxx STRIPE_PUBLISHABLE_KEY=pk_test_xxx STRIPE_SECRET_KEY=sk_test_xxx yarn test:browser
    ```
 
 ## Release

--- a/ghost/core/ghost.js
+++ b/ghost/core/ghost.js
@@ -17,9 +17,6 @@ switch (mode) {
 case 'repl':
 case 'timetravel':
 case 'generate-data':
-case 'record-test':
-    require('./core/cli/command').run(mode);
-    break;
 default:
     // New boot sequence
     require('./core/boot')();

--- a/ghost/core/test/e2e-browser/README.md
+++ b/ghost/core/test/e2e-browser/README.md
@@ -1,5 +1,7 @@
 ## Browser testing
 
+Further documentation on Playwright and writing tests can be found in the [Ghost's Playwright Tests docs](https://ghost.notion.site/Playwright-Tests-b49ccb6e2b4a40f1a4f8df5261391218).
+
 #### Install
 
 As per the [docs](https://playwright.dev/docs/intro#manually), run the following to install the supported browsers for Playwright:
@@ -10,21 +12,12 @@ npx playwright install
 
 #### Running tests
 
-Run the browser test suite with `yarn test:browser`.
+Tests should be run from the root of the repository, using `yarn test:browser` rather than from the `ghost/core` directory.
 
-#### Record test instructions
-
-After installing PlayWright, start to record tests using `yarn test:browser:record`.
-
-Available flags:
-* `--admin` - Runs a test starting in Ghost Admin
-* `--no-setup` - When testing Ghost Admin, prevents the automated setup from running (for testing the setup wizard)
-* `--fixtures="posts,users"` - Install a set of fixtures, given as a comma-delimited list
-
-When the window loads, hit the record button and click around. All of the link click steps will need to be tidied up to use better selectors, and any `page.goto` calls should be dropped (as they are likely a result of clicking links). The test generator is a useful assistant, but be wary of taking anything it generates as correct.
+Running from the root ensures that all of Ghost's apps are built from the local source code and made available to the test runner.
 
 #### Writing tests
 
-Recording tests will allow you to execute the steps in a browser that a user would follow. It's important to add assertions to ensure that we're not just testing that the site doesn't crash, but that we see the expected values on the page.
+It's important to add assertions to ensure that we're not just testing that the site doesn't crash, but that we see the expected values on the page.
 
 The test suite uses `beforeAll` and `afterAll` to setup Ghost and install fixtures. Each set of fixtures should have a new `describe` block to start a new instance of Ghost to be tested against.


### PR DESCRIPTION
no issue

- browser tests need to be run from the repo root rather than ghost/core, updated the readme to make that clearer
- removed section about recording using the non-existent `yarn test:browser:record` command
- added link to our more comprehensive Playwright testing docs
