### PR TITLE
fixed issue #24675 View button updated for dark theme 

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -14,7 +14,7 @@ export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
         <div className={
             cn('[&_svg]:size-4 flex items-center gap-1.5 text-base h-[22px] font-medium transition-all',
                 className,
-                props.onClick && 'hover:cursor-pointer hover:text-black'
+                props.onClick && 'hover:cursor-pointer hover:text-foreground'
             )} {...props}>
             {children}
         </div>


### PR DESCRIPTION
#24675 fixed - View members button has incorrect color/background-color (in dark mode) 
Changes Made:
Removed hover:text-black as it set to black and wasnt visible in dark theme to hover:text-foreground so the button changes as per theme
