### PR TITLE
Fixed card asset loading with absolute URLs in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -20,6 +20,7 @@ import {Activity} from '@src/api/activitypub';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useDebounce} from 'use-debounce';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -44,6 +45,7 @@ const ArticleBody: React.FC<{
     onIframeLoad?: (iframe: HTMLIFrameElement) => void;
     onLoadingChange?: (isLoading: boolean) => void;
     isPopoverOpen: boolean;
+    siteUrl?: string;
 }> = ({
     postUrl,
     heading,
@@ -57,7 +59,8 @@ const ArticleBody: React.FC<{
     onHeadingsExtracted,
     onIframeLoad,
     onLoadingChange,
-    isPopoverOpen
+    isPopoverOpen,
+    siteUrl
 }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -151,12 +154,12 @@ const ArticleBody: React.FC<{
                     waitForImages();
 
                     const script = document.createElement('script');
-                    script.src = '/public/cards.min.js';
+                    script.src = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.js` : '/public/cards.min.js'}';
                     document.head.appendChild(script);
 
                     const link = document.createElement('link');
                     link.rel = 'stylesheet';
-                    link.href = '/public/cards.min.css';
+                    link.href = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.css` : '/public/cards.min.css'}';
                     document.head.appendChild(link);
                 });
             </script>
@@ -424,6 +427,7 @@ export const Reader: React.FC<ReaderProps> = ({
         decreaseFontSize,
         resetFontSize
     } = useCustomizerSettings();
+    const {data: siteData} = useBrowseSite();
     const modalRef = useRef<HTMLElement>(null);
     const [isCustomizerOpen, setIsCustomizerOpen] = useState(false);
     const [isTOCOpen, setIsTOCOpen] = useState(false);
@@ -842,6 +846,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                             image={typeof object.image === 'string' ? object.image : object.image?.url}
                                             isPopoverOpen={isCustomizerOpen || isTOCOpen}
                                             postUrl={object?.url || ''}
+                                            siteUrl={siteData?.site?.url}
                                             onHeadingsExtracted={handleHeadingsExtracted}
                                             onIframeLoad={handleIframeLoad}
                                             onLoadingChange={setIsLoading}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2440/oss-issue-cards-display-incorrectly-in-the-activitypub-reader

- Changed card asset JS and CSS loading to use absolute URLs in reader
- Resolved issue where assets failed to load when frontend and admin were on different domains