### PR TITLE
Fixed members KPI chart missing comped members

### DIFF
--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -168,7 +168,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
         const free = lastMemberItem?.free ?? 0;
         const paid = lastMemberItem?.paid ?? 0;
         const comped = lastMemberItem?.comped ?? 0;
-        const paidTotal = paid + comped;  // Include comped in paid total for chart
+        const paidTotal = paid + comped;
         const value = free + paidTotal;
         const mrr = lastMrrItem?.mrr ?? 0;
         const paidSubscribed = lastMemberItem?.paid_subscribed ?? 0;
@@ -178,7 +178,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             date,
             value,
             free,
-            paid: paidTotal,  // Return combined paid + comped as paid
+            paid: paidTotal,
             comped,
             mrr,
             paid_subscribed: paidSubscribed,

--- a/apps/stats/src/hooks/useGrowthStats.ts
+++ b/apps/stats/src/hooks/useGrowthStats.ts
@@ -73,8 +73,11 @@ const calculateTotals = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             directions.free = freeChange > 0 ? 'up' : freeChange < 0 ? 'down' : 'same';
         }
 
-        if (first.paid > 0) {
-            const paidChange = ((latest.paid - first.paid) / first.paid) * 100;
+        const firstPaidTotal = first.paid + first.comped;
+        const latestPaidTotal = latest.paid + latest.comped;
+        
+        if (firstPaidTotal > 0) {
+            const paidChange = ((latestPaidTotal - firstPaidTotal) / firstPaidTotal) * 100;
             percentChanges.paid = formatPercentage(paidChange / 100);
             directions.paid = paidChange > 0 ? 'up' : paidChange < 0 ? 'down' : 'same';
         }
@@ -165,7 +168,8 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
         const free = lastMemberItem?.free ?? 0;
         const paid = lastMemberItem?.paid ?? 0;
         const comped = lastMemberItem?.comped ?? 0;
-        const value = free + paid + comped;
+        const paidTotal = paid + comped;  // Include comped in paid total for chart
+        const value = free + paidTotal;
         const mrr = lastMrrItem?.mrr ?? 0;
         const paidSubscribed = lastMemberItem?.paid_subscribed ?? 0;
         const paidCanceled = lastMemberItem?.paid_canceled ?? 0;
@@ -174,7 +178,7 @@ const formatChartData = (memberData: MemberStatusItem[], mrrData: MrrHistoryItem
             date,
             value,
             free,
-            paid,
+            paid: paidTotal,  // Return combined paid + comped as paid
             comped,
             mrr,
             paid_subscribed: paidSubscribed,

--- a/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthKPIs.tsx
@@ -193,7 +193,8 @@ const GrowthKPIs: React.FC<{
             break;
         default:
             processedData = sanitizedData.map((item) => {
-                const currentTotal = item.free + item.paid + item.comped;
+                // Note: item.paid already includes comped members
+                const currentTotal = item.free + item.paid;
                 return {
                     ...item,
                     value: currentTotal,

--- a/apps/stats/src/views/Stats/Overview/Overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/Overview.tsx
@@ -140,8 +140,8 @@ const Overview: React.FC = () => {
         // Then map the sanitized data to the final format
         const processedData: GhAreaChartDataItem[] = sanitizedData.map(item => ({
             date: item.date,
-            value: item.free + item.paid + item.comped,
-            formattedValue: formatNumber(item.free + item.paid + item.comped),
+            value: item.free + item.paid,
+            formattedValue: formatNumber(item.free + item.paid),
             label: 'Members'
         }));
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2465/
- fixed chart data points including comped members
- fixed calculation missing comped members in net change (%)

Users reported comped members missing from the paid member counts. We always returned comped members from the endpoint so this change only requires some simple adjustments to the frontend. This makes the behavior consistent with the old dashboard.

Notes for testing:
- Create/generate some members
- Ensure comped counts are included in the chart (view the members_count request in the Network tab of browser dev tools)
- Ensure the % change makes sense