### PR TITLE
Fixed passing CLI arguments to Ghost

### DIFF
--- a/ghost/core/ghost.js
+++ b/ghost/core/ghost.js
@@ -17,6 +17,8 @@ switch (mode) {
 case 'repl':
 case 'timetravel':
 case 'generate-data':
+    require('./core/cli/command').run(mode);
+    break;
 default:
     // New boot sequence
     require('./core/boot')();


### PR DESCRIPTION
ref 7547e0e8afd3f55f5cf251cac86be6b267841991

The referenced commit inadvertently removed the ability to run commands like the `repl` and `generate-data` command when removing one of the cases, so when running one of these commands it would fallback to the default and just boot Ghost. This adds back the proper command, while leaving the `record-test` case out.