### PR TITLE
Updated Content API author endpoint tests to use snapshots

### DIFF
--- a/ghost/core/test/e2e-api/content/__snapshots__/authors.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/authors.test.js.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authors Content API Can request author by id including post count 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": Any<Number>,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+}
+`;
+
+exports[`Authors Content API Can request author by id including post count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "459",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request authors 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "You can delete this user to remove all the welcome posts",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": "ghost",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "The Internet",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Ghost",
+      "profile_image": "https://static.ghost.org/v4.0.0/images/ghost-user.png",
+      "slug": "ghost",
+      "threads": null,
+      "tiktok": null,
+      "twitter": "ghost",
+      "url": "http://127.0.0.1:2369/author/ghost/",
+      "website": "https://ghost.org",
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Slimer McEctoplasm",
+      "profile_image": null,
+      "slug": "slimer-mcectoplasm",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/404/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 8,
+    },
+  },
+}
+`;
+
+exports[`Authors Content API Can request authors 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1429",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request authors including post count 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "You can delete this user to remove all the welcome posts",
+      "bluesky": null,
+      "count": Object {
+        "posts": Any<Number>,
+      },
+      "cover_image": null,
+      "facebook": "ghost",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "The Internet",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Ghost",
+      "profile_image": "https://static.ghost.org/v4.0.0/images/ghost-user.png",
+      "slug": "ghost",
+      "threads": null,
+      "tiktok": null,
+      "twitter": "ghost",
+      "url": "http://127.0.0.1:2369/author/ghost/",
+      "website": "https://ghost.org",
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": Any<Number>,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "count": Object {
+        "posts": Any<Number>,
+      },
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Slimer McEctoplasm",
+      "profile_image": null,
+      "slug": "slimer-mcectoplasm",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/404/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 8,
+    },
+  },
+}
+`;
+
+exports[`Authors Content API Can request authors including post count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1489",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authors Content API Can request single author 1: [body] 1`] = `
+Object {
+  "authors": Array [
+    Object {
+      "bio": "bio",
+      "bluesky": null,
+      "cover_image": null,
+      "facebook": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "instagram": null,
+      "linkedin": null,
+      "location": "location",
+      "mastodon": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "Joe Bloggs",
+      "profile_image": "https://example.com/super_photo.jpg",
+      "slug": "joe-bloggs",
+      "threads": null,
+      "tiktok": null,
+      "twitter": null,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+      "youtube": null,
+    },
+  ],
+}
+`;
+
+exports[`Authors Content API Can request single author 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "439",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -1,119 +1,125 @@
-const should = require('should');
-const supertest = require('supertest');
-const _ = require('lodash');
-const url = require('url');
-const configUtils = require('../../utils/configUtils');
-const config = require('../../../core/shared/config');
-const models = require('../../../core/server/models');
-const testUtils = require('../../utils');
+const assert = require('assert/strict');
+const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
+const {anyContentVersion, anyEtag, anyObjectId, anyNumber} = matchers;
+const {cacheInvalidateHeaderNotSet} = assertions;
 const localUtils = require('./utils');
-const {fixtureManager} = require('../../utils/e2e-framework');
+
+const authorMatcher = {
+    id: anyObjectId
+};
+
+const authorMatcherWithCount = {
+    ...authorMatcher,
+    count: {
+        posts: anyNumber
+    }
+};
 
 describe('Authors Content API', function () {
-    let request;
+    let agent;
 
     before(async function () {
-        await localUtils.startGhost();
-        request = supertest.agent(config.get('url'));
-        await testUtils.initFixtures('owner:post', 'users', 'user:inactive', 'posts', 'api_keys');
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('owner:post', 'users', 'user:inactive', 'posts', 'api_keys');
+        await agent.authenticate();
     });
-
-    afterEach(async function () {
-        await configUtils.restore();
-    });
-
-    const validKey = localUtils.getValidKey();
 
     it('Can request authors', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-        should.exist(jsonResponse.authors);
-        localUtils.API.checkResponse(jsonResponse, 'authors');
-        jsonResponse.authors.should.have.length(3);
-
-        // We don't expose the email address, status and other attrs.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['url'], null, null);
-
-        // Default order 'name asc' check
-        jsonResponse.authors[0].name.should.eql('Ghost');
-        jsonResponse.authors[2].name.should.eql('Slimer McEctoplasm');
-
-        should.exist(res.body.authors[0].url);
-        should.exist(url.parse(res.body.authors[0].url).protocol);
-        should.exist(url.parse(res.body.authors[0].url).host);
-
-        // Public api returns all authors, but no status! Locked/Inactive authors can still have written articles.
-        const response = await models.Author.findPage(Object.assign({status: 'all'}, testUtils.context.internal));
-        _.map(response.data, model => model.toJSON()).length.should.eql(3);
+        await agent.get('authors/')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(3).fill(authorMatcher)
+            })
+            .expect(cacheInvalidateHeaderNotSet())
+            .expect(({body}) => {
+                // Verify response structure
+                localUtils.API.checkResponse(body, 'authors');
+                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
+                
+                // Verify default order 'name asc'
+                assert.equal(body.authors[0].name, 'Ghost');
+                assert.equal(body.authors[2].name, 'Slimer McEctoplasm');
+                
+                // Verify URL structure
+                const urlParts = new URL(body.authors[0].url);
+                assert.equal(urlParts.protocol, 'http:');
+                assert.equal(urlParts.host, '127.0.0.1:2369');
+            });
     });
-
     it('Can request authors including post count', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}&include=count.posts&order=count.posts ASC`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        const jsonResponse = res.body;
-
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(3);
-
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['count', 'url'], null, null);
-
-        // Each user should have the correct count and be more than 0
-        _.find(jsonResponse.authors, {slug: 'joe-bloggs'}).count.posts.should.eql(4);
-        _.find(jsonResponse.authors, {slug: 'slimer-mcectoplasm'}).count.posts.should.eql(1);
-        _.find(jsonResponse.authors, {slug: 'ghost'}).count.posts.should.eql(7);
-
-        const ids = jsonResponse.authors
-            .filter(author => (author.slug !== 'ghost'))
-            .map(user => user.id);
-
-        ids.should.eql([
-            testUtils.DataGenerator.Content.users[3].id,
-            testUtils.DataGenerator.Content.users[0].id
-        ]);
+        await agent.get('authors/?include=count.posts')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(3).fill(authorMatcherWithCount)
+            })
+            .expect(cacheInvalidateHeaderNotSet())
+            .expect(({body}) => {
+                const {authors} = body;
+                
+                // Verify response structure
+                localUtils.API.checkResponse(body, 'authors');
+                localUtils.API.checkResponse(authors[0], 'author', ['count', 'url'], null, null);
+                
+                // Verify post counts for specific authors
+                const getAuthorBySlug = slug => authors.find(author => author.slug === slug);
+                
+                assert.equal(getAuthorBySlug('joe-bloggs').count.posts, 4);
+                assert.equal(getAuthorBySlug('slimer-mcectoplasm').count.posts, 1);
+                assert.equal(getAuthorBySlug('ghost').count.posts, 7);
+                
+                // Verify expected author IDs (excluding ghost)
+                const nonGhostIds = authors
+                    .filter(author => author.slug !== 'ghost')
+                    .map(author => author.id);
+                
+                assert.deepEqual(nonGhostIds, [
+                    fixtureManager.get('users', 0).id,
+                    fixtureManager.get('users', 3).id
+                ]);
+            });
     });
-
     it('Can request single author', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/slug/ghost/?key=${validKey}`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(1);
-
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['url'], null, null);
+        await agent.get(`authors/slug/${fixtureManager.get('users', 0).slug}`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(1).fill(authorMatcher)
+            })
+            .expect(cacheInvalidateHeaderNotSet())
+            .expect(({body}) => {
+                // Verify response structure
+                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
+                
+                assert.equal(body.authors.length, 1);
+            });
     });
-
     it('Can request author by id including post count', async function () {
-        const res = await request.get(localUtils.API.getApiQuery(`authors/${fixtureManager.get('users', 0).id}/?key=${validKey}&include=count.posts`))
-            .set('Origin', testUtils.API.getURL())
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.public)
-            .expect(200);
-
-        should.not.exist(res.headers['x-cache-invalidate']);
-        const jsonResponse = res.body;
-
-        should.exist(jsonResponse.authors);
-        jsonResponse.authors.should.have.length(1);
-
-        // We don't expose the email address.
-        localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['count', 'url'], null, null);
+        await agent.get(`authors/${fixtureManager.get('users', 0).id}/?include=count.posts`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                authors: new Array(1).fill(authorMatcherWithCount)
+            })
+            .expect(cacheInvalidateHeaderNotSet())
+            .expect(({body}) => {
+                // Verify response structure
+                localUtils.API.checkResponse(body.authors[0], 'author', ['count', 'url'], null, null);
+                
+                assert.equal(body.authors.length, 1);
+            });
     });
 });

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -85,11 +85,13 @@ describe('Authors Content API', function () {
                 etag: anyEtag
             })
             .matchBodySnapshot({
-                authors: new Array(1).fill(authorMatcher)
+                authors: [authorMatcher]
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
                 assert.equal(body.authors.length, 1);
+                const requestedId = fixtureManager.get('users', 0).id;
+                assert.equal(body.authors[0].id, requestedId);
             });
     });
     it('Can request author by id including post count', async function () {
@@ -100,7 +102,7 @@ describe('Authors Content API', function () {
                 etag: anyEtag
             })
             .matchBodySnapshot({
-                authors: new Array(1).fill(authorMatcherWithCount)
+                authors: [authorMatcherWithCount]
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -2,7 +2,6 @@ const assert = require('assert/strict');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyObjectId, anyNumber} = matchers;
 const {cacheInvalidateHeaderNotSet} = assertions;
-const localUtils = require('./utils');
 
 const authorMatcher = {
     id: anyObjectId
@@ -36,10 +35,6 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
-                // Verify response structure
-                localUtils.API.checkResponse(body, 'authors');
-                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
-                
                 // Verify default order 'name asc'
                 assert.equal(body.authors[0].name, 'Ghost');
                 assert.equal(body.authors[2].name, 'Slimer McEctoplasm');
@@ -63,11 +58,7 @@ describe('Authors Content API', function () {
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
                 const {authors} = body;
-                
-                // Verify response structure
-                localUtils.API.checkResponse(body, 'authors');
-                localUtils.API.checkResponse(authors[0], 'author', ['count', 'url'], null, null);
-                
+
                 // Verify post counts for specific authors
                 const getAuthorBySlug = slug => authors.find(author => author.slug === slug);
                 
@@ -98,9 +89,6 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
-                // Verify response structure
-                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
-                
                 assert.equal(body.authors.length, 1);
             });
     });
@@ -116,9 +104,6 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
-                // Verify response structure
-                localUtils.API.checkResponse(body.authors[0], 'author', ['count', 'url'], null, null);
-                
                 assert.equal(body.authors.length, 1);
             });
     });

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -2,6 +2,7 @@ const assert = require('assert/strict');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyObjectId, anyNumber} = matchers;
 const {cacheInvalidateHeaderNotSet} = assertions;
+const localUtils = require('./utils');
 
 const authorMatcher = {
     id: anyObjectId
@@ -35,6 +36,9 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
+                // We don't expose the email address, status and other attrs.
+                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
+
                 // Verify default order 'name asc'
                 assert.equal(body.authors[0].name, 'Ghost');
                 assert.equal(body.authors[2].name, 'Slimer McEctoplasm');
@@ -58,6 +62,8 @@ describe('Authors Content API', function () {
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
                 const {authors} = body;
+                // We don't expose the email address.
+                localUtils.API.checkResponse(body.authors[0], 'author', ['count', 'url'], null, null);
 
                 // Verify slugs and post counts for specific authors
                 const mustFind = (slug) => {
@@ -93,6 +99,9 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
+                // We don't expose the email address.
+                localUtils.API.checkResponse(body.authors[0], 'author', ['url'], null, null);
+
                 assert.equal(body.authors.length, 1);
                 const requestedId = fixtureManager.get('users', 0).id;
                 assert.equal(body.authors[0].id, requestedId);
@@ -110,6 +119,9 @@ describe('Authors Content API', function () {
             })
             .expect(cacheInvalidateHeaderNotSet())
             .expect(({body}) => {
+                // We don't expose the email address.
+                localUtils.API.checkResponse(body.authors[0], 'author', ['count', 'url'], null, null);
+
                 assert.equal(body.authors.length, 1);
                 const expectedId = fixtureManager.get('users', 0).id;
                 assert.equal(body.authors[0].id, expectedId);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-608

- Updates the content API author endpoints to use snapshots for testing
- Also moves away from using `should` and uses `assert` instead
- Maintains useful assertions in addition to the snapshots