### PR TITLE
Added deprecation message to facebook and twitter helpers

### DIFF
--- a/ghost/core/core/frontend/helpers/facebook_url.js
+++ b/ghost/core/core/frontend/helpers/facebook_url.js
@@ -6,6 +6,9 @@ const {socialUrls} = require('../services/proxy');
 const {localUtils} = require('../services/handlebars');
 
 // We use the name facebook_url to match the helper for consistency:
+/**
+ * @deprecated Use {{social_url type="facebook"}} instead.
+ */
 module.exports = function facebook_url(username, options) { // eslint-disable-line camelcase
     if (!options) {
         options = username;

--- a/ghost/core/core/frontend/helpers/twitter_url.js
+++ b/ghost/core/core/frontend/helpers/twitter_url.js
@@ -6,6 +6,9 @@ const {socialUrls} = require('../services/proxy');
 const {localUtils} = require('../services/handlebars');
 
 // We use the name twitter_url to match the helper for consistency:
+/**
+ * @deprecated Use {{social_url type="twitter"}} instead.
+ */
 module.exports = function twitter_url(username, options) { // eslint-disable-line camelcase
     if (!options) {
         options = username;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-1566

- adds a deprecation message to the facebook and twitter helpers, directing users to social_url instead