### PR TITLE
Make CI execution time for tests more consistent, by using dockerized playwright instead of installing dependencies

### DIFF
--- a/.github/actions/docker-playwright/action.yml
+++ b/.github/actions/docker-playwright/action.yml
@@ -1,5 +1,5 @@
-name: "Run E2E Tests"
-description: "Run E2E tests using Playwright in Docker"
+name: "Run Playwright Tests"
+description: "Run Playwright tests"
 
 inputs:
   ghost_base_url:
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: "http://localhost:2368"
   test_command:
-    description: "Test command to run"
+    description: "Command to execute tests"
     required: true
     default: "yarn test:e2e"
 
@@ -18,8 +18,8 @@ runs:
       id: playwright-version
       shell: bash
       run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
-      
-    - name: Run E2E tests
+
+    - name: Run tests
       shell: bash
       run: |
         docker run --rm \
@@ -29,5 +29,5 @@ runs:
           -w /workspace \
           -e GHOST_BASE_URL=${{ inputs.ghost_base_url }} \
           -e CI=true \
-          mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }}-noble \
+          mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }} \
           ${{ inputs.test_command }}

--- a/.github/actions/docker-playwright/action.yml
+++ b/.github/actions/docker-playwright/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Command to execute tests"
     required: true
     default: "yarn test:e2e"
+  env_vars:
+    description: "Environment variables to pass (space-separated KEY=value pairs)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -30,4 +34,4 @@ runs:
           -e GHOST_BASE_URL=${{ inputs.ghost_base_url }} \
           -e CI=true \
           mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }} \
-          ${{ inputs.test_command }}
+          bash -c "${{ inputs.env_vars }} ${{ inputs.test_command }}"

--- a/.github/actions/docker-playwright/action.yml
+++ b/.github/actions/docker-playwright/action.yml
@@ -1,0 +1,33 @@
+name: "Run E2E Tests"
+description: "Run E2E tests using Playwright in Docker"
+
+inputs:
+  ghost_base_url:
+    description: "Base URL for Ghost instance"
+    required: false
+    default: "http://localhost:2368"
+  test_command:
+    description: "Test command to run"
+    required: true
+    default: "yarn test:e2e"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Playwright version
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
+      
+    - name: Run E2E tests
+      shell: bash
+      run: |
+        docker run --rm \
+          --ipc=host \
+          --network=host \
+          -v $PWD:/workspace \
+          -w /workspace \
+          -e GHOST_BASE_URL=${{ inputs.ghost_base_url }} \
+          -e CI=true \
+          mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }}-noble \
+          ${{ inputs.test_command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,16 +359,18 @@ jobs:
       working-directory: ghost/core
       run: yarn knex-migrator init
 
+    - name: Setup Playwright
+      uses: ./.github/actions/setup-playwright
+
     - name: Build Admin
       run: yarn nx run ghost-admin:build:dev
 
-    - name: Run browser tests
-      uses: ./.github/actions/docker-playwright
-      with:
-        test_command: "yarn test:browser"
-        env_vars: >-
-          STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}
-          STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
+    - name: Run Playwright tests locally
+      run: yarn test:browser
+      env:
+        CI: true
+        STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+        STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
 
     - uses: tryghost/actions/actions/slack-build@main
       if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,14 +359,13 @@ jobs:
       working-directory: ghost/core
       run: yarn knex-migrator init
 
-    - name: Setup Playwright
-      uses: ./.github/actions/setup-playwright
-
     - name: Build Admin
       run: yarn nx run ghost-admin:build:dev
 
     - name: Run Playwright tests locally
-      run: yarn test:browser
+      uses: ./.github/actions/docker-playwright
+      with:
+        test_command: "yarn test:browser"            
       env:
         CI: true
         STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
@@ -658,11 +657,11 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
-      - run: yarn nx run @tryghost/admin-x-settings:test:acceptance
-
+      - name: Run playwright tests
+        uses: ./.github/actions/docker-playwright
+        with:
+          test_command: "yarn nx run @tryghost/admin-x-settings:test:acceptance"
+      
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -698,10 +697,10 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
-      - run: yarn nx run @tryghost/admin-x-activitypub:test:acceptance
+      - name: Run playwright tests
+        uses: ./.github/actions/docker-playwright
+        with:
+          test_command: "yarn nx run @tryghost/admin-x-activitypub:test:acceptance"          
 
       - name: Upload test results
         if: always()
@@ -738,10 +737,10 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
-      - run: yarn nx run @tryghost/comments-ui:test
+      - name: Run playwright tests
+        uses: ./.github/actions/docker-playwright
+        with:
+            test_command: "yarn nx run @tryghost/comments-ui:test"
 
       - name: Upload test results
         if: always()
@@ -778,10 +777,10 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
-      - run: yarn nx run @tryghost/signup-form:test:e2e
+      - name: Run E2E tests
+        uses: ./.github/actions/docker-playwright
+        with:
+          test_command: "yarn nx run @tryghost/signup-form:test:e2e"
 
       - name: Upload test results
         if: always()
@@ -835,9 +834,6 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
       - name: Install Tinybird CLI
         run: curl -fsSL https://tinybird.co/install.sh | sh
 
@@ -865,9 +861,9 @@ jobs:
           timeout 120 bash -c 'until curl -f http://localhost:2368; do sleep 1; done'
 
       - name: Run E2E tests
-        run: yarn test:e2e
-        env:
-          GHOST_BASE_URL: http://localhost:2368
+        uses: ./.github/actions/docker-playwright
+        with:
+          test_command: "yarn test:e2e"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,14 +362,13 @@ jobs:
     - name: Build Admin
       run: yarn nx run ghost-admin:build:dev
 
-    - name: Run Playwright tests locally
+    - name: Run browser tests
       uses: ./.github/actions/docker-playwright
       with:
-        test_command: "yarn test:browser"            
-      env:
-        CI: true
-        STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
-        STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        test_command: "yarn test:browser"
+        env_vars: >-
+          STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
 
     - uses: tryghost/actions/actions/slack-build@main
       if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -657,11 +656,11 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Run playwright tests
+      - name: Run acceptance tests
         uses: ./.github/actions/docker-playwright
         with:
           test_command: "yarn nx run @tryghost/admin-x-settings:test:acceptance"
-      
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -697,10 +696,10 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Run playwright tests
+      - name: Run acceptance tests
         uses: ./.github/actions/docker-playwright
         with:
-          test_command: "yarn nx run @tryghost/admin-x-activitypub:test:acceptance"          
+          test_command: "yarn nx run @tryghost/admin-x-activitypub:test:acceptance"
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
I have noticed slow `setup playwright` step, couple of time last week that could take 10 minutes, and it seems it was around before too, I noticed it here, in this [CI run](https://github.com/TryGhost/Ghost/actions/runs/17151367111/job/48658277972) or this [CI run](https://github.com/TryGhost/Ghost/actions/runs/16915051583/job/47926926233).

Docker pull is a slower action, but it is fairly fast, and seem to take similar time, even when cache is used for `setup playwright` since runtime dependencies need to be installed even when cache is used - which I checked [here](https://github.com/microsoft/playwright/issues/7249) and is how we used caching.

With docker pull, times seem constant.  What are your thoughts about this? I would love to hear your opinions

**note:** I intentionally did not add something like docker:test to projects to run these, to keep change minimal for now, if we like this approach.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
