### PR TITLE
Migrate tags list to React (part 1)

### DIFF
--- a/apps/admin-x-framework/src/api/tags.ts
+++ b/apps/admin-x-framework/src/api/tags.ts
@@ -1,8 +1,9 @@
+import {InfiniteData} from '@tanstack/react-query';
 import {
     Meta,
-    createQuery,
     createQueryWithId,
-    createMutation
+    createMutation,
+    createInfiniteQuery
 } from '../utils/api/hooks';
 
 export type Tag = {
@@ -42,9 +43,24 @@ export interface TagsResponseType {
 
 const dataType = 'TagsResponseType';
 
-const useBrowseTagsQuery = createQuery<TagsResponseType>({
+const useBrowseTagsQuery = createInfiniteQuery<TagsResponseType>({
     dataType,
-    path: '/tags/'
+    path: '/tags/',
+    defaultNextPageParams: (lastPage, otherParams) => ({
+        ...otherParams,
+        page: (lastPage.meta?.pagination.next || 1).toString()
+    }),
+    returnData: (originalData) => {
+        const {pages} = originalData as InfiniteData<TagsResponseType>;
+        const tags = pages.flatMap(page => page.tags);
+        const meta = pages[pages.length - 1].meta;
+
+        return {
+            tags,
+            meta,
+            isEnd: meta ? meta.pagination.pages === meta.pagination.page : true
+        };
+    }
 });
 
 export const useBrowseTags = ({

--- a/apps/admin-x-framework/src/api/tags.ts
+++ b/apps/admin-x-framework/src/api/tags.ts
@@ -46,10 +46,12 @@ const dataType = 'TagsResponseType';
 const useBrowseTagsQuery = createInfiniteQuery<TagsResponseType>({
     dataType,
     path: '/tags/',
-    defaultNextPageParams: (lastPage, otherParams) => ({
-        ...otherParams,
-        page: (lastPage.meta?.pagination.next || 1).toString()
-    }),
+    defaultNextPageParams: (lastPage, otherParams) => (lastPage.meta?.pagination.next
+        ? {
+            ...otherParams,
+            page: (lastPage.meta?.pagination.next || 1).toString()
+        }
+        : undefined),
     returnData: (originalData) => {
         const {pages} = originalData as InfiniteData<TagsResponseType>;
         const tags = pages.flatMap(page => page.tags);

--- a/apps/admin-x-framework/src/api/tags.ts
+++ b/apps/admin-x-framework/src/api/tags.ts
@@ -1,0 +1,79 @@
+import {
+    Meta,
+    createQuery,
+    createQueryWithId,
+    createMutation
+} from '../utils/api/hooks';
+
+export type Tag = {
+    id: string;
+    name: string;
+    slug: string;
+    url: string;
+    description: string;
+    visibility: 'public' | 'internal';
+    count?: {
+        posts: number;
+    };
+
+    // XXX: Ensure the types match the casing in the API response by either
+    // transforming them to camelCase or using snake_case
+    // metaTitle: string;
+    // metaDescription: string;
+    // twitterImage: string;
+    // twitterTitle: string;
+    // twitterDescription: string;
+    // ogImage: string;
+    // ogTitle: string;
+    // ogDescription: string;
+    // codeinjectionHead: string;
+    // codeinjectionFoot: string;
+    // canonicalUrl: string;
+    // accentColor: string;
+    // featureImage: string;
+    // createdAtUTC: string;
+    // updatedAtUTC: string;
+};
+
+export interface TagsResponseType {
+    meta?: Meta;
+    tags: Tag[];
+}
+
+const dataType = 'TagsResponseType';
+
+const useBrowseTagsQuery = createQuery<TagsResponseType>({
+    dataType,
+    path: '/tags/'
+});
+
+export const useBrowseTags = ({
+    filter,
+    ...args
+}: { filter: Record<string, string | number | boolean> } & Parameters<
+    typeof useBrowseTagsQuery
+>[0]) => {
+    const filterString = Object.entries(filter)
+        .map(([key, value]) => `${key}:${value}`)
+        .join(',');
+    return useBrowseTagsQuery({
+        ...args,
+        searchParams: {
+            limit: '100',
+            order: 'name asc',
+            include: 'count.posts',
+            filter: filterString,
+            ...args.searchParams
+        }
+    });
+};
+
+export const getTag = createQueryWithId<TagsResponseType>({
+    dataType,
+    path: id => `/tags/${id}/`
+});
+
+export const useDeleteTag = createMutation<unknown, string>({
+    method: 'DELETE',
+    path: id => `/tags/${id}/`
+});

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -104,7 +104,7 @@ export const createPaginatedQuery = <ResponseData extends {meta?: Meta}>(options
 
 type InfiniteQueryOptions<ResponseData> = Omit<QueryOptions<ResponseData>, 'returnData'> & {
     returnData: NonNullable<QueryOptions<ResponseData>['returnData']>
-    defaultNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string>;
+    defaultNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string> | undefined;
 }
 
 type InfiniteQueryHookOptions<ResponseData> = UseInfiniteQueryOptions<ResponseData> & {

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@tanstack/react-query": "4.36.1",
+        "@tanstack/react-virtual": "^3.13.12",
         "@testing-library/react": "14.3.1",
         "@types/jest": "29.5.14",
         "@types/react": "18.3.24",

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -3,6 +3,7 @@ import Newsletter from './views/PostAnalytics/Newsletter/Newsletter';
 import Overview from './views/PostAnalytics/Overview/Overview';
 import PostAnalytics from './views/PostAnalytics/PostAnalytics';
 import PostAnalyticsProvider from './providers/PostAnalyticsContext';
+import Tags from './views/Tags/Tags';
 import Web from './views/PostAnalytics/Web/Web';
 import {ErrorPage} from '@tryghost/shade';
 import {RouteObject} from '@tryghost/admin-x-framework';
@@ -47,6 +48,10 @@ export const routes: RouteObject[] = [
                         element: <Newsletter />
                     }
                 ]
+            },
+            {
+                path: 'tags',
+                element: <Tags />
             },
 
             // Error handling

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -3,7 +3,7 @@ import TagsContent from './components/TagsContent';
 import TagsHeader from './components/TagsHeader';
 import TagsLayout from './components/TagsLayout';
 import TagsList from './components/TagsList';
-import {LoadingIndicator} from '@tryghost/shade';
+import {Button, LoadingIndicator, LucideIcon} from '@tryghost/shade';
 import {useBrowseTags} from '@tryghost/admin-x-framework/api/tags';
 import {useLocation} from '@tryghost/admin-x-framework';
 
@@ -14,8 +14,7 @@ const Tags: React.FC = () => {
 
     const {
         data,
-        //error,
-        //isFetching,
+        isError,
         isLoading,
         isFetchingNextPage,
         fetchNextPage,
@@ -31,8 +30,30 @@ const Tags: React.FC = () => {
             <TagsHeader currentTab={type} />
             <TagsContent>
                 {isLoading ? (
-                    <div className="flex h-full items-center justify-center">
+                    <div className="flex h-full items-center justify-center"> 
                         <LoadingIndicator size="lg" />
+                    </div>
+                ) : isError ? (
+                    <div className="mb-16 flex h-full flex-col items-center justify-center">
+                        <h2 className="mb-2 text-xl font-medium">
+                            Error loading tags
+                        </h2>
+                        <p className="mb-4 text-muted-foreground">
+                            Please reload the page to try again
+                        </p>
+                        <Button onClick={() => window.location.reload()}>
+                            Reload page
+                        </Button>
+                    </div>
+                ) : !data?.tags.length ? (
+                    <div className="mb-16 flex h-full flex-col items-center justify-center gap-8">
+                        <LucideIcon.Tags className="-mb-4 size-16 text-muted-foreground" strokeWidth={1} />
+                        <h2 className="text-xl font-medium">
+                            Start organizing your content
+                        </h2>
+                        <Button asChild>
+                            <a href="#/tags/new">Create a new tag</a>
+                        </Button>
                     </div>
                 ) : (
                     <TagsList

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -3,6 +3,8 @@ import TagsContent from './components/TagsContent';
 import TagsHeader from './components/TagsHeader';
 import TagsLayout from './components/TagsLayout';
 import TagsList from './components/TagsList';
+import {LoadingIndicator} from '@tryghost/shade';
+import {useBrowseTags} from '@tryghost/admin-x-framework/api/tags';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 const Tags: React.FC = () => {
@@ -10,33 +12,23 @@ const Tags: React.FC = () => {
     const qs = new URLSearchParams(search);
     const type = qs.get('type') ?? 'public';
 
+    const {data, isLoading} = useBrowseTags({
+        filter: {
+            visibility: type
+        }
+    });
+
     return (
         <TagsLayout>
             <TagsHeader currentTab={type} />
             <TagsContent>
-
-                <TagsList items={[
-                    {
-                        id: 1,
-                        name: 'Tag 1',
-                        slug: 'tag-1',
-                        count: 10
-                    },
-                    
-                    {
-                        id: 2,
-                        name: 'Tag 2',
-                        slug: 'tag-2',
-                        count: 20
-                    },
-                    {
-                        id: 3,
-                        name: 'Tag 3',
-                        slug: 'tag-3',
-                        count: 30
-                    }
-                ]} />
-
+                {isLoading ? (
+                    <div className="flex h-full items-center justify-center">
+                        <LoadingIndicator size="lg" />
+                    </div>
+                ) : (
+                    <TagsList items={data?.tags ?? []} />
+                )}
             </TagsContent>
         </TagsLayout>
     );

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Tags: React.FC = () => {
+    return <h1>Tags in React</h1>;
+};
+
+export default Tags;

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -1,7 +1,45 @@
 import React from 'react';
+import TagsContent from './components/TagsContent';
+import TagsHeader from './components/TagsHeader';
+import TagsLayout from './components/TagsLayout';
+import TagsList from './components/TagsList';
+import {useLocation} from '@tryghost/admin-x-framework';
 
 const Tags: React.FC = () => {
-    return <h1>Tags in React</h1>;
+    const {search} = useLocation();
+    const qs = new URLSearchParams(search);
+    const type = qs.get('type') ?? 'public';
+
+    return (
+        <TagsLayout>
+            <TagsHeader currentTab={type} />
+            <TagsContent>
+
+                <TagsList items={[
+                    {
+                        id: 1,
+                        name: 'Tag 1',
+                        slug: 'tag-1',
+                        count: 10
+                    },
+                    
+                    {
+                        id: 2,
+                        name: 'Tag 2',
+                        slug: 'tag-2',
+                        count: 20
+                    },
+                    {
+                        id: 3,
+                        name: 'Tag 3',
+                        slug: 'tag-3',
+                        count: 30
+                    }
+                ]} />
+
+            </TagsContent>
+        </TagsLayout>
+    );
 };
 
 export default Tags;

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -61,7 +61,7 @@ const Tags: React.FC = () => {
                         hasNextPage={hasNextPage}
                         isFetchingNextPage={isFetchingNextPage}
                         items={data?.tags ?? []}
-                        totalCount={data?.meta?.pagination?.total ?? 0}
+                        totalItems={data?.meta?.pagination?.total ?? 0}
                     />
                 )}
             </TagsContent>

--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -12,7 +12,15 @@ const Tags: React.FC = () => {
     const qs = new URLSearchParams(search);
     const type = qs.get('type') ?? 'public';
 
-    const {data, isLoading} = useBrowseTags({
+    const {
+        data,
+        //error,
+        //isFetching,
+        isLoading,
+        isFetchingNextPage,
+        fetchNextPage,
+        hasNextPage
+    } = useBrowseTags({
         filter: {
             visibility: type
         }
@@ -27,7 +35,13 @@ const Tags: React.FC = () => {
                         <LoadingIndicator size="lg" />
                     </div>
                 ) : (
-                    <TagsList items={data?.tags ?? []} />
+                    <TagsList
+                        fetchNextPage={fetchNextPage}
+                        hasNextPage={hasNextPage}
+                        isFetchingNextPage={isFetchingNextPage}
+                        items={data?.tags ?? []}
+                        totalCount={data?.meta?.pagination?.total ?? 0}
+                    />
                 )}
             </TagsContent>
         </TagsLayout>

--- a/apps/posts/src/views/Tags/components/TagsContent.tsx
+++ b/apps/posts/src/views/Tags/components/TagsContent.tsx
@@ -3,7 +3,7 @@ import {cn} from '@tryghost/shade';
 
 const TagsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <section className={cn('flex gap-8 flex-col py-8 size-full grow', className)} {...props}>
+        <section className={cn('flex gap-8 flex-col p-4 lg:p-8 size-full grow', className)} {...props}>
             {children}
         </section>
     );

--- a/apps/posts/src/views/Tags/components/TagsContent.tsx
+++ b/apps/posts/src/views/Tags/components/TagsContent.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {cn} from '@tryghost/shade';
+
+const TagsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
+    return (
+        <section className={cn('flex gap-8 flex-col py-8 size-full grow', className)} {...props}>
+            {children}
+        </section>
+    );
+};
+
+export default TagsContent;

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -17,14 +17,14 @@ interface TagsHeaderProps {
 const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
     return (
         <>
-            <Navbar className="sticky top-0 z-50 -mb-8 flex-col items-start gap-y-5 border-none bg-white/70 py-8 backdrop-blur-md md:flex-row md:items-center dark:bg-black">
-                <H1 className="min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]">
+            <Navbar className="sticky top-0 z-50 -mb-4 flex-col items-start gap-y-2 border-none bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md md:flex-row md:items-center lg:-mb-8 lg:gap-y-4 lg:p-8 dark:bg-black">
+                <H1 className="min-h-[35px] max-w-[920px] indent-0 text-2xl leading-[1.2em] lg:text-3xl">
                     Tags
                 </H1>
 
-                <NavbarActions>
+                <NavbarActions className="w-full justify-between md:w-auto">
                     <PageMenu
-                        className="min-h-[34px] pr-4"
+                        className="min-h-[34px] pr-2 lg:pr-4"
                         defaultValue={currentTab}
                     >
                         <PageMenuItem value="public" asChild>

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {
+    Button,
+    H1,
+    Navbar,
+    NavbarActions,
+    PageMenu,
+    PageMenuItem
+} from '@tryghost/shade';
+import {Link} from '@tryghost/admin-x-framework';
+
+interface TagsHeaderProps {
+    currentTab?: string;
+    children?: React.ReactNode;
+}
+
+const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
+    return (
+        <>
+            <Navbar className="sticky top-0 z-50 -mb-8 flex-col items-start gap-y-5 border-none bg-white/70 py-8 backdrop-blur-md lg:flex-row lg:items-center dark:bg-black">
+                <H1 className="min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]">
+                    Tags
+                </H1>
+
+                <NavbarActions>
+                    <PageMenu
+                        className="min-h-[34px] pr-4"
+                        defaultValue={currentTab}
+                    >
+                        <PageMenuItem value="public" asChild>
+                            <Link to="/tags">Public tags</Link>
+                        </PageMenuItem>
+                        <PageMenuItem value="internal" asChild>
+                            <Link to="/tags?type=internal">Internal tags</Link>
+                        </PageMenuItem>
+                    </PageMenu>
+                    <Button asChild>
+                        <a className="font-bold" href="#/tags/new">
+                            New tag
+                        </a>
+                    </Button>
+                </NavbarActions>
+            </Navbar>
+        </>
+    );
+};
+
+export default TagsHeader;

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -17,7 +17,7 @@ interface TagsHeaderProps {
 const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
     return (
         <>
-            <Navbar className="sticky top-0 z-50 -mb-8 flex-col items-start gap-y-5 border-none bg-white/70 py-8 backdrop-blur-md lg:flex-row lg:items-center dark:bg-black">
+            <Navbar className="sticky top-0 z-50 -mb-8 flex-col items-start gap-y-5 border-none bg-white/70 py-8 backdrop-blur-md md:flex-row md:items-center dark:bg-black">
                 <H1 className="min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]">
                     Tags
                 </H1>

--- a/apps/posts/src/views/Tags/components/TagsLayout.tsx
+++ b/apps/posts/src/views/Tags/components/TagsLayout.tsx
@@ -1,0 +1,16 @@
+import MainLayout from '@src/components/layout/MainLayout';
+import React from 'react';
+
+const PostAnalyticsLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children}) => {
+    return (
+        <MainLayout>
+            <div className='grid w-full grow'>
+                <div className='flex h-full flex-col px-8'>
+                    {children}
+                </div>
+            </div>
+        </MainLayout>
+    );
+};
+
+export default PostAnalyticsLayout;

--- a/apps/posts/src/views/Tags/components/TagsLayout.tsx
+++ b/apps/posts/src/views/Tags/components/TagsLayout.tsx
@@ -5,7 +5,7 @@ const PostAnalyticsLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
     return (
         <MainLayout>
             <div className='grid w-full grow'>
-                <div className='flex h-full flex-col px-8'>
+                <div className='flex h-full flex-col'>
                     {children}
                 </div>
             </div>

--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -6,7 +6,8 @@ import {
     TableCell,
     TableHead,
     TableHeader,
-    TableRow
+    TableRow,
+    formatNumber
 } from '@tryghost/shade';
 import {Tag} from '@tryghost/admin-x-framework/api/tags';
 
@@ -15,30 +16,38 @@ const TagsList = ({items}: { items: Tag[] }) => {
         <Table>
             <TableHeader>
                 <TableRow>
-                    <TableHead>Tag</TableHead>
-                    <TableHead>Slug</TableHead>
-                    <TableHead>No. of posts</TableHead>
+                    <TableHead className="px-4">Tag</TableHead>
+                    <TableHead className="px-4">Slug</TableHead>
+                    <TableHead className="px-4">No. of posts</TableHead>
                     <TableHead></TableHead>
                 </TableRow>
             </TableHeader>
-            <TableBody className="border-b-0">
+            <TableBody>
                 {items.map(item => (
                     <TableRow
                         key={item.id}
-                        className="relative hover:bg-muted/50"
+                        className="relative"
                     >
-                        <TableCell className="static w-1/2">
+                        <TableCell className="static w-3/5 p-4">
                             <a
-                                className="block font-medium before:absolute before:inset-0 before:z-50 before:bg-transparent"
+                                className="block pb-1 text-lg font-medium before:absolute before:inset-0 before:z-10"
                                 href={`#/tags/${item.slug}`}
                             >
                                 {item.name}
                             </a>
-                            <span className="block truncate text-sm text-muted-foreground">{item.description}</span>
+                            <span className="block truncate text-muted-foreground">{item.description}</span>
                         </TableCell>
-                        <TableCell className="w-1/4">{item.slug}</TableCell>
-                        <TableCell className="">{item.count?.posts ?? 0}</TableCell>
-                        <TableCell className="w-4 justify-end">
+                        <TableCell className="p-4">{item.slug}</TableCell>
+                        <TableCell className="p-4">
+                            {item.count?.posts ? (
+                                <a className="relative z-10 -m-4 inline-block p-4 hover:underline" href={`#/posts?tag=${item.slug}`}>
+                                    {`${formatNumber(item.count?.posts)} ${item.count?.posts === 1 ? 'post' : 'posts'}`}
+                                </a>
+                            ) : (
+                                <span className="text-muted-foreground">0 posts</span>
+                            )}
+                        </TableCell>
+                        <TableCell className="w-4 justify-end p-4">
                             <Button
                                 className="w-12"
                                 size="icon"

--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -8,15 +8,18 @@ import {
     TableHeader,
     TableRow
 } from '@tryghost/shade';
+import {Tag} from '@tryghost/admin-x-framework/api/tags';
 
-const TagsList = ({items}: { items: any[] }) => {
+const TagsList = ({items}: { items: Tag[] }) => {
     return (
         <Table>
             <TableHeader>
-                <TableHead>Tag</TableHead>
-                <TableHead>Slug</TableHead>
-                <TableHead>No. of posts</TableHead>
-                <TableHead></TableHead>
+                <TableRow>
+                    <TableHead>Tag</TableHead>
+                    <TableHead>Slug</TableHead>
+                    <TableHead>No. of posts</TableHead>
+                    <TableHead></TableHead>
+                </TableRow>
             </TableHeader>
             <TableBody className="border-b-0">
                 {items.map(item => (
@@ -24,16 +27,17 @@ const TagsList = ({items}: { items: any[] }) => {
                         key={item.id}
                         className="relative hover:bg-muted/50"
                     >
-                        <TableCell className="static w-1/2 font-medium">
+                        <TableCell className="static w-1/2">
                             <a
-                                className="before:absolute before:inset-0 before:z-50 before:bg-transparent"
+                                className="block font-medium before:absolute before:inset-0 before:z-50 before:bg-transparent"
                                 href={`#/tags/${item.slug}`}
                             >
                                 {item.name}
                             </a>
+                            <span className="block truncate text-sm text-muted-foreground">{item.description}</span>
                         </TableCell>
                         <TableCell className="w-1/4">{item.slug}</TableCell>
-                        <TableCell className="">{item.count}</TableCell>
+                        <TableCell className="">{item.count?.posts ?? 0}</TableCell>
                         <TableCell className="w-4 justify-end">
                             <Button
                                 className="w-12"

--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -10,56 +10,186 @@ import {
     formatNumber
 } from '@tryghost/shade';
 import {Tag} from '@tryghost/admin-x-framework/api/tags';
+import {notUndefined, useVirtualizer} from '@tanstack/react-virtual';
+import {useEffect, useRef} from 'react';
 
-const TagsList = ({items}: { items: Tag[] }) => {
+function getScrollParent(node: Node | null): HTMLElement | null {
+    const isElement = node instanceof HTMLElement;
+    const overflowY = isElement && window.getComputedStyle(node).overflowY;
+    const isScrollable = overflowY !== 'visible' && overflowY !== 'hidden';
+
+    if (!node) {
+        return null;
+    } else if (
+        isScrollable &&
+        (node as HTMLElement).scrollHeight >= (node as HTMLElement).clientHeight
+    ) {
+        return node as HTMLElement;
+    }
+
+    return getScrollParent(node.parentNode) || document.body;
+}
+
+const TagsList = ({
+    items,
+    totalCount,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage
+}: {
+    items: Tag[];
+    totalCount: number;
+    hasNextPage?: boolean;
+    isFetchingNextPage?: boolean;
+    fetchNextPage: () => void;
+}) => {
+    const tagCount = items.length;
+    const parentRef = useRef<HTMLDivElement>(null);
+
+    const rowVirtualizer = useVirtualizer({
+        getScrollElement: () => getScrollParent(parentRef.current),
+        count: totalCount,
+        estimateSize: () => 100
+    });
+
+    useEffect(() => {
+        const [lastItem] = [...rowVirtualizer.getVirtualItems()].reverse();
+
+        if (!lastItem) {
+            return;
+        }
+
+        if (
+            lastItem.index >= tagCount - 1 &&
+            hasNextPage &&
+            !isFetchingNextPage
+        ) {
+            fetchNextPage();
+        }
+    }, [
+        hasNextPage,
+        fetchNextPage,
+        tagCount,
+        isFetchingNextPage,
+        rowVirtualizer.getVirtualItems()
+    ]);
+
+    const visibleItems = rowVirtualizer.getVirtualItems();
+    const [before, after] =
+        visibleItems.length > 0
+            ? [
+                notUndefined(visibleItems[0]).start -
+                      rowVirtualizer.options.scrollMargin,
+                rowVirtualizer.getTotalSize() -
+                      notUndefined(visibleItems[visibleItems.length - 1]).end
+            ]
+            : [0, 0];
+    const colSpan = 4;
+
     return (
-        <Table>
-            <TableHeader>
-                <TableRow>
-                    <TableHead className="px-4">Tag</TableHead>
-                    <TableHead className="px-4">Slug</TableHead>
-                    <TableHead className="px-4">No. of posts</TableHead>
-                    <TableHead></TableHead>
-                </TableRow>
-            </TableHeader>
-            <TableBody>
-                {items.map(item => (
-                    <TableRow
-                        key={item.id}
-                        className="relative"
-                    >
-                        <TableCell className="static w-3/5 p-4">
-                            <a
-                                className="block pb-1 text-lg font-medium before:absolute before:inset-0 before:z-10"
-                                href={`#/tags/${item.slug}`}
-                            >
-                                {item.name}
-                            </a>
-                            <span className="block truncate text-muted-foreground">{item.description}</span>
-                        </TableCell>
-                        <TableCell className="p-4">{item.slug}</TableCell>
-                        <TableCell className="p-4">
-                            {item.count?.posts ? (
-                                <a className="relative z-10 -m-4 inline-block p-4 hover:underline" href={`#/posts?tag=${item.slug}`}>
-                                    {`${formatNumber(item.count?.posts)} ${item.count?.posts === 1 ? 'post' : 'posts'}`}
-                                </a>
-                            ) : (
-                                <span className="text-muted-foreground">0 posts</span>
-                            )}
-                        </TableCell>
-                        <TableCell className="w-4 justify-end p-4">
-                            <Button
-                                className="w-12"
-                                size="icon"
-                                variant="outline"
-                            >
-                                <LucideIcon.Pencil />
-                            </Button>
-                        </TableCell>
+        <div
+            ref={parentRef}
+            style={{height: `${rowVirtualizer.getTotalSize()}px`}}
+        >
+            <Table className="flex table-fixed flex-col lg:table">
+                <TableHeader className="hidden lg:!visible lg:!table-header-group">
+                    <TableRow>
+                        <TableHead className="w-1/2 px-4 xl:w-3/5">Tag</TableHead>
+                        <TableHead className="w-1/5 px-4">Slug</TableHead>
+                        <TableHead className="w-1/5 px-4">No. of posts</TableHead>
+                        <TableHead className="w-16 px-4"></TableHead>
                     </TableRow>
-                ))}
-            </TableBody>
-        </Table>
+                </TableHeader>
+                <TableBody className="flex flex-col lg:table-row-group">
+                    {before > 0 && (
+                        <tr className="flex lg:table-row">
+                            <td
+                                className="flex lg:table-cell"
+                                colSpan={colSpan}
+                                style={{height: before}}
+                            />
+                        </tr>
+                    )}
+                    {visibleItems.map((virtualRow) => {
+                        const item = items[virtualRow.index];
+                        const isLoaderRow = virtualRow.index > items.length - 1;
+
+                        if (isLoaderRow) {
+                            return (
+                                <TableRow
+                                    key={virtualRow.key}
+                                    ref={rowVirtualizer.measureElement}
+                                    className="relative flex flex-col lg:table-row"
+                                    style={{
+                                        height: `${virtualRow.size}px`
+                                    }}
+                                >
+                                    <TableCell className="relative z-10 h-24 animate-pulse">
+                                        <div className="h-full rounded-md bg-muted" />
+                                    </TableCell>
+                                    <TableCell colSpan={3} />
+                                </TableRow>
+                            );
+                        }
+
+                        return (
+                            <TableRow
+                                key={virtualRow.key}
+                                ref={rowVirtualizer.measureElement}
+                                className="relative grid w-full grid-cols-[1fr_5rem] items-center gap-x-4 p-2 md:grid-cols-[1fr_auto_5rem] lg:table-row lg:p-0"
+                            >
+                                <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">
+                                    <a
+                                        className="block truncate pb-1 text-lg font-medium before:absolute before:inset-0 before:z-10"
+                                        href={`#/tags/${item.slug}`}
+                                    >
+                                        {item.name}
+                                    </a>
+                                    <span className="block truncate text-muted-foreground">
+                                        {item.description}
+                                    </span>
+                                </TableCell>
+                                <TableCell className="col-start-1 col-end-1 row-start-2 row-end-2 flex p-0 lg:table-cell lg:p-4">
+                                    <span className="block truncate">{item.slug}</span>
+                                </TableCell>
+                                <TableCell className="col-start-1 col-end-1 row-start-3 row-end-3 flex p-0 md:col-start-2 md:col-end-2 md:row-start-1 md:row-end-3 lg:table-cell lg:p-4">
+                                    {item.count?.posts ? (
+                                        <a
+                                            className="relative z-10 -m-4 inline-block p-4 hover:underline"
+                                            href={`#/posts?tag=${item.slug}`}
+                                        >
+                                            {`${formatNumber(item.count?.posts)}  ${item.count?.posts === 1 ? 'post' : 'posts'}`}
+                                        </a>
+                                    ) : (
+                                        <span className="text-muted-foreground">
+                                            0 posts
+                                        </span>
+                                    )}
+                                </TableCell>
+                                <TableCell className="col-start-2 col-end-2 row-start-1 row-end-3 w-4 p-0 md:col-start-3 md:col-end-3 lg:table-cell lg:p-4">
+                                    <Button
+                                        className="w-12"
+                                        size="icon"
+                                        variant="outline"
+                                    >
+                                        <LucideIcon.Pencil />
+                                    </Button>
+                                </TableCell>
+                            </TableRow>
+                        );
+                    })}
+                    {after > 0 && (
+                        <tr className="flex lg:table-row">
+                            <td
+                                className="flex lg:table-cell"
+                                colSpan={colSpan}
+                                style={{height: after}}
+                            />
+                        </tr>
+                    )}
+                </TableBody>
+            </Table>
+        </div>
     );
 };
 

--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -1,0 +1,53 @@
+import {
+    Button,
+    LucideIcon,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow
+} from '@tryghost/shade';
+
+const TagsList = ({items}: { items: any[] }) => {
+    return (
+        <Table>
+            <TableHeader>
+                <TableHead>Tag</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>No. of posts</TableHead>
+                <TableHead></TableHead>
+            </TableHeader>
+            <TableBody className="border-b-0">
+                {items.map(item => (
+                    <TableRow
+                        key={item.id}
+                        className="relative hover:bg-muted/50"
+                    >
+                        <TableCell className="static w-1/2 font-medium">
+                            <a
+                                className="before:absolute before:inset-0 before:z-50 before:bg-transparent"
+                                href={`#/tags/${item.slug}`}
+                            >
+                                {item.name}
+                            </a>
+                        </TableCell>
+                        <TableCell className="w-1/4">{item.slug}</TableCell>
+                        <TableCell className="">{item.count}</TableCell>
+                        <TableCell className="w-4 justify-end">
+                            <Button
+                                className="w-12"
+                                size="icon"
+                                variant="outline"
+                            >
+                                <LucideIcon.Pencil />
+                            </Button>
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+export default TagsList;

--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -65,14 +65,14 @@ function TagsList({
             <Table className="flex table-fixed flex-col lg:table">
                 <TableHeader className="hidden lg:!visible lg:!table-header-group">
                     <TableRow>
-                        <TableHead className="w-1/2 px-4 xl:w-3/5">
+                        <TableHead className="w-auto px-4">
                             Tag
                         </TableHead>
                         <TableHead className="w-1/5 px-4">Slug</TableHead>
                         <TableHead className="w-1/5 px-4">
                             No. of posts
                         </TableHead>
-                        <TableHead className="w-16 px-4"></TableHead>
+                        <TableHead className="w-20 px-4"></TableHead>
                     </TableRow>
                 </TableHeader>
                 <TableBody className="flex flex-col lg:table-row-group">
@@ -121,10 +121,12 @@ function TagsList({
                                         </span>
                                     )}
                                 </TableCell>
-                                <TableCell className="col-start-2 col-end-2 row-start-1 row-end-3 w-4 p-0 md:col-start-3 md:col-end-3 lg:table-cell lg:p-4">
+                                <TableCell className="col-start-2 col-end-2 row-start-1 row-end-3 p-0 md:col-start-3 md:col-end-3 lg:table-cell lg:p-4">
                                     <Button
+                                        aria-hidden="true"
                                         className="w-12"
                                         size="icon"
+                                        tabIndex={-1}
                                         variant="outline"
                                     >
                                         <LucideIcon.Pencil />

--- a/apps/posts/src/views/Tags/components/VirtualTable/getScrollParent.tsx
+++ b/apps/posts/src/views/Tags/components/VirtualTable/getScrollParent.tsx
@@ -1,0 +1,14 @@
+export function getScrollParent(node: Node | null): HTMLElement | null {
+    const isElement = node instanceof HTMLElement;
+    const overflowY = isElement && window.getComputedStyle(node).overflowY;
+    const isScrollable = overflowY !== 'visible' && overflowY !== 'hidden';
+
+    if (!node) {
+        return null;
+    } else if (isScrollable &&
+        (node as HTMLElement).scrollHeight >= (node as HTMLElement).clientHeight) {
+        return node as HTMLElement;
+    }
+
+    return getScrollParent(node.parentNode) || document.body;
+}

--- a/apps/posts/src/views/Tags/components/VirtualTable/useInfiniteVirtualScroll.tsx
+++ b/apps/posts/src/views/Tags/components/VirtualTable/useInfiniteVirtualScroll.tsx
@@ -1,0 +1,70 @@
+import {getScrollParent} from './getScrollParent';
+import {useEffect} from 'react';
+import {useVirtualizer} from '@tanstack/react-virtual';
+
+export function useInfiniteVirtualScroll<T>({
+    items,
+    totalItems,
+    parentRef,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    estimateSize = () => 100,
+    overscan = 5
+}: {
+    items: T[];
+    totalItems: number;
+    parentRef: React.RefObject<HTMLElement>;
+    hasNextPage?: boolean;
+    isFetchingNextPage?: boolean;
+    fetchNextPage: () => void;
+    estimateSize?: (index: number) => number;
+    overscan?: number;
+}) {
+    const virtualizer = useVirtualizer({
+        count: totalItems,
+        getScrollElement: () => getScrollParent(parentRef.current),
+        estimateSize,
+        overscan
+    });
+
+    const virtualItems = virtualizer.getVirtualItems();
+
+    const spaceBefore =
+        virtualItems.length > 0
+            ? (virtualItems.at(0)?.start ?? 0) -
+              virtualizer.options.scrollMargin
+            : 0;
+    const spaceAfter =
+        virtualItems.length > 0
+            ? virtualizer.getTotalSize() - (virtualItems.at(-1)?.end ?? 0)
+            : 0;
+
+    const itemsToRender = virtualItems.map(virtualItem => ({
+        virtualItem,
+        key: virtualItem.key,
+        item: items[virtualItem.index],
+        props: {
+            ref: virtualizer.measureElement,
+            'data-index': virtualItem.index
+        }
+    }));
+
+    // When the final item that is rendered (off screen) lacks data, meaning
+    // we render a placeholder, we should start fetching the next page
+    const shouldFetchNextPage =
+        itemsToRender.at(-1) && !itemsToRender.at(-1)?.item;
+
+    useEffect(() => {
+        if (hasNextPage && shouldFetchNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+        }
+    }, [hasNextPage, shouldFetchNextPage, isFetchingNextPage, fetchNextPage]);
+
+    return {
+        visibleItems: itemsToRender,
+        virtualizer,
+        spaceBefore,
+        spaceAfter
+    };
+}

--- a/ghost/admin/app/routes/tags.js
+++ b/ghost/admin/app/routes/tags.js
@@ -6,6 +6,11 @@ const CACHE_TIME = 1000 * 60 * 5; // 5 minutes
 export default class TagsRoute extends AuthenticatedRoute {
     @service infinity;
     @service tagsManager;
+    @service feature;
+
+    get templateName() {
+        return this.feature.tagsX ? 'tags-x' : 'tags';
+    }
 
     queryParams = {
         type: {
@@ -24,6 +29,10 @@ export default class TagsRoute extends AuthenticatedRoute {
     }
 
     model(params) {
+        if (this.feature.tagsX) {
+            return null;
+        }
+        
         const filterParams = {
             visibility: params.type
         };

--- a/ghost/admin/app/templates/tags-x.hbs
+++ b/ghost/admin/app/templates/tags-x.hbs
@@ -1,0 +1,2 @@
+<h1>React app?</h1>
+<AdminX::Posts />

--- a/ghost/admin/app/templates/tags-x.hbs
+++ b/ghost/admin/app/templates/tags-x.hbs
@@ -1,2 +1,1 @@
-<h1>React app?</h1>
 <AdminX::Posts />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7678,10 +7678,22 @@
   dependencies:
     "@tanstack/virtual-core" "3.0.0"
 
+"@tanstack/react-virtual@^3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz#d372dc2783739cc04ec1a728ca8203937687a819"
+  integrity sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==
+  dependencies:
+    "@tanstack/virtual-core" "3.13.12"
+
 "@tanstack/virtual-core@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz#637bee36f0cabf96a1d436887c90f138a7e9378b"
   integrity sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==
+
+"@tanstack/virtual-core@3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz#1dff176df9cc8f93c78c5e46bcea11079b397578"
+  integrity sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==
 
 "@testing-library/dom@10.4.0":
   version "10.4.0"


### PR DESCRIPTION
This is the first in a series of PRs to migrate the various tag related screens from Ember to React. The new tags list is available behind the `tagsX` feature flag. 

Once the new Playwright test setup is merged I'll follow up with a separate PR for tests so that we can go ahead and remove the feature flag for the list view.

The new tags list screen uses the Shade design system components and should be more or less a 1:1 port of the old Ember version. There are some minor cosmetic differences and an improved responsive layout. 

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
