### PR TITLE
🐛 Fixed validation issues with TikTok and Instagram usernames

### DIFF
--- a/apps/admin-x-settings/src/utils/socialUrls/instagram.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/instagram.ts
@@ -30,7 +30,7 @@ export function validateInstagramUrl(newUrl: string) {
 
     // Validate username: alphanumeric, underscore, period, 1–30 chars, no leading/trailing/consecutive periods
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
+        !username.match(/^[a-zA-Z0-9_][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length > 30
     ) {
@@ -60,7 +60,7 @@ export const instagramHandleToUrl = (handle: string) => {
 
     // Validate username: alphanumeric, underscore, period, 1–30 chars, no leading/trailing/consecutive periods
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
+        !username.match(/^[a-zA-Z0-9_][a-zA-Z0-9._]{0,28}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length > 30
     ) {

--- a/apps/admin-x-settings/src/utils/socialUrls/tiktok.ts
+++ b/apps/admin-x-settings/src/utils/socialUrls/tiktok.ts
@@ -31,7 +31,7 @@ export function validateTikTokUrl(newUrl: string) {
     // Validate username: alphanumeric, underscore, period, 2–24 chars, no leading/consecutive periods
     const username = handle.slice(1); // Remove @ for validation
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,22}[a-zA-Z0-9]$/) ||
+        !username.match(/^[a-zA-Z0-9_][a-zA-Z0-9._]{0,22}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length < 2 ||
         username.length > 24
@@ -61,7 +61,7 @@ export const tiktokHandleToUrl = (handle: string) => {
 
     // Validate username: alphanumeric, underscore, period, 2–24 chars, no leading/consecutive periods
     if (
-        !username.match(/^[a-zA-Z0-9][a-zA-Z0-9._]{0,22}[a-zA-Z0-9]$/) ||
+        !username.match(/^[a-zA-Z0-9_][a-zA-Z0-9._]{0,22}[a-zA-Z0-9_]$/) ||
         username.includes('..') ||
         username.length < 2 ||
         username.length > 24

--- a/apps/admin-x-settings/test/unit/utils/instagramUrls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/instagramUrls.test.ts
@@ -13,7 +13,7 @@ describe('Instagram URL validation', () => {
         assert.equal(validateInstagramUrl('instagram.com/john_smith_123'), 'https://www.instagram.com/john_smith_123');
         assert.equal(validateInstagramUrl('@johnsmith'), 'https://www.instagram.com/johnsmith');
         assert.equal(validateInstagramUrl('johnsmith'), 'https://www.instagram.com/johnsmith');
-        assert.equal(validateInstagramUrl('john_smith_'), 'https://www.instagram.com/john_smith_');
+        assert.equal(validateInstagramUrl('_john_smith_'), 'https://www.instagram.com/_john_smith_');
     });
 
     it('should reject URLs from other domains', () => {
@@ -36,7 +36,7 @@ describe('Instagram handle to URL conversion', () => {
         assert.equal(instagramHandleToUrl('johnsmith'), 'https://www.instagram.com/johnsmith');
         assert.equal(instagramHandleToUrl('@johnsmith'), 'https://www.instagram.com/johnsmith');
         assert.equal(instagramHandleToUrl('john.smith'), 'https://www.instagram.com/john.smith');
-        assert.equal(instagramHandleToUrl('john_smith_123'), 'https://www.instagram.com/john_smith_123');
+        assert.equal(instagramHandleToUrl('_john_smith_123_'), 'https://www.instagram.com/_john_smith_123_');
     });
 
     it('should reject invalid Instagram handles', () => {

--- a/apps/admin-x-settings/test/unit/utils/tiktok.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/tiktok.test.ts
@@ -13,6 +13,7 @@ describe('TikTok URL validation', () => {
         assert.equal(validateTikTokUrl('tiktok.com/@john_smith123'), 'https://www.tiktok.com/@john_smith123');
         assert.equal(validateTikTokUrl('@johnsmith'), 'https://www.tiktok.com/@johnsmith');
         assert.equal(validateTikTokUrl('johnsmith'), 'https://www.tiktok.com/@johnsmith');
+        assert.equal(validateTikTokUrl('_john_smith_'), 'https://www.tiktok.com/@_john_smith_');
     });
 
     it('should reject URLs from other domains', () => {
@@ -35,7 +36,7 @@ describe('TikTok handle to URL conversion', () => {
         assert.equal(tiktokHandleToUrl('johnsmith'), 'https://www.tiktok.com/@johnsmith');
         assert.equal(tiktokHandleToUrl('@johnsmith'), 'https://www.tiktok.com/@johnsmith');
         assert.equal(tiktokHandleToUrl('john.smith'), 'https://www.tiktok.com/@john.smith');
-        assert.equal(tiktokHandleToUrl('john_smith123'), 'https://www.tiktok.com/@john_smith123');
+        assert.equal(tiktokHandleToUrl('_john_smith123_'), 'https://www.tiktok.com/@_john_smith123_');
     });
 
     it('should reject invalid TikTok handles', () => {
@@ -52,7 +53,7 @@ describe('URL to TikTok handle extraction', () => {
     it('should extract TikTok handle from URL', () => {
         assert.equal(tiktokUrlToHandle('https://www.tiktok.com/@johnsmith'), '@johnsmith');
         assert.equal(tiktokUrlToHandle('https://www.tiktok.com/@john.smith'), '@john.smith');
-        assert.equal(tiktokUrlToHandle('tiktok.com/@john_smith123'), '@john_smith123');
+        assert.equal(tiktokUrlToHandle('tiktok.com/@_john_smith123_'), '@_john_smith123_');
         assert.equal(tiktokUrlToHandle('www.tiktok.com/@johnsmith'), '@johnsmith');
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2477

- Allows for underscore at start of Instagram usernames
- Allows for underscore at start and end of TikTok usernames

<img width="250" height="280" alt="Screenshot 2025-08-20 at 9 35 22 AM" src="https://github.com/user-attachments/assets/e235af87-4668-4625-9584-35d3ad546203" />
<img width="250" height="226" alt="Screenshot 2025-08-20 at 9 36 23 AM" src="https://github.com/user-attachments/assets/e915ea13-ffae-42a0-a55b-de68fc31a4b1" />
