### PR TITLE
Added `membersSigninOTC` labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -27,6 +27,10 @@ const features: Feature[] = [{
     title: 'Explore',
     description: 'Enables keeping in touch with the new Explore API',
     flag: 'explore'
+}, {
+    title: 'Members sign-in OTC (alpha)',
+    description: 'Enables one-time codes alongside magic links for members signin',
+    flag: 'membersSigninOTC'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -70,6 +70,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
+    @feature('membersSigninOTC') membersSigninOTC;
 
     _user = null;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -46,7 +46,8 @@ const PRIVATE_FEATURES = [
     'urlCache',
     'lexicalIndicators',
     'contentVisibilityAlpha',
-    'emailCustomization'
+    'emailCustomization',
+    'membersSigninOTC'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -22,6 +22,7 @@ Object {
       "importMemberTier": true,
       "lexicalIndicators": true,
       "members": true,
+      "membersSigninOTC": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
       "themeErrorsNotification": true,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2478/

- flag for gating logic of alpha development for a one-time-code flow alongside magic links for members signin
