### PR TITLE
Removed additional listeners for page_hit requests

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -164,7 +164,7 @@ export class GhostStats {
         const referrerData = parseReferrer(location?.href);
         referrerData.url = getReferrer(location?.href) || referrerData.url; // ensure the referrer.url is set for parsing
 
-        // Wait a bit for SPA routers
+        // Debounce tracking to avoid duplicates and ensure page has settled
         this.browser.setTimeout(() => {
             this.trackEvent('page_hit', {
                 'user-agent': navigator?.userAgent,
@@ -181,13 +181,6 @@ export class GhostStats {
         if (this.isListenersAttached) {
             return;
         }
-
-        // Track history navigation
-        this.browser.addEventListener('window', 'hashchange', () => this.trackPageHit());
-        
-        // Handle SPA navigation
-        this.browser.wrapHistoryMethod('pushState', () => this.trackPageHit());
-        this.browser.addEventListener('window', 'popstate', () => this.trackPageHit());
 
         // Handle visibility changes for prerendering
         if (this.browser.getVisibilityState() !== 'hidden') {

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -404,13 +404,6 @@ describe('ghost-stats.js', function () {
             ghostStats.initConfig();
         });
 
-        it('should setup navigation tracking', function () {
-            ghostStats.setupEventListeners();
-            
-            expect(mockWindow.addEventListener.calledWith('hashchange')).to.be.true;
-            expect(mockWindow.addEventListener.calledWith('popstate')).to.be.true;
-        });
-
         it('should handle visibility changes', async function () {
             mockDocument.visibilityState = 'hidden';
             ghostStats.setupEventListeners();
@@ -430,20 +423,14 @@ describe('ghost-stats.js', function () {
 
         it('should not attach listeners multiple times', function () {
             ghostStats.setupEventListeners();
-            const firstCallCounts = {
-                hashchange: mockWindow.addEventListener.withArgs('hashchange').callCount,
-                popstate: mockWindow.addEventListener.withArgs('popstate').callCount,
-                pushState: mockWindow.history.pushState.callCount
-            };
+            const firstCallCount = mockWindow.addEventListener.callCount;
 
             // Call setupEventListeners multiple times
             ghostStats.setupEventListeners();
             ghostStats.setupEventListeners();
 
             // Verify no additional listeners were attached
-            expect(mockWindow.addEventListener.withArgs('hashchange').callCount).to.equal(firstCallCounts.hashchange);
-            expect(mockWindow.addEventListener.withArgs('popstate').callCount).to.equal(firstCallCounts.popstate);
-            expect(mockWindow.history.pushState.callCount).to.equal(firstCallCounts.pushState);
+            expect(mockWindow.addEventListener.callCount).to.equal(firstCallCount);
         });
 
         it('should maintain single visibility change listener when called multiple times', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2483/
- removed listeners for SPA navigation and hashchange

Theme's using SPA navigation does not play well with our implementation of the ghost-stats script. We're removing these listeners to prevent bad data from being submitted. The initial page hit will still register, so overall visitor data will at least be accurate, if not views.

We may follow this up with changes to make it easier to support SPA-like frontend themes.