### PR TITLE
Fix view members link alignments

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -71,7 +71,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                 <CardDescription>How did this post perform</CardDescription>
                             </CardHeader>
                             <CardContent className='p-0'>
-                                <div className='flex flex-col md:grid md:grid-cols-3 md:items-stretch'>
+                                <div className={`md:grid-cols- md:grid- flex flex-col${appSettings?.paidMembersEnabled ? 3 : 1} md:items-stretch`}>
                                     <KpiCard className='grow'>
                                         <KpiCardMoreButton onClick={() => {
                                             const filterParam = encodeURIComponent(`signup:'${postId}'+conversion:-'${postId}'`);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2452/post-analytics-growth-free-members-view-member-link-is-missaligned