### PR TITLE
Fixed spacing of "View members" button on Post Analytics > Growth

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -71,7 +71,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                 <CardDescription>How did this post perform</CardDescription>
                             </CardHeader>
                             <CardContent className='p-0'>
-                                <div className='flex flex-col md:grid md:grid-cols-3 md:items-stretch'>
+                                <div className={`flex flex-col md:grid md:items-stretch ${appSettings?.paidMembersEnabled ? 'md:grid-cols-3' : 'md:grid-cols-1'}`}>
                                     <KpiCard className='grow'>
                                         <KpiCardMoreButton onClick={() => {
                                             const filterParam = encodeURIComponent(`signup:'${postId}'+conversion:-'${postId}'`);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2452/post-analytics-growth-free-members-view-member-link-is-missaligned

The "View members" button on the Post Analytics > Growth > Free Members KPI card was rendering on the left side of the card when paid members was disabled. This was caused by the KPI card rendering 3 columns, even though 2 of the columns are hidden when paid members is disabled.

<img width="2624" height="1686" alt="image" src="https://github.com/user-attachments/assets/1ba80be7-634a-4b22-8704-269224279a06" />

## Testing:
- On a site with paid members disabled (stripe not setup in settings), hover over the Post Analytics > Growth > Free members KPI card. The "View More" button should appear in the top right corner of the card.
- On a site with paid members enabled, the Free members, Paid members, and MRR should all render in the top row, and the "View More" button should appear in the top right of the Free Members and Paid member cards on hover