### PR TITLE
Added `inserted_at` field to Tinybird datasources

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000', 3)) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -8,11 +8,11 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime DEFAULT now() `json:$.inserted_at`
+    `inserted_at` DateTime64(3) DEFAULT now() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime') AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000')) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,13 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at
+    SELECT timestamp,
+        session_id,
+        action,
+        version,
+        toString(payload) as payload,
+        site_uuid,
+        coalesce(
+            parseDateTime64BestEffortOrNull(inserted_at, 3),
+            toDateTime64('1970-01-01 00:00:00', 3)
+        ) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -8,7 +8,7 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime DEFAULT now()
+    `inserted_at` DateTime DEFAULT now() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -7,11 +7,12 @@ SCHEMA >
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
-    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
+    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
+    `inserted_at` DateTime DEFAULT now()
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -8,7 +8,7 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime64(3) DEFAULT now() `json:$.inserted_at`
+    `inserted_at` DateTime64(3) DEFAULT now64() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,4 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000')) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000', 3)) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events.datasource
@@ -15,13 +15,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp,
-        session_id,
-        action,
-        version,
-        toString(payload) as payload,
-        site_uuid,
-        coalesce(
-            parseDateTime64BestEffortOrNull(inserted_at, 3),
-            toDateTime64('1970-01-01 00:00:00', 3)
-        ) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,13 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp,
-        session_id,
-        action,
-        version,
-        toString(payload) as payload,
-        site_uuid,
-        coalesce(
-            parseDateTime64BestEffortOrNull(inserted_at, 3),
-            toDateTime64('1970-01-01 00:00:00', 3)
-        ) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000', 3)) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime') AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000')) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -9,11 +9,12 @@ SCHEMA >
     `action` LowCardinality(String) `json:$.action`,
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
-    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`
+    `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
+    `inserted_at` DateTime DEFAULT now()
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -10,7 +10,7 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime DEFAULT now()
+    `inserted_at` DateTime DEFAULT now() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -10,11 +10,11 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime DEFAULT now() `json:$.inserted_at`
+    `inserted_at` DateTime64(3) DEFAULT now() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime') AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,4 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000')) AS inserted_at
+    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, toDateTime64OrDefault(inserted_at, 3, 'UTC', toDateTime64('1970-01-01 00:00:00.000', 3)) AS inserted_at

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -10,7 +10,7 @@ SCHEMA >
     `version` LowCardinality(String) `json:$.version`,
     `payload` String `json:$.payload`,
     `site_uuid` LowCardinality(String) `json:$.payload.site_uuid`,
-    `inserted_at` DateTime64(3) DEFAULT now() `json:$.inserted_at`
+    `inserted_at` DateTime64(3) DEFAULT now64() `json:$.inserted_at`
 
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"

--- a/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/analytics_events_test.datasource
@@ -17,4 +17,13 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "site_uuid, timestamp"
 
 FORWARD_QUERY >
-    SELECT timestamp, session_id, action, version, toString(payload) as payload, site_uuid, defaultValueOfTypeName('DateTime64(3)') AS inserted_at
+    SELECT timestamp,
+        session_id,
+        action,
+        version,
+        toString(payload) as payload,
+        site_uuid,
+        coalesce(
+            parseDateTime64BestEffortOrNull(inserted_at, 3),
+            toDateTime64('1970-01-01 00:00:00', 3)
+        ) AS inserted_at


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2396/add-an-ingested-at-column-to-tinybird-analytics-events

To measure the end to end latency of the event tracking pipeline, this adds an `inserted_at` field to the Tinybird analytics_events datasource that is automatically populated with the current timestamp.

Note 1: for past events, the `inserted_at` column will be populated with `1970-01-01 00:00:00.000` since we can't possibly know when they were inserted, to indicate that this field should be ignored for these rows.

Note 2: apparently it's not possible to add a column without a JSON path, to ensure it always uses the default value. This means technically this value can be overwritten if an `inserted_at` field is included in the JSON payload - we don't do this ourselves so it will default to `now()` but we should probably add some protection for this in the analytics service to be extra safe.