### PR TITLE
Updated member attribution to use session instead of local storage 

### DIFF
--- a/.github/scripts/release-apps.js
+++ b/.github/scripts/release-apps.js
@@ -10,7 +10,8 @@ const CONFIG_KEYS = {
     '@tryghost/portal': 'portal',
     '@tryghost/sodo-search': 'sodoSearch',
     '@tryghost/comments-ui': 'comments',
-    '@tryghost/announcement-bar': 'announcementBar'
+    '@tryghost/announcement-bar': 'announcementBar',
+    '@tryghost/signup-form': 'signupForm'
 };
 
 const CURRENT_DIR = process.cwd();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1156,6 +1156,12 @@ jobs:
           - package_name: '@tryghost/comments-ui'
             package_path: 'apps/comments-ui'
             cdn_paths: 'https://cdn.jsdelivr.net/ghost/comments-ui@~CURRENT_MINOR/umd/comments-ui.min.js'
+          - package_name: '@tryghost/signup-form'
+            package_path: 'apps/signup-form'
+            cdn_paths: 'https://cdn.jsdelivr.net/ghost/signup-form@~CURRENT_MINOR/umd/signup-form.min.js'
+          - package_name: '@tryghost/announcement-bar'
+            package_path: 'apps/announcement-bar'
+            cdn_paths: 'https://cdn.jsdelivr.net/ghost/announcement-bar@~CURRENT_MINOR/umd/announcement-bar.min.js'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.51.3",
+  "version": "2.52.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -887,7 +887,7 @@ export const transformApiTiersData = ({tiers}) => {
 };
 
 /**
- * Returns the member attribution URL history, which is stored in localStorage, if there is any.
+ * Returns the member attribution URL history, which is stored in sessionStorage, if there is any.
  * @warning If you make changes here, please also update the one in signup-form!
  * @returns {Object[]|undefined}
  */
@@ -895,7 +895,7 @@ export function getUrlHistory() {
     const STORAGE_KEY = 'ghost-history';
 
     try {
-        const historyString = localStorage.getItem(STORAGE_KEY);
+        const historyString = sessionStorage.getItem(STORAGE_KEY);
         if (historyString) {
             const parsed = JSON.parse(historyString);
 
@@ -904,7 +904,7 @@ export function getUrlHistory() {
             }
         }
     } catch (error) {
-        // Failed to access localStorage or something related to that.
+        // Failed to access sessionStorage or something related to that.
         // Log a warning, as this shouldn't happen on a modern browser.
 
         /* eslint-disable no-console */

--- a/apps/portal/src/utils/helpers.test.js
+++ b/apps/portal/src/utils/helpers.test.js
@@ -447,23 +447,23 @@ describe('Helpers - ', () => {
                 }
             ]));
             const urlHistory = getUrlHistory();
-            expect(localStorage.getItem).toHaveBeenCalled();
+            expect(sessionStorage.getItem).toHaveBeenCalled();
             expect(urlHistory).toHaveLength(1);
         });
 
         test('ignores invalid history ', () => {
             jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('invalid');
             const urlHistory = getUrlHistory();
-            expect(localStorage.getItem).toHaveBeenCalled();
+            expect(sessionStorage.getItem).toHaveBeenCalled();
             expect(urlHistory).toBeUndefined();
         });
 
-        test('doesn\'t throw if localStorage is disabled', () => {
+        test('doesn\'t throw if sessionStorage is disabled', () => {
             jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
-                throw new Error('LocalStorage disabled');
+                throw new Error('SessionStorage disabled');
             });
             const urlHistory = getUrlHistory();
-            expect(localStorage.getItem).toHaveBeenCalled();
+            expect(sessionStorage.getItem).toHaveBeenCalled();
             expect(urlHistory).toBeUndefined();
         });
     });

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -30,7 +30,7 @@
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
         "preship": "yarn lint",
-        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; fi",
+        "ship": "node ../../.github/scripts/release-apps.js",
         "postship": "git push ${GHOST_UPSTREAM:-origin} --follow-tags && npm publish",
         "prepublishOnly": "yarn build"
     },

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tryghost/signup-form",
-    "version": "0.2.4",
+    "version": "0.3.0",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/apps/signup-form/src/utils/helpers.tsx
+++ b/apps/signup-form/src/utils/helpers.tsx
@@ -20,7 +20,7 @@ export function getDefaultUrlHistory() {
     const STORAGE_KEY = 'ghost-history';
 
     try {
-        const historyString = localStorage.getItem(STORAGE_KEY);
+        const historyString = sessionStorage.getItem(STORAGE_KEY);
         if (historyString) {
             const parsed = JSON.parse(historyString);
 
@@ -29,7 +29,7 @@ export function getDefaultUrlHistory() {
             }
         }
     } catch (error) {
-        // Failed to access localStorage or something related to that.
+        // Failed to access sessionStorage or something related to that.
         // Log a warning, as this shouldn't happen on a modern browser.
 
         /* eslint-disable no-console */
@@ -38,7 +38,7 @@ export function getDefaultUrlHistory() {
 }
 
 export function getUrlHistory({siteUrl}: {siteUrl: string}): URLHistory {
-    // If we are embedded on the site itself, use the default attribution localStorage, just like Portal
+    // If we are embedded on the site itself, use the default attribution sessionStorage, just like Portal
     try {
         if (window.location.host === new URL(siteUrl).host) {
             const history = getDefaultUrlHistory();

--- a/apps/signup-form/test/e2e/attribution.test.ts
+++ b/apps/signup-form/test/e2e/attribution.test.ts
@@ -3,12 +3,12 @@ import {initialize} from '../utils/e2e';
 import {test} from '@playwright/test';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function testHistory({page, embeddedOnUrl, path, urlHistory, localStorageHistory}: {page: any, embeddedOnUrl?: string, path: string, urlHistory: any[], localStorageHistory?: any[]}) {
+async function testHistory({page, embeddedOnUrl, path, urlHistory, sessionStorageHistory}: {page: any, embeddedOnUrl?: string, path: string, urlHistory: any[], sessionStorageHistory?: any[]}) {
     const {frame, lastApiRequest} = await initialize({page, title: 'Sign up', embeddedOnUrl, path});
 
     await page.evaluate((history) => {
-        localStorage.setItem('ghost-history', JSON.stringify(history));
-    }, localStorageHistory);
+        sessionStorage.setItem('ghost-history', JSON.stringify(history));
+    }, sessionStorageHistory);
 
     // Fill out the form
     const emailInput = frame.getByTestId('input');
@@ -60,8 +60,8 @@ test.describe('Attribution', async () => {
         );
     });
 
-    test('uses current localStorage history', async ({page}) => {
-        // Save history as localstorage item 'ghost-history'
+    test('uses current sessionStorage history', async ({page}) => {
+        // Save history as sessionStorage item 'ghost-history'
         const history = [
             {path: '/p/573d2c92-183a-435f-b0e7-34595e1ceae7/', time: 1686667443580, referrerSource: null, referrerMedium: null, referrerUrl: 'http://admin.ghost/'},
             {path: '/', time: 1686748392078, referrerSource: null, referrerMedium: null, referrerUrl: null}
@@ -71,12 +71,12 @@ test.describe('Attribution', async () => {
             page,
             path: '/my-custom-path/123?ref=ghost',
             urlHistory: history,
-            localStorageHistory: history
+            sessionStorageHistory: history
         });
     });
 
-    test('does not use current localStorage history if on external site', async ({page}) => {
-        // Save history as localstorage item 'ghost-history'
+    test('does not use current sessionStorage history if on external site', async ({page}) => {
+        // Save history as sessionStorage item 'ghost-history'
         const history = [
             {path: '/p/573d2c92-183a-435f-b0e7-34595e1ceae7/', time: 1686667443580, referrerSource: null, referrerMedium: null, referrerUrl: 'http://admin.ghost/'},
             {path: '/', time: 1686748392078, referrerSource: null, referrerMedium: null, referrerUrl: null}
@@ -94,7 +94,7 @@ test.describe('Attribution', async () => {
                     time: expect.any(Number)
                 }
             ],
-            localStorageHistory: history
+            sessionStorageHistory: history
         });
     });
 });

--- a/ghost/core/core/frontend/src/member-attribution/member-attribution.js
+++ b/ghost/core/core/frontend/src/member-attribution/member-attribution.js
@@ -4,10 +4,12 @@ const urlAttribution = require('../utils/url-attribution');
 const parseReferrer = urlAttribution.parseReferrer;
 const getReferrer = urlAttribution.getReferrer;
 
-// Location where we want to store the history in localStorage
+// Location where we want to store the history in sessionStorage
 const STORAGE_KEY = 'ghost-history';
 
 // How long before an item should expire (24h)
+// Note: With sessionStorage, data automatically expires when the session ends,
+// but we still enforce time limits for long-running sessions
 const TIMEOUT = 24 * 60 * 60 * 1000;
 
 // Maximum amount of urls in the history
@@ -33,7 +35,7 @@ const LIMIT = 15;
 
 (async function () {
     try {
-        const storage = window.localStorage;
+        const storage = window.sessionStorage;
         const historyString = storage.getItem(STORAGE_KEY);
         const currentTime = new Date().getTime();
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -212,7 +212,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.51"
+        "version": "2.52"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",
@@ -229,7 +229,7 @@
     },
     "signupForm": {
         "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
-        "version": "0.2"
+        "version": "0.3"
     },
     "tenor": {
         "googleApiKey": null,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -36,7 +36,7 @@ Object {
     },
     "signupForm": Object {
       "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
-      "version": "0.2",
+      "version": "0.3",
     },
     "stripeDirect": false,
     "tenor": Object {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1976/
- changed from localStorage to sessionStorage
- added missing /apps/ packages to shipping workflow

In an effort to be more GDPR compliant - and to avoid pop-ups out of the box - we're changing the attribution script to use session storage.

This should have minimal impact as we send the attribution object on the signup request from Portal/signup form. So even though the user needs to check their email to verify their email and click the magic link, the magic link contains the attribution data in the JWT, rather than pulling the data after the magic link click. This would otherwise be problematic as magic links open in a new tab (ie new session).

There will be a brief cutover as we didn't choose to copy-forward or add handling for the local storage values. Given that we only have 24h lookback anyways, moving to session storage without addtl handling seems acceptable.

__Release Changes__
We [introduced](https://github.com/TryGhost/Ghost/pull/22127) a new script for shipping the /apps/ a while back. Other apps were added later, but incrementally, instead of adding all of them once the test was proven to work. The `ci.yml` and `release-apps.js` changes incorporate the missing apps.

__Testing__
- [ ] Ensure page views are saving data to session storage, NOT local storage
- [ ] Ensure attribution is working appropriately (sign up a member on a post or homepage, visit Admin > Members > member to confirm)