### PR TITLE
Updated compose to be compatible with locally running analytics service

### DIFF
--- a/.docker/analytics/entrypoint.sh
+++ b/.docker/analytics/entrypoint.sh
@@ -26,16 +26,16 @@ trap _term TERM INT
 
 # Set the TINYBIRD_TRACKER_TOKEN environment variable from the .env file
 # This file is created by the `tb-cli` service and mounted into the Analytics service container
-if [ -f /app/.env ]; then
-    . /app/.env
+if [ -f /mnt/shared-config/.env.tinybird ]; then
+    . /mnt/shared-config/.env.tinybird
     if [ -n "${TINYBIRD_TRACKER_TOKEN:-}" ]; then
         export TINYBIRD_TRACKER_TOKEN="$TINYBIRD_TRACKER_TOKEN"
         echo "Tinybird tracker token configured successfully"
     else
-        echo "WARNING: TINYBIRD_TRACKER_TOKEN not found in /app/.env" >&2
+        echo "WARNING: TINYBIRD_TRACKER_TOKEN not found in /mnt/shared-config/.env.tinybird" >&2
     fi
 else
-    echo "WARNING: /app/.env file not found - Tinybird tracking may not work" >&2
+    echo "WARNING: /mnt/shared-config/.env.tinybird file not found - Tinybird tracking may not work" >&2
 fi
 
 # Start the process in the background

--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -14,7 +14,7 @@
     @analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
     handle @analytics_paths {
         rewrite * {re.analytics_match.2}
-        reverse_proxy analytics:3000
+        reverse_proxy {$ANALYTICS_PROXY_TARGET:-analytics:3000}
     }
 
     handle /ember-cli-live-reload.js {

--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -14,7 +14,7 @@
     @analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
     handle @analytics_paths {
         rewrite * {re.analytics_match.2}
-        reverse_proxy {$ANALYTICS_PROXY_TARGET:-analytics:3000}
+        reverse_proxy {$ANALYTICS_PROXY_TARGET}
     }
 
     handle /ember-cli-live-reload.js {

--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -27,8 +27,8 @@ set -euo pipefail
 )
 
 # Configure Ghost to use Tinybird Local
-if [ -f /home/ghost/ghost/core/core/server/data/tinybird/.env ]; then
-    source /home/ghost/ghost/core/core/server/data/tinybird/.env
+if [ -f /mnt/shared-config/.env.tinybird ]; then
+    source /mnt/shared-config/.env.tinybird
     if [ -n "${TINYBIRD_WORKSPACE_ID:-}" ] && [ -n "${TINYBIRD_ADMIN_TOKEN:-}" ]; then
         export tinybird__workspaceId="$TINYBIRD_WORKSPACE_ID"
         export tinybird__adminToken="$TINYBIRD_ADMIN_TOKEN"

--- a/.docker/tb-cli/entrypoint.sh
+++ b/.docker/tb-cli/entrypoint.sh
@@ -52,8 +52,8 @@ if [ -z "$TRACKER_TOKEN" ] || [ "$TRACKER_TOKEN" = "null" ]; then
 fi
 
 # Write environment variables to .env file
-ENV_FILE="/home/tinybird/.env"
-TMP_ENV_FILE="/home/tinybird/.env.tmp"
+ENV_FILE="/mnt/shared-config/.env.tinybird"
+TMP_ENV_FILE="/mnt/shared-config/.env.tinybird.tmp"
 
 echo "Writing Tinybird configuration to $ENV_FILE..."
 

--- a/compose.yml
+++ b/compose.yml
@@ -81,7 +81,6 @@ services:
       - tinybird__stats__endpoint=http://tinybird-local:7181
       - tinybird__stats__endpointBrowser=http://localhost:7181
       - tinybird__tracker__endpoint=http://localhost/.ghost/analytics/api/v1/page_hit
-      - ANALYTICS_PROXY_TARGET=${ANALYTICS_PROXY_TARGET:-analytics:3000}
 
   admin:
     <<: *service-template
@@ -106,7 +105,7 @@ services:
       - ./.docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
     environment:
-      - ANALYTICS_PROXY_TARGET=${ANALYTICS_PROXY_TARGET:-}
+      - ANALYTICS_PROXY_TARGET=${ANALYTICS_PROXY_TARGET:-analytics:3000}
     restart: always
 
   ghost:

--- a/compose.yml
+++ b/compose.yml
@@ -7,6 +7,7 @@ x-service-template: &service-template
     - ${SSH_AUTH_SOCK}:/ssh-agent
     - ${HOME}/.gitconfig:/root/.gitconfig:ro
     - ${HOME}/.yalc:/root/.yalc
+    - shared-config:/mnt/shared-config:ro
     - node_modules_yarn_lock_hash:/home/ghost/.yarnhash:delegated
     - node_modules_ghost_root:/home/ghost/node_modules:delegated
     - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
@@ -103,6 +104,8 @@ services:
     volumes:
       - ./.docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
+    environment:
+      - ANALYTICS_PROXY_TARGET=${ANALYTICS_PROXY_TARGET:-}
     restart: always
 
   ghost:
@@ -184,7 +187,7 @@ services:
       retries: 120
     volumes:
       - ./.docker/analytics/entrypoint.sh:/app/entrypoint.sh:ro
-      - ./ghost/core/core/server/data/tinybird/.env:/app/.env:ro
+      - shared-config:/mnt/shared-config:ro
     environment:
       - PROXY_TARGET=http://tinybird-local:7181/v0/events
     depends_on:
@@ -206,6 +209,7 @@ services:
       - TB_LOCAL_HOST=tinybird-local
     volumes:
       - ./ghost/core/core/server/data/tinybird:/home/tinybird
+      - shared-config:/mnt/shared-config
     depends_on:
       tinybird-local:
         condition: service_healthy
@@ -268,6 +272,7 @@ services:
 volumes:
   mysql-data: {}
   redis-data: {}
+  shared-config: {}
   caddy_data: {}
   node_modules_yarn_lock_hash: {}
   node_modules_ghost_root: {}

--- a/compose.yml
+++ b/compose.yml
@@ -81,6 +81,7 @@ services:
       - tinybird__stats__endpoint=http://tinybird-local:7181
       - tinybird__stats__endpointBrowser=http://localhost:7181
       - tinybird__tracker__endpoint=http://localhost/.ghost/analytics/api/v1/page_hit
+      - ANALYTICS_PROXY_TARGET=${ANALYTICS_PROXY_TARGET:-analytics:3000}
 
   admin:
     <<: *service-template


### PR DESCRIPTION
Building on b16e0a1405fe35df74d6bbe7cfccbcbd3665fb2b, this PR makes it possible to easily run Ghost using your local clone of the Analytics service running in its own docker compose project.

Related PR in the analytics service: https://github.com/TryGhost/TrafficAnalytics/pull/408

Key changes:
- Switched to using a shared named volume for configuration files, so docker services running in other projects can access the same shared config. This allows the analytics service, which runs in a separate docker compose project, to access the shared configuration without hardcoding any assumptions about where the two projects are relative to one another in the filesystem.
- Allowed overriding the proxy target that caddy uses for the `/.ghost/analytics/*` routes, so we can set it to the locally running analytics service's hostname. This falls back to the bundled `analytics` service if not provided.