### PR TITLE
Updated activitypub client to use new Bluesky API

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.23",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/api/activitypub.test.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.test.ts
@@ -1596,4 +1596,145 @@ describe('ActivityPubAPI', function () {
             expect(result).toBe(true);
         });
     });
+
+    describe('enableBluesky', function () {
+        test('It enables bluesky', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                    response: JSONResponse({
+                        handle: '@foo@bar.baz'
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.enableBluesky();
+
+            expect(result).toBe('@foo@bar.baz');
+        });
+
+        test('It returns an empty string if the response is null', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                    response: JSONResponse(null)
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.enableBluesky();
+
+            expect(result).toBe('');
+        });
+
+        test('It returns an empty string if the response does not contain a handle property', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                    response: JSONResponse({
+                        foo: 'bar'
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.enableBluesky();
+
+            expect(result).toBe('');
+        });
+
+        test('It returns an empty string if the response contains an invalid handle property', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                    response: JSONResponse({
+                        handle: ['@foo@bar.baz']
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.enableBluesky();
+
+            expect(result).toBe('');
+        });
+    });
+
+    describe('disableBluesky', function () {
+        test('It disables bluesky', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/disable`]: {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('POST');
+                    },
+                    response: JSONResponse(null)
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            await api.disableBluesky();
+        });
+    });
 });

--- a/apps/admin-x-activitypub/src/api/activitypub.ts
+++ b/apps/admin-x-activitypub/src/api/activitypub.ts
@@ -25,6 +25,8 @@ export interface Account {
     blockedByMe: boolean;
     domainBlockedByMe: boolean;
     attachment: { name: string; value: string }[];
+    blueskyEnabled?: boolean;
+    blueskyHandle?: string;
 }
 
 export type AccountSearchResult = Pick<
@@ -653,5 +655,23 @@ export class ActivityPubAPI {
 
         const json = await response.json();
         return json.fileUrl;
+    }
+
+    async enableBluesky(): Promise<string> {
+        const url = new URL('.ghost/activitypub/v1/actions/bluesky/enable', this.apiUrl);
+
+        const json = await this.fetchJSON(url, 'POST');
+
+        if (json === null || !('handle' in json) || typeof json.handle !== 'string') {
+            return '';
+        }
+
+        return String(json.handle);
+    }
+
+    async disableBluesky() {
+        const url = new URL('.ghost/activitypub/v1/actions/bluesky/disable', this.apiUrl);
+
+        await this.fetchJSON(url, 'POST');
     }
 }

--- a/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
+++ b/apps/admin-x-activitypub/src/views/Preferences/components/Settings.tsx
@@ -1,9 +1,8 @@
 import EditProfile from './EditProfile';
 import React, {useState} from 'react';
 import {Account} from '@src/api/activitypub';
-import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LoadingIndicator, LucideIcon, cn} from '@tryghost/shade';
+import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LucideIcon, cn} from '@tryghost/shade';
 import {Link, useNavigate} from '@tryghost/admin-x-framework';
-import {useSearchForUser} from '@hooks/use-activity-pub-queries';
 
 interface SettingsProps {
     account?: Account;
@@ -13,11 +12,6 @@ interface SettingsProps {
 const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
     const [isEditingProfile, setIsEditingProfile] = useState(false);
     const navigate = useNavigate();
-
-    const {searchQuery: blueskySearchQuery} = useSearchForUser('index', '@bsky.brid.gy@bsky.brid.gy');
-    const {data: blueskyData, isFetching: blueskyIsFetching} = blueskySearchQuery;
-
-    const blueskyEnabled = blueskyData?.accounts[0]?.followedByMe;
 
     return (
         <div className={`flex flex-col ${className}`}>
@@ -50,13 +44,13 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                     <LucideIcon.ChevronRight size={20} />
                 </SettingAction>
             </SettingItem>
-            <SettingItem withHover onClick={() => !blueskyIsFetching && navigate('/preferences/bluesky-sharing', {state: {account, blueskyAccount: blueskyData?.accounts[0], isEnabled: blueskyEnabled}})}>
+            <SettingItem withHover onClick={() => navigate('/preferences/bluesky-sharing')}>
                 <SettingHeader>
                     <SettingTitle>Bluesky sharing</SettingTitle>
                     <SettingDescription>Share content directly on Bluesky</SettingDescription>
                 </SettingHeader>
                 <SettingAction className='flex items-center gap-2'>
-                    {blueskyIsFetching ? <LoadingIndicator size='sm' /> : blueskyEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
+                    {account?.blueskyEnabled ? <span className='font-medium text-black'>On</span> : <span>Off</span>}
                     <LucideIcon.ChevronRight size={20} />
                 </SettingAction>
             </SettingItem>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2410
ref https://github.com/TryGhost/ActivityPub/pull/1223

Updated the activitypub client to use new Bluesky API that allows the client to enable / disable the Bluesky sharing functionality without having to know the implementation details of this process. 2 new properties are also returned by the `/accounts/me` endpoint: `blueskyEnabled` and `blueskyHandle` that are used to simplify the logic of rendering the Bluesky sharing settings
