### PR TITLE
Added card assets endpoint in the admin

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -20,7 +20,6 @@ import {Activity} from '@src/api/activitypub';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
-import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useDebounce} from 'use-debounce';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -45,7 +44,6 @@ const ArticleBody: React.FC<{
     onIframeLoad?: (iframe: HTMLIFrameElement) => void;
     onLoadingChange?: (isLoading: boolean) => void;
     isPopoverOpen: boolean;
-    siteUrl?: string;
 }> = ({
     postUrl,
     heading,
@@ -59,8 +57,7 @@ const ArticleBody: React.FC<{
     onHeadingsExtracted,
     onIframeLoad,
     onLoadingChange,
-    isPopoverOpen,
-    siteUrl
+    isPopoverOpen
 }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -154,12 +151,12 @@ const ArticleBody: React.FC<{
                     waitForImages();
 
                     const script = document.createElement('script');
-                    script.src = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.js` : '/public/cards.min.js'}';
+                    script.src = '/ghost/cards/admin-cards.min.js';
                     document.head.appendChild(script);
 
                     const link = document.createElement('link');
                     link.rel = 'stylesheet';
-                    link.href = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.css` : '/public/cards.min.css'}';
+                    link.href = '/ghost/cards/admin-cards.min.css';
                     document.head.appendChild(link);
                 });
             </script>
@@ -427,7 +424,6 @@ export const Reader: React.FC<ReaderProps> = ({
         decreaseFontSize,
         resetFontSize
     } = useCustomizerSettings();
-    const {data: siteData} = useBrowseSite();
     const modalRef = useRef<HTMLElement>(null);
     const [isCustomizerOpen, setIsCustomizerOpen] = useState(false);
     const [isTOCOpen, setIsTOCOpen] = useState(false);
@@ -846,7 +842,6 @@ export const Reader: React.FC<ReaderProps> = ({
                                             image={typeof object.image === 'string' ? object.image : object.image?.url}
                                             isPopoverOpen={isCustomizerOpen || isTOCOpen}
                                             postUrl={object?.url || ''}
-                                            siteUrl={siteData?.site?.url}
                                             onHeadingsExtracted={handleHeadingsExtracted}
                                             onIframeLoad={handleIframeLoad}
                                             onLoadingChange={setIsLoading}

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -151,12 +151,12 @@ const ArticleBody: React.FC<{
                     waitForImages();
 
                     const script = document.createElement('script');
-                    script.src = 'cards/admin-cards.min.js';
+                    script.src = '/ghost/cards/admin-cards.min.js';
                     document.head.appendChild(script);
 
                     const link = document.createElement('link');
                     link.rel = 'stylesheet';
-                    link.href = 'cards/admin-cards.min.css';
+                    link.href = '/ghost/cards/admin-cards.min.css';
                     document.head.appendChild(link);
                 });
             </script>

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -151,12 +151,12 @@ const ArticleBody: React.FC<{
                     waitForImages();
 
                     const script = document.createElement('script');
-                    script.src = '/ghost/cards/admin-cards.min.js';
+                    script.src = 'cards/admin-cards.min.js';
                     document.head.appendChild(script);
 
                     const link = document.createElement('link');
                     link.rel = 'stylesheet';
-                    link.href = '/ghost/cards/admin-cards.min.css';
+                    link.href = 'cards/admin-cards.min.css';
                     document.head.appendChild(link);
                 });
             </script>

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -9,6 +9,7 @@ const errorHandler = require('@tryghost/mw-error-handler');
 const sentry = require('../../../shared/sentry');
 const redirectAdminUrls = require('./middleware/redirect-admin-urls');
 const bridge = require('../../../bridge');
+const adminCardAssets = require('./card-assets');
 
 /**
  *
@@ -53,6 +54,9 @@ module.exports = function setupAdminApp() {
     }, serveStatic(
         path.join(config.getContentPath('public'), 'admin-auth')
     ));
+
+    // Card assets for admin features (independent of theme configuration)
+    adminApp.use('/cards', adminCardAssets.serveMiddleware());
 
     // Ember CLI's live-reload script
     if (config.get('env') === 'development') {

--- a/ghost/core/core/server/web/admin/card-assets.js
+++ b/ghost/core/core/server/web/admin/card-assets.js
@@ -23,6 +23,7 @@ class AdminCardAssets {
         this.dest = path.join(config.get('paths').adminAssets, 'cards');
         this.ready = false;
         this.files = {};
+        this._loadingPromise = null;
     }
 
     async ensureDestDir() {
@@ -111,9 +112,23 @@ class AdminCardAssets {
         }
     }
 
+    _loadAssets() {
+        if (!this._loadingPromise) {
+            this._loadingPromise = this.load()
+                .then(() => {
+                    this._loadingPromise = null;
+                    return this;
+                });
+        }
+
+        return this._loadingPromise;
+    }
+
     async ensureLoaded() {
         if (!this.ready) {
-            await this.load();
+            return this._loadAssets();
+        } else {
+            return this;
         }
     }
 

--- a/ghost/core/core/server/web/admin/card-assets.js
+++ b/ghost/core/core/server/web/admin/card-assets.js
@@ -16,6 +16,7 @@ const config = require('../../../shared/config');
 const glob = require('tiny-glob');
 const CleanCSS = require('clean-css');
 const terser = require('terser');
+const errors = require('@tryghost/errors');
 
 class AdminCardAssets {
     constructor() {
@@ -155,7 +156,9 @@ class AdminCardAssets {
             const filename = path.basename(req.path);
 
             if (!self.hasFile(filename)) {
-                return next();
+                return next(new errors.NotFoundError({
+                    message: `Card asset not found: ${filename}`
+                }));
             }
 
             const file = self.getFile(filename);

--- a/ghost/core/core/server/web/admin/card-assets.js
+++ b/ghost/core/core/server/web/admin/card-assets.js
@@ -1,0 +1,168 @@
+/**
+ * Admin Card Assets
+ *
+ * This module provides full card assets for the admin,
+ * independent of theme configuration. This ensures that admin
+ * features like the ActivityPub reader always have access to
+ * all card styles and scripts.
+ */
+
+const path = require('path');
+const fs = require('fs').promises;
+const crypto = require('crypto');
+const debug = require('@tryghost/debug')('web:admin:card-assets');
+const logging = require('@tryghost/logging');
+const config = require('../../../shared/config');
+const glob = require('tiny-glob');
+const CleanCSS = require('clean-css');
+const terser = require('terser');
+
+class AdminCardAssets {
+    constructor() {
+        this.src = path.join(config.get('paths').assetSrc, 'cards');
+        this.dest = path.join(config.get('paths').adminAssets, 'cards');
+        this.ready = false;
+        this.files = {};
+    }
+
+    async ensureDestDir() {
+        try {
+            await fs.mkdir(this.dest, {recursive: true});
+        } catch (error) {
+            if (error.code !== 'EEXIST') {
+                throw error;
+            }
+        }
+    }
+
+    async minifyAssets(globs) {
+        const results = [];
+        for (const [destFile, globPattern] of Object.entries(globs)) {
+            const files = await glob(globPattern, {cwd: this.src});
+            if (files.length === 0) {
+                continue;
+            }
+
+            let combinedContent = '';
+            for (const file of files) {
+                const filePath = path.join(this.src, file);
+                const content = await fs.readFile(filePath, 'utf8');
+                combinedContent += content + '\n';
+            }
+
+            let minifiedContent;
+            if (destFile.endsWith('.css')) {
+                const result = new CleanCSS().minify(combinedContent);
+                minifiedContent = result.styles;
+            } else if (destFile.endsWith('.js')) {
+                const result = await terser.minify(combinedContent);
+                minifiedContent = result.code;
+            }
+
+            if (minifiedContent) {
+                const destPath = path.join(this.dest, destFile);
+                await fs.writeFile(destPath, minifiedContent);
+                results.push(destFile);
+            }
+        }
+        return results;
+    }
+
+    async load() {
+        if (this.ready) {
+            return;
+        }
+
+        debug('Loading admin card assets');
+
+        try {
+            await this.ensureDestDir();
+
+            // Always include ALL card assets for admin
+            const globs = {
+                'admin-cards.min.css': 'css/*.css',
+                'admin-cards.min.js': 'js/*.js'
+            };
+
+            const result = await this.minifyAssets(globs);
+
+            if (result) {
+                // Store file content for ETag generation
+                for (const file of result) {
+                    const filePath = path.join(this.dest, file);
+                    try {
+                        const content = await fs.readFile(filePath);
+                        const hash = crypto.createHash('md5').update(content).digest('hex');
+                        this.files[file] = {
+                            path: filePath,
+                            etag: hash
+                        };
+                    } catch (err) {
+                        logging.warn(`Could not read card asset file: ${file}`, err);
+                    }
+                }
+            }
+
+            this.ready = true;
+            debug('Admin card assets loaded successfully');
+        } catch (error) {
+            logging.error('Failed to load admin card assets:', error);
+            // Don't throw - allow admin to work without card assets
+        }
+    }
+
+    async ensureLoaded() {
+        if (!this.ready) {
+            await this.load();
+        }
+    }
+
+    hasFile(filename) {
+        return Object.prototype.hasOwnProperty.call(this.files, filename);
+    }
+
+    getFile(filename) {
+        return this.files[filename];
+    }
+
+    /**
+     * Express middleware to serve admin card assets
+     */
+    serveMiddleware() {
+        const self = this;
+
+        return async function adminCardAssetsMiddleware(req, res, next) {
+            // Ensure assets are loaded
+            await self.ensureLoaded();
+
+            // Extract the filename from the URL
+            const filename = path.basename(req.path);
+
+            if (!self.hasFile(filename)) {
+                return next();
+            }
+
+            const file = self.getFile(filename);
+
+            // Set cache headers
+            res.set({
+                'Cache-Control': `public, max-age=${config.get('caching:admin:maxAge')}`,
+                ETag: file.etag
+            });
+
+            // Check if client has cached version
+            if (req.get('If-None-Match') === file.etag) {
+                return res.status(304).end();
+            }
+
+            // Determine content type
+            const contentType = filename.endsWith('.css') ? 'text/css' : 'application/javascript';
+            res.type(contentType);
+
+            // Send the file
+            res.sendFile(file.path);
+        };
+    }
+}
+
+module.exports = new AdminCardAssets();

--- a/ghost/core/core/server/web/admin/card-assets.js
+++ b/ghost/core/core/server/web/admin/card-assets.js
@@ -109,6 +109,7 @@ class AdminCardAssets {
         } catch (error) {
             logging.error('Failed to load admin card assets:', error);
             // Don't throw - allow admin to work without card assets
+            this.ready = true;
         }
     }
 

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -152,16 +152,16 @@ describe('Admin Routing', function () {
     });
 
     describe('Card Assets', function () {
-        before(function () {
+        before(async function () {
             // Create test card asset fixtures
             const cardAssetsFixtures = require('../utils/fixtures/card-assets');
-            cardAssetsFixtures.setup();
+            await cardAssetsFixtures.setup();
         });
 
-        after(function () {
+        after(async function () {
             // Clean up test card asset fixtures
             const cardAssetsFixtures = require('../utils/fixtures/card-assets');
-            cardAssetsFixtures.cleanup();
+            await cardAssetsFixtures.cleanup();
         });
 
         it('should serve admin card CSS with correct headers', async function () {

--- a/ghost/core/test/unit/server/web/admin/card-assets.test.js
+++ b/ghost/core/test/unit/server/web/admin/card-assets.test.js
@@ -1,0 +1,394 @@
+const should = require('should');
+const sinon = require('sinon');
+const path = require('path');
+const fs = require('fs').promises;
+const configUtils = require('../../../../utils/configUtils');
+const logging = require('@tryghost/logging');
+
+describe('AdminCardAssets', function () {
+    let sandbox;
+    let adminCardAssets;
+    let testSrcDir;
+    let testDestDir;
+
+    beforeEach(async function () {
+        sandbox = sinon.createSandbox();
+
+        // Create temporary test directories
+        testSrcDir = path.join(__dirname, 'test-card-src', 'cards');
+        testDestDir = path.join(__dirname, 'test-card-dest', 'cards');
+
+        // Configure test paths - AdminCardAssets adds 'cards' to these paths
+        configUtils.set({
+            paths: {
+                assetSrc: path.dirname(testSrcDir), // AdminCardAssets will add '/cards'
+                adminAssets: path.dirname(testDestDir) // AdminCardAssets will add '/cards'
+            },
+            caching: {
+                admin: {
+                    maxAge: 3600
+                }
+            }
+        });
+
+        // Create a fresh instance of AdminCardAssets for each test
+        // Re-require to get a fresh instance since module exports a singleton
+        delete require.cache[require.resolve('../../../../../core/server/web/admin/card-assets')];
+        adminCardAssets = require('../../../../../core/server/web/admin/card-assets');
+
+        // Stub logging to avoid noise in tests
+        sandbox.stub(logging, 'warn');
+        sandbox.stub(logging, 'error');
+    });
+
+    afterEach(async function () {
+        sandbox.restore();
+        await configUtils.restore();
+
+        // Clean up test directories
+        try {
+            await fs.rm(testSrcDir, {recursive: true, force: true});
+        } catch (err) {
+            // Ignore if directory doesn't exist
+        }
+        try {
+            await fs.rm(testDestDir, {recursive: true, force: true});
+        } catch (err) {
+            // Ignore if directory doesn't exist
+        }
+    });
+
+    describe('constructor', function () {
+        it('should initialize with correct default values', function () {
+            adminCardAssets.ready.should.equal(false);
+            adminCardAssets.files.should.deepEqual({});
+            should.equal(adminCardAssets._loadingPromise, null);
+        });
+    });
+
+    describe('ensureDestDir', function () {
+        it('should create destination directory if it does not exist', async function () {
+            await adminCardAssets.ensureDestDir();
+
+            const stats = await fs.stat(adminCardAssets.dest);
+            stats.isDirectory().should.be.true;
+        });
+
+        it('should not throw error if directory already exists', async function () {
+            // Create directory first
+            await fs.mkdir(adminCardAssets.dest, {recursive: true});
+
+            // Should not throw
+            await adminCardAssets.ensureDestDir();
+
+            const stats = await fs.stat(adminCardAssets.dest);
+            stats.isDirectory().should.be.true;
+        });
+    });
+
+    describe('minifyAssets', function () {
+        beforeEach(async function () {
+            // Create test source files - note: no 'cards' subdirectory since testSrcDir is the cards dir
+            await fs.mkdir(path.join(testSrcDir, 'css'), {recursive: true});
+            await fs.mkdir(path.join(testSrcDir, 'js'), {recursive: true});
+
+            await fs.writeFile(
+                path.join(testSrcDir, 'css', 'card1.css'),
+                '.card1 { color: red; }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'css', 'card2.css'),
+                '.card2 { color: blue; }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'js', 'card1.js'),
+                'function card1() { console.log("card1"); }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'js', 'card2.js'),
+                'function card2() { console.log("card2"); }'
+            );
+        });
+
+        it('should minify and combine CSS files', async function () {
+            const globs = {
+                'admin-cards.min.css': 'css/*.css'
+            };
+
+            await adminCardAssets.ensureDestDir();
+            const result = await adminCardAssets.minifyAssets(globs);
+
+            result.should.deepEqual(['admin-cards.min.css']);
+
+            const minifiedContent = await fs.readFile(
+                path.join(adminCardAssets.dest, 'admin-cards.min.css'),
+                'utf8'
+            );
+
+            // Should contain both card styles minified (CleanCSS converts blue to #00f)
+            minifiedContent.should.match(/\.card1\{color:red\}/);
+            minifiedContent.should.match(/\.card2\{color:#00f\}/);
+        });
+
+        it('should minify and combine JS files', async function () {
+            const globs = {
+                'admin-cards.min.js': 'js/*.js'
+            };
+
+            await adminCardAssets.ensureDestDir();
+            const result = await adminCardAssets.minifyAssets(globs);
+
+            result.should.deepEqual(['admin-cards.min.js']);
+
+            const minifiedContent = await fs.readFile(
+                path.join(adminCardAssets.dest, 'admin-cards.min.js'),
+                'utf8'
+            );
+
+            // Should contain both functions minified
+            minifiedContent.should.match(/function card1\(\)/);
+            minifiedContent.should.match(/function card2\(\)/);
+        });
+
+        it('should handle empty glob results', async function () {
+            const globs = {
+                'empty.css': 'nonexistent/*.css'
+            };
+
+            await adminCardAssets.ensureDestDir();
+
+            // Create the source directory first so glob can scan it
+            await fs.mkdir(path.join(testSrcDir, 'nonexistent'), {recursive: true});
+
+            const result = await adminCardAssets.minifyAssets(globs);
+
+            result.should.deepEqual([]);
+        });
+    });
+
+    describe('load', function () {
+        beforeEach(async function () {
+            // Create test source files
+            await fs.mkdir(path.join(testSrcDir, 'css'), {recursive: true});
+            await fs.mkdir(path.join(testSrcDir, 'js'), {recursive: true});
+
+            await fs.writeFile(
+                path.join(testSrcDir, 'css', 'test.css'),
+                '.test { color: red; }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'js', 'test.js'),
+                'console.log("test");'
+            );
+        });
+
+        it('should load and process assets successfully', async function () {
+            await adminCardAssets.load();
+
+            adminCardAssets.ready.should.be.true();
+            adminCardAssets.hasFile('admin-cards.min.css').should.be.true();
+            adminCardAssets.hasFile('admin-cards.min.js').should.be.true();
+
+            const cssFile = adminCardAssets.getFile('admin-cards.min.css');
+            const jsFile = adminCardAssets.getFile('admin-cards.min.js');
+
+            should.exist(cssFile.path);
+            should.exist(cssFile.etag);
+            should.exist(jsFile.path);
+            should.exist(jsFile.etag);
+
+            // ETags should be valid MD5 hashes
+            cssFile.etag.should.match(/^[a-f0-9]{32}$/);
+            jsFile.etag.should.match(/^[a-f0-9]{32}$/);
+        });
+
+        it('should not load again if already ready', async function () {
+            adminCardAssets.ready = true;
+            const ensureDestDirSpy = sandbox.spy(adminCardAssets, 'ensureDestDir');
+
+            await adminCardAssets.load();
+
+            ensureDestDirSpy.called.should.be.false();
+        });
+
+        it('should handle errors gracefully', async function () {
+            // Remove source directory to cause error
+            await fs.rm(testSrcDir, {recursive: true, force: true});
+
+            // Should not throw
+            await adminCardAssets.load();
+
+            adminCardAssets.ready.should.be.true; // Should still mark as ready
+            logging.error.calledOnce.should.be.true;
+        });
+    });
+
+    describe('concurrent loading protection', function () {
+        beforeEach(async function () {
+            // Create test source files
+            await fs.mkdir(path.join(testSrcDir, 'css'), {recursive: true});
+            await fs.writeFile(
+                path.join(testSrcDir, 'css', 'test.css'),
+                '.test { color: red; }'
+            );
+        });
+
+        it('should handle multiple simultaneous ensureLoaded calls', async function () {
+            const loadSpy = sandbox.spy(adminCardAssets, 'load');
+
+            // Start multiple simultaneous loads
+            const promises = [
+                adminCardAssets.ensureLoaded(),
+                adminCardAssets.ensureLoaded(),
+                adminCardAssets.ensureLoaded()
+            ];
+
+            const results = await Promise.all(promises);
+
+            // All should return the same instance
+            results[0].should.equal(adminCardAssets);
+            results[1].should.equal(adminCardAssets);
+            results[2].should.equal(adminCardAssets);
+
+            // Load should only be called once despite multiple requests
+            loadSpy.calledOnce.should.be.true;
+            adminCardAssets.ready.should.be.true;
+        });
+
+        it('should reset loading promise after successful load', async function () {
+            await adminCardAssets.ensureLoaded();
+
+            // Loading promise should be null after completion
+            should.equal(adminCardAssets._loadingPromise, null);
+            adminCardAssets.ready.should.be.true;
+        });
+
+        it('should handle subsequent calls after loading is complete', async function () {
+            // First load
+            await adminCardAssets.ensureLoaded();
+            adminCardAssets.ready.should.be.true;
+
+            const loadSpy = sandbox.spy(adminCardAssets, 'load');
+
+            // Subsequent call should not trigger load again
+            const result = await adminCardAssets.ensureLoaded();
+
+            result.should.equal(adminCardAssets);
+            loadSpy.called.should.be.false;
+        });
+    });
+
+    describe('hasFile and getFile', function () {
+        it('should correctly identify and retrieve files', async function () {
+            adminCardAssets.files = {
+                'test.css': {
+                    path: '/path/to/test.css',
+                    etag: 'abc123'
+                }
+            };
+
+            adminCardAssets.hasFile('test.css').should.be.true();
+            adminCardAssets.hasFile('nonexistent.css').should.be.false();
+
+            const file = adminCardAssets.getFile('test.css');
+            file.should.deepEqual({
+                path: '/path/to/test.css',
+                etag: 'abc123'
+            });
+        });
+    });
+
+    describe('serveMiddleware', function () {
+        let req, res, next;
+        let middleware;
+
+        beforeEach(async function () {
+            // Set up test files
+            await fs.mkdir(path.join(testSrcDir, 'css'), {recursive: true});
+            await fs.mkdir(path.join(testSrcDir, 'js'), {recursive: true});
+            await fs.writeFile(
+                path.join(testSrcDir, 'css', 'test.css'),
+                '.test { color: red; }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'js', 'test.js'),
+                'console.log("test");'
+            );
+
+            await adminCardAssets.load();
+
+            // Verify assets were loaded
+            adminCardAssets.ready.should.be.true;
+            adminCardAssets.hasFile('admin-cards.min.css').should.be.true;
+            adminCardAssets.hasFile('admin-cards.min.js').should.be.true;
+
+            middleware = adminCardAssets.serveMiddleware();
+
+            req = {
+                path: '/admin-cards.min.css',
+                get: sandbox.stub()
+            };
+            res = {
+                set: sandbox.stub(),
+                status: sandbox.stub().returnsThis(),
+                end: sandbox.stub(),
+                type: sandbox.stub(),
+                sendFile: sandbox.stub()
+            };
+            next = sandbox.stub();
+        });
+
+        it('should serve existing files with correct headers', async function () {
+            await middleware(req, res, next);
+
+            res.set.calledOnce.should.be.true;
+            const setArgs = res.set.firstCall.args[0];
+            setArgs.should.have.property('Cache-Control', 'public, max-age=3600');
+            setArgs.should.have.property('ETag');
+
+            res.type.calledWith('text/css').should.be.true;
+            res.sendFile.calledOnce.should.be.true;
+        });
+
+        it('should return 304 for cached requests', async function () {
+            const file = adminCardAssets.getFile('admin-cards.min.css');
+            req.get.withArgs('If-None-Match').returns(file.etag);
+
+            await middleware(req, res, next);
+
+            res.status.calledWith(304).should.be.true();
+            res.end.calledOnce.should.be.true();
+            res.sendFile.called.should.be.false();
+        });
+
+        it('should call next() for unknown files', async function () {
+            req.path = '/unknown.css';
+
+            await middleware(req, res, next);
+
+            next.calledOnce.should.be.true();
+            res.sendFile.called.should.be.false();
+        });
+
+        it('should set correct content type for JS files', async function () {
+            req.path = '/admin-cards.min.js';
+
+            await middleware(req, res, next);
+
+            res.type.calledWith('application/javascript').should.be.true;
+        });
+
+        it('should ensure assets are loaded before serving', async function () {
+            // Create a fresh instance that hasn't been loaded
+            delete require.cache[require.resolve('../../../../../core/server/web/admin/card-assets')];
+            const freshInstance = require('../../../../../core/server/web/admin/card-assets');
+            const freshMiddleware = freshInstance.serveMiddleware();
+
+            const ensureLoadedSpy = sandbox.spy(freshInstance, 'ensureLoaded');
+
+            await freshMiddleware(req, res, next);
+
+            ensureLoadedSpy.calledOnce.should.be.true();
+        });
+    });
+});

--- a/ghost/core/test/unit/server/web/admin/card-assets.test.js
+++ b/ghost/core/test/unit/server/web/admin/card-assets.test.js
@@ -71,7 +71,7 @@ describe('AdminCardAssets', function () {
             await adminCardAssets.ensureDestDir();
 
             const stats = await fs.stat(adminCardAssets.dest);
-            stats.isDirectory().should.be.true;
+            should(stats.isDirectory()).be.true();
         });
 
         it('should not throw error if directory already exists', async function () {
@@ -82,7 +82,7 @@ describe('AdminCardAssets', function () {
             await adminCardAssets.ensureDestDir();
 
             const stats = await fs.stat(adminCardAssets.dest);
-            stats.isDirectory().should.be.true;
+            should(stats.isDirectory()).be.true();
         });
     });
 
@@ -218,8 +218,8 @@ describe('AdminCardAssets', function () {
             // Should not throw
             await adminCardAssets.load();
 
-            adminCardAssets.ready.should.be.true; // Should still mark as ready
-            logging.error.calledOnce.should.be.true;
+            adminCardAssets.ready.should.be.true(); // Should still mark as ready
+            logging.error.calledOnce.should.be.true();
         });
     });
 
@@ -227,9 +227,14 @@ describe('AdminCardAssets', function () {
         beforeEach(async function () {
             // Create test source files
             await fs.mkdir(path.join(testSrcDir, 'css'), {recursive: true});
+            await fs.mkdir(path.join(testSrcDir, 'js'), {recursive: true});
             await fs.writeFile(
                 path.join(testSrcDir, 'css', 'test.css'),
                 '.test { color: red; }'
+            );
+            await fs.writeFile(
+                path.join(testSrcDir, 'js', 'test.js'),
+                'console.log("test");'
             );
         });
 
@@ -251,8 +256,8 @@ describe('AdminCardAssets', function () {
             results[2].should.equal(adminCardAssets);
 
             // Load should only be called once despite multiple requests
-            loadSpy.calledOnce.should.be.true;
-            adminCardAssets.ready.should.be.true;
+            loadSpy.calledOnce.should.be.true();
+            adminCardAssets.ready.should.be.true();
         });
 
         it('should reset loading promise after successful load', async function () {
@@ -260,13 +265,13 @@ describe('AdminCardAssets', function () {
 
             // Loading promise should be null after completion
             should.equal(adminCardAssets._loadingPromise, null);
-            adminCardAssets.ready.should.be.true;
+            adminCardAssets.ready.should.be.true();
         });
 
         it('should handle subsequent calls after loading is complete', async function () {
             // First load
             await adminCardAssets.ensureLoaded();
-            adminCardAssets.ready.should.be.true;
+            adminCardAssets.ready.should.be.true();
 
             const loadSpy = sandbox.spy(adminCardAssets, 'load');
 
@@ -274,7 +279,7 @@ describe('AdminCardAssets', function () {
             const result = await adminCardAssets.ensureLoaded();
 
             result.should.equal(adminCardAssets);
-            loadSpy.called.should.be.false;
+            loadSpy.called.should.be.false();
         });
     });
 
@@ -318,9 +323,9 @@ describe('AdminCardAssets', function () {
             await adminCardAssets.load();
 
             // Verify assets were loaded
-            adminCardAssets.ready.should.be.true;
-            adminCardAssets.hasFile('admin-cards.min.css').should.be.true;
-            adminCardAssets.hasFile('admin-cards.min.js').should.be.true;
+            adminCardAssets.ready.should.be.true();
+            adminCardAssets.hasFile('admin-cards.min.css').should.be.true();
+            adminCardAssets.hasFile('admin-cards.min.js').should.be.true();
 
             middleware = adminCardAssets.serveMiddleware();
 
@@ -341,13 +346,13 @@ describe('AdminCardAssets', function () {
         it('should serve existing files with correct headers', async function () {
             await middleware(req, res, next);
 
-            res.set.calledOnce.should.be.true;
+            res.set.calledOnce.should.be.true();
             const setArgs = res.set.firstCall.args[0];
             setArgs.should.have.property('Cache-Control', 'public, max-age=3600');
             setArgs.should.have.property('ETag');
 
-            res.type.calledWith('text/css').should.be.true;
-            res.sendFile.calledOnce.should.be.true;
+            res.type.calledWith('text/css').should.be.true();
+            res.sendFile.calledOnce.should.be.true();
         });
 
         it('should return 304 for cached requests', async function () {
@@ -375,7 +380,7 @@ describe('AdminCardAssets', function () {
 
             await middleware(req, res, next);
 
-            res.type.calledWith('application/javascript').should.be.true;
+            res.type.calledWith('application/javascript').should.be.true();
         });
 
         it('should ensure assets are loaded before serving', async function () {

--- a/ghost/core/test/unit/server/web/admin/card-assets.test.js
+++ b/ghost/core/test/unit/server/web/admin/card-assets.test.js
@@ -366,12 +366,15 @@ describe('AdminCardAssets', function () {
             res.sendFile.called.should.be.false();
         });
 
-        it('should call next() for unknown files', async function () {
+        it('should return 404 error for unknown files', async function () {
             req.path = '/unknown.css';
 
             await middleware(req, res, next);
 
             next.calledOnce.should.be.true();
+            const error = next.firstCall.args[0];
+            error.should.be.an.instanceOf(require('@tryghost/errors').NotFoundError);
+            error.message.should.equal('Card asset not found: unknown.css');
             res.sendFile.called.should.be.false();
         });
 

--- a/ghost/core/test/utils/fixtures/card-assets.js
+++ b/ghost/core/test/utils/fixtures/card-assets.js
@@ -143,12 +143,12 @@ class CardAssetsFixtures {
         try {
             // Clean up source files
             if (this.srcPath) {
-                await fs.rmdir(this.srcPath, {recursive: true});
+                await fs.rm(this.srcPath, {recursive: true, force: true});
             }
-
+            
             // Clean up destination files
             if (this.destPath) {
-                await fs.rmdir(this.destPath, {recursive: true});
+                await fs.rm(this.destPath, {recursive: true, force: true});
             }
         } catch (err) {
             // Ignore errors during cleanup

--- a/ghost/core/test/utils/fixtures/card-assets.js
+++ b/ghost/core/test/utils/fixtures/card-assets.js
@@ -1,0 +1,163 @@
+const fs = require('fs').promises;
+const path = require('path');
+const config = require('../../../core/shared/config');
+
+class CardAssetsFixtures {
+    constructor() {
+        this.srcPath = null;
+        this.destPath = null;
+        this.created = false;
+    }
+
+    async setup() {
+        if (this.created) {
+            return;
+        }
+
+        this.srcPath = path.join(config.get('paths').assetSrc, 'cards');
+        this.destPath = path.join(config.get('paths').adminAssets, 'cards');
+
+        // Create test card source files
+        await fs.mkdir(path.join(this.srcPath, 'css'), {recursive: true});
+        await fs.mkdir(path.join(this.srcPath, 'js'), {recursive: true});
+
+        // Create test CSS files
+        await fs.writeFile(
+            path.join(this.srcPath, 'css', 'test-card1.css'),
+            `
+/* Test Card 1 CSS */
+.test-card1 {
+    background: #f0f0f0;
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin: 5px;
+}
+
+.test-card1 h2 {
+    color: #333;
+    font-size: 1.2em;
+}
+
+.test-card1 p {
+    color: #666;
+    line-height: 1.4;
+}
+            `.trim()
+        );
+
+        await fs.writeFile(
+            path.join(this.srcPath, 'css', 'test-card2.css'),
+            `
+/* Test Card 2 CSS */
+.test-card2 {
+    background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+    color: white;
+    padding: 15px;
+    border-radius: 8px;
+}
+
+.test-card2 .title {
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+.test-card2 .content {
+    margin-top: 10px;
+    opacity: 0.9;
+}
+            `.trim()
+        );
+
+        // Create test JS files
+        await fs.writeFile(
+            path.join(this.srcPath, 'js', 'test-card1.js'),
+            `
+// Test Card 1 JavaScript
+(function() {
+    'use strict';
+
+    function initTestCard1() {
+        console.log('Test Card 1 initialized');
+
+        // Sample card functionality
+        const cards = document.querySelectorAll('.test-card1');
+        cards.forEach(card => {
+            card.addEventListener('click', function() {
+                this.style.transform = this.style.transform === 'scale(1.05)' ? 'scale(1)' : 'scale(1.05)';
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTestCard1);
+    } else {
+        initTestCard1();
+    }
+})();
+            `.trim()
+        );
+
+        await fs.writeFile(
+            path.join(this.srcPath, 'js', 'test-card2.js'),
+            `
+// Test Card 2 JavaScript
+(function() {
+    'use strict';
+
+    function initTestCard2() {
+        console.log('Test Card 2 initialized');
+
+        // Sample interactive functionality
+        const cards = document.querySelectorAll('.test-card2');
+        cards.forEach(card => {
+            const title = card.querySelector('.title');
+            if (title) {
+                title.addEventListener('mouseenter', function() {
+                    this.style.textShadow = '2px 2px 4px rgba(0,0,0,0.3)';
+                });
+
+                title.addEventListener('mouseleave', function() {
+                    this.style.textShadow = 'none';
+                });
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTestCard2);
+    } else {
+        initTestCard2();
+    }
+})();
+            `.trim()
+        );
+
+        this.created = true;
+    }
+
+    async cleanup() {
+        if (!this.created) {
+            return;
+        }
+
+        try {
+            // Clean up source files
+            if (this.srcPath) {
+                await fs.rmdir(this.srcPath, {recursive: true});
+            }
+
+            // Clean up destination files
+            if (this.destPath) {
+                await fs.rmdir(this.destPath, {recursive: true});
+            }
+        } catch (err) {
+            // Ignore errors during cleanup
+        }
+
+        this.created = false;
+        this.srcPath = null;
+        this.destPath = null;
+    }
+}
+
+module.exports = new CardAssetsFixtures();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2481/oss-issue-cardsmincss-and-js-problems-for-self-hosters

- Added `/ghost/cards/` route for theme-independent CSS/JS card assets
- Updated ActivityPub reader to use admin card assets instead of theme-dependent ones
- Ensured all card styles and functionality available regardless of theme settings