### PR TITLE
Added otc_ref to send-magic-link

### DIFF
--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -85,7 +85,12 @@ class MagicLink {
         
         let tokenId = null;
         if (this.labsService?.isSet('membersSigninOTC') && typeof this.tokenProvider.getIdByToken === 'function') {
-            tokenId = await this.tokenProvider.getIdByToken(token);
+            try {
+                tokenId = await this.tokenProvider.getIdByToken(token);
+            } catch (err) {
+                this.sentry?.captureException?.(err);
+                tokenId = null;
+            }
         }
 
         return {token, tokenId, info};

--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -17,7 +17,7 @@ const messages = {
  * @typedef {Object} TokenProvider<T, D>
  * @prop {(data: D) => Promise<T>} create
  * @prop {(token: T) => Promise<D>} validate
- * @prop {(token: T) => Promise<string | null>} [getIdByToken]
+ * @prop {(token: T) => Promise<string | null>} getIdByToken
  */
 
 /**

--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -17,7 +17,7 @@ const messages = {
  * @typedef {Object} TokenProvider<T, D>
  * @prop {(data: D) => Promise<T>} create
  * @prop {(token: T) => Promise<D>} validate
- * @prop {(token: T) => Promise<string | null>} getIdByToken
+ * @prop {(token: T) => Promise<string | null>} [getIdByToken]
  */
 
 /**

--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -35,6 +35,7 @@ class MagicLink {
      * @param {typeof defaultGetHTML} [options.getHTML]
      * @param {typeof defaultGetSubject} [options.getSubject]
      * @param {object} [options.sentry]
+     * @param {{isSet(name: string): boolean}} [options.labsService]
      */
     constructor(options) {
         if (!options || !options.transporter || !options.tokenProvider || !options.getSigninURL) {
@@ -47,6 +48,7 @@ class MagicLink {
         this.getHTML = options.getHTML || defaultGetHTML;
         this.getSubject = options.getSubject || defaultGetSubject;
         this.sentry = options.sentry || undefined;
+        this.labsService = options.labsService || undefined;
     }
 
     /**
@@ -81,9 +83,8 @@ class MagicLink {
             html: this.getHTML(url, type, options.email)
         });
         
-        // Only get tokenId if the provider supports it
         let tokenId = null;
-        if (typeof this.tokenProvider.getIdByToken === 'function') {
+        if (this.labsService?.isSet('membersSigninOTC') && typeof this.tokenProvider.getIdByToken === 'function') {
             tokenId = await this.tokenProvider.getIdByToken(token);
         }
 

--- a/ghost/core/core/server/services/members/SingleUseTokenProvider.js
+++ b/ghost/core/core/server/services/members/SingleUseTokenProvider.js
@@ -150,6 +150,22 @@ class SingleUseTokenProvider {
         const counter = this.deriveCounter(tokenId, tokenValue);
         return hotp.generate(this.secret, counter);
     }
+
+    /**
+     * @method getIdByToken
+     * Retrieves the ID associated with a given token.
+     *
+     * @param {string} token - The token to look up.
+     * @returns {Promise<string|null>} The ID if found, or null if not found or on error.
+     */
+    async getIdByToken(token) {
+        try {
+            const model = await this.model.findOne({token});
+            return model ? model.get('id') : null;
+        } catch (err) {
+            return null;
+        }
+    }
 }
 
 module.exports = SingleUseTokenProvider;

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -628,7 +628,7 @@ module.exports = class RouterController {
             } else {
                 const signIn = await this._handleSignin(req, normalizedEmail, referrer);
                 
-                if (signIn.tokenId) {
+                if (this.labsService.isSet('membersSigninOTC') && signIn.tokenId) {
                     res.writeHead(201, {'Content-Type': 'application/json'});
                     return res.end(JSON.stringify({otc_ref: signIn.tokenId}));
                 }

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -626,7 +626,12 @@ module.exports = class RouterController {
             if (emailType === 'signup' || emailType === 'subscribe') {
                 await this._handleSignup(req, normalizedEmail, referrer);
             } else {
-                await this._handleSignin(req, normalizedEmail, referrer);
+                const signIn = await this._handleSignin(req, normalizedEmail, referrer);
+                
+                if (signIn.tokenId) {
+                    res.writeHead(201, {'Content-Type': 'application/json'});
+                    return res.end(JSON.stringify({otc_ref: signIn.tokenId}));
+                }
             }
 
             res.writeHead(201);

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -158,7 +158,8 @@ module.exports = function MembersAPI({
         getText,
         getHTML,
         getSubject,
-        sentry
+        sentry,
+        labsService
     });
 
     const paymentsService = new PaymentsService({

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -345,36 +345,80 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
         });
 
-        it('allows signins from email domains blocked in config', async function () {
-            // Create member with the blocked email address in the database
-            const email = 'hello@blocked-domain-config.com';
-            await membersService.api.members.create({email, name: 'Member Test'});
+        describe('signin from blocked domains', function () {
+            describe('with membersSigninOTC feature flag enabled', function () {
+                beforeEach(function () {
+                    settingsCache.set('labs', {value: JSON.stringify({membersSigninOTC: true})});
+                });
 
-            // Check that the member can still sign in
-            await membersAgent.post('/api/send-magic-link')
-                .body({
-                    email,
-                    emailType: 'signin'
-                })
-                .expectEmptyBody()
-                .expectStatus(201);
-        });
+                it('allows signins from email domains blocked in config', async function () {
+                    const email = 'hello-enabled@blocked-domain-config.com';
+                    await membersService.api.members.create({email, name: 'Member Test'});
 
-        it('allows signins from email domains blocked in settings', async function () {
-            settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
+                    await membersAgent.post('/api/send-magic-link')
+                        .body({
+                            email,
+                            emailType: 'signin'
+                        })
+                        .expectStatus(201)
+                        .expect(({body}) => {
+                            should.exist(body.otc_ref);
+                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9]{24}$/);
+                        });
+                });
 
-            // Create member with the blocked email address in the database
-            const email = 'hello@blocked-domain-setting.com';
-            await membersService.api.members.create({email, name: 'Member Test'});
+                it('allows signins from email domains blocked in settings', async function () {
+                    settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
 
-            // Check that the member can still sign in
-            await membersAgent.post('/api/send-magic-link')
-                .body({
-                    email,
-                    emailType: 'signin'
-                })
-                .expectEmptyBody()
-                .expectStatus(201);
+                    const email = 'hello-enabled@blocked-domain-setting.com';
+                    await membersService.api.members.create({email, name: 'Member Test'});
+
+                    await membersAgent.post('/api/send-magic-link')
+                        .body({
+                            email,
+                            emailType: 'signin'
+                        })
+                        .expectStatus(201)
+                        .expect(({body}) => {
+                            should.exist(body.otc_ref);
+                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9]{24}$/);
+                        });
+                });
+            });
+
+            describe('with membersSigninOTC feature flag disabled', function () {
+                beforeEach(function () {
+                    settingsCache.set('labs', {value: JSON.stringify({membersSigninOTC: false})});
+                });
+
+                it('allows signins from email domains blocked in config', async function () {
+                    const email = 'hello-disabled@blocked-domain-config.com';
+                    await membersService.api.members.create({email, name: 'Member Test'});
+
+                    await membersAgent.post('/api/send-magic-link')
+                        .body({
+                            email,
+                            emailType: 'signin'
+                        })
+                        .expectEmptyBody()
+                        .expectStatus(201);
+                });
+
+                it('allows signins from email domains blocked in settings', async function () {
+                    settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
+
+                    const email = 'hello-disabled@blocked-domain-setting.com';
+                    await membersService.api.members.create({email, name: 'Member Test'});
+
+                    await membersAgent.post('/api/send-magic-link')
+                        .body({
+                            email,
+                            emailType: 'signin'
+                        })
+                        .expectEmptyBody()
+                        .expectStatus(201);
+                });
+            });
         });
 
         it('blocks changing email to a blocked domain', async function () {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -362,7 +362,7 @@ describe('sendMagicLink', function () {
                         })
                         .expectStatus(201)
                         .expect(({body}) => {
-                            should.exist(body.otc_ref);
+                            Object.keys(body).should.eql(['otc_ref']);
                             body.otc_ref.should.be.a.String().and.match(/^[a-f0-9]{24}$/);
                         });
                 });

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -122,4 +122,190 @@ describe('MagicLink', function () {
             assert.deepEqual(data.id, args.tokenData.id);
         });
     });
+
+    describe('#sendMagicLink with labsService', function () {
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('should return tokenId when labsService is provided and flag is enabled', async function () {
+            const mockTokenProvider = {
+                create: sandbox.stub().resolves('mock-token'),
+                getIdByToken: sandbox.stub().resolves('test-token-id-123')
+            };
+            
+            const labsService = {
+                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
+            };
+
+            const options = {
+                tokenProvider: mockTokenProvider,
+                getSigninURL: sandbox.stub().returns('FAKEURL'),
+                getText: sandbox.stub().returns('SOMETEXT'),
+                getHTML: sandbox.stub().returns('SOMEHTML'),
+                getSubject: sandbox.stub().returns('SOMESUBJECT'),
+                transporter: {
+                    sendMail: sandbox.stub().resolves({messageId: 'test'})
+                },
+                labsService
+            };
+            
+            const service = new MagicLink(options);
+            
+            const args = {
+                email: 'test@example.com',
+                tokenData: {
+                    id: '420'
+                }
+            };
+
+            const result = await service.sendMagicLink(args);
+
+            assert.equal(result.tokenId, 'test-token-id-123');
+            assert(labsService.isSet.calledWith('membersSigninOTC'));
+            assert(mockTokenProvider.getIdByToken.calledOnce);
+        });
+
+        it('should not return tokenId when labsService flag is disabled', async function () {
+            const mockTokenProvider = {
+                create: sandbox.stub().resolves('mock-token'),
+                getIdByToken: sandbox.stub().resolves('test-token-id-123')
+            };
+            
+            const labsService = {
+                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(false)
+            };
+
+            const options = {
+                tokenProvider: mockTokenProvider,
+                getSigninURL: sandbox.stub().returns('FAKEURL'),
+                getText: sandbox.stub().returns('SOMETEXT'),
+                getHTML: sandbox.stub().returns('SOMEHTML'),
+                getSubject: sandbox.stub().returns('SOMESUBJECT'),
+                transporter: {
+                    sendMail: sandbox.stub().resolves({messageId: 'test'})
+                },
+                labsService
+            };
+            
+            const service = new MagicLink(options);
+            
+            const args = {
+                email: 'test@example.com',
+                tokenData: {
+                    id: '420'
+                }
+            };
+
+            const result = await service.sendMagicLink(args);
+
+            assert.equal(result.tokenId, null);
+            assert(labsService.isSet.calledWith('membersSigninOTC'));
+            assert(mockTokenProvider.getIdByToken.notCalled);
+        });
+
+        it('should not return tokenId when labsService is not provided', async function () {
+            const mockTokenProvider = {
+                create: sandbox.stub().resolves('mock-token'),
+                getIdByToken: sandbox.stub().resolves('test-token-id-123')
+            };
+
+            const options = {
+                tokenProvider: mockTokenProvider,
+                getSigninURL: sandbox.stub().returns('FAKEURL'),
+                getText: sandbox.stub().returns('SOMETEXT'),
+                getHTML: sandbox.stub().returns('SOMEHTML'),
+                getSubject: sandbox.stub().returns('SOMESUBJECT'),
+                transporter: {
+                    sendMail: sandbox.stub().resolves({messageId: 'test'})
+                }
+                // No labsService provided
+            };
+            
+            const service = new MagicLink(options);
+            
+            const args = {
+                email: 'test@example.com',
+                tokenData: {
+                    id: '420'
+                }
+            };
+
+            const result = await service.sendMagicLink(args);
+
+            assert.equal(result.tokenId, null);
+            assert(mockTokenProvider.getIdByToken.notCalled);
+        });
+
+        it('should work when tokenProvider does not have getIdByToken method', async function () {
+            const mockTokenProvider = {
+                create: sandbox.stub().resolves('mock-token')
+                // No getIdByToken method
+            };
+            
+            const labsService = {
+                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
+            };
+
+            const options = {
+                tokenProvider: mockTokenProvider,
+                getSigninURL: sandbox.stub().returns('FAKEURL'),
+                getText: sandbox.stub().returns('SOMETEXT'),
+                getHTML: sandbox.stub().returns('SOMEHTML'),
+                getSubject: sandbox.stub().returns('SOMESUBJECT'),
+                transporter: {
+                    sendMail: sandbox.stub().resolves({messageId: 'test'})
+                },
+                labsService
+            };
+            
+            const service = new MagicLink(options);
+            
+            const args = {
+                email: 'test@example.com',
+                tokenData: {
+                    id: '420'
+                }
+            };
+
+            const result = await service.sendMagicLink(args);
+
+            assert.equal(result.tokenId, null);
+            assert(labsService.isSet.calledWith('membersSigninOTC'));
+        });
+
+        it('should work without errors when labsService is undefined (backward compatibility)', async function () {
+            const mockTokenProvider = {
+                create: sandbox.stub().resolves('mock-token'),
+                getIdByToken: sandbox.stub().resolves('test-token-id-123')
+            };
+
+            const options = {
+                tokenProvider: mockTokenProvider,
+                getSigninURL: sandbox.stub().returns('FAKEURL'),
+                getText: sandbox.stub().returns('SOMETEXT'),
+                getHTML: sandbox.stub().returns('SOMEHTML'),
+                getSubject: sandbox.stub().returns('SOMESUBJECT'),
+                transporter: {
+                    sendMail: sandbox.stub().resolves({messageId: 'test'})
+                },
+                labsService: undefined
+            };
+            
+            const service = new MagicLink(options);
+            
+            const args = {
+                email: 'test@example.com',
+                tokenData: {
+                    id: '420'
+                }
+            };
+
+            // Should not throw any errors
+            const result = await service.sendMagicLink(args);
+
+            assert.equal(result.tokenId, null);
+            assert(mockTokenProvider.getIdByToken.notCalled);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -275,7 +275,7 @@ describe('MagicLink', function () {
             assert(options.transporter.sendMail.calledOnce);
         });
 
-        it('should work without errors when labsService is undefined (backward compatibility)', async function () {
+        it('should work without errors when labsService is undefined', async function () {
             const mockTokenProvider = {
                 create: sandbox.stub().resolves('mock-token'),
                 getIdByToken: sandbox.stub().resolves('test-token-id-123')

--- a/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
@@ -106,7 +106,6 @@ describe('SingleUseTokenProvider', function () {
             const testTokenValue = 'test-token-value';
             const expectedId = 'test-token-id';
             
-            // Mock successful token lookup
             mockModel.findOne.resolves({
                 get: sinon.stub().returns(expectedId)
             });
@@ -120,7 +119,6 @@ describe('SingleUseTokenProvider', function () {
         it('should return null when a token does not exist', async function () {
             const testTokenValue = 'nonexistent-token';
             
-            // Mock token not found
             mockModel.findOne.resolves(null);
 
             const result = await tokenProvider.getIdByToken(testTokenValue);
@@ -132,7 +130,6 @@ describe('SingleUseTokenProvider', function () {
         it('should return null when a database error occurs', async function () {
             const testTokenValue = 'test-token-value';
             
-            // Mock database error
             mockModel.findOne.rejects(new Error('Database connection failed'));
 
             const result = await tokenProvider.getIdByToken(testTokenValue);
@@ -144,7 +141,6 @@ describe('SingleUseTokenProvider', function () {
         it('should handle an empty token gracefully', async function () {
             const emptyToken = '';
             
-            // Mock token lookup for empty string
             mockModel.findOne.resolves(null);
 
             const result = await tokenProvider.getIdByToken(emptyToken);
@@ -156,7 +152,6 @@ describe('SingleUseTokenProvider', function () {
         it('should handle an undefined token gracefully', async function () {
             const undefinedToken = undefined;
             
-            // Mock token lookup for undefined
             mockModel.findOne.resolves(null);
 
             const result = await tokenProvider.getIdByToken(undefinedToken);
@@ -168,7 +163,6 @@ describe('SingleUseTokenProvider', function () {
         it('should return null when model.get throws an error', async function () {
             const testTokenValue = 'test-token-value';
             
-            // Mock model found but get() throws error
             mockModel.findOne.resolves({
                 get: sinon.stub().throws(new Error('Model error'))
             });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
@@ -856,6 +856,100 @@ describe('RouterController', function () {
                 sendEmailWithMagicLinkStub.notCalled.should.be.true();
             });
         });
+
+        describe('membersSigninOTC feature flag', function () {
+            let req, res, handleSigninStub, routerController;
+
+            beforeEach(function () {
+                req = {
+                    body: {
+                        email: 'test@example.com',
+                        emailType: 'signin'
+                    },
+                    get: sinon.stub()
+                };
+                res = {
+                    writeHead: sinon.stub(),
+                    end: sinon.stub()
+                };
+                handleSigninStub = sinon.stub();
+                
+                routerController = new RouterController({
+                    allowSelfSignup: sinon.stub().returns(true),
+                    memberAttributionService: {
+                        getAttribution: sinon.stub().resolves({})
+                    },
+                    labsService: {
+                        isSet: sinon.stub()
+                    },
+                    settingsCache: {
+                        get: sinon.stub().returns([])
+                    },
+                    offersAPI: {},
+                    paymentsService: {},
+                    memberRepository: {},
+                    StripePrice: {},
+                    magicLinkService: {},
+                    stripeAPIService: {},
+                    tokenService: {},
+                    sendEmailWithMagicLink: sinon.stub(),
+                    newslettersService: {},
+                    sentry: {},
+                    urlUtils: {}
+                });
+                
+                // Stub the _handleSignin method
+                routerController._handleSignin = handleSigninStub;
+            });
+
+            it('should return otc_ref when flag is enabled and tokenId exists', async function () {
+                // Setup mocks
+                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+                handleSigninStub.resolves({tokenId: 'test-token-123'});
+
+                await routerController.sendMagicLink(req, res);
+
+                // Should set JSON content type and return otc_ref
+                res.writeHead.calledWith(201, {'Content-Type': 'application/json'}).should.be.true();
+                res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})).should.be.true();
+            });
+
+            it('should not return otc_ref when flag is disabled', async function () {
+                // Setup mocks
+                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(false);
+                handleSigninStub.resolves({tokenId: 'test-token-123'});
+
+                await routerController.sendMagicLink(req, res);
+
+                // Should return standard response
+                res.writeHead.calledWith(201).should.be.true();
+                res.end.calledWith('Created.').should.be.true();
+            });
+
+            it('should not return otc_ref when flag is enabled but no tokenId', async function () {
+                // Setup mocks
+                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+                handleSigninStub.resolves({tokenId: null});
+
+                await routerController.sendMagicLink(req, res);
+
+                // Should return standard response
+                res.writeHead.calledWith(201).should.be.true();
+                res.end.calledWith('Created.').should.be.true();
+            });
+
+            it('should not return otc_ref when flag is enabled but tokenId is undefined', async function () {
+                // Setup mocks
+                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+                handleSigninStub.resolves({});
+
+                await routerController.sendMagicLink(req, res);
+
+                // Should return standard response
+                res.writeHead.calledWith(201).should.be.true();
+                res.end.calledWith('Created.').should.be.true();
+            });
+        });
     });
 
     describe('_generateSuccessUrl', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
@@ -898,54 +898,45 @@ describe('RouterController', function () {
                     urlUtils: {}
                 });
                 
-                // Stub the _handleSignin method
                 routerController._handleSignin = handleSigninStub;
             });
 
             it('should return otc_ref when flag is enabled and tokenId exists', async function () {
-                // Setup mocks
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
                 handleSigninStub.resolves({tokenId: 'test-token-123'});
 
                 await routerController.sendMagicLink(req, res);
 
-                // Should set JSON content type and return otc_ref
                 res.writeHead.calledWith(201, {'Content-Type': 'application/json'}).should.be.true();
                 res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})).should.be.true();
             });
 
             it('should not return otc_ref when flag is disabled', async function () {
-                // Setup mocks
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(false);
                 handleSigninStub.resolves({tokenId: 'test-token-123'});
 
                 await routerController.sendMagicLink(req, res);
 
-                // Should return standard response
                 res.writeHead.calledWith(201).should.be.true();
                 res.end.calledWith('Created.').should.be.true();
             });
 
             it('should not return otc_ref when flag is enabled but no tokenId', async function () {
-                // Setup mocks
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
                 handleSigninStub.resolves({tokenId: null});
 
                 await routerController.sendMagicLink(req, res);
 
-                // Should return standard response
                 res.writeHead.calledWith(201).should.be.true();
                 res.end.calledWith('Created.').should.be.true();
             });
 
             it('should not return otc_ref when flag is enabled but tokenId is undefined', async function () {
-                // Setup mocks
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
                 handleSigninStub.resolves({});
 
                 await routerController.sendMagicLink(req, res);
 
-                // Should return standard response
                 res.writeHead.calledWith(201).should.be.true();
                 res.end.calledWith('Created.').should.be.true();
             });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2491

- Adds an otc_ref to the response from send-magic-link
- Once the OTC verification is implemented, the front end will be able to use that value (token.id, currently) along with an OTC to verify and sign in
- Utilizes the `membersSigninOTC` flag where applicable