### PR TITLE
Added vscode configuration for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ typings/
 .vscode/*
 !.vscode/launch.json
 !.vscode/settings.json
+!.vscode/extensions.json
 
 # OSX
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "always",
+    "source.fixAll.eslint": "always"
+  },
   "editor.quickSuggestions": {
     "strings": true
   },


### PR DESCRIPTION
Configuring VSCode to fix linting errors on save is a common pain point for new contributors just getting started with the codebase. This configuration, combined with the ESLint extension have always worked for me, so I figure we should add these to source control so new contributors don't have to figure this out for themselves anymore. 