### PR TITLE
Updated Dockerfile and compose for the e2e package

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -67,6 +67,7 @@ COPY apps/posts/package.json apps/posts/package.json
 COPY apps/shade/package.json apps/shade/package.json
 COPY apps/signup-form/package.json apps/signup-form/package.json
 COPY apps/sodo-search/package.json apps/sodo-search/package.json
+COPY e2e/package.json e2e/package.json
 COPY ghost/admin/lib/asset-delivery/package.json ghost/admin/lib/asset-delivery/package.json
 COPY ghost/admin/lib/ember-power-calendar-moment/package.json ghost/admin/lib/ember-power-calendar-moment/package.json
 COPY ghost/admin/lib/ember-power-calendar-utils/package.json ghost/admin/lib/ember-power-calendar-utils/package.json

--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,7 @@ x-service-template: &service-template
     - node_modules_ghost_admin:/home/ghost/ghost/admin/node_modules:delegated
     - node_modules_ghost_core:/home/ghost/ghost/core/node_modules:delegated
     - node_modules_ghost_i18n:/home/ghost/ghost/i18n/node_modules:delegated
+    - node_modules_e2e:/home/ghost/e2e/node_modules:delegated
     - node_modules_apps_admin-x-activitypub:/home/ghost/apps/admin-x-activitypub/node_modules:delegated
     - node_modules_apps_admin-x-design-system:/home/ghost/apps/admin-x-design-system/node_modules:delegated
     - node_modules_apps_admin-x-framework:/home/ghost/apps/admin-x-framework/node_modules:delegated
@@ -273,6 +274,7 @@ volumes:
   node_modules_ghost_admin: {}
   node_modules_ghost_core: {}
   node_modules_ghost_i18n: {}
+  node_modules_e2e: {}
   node_modules_apps_admin-x-activitypub: {}
   node_modules_apps_admin-x-design-system: {}
   node_modules_apps_admin-x-framework: {}


### PR DESCRIPTION
Docker builds are sometimes failing at the `yarn install` step because the `e2e/package.json` file wasn't being copied into the image before installing dependencies. The compose file was also missing the volume for the `e2e/node_modules` directory, which makes the main bind mount less performant and can lead to unexpected behavior in Docker.