### PR TITLE
Fixed subscriber count history in Analytics > Newsletters

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -117,14 +117,14 @@ export type NewsletterStatsResponseType = {
     meta: Meta;
 };
 
-export type NewsletterSubscriberDelta = {
+export type NewsletterSubscriberValue = {
     date: string;
-    value: number;
+    value: number; // Cumulative subscriber count for this date
 };
 
 export type NewsletterSubscriberStats = {
     total: number;
-    deltas: NewsletterSubscriberDelta[];
+    values: NewsletterSubscriberValue[];
 };
 
 export type NewsletterSubscriberStatsResponseType = {

--- a/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/Newsletters.tsx
@@ -292,7 +292,7 @@ const Newsletters: React.FC = () => {
 
     // Create subscribers data from newsletter subscriber stats
     const subscribersData = useMemo(() => {
-        if (!subscriberStatsData?.stats?.[0]?.deltas || subscriberStatsData.stats[0].deltas.length === 0) {
+        if (!subscriberStatsData?.stats?.[0]?.values || subscriberStatsData.stats[0].values.length === 0) {
             // When there's no data, create zero points for each day spanning the range
             const {startDate, endDate} = getRangeDates(range);
 
@@ -310,11 +310,11 @@ const Newsletters: React.FC = () => {
             return dailyData;
         }
 
-        const deltas = subscriberStatsData.stats[0].deltas;
+        const values = subscriberStatsData.stats[0].values;
 
         // If we only have one data point, create two points spanning the range
-        if (deltas.length === 1) {
-            const singlePoint = deltas[0];
+        if (values.length === 1) {
+            const singlePoint = values[0];
             const now = new Date();
             const rangeInDays = range;
             const startDate = new Date(now.getTime() - (rangeInDays * 24 * 60 * 60 * 1000));
@@ -332,7 +332,7 @@ const Newsletters: React.FC = () => {
         }
 
         // Convert to the required format - already in the correct format
-        return deltas;
+        return values;
     }, [subscriberStatsData, range]);
 
     // Create avgsData from newsletter stats for the bar charts

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -74,7 +74,7 @@ const {getDateBoundaries, applyDateFilter} = require('./utils/date-utils');
 /**
  * @typedef {Object} NewsletterSubscriberStats
  * @property {number} total - Total current subscriber count
- * @property {Array<{date: string, value: number}>} values - Daily subscription deltas
+ * @property {Array<{date: string, value: number}>} values - Daily subscription cumulative values
  */
 
 class PostsStatsService {

--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -74,7 +74,7 @@ const {getDateBoundaries, applyDateFilter} = require('./utils/date-utils');
 /**
  * @typedef {Object} NewsletterSubscriberStats
  * @property {number} total - Total current subscriber count
- * @property {Array<{date: string, value: number}>} deltas - Daily subscription deltas
+ * @property {Array<{date: string, value: number}>} values - Daily subscription deltas
  */
 
 class PostsStatsService {
@@ -932,7 +932,7 @@ class PostsStatsService {
      * @param {string} [options.date_from] - Optional start date filter (YYYY-MM-DD)
      * @param {string} [options.date_to] - Optional end date filter (YYYY-MM-DD)
      * @param {string} [options.timezone] - Timezone to use for date interpretation
-     * @returns {Promise<{data: Array<{total: number, deltas: Array<{date: string, value: number}>}>}>} The newsletter subscriber stats
+     * @returns {Promise<{data: Array<{total: number, values: Array<{date: string, value: number}>}>}>} The newsletter subscriber stats with cumulative values
      */
     async getNewsletterSubscriberStats(newsletterId, options = {}) {
         try {
@@ -956,25 +956,42 @@ class PostsStatsService {
             const totalValue = totalResult[0] ? totalResult[0].total : 0;
             const total = parseInt(String(totalValue), 10);
 
-            // Transform raw database results to properly typed objects
-            const deltas = [];
+            // Transform raw database results (daily changes) to cumulative values
+            const values = [];
+            let cumulativeTotal = 0;
+            
+            // First pass: collect all daily changes from database
+            const dailyChanges = [];
             for (const row of rawDeltas) {
                 if (row) {
                     // @ts-ignore
                     const dateValue = row.date || '';
                     // @ts-ignore
-                    const deltaValue = row.value || 0;
-                    deltas.push({
+                    const changeValue = row.value || 0;
+                    dailyChanges.push({
                         date: String(dateValue),
-                        value: parseInt(String(deltaValue), 10)
+                        change: parseInt(String(changeValue), 10)
                     });
                 }
+            }
+            
+            // Calculate the starting point by working backwards from the current total
+            const totalChange = dailyChanges.reduce((sum, item) => sum + item.change, 0);
+            cumulativeTotal = total - totalChange;
+            
+            // Second pass: build cumulative values from daily changes
+            for (const dayData of dailyChanges) {
+                cumulativeTotal += dayData.change;
+                values.push({
+                    date: dayData.date,
+                    value: cumulativeTotal
+                });
             }
 
             return {
                 data: [{
                     total,
-                    deltas
+                    values
                 }]
             };
         } catch (error) {
@@ -982,7 +999,7 @@ class PostsStatsService {
             return {
                 data: [{
                     total: 0,
-                    deltas: []
+                    values: []
                 }]
             };
         }

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -156,7 +156,7 @@ class StatsService {
         
         // If no newsletterId is provided, we can't get specific stats
         if (!newsletterId) {
-            return {data: [{total: 0, deltas: []}]};
+            return {data: [{total: 0, values: []}]};
         }
         
         const result = await this.posts.getNewsletterSubscriberStats(newsletterId, otherOptions);

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -1851,11 +1851,9 @@ describe('PostsStatsService', function () {
             await _createMember('member3');
 
             // Current state
-            await db('members_newsletters').insert([
-                {id: 'mn1', member_id: 'member1', newsletter_id: newsletterId},
-                {id: 'mn2', member_id: 'member2', newsletter_id: newsletterId},
-                {id: 'mn3', member_id: 'member3', newsletter_id: newsletterId}
-            ]);
+            await _createMemberNewsletterSubscription('member1', newsletterId);
+            await _createMemberNewsletterSubscription('member2', newsletterId);
+            await _createMemberNewsletterSubscription('member3', newsletterId);
 
             // Events spanning multiple days
             await _createNewsletterSubscription(newsletterId, 'member1', true, new Date('2024-01-01T00:00:00Z'));

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -1816,11 +1816,9 @@ describe('PostsStatsService', function () {
             
             await _createNewsletter(newsletterId, 'Test Newsletter');
 
-            await db('members').insert([
-                {id: 'member1', email: 'member1@test.com', email_disabled: false},
-                {id: 'member2', email: 'member2@test.com', email_disabled: false},
-                {id: 'member3', email: 'member3@test.com', email_disabled: false}
-            ]);
+            await _createMember('member1');
+            await _createMember('member2');
+            await _createMember('member3');
 
             // Current state: 2 subscribers
             await _createMemberNewsletterSubscription('member1', newsletterId);
@@ -1848,11 +1846,9 @@ describe('PostsStatsService', function () {
             
             await _createNewsletter(newsletterId, 'Test Newsletter');
 
-            await db('members').insert([
-                {id: 'member1', email: 'member1@test.com', email_disabled: false},
-                {id: 'member2', email: 'member2@test.com', email_disabled: false},
-                {id: 'member3', email: 'member3@test.com', email_disabled: false}
-            ]);
+            await _createMember('member1');
+            await _createMember('member2');
+            await _createMember('member3');
 
             // Current state
             await db('members_newsletters').insert([
@@ -1862,29 +1858,9 @@ describe('PostsStatsService', function () {
             ]);
 
             // Events spanning multiple days
-            await db('members_subscribe_events').insert([
-                {
-                    id: 'event1',
-                    member_id: 'member1',
-                    newsletter_id: newsletterId,
-                    subscribed: true,
-                    created_at: new Date('2024-01-01T00:00:00Z').toISOString()
-                },
-                {
-                    id: 'event2',
-                    member_id: 'member2',
-                    newsletter_id: newsletterId,
-                    subscribed: true,
-                    created_at: new Date('2024-01-05T00:00:00Z').toISOString()
-                },
-                {
-                    id: 'event3',
-                    member_id: 'member3',
-                    newsletter_id: newsletterId,
-                    subscribed: true,
-                    created_at: new Date('2024-01-10T00:00:00Z').toISOString()
-                }
-            ]);
+            await _createNewsletterSubscription(newsletterId, 'member1', true, new Date('2024-01-01T00:00:00Z'));
+            await _createNewsletterSubscription(newsletterId, 'member2', true, new Date('2024-01-05T00:00:00Z'));
+            await _createNewsletterSubscription(newsletterId, 'member3', true, new Date('2024-01-10T00:00:00Z'));
 
             // Request only middle date range
             const result = await service.getNewsletterSubscriberStats(newsletterId, {

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -1680,8 +1680,8 @@ describe('PostsStatsService', function () {
             // Subscribe/unsubscribe events
             await _createNewsletterSubscription(newsletterId, 'member1', true, new Date('2024-01-01T00:00:00Z'));
             await _createNewsletterSubscription(newsletterId, 'member2', true, new Date('2024-01-02T00:00:00Z'));
-            await _createNewsletterSubscription(newsletterId, 'member3', false, new Date('2024-01-03T00:00:00Z'));
             await _createNewsletterSubscription(newsletterId, 'member3', true, new Date('2024-01-03T00:00:00Z'));
+            await _createNewsletterSubscription(newsletterId, 'member3', false, new Date('2024-01-03T01:00:00Z'));
 
             const result = await service.getNewsletterSubscriberStats(newsletterId, {
                 date_from: '2024-01-01',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2525/
- aggregation type was incorrect for summarizing subscriber data ('exact' vs 'sum')
- updated /stats/subscriber-count API to return absolute values, not deltas; this is more useful for our use case
- renamed return to 'values' instead of 'deltas' to correspond with API changes

Root problem: we were using the 'exact' aggregation when calling `sanitizeChartData` which was an oversight and incorrect when using delta counts. In general, this function is doing too much, but that's a problem to sort out at a later date.

Trying to handle cumulative values was pushing the boundaries of `sanitizeChartData`, which is shared by several other charts. In the spirit of limiting the blast radius of this change, I adjusted the API rather than the util used by most of the front end, given we don't have good test coverage.

The API now returns absolute values for each day. Since we don't display a +/- chart, we don't need individual deltas. This is easier to reason about and takes the load off the frontend from doing additional processing; it just needs to pick the date it wants to display.

Note: We still pull deltas on the backend because that's how the data is stored.

__Testing__
1. `yarn docker:reset`
2. `yarn dev` and set up Ghost
3. Kill process, `yarn reset:data:analytics`, then run Ghost again
4. `yarn tb` in a separate container; make sure config is appropriately set (workspaceId, token, stats.id = `mock_site_uuid`)

This should get you data in Analytics, and the generated data should be enough to generate for the past 12mo which is enough to see the original issue. You may need to do some jockeying with `config` to make it work, or manually load the generated `analytics_events.ndjson` in to Tinybird. The key thing to validate is that timeframes make sense and that data points line up, e.g. 'Last 3 months' summaries for m-1 and m-2 line up with the same for 'YTD' and 'Last 12 months'.