### PR TITLE
Add feature flag ahead of tags migration

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -31,7 +31,12 @@ const features: Feature[] = [{
     title: 'Members sign-in OTC (alpha)',
     description: 'Enables one-time codes alongside magic links for members signin',
     flag: 'membersSigninOTC'
-}];
+}, {
+    title: 'Tags X',
+    description: 'Enables the new Tags UI',
+    flag: 'tagsX'
+}
+];
 
 const AlphaFeatures: React.FC = () => {
     const limiter = useLimiter();

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -71,6 +71,7 @@ export default class FeatureService extends Service {
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
     @feature('membersSigninOTC') membersSigninOTC;
+    @feature('tagsX') tagsX;
 
     _user = null;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -47,7 +47,8 @@ const PRIVATE_FEATURES = [
     'lexicalIndicators',
     'contentVisibilityAlpha',
     'emailCustomization',
-    'membersSigninOTC'
+    'membersSigninOTC',
+    'tagsX'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -25,6 +25,7 @@ Object {
       "membersSigninOTC": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
+      "tagsX": true,
       "themeErrorsNotification": true,
       "urlCache": true,
       "webmentions": true,


### PR DESCRIPTION
This will allow us to migrate the tags screens to React while keeping the Ember version around in the mean time.