### PR TITLE
Remove posts app router basepath

### DIFF
--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -8,7 +8,7 @@ import {ErrorPage} from '@tryghost/shade';
 import {RouteObject} from '@tryghost/admin-x-framework';
 // import {withFeatureFlag} from '@src/hooks/withFeatureFlag';
 
-export const APP_ROUTE_PREFIX = '/posts';
+export const APP_ROUTE_PREFIX = '/';
 
 // Wrap components with feature flag protection where needed
 //  e.g.
@@ -23,7 +23,7 @@ export const routes: RouteObject[] = [
             {
 
                 // Post Analytics
-                path: 'analytics/:postId',
+                path: 'posts/analytics/:postId',
                 element: (
                     <PostAnalyticsProvider>
                         <PostAnalytics />

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -83,7 +83,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     useEffect(() => {
         // Redirect to overview if the post wasn't sent as a newsletter
         if (!isPostLoading && !showNewsletterSection) {
-            navigate(`/analytics/${postId}`);
+            navigate(`/posts/analytics/${postId}`);
         }
     }, [navigate, postId, isPostLoading, showNewsletterSection]);
 

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -98,7 +98,7 @@ const Overview: React.FC = () => {
     // Redirect to Growth tab if this is a published-only post with web analytics disabled
     useEffect(() => {
         if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics) {
-            navigate(`/analytics/${postId}/growth`);
+            navigate(`/posts/analytics/${postId}/growth`);
         }
     }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId]);
 
@@ -140,7 +140,7 @@ const Overview: React.FC = () => {
                                 </CardTitle>
                             </CardHeader>
                             <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                                navigate(`/analytics/${postId}/growth`);
+                                navigate(`/posts/analytics/${postId}/growth`);
                             }}>View more</Button>
                         </div>
                         <CardContent className='flex flex-col gap-8 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/NewsletterOverview.tsx
@@ -72,7 +72,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                     </CardTitle>
                 </CardHeader>
                 <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
-                    navigate(`/analytics/${postId}/newsletter`);
+                    navigate(`/posts/analytics/${postId}/newsletter`);
                 }}>View more</Button>
             </div>
             {isNewsletterStatsLoading ?
@@ -172,7 +172,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                         </div>
                     </div>
                     {/* <Button variant='outline' onClick={() => {
-                        navigate(`/analytics/${postId}/newsletter`);
+                        navigate(`/posts/analytics/${postId}/newsletter`);
                     }}>
                         View all
                         <LucideIcon.ArrowRight />

--- a/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/WebOverview.tsx
@@ -41,7 +41,7 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
                         </CardTitle>
                     </CardHeader>
                     <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
-                        navigate(`/analytics/${postId}/web`);
+                        navigate(`/posts/analytics/${postId}/web`);
                     }}>View more</Button>
                 </div>
                 <CardContent>

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -34,7 +34,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
     // Redirect to Overview if this is an email-only post
     useEffect(() => {
         if (!isPostLoading && post?.email_only) {
-            navigate(`/analytics/${postId}`);
+            navigate(`/posts/analytics/${postId}`);
         }
     }, [isPostLoading, post?.email_only, navigate, postId]);
 

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -200,28 +200,28 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                     <PageMenu className='min-h-[34px]' defaultValue={currentTab} responsive>
                         {availableTabs.includes('Overview') && (
                             <PageMenuItem value="Overview" onClick={() => {
-                                navigate(`/analytics/${postId}`);
+                                navigate(`/posts/analytics/${postId}`);
                             }}>
                                     Overview
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Web') && (
                             <PageMenuItem value="Web" onClick={() => {
-                                navigate(`/analytics/${postId}/web`);
+                                navigate(`/posts/analytics/${postId}/web`);
                             }}>
                                     Web traffic
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Newsletter') && (
                             <PageMenuItem value="Newsletter" onClick={() => {
-                                navigate(`/analytics/${postId}/newsletter`);
+                                navigate(`/posts/analytics/${postId}/newsletter`);
                             }}>
                                     Newsletter
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Growth') && (
                             <PageMenuItem value="Growth" onClick={() => {
-                                navigate(`/analytics/${postId}/growth`);
+                                navigate(`/posts/analytics/${postId}/growth`);
                             }}>
                                     Growth
                             </PageMenuItem>

--- a/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/Sidebar.tsx
@@ -19,15 +19,15 @@ const Sidebar:React.FC = () => {
     return (
         <div className='grow py-8 pr-0'>
             <RightSidebarMenu>
-                <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}`} onClick={() => {
-                    navigate(`/analytics/${postId}`);
+                <RightSidebarMenuLink active={location.pathname === `/posts/analytics/${postId}`} onClick={() => {
+                    navigate(`/posts/analytics/${postId}`);
                 }}>
                     <LucideIcon.LayoutTemplate size={16} strokeWidth={1.25} />
                     Overview
                 </RightSidebarMenuLink>
                 {!post?.email_only && (
-                    <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}/web`} onClick={() => {
-                        navigate(`/analytics/${postId}/web`);
+                    <RightSidebarMenuLink active={location.pathname === `/posts/analytics/${postId}/web`} onClick={() => {
+                        navigate(`/posts/analytics/${postId}/web`);
                     }}>
                         <LucideIcon.MousePointer size={16} strokeWidth={1.25} />
                         Web
@@ -35,16 +35,16 @@ const Sidebar:React.FC = () => {
                 )}
 
                 {hasBeenEmailed && (
-                    <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}/newsletter`} onClick={() => {
-                        navigate(`/analytics/${postId}/newsletter`);
+                    <RightSidebarMenuLink active={location.pathname === `/posts/analytics/${postId}/newsletter`} onClick={() => {
+                        navigate(`/posts/analytics/${postId}/newsletter`);
                     }}>
                         <LucideIcon.Mail size={16} strokeWidth={1.25} />
                         Newsletter
                     </RightSidebarMenuLink>
                 )}
 
-                <RightSidebarMenuLink active={location.pathname === `/analytics/${postId}/growth`} onClick={() => {
-                    navigate(`/analytics/${postId}/growth`);
+                <RightSidebarMenuLink active={location.pathname === `/posts/analytics/${postId}/growth`} onClick={() => {
+                    navigate(`/posts/analytics/${postId}/growth`);
                 }}>
                     <LucideIcon.Sprout size={16} strokeWidth={1.25} />
                 Growth


### PR DESCRIPTION
The `/posts` basepath prevents us from adding the root level `/tags` routes to the posts app (i.e. the soon to be new admin app). I think I've caught all the references, but I'd really appreciate another set of eyes on this!