### PR TITLE
Added error handling for outdated API endpoints

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/admin-x-activitypub/src/components/layout/Error/Error.tsx
@@ -66,6 +66,19 @@ const Error = ({statusCode, errorCode}: {statusCode?: number, errorCode?: string
         );
     }
 
+    if (statusCode === 410 && errorCode === 'INVALID_VERSION') {
+        return (
+            <EmptyViewIndicator className='mt-[50vh] -translate-y-1/2'>
+                <EmptyViewIcon><LucideIcon.DownloadCloud /></EmptyViewIcon>
+                <H4 className='-mb-4'>New version available</H4>
+                <div>We&apos;ve made some updates! Refresh your page to see what&apos;s new</div>
+                <Button asChild>
+                    <button type='button' onClick={() => window.location.reload()}>Refresh your page</button>
+                </Button>
+            </EmptyViewIndicator>
+        );
+    }
+
     return (
         <div className="admin-x-container-error">
             <div className="admin-x-error max-w-xl">


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2441
ref https://github.com/TryGhost/Ghost/pull/24646

- When the ActivityPub API drops supports for an older version of an API endpoint, it will return a HTTP 410 Gone with the code "INVALID_VERSION"
- With this change, we display a notice for the user to refresh their page in that case. Refreshing the page will dynamically load a newer version of the client app, as per https://github.com/TryGhost/Ghost/pull/24646

