### PR TITLE
Added verifyOTC to SingleUseTokenProvider

### DIFF
--- a/ghost/core/core/server/services/members/SingleUseTokenProvider.js
+++ b/ghost/core/core/server/services/members/SingleUseTokenProvider.js
@@ -152,6 +152,34 @@ class SingleUseTokenProvider {
     }
 
     /**
+     * @method verifyOTC
+     * Verifies an OTC (one-time code) against a token ID by looking up the token and performing verification
+     *
+     * @param {string} tokenId - Token ID
+     * @param {string} otc - The one-time code to verify
+     * @returns {Promise<boolean>} Returns true if the OTC is valid, false otherwise
+     */
+    async verifyOTC(tokenId, otc) {
+        if (!this.secret || !tokenId || !otc) {
+            return false;
+        }
+
+        try {
+            const model = await this.model.findOne({id: tokenId});
+
+            if (!model) {
+                return false;
+            }
+
+            const tokenValue = model.get('token');
+            const counter = this.deriveCounter(tokenId, tokenValue);
+            return hotp.verify({token: otc, secret: this.secret, counter});
+        } catch (err) {
+            return false;
+        }
+    }
+        
+    /**
      * @method getIdByToken
      * Retrieves the ID associated with a given token.
      *

--- a/ghost/core/core/server/services/members/SingleUseTokenProvider.js
+++ b/ghost/core/core/server/services/members/SingleUseTokenProvider.js
@@ -153,26 +153,26 @@ class SingleUseTokenProvider {
 
     /**
      * @method verifyOTC
-     * Verifies an OTC (one-time code) against a token ID by looking up the token and performing verification
+     * Verifies an OTC (one-time code) by looking up the token and performing HOTP verification
      *
-     * @param {string} tokenId - Token ID
+     * @param {string} otcRef - Reference for the one-time code
      * @param {string} otc - The one-time code to verify
      * @returns {Promise<boolean>} Returns true if the OTC is valid, false otherwise
      */
-    async verifyOTC(tokenId, otc) {
-        if (!this.secret || !tokenId || !otc) {
+    async verifyOTC(otcRef, otc) {
+        if (!this.secret || !otcRef || !otc) {
             return false;
         }
 
         try {
-            const model = await this.model.findOne({id: tokenId});
+            const model = await this.model.findOne({id: otcRef});
 
             if (!model) {
                 return false;
             }
 
             const tokenValue = model.get('token');
-            const counter = this.deriveCounter(tokenId, tokenValue);
+            const counter = this.deriveCounter(otcRef, tokenValue);
             return hotp.verify({token: otc, secret: this.secret, counter});
         } catch (err) {
             return false;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2498

- Adds the `verifyOTC` method to `SingleUseTokenProvider`
- `verifyOTC` checks for required fields, finds the token, derives the counter, then uses `hotp.verify` to make sure the OTC is correct