### PR TITLE
Renamed `tokenId` to `otcRef` in `sendMagicLink` return value

### DIFF
--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -19,7 +19,7 @@ const messages = {
  * @prop {(data: D) => Promise<T>} create
  * @prop {(token: T) => Promise<D>} validate
  * @prop {(token: T) => Promise<string | null>} [getIdByToken]
- * @prop {(tokenId: string, tokenValue: T) => string} [deriveOTC]
+ * @prop {(otcRef: string, tokenValue: T) => string} [deriveOTC]
  */
 
 /**
@@ -62,7 +62,7 @@ class MagicLink {
      * @param {string} [options.type='signin'] - The type to be passed to the url and content generator functions
      * @param {string} [options.referrer=null] - The referrer of the request, if exists. The member will be redirected back to this URL after signin.
      * @param {boolean} [options.includeOTC=false] - Whether to send a one-time-code in the email.
-     * @returns {Promise<{token: Token, tokenId: string | null, info: SentMessageInfo}>}
+     * @returns {Promise<{token: Token, otcRef: string | null, info: SentMessageInfo}>}
      */
     async sendMagicLink(options) {
         this.sentry?.captureMessage?.(`[Magic Link] Generating magic link`, {extra: options});
@@ -96,21 +96,21 @@ class MagicLink {
             html: this.getHTML(url, type, options.email, otc)
         });
 
-        // return tokenId so we can pass it as a reference to the client so it
+        // return otcRef so we can pass it as a reference to the client so it
         // can pass it back as a reference when verifying the OTC. We only do
         // this if we've successfully generated an OTC to avoid clients showing
         // a token input field when the email doesn't contain an OTC
-        let tokenId = null;
+        let otcRef = null;
         if (this.labsService?.isSet('membersSigninOTC') && otc) {
             try {
-                tokenId = await this.getIdFromToken(token);
+                otcRef = await this.getIdFromToken(token);
             } catch (err) {
                 this.sentry?.captureException?.(err);
-                tokenId = null;
+                otcRef = null;
             }
         }
 
-        return {token, tokenId, info};
+        return {token, otcRef, info};
     }
 
     /**

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -628,9 +628,9 @@ module.exports = class RouterController {
             } else {
                 const signIn = await this._handleSignin(req, normalizedEmail, referrer);
 
-                if (this.labsService.isSet('membersSigninOTC') && signIn.tokenId) {
+                if (this.labsService.isSet('membersSigninOTC') && signIn.otcRef) {
                     res.writeHead(201, {'Content-Type': 'application/json'});
-                    return res.end(JSON.stringify({otc_ref: signIn.tokenId}));
+                    return res.end(JSON.stringify({otc_ref: signIn.otcRef}));
                 }
             }
 

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -114,7 +114,7 @@ describe('MagicLink', function () {
     });
 
     describe('#sendMagicLink with labsService', function () {
-        it('should not return tokenId when labsService is provided and flag is enabled but includeOTC is not set', async function () {
+        it('should not return otcRef when labsService is provided and flag is enabled but includeOTC is not set', async function () {
             const labsService = {
                 isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
             };
@@ -130,11 +130,11 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
             assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
         });
 
-        it('should not return tokenId when labsService flag is disabled', async function () {
+        it('should not return otcRef when labsService flag is disabled', async function () {
             const labsService = {
                 isSet: sandbox.stub().withArgs('membersSigninOTC').returns(false)
             };
@@ -151,11 +151,11 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
             assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
         });
 
-        it('should not return tokenId when labsService is not provided', async function () {
+        it('should not return otcRef when labsService is not provided', async function () {
             const service = new MagicLink(buildOptions({labsService: undefined}));
 
             const args = {
@@ -169,7 +169,7 @@ describe('MagicLink', function () {
             // Should not throw any errors
             const result = await service.sendMagicLink(args);
 
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
             assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
         });
 
@@ -194,11 +194,11 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
             assert(options.transporter.sendMail.calledOnce);
         });
 
-        it('should return tokenId as null when getIdByToken resolves to null', async function () {
+        it('should return otcRef as null when getIdByToken resolves to null', async function () {
             mockSingleUseTokenProvider.getIdByToken.resolves(null);
 
             const labsService = {
@@ -217,7 +217,7 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
             // deriveOTC is only possible with a token so it's skipped if getIdByToken returns null
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
             assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
@@ -244,7 +244,7 @@ describe('MagicLink', function () {
             assert(mockSingleUseTokenProvider.getIdByToken.calledTwice);
             assert(mockSingleUseTokenProvider.deriveOTC.calledOnce);
             assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-id-123', 'mock-token'));
-            assert.equal(result.tokenId, 'test-token-id-123');
+            assert.equal(result.otcRef, 'test-token-id-123');
 
             // Verify OTC is passed to email content functions
             assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
@@ -272,7 +272,7 @@ describe('MagicLink', function () {
 
             assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
 
             // Verify OTC is not passed to email content functions
             assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', null));
@@ -299,7 +299,7 @@ describe('MagicLink', function () {
 
             assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
-            assert.equal(result.tokenId, null);
+            assert.equal(result.otcRef, null);
         });
 
         it('should pass OTC to email content functions when OTC is enabled', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
@@ -873,7 +873,7 @@ describe('RouterController', function () {
                     end: sinon.stub()
                 };
                 handleSigninStub = sinon.stub();
-                
+
                 routerController = new RouterController({
                     allowSelfSignup: sinon.stub().returns(true),
                     memberAttributionService: {
@@ -897,13 +897,13 @@ describe('RouterController', function () {
                     sentry: {},
                     urlUtils: {}
                 });
-                
+
                 routerController._handleSignin = handleSigninStub;
             });
 
-            it('should return otc_ref when flag is enabled and tokenId exists', async function () {
+            it('should return otc_ref when flag is enabled and otcRef exists', async function () {
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
-                handleSigninStub.resolves({tokenId: 'test-token-123'});
+                handleSigninStub.resolves({otcRef: 'test-token-123'});
 
                 await routerController.sendMagicLink(req, res);
 
@@ -913,7 +913,7 @@ describe('RouterController', function () {
 
             it('should not return otc_ref when flag is disabled', async function () {
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(false);
-                handleSigninStub.resolves({tokenId: 'test-token-123'});
+                handleSigninStub.resolves({otcRef: 'test-token-123'});
 
                 await routerController.sendMagicLink(req, res);
 
@@ -921,9 +921,9 @@ describe('RouterController', function () {
                 res.end.calledWith('Created.').should.be.true();
             });
 
-            it('should not return otc_ref when flag is enabled but no tokenId', async function () {
+            it('should not return otc_ref when flag is enabled but no otcRef', async function () {
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
-                handleSigninStub.resolves({tokenId: null});
+                handleSigninStub.resolves({otcRef: null});
 
                 await routerController.sendMagicLink(req, res);
 
@@ -931,7 +931,7 @@ describe('RouterController', function () {
                 res.end.calledWith('Created.').should.be.true();
             });
 
-            it('should not return otc_ref when flag is enabled but tokenId is undefined', async function () {
+            it('should not return otc_ref when flag is enabled but otcRef is undefined', async function () {
                 routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
                 handleSigninStub.resolves({});
 


### PR DESCRIPTION
no issue

- `tokenId` was too close to the implementation detail
  1. the underlying data is currently `token.id` but will change to `token.uuid` later
  2. we then rename the data to `otc_ref` in the API return value
- renamed to `otcRef` to better reflect it's use-case and provide consistency with the API meaning it's easier to follow the data flow through the API/controller/magic-link setup
