### PR TITLE
Renamed `otc` to `includeOTC` in send-magic-link request body

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -81,11 +81,11 @@ async function signout({api, state}) {
 async function signin({data, api, state}) {
     const {t, labs} = state;
 
-    const otc = labs.membersSigninOTC ? true : undefined;
+    const includeOTC = labs?.membersSigninOTC ? true : undefined;
 
     try {
         const integrityToken = await api.member.getIntegrityToken();
-        await api.member.sendMagicLink({...data, emailType: 'signin', integrityToken, otc});
+        await api.member.sendMagicLink({...data, emailType: 'signin', integrityToken, includeOTC});
         return {
             page: 'magiclink',
             lastPage: 'signin'

--- a/apps/portal/src/tests/SigninFlow.test.js
+++ b/apps/portal/src/tests/SigninFlow.test.js
@@ -176,7 +176,7 @@ describe('Signin', () => {
                 email: 'jamie@example.com',
                 emailType: 'signin',
                 integrityToken: 'testtoken',
-                otc: true
+                includeOTC: true
             });
         });
 

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -265,7 +265,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             }
         },
 
-        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, integrityToken, phonenumber, customUrlHistory, token, autoRedirect = true, otc}) {
+        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, integrityToken, phonenumber, customUrlHistory, token, autoRedirect = true, includeOTC}) {
             const url = endpointFor({type: 'members', resource: 'send-magic-link'});
             const body = {
                 name,
@@ -281,7 +281,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 honeypot: phonenumber,
                 token,
                 autoRedirect,
-                otc
+                includeOTC
             };
             const urlHistory = customUrlHistory ?? getUrlHistory();
             if (urlHistory) {

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -684,11 +684,11 @@ module.exports = class RouterController {
     }
 
     async _handleSignin(req, normalizedEmail, referrer = null) {
-        const {emailType, otc} = req.body;
+        const {emailType, includeOTC: reqIncludeOTC} = req.body;
 
         let includeOTC = false;
 
-        if (this.labsService.isSet('membersSigninOTC') && (otc === true || otc === 'true')) {
+        if (this.labsService.isSet('membersSigninOTC') && (reqIncludeOTC === true || reqIncludeOTC === 'true')) {
             includeOTC = true;
         }
 

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -342,7 +342,7 @@ describe('sendMagicLink', function () {
 
         it('matches OTC snapshot (membersSigninOTC enabled)', async function () {
             mockManager.mockLabsEnabled('membersSigninOTC');
-            const mail = await sendSigninRequest({otc: true});
+            const mail = await sendSigninRequest({includeOTC: true});
             const scrubbedEmail = scrubEmailContent(mail);
             should(scrubbedEmail).matchSnapshot();
         });
@@ -420,7 +420,7 @@ describe('sendMagicLink', function () {
                         .body({
                             email,
                             emailType: 'signin',
-                            otc: true
+                            includeOTC: true
                         })
                         .expectStatus(201)
                         .expect(({body}) => {
@@ -439,7 +439,7 @@ describe('sendMagicLink', function () {
                         .body({
                             email,
                             emailType: 'signin',
-                            otc: true
+                            includeOTC: true
                         })
                         .expectStatus(201)
                         .expect(({body}) => {
@@ -807,7 +807,7 @@ describe('sendMagicLink', function () {
         function sendMagicLinkRequest(email, emailType = 'signin', otc = false) {
             const body = {email, emailType};
             if (otc) {
-                body.otc = otc;
+                body.includeOTC = otc;
             }
 
             return membersAgent
@@ -901,7 +901,7 @@ describe('sendMagicLink', function () {
                     const response = await sendMagicLinkRequest('member1@test.com', 'signin', otcValue)
                         .expectStatus(201);
 
-                    assert(response.body.otc_ref, `Response should contain otc_ref for otc=${otcValue}`);
+                    assert(response.body.otc_ref, `Response should contain otc_ref for includeOTC=${otcValue}`);
 
                     const mail = mockManager.assert.sentEmail({
                         to: 'member1@test.com'
@@ -916,7 +916,7 @@ describe('sendMagicLink', function () {
                     const response = await sendMagicLinkRequest('member1@test.com', 'signin', otcValue)
                         .expectStatus(201);
 
-                    assert(!response.body.otc_ref, `Response should not contain otc_ref for otc=${otcValue}`);
+                    assert(!response.body.otc_ref, `Response should not contain otc_ref for includeOTC=${otcValue}`);
 
                     const mail = mockManager.assert.sentEmail({
                         to: 'member1@test.com'


### PR DESCRIPTION
no issue

- avoids confusion around `otc` looking like a value property rather than a boolean flag property
- matches the `otc`->`includeOTC` internal re-naming we were already doing
