### PR TITLE
Updated layout of Post Analytics Growth tab

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -31,8 +31,10 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const testingSiteUrl = siteUrl || 'https://levernews.com';
 
     let containerClass = 'flex flex-col items-stretch gap-8';
+    let cardClass = '';
     if (!appSettings?.paidMembersEnabled) {
-        containerClass = 'grid grid-cols-2 gap-8';
+        containerClass = 'grid grid-cols-1 border rounded-md';
+        cardClass = 'border-none hover:shadow-none';
     }
 
     return (
@@ -41,7 +43,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
             <PostAnalyticsContent>
                 {isLoading ?
                     <div className={containerClass}>
-                        <Card>
+                        <Card className={cardClass}>
                             <CardContent className='grid grid-cols-3 p-0'>
                                 {Array.from({length: 3}, (_, i) => (
                                     <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
@@ -52,7 +54,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
 
                             </CardContent>
                         </Card>
-                        <Card>
+                        <Card className={cardClass}>
                             <CardHeader>
                                 <CardTitle>Top sources</CardTitle>
                                 <CardDescription>Where did your growth come from?</CardDescription>
@@ -65,7 +67,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                     </div>
                     :
                     <div className={containerClass}>
-                        <Card data-testid='members-card'>
+                        <Card className={cardClass} data-testid='members-card'>
                             <CardHeader className='hidden'>
                                 <CardTitle>Newsletters</CardTitle>
                                 <CardDescription>How did this post perform</CardDescription>
@@ -124,7 +126,9 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                                 </div>
                             </CardContent>
                         </Card>
+                        {!appSettings?.paidMembersEnabled && <Separator />}
                         <GrowthSources
+                            className={cardClass}
                             data={postReferrers}
                             mode="growth"
                             siteIcon={siteIcon}

--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, formatNumber} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/App';
 
 // Default source icon URL - apps can override this
@@ -90,6 +90,7 @@ interface SourcesCardProps {
     siteIcon?: string;
     defaultSourceIconUrl?: string;
     getPeriodText?: (range: number) => string;
+    className?: string;
 }
 
 export const GrowthSources: React.FC<SourcesCardProps> = ({
@@ -102,7 +103,8 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
     siteUrl,
     siteIcon,
     defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
-    getPeriodText
+    getPeriodText,
+    className
 }) => {
     const {appSettings} = useAppContext();
     const navigate = useNavigate();
@@ -141,7 +143,7 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
         : `How readers found your ${range ? 'site' : 'post'}${range && getPeriodText ? ` ${getPeriodText(range)}` : ''}`;
 
     return (
-        <Card className='group/datalist w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]' data-testid='top-sources-card'>
+        <Card className={cn('group/datalist w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]', className)} data-testid='top-sources-card'>
             {topSources.length <= 0 &&
                 <CardHeader>
                     <CardTitle>{title}</CardTitle>


### PR DESCRIPTION
ref. https://linear.app/ghost/issue/ENG-2499/improve-layout-of-post-analytics-growth-for-sites-with-no-paid

- Adjusted the layout and styling of the Growth component based on the appSettings for better visual consistency, for paid-members-OFF use case.