### PR TITLE
Added tests for SingleUseTokenProvider validate function

### DIFF
--- a/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
@@ -339,9 +339,10 @@ describe('SingleUseTokenProvider', function () {
 
             await assert.rejects(
                 tokenProvider.validate(testToken),
-                ValidationError,
-                ERROR_MESSAGES.INVALID_TOKEN
+                {code: 'INVALID_TOKEN'}
             );
+
+            sinon.assert.calledWith(notFoundMockModel.findOne, {token: testToken}, {transacting: 'test-transaction', forUpdate: true});
         });
 
         describe('expiration scenarios', function () {
@@ -349,8 +350,7 @@ describe('SingleUseTokenProvider', function () {
                 buildModel({usedCount: 7});
                 await assert.rejects(
                     tokenProvider.validate(testToken),
-                    ValidationError,
-                    ERROR_MESSAGES.TOKEN_EXPIRED
+                    {code: 'TOKEN_EXPIRED'}
                 );
             });
 
@@ -359,8 +359,7 @@ describe('SingleUseTokenProvider', function () {
                 buildModel({createdAt: oldDate});
                 await assert.rejects(
                     tokenProvider.validate(testToken),
-                    ValidationError,
-                    ERROR_MESSAGES.TOKEN_EXPIRED
+                    {code: 'TOKEN_EXPIRED'}
                 );
             });
 
@@ -369,8 +368,7 @@ describe('SingleUseTokenProvider', function () {
                 buildModel({usedCount: 1, firstUsedAt: oldUsageDate});
                 await assert.rejects(
                     tokenProvider.validate(testToken),
-                    ValidationError,
-                    ERROR_MESSAGES.TOKEN_EXPIRED
+                    {code: 'TOKEN_EXPIRED'}
                 );
             });
         });

--- a/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
@@ -355,7 +355,7 @@ describe('SingleUseTokenProvider', function () {
             });
 
             it('should throw ValidationError when token is expired by lifetime', async function () {
-                const oldDate = new Date(Date.now() - 86400001);
+                const oldDate = new Date(Date.now() - 86400001); // 24 hours + 1 ms ago (exceeds lifetime)
                 buildModel({createdAt: oldDate});
                 await assert.rejects(
                     tokenProvider.validate(testToken),
@@ -364,7 +364,7 @@ describe('SingleUseTokenProvider', function () {
             });
 
             it('should throw ValidationError when token is expired after usage', async function () {
-                const oldUsageDate = new Date(Date.now() - 3600001);
+                const oldUsageDate = new Date(Date.now() - 3600001); // 1 hour + 1 ms ago (exceeds post-usage validity)
                 buildModel({usedCount: 1, firstUsedAt: oldUsageDate});
                 await assert.rejects(
                     tokenProvider.validate(testToken),
@@ -374,7 +374,7 @@ describe('SingleUseTokenProvider', function () {
         });
 
         it('should increment usage count for previously used token', async function () {
-            const firstUsedDate = new Date(Date.now() - 1800000);
+            const firstUsedDate = new Date(Date.now() - 1800000); // 30 minutes ago (within 1-hour window)
             const usedMockModel = createMockModel({
                 usedCount: 1,
                 firstUsedAt: firstUsedDate


### PR DESCRIPTION
no issue

- Adds tests for the basic functionality of the `validate` function in `SingleUseTokenProvider`, other than for the otc path (already added)
