### PR TITLE
Added optional `otcVerification` arg to members `getSigninURL()`

### DIFF
--- a/ghost/core/core/server/services/members/MembersConfigProvider.js
+++ b/ghost/core/core/server/services/members/MembersConfigProvider.js
@@ -82,13 +82,23 @@ class MembersConfigProvider {
         };
     }
 
-    getSigninURL(token, type, referrer) {
+    /**
+     * @param {string} token
+     * @param {string} type - also known as "action", e.g. "signin" or "signup"
+     * @param {string} [referrer] - optional URL for redirecting to after signin
+     * @param {string} [otcVerification] - optional for verifying an OTC signin redirect
+     * @returns {string}
+     */
+    getSigninURL(token, type, referrer, otcVerification) {
         const siteUrl = this._urlUtils.urlFor({relativeUrl: '/members/'}, true);
         const signinURL = new URL(siteUrl);
         signinURL.searchParams.set('token', token);
         signinURL.searchParams.set('action', type);
         if (referrer) {
             signinURL.searchParams.set('r', referrer);
+        }
+        if (otcVerification) {
+            signinURL.searchParams.set('otc_verification', otcVerification);
         }
         return signinURL.toString();
     }

--- a/ghost/core/test/unit/server/services/members/config.test.js
+++ b/ghost/core/test/unit/server/services/members/config.test.js
@@ -74,7 +74,26 @@ describe('Members - config', function () {
     });
 
     it('can get correct signinUrl', function () {
-        const signinUrl = membersConfig.getSigninURL('a', 'b');
-        assert.equal(signinUrl, 'http://domain.tld/subdir/members/?token=a&action=b');
+        const signinUrl = new URL(membersConfig.getSigninURL('a', 'b'));
+        assert.equal(signinUrl.origin + signinUrl.pathname, 'http://domain.tld/subdir/members/');
+        assert.equal(signinUrl.searchParams.get('token'), 'a');
+        assert.equal(signinUrl.searchParams.get('action'), 'b');
+    });
+
+    it('can get correct signinUrl with referrer', function () {
+        const signinUrl = new URL(membersConfig.getSigninURL('a', 'b', 'http://domain.tld/my-post/'));
+        assert.equal(signinUrl.origin + signinUrl.pathname, 'http://domain.tld/subdir/members/');
+        assert.equal(signinUrl.searchParams.get('token'), 'a');
+        assert.equal(signinUrl.searchParams.get('action'), 'b');
+        assert.equal(signinUrl.searchParams.get('r'), 'http://domain.tld/my-post/');
+    });
+
+    it('can get correct signinUrl with referrer and otcVerification', function () {
+        const signinUrl = new URL(membersConfig.getSigninURL('a', 'b', 'c', 'd'));
+        assert.equal(signinUrl.origin + signinUrl.pathname, 'http://domain.tld/subdir/members/');
+        assert.equal(signinUrl.searchParams.get('token'), 'a');
+        assert.equal(signinUrl.searchParams.get('action'), 'b');
+        assert.equal(signinUrl.searchParams.get('r'), 'c');
+        assert.equal(signinUrl.searchParams.get('otc_verification'), 'd');
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2497

- after verifying a OTC we'll redirect to the normal signin URL with an OTC verification hash
- this updates our `getSigninURL` method to correctly build such a URL
- updated tests to use URL parsing to ensure we're escaping correctly and avoid param ordering dependency
