### PR TITLE
Resolve Playwright session storage path correctly

### DIFF
--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import path from 'path';
 dotenv.config();
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
@@ -25,7 +26,7 @@ const config = {
             testDir: './tests',
             use: {
                 // Use authentication state for all tests by default
-                storageState: 'playwright/.auth/user.json',
+                storageState: path.resolve(import.meta.dirname, './playwright/.auth/user.json'),
                 viewport: {width: 1920, height: 1080}
             },
             dependencies: ['setup']


### PR DESCRIPTION
Use `path.resolve` to get full path to user auth state. With only a relative path Playwright fails with the error below when running from within the test explorer in VSCode or Cursor.

> Error: Error reading storage state from playwright/.auth/user.json

With the fix in place, the test explorer and inline reporter works as expected!

<img width="1485" height="1035" alt="Screenshot 2025-09-02 at 12 57 20" src="https://github.com/user-attachments/assets/f7248cc2-cffa-4aa7-baa1-a13c8f5e7ff1" />
