### PR TITLE
Reduced hidden nav hover area to improve clickability

### DIFF
--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -139,7 +139,10 @@ body:not(.gh-body-fullscreen) .gh-viewport {
 
 .gh-nav-hidden .gh-toggle-nav-menu {
     width: 60px;
+    max-height: 400px;
+    top: 50%;
     right: -60px;
+    transform: translateY(-50%);
 }
 
 .gh-nav:hover .gh-toggle-nav-menu,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2368/back-button-becomes-impossible-to-click-when-the-sidebar-is-hidden

- Decreased hover detection area of hidden navigation menu
- Fixed issue where attempting to click top screen elements triggered nav appearance
- Prevented accidental nav activation when interacting with content