### PR TITLE
Improved docker build caching for admin & microfrontends

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -81,9 +81,113 @@ COPY patches patches
 RUN yarn install --frozen-lockfile --prefer-offline
 
 # --------------------
+# Shade Builder
+# --------------------
+FROM development-base AS shade-builder
+WORKDIR /home/ghost
+COPY apps/shade apps/shade
+RUN cd apps/shade && yarn build
+
+# --------------------
+# Admin-x-design-system Builder
+# --------------------
+FROM development-base AS admin-x-design-system-builder
+WORKDIR /home/ghost
+COPY apps/admin-x-design-system apps/admin-x-design-system
+RUN cd apps/admin-x-design-system && yarn build
+
+# --------------------
+# Admin-x-framework Builder
+# --------------------
+FROM development-base AS admin-x-framework-builder
+WORKDIR /home/ghost
+COPY apps/admin-x-framework apps/admin-x-framework
+COPY --from=shade-builder /home/ghost/apps/shade/es apps/shade/es
+COPY --from=shade-builder /home/ghost/apps/shade/types apps/shade/types
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/es apps/admin-x-design-system/es
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/types apps/admin-x-design-system/types
+RUN cd apps/admin-x-framework && yarn build
+
+# --------------------
+# Stats Builder
+# --------------------
+FROM development-base AS stats-builder
+WORKDIR /home/ghost
+COPY apps/stats apps/stats
+COPY --from=shade-builder /home/ghost/apps/shade apps/shade
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/es apps/admin-x-design-system/es
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/types apps/admin-x-design-system/types
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/dist apps/admin-x-framework/dist
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/types apps/admin-x-framework/types
+RUN cd apps/stats && yarn build
+
+# --------------------
+# Posts Builder
+# --------------------
+FROM development-base AS posts-builder
+WORKDIR /home/ghost
+COPY apps/posts apps/posts
+COPY --from=shade-builder /home/ghost/apps/shade apps/shade
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/es apps/admin-x-design-system/es
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/types apps/admin-x-design-system/types
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/dist apps/admin-x-framework/dist
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/types apps/admin-x-framework/types
+RUN cd apps/posts && yarn build
+
+# --------------------
+# Admin-x-settings Builder
+# --------------------
+FROM development-base AS admin-x-settings-builder
+WORKDIR /home/ghost
+COPY apps/admin-x-settings apps/admin-x-settings
+COPY --from=shade-builder /home/ghost/apps/shade apps/shade
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system apps/admin-x-design-system
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/dist apps/admin-x-framework/dist
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/types apps/admin-x-framework/types
+RUN cd apps/admin-x-settings && yarn build
+
+# --------------------
+# Admin-x-activitypub Builder
+# --------------------
+FROM development-base AS admin-x-activitypub-builder
+WORKDIR /home/ghost
+COPY apps/admin-x-activitypub apps/admin-x-activitypub
+COPY --from=shade-builder /home/ghost/apps/shade apps/shade
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/es apps/admin-x-design-system/es
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/types apps/admin-x-design-system/types
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/dist apps/admin-x-framework/dist
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/types apps/admin-x-framework/types
+RUN cd apps/admin-x-activitypub && yarn build
+
+# --------------------
+# Admin Ember Builder
+# --------------------
+FROM development-base AS admin-ember-builder
+WORKDIR /home/ghost
+COPY ghost/admin ghost/admin
+COPY ghost/core ghost/core
+COPY --from=stats-builder /home/ghost/apps/stats/dist apps/stats/dist
+COPY --from=posts-builder /home/ghost/apps/posts/dist apps/posts/dist
+COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps/admin-x-settings/dist
+COPY --from=admin-x-activitypub-builder /home/ghost/apps/admin-x-activitypub/dist apps/admin-x-activitypub/dist
+RUN cd ghost/admin && yarn build
+
+# --------------------
 # Development
 # --------------------
 FROM development-base AS development
 COPY . .
-RUN yarn build
+COPY --from=shade-builder /home/ghost/apps/shade/es apps/shade/es
+COPY --from=shade-builder /home/ghost/apps/shade/types apps/shade/types
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/es apps/admin-x-design-system/es
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system/types apps/admin-x-design-system/types
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/dist apps/admin-x-framework/dist
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework/types apps/admin-x-framework/types
+COPY --from=stats-builder /home/ghost/apps/stats/dist apps/stats/dist
+COPY --from=posts-builder /home/ghost/apps/posts/dist apps/posts/dist
+COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps/admin-x-settings/dist
+COPY --from=admin-x-activitypub-builder /home/ghost/apps/admin-x-activitypub/dist apps/admin-x-activitypub/dist
+COPY --from=admin-ember-builder /home/ghost/ghost/admin ghost/admin/dist
+COPY --from=admin-ember-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
+
 CMD ["yarn", "dev"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -187,7 +187,7 @@ COPY --from=stats-builder /home/ghost/apps/stats/dist apps/stats/dist
 COPY --from=posts-builder /home/ghost/apps/posts/dist apps/posts/dist
 COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps/admin-x-settings/dist
 COPY --from=admin-x-activitypub-builder /home/ghost/apps/admin-x-activitypub/dist apps/admin-x-activitypub/dist
-COPY --from=admin-ember-builder /home/ghost/ghost/admin ghost/admin/dist
+COPY --from=admin-ember-builder /home/ghost/ghost/admin/dist ghost/admin/dist
 COPY --from=admin-ember-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
 
 CMD ["yarn", "dev"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,5 @@ compose.yml
 .docker
 !.docker/**/*.entrypoint.sh
 !.docker/**/*entrypoint.sh
+
+ghost/core/core/built/admin


### PR DESCRIPTION
With the current Dockerfile, we aren't able to cache any of the admin microfrontend builds, so we rebuild _all_ of them whenever _any_ file in the repo has changed. This PR uses multi-stage builds to improve our caching, so we only rebuild packages when their own code has changed.

Each package gets its own "builder" stage, which copies only the files it needs to build itself. Then in the final development image, we copy all of the code from the whole repo, then copy the build outputs from each builder stage into their proper locations.

In a best case scenario where you're only changing code in `ghost/core` and not touching any of the microfrontends, this reduces the warm build time by upwards of 90 seconds.

The main benefit here is in CI: now if you only change code in `ghost/core` without changing dependencies, all of the package builds should be fully cached, saving up to 3 minutes on the build time. This is less impactful for local development, since the code is mounted into the container and we rebuild on file changes _within_ the container.