### PR TITLE
Bundled card assets with ActivityPub client

### DIFF
--- a/apps/admin-x-activitypub/src/utils/cards-assets.ts
+++ b/apps/admin-x-activitypub/src/utils/cards-assets.ts
@@ -1,0 +1,10 @@
+const jsModules = import.meta.glob('@ghost-cards/js/*.js', {query: 'raw', eager: true}) as Record<string, {default: string}>;
+const cssModules = import.meta.glob('@ghost-cards/css/*.css', {query: 'raw', eager: true}) as Record<string, {default: string}>;
+
+export const cardsJS = Object.values(jsModules)
+    .map(module => module.default)
+    .join('\n\n');
+
+export const cardsCSS = Object.values(cssModules)
+    .map(module => module.default)
+    .join('\n\n');

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -17,10 +17,10 @@ import TableOfContents, {TOCItem} from '@src/components/feed/TableOfContents';
 import articleBodyStyles from '@src/components/articleBodyStyles';
 import getReadingTime from '../../../utils/get-reading-time';
 import {Activity} from '@src/api/activitypub';
+import {cardsCSS, cardsJS} from '@src/utils/cards-assets';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
-import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useDebounce} from 'use-debounce';
 import {useNavigate} from '@tryghost/admin-x-framework';
 
@@ -45,7 +45,6 @@ const ArticleBody: React.FC<{
     onIframeLoad?: (iframe: HTMLIFrameElement) => void;
     onLoadingChange?: (isLoading: boolean) => void;
     isPopoverOpen: boolean;
-    siteUrl?: string;
 }> = ({
     postUrl,
     heading,
@@ -59,8 +58,7 @@ const ArticleBody: React.FC<{
     onHeadingsExtracted,
     onIframeLoad,
     onLoadingChange,
-    isPopoverOpen,
-    siteUrl
+    isPopoverOpen
 }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -85,6 +83,9 @@ const ArticleBody: React.FC<{
                 .has-sepia-bg {
                     --background-color: #FCF8F1;
                 }
+            </style>
+            <style>
+                ${cardsCSS}
             </style>
 
             <script>
@@ -152,15 +153,6 @@ const ArticleBody: React.FC<{
                 document.addEventListener('DOMContentLoaded', () => {
                     setupResizeObservers();
                     waitForImages();
-
-                    const script = document.createElement('script');
-                    script.src = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.js` : '/public/cards.min.js'}';
-                    document.head.appendChild(script);
-
-                    const link = document.createElement('link');
-                    link.rel = 'stylesheet';
-                    link.href = '${siteUrl ? `${siteUrl.replace(/\/$/, '')}/public/cards.min.css` : '/public/cards.min.css'}';
-                    document.head.appendChild(link);
                 });
             </script>
 
@@ -214,6 +206,9 @@ const ArticleBody: React.FC<{
                     ];
                     reframe(document.querySelectorAll(sources.join(',')));
                 })();
+            </script>
+            <script>
+                ${cardsJS}
             </script>
         </body>
         </html>
@@ -427,7 +422,6 @@ export const Reader: React.FC<ReaderProps> = ({
         decreaseFontSize,
         resetFontSize
     } = useCustomizerSettings();
-    const {data: siteData} = useBrowseSite();
     const modalRef = useRef<HTMLElement>(null);
     const [isCustomizerOpen, setIsCustomizerOpen] = useState(false);
     const [isTOCOpen, setIsTOCOpen] = useState(false);
@@ -846,7 +840,6 @@ export const Reader: React.FC<ReaderProps> = ({
                                             image={typeof object.image === 'string' ? object.image : object.image?.url}
                                             isPopoverOpen={isCustomizerOpen || isTOCOpen}
                                             postUrl={object?.url || ''}
-                                            siteUrl={siteData?.site?.url}
                                             onHeadingsExtracted={handleHeadingsExtracted}
                                             onIframeLoad={handleIframeLoad}
                                             onLoadingChange={setIsLoading}

--- a/apps/admin-x-activitypub/vite.config.mjs
+++ b/apps/admin-x-activitypub/vite.config.mjs
@@ -1,9 +1,47 @@
 import adminXViteConfig from '@tryghost/admin-x-framework/vite';
 import pkg from './package.json';
 import {resolve} from 'path';
+import fs from 'fs';
+
+const GHOST_CARDS_PATH = resolve(__dirname, '../../ghost/core/core/frontend/src/cards');
+
+const validateCardsDirectoryPlugin = (cardsPath) => {
+    return {
+        name: 'validate-cards-directory',
+        buildStart() {
+            const jsPath = resolve(cardsPath, 'js');
+            const cssPath = resolve(cardsPath, 'css');
+
+            if (!fs.existsSync(cardsPath)) {
+                throw new Error(`Ghost cards directory not found at: ${cardsPath}`);
+            }
+
+            if (!fs.existsSync(jsPath)) {
+                throw new Error(`Ghost cards JS directory not found at: ${jsPath}`);
+            }
+
+            if (!fs.existsSync(cssPath)) {
+                throw new Error(`Ghost cards CSS directory not found at: ${cssPath}`);
+            }
+
+            const jsFiles = fs.readdirSync(jsPath).filter(f => f.endsWith('.js'));
+            const cssFiles = fs.readdirSync(cssPath).filter(f => f.endsWith('.css'));
+
+            if (jsFiles.length === 0) {
+                throw new Error(`No JavaScript files found in Ghost cards directory: ${jsPath}`);
+            }
+
+            if (cssFiles.length === 0) {
+                throw new Error(`No CSS files found in Ghost cards directory: ${cssPath}`);
+            }
+
+            console.log(`✓ Found ${jsFiles.length} JS and ${cssFiles.length} CSS card files at: ${cardsPath}`);
+        }
+    };
+};
 
 export default (function viteConfig() {
-    return adminXViteConfig({
+    const config = adminXViteConfig({
         packageName: pkg.name,
         entry: resolve(__dirname, 'src/index.tsx'),
         overrides: {
@@ -20,9 +58,15 @@ export default (function viteConfig() {
                     '@components': resolve(__dirname, './src/components'),
                     '@hooks': resolve(__dirname, './src/hooks'),
                     '@utils': resolve(__dirname, './src/utils'),
-                    '@views': resolve(__dirname, './src/views')
+                    '@views': resolve(__dirname, './src/views'),
+                    '@ghost-cards': GHOST_CARDS_PATH
                 }
-            }
+            },
+            plugins: [
+                validateCardsDirectoryPlugin(GHOST_CARDS_PATH)
+            ]
         }
     });
+
+    return config;
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2481

Loading card assets from the frontend is unreliable because themes can exclude certain assets, but we need all of them. Bundling them with the ActivityPub client means that our dependencies are self contained. If we were to load them via the Admin, that would introduce a dependancy and make versioning more difficult.

