### PR TITLE
Updated daily charts of Analytics to show hours

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Kpis.tsx
@@ -100,6 +100,7 @@ const Kpis:React.FC<KpisProps> = ({data, range}) => {
                             data={chartData}
                             id={currentMetric.dataKey}
                             range={range}
+                            showHours={true}
                             syncId="overview-charts"
                         />
                     </div>

--- a/apps/shade/src/components/ui/gh-chart.tsx
+++ b/apps/shade/src/components/ui/gh-chart.tsx
@@ -21,10 +21,11 @@ interface TooltipProps {
     active?: boolean;
     payload?: TooltipPayload[];
     range?: number;
+    showHours?: boolean;
     color?: string;
 }
 
-const GhCustomTooltipContent = ({active, payload, range, color}: TooltipProps) => {
+const GhCustomTooltipContent = ({active, payload, range, showHours, color}: TooltipProps) => {
     if (!active || !payload?.length) {
         return null;
     }
@@ -34,7 +35,7 @@ const GhCustomTooltipContent = ({active, payload, range, color}: TooltipProps) =
 
     return (
         <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
-            {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range || 0)}</div>}
+            {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range || 0, showHours)}</div>}
             <div className='flex items-start gap-2'>
                 <span className='mt-1.5 inline-block size-2 rounded-full opacity-50' style={{backgroundColor: color || 'hsl(var(--chart-blue))'}}></span>
                 <div className='flex grow items-start justify-between gap-5'>
@@ -83,6 +84,7 @@ interface GhAreaChartProps {
     showYAxisValues?: boolean;
     showHorizontalLines?: boolean;
     dataFormatter?: (value: number) => string;
+    showHours?: boolean;
 }
 
 const GhAreaChart: React.FC<GhAreaChartProps> = ({
@@ -96,7 +98,8 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
     allowDataOverflow = false,
     showYAxisValues = true,
     showHorizontalLines = true,
-    dataFormatter = formatNumber
+    dataFormatter = formatNumber,
+    showHours = false
 }) => {
     const yRange = yAxisRange || [getYRange(data).min, getYRange(data).max];
     const chartConfig = {
@@ -131,8 +134,8 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                     axisLine={{stroke: 'hsl(var(--border))', strokeWidth: 1}}
                     dataKey="date"
                     interval={0}
-                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(String(value), range)} />}
-                    tickFormatter={value => formatDisplayDateWithRange(String(value), range)}
+                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(String(value), range, showHours)} />}
+                    tickFormatter={value => formatDisplayDateWithRange(String(value), range, showHours)}
                     tickLine={false}
                     tickMargin={10}
                     ticks={data && data.length > 0 ? [data[0].date, data[data.length - 1].date] : []}
@@ -150,7 +153,7 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                     width={showYAxisValues ? calculateYAxisWidth(yRange, dataFormatter) : 0}
                 />
                 <ChartTooltip
-                    content={<GhCustomTooltipContent color={color} range={range} />}
+                    content={<GhCustomTooltipContent color={color} range={range} showHours={showHours} />}
                     cursor={true}
                     isAnimationActive={false}
                     position={{y: 10}}

--- a/apps/shade/src/components/ui/gh-chart.tsx
+++ b/apps/shade/src/components/ui/gh-chart.tsx
@@ -116,6 +116,8 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
     const isWholeMid = Number.isInteger(midValue);
     const yTicks = isWholeMid ? [yRange[0], midValue, yRange[1]] : yRange;
 
+    const xTickHoursOnly = showHours && range === 1;
+
     return (
         <ChartContainer className={
             cn('w-full', className)
@@ -134,7 +136,7 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                     axisLine={{stroke: 'hsl(var(--border))', strokeWidth: 1}}
                     dataKey="date"
                     interval={0}
-                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(String(value), range, showHours)} />}
+                    tick={props => <AlignedAxisTick {...props} formatter={value => formatDisplayDateWithRange(String(value), range, showHours, xTickHoursOnly)} />}
                     tickFormatter={value => formatDisplayDateWithRange(String(value), range, showHours)}
                     tickLine={false}
                     tickMargin={10}

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -594,8 +594,10 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
  * - For ranges above 91 days: shows "Week of [date]"
  * - For other ranges: uses the default formatDisplayDate
  */
-export const formatDisplayDateWithRange = (date: string, range: number, showHours: boolean = false): string => {
-    if (range === 1 && showHours) {
+export const formatDisplayDateWithRange = (date: string, range: number, showHours: boolean = false, hoursOnly: boolean = false): string => {
+    if (range === 1 && hoursOnly) {
+        return moment(date).format('h:mma');
+    } else if (range === 1 && showHours) {
         return moment(date).format('MMM D, h:mma');
     } else if (range > 365) {
         return moment(date).format('MMM YYYY');

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -172,12 +172,12 @@ export const formatDisplayDate = (dateString: string): string => {
 
     // Check if this is a datetime string (contains time) or just a date
     const hasTime = dateString.includes(':');
-    
+
     const date = new Date(dateString);
     const today = new Date();
-    
+
     let day, month, year, isToday, isCurrentYear;
-    
+
     if (hasTime && !dateString.includes('T') && !dateString.includes('Z')) {
         // This is a localized datetime string like "2025-07-29 19:00:00"
         // Use local date methods to avoid timezone conversion
@@ -595,7 +595,9 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
  * - For other ranges: uses the default formatDisplayDate
  */
 export const formatDisplayDateWithRange = (date: string, range: number): string => {
-    if (range > 365) {
+    if (range === 1) {
+        return moment(date).format('MMM D, h:mma');
+    } else if (range > 365) {
         return moment(date).format('MMM YYYY');
     } else if (range >= 91) {
         return `Week of ${formatDisplayDate(date)}`;

--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -594,8 +594,8 @@ export const sanitizeChartData = <T extends {date: string}>(data: T[], range: nu
  * - For ranges above 91 days: shows "Week of [date]"
  * - For other ranges: uses the default formatDisplayDate
  */
-export const formatDisplayDateWithRange = (date: string, range: number): string => {
-    if (range === 1) {
+export const formatDisplayDateWithRange = (date: string, range: number, showHours: boolean = false): string => {
+    if (range === 1 && showHours) {
         return moment(date).format('MMM D, h:mma');
     } else if (range > 365) {
         return moment(date).format('MMM YYYY');

--- a/apps/stats/src/views/Stats/Web/components/WebKPIs.tsx
+++ b/apps/stats/src/views/Stats/Web/components/WebKPIs.tsx
@@ -106,6 +106,7 @@ const WebKPIs: React.FC<WebKPIsProps> = ({data, range, isLoading}) => {
                     data={chartData}
                     id="mrr"
                     range={range}
+                    showHours={true}
                     yAxisRange={[0, getYRange(chartData).max]}
                 />
             </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1858/add-hours-to-tooltip-when-in-today-view

- When "Today" is selected as the range for charts, we still show a daily breakdown in tooltips and in the chart labels. For daily range it should show hours which is much more useful for users.