### PR TITLE
Updated icon in growth sources tables for email

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -1,35 +1,11 @@
 import React from 'react';
+import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate} from '@tryghost/admin-x-framework';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/App';
 
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
-
-interface SourceIconProps {
-    displayName: string;
-    iconSrc: string;
-    defaultSourceIconUrl: string;
-}
-
-const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
-    return (
-        <>
-            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
-                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
-            ) : (
-                <img
-                    alt=""
-                    className="size-4"
-                    src={iconSrc}
-                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                        e.currentTarget.src = defaultSourceIconUrl;
-                    }}
-                />
-            )}
-        </>
-    );
-};
 
 interface SourcesTableProps {
     data: ProcessedSourceData[] | null;

--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -6,6 +6,31 @@ import {useAppContext} from '@src/App';
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
 
+interface SourceIconProps {
+    displayName: string;
+    iconSrc: string;
+    defaultSourceIconUrl: string;
+}
+
+const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
+    return (
+        <>
+            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+            ) : (
+                <img
+                    alt=""
+                    className="size-4"
+                    src={iconSrc}
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                        e.currentTarget.src = defaultSourceIconUrl;
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
 interface SourcesTableProps {
     data: ProcessedSourceData[] | null;
     mode: 'visits' | 'growth';
@@ -43,22 +68,20 @@ const SourcesTable: React.FC<SourcesTableProps> = ({headerStyle = 'table', child
                                 <TableCell>
                                     {row.linkUrl ?
                                         <a className='group flex items-center gap-2' href={row.linkUrl} rel="noreferrer" target="_blank">
-                                            <img
-                                                className="size-4"
-                                                src={row.iconSrc}
-                                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                    e.currentTarget.src = defaultSourceIconUrl;
-                                                }} />
+                                            <SourceIcon
+                                                defaultSourceIconUrl={defaultSourceIconUrl}
+                                                displayName={row.displayName}
+                                                iconSrc={row.iconSrc}
+                                            />
                                             <span className='group-hover:underline'>{row.displayName}</span>
                                         </a>
                                         :
                                         <span className='flex items-center gap-2'>
-                                            <img
-                                                className="size-4"
-                                                src={row.iconSrc}
-                                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                    e.currentTarget.src = defaultSourceIconUrl;
-                                                }} />
+                                            <SourceIcon
+                                                defaultSourceIconUrl={defaultSourceIconUrl}
+                                                displayName={row.displayName}
+                                                iconSrc={row.iconSrc}
+                                            />
                                             <span>{row.displayName}</span>
                                         </span>
                                     }

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -1,35 +1,11 @@
 import React from 'react';
+import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
-
-interface SourceIconProps {
-    displayName: string;
-    iconSrc: string;
-    defaultSourceIconUrl: string;
-}
-
-const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
-    return (
-        <>
-            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
-                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
-            ) : (
-                <img
-                    alt=""
-                    className="size-4"
-                    src={iconSrc}
-                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                        e.currentTarget.src = defaultSourceIconUrl;
-                    }}
-                />
-            )}
-        </>
-    );
-};
 
 interface SourcesTableProps {
     data: ProcessedSourceData[] | null;

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -6,6 +6,31 @@ import {getPeriodText} from '@src/utils/chart-helpers';
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
 
+interface SourceIconProps {
+    displayName: string;
+    iconSrc: string;
+    defaultSourceIconUrl: string;
+}
+
+const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
+    return (
+        <>
+            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+            ) : (
+                <img
+                    alt=""
+                    className="size-4"
+                    src={iconSrc}
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                        e.currentTarget.src = defaultSourceIconUrl;
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
 interface SourcesTableProps {
     data: ProcessedSourceData[] | null;
     range?: number;
@@ -34,22 +59,20 @@ export const SourcesTable: React.FC<SourcesTableProps> = ({dataTableHeader, data
                                     <div className='truncate font-medium'>
                                         {row.linkUrl ?
                                             <a className='group/link flex items-center gap-2' href={row.linkUrl} rel="noreferrer" target="_blank">
-                                                <img
-                                                    className="size-4"
-                                                    src={row.iconSrc}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = defaultSourceIconUrl;
-                                                    }} />
+                                                <SourceIcon
+                                                    defaultSourceIconUrl={defaultSourceIconUrl}
+                                                    displayName={row.displayName}
+                                                    iconSrc={row.iconSrc}
+                                                />
                                                 <span className='group-hover/link:underline'>{row.displayName}</span>
                                             </a>
                                             :
                                             <span className='flex items-center gap-2'>
-                                                <img
-                                                    className="size-4"
-                                                    src={row.iconSrc}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = defaultSourceIconUrl;
-                                                    }} />
+                                                <SourceIcon
+                                                    defaultSourceIconUrl={defaultSourceIconUrl}
+                                                    displayName={row.displayName}
+                                                    iconSrc={row.iconSrc}
+                                                />
                                                 <span>{row.displayName}</span>
                                             </span>
                                         }

--- a/apps/posts/src/views/PostAnalytics/components/SourceIcon.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/SourceIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {LucideIcon} from '@tryghost/shade';
+
+interface SourceIconProps {
+    displayName: string;
+    iconSrc: string;
+    defaultSourceIconUrl: string;
+}
+
+const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
+    return (
+        <>
+            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+            ) : (
+                <img
+                    alt=""
+                    className="size-4"
+                    src={iconSrc}
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                        e.currentTarget.src = defaultSourceIconUrl;
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
+export default SourceIcon;

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import SortButton from '../../components/SortButton';
+import SourceIcon from '../../components/SourceIcon';
 import {Button, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, centsToDollars, formatNumber} from '@tryghost/shade';
 import {getFaviconDomain, getSymbol, useAppContext} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@src/utils/chart-helpers';
@@ -37,18 +38,11 @@ const GrowthSourcesTableBody: React.FC<GrowthSourcesTableProps> = ({data, curren
                 <TableRow key={row.source} className='last:border-none'>
                     <TableCell className="font-medium">
                         <div className="flex items-center gap-2">
-                            {row.displayName.trim().toLowerCase().endsWith('newsletter') ? (
-                                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
-                            ) : (
-                                <img
-                                    alt=""
-                                    className="size-4"
-                                    src={row.iconSrc}
-                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                        e.currentTarget.src = defaultSourceIconUrl;
-                                    }}
-                                />
-                            )}
+                            <SourceIcon
+                                defaultSourceIconUrl={defaultSourceIconUrl}
+                                displayName={row.displayName}
+                                iconSrc={row.iconSrc}
+                            />
                             {row.linkUrl ? (
                                 <a
                                     className="hover:underline"

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -37,14 +37,18 @@ const GrowthSourcesTableBody: React.FC<GrowthSourcesTableProps> = ({data, curren
                 <TableRow key={row.source} className='last:border-none'>
                     <TableCell className="font-medium">
                         <div className="flex items-center gap-2">
-                            <img
-                                alt=""
-                                className="size-4"
-                                src={row.iconSrc}
-                                onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                    e.currentTarget.src = defaultSourceIconUrl;
-                                }}
-                            />
+                            {row.displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+                            ) : (
+                                <img
+                                    alt=""
+                                    className="size-4"
+                                    src={row.iconSrc}
+                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                                        e.currentTarget.src = defaultSourceIconUrl;
+                                    }}
+                                />
+                            )}
                             {row.linkUrl ? (
                                 <a
                                     className="hover:underline"

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
@@ -12,31 +13,6 @@ interface SourcesTableProps {
     defaultSourceIconUrl?: string;
     tableHeader: boolean;
 }
-
-interface SourceIconProps {
-    displayName: string;
-    iconSrc: string;
-    defaultSourceIconUrl: string;
-}
-
-const SourceIcon: React.FC<SourceIconProps> = ({displayName, iconSrc, defaultSourceIconUrl}) => {
-    return (
-        <>
-            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
-                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
-            ) : (
-                <img
-                    alt=""
-                    className="size-4"
-                    src={iconSrc}
-                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                        e.currentTarget.src = defaultSourceIconUrl;
-                    }}
-                />
-            )}
-        </>
-    );
-};
 
 const SourcesTable: React.FC<SourcesTableProps> = ({tableHeader, data, defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL}) => {
     return (

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -13,6 +13,31 @@ interface SourcesTableProps {
     tableHeader: boolean;
 }
 
+interface SourceIconProps {
+    displayName: string;
+    iconSrc: string;
+    defaultSourceIconUrl: string;
+}
+
+const SourceIcon: React.FC<SourceIconProps> = ({displayName, iconSrc, defaultSourceIconUrl}) => {
+    return (
+        <>
+            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+            ) : (
+                <img
+                    alt=""
+                    className="size-4"
+                    src={iconSrc}
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                        e.currentTarget.src = defaultSourceIconUrl;
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
 const SourcesTable: React.FC<SourcesTableProps> = ({tableHeader, data, defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL}) => {
     return (
         <DataList>
@@ -34,22 +59,20 @@ const SourcesTable: React.FC<SourcesTableProps> = ({tableHeader, data, defaultSo
                                     <div className='truncate font-medium'>
                                         {row.linkUrl ?
                                             <a className='group/link flex items-center gap-2' href={row.linkUrl} rel="noreferrer" target="_blank">
-                                                <img
-                                                    className="size-4"
-                                                    src={row.iconSrc}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = defaultSourceIconUrl;
-                                                    }} />
+                                                <SourceIcon
+                                                    defaultSourceIconUrl={defaultSourceIconUrl}
+                                                    displayName={row.displayName}
+                                                    iconSrc={row.iconSrc}
+                                                />
                                                 <span className='group-hover/link:underline'>{row.displayName}</span>
                                             </a>
                                             :
                                             <span className='flex items-center gap-2'>
-                                                <img
-                                                    className="size-4"
-                                                    src={row.iconSrc}
-                                                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                                                        e.currentTarget.src = defaultSourceIconUrl;
-                                                    }} />
+                                                <SourceIcon
+                                                    defaultSourceIconUrl={defaultSourceIconUrl}
+                                                    displayName={row.displayName}
+                                                    iconSrc={row.iconSrc}
+                                                />
                                                 <span>{row.displayName}</span>
                                             </span>
                                         }

--- a/apps/stats/src/views/Stats/components/SourceIcon.tsx
+++ b/apps/stats/src/views/Stats/components/SourceIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {LucideIcon} from '@tryghost/shade';
+
+interface SourceIconProps {
+    displayName: string;
+    iconSrc: string;
+    defaultSourceIconUrl: string;
+}
+
+const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
+    return (
+        <>
+            {displayName.trim().toLowerCase().endsWith('newsletter') ? (
+                <LucideIcon.Mail aria-label="Newsletter" className="size-4 text-muted-foreground" />
+            ) : (
+                <img
+                    alt=""
+                    className="size-4"
+                    src={iconSrc}
+                    onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                        e.currentTarget.src = defaultSourceIconUrl;
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
+export default SourceIcon;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-209/change-icon-on-sources-from-the-sites-newsletter-to-an-email

- It's been hard to distinguish between newsletter and direct sources in growth sources tables. Using a mail icon makes it much easier to understand at a glance.