### PR TITLE
Add new Header component to Shade

### DIFF
--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-    Button,
-    H1,
-    Navbar,
-    NavbarActions,
-    PageMenu,
-    PageMenuItem
-} from '@tryghost/shade';
+import {Button, Header, PageMenu, PageMenuItem} from '@tryghost/shade';
 import {Link} from '@tryghost/admin-x-framework';
 
 interface TagsHeaderProps {
@@ -16,32 +9,28 @@ interface TagsHeaderProps {
 
 const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
     return (
-        <>
-            <Navbar className="sticky top-0 z-50 -mb-4 flex-col items-start gap-y-2 border-none bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md md:flex-row md:items-center lg:-mb-8 lg:gap-y-4 lg:p-8 dark:bg-black">
-                <H1 className="min-h-[35px] max-w-[920px] indent-0 text-2xl leading-[1.2em] lg:text-3xl">
-                    Tags
-                </H1>
+        <Header variant="inline-nav">
+            <Header.Title>Tags</Header.Title>
 
-                <NavbarActions className="w-full justify-between md:w-auto">
-                    <PageMenu
-                        className="min-h-[34px] pr-2 lg:pr-4"
-                        defaultValue={currentTab}
-                    >
-                        <PageMenuItem value="public" asChild>
-                            <Link to="/tags">Public tags</Link>
-                        </PageMenuItem>
-                        <PageMenuItem value="internal" asChild>
-                            <Link to="/tags?type=internal">Internal tags</Link>
-                        </PageMenuItem>
-                    </PageMenu>
-                    <Button asChild>
-                        <a className="font-bold" href="#/tags/new">
-                            New tag
-                        </a>
-                    </Button>
-                </NavbarActions>
-            </Navbar>
-        </>
+            <Header.Nav>
+                <PageMenu defaultValue={currentTab}>
+                    <PageMenuItem value="public" asChild>
+                        <Link to="/tags">Public tags</Link>
+                    </PageMenuItem>
+                    <PageMenuItem value="internal" asChild>
+                        <Link to="/tags?type=internal">Internal tags</Link>
+                    </PageMenuItem>
+                </PageMenu>
+            </Header.Nav>
+
+            <Header.Actions>
+                <Button asChild>
+                    <a className="font-bold" href="#/tags/new">
+                        New tag
+                    </a>
+                </Button>
+            </Header.Actions>
+        </Header>
     );
 };
 

--- a/apps/shade/src/components/layout/header.stories.tsx
+++ b/apps/shade/src/components/layout/header.stories.tsx
@@ -1,0 +1,157 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Button} from '@/components/ui/button';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator
+} from '@/components/ui/breadcrumb';
+import {Header} from './header';
+import {PageMenu, PageMenuItem} from '@/components/ui/pagemenu';
+
+const meta = {
+    title: 'Layout / Page Header',
+    component: Header,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen'
+    }
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const WithTitleAndActionsAndMenu: Story = {
+    args: {
+        children: (
+            <>
+                <Header.Above>
+                    <Breadcrumb>
+                        <BreadcrumbList>
+                            <BreadcrumbItem>
+                                <BreadcrumbLink href="/">Home</BreadcrumbLink>
+                                <BreadcrumbSeparator />
+                                <BreadcrumbPage>Content Management</BreadcrumbPage>
+                            </BreadcrumbItem>
+                        </BreadcrumbList>
+
+                    </Breadcrumb>
+                </Header.Above>
+                <Header.Title>Content Management</Header.Title>
+                <Header.Meta>Manage your content</Header.Meta>
+                <Header.Actions>
+                    <Button variant="outline">Import</Button>
+                    <Button variant="outline">Export</Button>
+                    <Button variant="destructive">Delete</Button>
+                    <Button>Create New</Button>
+                </Header.Actions>
+                <Header.Nav>
+                    <PageMenu defaultValue="content">
+                        <PageMenuItem value="content">Content</PageMenuItem>
+                        <PageMenuItem value="design">Design</PageMenuItem>
+                        <PageMenuItem value="settings">Settings</PageMenuItem>
+                        <PageMenuItem value="analytics">Analytics</PageMenuItem>
+                    </PageMenu>
+                </Header.Nav>
+            </>
+        )
+    }
+};
+
+export const WithTitleAndActions: Story = {
+    args: {
+        children: (
+            <>
+                <Header.Title>Page Title with Actions</Header.Title>
+                <Header.Actions>
+                    <Button variant="outline">Cancel</Button>
+                    <Button>Save</Button>
+                </Header.Actions>
+            </>
+        )
+    }
+};
+
+export const WithBreadcrumb: Story = {
+    args: {
+        children: (
+            <>
+                <Header.Above>
+                    <Breadcrumb>
+                        <BreadcrumbList>
+                            <BreadcrumbItem>
+                                <BreadcrumbLink href="/">Home</BreadcrumbLink>
+                            </BreadcrumbItem>
+                            <BreadcrumbSeparator />
+                            <BreadcrumbItem>
+                                <BreadcrumbLink href="/settings">
+                                Settings
+                                </BreadcrumbLink>
+                            </BreadcrumbItem>
+                            <BreadcrumbSeparator />
+                            <BreadcrumbItem>
+                                <BreadcrumbPage>General</BreadcrumbPage>
+                            </BreadcrumbItem>
+                        </BreadcrumbList>
+                    </Breadcrumb>
+                </Header.Above>
+
+                <Header.Title>General Settings</Header.Title>
+                
+                <Header.Actions>
+                    <Button variant="outline">Reset</Button>
+                    <Button>Save Changes</Button>
+                </Header.Actions>
+            </>
+        )
+    }
+};
+
+export const LongTitle: Story = {
+    args: {
+        children: (
+            <>
+                <Header.Title>
+                    This is a very long page title that might wrap to multiple
+                    lines depending on the viewport size
+                </Header.Title>
+                <Header.Actions>
+                    <Button>Action</Button>
+                </Header.Actions>
+            </>
+        )
+    }
+};
+
+export const WithInlineMenuAndActions: Story = {
+    args: {
+        variant: 'inline-nav',
+        children: (
+            <>
+                <Header.Title>Content Management</Header.Title>
+                <Header.Nav>
+                    <PageMenu defaultValue="content">
+                        <PageMenuItem value="content">Content</PageMenuItem>
+                        <PageMenuItem value="design">Design</PageMenuItem>
+                        <PageMenuItem value="settings">Settings</PageMenuItem>
+                        <PageMenuItem value="analytics">Analytics</PageMenuItem>
+                    </PageMenu>
+                </Header.Nav>
+                <Header.Actions>
+                    <Button variant="outline">Import</Button>
+                    <Button variant="outline">Export</Button>
+                    <Button variant="destructive">Delete</Button>
+                    <Button>Create New</Button>
+                </Header.Actions>
+            </>
+        )
+    }
+};
+
+export const TitleOnly: Story = {
+    args: {
+        children: <Header.Title>Simple Page Title</Header.Title>
+    }
+};

--- a/apps/shade/src/components/layout/header.tsx
+++ b/apps/shade/src/components/layout/header.tsx
@@ -1,0 +1,86 @@
+import {H1} from './heading';
+import {cn} from '@/lib/utils';
+import {cva, VariantProps} from 'class-variance-authority';
+
+import React from 'react';
+
+type PropsWithChildrenAndClassName = React.PropsWithChildren & {
+    className?: string;
+};
+
+interface HeaderAboveProps extends PropsWithChildrenAndClassName {}
+function HeaderAbove({className, children}: HeaderAboveProps) {
+    return (
+        <div className={cn('flex items-center gap-2 [grid-area:above]', className)}>
+            {children}
+        </div>
+    );
+}
+
+interface HeaderTitleProps extends PropsWithChildrenAndClassName {}
+function HeaderTitle({className, children}: HeaderTitleProps) {
+    return (
+        <H1
+            className={cn(
+                'text-2xl leading-[1.2em] lg:text-3xl [grid-area:title] py-2',
+                className
+            )}
+        >
+            {children}
+        </H1>
+    );
+}
+
+interface HeaderMetaProps extends PropsWithChildrenAndClassName {}
+function HeaderMeta({className, children}: HeaderMetaProps) {
+    return (
+        <div className={cn('flex items-center justify-start text-muted-foreground [grid-area:meta] pb-4', className)}>
+            {children}
+        </div>
+    );
+}
+
+interface HeaderActionsProps extends PropsWithChildrenAndClassName {}
+function HeaderActions({className, children}: HeaderActionsProps) {
+    return (
+        <div className={cn('flex items-center gap-2 [grid-area:actions] sm:justify-self-end place-self-baseline py-2', className)}>
+            {children}
+        </div>
+    );
+}
+interface HeaderNavProps extends PropsWithChildrenAndClassName {}
+function HeaderNav({className, children}: HeaderNavProps) {
+    return (
+        <div className={cn('flex items-center gap-2 [grid-area:nav] place-self-baseline py-2', className)}>
+            {children}
+        </div>
+    );
+}
+
+const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md [grid-template-areas:'above''title''meta''actions''nav'] sm:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav'] lg:-mb-8 lg:p-8 dark:bg-black`, {
+    variants: {
+        variant: {
+            default: `lg:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav']`,
+            'inline-nav': `lg:[grid-template-areas:'above_above_above''title_nav_actions''meta_nav_actions'] lg:[grid-template-columns:1fr_auto_auto]`
+        }
+    },
+    defaultVariants: {
+        variant: 'default'
+    }
+});
+interface HeaderProps extends PropsWithChildrenAndClassName, VariantProps<typeof headerVariants> {}
+function Header({className, children, variant}: HeaderProps) {
+    return (
+        <header className={cn(headerVariants({variant, className}))}>
+            {children}
+        </header>
+    );
+}
+
+Header.Above = HeaderAbove;
+Header.Title = HeaderTitle;
+Header.Actions = HeaderActions;
+Header.Nav = HeaderNav;
+Header.Meta = HeaderMeta;
+
+export {Header, HeaderActions, HeaderTitle, HeaderNav, HeaderMeta};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -41,6 +41,7 @@ export type {DropdownMenuCheckboxItemProps as DropdownMenuCheckboxItemProps} fro
 export * from './components/layout/page';
 export {ErrorPage} from './components/layout/error-page';
 export * from './components/layout/heading';
+export * from './components/layout/header';
 export * from './components/layout/view-header';
 
 // Feature components — Complete functional components (share modal, etc.)


### PR DESCRIPTION
Refs https://linear.app/ghost/issue/PROD-2506/extract-reusable-header-component-to-shade

Using named grid areas in Tailwind is a bit unintuitive, but it's worth it  since it lets us decouple the order and combination of child components from  the layout.

## Default variant

<img width="1314" height="234" alt="Screenshot 2025-09-05 at 09 45 59" src="https://github.com/user-attachments/assets/967b35a7-bcd8-4e53-b79d-7ef8f18daf82" />

<img width="415" height="236" alt="Screenshot 2025-09-05 at 09 46 32" src="https://github.com/user-attachments/assets/e036d116-8340-4c6e-8d95-381d393d9d83" />


## Inline nav variant

<img width="1315" height="109" alt="Screenshot 2025-09-05 at 09 47 37" src="https://github.com/user-attachments/assets/896fa833-777a-49fc-bb19-431c67cc028d" />

<img width="722" height="119" alt="Screenshot 2025-09-05 at 09 47 54" src="https://github.com/user-attachments/assets/d04707da-788e-4c62-a09d-5e6402e7795b" />
