### PR TITLE
Added UTM query param parsing to frontend scripts

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -1,5 +1,5 @@
 import { getCountryForTimezone } from 'countries-and-timezones';
-import { getReferrer, parseReferrer } from '../utils/url-attribution';
+import { getReferrer, parseReferrerData } from '../utils/url-attribution';
 import { processPayload } from '../utils/privacy';
 import { BrowserService } from './browser-service';
 
@@ -161,7 +161,7 @@ export class GhostStats {
         const navigator = this.browser.getNavigator();
         const location = this.browser.getLocation();
 
-        const referrerData = parseReferrer(location?.href);
+        const referrerData = parseReferrerData(location?.href);
         referrerData.url = getReferrer(location?.href) || referrerData.url; // ensure the referrer.url is set for parsing
 
         // Debounce tracking to avoid duplicates and ensure page has settled

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -162,7 +162,12 @@ export class GhostStats {
         const location = this.browser.getLocation();
 
         const referrerData = parseReferrerData(location?.href);
-        referrerData.url = getReferrer(location?.href) || referrerData.url; // ensure the referrer.url is set for parsing
+        // WORKAROUND: The downstream referrer-parser library requires the 'url' field to be populated
+        // even when attribution comes from query params (e.g., ?ref=ghost-newsletter) with no document.referrer.
+        // We use getReferrer() to get the primary attribution source and fall back to document.referrer.
+        // This means 'url' might contain non-URL values like "ghost-newsletter" when there's no actual referrer.
+        // TODO: Refactor the referrer-parser to handle query param attribution without requiring this hack.
+        referrerData.url = getReferrer(location?.href) || referrerData.url;
 
         // Debounce tracking to avoid duplicates and ensure page has settled
         this.browser.setTimeout(() => {

--- a/ghost/core/core/frontend/src/member-attribution/member-attribution.js
+++ b/ghost/core/core/frontend/src/member-attribution/member-attribution.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 /* eslint-disable no-console */
 const urlAttribution = require('../utils/url-attribution');
-const parseReferrer = urlAttribution.parseReferrer;
+const parseReferrerData = urlAttribution.parseReferrerData;
 const getReferrer = urlAttribution.getReferrer;
 
 // Location where we want to store the history in sessionStorage
@@ -79,10 +79,10 @@ const LIMIT = 15;
             history = [];
         }
 
-        // Get detailed referrer information using parseReferrer
+        // Get detailed referrer information using parseReferrerData
         let referrerData;
         try {
-            referrerData = parseReferrer(window.location.href);
+            referrerData = parseReferrerData(window.location.href);
         } catch (e) {
             console.error('[Member Attribution] Parsing referrer failed', e);
             referrerData = {source: null, medium: null, url: null};
@@ -98,7 +98,7 @@ const LIMIT = 15;
         try {
             referrerUrl = getReferrer(window.location.href);
             // If no referrer value returned by getReferrer but we have a document.referrer,
-            // use the original URL from parseReferrer
+            // use the original URL from parseReferrerData
             if (!referrerUrl && referrerData.url) {
                 referrerUrl = referrerData.url;
             }

--- a/ghost/core/core/frontend/src/utils/url-attribution.js
+++ b/ghost/core/core/frontend/src/utils/url-attribution.js
@@ -7,11 +7,11 @@
  * @property {string|null} source - Primary attribution source (ref || source || utm_source)
  * @property {string|null} medium - UTM medium parameter
  * @property {string|null} url - Browser's document.referrer
- * @property {string|null} utm_source - UTM source parameter
- * @property {string|null} utm_medium - UTM medium parameter
- * @property {string|null} utm_term - UTM term/keyword parameter
- * @property {string|null} utm_campaign - UTM campaign parameter
- * @property {string|null} utm_content - UTM content/variant parameter
+ * @property {string|null} utmSource - UTM source parameter
+ * @property {string|null} utmMedium - UTM medium parameter
+ * @property {string|null} utmTerm - UTM term/keyword parameter
+ * @property {string|null} utmCampaign - UTM campaign parameter
+ * @property {string|null} utmContent - UTM content/variant parameter
  */
 
 /**
@@ -36,11 +36,11 @@ function extractParams(searchParams) {
         source: referrerSource,
         medium: utmMediumParam || null,
         url: window.document.referrer || null,
-        utm_source: utmSourceParam || null,
-        utm_medium: utmMediumParam || null,
-        utm_term: utmTermParam || null,
-        utm_campaign: utmCampaignParam || null,
-        utm_content: utmContentParam || null
+        utmSource: utmSourceParam || null,
+        utmMedium: utmMediumParam || null,
+        utmTerm: utmTermParam || null,
+        utmCampaign: utmCampaignParam || null,
+        utmContent: utmContentParam || null
     };
 }
 

--- a/ghost/core/core/frontend/src/utils/url-attribution.js
+++ b/ghost/core/core/frontend/src/utils/url-attribution.js
@@ -45,12 +45,12 @@ function extractParams(searchParams) {
 }
 
 /**
- * Parses URL parameters to extract attribution information
+ * Parses URL parameters to extract complete referrer/attribution data
  * 
- * @param {string} url - The URL to parse
- * @returns {AttributionData} Parsed attribution data
+ * @param {string} url - The URL to parse (defaults to current URL)
+ * @returns {AttributionData} Complete attribution data including all UTM parameters
  */
-export function parseReferrer(url) {
+export function parseReferrerData(url) {
     // Extract current URL parameters
     const currentUrl = new URL(url || window.location.href);
     let searchParams = currentUrl.searchParams;
@@ -65,12 +65,14 @@ export function parseReferrer(url) {
 }
 
 /**
- * Gets the final referrer value based on parsed data
- * 
+ * Selects the primary referrer value from parsed attribution data
+ * Prioritizes: source → medium → url
+ * Filters out same-domain referrers
+ * @private
  * @param {AttributionData} referrerData - Parsed referrer data
- * @returns {string|null} Final referrer value or null
+ * @returns {string|null} Primary referrer value or null
  */
-export function getFinalReferrer(referrerData) {
+function selectPrimaryReferrer(referrerData) {
     const { source, medium, url } = referrerData;
     const finalReferrer = source || medium || url || null;
     
@@ -98,6 +100,9 @@ export function getFinalReferrer(referrerData) {
  * @returns {string|null} Final referrer value
  */
 export function getReferrer(url) {
-    const referrerData = parseReferrer(url);
-    return getFinalReferrer(referrerData);
+    const referrerData = parseReferrerData(url);
+    return selectPrimaryReferrer(referrerData);
 }
+
+// Legacy export name for backward compatibility
+export const parseReferrer = parseReferrerData;

--- a/ghost/core/core/frontend/src/utils/url-attribution.js
+++ b/ghost/core/core/frontend/src/utils/url-attribution.js
@@ -103,6 +103,3 @@ export function getReferrer(url) {
     const referrerData = parseReferrerData(url);
     return selectPrimaryReferrer(referrerData);
 }
-
-// Legacy export name for backward compatibility
-export const parseReferrer = parseReferrerData;

--- a/ghost/core/core/frontend/src/utils/url-attribution.js
+++ b/ghost/core/core/frontend/src/utils/url-attribution.js
@@ -3,10 +3,22 @@
  */
 
 /**
+ * @typedef {Object} AttributionData
+ * @property {string|null} source - Primary attribution source (ref || source || utm_source)
+ * @property {string|null} medium - UTM medium parameter
+ * @property {string|null} url - Browser's document.referrer
+ * @property {string|null} utm_source - UTM source parameter
+ * @property {string|null} utm_medium - UTM medium parameter
+ * @property {string|null} utm_term - UTM term/keyword parameter
+ * @property {string|null} utm_campaign - UTM campaign parameter
+ * @property {string|null} utm_content - UTM content/variant parameter
+ */
+
+/**
  * Extracts attribution parameters from URL search params
  * @private
  * @param {URLSearchParams} searchParams - The search params to parse
- * @returns {Object} Parsed attribution data with all UTM parameters
+ * @returns {AttributionData} Parsed attribution data with all UTM parameters
  */
 function extractParams(searchParams) {
     const refParam = searchParams.get('ref');
@@ -36,7 +48,7 @@ function extractParams(searchParams) {
  * Parses URL parameters to extract attribution information
  * 
  * @param {string} url - The URL to parse
- * @returns {Object} Parsed attribution data
+ * @returns {AttributionData} Parsed attribution data
  */
 export function parseReferrer(url) {
     // Extract current URL parameters
@@ -55,7 +67,7 @@ export function parseReferrer(url) {
 /**
  * Gets the final referrer value based on parsed data
  * 
- * @param {Object} referrerData - Parsed referrer data
+ * @param {AttributionData} referrerData - Parsed referrer data
  * @returns {string|null} Final referrer value or null
  */
 export function getFinalReferrer(referrerData) {

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -78,11 +78,11 @@ describe('URL Attribution Utils', function () {
         it('should extract all UTM parameters', function () {
             const result = parseReferrerData('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
-            should.equal(result.utm_source, 'google');
-            should.equal(result.utm_medium, 'cpc');
-            should.equal(result.utm_campaign, 'summer');
-            should.equal(result.utm_term, 'ghost');
-            should.equal(result.utm_content, 'banner');
+            should.equal(result.utmSource, 'google');
+            should.equal(result.utmMedium, 'cpc');
+            should.equal(result.utmCampaign, 'summer');
+            should.equal(result.utmTerm, 'ghost');
+            should.equal(result.utmContent, 'banner');
             should.equal(result.source, 'google'); // source should be utm_source
         });
     });
@@ -104,11 +104,11 @@ describe('URL Attribution Utils', function () {
         it('should extract all UTM parameters from portal hash', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
-            should.equal(result.utm_source, 'google');
-            should.equal(result.utm_medium, 'cpc');
-            should.equal(result.utm_campaign, 'summer');
-            should.equal(result.utm_term, 'ghost');
-            should.equal(result.utm_content, 'banner');
+            should.equal(result.utmSource, 'google');
+            should.equal(result.utmMedium, 'cpc');
+            should.equal(result.utmCampaign, 'summer');
+            should.equal(result.utmTerm, 'ghost');
+            should.equal(result.utmContent, 'banner');
             should.equal(result.source, 'google'); // source should be utm_source
         });
     });

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -5,7 +5,6 @@ const {JSDOM} = require('jsdom');
 // Use path relative to test file
 const {
     parseReferrer,
-    parsePortalHash,
     getFinalReferrer,
     getReferrer
 } = require('../../../../core/frontend/src/utils/url-attribution');
@@ -76,22 +75,42 @@ describe('URL Attribution Utils', function () {
             should.exist(result);
             should.equal(result.url, 'https://external-site.com/');
         });
+        
+        it('should extract all UTM parameters', function () {
+            const result = parseReferrer('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
+            should.exist(result);
+            should.equal(result.utm_source, 'google');
+            should.equal(result.utm_medium, 'cpc');
+            should.equal(result.utm_campaign, 'summer');
+            should.equal(result.utm_term, 'ghost');
+            should.equal(result.utm_content, 'banner');
+            should.equal(result.source, 'google'); // source should be utm_source
+        });
     });
     
-    describe('parsePortalHash', function () {
+    describe('parseReferrer with portal hash', function () {
         it('should extract parameters from portal hash URL', function () {
-            const url = new URL('https://example.com/#/portal/signup?ref=newsletter');
-            const result = parsePortalHash(url);
+            const result = parseReferrer('https://example.com/#/portal/signup?ref=newsletter');
             should.exist(result);
             should.equal(result.source, 'newsletter');
         });
         
-        it('should handle multiple parameters', function () {
-            const url = new URL('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
-            const result = parsePortalHash(url);
+        it('should handle multiple parameters in portal hash', function () {
+            const result = parseReferrer('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
             should.exist(result);
             should.equal(result.source, 'newsletter');
             should.equal(result.medium, 'email');
+        });
+        
+        it('should extract all UTM parameters from portal hash', function () {
+            const result = parseReferrer('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
+            should.exist(result);
+            should.equal(result.utm_source, 'google');
+            should.equal(result.utm_medium, 'cpc');
+            should.equal(result.utm_campaign, 'summer');
+            should.equal(result.utm_term, 'ghost');
+            should.equal(result.utm_content, 'banner');
+            should.equal(result.source, 'google'); // source should be utm_source
         });
     });
     

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -4,8 +4,7 @@ const {JSDOM} = require('jsdom');
 
 // Use path relative to test file
 const {
-    parseReferrer,
-    getFinalReferrer,
+    parseReferrerData,
     getReferrer
 } = require('../../../../core/frontend/src/utils/url-attribution');
 
@@ -45,39 +44,39 @@ describe('URL Attribution Utils', function () {
         global.document = undefined;
     });
     
-    describe('parseReferrer', function () {
+    describe('parseReferrerData', function () {
         it('should extract ref parameter correctly', function () {
-            const result = parseReferrer('https://example.com/?ref=newsletter');
+            const result = parseReferrerData('https://example.com/?ref=newsletter');
             should.exist(result);
             should.equal(result.source, 'newsletter');
         });
         
         it('should extract source parameter correctly', function () {
-            const result = parseReferrer('https://example.com/?source=twitter');
+            const result = parseReferrerData('https://example.com/?source=twitter');
             should.exist(result);
             should.equal(result.source, 'twitter');
         });
         
         it('should extract utm_source parameter correctly', function () {
-            const result = parseReferrer('https://example.com/?utm_source=facebook');
+            const result = parseReferrerData('https://example.com/?utm_source=facebook');
             should.exist(result);
             should.equal(result.source, 'facebook');
         });
         
         it('should handle portal hash URLs', function () {
-            const result = parseReferrer('https://example.com/#/portal/signup?ref=portal-hash');
+            const result = parseReferrerData('https://example.com/#/portal/signup?ref=portal-hash');
             should.exist(result);
             should.equal(result.source, 'portal-hash');
         });
         
         it('should return document.referrer when no source params are present', function () {
-            const result = parseReferrer('https://example.com/');
+            const result = parseReferrerData('https://example.com/');
             should.exist(result);
             should.equal(result.url, 'https://external-site.com/');
         });
         
         it('should extract all UTM parameters', function () {
-            const result = parseReferrer('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
+            const result = parseReferrerData('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
             should.equal(result.utm_source, 'google');
             should.equal(result.utm_medium, 'cpc');
@@ -88,22 +87,22 @@ describe('URL Attribution Utils', function () {
         });
     });
     
-    describe('parseReferrer with portal hash', function () {
+    describe('parseReferrerData with portal hash', function () {
         it('should extract parameters from portal hash URL', function () {
-            const result = parseReferrer('https://example.com/#/portal/signup?ref=newsletter');
+            const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter');
             should.exist(result);
             should.equal(result.source, 'newsletter');
         });
         
         it('should handle multiple parameters in portal hash', function () {
-            const result = parseReferrer('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
+            const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
             should.exist(result);
             should.equal(result.source, 'newsletter');
             should.equal(result.medium, 'email');
         });
         
         it('should extract all UTM parameters from portal hash', function () {
-            const result = parseReferrer('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
+            const result = parseReferrerData('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
             should.equal(result.utm_source, 'google');
             should.equal(result.utm_medium, 'cpc');
@@ -114,59 +113,40 @@ describe('URL Attribution Utils', function () {
         });
     });
     
-    describe('getFinalReferrer', function () {
-        it('should prioritize source over medium and url', function () {
-            const referrerData = {
-                source: 'newsletter',
-                medium: 'email',
-                url: 'https://external-site.com'
-            };
-            
-            const result = getFinalReferrer(referrerData);
+    describe('getReferrer prioritization logic', function () {
+        it('should prioritize ref/source over medium and document.referrer', function () {
+            // When ref is present along with utm_medium
+            const result = getReferrer('https://example.com/?ref=newsletter&utm_medium=email');
             should.equal(result, 'newsletter');
         });
         
-        it('should fall back to medium if source is not available', function () {
-            const referrerData = {
-                source: null,
-                medium: 'email',
-                url: 'https://external-site.com'
-            };
-            
-            const result = getFinalReferrer(referrerData);
+        it('should prioritize utm_source over medium', function () {
+            // When utm_source is present along with utm_medium
+            const result = getReferrer('https://example.com/?utm_source=twitter&utm_medium=social');
+            should.equal(result, 'twitter');
+        });
+        
+        it('should fall back to utm_medium if no ref/source/utm_source', function () {
+            // Only utm_medium is present
+            const result = getReferrer('https://example.com/?utm_medium=email');
             should.equal(result, 'email');
         });
         
-        it('should fall back to url if source and medium are not available', function () {
-            const referrerData = {
-                source: null,
-                medium: null,
-                url: 'https://external-site.com'
-            };
-            
-            const result = getFinalReferrer(referrerData);
-            should.equal(result, 'https://external-site.com');
+        it('should fall back to document.referrer if no params are present', function () {
+            // No URL params, should use document.referrer (https://external-site.com/ from test setup)
+            const result = getReferrer('https://example.com/');
+            should.equal(result, 'https://external-site.com/');
         });
         
         it('should return null if referrer matches current hostname', function () {
-            const referrerData = {
-                source: 'https://example.com/some-page',
-                medium: null,
-                url: null
-            };
-            
-            const result = getFinalReferrer(referrerData);
+            // Same-domain referrer should be filtered out
+            const result = getReferrer('https://example.com/?ref=https://example.com/some-page');
             should.equal(result, null);
         });
         
-        it('should return non-URL referrers even if hostname parsing fails', function () {
-            const referrerData = {
-                source: 'ghost-newsletter',
-                medium: null,
-                url: null
-            };
-            
-            const result = getFinalReferrer(referrerData);
+        it('should return non-URL referrers like ghost-newsletter', function () {
+            // Non-URL refs should work fine
+            const result = getReferrer('https://example.com/?ref=ghost-newsletter');
             should.equal(result, 'ghost-newsletter');
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2560/
- added utm_ params parsing to the url-attribution helper library; this lib returns the referrer/attribution data we use for memberships in ghost
- refactored url-attribution script file to be easier to read/make sense of; updated tests accordingly (tried to decouple a bit w/ implementation)
- updated member-attribution script to pass along utm data; this isn't wired up on the backend yet

The `url-attribution` helpers are used by the `member-attribution` and `ghost-stats` scripts, which are our frontend scripts for handling attribution (member signups + web traffic). We need to update these to pass along the various `utm_{param}` query params in order to support expanding our attribution and analytics data sets.

This change allows us to pass along the data, and we'll need follow-up PRs to handle ingesting that data and properly storing it.

I've included a bit of a refactor here to try and make better sense of the url-attribution script. This has some confusion because historically it has been used for member attribution which has a confusing relationship with referrer data. We haven't been clear about what we call this.

__Testing__
In terms of testing, we should only need to check that the frontend scripts store the additional data. W/r to member-attribution, you can check `sessionStroage` and ensure the `utm_{param}` fields exist in the JSON data. For ghost-stats, you can look at the request payload sent to the traffic analytics proxy.