### PR TITLE
Added source tabs component to Shade

### DIFF
--- a/apps/shade/src/components/features/sources/source-tabs.tsx
+++ b/apps/shade/src/components/features/sources/source-tabs.tsx
@@ -1,0 +1,83 @@
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem} from '@/components/ui/dropdown-menu';
+import {Tabs, TabsDropdownTrigger, TabsList, TabsTrigger} from '@/components/ui/tabs';
+import {ChevronDown} from 'lucide-react';
+import React from 'react';
+
+export type CampaignType = '' | 'UTM sources' | 'UTM mediums' | 'UTM campaigns' | 'UTM contents' | 'UTM terms';
+export type TabType = 'sources' | 'campaigns';
+
+export const CAMPAIGN_TYPES: readonly CampaignType[] = [
+    '',
+    'UTM sources',
+    'UTM mediums',
+    'UTM campaigns',
+    'UTM contents',
+    'UTM terms'
+] as const;
+
+const getCampaignDisplayText = (campaign: CampaignType) => {
+    return campaign || 'Campaigns';
+};
+
+interface SourceTabsProps {
+    className?: string;
+    selectedTab: TabType;
+    onTabChange: (tab: TabType) => void;
+    selectedCampaign: CampaignType;
+    onCampaignChange: (campaign: CampaignType) => void;
+}
+
+const SourceTabs: React.FC<SourceTabsProps> = ({
+    className,
+    selectedTab,
+    onTabChange,
+    selectedCampaign,
+    onCampaignChange
+}) => {
+    return (
+        <Tabs
+            className={className}
+            defaultValue={'sources'}
+            value={selectedTab}
+            variant='button-sm'
+            onValueChange={(value: string) => {
+                const newTab = value as TabType;
+                // Only allow switching to campaigns tab if a campaign is selected
+                if (newTab === 'campaigns' && !selectedCampaign) {
+                    return;
+                }
+                onTabChange(newTab);
+                if (newTab !== 'campaigns') {
+                    onCampaignChange('');
+                }
+            }}
+        >
+            <TabsList>
+                <TabsTrigger value={'sources'}>Sources</TabsTrigger>
+                <DropdownMenu>
+                    <TabsDropdownTrigger
+                        className="flex items-center gap-2"
+                        value={'campaigns'}
+                    >
+                        {getCampaignDisplayText(selectedCampaign)} <ChevronDown className="size-4" />
+                    </TabsDropdownTrigger>
+                    <DropdownMenuContent>
+                        {CAMPAIGN_TYPES.filter(campaign => campaign !== '').map(campaign => (
+                            <DropdownMenuItem
+                                key={campaign}
+                                onClick={() => {
+                                    onCampaignChange(campaign);
+                                    onTabChange('campaigns');
+                                }}
+                            >
+                                {campaign}
+                            </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </TabsList>
+        </Tabs>
+    );
+};
+
+export default SourceTabs;

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -25,7 +25,6 @@ const tabsVariants = cva(
                 'segmented-sm': '',
                 button: '',
                 'button-sm': '',
-                'button-sm-dropdown': '',
                 underline: '',
                 navbar: '',
                 pill: '',

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
+import {DropdownMenuTrigger} from './dropdown-menu';
 
 import {cn} from '@/lib/utils';
 import {cva} from 'class-variance-authority';
@@ -24,6 +25,7 @@ const tabsVariants = cva(
                 'segmented-sm': '',
                 button: '',
                 'button-sm': '',
+                'button-sm-dropdown': '',
                 underline: '',
                 navbar: '',
                 pill: '',
@@ -258,4 +260,48 @@ const KpiDropdownButton = React.forwardRef<HTMLButtonElement, KpiDropdownButtonP
 );
 KpiDropdownButton.displayName = 'KpiDropdownButton';
 
-export {Tabs, TabsList, TabsTrigger, TabsTriggerCount, TabsContent, KpiTabTrigger, KpiTabValue, KpiDropdownButton, tabsVariants};
+interface TabsDropdownTriggerProps extends Omit<React.ComponentProps<typeof TabsPrimitive.Trigger>, 'asChild'> {
+    children: React.ReactNode;
+}
+
+const TabsDropdownTrigger = React.forwardRef<HTMLButtonElement, TabsDropdownTriggerProps>(({
+    children,
+    className,
+    ...props
+}, ref) => {
+    const variant = React.useContext(TabsVariantContext);
+    return (
+        <div className="relative rounded-md hover:bg-muted">
+            <TabsPrimitive.Trigger
+                ref={ref}
+                className={cn(tabsTriggerVariants({variant, className}))}
+                {...props}
+            >
+                <div className="flex items-center gap-2">
+                    {children}
+                </div>
+            </TabsPrimitive.Trigger>
+            <DropdownMenuTrigger
+                className="absolute inset-0 size-full cursor-pointer"
+                onClick={(e) => {
+                    // Stop propagation to prevent tab change
+                    e.preventDefault();
+                }}
+            />
+        </div>
+    );
+});
+TabsDropdownTrigger.displayName = 'TabsDropdownTrigger';
+
+export {
+    Tabs,
+    TabsList,
+    TabsTrigger,
+    TabsTriggerCount,
+    TabsContent,
+    KpiTabTrigger,
+    KpiTabValue,
+    KpiDropdownButton,
+    TabsDropdownTrigger,
+    tabsVariants
+};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -45,6 +45,8 @@ export * from './components/layout/view-header';
 
 // Feature components — Complete functional components (share modal, etc.)
 export {default as PostShareModal} from './components/features/post_share_modal';
+export {default as SourceTabs} from './components/features/sources/source-tabs';
+export type {CampaignType, TabType} from './components/features/sources/source-tabs';
 
 // Third party components
 export * as Recharts from 'recharts';

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -1,6 +1,6 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
-import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, SourceTabs, TabType, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Default source icon URL - apps can override this
@@ -87,9 +87,6 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
     isLoading
 }) => {
-    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
-    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
-
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
         return processSources({
@@ -140,14 +137,6 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
-                <div className='mb-2'>
-                    <SourceTabs
-                        selectedCampaign={selectedCampaign}
-                        selectedTab={selectedTab}
-                        onCampaignChange={setSelectedCampaign}
-                        onTabChange={setSelectedTab}
-                    />
-                </div>
                 <Separator />
                 {topSources.length > 0 ? (
                     <SourcesTable

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, SourceTabs, TabType, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Default source icon URL - apps can override this
@@ -87,6 +87,9 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
     isLoading
 }) => {
+    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
+    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
+
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
         return processSources({
@@ -137,6 +140,14 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
+                <div className='mb-2'>
+                    <SourceTabs
+                        selectedCampaign={selectedCampaign}
+                        selectedTab={selectedTab}
+                        onCampaignChange={setSelectedCampaign}
+                        onTabChange={setSelectedTab}
+                    />
+                </div>
                 <Separator />
                 {topSources.length > 0 ? (
                     <SourcesTable


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2554/create-new-dropdown-components-for-utm-filters

- Source tabs in Analytics is a special feature component that is combining tabs and a dropdown menu. To be reusable in multiple places it's being added to Shade.