### PR TITLE
Updated copy for error on OTC field in portal

### DIFF
--- a/apps/portal/src/components/common/InputField.js
+++ b/apps/portal/src/components/common/InputField.js
@@ -97,6 +97,7 @@ function InputField({
     tabindex,
     maxlength,
     autoFocus,
+    required = false,
     errorMessage
 }) {
     const fieldNode = useRef(null);
@@ -172,6 +173,7 @@ function InputField({
                 aria-label={label}
                 inputMode={inputMode}
                 pattern={pattern}
+                required={required}
             />
         </section>
     );

--- a/apps/portal/src/components/common/InputField.js
+++ b/apps/portal/src/components/common/InputField.js
@@ -97,7 +97,6 @@ function InputField({
     tabindex,
     maxlength,
     autoFocus,
-    required = false,
     errorMessage
 }) {
     const fieldNode = useRef(null);
@@ -173,7 +172,6 @@ function InputField({
                 aria-label={label}
                 inputMode={inputMode}
                 pattern={pattern}
-                required={required}
             />
         </section>
     );

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -4,7 +4,6 @@ import CloseButton from '../common/CloseButton';
 import AppContext from '../../AppContext';
 import {ReactComponent as EnvelopeIcon} from '../../images/icons/envelope.svg';
 
-import {ValidateInputForm} from '../../utils/form';
 import InputField from '../common/InputField';
 
 export const MagicLinkStyles = `
@@ -110,12 +109,11 @@ export default class MagicLinkPage extends React.Component {
 
     doVerifyOTC() {
         this.setState((state) => {
+            const {t} = this.context;
             return {
-                errors: ValidateInputForm({fields: [{
-                    name: OTC_FIELD_NAME,
-                    value: state.otc,
-                    required: true
-                }], t: this.context.t})
+                errors: {
+                    [OTC_FIELD_NAME]: !state.otc ? t('Enter code below') : ''
+                }
             };
         }, () => {
             const {otc, errors} = this.state;
@@ -163,6 +161,7 @@ export default class MagicLinkPage extends React.Component {
                         autoFocus={false}
                         maxlength={6}
                         onChange={e => this.handleInputChange(e, {name: OTC_FIELD_NAME})}
+                        required
                     />
                 </section>
                 <footer className='gh-portal-signin-footer'>

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -110,9 +110,10 @@ export default class MagicLinkPage extends React.Component {
     doVerifyOTC() {
         this.setState((state) => {
             const {t} = this.context;
+            const code = (state.otc || '').trim();
             return {
                 errors: {
-                    [OTC_FIELD_NAME]: !state.otc ? t('Enter code below') : ''
+                    [OTC_FIELD_NAME]: code ? '' : t('Enter code below')
                 }
             };
         }, () => {

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -161,7 +161,6 @@ export default class MagicLinkPage extends React.Component {
                         autoFocus={false}
                         maxlength={6}
                         onChange={e => this.handleInputChange(e, {name: OTC_FIELD_NAME})}
-                        required
                     />
                 </section>
                 <footer className='gh-portal-signin-footer'>

--- a/apps/portal/src/components/pages/MagicLinkPage.test.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '../../utils/test-utils';
 import MagicLinkPage from './MagicLinkPage';
 
 const OTC_LABEL_REGEX = /Code/i;
-const OTC_ERROR_REGEX = /please enter otc/i;
+const OTC_ERROR_REGEX = /Enter code below/i;
 
 const setupTest = (options = {}) => {
     const {

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-posse",
     "Emails disabled": "E-posse afgeskakel",
     "Ends {offerEndDate}": "Eindig {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Fout",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -66,6 +66,7 @@
     "Emails": "رسائل البريد الإلكتروني",
     "Emails disabled": "تم تعطيل جميع رسائل البريد الإلكتروني",
     "Ends {offerEndDate}": "{offerEndDate} ينتهي في ",
+    "Enter code below": "",
     "Enter your email address": "أدخل عنوان بريدك الإلكتروني",
     "Enter your name": "أدخل اسمك",
     "Error": "خطأ",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Имейли",
     "Emails disabled": "Имейлите са спрени",
     "Ends {offerEndDate}": "До {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Попълнете своя имейл адрес",
     "Enter your name": "Попълнете вашето име",
     "Error": "Грешка",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ইমেল",
     "Emails disabled": "ইমেল নিষ্ক্রিয়",
     "Ends {offerEndDate}": "{offerEndDate} এ শেষ হবে",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "ত্রুটি",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Email adrese",
     "Emails disabled": "Onemogućene Email adrese",
     "Ends {offerEndDate}": "Završava {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Greška",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Correus electrònics",
     "Emails disabled": "Correus electrònics desactivats",
     "Ends {offerEndDate}": "Finalitza el {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Escriu la teva adreça d'email",
     "Enter your name": "Escriu el teu nom",
     "Error": "Error",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-maily",
     "Emails disabled": "E-maily vypnuty",
     "Ends {offerEndDate}": "Končí {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Zadejte svou e-mailovou adresu",
     "Enter your name": "Zadejte své jméno",
     "Error": "Chyba",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mails",
     "Emails disabled": "E-mails deaktiveret",
     "Ends {offerEndDate}": "Udløber {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Indtast din e-mailadresse",
     "Enter your name": "Indtast dit navn",
     "Error": "Fejl",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-Mails",
     "Emails disabled": "E-Mails deaktiviert",
     "Ends {offerEndDate}": "Endet am {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Geben Sie Ihre E-Mail-Adresse ein",
     "Enter your name": "Geben Sie Ihren Namen ein",
     "Error": "Fehler",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-Mails",
     "Emails disabled": "E-Mails deaktiviert",
     "Ends {offerEndDate}": "Endet am {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Gebe deine Email-Adresse ein",
     "Enter your name": "Gebe deinen Namen ein",
     "Error": "Fehler",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Emails",
     "Emails disabled": "Τα emails είναι απενεργοποιημένα",
     "Ends {offerEndDate}": "Λήγει {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Σφάλμα",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -66,6 +66,7 @@
     "Emails": "",
     "Emails disabled": "",
     "Ends {offerEndDate}": "",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Retpoŝtoj",
     "Emails disabled": "Retpoŝtoj malŝaltitaj",
     "Ends {offerEndDate}": "",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Correos electrónicos",
     "Emails disabled": "Correos electrónicos desactivados",
     "Ends {offerEndDate}": "Termina el {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Escribe tu correo electrónico",
     "Enter your name": "Escribe tu nombre",
     "Error": "Error",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-kirjad",
     "Emails disabled": "E-kirjad keelatud",
     "Ends {offerEndDate}": "Lõpeb {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Sisestage oma e-posti aadress",
     "Enter your name": "Sisestage oma nimi",
     "Error": "Viga",

--- a/ghost/i18n/locales/eu/portal.json
+++ b/ghost/i18n/locales/eu/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ePostak",
     "Emails disabled": "ePostak desgaituta",
     "Ends {offerEndDate}": "{offerEndDate}(e)an amaituko da",
+    "Enter code below": "",
     "Enter your email address": "Sartu zure ePosta helbidea",
     "Enter your name": "Sartu zure izena",
     "Error": "Errorea",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ایمیل\u200cها",
     "Emails disabled": "ایمیل\u200cها غیرفعال هستند",
     "Ends {offerEndDate}": "در {offerEndDate} تمام می\u200cشود",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "خطا",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Sähköpostit",
     "Emails disabled": "Sähköpostit pois käytöstä",
     "Ends {offerEndDate}": "Loppuu {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Virhe",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mails",
     "Emails disabled": "E-mails désactivés",
     "Ends {offerEndDate}": "Se termine le {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Saisissez votre adresse e-mail",
     "Enter your name": "Saisissez votre nom",
     "Error": "Erreur",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Puist-d",
     "Emails disabled": "Puist-d à comas",
     "Ends {offerEndDate}": "Falbhaidh an ùine air: {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Cuir a-steach seòladh a' phuist-d agad",
     "Enter your name": "Cuir a-steach d' ainm",
     "Error": "Mearachd",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -66,6 +66,7 @@
     "Emails": "מיילים",
     "Emails disabled": "מיילים מושבתים",
     "Ends {offerEndDate}": "מסתיים ב {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "כתבו את כתובת המייל שלכם",
     "Enter your name": "רשמו את השם שלכם",
     "Error": "שגיאה",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ईमेल",
     "Emails disabled": "ईमेल निष्क्रिय",
     "Ends {offerEndDate}": "{offerEndDate} को समाप्त होता है",
+    "Enter code below": "",
     "Enter your email address": "अपना ईमेल दर्ज करें",
     "Enter your name": "अपना नाम दर्ज करें",
     "Error": "त्रुटि",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-pošta",
     "Emails disabled": "Isključena e-pošta",
     "Ends {offerEndDate}": "Završava {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Unesite svoju email adresu",
     "Enter your name": "Unesite svoje ime",
     "Error": "Greška",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mailek",
     "Emails disabled": "E-mailek kikapcsolva",
     "Ends {offerEndDate}": "Ajánlat vége: {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Add meg az e-mail-címed",
     "Enter your name": "Neved",
     "Error": "Hiba",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Email",
     "Emails disabled": "Email dinonaktifkan",
     "Ends {offerEndDate}": "Berakhir {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Masukkan alamat email Anda",
     "Enter your name": "Masukkan nama Anda",
     "Error": "Eror",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Netföng",
     "Emails disabled": "Netföng gerð óvirk",
     "Ends {offerEndDate}": "Lýkur {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Villa",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Email",
     "Emails disabled": "Email disattivate",
     "Ends {offerEndDate}": "Finisce il {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Insirisci il tuo indirizzo email",
     "Enter your name": "Inserisci il tuo nome",
     "Error": "Errore",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -66,6 +66,7 @@
     "Emails": "メール",
     "Emails disabled": "メールが無効になっています",
     "Ends {offerEndDate}": "{offerEndDate}まで",
+    "Enter code below": "",
     "Enter your email address": "メールアドレスを入力してください",
     "Enter your name": "お名前を入力してください。",
     "Error": "エラー",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -66,6 +66,7 @@
     "Emails": "이메일",
     "Emails disabled": "이메일 사용 중지됨",
     "Ends {offerEndDate}": "{offerEndDate}에 종료돼요",
+    "Enter code below": "",
     "Enter your email address": "이메일 주소를 입력해 주세요",
     "Enter your name": "이름을 입력해 주세요",
     "Error": "오류",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Электрондық хаттар",
     "Emails disabled": "Электрондық хаттар өшірілген",
     "Ends {offerEndDate}": "{offerEndDate} аяқталады",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Қате",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Laiškai",
     "Emails disabled": "El. laiškai deaktyvuoti",
     "Ends {offerEndDate}": "Baigiasi {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Klaida",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-pasti",
     "Emails disabled": "E-pasti ir atspējoti",
     "Ends {offerEndDate}": "Beidzas: {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Ievadiet savu e-pasta adresi",
     "Enter your name": "Ievadiet savu vārdu",
     "Error": "Kļūda",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Електронски пошти",
     "Emails disabled": "Оневозможени електронски пошти",
     "Ends {offerEndDate}": "Завршува на {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Грешка",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Имэйлүүд",
     "Emails disabled": "Имэйл идэвхгүй болсон",
     "Ends {offerEndDate}": "{offerEndDate} дуусна",
+    "Enter code below": "",
     "Enter your email address": "Имэйл хаягаа оруулна уу",
     "Enter your name": "Нэрээ оруулна уу",
     "Error": "Алдаа",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mel",
     "Emails disabled": "E-mel dilumpuhkan",
     "Ends {offerEndDate}": "Tamat pada {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Ralat",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-poster",
     "Emails disabled": "E-poster deaktivert",
     "Ends {offerEndDate}": "Avsluttes {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Oppgi din e-postadresse",
     "Enter your name": "Oppgi navnet ditt",
     "Error": "Feil",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -66,6 +66,7 @@
     "Emails": "",
     "Emails disabled": "",
     "Ends {offerEndDate}": "",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mails",
     "Emails disabled": "E-mails zijn uitgeschakeld",
     "Ends {offerEndDate}": "Eindigt op {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Vul je e-mailadres in",
     "Enter your name": "Vul je naam in",
     "Error": "Fout",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-postar.",
     "Emails disabled": "E-postar skrudd av",
     "Ends {offerEndDate}": "Sluttar {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Feil",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ਈਮੇਲਾਂ",
     "Emails disabled": "ਈਮੇਲਾਂ ਅਸਮਰੱਥ ਕੀਤੀਆਂ ਗਈਆਂ",
     "Ends {offerEndDate}": "{offerEndDate} ਨੂੰ ਸਮਾਪਤ ਹੁੰਦਾ ਹੈ",
+    "Enter code below": "",
     "Enter your email address": "ਆਪਣਾ ਈਮੇਲ ਪਤਾ ਦਰਜ ਕਰੋ",
     "Enter your name": "ਆਪਣਾ ਨਾਮ ਦਰਜ ਕਰੋ",
     "Error": "ਗਲਤੀ",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Emaile",
     "Emails disabled": "Wysyłanie emaili zablokowane",
     "Ends {offerEndDate}": "Kończy się {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Wpisz swój adres email",
     "Enter your name": "Wpisz swoje imię",
     "Error": "Błąd",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-mails",
     "Emails disabled": "E-mails desativados",
     "Ends {offerEndDate}": "Termina em {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Insira seu endereço de e-mail",
     "Enter your name": "Insira seu nome",
     "Error": "Erro",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Emails",
     "Emails disabled": "Email desativado",
     "Ends {offerEndDate}": "Termina em {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Insira o seu endereço de email",
     "Enter your name": "Insira o seu nome",
     "Error": "Erro",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Emailuri",
     "Emails disabled": "Emailuri dezactivate",
     "Ends {offerEndDate}": "Se termină {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Introduce adresa ta de email",
     "Enter your name": "Introduce numele tău",
     "Error": "Eroare",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Письма",
     "Emails disabled": "Доставка писем отключена",
     "Ends {offerEndDate}": "Предложение заканчивается {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Введите свой email адрес",
     "Enter your name": "Введите ваше имя",
     "Error": "Ошибка",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ඊමේල්",
     "Emails disabled": "Emails නවත්වා ඇත",
     "Ends {offerEndDate}": "{offerEndDate} දී අවසන් වනු ඇත",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Error එකක්",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-maily",
     "Emails disabled": "E-maily vypnuté",
     "Ends {offerEndDate}": "Vyprší {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Zadajte svoju e-mailovú adresu",
     "Enter your name": "Zadajte svoje meno",
     "Error": "Chyba",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-pošta",
     "Emails disabled": "E-pošta onemogočena",
     "Ends {offerEndDate}": "Poteče {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Vnesite svoj e-poštni naslov",
     "Enter your name": "Vnesite svoje ime",
     "Error": "Napaka",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Emailet",
     "Emails disabled": "Emailet e çaktivizuara",
     "Ends {offerEndDate}": "Perfundon {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Gabim",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Мејлови",
     "Emails disabled": "Мејлови онемогућени",
     "Ends {offerEndDate}": "Завршава се {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Унесите вашу мејл адресу",
     "Enter your name": "Унесите ваше име",
     "Error": "Грешка",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Imejlovi",
     "Emails disabled": "Onemogućeni imejlovi",
     "Ends {offerEndDate}": "Završava se {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Greška",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-postmeddelanden",
     "Emails disabled": "E-post inaktiverad",
     "Ends {offerEndDate}": "Avslutas {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Skriv din e-postadress",
     "Enter your name": "Skriv ditt namn",
     "Error": "Fel",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Barua pepe",
     "Emails disabled": "Barua pepe zimezimwa",
     "Ends {offerEndDate}": "Inaisha {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "Hitilafu",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -66,6 +66,7 @@
     "Emails": "மின்னஞ்சல்கள்",
     "Emails disabled": "மின்னஞ்சல்கள் முடக்கப்பட்டன",
     "Ends {offerEndDate}": "{offerEndDate} முடிவடைகிறது",
+    "Enter code below": "",
     "Enter your email address": "உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்",
     "Enter your name": "உங்கள் பெயரை உள்ளிடவும்",
     "Error": "பிழை",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -66,6 +66,7 @@
     "Emails": "อีเมล",
     "Emails disabled": "อีเมลถูกปิดใช้งาน",
     "Ends {offerEndDate}": "สิ้นสุด {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "ข้อผิดพลาด",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -66,6 +66,7 @@
     "Emails": "E-postalar",
     "Emails disabled": "E-postalar devre dışı",
     "Ends {offerEndDate}": "{offerEndDate} tarihinde bitiyor",
+    "Enter code below": "",
     "Enter your email address": "E-posta adresinizi girin",
     "Enter your name": "Adınızı girin",
     "Error": "Hata",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Електронні листи",
     "Emails disabled": "Електронна пошта вимкнена",
     "Ends {offerEndDate}": "Закунчується {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Введіть свій імейл",
     "Enter your name": "Введіть імʼя",
     "Error": "Помилка",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -66,6 +66,7 @@
     "Emails": "ای میلز",
     "Emails disabled": "ای میلز غیر فعال ہیں",
     "Ends {offerEndDate}": "ختم ہوتا ہے {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "خطا",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Elektron xatlar",
     "Emails disabled": "Elektron pochta xabarlari o‘chirilgan",
     "Ends {offerEndDate}": "",
+    "Enter code below": "",
     "Enter your email address": "",
     "Enter your name": "",
     "Error": "",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -66,6 +66,7 @@
     "Emails": "Email",
     "Emails disabled": "Vô hiệu hóa email",
     "Ends {offerEndDate}": "Kết thúc {offerEndDate}",
+    "Enter code below": "",
     "Enter your email address": "Nhập địa chỉ email của bạn",
     "Enter your name": "Nhập tên của bạn",
     "Error": "Lỗi",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -66,6 +66,7 @@
     "Emails": "電子報",
     "Emails disabled": "已停止接收電子報",
     "Ends {offerEndDate}": "於 {offerEndDate} 結束",
+    "Enter code below": "",
     "Enter your email address": "輸入你的 Email",
     "Enter your name": "輸入你的名字",
     "Error": "錯誤",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -66,6 +66,7 @@
     "Emails": "电子邮件列表",
     "Emails disabled": "关闭电子邮件列表",
     "Ends {offerEndDate}": "于{offerEndDate}结束",
+    "Enter code below": "",
     "Enter your email address": "输入您的电子邮箱地址",
     "Enter your name": "输入您的名字",
     "Error": "错误",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PROD-2578

- Updates error copy on the OTC field in Portal from "Please enter otc" to "Enter code below"
- Instead of trying to further extend the existing ValidateInputForm helper, this just handles the error checking directly when the form is submitted - makes it a little bit simpler for this form that only has one field