### PR TITLE
Added UTM dropdown to Stats > Web sources

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -2,7 +2,7 @@ import {createQuery} from '../utils/api/hooks';
 
 export type JSONValue = string|number|boolean|null|Date|JSONObject|JSONArray;
 export interface JSONObject { [key: string]: JSONValue }
-export interface JSONArray extends Array<string|number|boolean|Date|JSONObject|JSONValue> {}
+interface JSONArray extends Array<string|number|boolean|Date|JSONObject|JSONValue> {}
 
 export type Config = {
     version: string;
@@ -21,6 +21,15 @@ export type Config = {
     labs: Record<string, boolean>;
     stripeDirect: boolean;
     mail: string;
+    stats?: JSONObject & {
+        endpoint?: string;
+        id?: string;
+    };
+    emailAnalytics?: boolean;
+    tenor?: {
+        googleApiKey?: string | null;
+        contentFilter?: string;
+    };
     hostSettings?: {
         siteId?: string;
         limits?: {

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -5,17 +5,8 @@ import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settin
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
-// The actual shape of the config data from the API
-type ConfigData = Config & {
-    config?: {
-        stats?: StatsConfig;
-        labs?: Record<string, boolean>;
-        [key: string]: unknown;
-    };
-};
-
 interface GlobalData {
-    data: ConfigData | undefined;
+    data: Config | undefined;
     site: {
         url?: string;
         icon?: string;
@@ -46,15 +37,10 @@ export const useGlobalData = () => {
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const settings = useBrowseSettings();
     const site = useBrowseSite();
-    // The actual response structure includes nested config with labs and stats
-    const configQuery = useBrowseConfig();
-    const config = {
-        data: configQuery.data?.config as ConfigData | undefined,
-        isLoading: configQuery.isLoading,
-        error: configQuery.error as Error | null
-    };
-    // Only fetch Tinybird token if stats config is present
-    const hasStatsConfig = Boolean(config.data?.config?.stats);
+    const config = useBrowseConfig();
+    // config.data is ConfigResponseType which has shape { config: Config }
+    const configData = config.data?.config;
+    const hasStatsConfig = Boolean(configData?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     // Initialize with all audiences selected (binary 111 = 7)
@@ -84,9 +70,9 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     };
 
     return <GlobalDataContext.Provider value={{
-        data: config.data || undefined,
+        data: configData,
         site: siteData,
-        statsConfig: config.data?.config?.stats,
+        statsConfig: configData?.stats,
         tinybirdToken: tinybirdTokenQuery.token,
         isLoading,
         range,

--- a/apps/stats/src/providers/GlobalDataProvider.tsx
+++ b/apps/stats/src/providers/GlobalDataProvider.tsx
@@ -5,8 +5,17 @@ import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settin
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
+// The actual shape of the config data from the API
+type ConfigData = Config & {
+    config?: {
+        stats?: StatsConfig;
+        labs?: Record<string, boolean>;
+        [key: string]: unknown;
+    };
+};
+
 interface GlobalData {
-    data: Config | undefined;
+    data: ConfigData | undefined;
     site: {
         url?: string;
         icon?: string;
@@ -37,7 +46,13 @@ export const useGlobalData = () => {
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const settings = useBrowseSettings();
     const site = useBrowseSite();
-    const config = useBrowseConfig() as unknown as { data: Config & { config: { stats?: StatsConfig } } | null, isLoading: boolean, error: Error | null };
+    // The actual response structure includes nested config with labs and stats
+    const configQuery = useBrowseConfig();
+    const config = {
+        data: configQuery.data?.config as ConfigData | undefined,
+        isLoading: configQuery.isLoading,
+        error: configQuery.error as Error | null
+    };
     // Only fetch Tinybird token if stats config is present
     const hasStatsConfig = Boolean(config.data?.config?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -55,7 +55,7 @@ const Web: React.FC = () => {
     const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
     
     // Check if UTM tracking is enabled in labs
-    const utmTrackingEnabled = data?.config?.labs?.utmTracking || false;
+    const utmTrackingEnabled = data?.labs?.utmTracking || false;
 
     // Get site URL and icon for domain comparison and Direct traffic favicon
     const siteUrl = data?.url as string | undefined;

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -87,7 +87,7 @@ const Web: React.FC = () => {
         params
     });
 
-    // Get top sources data (always fetch this)
+    // Get top sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -1,13 +1,13 @@
 import AudienceSelect, {getAudienceQueryParam} from '../components/AudienceSelect';
 import DateRangeSelect from '../components/DateRangeSelect';
-import React from 'react';
+import React, {useState} from 'react';
 import SourcesCard from './components/SourcesCard';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
 import TopContent from './components/TopContent';
 import WebKPIs, {KpiDataItem} from './components/WebKPIs';
-import {Card, CardContent, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {CampaignType, Card, CardContent, TabType, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {Navigate, useAppContext, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
@@ -51,6 +51,11 @@ const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {appSettings} = useAppContext();
+    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
+    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
+    
+    // Check if UTM tracking is enabled in labs
+    const utmTrackingEnabled = data?.config?.labs?.utmTracking || false;
 
     // Get site URL and icon for domain comparison and Direct traffic favicon
     const siteUrl = data?.url as string | undefined;
@@ -82,12 +87,63 @@ const Web: React.FC = () => {
         params
     });
 
-    // Get top sources data
+    // Get top sources data (always fetch this)
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,
         params
     });
+
+    // Map campaign types to endpoints
+    const campaignEndpointMap: Record<CampaignType, string> = {
+        '': '',
+        'UTM sources': 'api_top_utm_sources',
+        'UTM mediums': 'api_top_utm_mediums',
+        'UTM campaigns': 'api_top_utm_campaigns',
+        'UTM contents': 'api_top_utm_contents',
+        'UTM terms': 'api_top_utm_terms'
+    };
+
+    // Get UTM campaign data (only fetch when a campaign is selected)
+    const campaignEndpoint = selectedCampaign ? campaignEndpointMap[selectedCampaign] : '';
+    const {data: utmData, loading: isUtmLoading} = useTinybirdQuery({
+        endpoint: campaignEndpoint,
+        statsConfig,
+        params,
+        enabled: !!selectedCampaign && selectedTab === 'campaigns'
+    });
+
+    // Select and transform the appropriate data based on current view
+    const displayData = React.useMemo(() => {
+        // If we're viewing UTM campaigns, use and transform the UTM data
+        if (selectedTab === 'campaigns' && selectedCampaign && utmData) {
+            // Map UTM field names to the generic key name
+            const utmKeyMap: Record<CampaignType, string> = {
+                '': '',
+                'UTM sources': 'utm_source',
+                'UTM mediums': 'utm_medium',
+                'UTM campaigns': 'utm_campaign',
+                'UTM contents': 'utm_content',
+                'UTM terms': 'utm_term'
+            };
+            
+            const utmKey = utmKeyMap[selectedCampaign];
+            if (!utmKey) {
+                return utmData;
+            }
+            
+            // Transform the data to use 'source' as the key
+            return utmData.map((item: SourcesData) => ({
+                ...item,
+                source: String((item as Record<string, unknown>)[utmKey] || '(not set)'),
+                // Remove the original utm_* key to avoid confusion
+                [utmKey]: undefined
+            }));
+        }
+        
+        // Default to regular sources data
+        return sourcesData;
+    }, [sourcesData, utmData, selectedTab, selectedCampaign]);
 
     // Get total visitors for table
     const totalVisitors = kpiData?.length ? kpiData.reduce((sum, item) => sum + Number(item.visits), 0) : 0;
@@ -123,13 +179,18 @@ const Web: React.FC = () => {
                         totalVisitors={totalVisitors}
                     />
                     <SourcesCard
-                        data={sourcesData as SourcesData[] | null}
+                        data={displayData as SourcesData[] | null}
                         defaultSourceIconUrl={STATS_DEFAULT_SOURCE_ICON_URL}
-                        isLoading={isSourcesLoading}
+                        isLoading={selectedTab === 'campaigns' ? isUtmLoading : isSourcesLoading}
                         range={range}
+                        selectedCampaign={selectedCampaign}
+                        selectedTab={selectedTab}
                         siteIcon={siteIcon}
                         siteUrl={siteUrl}
                         totalVisitors={totalVisitors}
+                        utmTrackingEnabled={utmTrackingEnabled}
+                        onCampaignChange={setSelectedCampaign}
+                        onTabChange={setSelectedTab}
                     />
                 </div>
             </StatsView>

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -167,20 +167,12 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                         range={range}
                         tableHeader={false} />
                 ) : (
-                    // Only show empty state if we're not loading
-                    !isLoading ? (
-                        <EmptyIndicator
-                            className='mt-8 w-full py-20'
-                            title={`No visitors ${getPeriodText(range)}`}
-                        >
-                            <LucideIcon.Globe strokeWidth={1.5} />
-                        </EmptyIndicator>
-                    ) : (
-                        // Show skeleton while loading if no data
-                        <div className='mt-4'>
-                            <SkeletonTable lines={5} />
-                        </div>
-                    )
+                    <EmptyIndicator
+                        className='mt-8 w-full py-20'
+                        title={`No visitors ${getPeriodText(range)}`}
+                    >
+                        <LucideIcon.Globe strokeWidth={1.5} />
+                    </EmptyIndicator>
                 )}
             </CardContent>
             {extendedData.length > 11 &&

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -119,7 +119,7 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     const topSources = extendedData.slice(0, 11);
 
     // Generate description based on mode and range
-    const title = selectedTab === 'campaigns' && selectedCampaign ? `Top ${selectedCampaign}` : 'Top sources';
+    const title = selectedTab === 'campaigns' && selectedCampaign ? `${selectedCampaign}` : 'Top sources';
     const description = `How readers found your ${range ? 'site' : 'post'} ${getPeriodText(range)}`;
 
     // Only show skeleton on initial load, not when switching between tabs
@@ -148,18 +148,16 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
             </div>
             <CardContent className='overflow-hidden'>
                 {utmTrackingEnabled && (
-                    <>
-                        <div className='mb-2'>
-                            <SourceTabs
-                                selectedCampaign={selectedCampaign}
-                                selectedTab={selectedTab}
-                                onCampaignChange={onCampaignChange}
-                                onTabChange={onTabChange}
-                            />
-                        </div>
-                        <Separator />
-                    </>
+                    <div className='mb-4'>
+                        <SourceTabs
+                            selectedCampaign={selectedCampaign}
+                            selectedTab={selectedTab}
+                            onCampaignChange={onCampaignChange}
+                            onTabChange={onTabChange}
+                        />
+                    </div>
                 )}
+                <Separator />
                 {topSources.length > 0 ? (
                     <SourcesTable
                         data={topSources}

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, SourceTabs, TabType, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Default source icon URL - apps can override this
@@ -75,6 +75,11 @@ interface SourcesCardProps {
     siteIcon?: string;
     defaultSourceIconUrl?: string;
     isLoading: boolean;
+    selectedTab: TabType;
+    selectedCampaign: CampaignType;
+    utmTrackingEnabled?: boolean;
+    onTabChange: (tab: TabType) => void;
+    onCampaignChange: (campaign: CampaignType) => void;
 }
 
 export const SourcesCard: React.FC<SourcesCardProps> = ({
@@ -84,7 +89,12 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     siteUrl,
     siteIcon,
     defaultSourceIconUrl = DEFAULT_SOURCE_ICON_URL,
-    isLoading
+    isLoading,
+    selectedTab,
+    selectedCampaign,
+    utmTrackingEnabled = false,
+    onTabChange,
+    onCampaignChange
 }) => {
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
@@ -109,10 +119,11 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     const topSources = extendedData.slice(0, 11);
 
     // Generate description based on mode and range
-    const title = 'Top sources';
+    const title = selectedTab === 'campaigns' && selectedCampaign ? `Top ${selectedCampaign}` : 'Top sources';
     const description = `How readers found your ${range ? 'site' : 'post'} ${getPeriodText(range)}`;
 
-    if (isLoading) {
+    // Only show skeleton on initial load, not when switching between tabs
+    if (isLoading && !data) {
         return (
             <Card className='group/datalist'>
                 <CardHeader>
@@ -136,7 +147,19 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
-                <Separator />
+                {utmTrackingEnabled && (
+                    <>
+                        <div className='mb-2'>
+                            <SourceTabs
+                                selectedCampaign={selectedCampaign}
+                                selectedTab={selectedTab}
+                                onCampaignChange={onCampaignChange}
+                                onTabChange={onTabChange}
+                            />
+                        </div>
+                        <Separator />
+                    </>
+                )}
                 {topSources.length > 0 ? (
                     <SourcesTable
                         data={topSources}
@@ -144,12 +167,20 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                         range={range}
                         tableHeader={false} />
                 ) : (
-                    <EmptyIndicator
-                        className='mt-8 w-full py-20'
-                        title={`No visitors ${getPeriodText(range)}`}
-                    >
-                        <LucideIcon.Globe strokeWidth={1.5} />
-                    </EmptyIndicator>
+                    // Only show empty state if we're not loading
+                    !isLoading ? (
+                        <EmptyIndicator
+                            className='mt-8 w-full py-20'
+                            title={`No visitors ${getPeriodText(range)}`}
+                        >
+                            <LucideIcon.Globe strokeWidth={1.5} />
+                        </EmptyIndicator>
+                    ) : (
+                        // Show skeleton while loading if no data
+                        <div className='mt-4'>
+                            <SkeletonTable lines={5} />
+                        </div>
+                    )
                 )}
             </CardContent>
             {extendedData.length > 11 &&

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -153,7 +153,7 @@ const TopContent: React.FC<TopContentProps> = ({range, totalVisitors}) => {
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
-                <div className='mb-2'>
+                <div className='mb-4'>
                     <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
                         setSelectedContentType(value as ContentType);
                     }}>

--- a/ghost/core/core/server/services/tinybird/TinybirdService.js
+++ b/ghost/core/core/server/services/tinybird/TinybirdService.js
@@ -53,7 +53,12 @@ const TINYBIRD_PIPES = [
     'api_top_locations',
     'api_top_os',
     'api_top_pages',
-    'api_top_sources'
+    'api_top_sources',
+    'api_top_utm_sources',
+    'api_top_utm_mediums',
+    'api_top_utm_campaigns',
+    'api_top_utm_contents',
+    'api_top_utm_terms'
 ];
 
 /**


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2556/
- added new UTM filters to top sources component
- new filters are behind utmTracking flag
- expanded scope of TinybirdService to include new pipes for JWT

There's a few rough edges here, to be expected. The rendering of the Sources subcomponent flashes the full empty state when loading each of the UTM filters. We can fix that down the line, as well as sorting out how we want to do icon display.

__Testing__
- [ ] Make sure the flag shows/hides the UTM filters
- [ ] Make sure the return values display appropriately (can check the Network tab for responses; these are fixtures for the moment)