### PR TITLE
Fixed minor visual bugs in Traffic Analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -433,9 +433,9 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
                                 <HTable className='mr-2'>Members</HTable>
                             </div>
                             {isLoading ?
-                                <CardContent className='p-6'>
+                                <CardContent className='p-6 pt-0'>
                                     <Separator />
-                                    <SkeletonTable />
+                                    <SkeletonTable className='mt-6' />
                                 </CardContent>
                                 :
                                 <CardContent className='pb-0'>

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -181,7 +181,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
                         <div className='grow'>
                             <EmptyIndicator
                                 className='h-full'
-                                description='Try adjusting your date range to see more data.'
+                                description='Try adjusting filters to see more data.'
                                 title={`No visitors ${getPeriodText(range)}`}
                             >
                                 <LucideIcon.Globe strokeWidth={1.5} />

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -34,11 +34,11 @@ const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, d
     const getTableHeader = () => {
         switch (contentType) {
         case CONTENT_TYPES.POSTS:
-            return 'Post';
+            return 'Posts';
         case CONTENT_TYPES.PAGES:
-            return 'Page';
+            return 'Pages';
         default:
-            return 'Post';
+            return 'Posts & pages';
         }
     };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2383/newsletter-link-loading-state-needs-additional-spacing
ref https://linear.app/ghost/issue/ENG-2490/analytics-post-analytics-web-traffics-on-blank-page-message-to-change
ref https://linear.app/ghost/issue/ENG-2489/analytics-web-traffics-top-content-header-name-is-post-while-it-should

- The newsletter links loading skeleton was missing some spacing.
- The empty state copy on post analytics Web tab was too specific.
- The Top content (sidebar) sheet's table heading was incorrectly showing "Post" when "Posts & pages" were selected