### PR TITLE
Fixed "View more" button dark mode bug

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/KpiCard.tsx
@@ -14,7 +14,7 @@ export const KpiCardLabel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
         <div className={
             cn('[&_svg]:size-4 flex items-center gap-1.5 text-base h-[22px] font-medium transition-all',
                 className,
-                props.onClick && 'hover:cursor-pointer hover:text-black'
+                props.onClick && 'hover:cursor-pointer hover:text-black dark:hover:text-white'
             )} {...props}>
             {children}
         </div>
@@ -31,7 +31,7 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
 
 export const KpiCardMoreButton: React.FC<React.ComponentProps<typeof Button>> = ({children, className, ...props}) => {
     return (
-        <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 md:!visible md:!block', className)} size='sm' variant='outline' {...props}>
+        <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black dark:text-white/80 dark:hover:text-white opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 md:!visible md:!block', className)} size='sm' variant='outline' {...props}>
             {children}
         </Button>
     );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2459/oss-issue-view-members-button-has-incorrect-colorbackground-color 
closes https://github.com/TryGhost/Ghost/issues/24675

- The "View more" button was not visible in dark mode on the Post Analytics / Newsletter page.