### PR TITLE
Fixed radial chart bug in Newsletter page

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -260,7 +260,7 @@ const Newsletter: React.FC<postAnalyticsProps> = () => {
     }
     if (!emailTrackClicksEnabled && !emailTrackOpensEnabled) {
         chartHeaderClass = 'grid-cols-1';
-        chartClass = 'aspect-square w-full max-w-[320px] md:max-w-none max-h-[220px] md:max-h-[240px] xl:max-h-[320px]';
+        chartClass = 'aspect-square w-full sm:aspect-[16/10] md:max-w-[320px] md:max-h-[320px] lg:aspect-[12/10]';
     }
 
     return (


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2357/sent-kpi-shows-oddly-in-safari-when-clicksopens-disabled

- The radial chart was not displaying correctly when clicks and opens were disabled.