### PR TITLE
Added confirmation for closing notes with content in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/admin-x-activitypub/src/components/modals/NewNoteModal.tsx
@@ -442,11 +442,11 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel onClick={handleDiscardAndClose}>
-                            Discard
-                        </AlertDialogCancel>
-                        <AlertDialogAction onClick={handleCancelDiscard}>
+                        <AlertDialogCancel onClick={handleCancelDiscard}>
                             Continue writing
+                        </AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDiscardAndClose}>
+                            Discard
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/apps/shade/src/components/ui/dialog.tsx
+++ b/apps/shade/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 import {cn} from '@/lib/utils';
 import {SHADE_APP_NAMESPACES} from '@/ShadeApp';
+import {XIcon} from 'lucide-react';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -29,8 +30,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({className, children, ...props}, ref) => (
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+        showCloseButton?: boolean;
+    }
+>(({className, children, showCloseButton = false, ...props}, ref) => (
     <DialogPortal>
         <div className={SHADE_APP_NAMESPACES}>
             <DialogOverlay />
@@ -43,6 +46,15 @@ const DialogContent = React.forwardRef<
                 {...props}
             >
                 {children}
+                {showCloseButton && (
+                    <DialogPrimitive.Close
+                        className="rounded-xs focus:outline-hidden absolute right-5 top-5 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+                        data-slot="dialog-close"
+                    >
+                        <XIcon />
+                        <span className="sr-only">Close</span>
+                    </DialogPrimitive.Close>
+                )}
             </DialogPrimitive.Content>
         </div>
     </DialogPortal>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2211/create-note-modal-gets-accidentally-closed

- Implemented confirmation dialog when closing note/reply modal with unsaved content
- Allowed direct closing only for empty notes without confirmation
- Added X close button option to dialog component in Shade design system