### PR TITLE
Moved ghost-stats script above injected code in ghost_head

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -335,6 +335,15 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
             head.push(`<script defer src="${getAssetUrl('public/member-attribution.min.js')}"></script>`);
         }
 
+        // Use settingsHelpers to check if web analytics is enabled (includes all necessary checks)
+        if (settingsHelpers.isWebAnalyticsEnabled()) {
+            head.push(getTinybirdTrackerScript(dataRoot));
+            // Set a flag in response locals to indicate tracking script is being served
+            if (dataRoot._locals) {
+                dataRoot._locals.ghostAnalytics = true;
+            }
+        }
+
         if (options.data.site.accent_color) {
             const accentColor = escapeExpression(options.data.site.accent_color);
             const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};}</style>`;
@@ -356,15 +365,6 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
 
         if (!_.isEmpty(tagCodeInjection)) {
             head.push(tagCodeInjection);
-        }
-
-        // Use settingsHelpers to check if web analytics is enabled (includes all necessary checks)
-        if (settingsHelpers.isWebAnalyticsEnabled()) {
-            head.push(getTinybirdTrackerScript(dataRoot));
-            // Set a flag in response locals to indicate tracking script is being served
-            if (dataRoot._locals) {
-                dataRoot._locals.ghostAnalytics = true;
-            }
         }
 
         // Check if if the request is for a site preview, in which case we **always** use the custom font values


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2612/

This is a simple re-ordering change to improve the resiliency of the ghost-stats script as it relates to injected code. Because of how ghost_head is built, if a user doesn't create the correct enclosures in their injected header code, it's possible for the ghost-stats script to be appended to that code. This can result in the script not loading at all.

As a general best practice, we should do all of our script loading before the injected code.