### PR TITLE
Added utm sources to Post Analytics > Web Sources

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, {useState} from 'react';
 import SourceIcon from '../../components/SourceIcon';
-import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, formatNumber, formatPercentage} from '@tryghost/shade';
+import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useTinybirdQuery} from '@tryghost/admin-x-framework';
+import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SourceTabs, TabType, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {getAudienceQueryParam} from '../../components/AudienceSelect';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
@@ -67,6 +69,13 @@ export const SourcesTable: React.FC<SourcesTableProps> = ({dataTableHeader, data
     );
 };
 
+interface SourcesData {
+    source?: string | number;
+    visits?: number;
+    [key: string]: unknown;
+    percentage?: number;
+}
+
 interface SourcesCardProps {
     title?: string;
     description?: string;
@@ -91,16 +100,104 @@ export const Sources: React.FC<SourcesCardProps> = ({
     tableOnly = false,
     topSourcesLimit = 10
 }) => {
+    const {data: globalData, statsConfig, audience, post, isPostLoading} = useGlobalData();
+    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
+    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
+    
+    // Check if UTM tracking is enabled in labs
+    const utmTrackingEnabled = globalData?.labs?.utmTracking || false;
+
+    // Get date range parameters
+    const {startDate, endDate, timezone} = getRangeDates(range);
+
+    // Construct params object
+    const params = React.useMemo(() => {
+        const baseParams = {
+            site_uuid: statsConfig?.id || '',
+            date_from: formatQueryDate(startDate),
+            date_to: formatQueryDate(endDate),
+            timezone: timezone,
+            member_status: getAudienceQueryParam(audience),
+            post_uuid: ''
+        };
+
+        if (!isPostLoading && post?.uuid) {
+            return {
+                ...baseParams,
+                post_uuid: post.uuid
+            };
+        }
+
+        return baseParams;
+    }, [isPostLoading, post, statsConfig?.id, startDate, endDate, timezone, audience]);
+
+    // Map campaign types to endpoints
+    const campaignEndpointMap: Record<CampaignType, string> = {
+        '': '',
+        'UTM sources': 'api_top_utm_sources',
+        'UTM mediums': 'api_top_utm_mediums',
+        'UTM campaigns': 'api_top_utm_campaigns',
+        'UTM contents': 'api_top_utm_contents',
+        'UTM terms': 'api_top_utm_terms'
+    };
+
+    // Get UTM campaign data (only fetch when UTM is enabled, campaigns tab is selected, and a campaign is selected)
+    const campaignEndpoint = selectedCampaign ? campaignEndpointMap[selectedCampaign] : '';
+    const {data: utmData} = useTinybirdQuery({
+        endpoint: campaignEndpoint,
+        statsConfig: statsConfig || {id: ''},
+        params: params || {},
+        enabled: utmTrackingEnabled && selectedTab === 'campaigns' && !!selectedCampaign
+    });
+
+    // Select and transform the appropriate data based on current view
+    const displayData = React.useMemo(() => {
+        // If we're viewing UTM campaigns, use and transform the UTM data
+        if (selectedTab === 'campaigns' && selectedCampaign) {
+            // If UTM data is still loading or undefined, return null
+            if (!utmData) {
+                return null;
+            }
+            
+            // Map UTM field names to the generic key name
+            const utmKeyMap: Record<CampaignType, string> = {
+                '': '',
+                'UTM sources': 'utm_source',
+                'UTM mediums': 'utm_medium',
+                'UTM campaigns': 'utm_campaign',
+                'UTM contents': 'utm_content',
+                'UTM terms': 'utm_term'
+            };
+            
+            const utmKey = utmKeyMap[selectedCampaign];
+            if (!utmKey) {
+                return utmData;
+            }
+            
+            // Transform the data to use 'source' as the key, omitting the original utm_* field
+            return utmData.map((item: SourcesData) => {
+                const {[utmKey]: utmValue, ...rest} = item as Record<string, unknown>;
+                return {
+                    ...rest,
+                    source: String(utmValue || '(not set)')
+                };
+            });
+        }
+        
+        // Default to regular sources data
+        return data;
+    }, [data, utmData, selectedTab, selectedCampaign]);
+
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
         return processSources({
-            data,
+            data: displayData,
             mode: 'visits',
             siteUrl,
             siteIcon,
             defaultSourceIconUrl
         });
-    }, [data, siteUrl, siteIcon, defaultSourceIconUrl]);
+    }, [displayData, siteUrl, siteIcon, defaultSourceIconUrl]);
 
     // Extend processed data with percentage values for visits mode
     const extendedData = React.useMemo(() => {
@@ -113,7 +210,8 @@ export const Sources: React.FC<SourcesCardProps> = ({
 
     const topSources = extendedData.slice(0, topSourcesLimit);
 
-    // Generate description based on mode and range
+    // Generate title and description based on mode and range
+    const cardTitle = selectedTab === 'campaigns' && selectedCampaign ? `${selectedCampaign}` : 'Top sources';
     const cardDescription = `How readers found this post ${range && ` ${getPeriodText(range)}`}`;
 
     if (tableOnly) {
@@ -138,7 +236,7 @@ export const Sources: React.FC<SourcesCardProps> = ({
                             </SheetTrigger>
                             <SheetContent className='overflow-y-auto pt-0 sm:max-w-[600px]'>
                                 <SheetHeader className='sticky top-0 z-40 -mx-6 bg-background/60 p-6 backdrop-blur'>
-                                    <SheetTitle>Sources</SheetTitle>
+                                    <SheetTitle>{cardTitle}</SheetTitle>
                                     <SheetDescription>{cardDescription}</SheetDescription>
                                 </SheetHeader>
                                 <div className='group/datalist'>
@@ -161,13 +259,23 @@ export const Sources: React.FC<SourcesCardProps> = ({
         <Card className='group/datalist'>
             <div className='flex items-center justify-between p-6'>
                 <CardHeader className='p-0'>
-                    <CardTitle>Top sources</CardTitle>
+                    <CardTitle>{cardTitle}</CardTitle>
                     <CardDescription>{cardDescription}</CardDescription>
                 </CardHeader>
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
-                <Separator />
+                {utmTrackingEnabled && (
+                    <div className='mb-4'>
+                        <SourceTabs
+                            selectedCampaign={selectedCampaign}
+                            selectedTab={selectedTab}
+                            onCampaignChange={setSelectedCampaign}
+                            onTabChange={setSelectedTab}
+                        />
+                    </div>
+                )}
+                <div className='h-[1px] w-full bg-border' />
                 {topSources.length > 0 ? (
                     <SourcesTable
                         data={topSources}
@@ -189,7 +297,7 @@ export const Sources: React.FC<SourcesCardProps> = ({
                         </SheetTrigger>
                         <SheetContent className='overflow-y-auto pt-0 sm:max-w-[600px]'>
                             <SheetHeader className='sticky top-0 z-40 -mx-6 bg-background/60 p-6 backdrop-blur'>
-                                <SheetTitle>Sources</SheetTitle>
+                                <SheetTitle>{cardTitle}</SheetTitle>
                                 <SheetDescription>{cardDescription}</SheetDescription>
                             </SheetHeader>
                             <div className='group/datalist'>

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -148,7 +148,7 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
             </div>
             <CardContent className='overflow-hidden'>
                 {utmTrackingEnabled && (
-                    <div className='mb-4'>
+                    <div className='mb-2'>
                         <SourceTabs
                             selectedCampaign={selectedCampaign}
                             selectedTab={selectedTab}

--- a/apps/stats/src/views/Stats/Web/components/TopContent.tsx
+++ b/apps/stats/src/views/Stats/Web/components/TopContent.tsx
@@ -153,7 +153,7 @@ const TopContent: React.FC<TopContentProps> = ({range, totalVisitors}) => {
                 <HTable className='mr-2'>Visitors</HTable>
             </div>
             <CardContent className='overflow-hidden'>
-                <div className='mb-4'>
+                <div className='mb-2'>
                     <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
                         setSelectedContentType(value as ContentType);
                     }}>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2558/add-utm-dropdown-to-posts-web-top-sources
- added utm sources to Web > Sources component behind utmTracking flag

There's still some rough edges:
- loading state, like with Stats > Web, is disruptive when switching tabs
- there is not separators on Locations and Sources on this tab; I attempted to add these, and was having display issues