### PR TITLE
Updated ghost-stats UTM payload

### DIFF
--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -182,11 +182,11 @@ export class GhostStats {
                 },
                 pathname: location?.pathname,
                 href: location?.href,
-                utmSource: referrerData.utmSource,
-                utmMedium: referrerData.utmMedium,
-                utmCampaign: referrerData.utmCampaign,
-                utmTerm: referrerData.utmTerm,
-                utmContent: referrerData.utmContent
+                utm_source: referrerData.utmSource,
+                utm_medium: referrerData.utmMedium,
+                utm_campaign: referrerData.utmCampaign,
+                utm_term: referrerData.utmTerm,
+                utm_content: referrerData.utmContent
             });
         }, 300);
     }

--- a/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
+++ b/ghost/core/core/frontend/src/ghost-stats/ghost-stats.js
@@ -175,9 +175,18 @@ export class GhostStats {
                 'user-agent': navigator?.userAgent,
                 locale,
                 location: country,
-                parsedReferrer: referrerData,
+                parsedReferrer: {
+                    url: referrerData.url,
+                    source: referrerData.source,
+                    medium: referrerData.medium,
+                },
                 pathname: location?.pathname,
                 href: location?.href,
+                utmSource: referrerData.utmSource,
+                utmMedium: referrerData.utmMedium,
+                utmCampaign: referrerData.utmCampaign,
+                utmTerm: referrerData.utmTerm,
+                utmContent: referrerData.utmContent
             });
         }, 300);
     }

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -310,11 +310,11 @@ describe('ghost-stats.js', function () {
             
             // Verify UTM fields are present at top level
             expect(payload).to.include({
-                utmSource: 'test-source',
-                utmMedium: 'test-medium',
-                utmCampaign: 'test-campaign',
-                utmTerm: 'test-term',
-                utmContent: 'test-content'
+                utm_source: 'test-source',
+                utm_medium: 'test-medium',
+                utm_campaign: 'test-campaign',
+                utm_term: 'test-term',
+                utm_content: 'test-content'
             });
         });
 
@@ -385,11 +385,11 @@ describe('ghost-stats.js', function () {
             
             // Verify UTM tracking fields are present
             expect(innerPayload).to.include({
-                utmSource: 'test-source',
-                utmMedium: 'test-medium',
-                utmCampaign: 'test-campaign',
-                utmTerm: 'test-term',
-                utmContent: 'test-content'
+                utm_source: 'test-source',
+                utm_medium: 'test-medium',
+                utm_campaign: 'test-campaign',
+                utm_term: 'test-term',
+                utm_content: 'test-content'
             });
             
             // Verify data types
@@ -403,7 +403,7 @@ describe('ghost-stats.js', function () {
             
             // Verify referrer structure is clean (no UTM fields)
             expect(innerPayload.parsedReferrer).to.have.all.keys(['url', 'source', 'medium']);
-            expect(innerPayload.parsedReferrer).to.not.have.any.keys(['utmSource', 'utmMedium', 'utmCampaign', 'utmTerm', 'utmContent']);
+            expect(innerPayload.parsedReferrer).to.not.have.any.keys(['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content']);
         });
 
         it('should handle missing token gracefully', async function () {

--- a/ghost/core/test/unit/frontend/public/ghost-stats.test.js
+++ b/ghost/core/test/unit/frontend/public/ghost-stats.test.js
@@ -615,11 +615,11 @@ describe('ghost-stats.js', function () {
             
             // Verify UTM data is at top level
             expect(innerPayload).to.include({
-                utmSource: 'twitter',
-                utmMedium: 'social',
-                utmCampaign: 'test-campaign',
-                utmTerm: 'test-term',
-                utmContent: 'test-content'
+                utm_source: 'twitter',
+                utm_medium: 'social',
+                utm_campaign: 'test-campaign',
+                utm_term: 'test-term',
+                utm_content: 'test-content'
             });
         });
 
@@ -639,11 +639,11 @@ describe('ghost-stats.js', function () {
             
             // UTM fields should still be present and null
             expect(innerPayload).to.include({
-                utmSource: null,
-                utmMedium: null,
-                utmCampaign: null,
-                utmTerm: null,
-                utmContent: null
+                utm_source: null,
+                utm_medium: null,
+                utm_campaign: null,
+                utm_term: null,
+                utm_content: null
             });
         });
 
@@ -664,11 +664,11 @@ describe('ghost-stats.js', function () {
             
             // UTM fields should be present and null
             expect(innerPayload).to.include({
-                utmSource: null,
-                utmMedium: null,
-                utmCampaign: null,
-                utmTerm: null,
-                utmContent: null
+                utm_source: null,
+                utm_medium: null,
+                utm_campaign: null,
+                utm_term: null,
+                utm_content: null
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2619/
- updated payload to only keep referrer fields in parsedReferrer, utm fields at top level
- updated tests
- refactored tests to be a bit more readable/usable

After deciding to change the shape of the payload in the TryGhost/TrafficAnalytics repo, we need this change to the ghost-stats payload.