### PR TITLE
🎨 Added uuid column to tokens table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-38-13-add-uuid-column-to-tokens.js
+++ b/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-38-13-add-uuid-column-to-tokens.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('tokens', 'uuid', {
+    type: 'string',
+    maxlength: 36,
+    nullable: true,
+    unique: true
+});

--- a/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-39-08-backfill-tokens-uuid.js
+++ b/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-39-08-backfill-tokens-uuid.js
@@ -1,0 +1,19 @@
+const logging = require('@tryghost/logging');
+const crypto = require('crypto');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const tokensWithoutUUID = await knex.select('id').from('tokens').whereNull('uuid');
+
+        logging.info(`Adding uuid field value to ${tokensWithoutUUID.length} tokens.`);
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const token of tokensWithoutUUID) {
+            await knex('tokens').update('uuid', crypto.randomUUID()).where('id', token.id);
+        }
+    },
+    // down is a no-op
+    async function down() {}
+);

--- a/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-39-36-tokens-drop-nullable-uuid.js
+++ b/ghost/core/core/server/data/migrations/versions/6.1/2025-09-11-00-39-36-tokens-drop-nullable-uuid.js
@@ -1,0 +1,4 @@
+const {createDropNullableMigration} = require('../../utils');
+
+module.exports = createDropNullableMigration('tokens', 'uuid');
+

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -896,6 +896,7 @@ module.exports = {
     tokens: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         token: {type: 'string', maxlength: 32, nullable: false, index: true},
+        uuid: {type: 'string', maxlength: 36, nullable: false, unique: true, validations: {isUUID: true}},
         data: {type: 'string', maxlength: 2000, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/models/single-use-token.js
+++ b/ghost/core/core/server/models/single-use-token.js
@@ -7,6 +7,7 @@ const SingleUseToken = ghostBookshelf.Model.extend({
     defaults() {
         return {
             used_count: 0,
+            uuid: crypto.randomUUID(),
             token: crypto
                 .randomBytes(192 / 8)
                 .toString('base64')

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '4f96cec9c93388cd1e619ea59d111cac';
+    const currentSchemaHash = '526d04f5d3321f1ce1399acd4acb75c7';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = '17f64e5c9cd6075f6939903439dce56c';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -2,6 +2,7 @@ const models = require('../../../../core/server/models');
 const should = require('should');
 const sinon = require('sinon');
 const assert = require('assert/strict');
+const validator = require('validator');
 
 let clock;
 let sandbox;
@@ -23,6 +24,26 @@ describe('Unit: models/single-use-token', function () {
             const model = new models.SingleUseToken();
             const defaults = model.defaults();
             assert.equal(defaults.used_count, 0);
+        });
+
+        it('Generates a valid v4 UUID by default', async function () {
+            const model = new models.SingleUseToken();
+            const defaults = model.defaults();
+            
+            should.exist(defaults.uuid);
+            assert.equal(validator.isUUID(defaults.uuid, 4), true, 'Generated UUID should be a valid v4 UUID');
+        });
+
+        it('Generates unique UUIDs for different instances', async function () {
+            const model1 = new models.SingleUseToken();
+            const model2 = new models.SingleUseToken();
+            
+            const defaults1 = model1.defaults();
+            const defaults2 = model2.defaults();
+            
+            should.exist(defaults1.uuid);
+            should.exist(defaults2.uuid);
+            assert.notEqual(defaults1.uuid, defaults2.uuid, 'Each instance should generate a unique UUID');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2492

- Adds the `uuid` column to the tokens table
- We want to keep `token.id` non-public so we are able to use it any future Admin operations, and so there's no public data used when deriving a token code
- But we need to provide a public lookup reference from the `/send-magic-link/` endpoint so clients can pass the reference+code (future work)
- Adding a `uuid` column follows patterns we use elsewhere