### PR TITLE
🐛 Fixed limit changes not updating without page refresh

### DIFF
--- a/apps/admin-x-settings/src/hooks/useLimiter.tsx
+++ b/apps/admin-x-settings/src/hooks/useLimiter.tsx
@@ -74,8 +74,18 @@ export const useLimiter = () => {
     }, [config.hostSettings?.billing]);
 
     return useMemo(() => {
+        // Return a stable no-op API when the limiter isn't ready
+        // This prevents runtime errors while maintaining backward compatibility
+        const noOpLimiter = {
+            isLimited: (): boolean => false,
+            isDisabled: (): boolean => false,
+            checkWouldGoOverLimit: (): Promise<boolean> => Promise.resolve(false),
+            errorIfWouldGoOverLimit: (): Promise<void> => Promise.resolve(),
+            errorIfIsOverLimit: (): Promise<void> => Promise.resolve()
+        };
+
         if (!LimitService || !config.hostSettings?.limits || isLoading) {
-            return;
+            return noOpLimiter;
         }
 
         const limits = {...config.hostSettings.limits} as LimiterLimits;

--- a/apps/admin-x-settings/src/hooks/useLimiter.tsx
+++ b/apps/admin-x-settings/src/hooks/useLimiter.tsx
@@ -122,5 +122,5 @@ export const useLimiter = () => {
             errorIfWouldGoOverLimit: (limitName: string, metadata: Record<string, unknown> = {}): Promise<void> => limiter.errorIfWouldGoOverLimit(limitName, metadata),
             errorIfIsOverLimit: (limitName: string): Promise<void> => limiter.errorIfIsOverLimit(limitName)
         };
-    }, [LimitService, config.hostSettings?.limits, contributorUsers, fetchMembers, fetchNewsletters, helpLink, invites, isLoading, users]);
+    }, [LimitService, config, contributorUsers, fetchMembers, fetchNewsletters, helpLink, invites, isLoading, users]);
 };

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -119,7 +119,7 @@ export default class GhBillingIframe extends Component {
         await this.limit.reload();
 
         // Invalidate React Query cache for config data in admin-x-settings
-        if (window.adminXQueryClient) {
+        if (window?.adminXQueryClient?.invalidateQueries && typeof window.adminXQueryClient.invalidateQueries === 'function') {
             window.adminXQueryClient.invalidateQueries(['ConfigResponseType']);
         }
 

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -48,10 +48,6 @@ export default class GhBillingIframe extends Component {
             if (event.data?.subscription) {
                 this._handleSubscriptionUpdate(event.data);
             }
-
-            if (event.data?.request === 'refreshRequired') {
-                this._handleRefreshRequired();
-            }
         }
     }
 

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -112,7 +112,7 @@ export default class GhBillingIframe extends Component {
         await this.configManager.fetch();
 
         // Reload the limit service to ensure all admin pages can enforce limits
-        await this.limit.reload();
+        this.limit.reload();
 
         // Invalidate React Query cache for config data in admin-x-settings
         if (window?.adminXQueryClient?.invalidateQueries && typeof window.adminXQueryClient.invalidateQueries === 'function') {

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -122,11 +122,11 @@ export default class GhBillingIframe extends Component {
         if (window?.adminXQueryClient?.invalidateQueries && typeof window.adminXQueryClient.invalidateQueries === 'function') {
             try {
                 // React Query v5+
-                window.adminXQueryClient.invalidateQueries({queryKey: ['ConfigResponseType']});
+                window.adminXQueryClient.invalidateQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
             } catch (_) {
                 // TODO: remove this fallback when Admin-X-Settings updates to React Query v5+ (@tanstack/react-query)
                 // React Query v4 fallback
-                window.adminXQueryClient.invalidateQueries(['ConfigResponseType']);
+                window.adminXQueryClient.invalidateQueries(['ConfigResponseType']).catch(() => {});
             }
         }
 

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -118,6 +118,11 @@ export default class GhBillingIframe extends Component {
         // Reload the limit service to ensure all admin pages can enforce limits
         await this.limit.reload();
 
+        // Invalidate React Query cache for config data in admin-x-settings
+        if (window.adminXQueryClient) {
+            window.adminXQueryClient.invalidateQueries(['ConfigResponseType']);
+        }
+
         this.billing.subscription = data.subscription;
         this.billing.checkoutRoute = data?.checkoutRoute ?? '/plans';
 

--- a/ghost/admin/app/services/limit.js
+++ b/ghost/admin/app/services/limit.js
@@ -34,9 +34,16 @@ export default class LimitsService extends Service {
     constructor() {
         super(...arguments);
 
-        let limits = this.config.hostSettings?.limits;
-
         this.limiter = new LimitService();
+        this.loadLimits();
+    }
+
+    async checkWouldGoOverLimit(limitName, metadata = {}) {
+        return this.limiter.checkWouldGoOverLimit(limitName, metadata);
+    }
+
+    loadLimits() {
+        let limits = this.config.hostSettings?.limits;
 
         if (!limits) {
             return;
@@ -60,8 +67,8 @@ export default class LimitsService extends Service {
         });
     }
 
-    async checkWouldGoOverLimit(limitName, metadata = {}) {
-        return this.limiter.checkWouldGoOverLimit(limitName, metadata);
+    reload() {
+        this.loadLimits();
     }
 
     decorateWithCountQueries(limits) {


### PR DESCRIPTION
closes [BAE-492](https://linear.app/ghost/issue/BAE-492/limit-changes-requires-a-page-refresh-to-be-reflected-in-admin)

When users upgraded or changed their subscription plan through the billing iframe, the configuration limits in Admin Settings remained stale until a manual page refresh. This prevented users from immediately accessing newly unlocked features like Stripe Connect, Web Analytics, or additional newsletter creation after upgrading their plan.

The issue occurred because React Query was caching the config data in Admin-X Settings without invalidation when external subscription updates occurred, the `useLimiter` hook's memoization wasn't properly tracking config changes due to using a nested property (`config.hostSettings?.limits`) instead of the full config object as a dependency, and the limit service in Ghost Admin wasn't reloading when subscription changes were received.

This PR implements a comprehensive fix that ensures all admin interfaces update in real-time when plan changes occur. Added React Query cache invalidation in `gh-billing-iframe.js` when subscription update messages are received from the billing iframe, with fallback support for both React Query v4 and v5. Implemented config refresh and limit service reload to ensure Ghost Admin pages can immediately enforce updated limits. Fixed memoization in `useLimiter` hook to properly track config changes by using the full `config` object as a dependency. Added defensive no-op limiter API to prevent runtime errors when the limiter service isn't ready, improving overall stability.

Users now have immediate access to newly available features after plan upgrades without requiring page refreshes. All limit-dependent UI elements update in real-time across both Ghost Admin and Admin-X Settings. Improved error handling prevents potential runtime exceptions when accessing React Query client or during initialization.

Due to the nature of billing integrations, this needs to be verified on staging environments with actual subscription changes.