### PR TITLE
Added stories for Shade data components

### DIFF
--- a/apps/shade/src/components/ui/avatar.stories.tsx
+++ b/apps/shade/src/components/ui/avatar.stories.tsx
@@ -5,6 +5,13 @@ const meta = {
     title: 'Components / Avatar',
     component: Avatar,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Display user profile images with fallback initials when images fail to load. Built on Radix UI primitives with consistent sizing and styling.'
+            }
+        }
+    },
     argTypes: {
         children: {
             table: {
@@ -32,4 +39,76 @@ export const WithImage: Story = {
             </>
         )
     }
+};
+
+export const BrokenImage: Story = {
+    args: {
+        children: (
+            <>
+                <AvatarImage src="https://broken-url.example.com/image.jpg" />
+                <AvatarFallback>BU</AvatarFallback>
+            </>
+        )
+    }
+};
+
+export const DifferentSizes: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <Avatar className="size-6">
+                <AvatarFallback className="text-xs">XS</AvatarFallback>
+            </Avatar>
+            <Avatar>
+                <AvatarFallback>SM</AvatarFallback>
+            </Avatar>
+            <Avatar className="size-12">
+                <AvatarFallback>MD</AvatarFallback>
+            </Avatar>
+            <Avatar className="size-16">
+                <AvatarFallback>LG</AvatarFallback>
+            </Avatar>
+        </div>
+    )
+};
+
+export const MultipleAvatars: Story = {
+    render: () => (
+        <div className="flex items-center gap-2">
+            <Avatar>
+                <AvatarImage src="https://avatars.githubusercontent.com/u/2178663?s=200&v=4" />
+                <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <Avatar>
+                <AvatarImage src="https://avatars.githubusercontent.com/u/124599?s=200&v=4" />
+                <AvatarFallback>JS</AvatarFallback>
+            </Avatar>
+            <Avatar>
+                <AvatarFallback>AB</AvatarFallback>
+            </Avatar>
+            <Avatar>
+                <AvatarFallback>CD</AvatarFallback>
+            </Avatar>
+        </div>
+    )
+};
+
+export const StackedAvatars: Story = {
+    render: () => (
+        <div className="flex -space-x-2">
+            <Avatar className="border-2 border-background">
+                <AvatarImage src="https://avatars.githubusercontent.com/u/2178663?s=200&v=4" />
+                <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <Avatar className="border-2 border-background">
+                <AvatarImage src="https://avatars.githubusercontent.com/u/124599?s=200&v=4" />
+                <AvatarFallback>JS</AvatarFallback>
+            </Avatar>
+            <Avatar className="border-2 border-background">
+                <AvatarFallback>AB</AvatarFallback>
+            </Avatar>
+            <Avatar className="border-2 border-background">
+                <AvatarFallback>+5</AvatarFallback>
+            </Avatar>
+        </div>
+    )
 };

--- a/apps/shade/src/components/ui/badge.stories.tsx
+++ b/apps/shade/src/components/ui/badge.stories.tsx
@@ -4,7 +4,20 @@ import {Badge} from './badge';
 const meta = {
     title: 'Components / Badge',
     component: Badge,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Small status indicators and labels with multiple variants. Use for displaying tags, statuses, categories, or any short descriptive text that needs visual emphasis.'
+            }
+        }
+    },
+    argTypes: {
+        variant: {
+            control: {type: 'select'},
+            options: ['default', 'secondary', 'destructive', 'success', 'outline']
+        }
+    }
 } satisfies Meta<typeof Badge>;
 
 export default meta;
@@ -14,4 +27,44 @@ export const Default: Story = {
     args: {
         children: 'Badge'
     }
+};
+
+export const Secondary: Story = {
+    args: {
+        variant: 'secondary',
+        children: 'Secondary'
+    }
+};
+
+export const Destructive: Story = {
+    args: {
+        variant: 'destructive',
+        children: 'Error'
+    }
+};
+
+export const Success: Story = {
+    args: {
+        variant: 'success',
+        children: 'Success'
+    }
+};
+
+export const Outline: Story = {
+    args: {
+        variant: 'outline',
+        children: 'Outline'
+    }
+};
+
+export const AllVariants: Story = {
+    render: () => (
+        <div className="flex gap-2">
+            <Badge>Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="destructive">Error</Badge>
+            <Badge variant="success">Success</Badge>
+            <Badge variant="outline">Outline</Badge>
+        </div>
+    )
 };

--- a/apps/shade/src/components/ui/card.stories.tsx
+++ b/apps/shade/src/components/ui/card.stories.tsx
@@ -6,7 +6,14 @@ import {Eye, User, Coins} from 'lucide-react';
 const meta = {
     title: 'Components / Card',
     component: Card,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Flexible containers for displaying content with consistent styling. Includes standard cards for general content and specialized KPI cards for displaying metrics and trends.'
+            }
+        }
+    }
 } satisfies Meta<typeof Card>;
 
 export default meta;

--- a/apps/shade/src/components/ui/chart.stories.tsx
+++ b/apps/shade/src/components/ui/chart.stories.tsx
@@ -1,12 +1,19 @@
 import type {Meta} from '@storybook/react';
 import {ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent} from './chart';
 import React from 'react';
-import {Label, Pie, PieChart} from 'recharts';
+import {Label, Pie, PieChart, Bar, BarChart, XAxis, YAxis, Line, LineChart} from 'recharts';
 
 const meta = {
     title: 'Components / Charts',
     component: ChartContainer,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Chart components built on ShadCN/UI and Recharts for data visualization. Provides consistent theming and responsive containers for various chart types including pie, bar, and line charts.'
+            }
+        }
+    },
     argTypes: {
         children: {
             control: false
@@ -97,6 +104,73 @@ export const Default = {
                     Visit <a className="underline" href="https://ui.shadcn.com/docs/components/chart" rel="noreferrer" target="_blank">ShadCN/UI Charts docs</a> for usage details.
                 </div>
             </>
+        );
+    }
+};
+
+export const BarChartExample = {
+    render: function BarChartStory() {
+        const chartData = [
+            {month: 'January', visitors: 186},
+            {month: 'February', visitors: 305},
+            {month: 'March', visitors: 237},
+            {month: 'April', visitors: 273},
+            {month: 'May', visitors: 209},
+            {month: 'June', visitors: 214}
+        ];
+
+        const chartConfig = {
+            visitors: {
+                label: 'Visitors',
+                color: 'hsl(var(--chart-blue))'
+            }
+        } satisfies ChartConfig;
+
+        return (
+            <ChartContainer className="h-[200px]" config={chartConfig}>
+                <BarChart data={chartData}>
+                    <XAxis dataKey="month" />
+                    <ChartTooltip content={<ChartTooltipContent />} />
+                    <Bar dataKey="visitors" fill="var(--color-visitors)" radius={4} />
+                </BarChart>
+            </ChartContainer>
+        );
+    }
+};
+
+export const LineChartExample = {
+    render: function LineChartStory() {
+        const chartData = [
+            {month: 'Jan', revenue: 2400},
+            {month: 'Feb', revenue: 1398},
+            {month: 'Mar', revenue: 9800},
+            {month: 'Apr', revenue: 3908},
+            {month: 'May', revenue: 4800},
+            {month: 'Jun', revenue: 3800}
+        ];
+
+        const chartConfig = {
+            revenue: {
+                label: 'Revenue',
+                color: 'hsl(var(--chart-green))'
+            }
+        } satisfies ChartConfig;
+
+        return (
+            <ChartContainer className="h-[200px]" config={chartConfig}>
+                <LineChart data={chartData}>
+                    <XAxis dataKey="month" />
+                    <YAxis />
+                    <ChartTooltip content={<ChartTooltipContent />} />
+                    <Line 
+                        dataKey="revenue"
+                        dot={false}
+                        stroke="var(--color-revenue)" 
+                        strokeWidth={2}
+                        type="monotone"
+                    />
+                </LineChart>
+            </ChartContainer>
         );
     }
 };

--- a/apps/shade/src/components/ui/data-list.stories.tsx
+++ b/apps/shade/src/components/ui/data-list.stories.tsx
@@ -4,7 +4,14 @@ import {DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataL
 const meta = {
     title: 'Components / Data List',
     component: DataList,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Display structured data with visual bars for comparison. Ideal for analytics dashboards, leaderboards, and any data requiring visual ranking or comparison.'
+            }
+        }
+    }
 } satisfies Meta<typeof DataList>;
 
 export default meta;
@@ -85,3 +92,43 @@ export const Default: Story = {
         ]
     }
 };
+
+export const WithoutHeader: Story = {
+    args: {
+        children: [
+            <DataListBody className='group/datalist'>
+                <DataListRow>
+                    <DataListBar style={{width: '100%'}} />
+                    <DataListItemContent>
+                        <div className='flex items-center space-x-4 overflow-hidden'>
+                            <div>🏆</div>
+                            <div className='truncate font-medium'>
+                                Top Performer
+                            </div>
+                        </div>
+                    </DataListItemContent>
+                    <DataListItemValue>
+                        <DataListItemValueAbs>1,500</DataListItemValueAbs>
+                        <DataListItemValuePerc>100%</DataListItemValuePerc>
+                    </DataListItemValue>
+                </DataListRow>
+                <DataListRow>
+                    <DataListBar style={{width: '80%'}} />
+                    <DataListItemContent>
+                        <div className='flex items-center space-x-4 overflow-hidden'>
+                            <div>🥈</div>
+                            <div className='truncate font-medium'>
+                                Second Place
+                            </div>
+                        </div>
+                    </DataListItemContent>
+                    <DataListItemValue>
+                        <DataListItemValueAbs>1,200</DataListItemValueAbs>
+                        <DataListItemValuePerc>80%</DataListItemValuePerc>
+                    </DataListItemValue>
+                </DataListRow>
+            </DataListBody>
+        ]
+    }
+};
+

--- a/apps/shade/src/components/ui/flag.stories.tsx
+++ b/apps/shade/src/components/ui/flag.stories.tsx
@@ -1,0 +1,105 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Flag} from './flag';
+
+const meta = {
+    title: 'Components / Flag',
+    component: Flag,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Display country flags using ISO country codes. Built on react-world-flags with customizable sizing and fallback support for invalid or missing country codes.'
+            }
+        }
+    },
+    argTypes: {
+        countryCode: {
+            control: {type: 'text'},
+            description: 'ISO country code (e.g., US, GB, FR)'
+        },
+        width: {
+            control: {type: 'text'}
+        },
+        height: {
+            control: {type: 'text'}
+        },
+        fallback: {
+            control: false
+        }
+    }
+} satisfies Meta<typeof Flag>;
+
+export default meta;
+type Story = StoryObj<typeof Flag>;
+
+export const Default: Story = {
+    args: {
+        countryCode: 'US'
+    }
+};
+
+export const UnitedKingdom: Story = {
+    args: {
+        countryCode: 'GB'
+    }
+};
+
+export const France: Story = {
+    args: {
+        countryCode: 'FR'
+    }
+};
+
+export const Germany: Story = {
+    args: {
+        countryCode: 'DE'
+    }
+};
+
+export const Canada: Story = {
+    args: {
+        countryCode: 'CA'
+    }
+};
+
+export const CustomSize: Story = {
+    args: {
+        countryCode: 'JP',
+        width: '32px',
+        height: '20px'
+    }
+};
+
+export const LargeSize: Story = {
+    args: {
+        countryCode: 'BR',
+        width: '48px',
+        height: '32px'
+    }
+};
+
+export const InvalidCode: Story = {
+    args: {
+        countryCode: 'XX'
+    }
+};
+
+export const WithCustomFallback: Story = {
+    args: {
+        countryCode: 'INVALID',
+        fallback: <span className="flex items-center justify-center text-xs">?</span>
+    }
+};
+
+export const MultipleFlags: Story = {
+    render: () => (
+        <div className="flex gap-2">
+            <Flag countryCode="US" />
+            <Flag countryCode="GB" />
+            <Flag countryCode="FR" />
+            <Flag countryCode="DE" />
+            <Flag countryCode="JP" />
+            <Flag countryCode="AU" />
+        </div>
+    )
+};

--- a/apps/shade/src/components/ui/gh-chart.stories.tsx
+++ b/apps/shade/src/components/ui/gh-chart.stories.tsx
@@ -1,0 +1,116 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {GhAreaChart, type GhAreaChartDataItem} from './gh-chart';
+
+const meta = {
+    title: 'Components / Ghost Chart',
+    component: GhAreaChart,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Ghost-specific area charts for analytics dashboards. Built on Recharts with custom tooltips, trend indicators, and optimized date formatting for time-series data visualization.'
+            }
+        }
+    },
+    argTypes: {
+        data: {
+            control: false
+        },
+        range: {
+            control: {type: 'number'}
+        },
+        color: {
+            control: {type: 'color'}
+        }
+    }
+} satisfies Meta<typeof GhAreaChart>;
+
+export default meta;
+type Story = StoryObj<typeof GhAreaChart>;
+
+// Sample data for stories
+const sampleData: GhAreaChartDataItem[] = [
+    {date: '2024-01-01', value: 120, formattedValue: '120', label: 'Visitors'},
+    {date: '2024-01-02', value: 95, formattedValue: '95', label: 'Visitors'},
+    {date: '2024-01-03', value: 180, formattedValue: '180', label: 'Visitors'},
+    {date: '2024-01-04', value: 220, formattedValue: '220', label: 'Visitors'},
+    {date: '2024-01-05', value: 160, formattedValue: '160', label: 'Visitors'},
+    {date: '2024-01-06', value: 310, formattedValue: '310', label: 'Visitors'},
+    {date: '2024-01-07', value: 250, formattedValue: '250', label: 'Visitors'}
+];
+
+const revenueData: GhAreaChartDataItem[] = [
+    {date: '2024-01-01', value: 2400, formattedValue: '$2,400', label: 'Revenue'},
+    {date: '2024-01-02', value: 1890, formattedValue: '$1,890', label: 'Revenue'},
+    {date: '2024-01-03', value: 3200, formattedValue: '$3,200', label: 'Revenue'},
+    {date: '2024-01-04', value: 4100, formattedValue: '$4,100', label: 'Revenue'},
+    {date: '2024-01-05', value: 2800, formattedValue: '$2,800', label: 'Revenue'},
+    {date: '2024-01-06', value: 5200, formattedValue: '$5,200', label: 'Revenue'},
+    {date: '2024-01-07', value: 3900, formattedValue: '$3,900', label: 'Revenue'}
+];
+
+export const Default: Story = {
+    args: {
+        data: sampleData,
+        range: 7,
+        id: 'visitors-chart',
+        className: 'h-[200px]'
+    }
+};
+
+export const WithCustomColor: Story = {
+    args: {
+        data: revenueData,
+        range: 7,
+        color: 'hsl(var(--chart-green))',
+        id: 'revenue-chart',
+        className: 'h-[200px]'
+    }
+};
+
+export const WithoutYAxisValues: Story = {
+    args: {
+        data: sampleData,
+        range: 7,
+        id: 'no-yaxis-chart',
+        className: 'h-[200px]',
+        showYAxisValues: false
+    }
+};
+
+export const WithoutHorizontalLines: Story = {
+    args: {
+        data: sampleData,
+        range: 7,
+        id: 'no-grid-chart',
+        className: 'h-[200px]',
+        showHorizontalLines: false
+    }
+};
+
+export const WithCustomYAxisRange: Story = {
+    args: {
+        data: sampleData,
+        range: 7,
+        yAxisRange: [0, 500],
+        id: 'custom-range-chart',
+        className: 'h-[200px]'
+    }
+};
+
+export const HourlyData: Story = {
+    args: {
+        data: [
+            {date: '2024-01-01T00:00:00', value: 45, formattedValue: '45', label: 'Page Views'},
+            {date: '2024-01-01T04:00:00', value: 23, formattedValue: '23', label: 'Page Views'},
+            {date: '2024-01-01T08:00:00', value: 67, formattedValue: '67', label: 'Page Views'},
+            {date: '2024-01-01T12:00:00', value: 89, formattedValue: '89', label: 'Page Views'},
+            {date: '2024-01-01T16:00:00', value: 156, formattedValue: '156', label: 'Page Views'},
+            {date: '2024-01-01T20:00:00', value: 134, formattedValue: '134', label: 'Page Views'}
+        ],
+        range: 1,
+        id: 'hourly-chart',
+        className: 'h-[200px]',
+        showHours: true
+    }
+};

--- a/apps/shade/src/components/ui/table.stories.tsx
+++ b/apps/shade/src/components/ui/table.stories.tsx
@@ -1,11 +1,20 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {Table, TableCaption, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell} from './table';
+import {Table, TableCaption, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableHeadButton} from './table';
 import {CardDescription, CardHeader, CardTitle} from './card';
+import {Badge} from './badge';
+import {ArrowUpDown} from 'lucide-react';
 
 const meta = {
     title: 'Components / Table',
     component: Table,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Flexible table components for displaying structured data with sorting, headers, and footers. Built with semantic HTML and accessible markup.'
+            }
+        }
+    },
     argTypes: {
         children: {
             table: {
@@ -38,13 +47,114 @@ export const Default: Story = {
                         <TableCell>Card</TableCell>
                         <TableCell className="text-right">$2,500.00</TableCell>
                     </TableRow>
+                    <TableRow>
+                        <TableCell className="font-medium">DEF-456</TableCell>
+                        <TableCell>Pending</TableCell>
+                        <TableCell>Bank Transfer</TableCell>
+                        <TableCell className="text-right">$1,200.00</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell className="font-medium">GHI-789</TableCell>
+                        <TableCell>Failed</TableCell>
+                        <TableCell>Card</TableCell>
+                        <TableCell className="text-right">$750.00</TableCell>
+                    </TableRow>
                 </TableBody>
                 <TableFooter>
                     <TableRow>
                         <TableCell colSpan={3}>Total</TableCell>
-                        <TableCell className="text-right">$2,500.00</TableCell>
+                        <TableCell className="text-right">$4,450.00</TableCell>
                     </TableRow>
                 </TableFooter>
+            </>
+        )
+    }
+};
+
+export const WithStatusBadges: Story = {
+    args: {
+        children: (
+            <>
+                <TableCaption>Transaction history with status indicators.</TableCaption>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Transaction ID</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Amount</TableHead>
+                        <TableHead>Date</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    <TableRow>
+                        <TableCell className="font-medium">TXN-001</TableCell>
+                        <TableCell><Badge variant="success">Completed</Badge></TableCell>
+                        <TableCell>$1,250.00</TableCell>
+                        <TableCell>2024-01-15</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell className="font-medium">TXN-002</TableCell>
+                        <TableCell><Badge variant="secondary">Pending</Badge></TableCell>
+                        <TableCell>$850.00</TableCell>
+                        <TableCell>2024-01-14</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell className="font-medium">TXN-003</TableCell>
+                        <TableCell><Badge variant="destructive">Failed</Badge></TableCell>
+                        <TableCell>$420.00</TableCell>
+                        <TableCell>2024-01-13</TableCell>
+                    </TableRow>
+                </TableBody>
+            </>
+        )
+    }
+};
+
+export const WithSortableHeaders: Story = {
+    args: {
+        children: (
+            <>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>
+                            <TableHeadButton>
+                                Name
+                                <ArrowUpDown />
+                            </TableHeadButton>
+                        </TableHead>
+                        <TableHead>
+                            <TableHeadButton>
+                                Email
+                                <ArrowUpDown />
+                            </TableHeadButton>
+                        </TableHead>
+                        <TableHead>
+                            <TableHeadButton>
+                                Role
+                                <ArrowUpDown />
+                            </TableHeadButton>
+                        </TableHead>
+                        <TableHead>
+                            <TableHeadButton>
+                                Date Joined
+                                <ArrowUpDown />
+                            </TableHeadButton>
+                        </TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    <TableRow>
+                        <TableCell className="font-medium">John Doe</TableCell>
+                        <TableCell>john@example.com</TableCell>
+                        <TableCell><Badge>Admin</Badge></TableCell>
+                        <TableCell>2024-01-01</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell className="font-medium">Jane Smith</TableCell>
+                        <TableCell>jane@example.com</TableCell>
+                        <TableCell><Badge variant="secondary">Editor</Badge></TableCell>
+                        <TableCell>2024-01-05</TableCell>
+                    </TableRow>
+                </TableBody>
             </>
         )
     }
@@ -82,6 +192,39 @@ export const CardHead: Story = {
                         <TableCell className="text-right">$2,500.00</TableCell>
                     </TableRow>
                 </TableFooter>
+            </>
+        )
+    }
+};
+
+export const SimpleTable: Story = {
+    args: {
+        children: (
+            <>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Product</TableHead>
+                        <TableHead>Price</TableHead>
+                        <TableHead>Stock</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    <TableRow>
+                        <TableCell>Widget A</TableCell>
+                        <TableCell>$19.99</TableCell>
+                        <TableCell>In Stock</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>Widget B</TableCell>
+                        <TableCell>$29.99</TableCell>
+                        <TableCell>Low Stock</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>Widget C</TableCell>
+                        <TableCell>$39.99</TableCell>
+                        <TableCell>Out of Stock</TableCell>
+                    </TableRow>
+                </TableBody>
             </>
         )
     }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2618/document-existing-shade-components

- Enhanced existing stories for table, card, data-list, chart, badge, and avatar components with additional variants and use cases
- Created new stories for gh-chart and flag components with examples
- Added component descriptions to all story metadata explaining primary use cases
- Demonstrated key variants, states, and sizing options for each component
- Stories now follow AGENTS.md guidelines with proper overviews and representative examples

Improves component discoverability and provides clear usage guidance for developers and AI agents working with the Shade design system.