### PR TITLE
Improved Storybook docs for feedback components

### DIFF
--- a/apps/shade/src/components/ui/animated-number.stories.tsx
+++ b/apps/shade/src/components/ui/animated-number.stories.tsx
@@ -6,7 +6,14 @@ import {AnimatedNumber} from './animated-number';
 const meta = {
     title: 'Components / Animated number',
     component: AnimatedNumber,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Animated numeric transitions using `@number-flow/react`. Pass any `Intl.NumberFormat` options via the `format` prop.'
+            }
+        }
+    }
 } satisfies Meta<typeof AnimatedNumber>;
 
 export default meta;

--- a/apps/shade/src/components/ui/empty-indicator.stories.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.stories.tsx
@@ -1,0 +1,85 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {EmptyIndicator} from './empty-indicator';
+import {Button} from './button';
+import {Inbox, Plus} from 'lucide-react';
+
+const meta = {
+    title: 'Components / Empty indicator',
+    component: EmptyIndicator,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Communicates an empty state for lists or sections. Pair with a short title, one-line description, and optional follow-up actions.'
+            }
+        }
+    }
+} satisfies Meta<typeof EmptyIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof EmptyIndicator>;
+
+export const Default: Story = {
+    args: {
+        title: 'No items yet',
+        description: 'When you add your first item it will show up here.'
+    },
+    render: args => (
+        <EmptyIndicator {...args}>
+            <Inbox />
+        </EmptyIndicator>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use for initial empty states. Keep copy short and direct.'
+            }
+        }
+    }
+};
+
+export const WithActions: Story = {
+    args: {
+        title: 'No posts yet',
+        description: 'Create your first post to get started.',
+        actions: (
+            <>
+                <Button>
+                    <Plus /> New post
+                </Button>
+            </>
+        )
+    },
+    render: args => (
+        <EmptyIndicator {...args}>
+            <Inbox />
+        </EmptyIndicator>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Include primary and secondary actions to guide the next step.'
+            }
+        }
+    }
+};
+
+export const CompactCopy: Story = {
+    args: {
+        title: 'Nothing to show',
+        description: 'Try adjusting your filters.'
+    },
+    render: args => (
+        <EmptyIndicator {...args}>
+            <Inbox />
+        </EmptyIndicator>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Short, focused copy works best in constrained layouts.'
+            }
+        }
+    }
+};
+

--- a/apps/shade/src/components/ui/loading-indicator.stories.tsx
+++ b/apps/shade/src/components/ui/loading-indicator.stories.tsx
@@ -1,15 +1,79 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {LoadingIndicator} from './loading-indicator';
+import {BarChartLoadingIndicator, LoadingIndicator} from './loading-indicator';
 
 const meta = {
     title: 'Components / Loading indicator',
     component: LoadingIndicator,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Lightweight spinner for inline and page-level loading. Supports `sm`/`md`/`lg` sizes and `dark`/`light` color for contrast on different backgrounds.'
+            }
+        }
+    }
 } satisfies Meta<typeof LoadingIndicator>;
 
 export default meta;
 type Story = StoryObj<typeof LoadingIndicator>;
 
 export const Default: Story = {
-    args: {size: 'md'}
+    args: {size: 'md'},
+    parameters: {
+        docs: {
+            description: {
+                story: 'Default medium size spinner for general loading states.'
+            }
+        }
+    }
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex items-center gap-2"><LoadingIndicator size="sm" /><span className="text-sm">sm</span></div>
+            <div className="flex items-center gap-2"><LoadingIndicator size="md" /><span className="text-sm">md</span></div>
+            <div className="flex items-center gap-2"><LoadingIndicator size="lg" /><span className="text-sm">lg</span></div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Compare available sizes for different contexts.'
+            }
+        }
+    }
+};
+
+export const LightOnDark: Story = {
+    render: () => (
+        <div className="rounded-md bg-black/80 p-6">
+            <div className="flex items-center gap-4 text-white">
+                <LoadingIndicator color="light" size="md" />
+                <span className="text-sm">Use `color=light` on dark surfaces</span>
+            </div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use the `light` variant on dark backgrounds to ensure sufficient contrast.'
+            }
+        }
+    }
+};
+
+export const BarChartVariant: Story = {
+    render: () => (
+        <div className="flex h-[120px] items-center justify-center">
+            <BarChartLoadingIndicator />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Alternative loading indicator styled like a bar chart, useful for data-heavy views.'
+            }
+        }
+    }
 };

--- a/apps/shade/src/components/ui/no-value-label.stories.tsx
+++ b/apps/shade/src/components/ui/no-value-label.stories.tsx
@@ -1,11 +1,18 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {NoValueLabel, NoValueLabelIcon} from './no-value-label';
-import {Ban} from 'lucide-react';
+import {Ban, EyeOff} from 'lucide-react';
 
 const meta = {
     title: 'Components / No value label',
     component: NoValueLabel,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Inline helper to explain why a value is missing or unavailable. Compose with `NoValueLabelIcon` and short copy.'
+            }
+        }
+    }
 } satisfies Meta<typeof NoValueLabel>;
 
 export default meta;
@@ -21,4 +28,22 @@ export const Default: Story = {
             You blocked this domain.
         </NoValueLabel>
     )
+};
+
+export const WithLongerCopy: Story = {
+    render: () => (
+        <NoValueLabel>
+            <NoValueLabelIcon>
+                <EyeOff />
+            </NoValueLabelIcon>
+            This value is hidden based on your current plan. Upgrade to unlock it.
+        </NoValueLabel>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use concise, actionable copy. A single sentence usually works best.'
+            }
+        }
+    }
 };

--- a/apps/shade/src/components/ui/skeleton.stories.tsx
+++ b/apps/shade/src/components/ui/skeleton.stories.tsx
@@ -4,7 +4,14 @@ import {Skeleton, SkeletonTable} from './skeleton';
 const meta = {
     title: 'Components / Skeleton',
     component: Skeleton,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Use `Skeleton` for simple loading lines (supports multiple lines and optional width randomization). `SkeletonTable` provides a ready-made list/table placeholder with varied line widths.'
+            }
+        }
+    }
 } satisfies Meta<typeof Skeleton>;
 
 export default meta;
@@ -14,6 +21,35 @@ type SkeletonTableStory = StoryObj<typeof SkeletonTable>;
 export const Default: Story = {
     args: {
         style: {width: 160, height: 16}
+    }
+};
+
+export const MultipleLines: Story = {
+    args: {
+        count: 3
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Render multiple lines using `count` for paragraphs or stacked labels.'
+            }
+        }
+    }
+};
+
+export const Randomized: Story = {
+    args: {
+        count: 4,
+        randomize: true,
+        minWidth: 40,
+        maxWidth: 90
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Enable `randomize` to simulate natural text line length. Control range with `minWidth`/`maxWidth`.'
+            }
+        }
     }
 };
 

--- a/apps/shade/src/components/ui/sonner.stories.tsx
+++ b/apps/shade/src/components/ui/sonner.stories.tsx
@@ -6,7 +6,14 @@ import {Button} from './button';
 const meta = {
     title: 'Components / Sonner',
     component: Toaster,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'Toast notifications powered by `sonner`. Shade mounts a `Toaster` via `ShadeProvider`, so you only call `toast(...)` where needed.'
+            }
+        }
+    }
 } satisfies Meta<typeof Toaster>;
 
 export default meta;
@@ -38,4 +45,27 @@ export const Info: Story = {
     render: () => (
         <Button onClick={() => toast.info('Hello world!', {description: 'Error description', duration: Infinity})}>Toast!</Button>
     )
+};
+
+export const WithAction: Story = {
+    render: () => (
+        <Button
+            onClick={() => toast('Item archived', {
+                description: 'You can undo this action for a short time.',
+                action: {
+                    label: 'Undo',
+                    onClick: () => toast.success('Restored')
+                }
+            })}
+        >
+            Toast with action
+        </Button>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Actions provide quick affordances (e.g., Undo). Keep labels short.'
+            }
+        }
+    }
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2618/document-existing-shade-components

- Added EmptyIndicator stories (Default, WithActions, CompactCopy)
- Expanded LoadingIndicator (sizes, light-on-dark, bar chart)
- Enhanced Skeleton docs (MultipleLines, Randomized usage)
- Clarified NoValueLabel and added longer-copy example
- Enriched Sonner with action example and docs
- Documented AnimatedNumber usage; kept formatting variants