### PR TITLE
Added stories for Shade modals and dialogs

### DIFF
--- a/apps/shade/src/components/ui/alert-dialog.stories.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,74 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+    AlertDialog,
+    AlertDialogTrigger,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogCancel,
+    AlertDialogAction
+} from './alert-dialog';
+import {Button} from './button';
+
+const meta = {
+    title: 'Components / Alert Dialog',
+    component: AlertDialog,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Destructive action confirmation modal. Use for critical, irreversible operations where an explicit confirm/cancel choice is required.'
+            }
+        }
+    },
+    argTypes: {
+        children: {
+            table: {
+                disable: true
+            }
+        }
+    }
+} satisfies Meta<typeof AlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'Use for confirming destructive actions (e.g., delete). Primary action should be explicit; provide a safe Cancel.'
+            }
+        }
+    },
+    args: {
+        children: (
+            <>
+                <AlertDialogTrigger asChild>
+                    <Button variant="destructive">Delete item</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete this item?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This action cannot be undone. This will permanently delete the item and remove its data from our servers.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel asChild>
+                            <Button variant="outline">Cancel</Button>
+                        </AlertDialogCancel>
+                        <AlertDialogAction asChild>
+                            <Button variant="destructive">Confirm delete</Button>
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </>
+        )
+    }
+};
+

--- a/apps/shade/src/components/ui/dialog.stories.tsx
+++ b/apps/shade/src/components/ui/dialog.stories.tsx
@@ -1,11 +1,19 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription} from './dialog';
+import {Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription, DialogClose} from './dialog';
 import {Button} from './button';
 
 const meta = {
     title: 'Components / Dialog',
     component: Dialog,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'General purpose modal dialog for non-destructive tasks like forms, settings, and focused flows.'
+            }
+        }
+    },
     argTypes: {
         children: {
             table: {
@@ -19,6 +27,13 @@ export default meta;
 type Story = StoryObj<typeof Dialog>;
 
 export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Basic dialog with header, body content, and footer actions.'
+            }
+        }
+    },
     args: {
         children: (
             <>
@@ -32,8 +47,41 @@ export const Default: Story = {
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
-                        <Button type="submit" variant="outline">Cancel</Button>
+                        <DialogClose asChild>
+                            <Button type="button" variant="outline">Cancel</Button>
+                        </DialogClose>
                         <Button type="submit">Confirm</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </>
+        )
+    }
+};
+
+export const PlacementExample: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'Dialogs are centered by default. Keep content concise to avoid scroll in small viewports.'
+            }
+        }
+    },
+    args: {
+        children: (
+            <>
+                <DialogTrigger asChild><Button variant="outline">Open centered dialog</Button></DialogTrigger>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Centered by default</DialogTitle>
+                        <DialogDescription>Dialog positions are handled internally; no size prop is required.</DialogDescription>
+                    </DialogHeader>
+                    <div className="text-sm text-muted-foreground">Add your form or content here.</div>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button variant="outline">Close</Button>
+                        </DialogClose>
+                        <Button>Save</Button>
                     </DialogFooter>
                 </DialogContent>
             </>

--- a/apps/shade/src/components/ui/dropdown-menu.stories.tsx
+++ b/apps/shade/src/components/ui/dropdown-menu.stories.tsx
@@ -5,13 +5,28 @@ import {Button} from './button';
 const meta = {
     title: 'Components / Dropdown menu',
     component: DropdownMenu,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Contextual menu for grouped actions. Use for navigation or object-specific commands triggered from a button or icon.'
+            }
+        }
+    }
 } satisfies Meta<typeof DropdownMenu>;
 
 export default meta;
 type Story = StoryObj<typeof DropdownMenu>;
 
 export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Includes groups, separators, submenus, disabled items, and keyboard shortcuts.'
+            }
+        }
+    },
     args: {
         children: [
             <DropdownMenuTrigger key="trigger" asChild>

--- a/apps/shade/src/components/ui/popover.stories.tsx
+++ b/apps/shade/src/components/ui/popover.stories.tsx
@@ -5,13 +5,28 @@ import {Button} from './button';
 const meta = {
     title: 'Components / Popover',
     component: Popover,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Small, contextual surface for supplementary content triggered by a control. Use for pickers, hints, or compact forms.'
+            }
+        }
+    }
 } satisfies Meta<typeof Popover>;
 
 export default meta;
 type Story = StoryObj<typeof Popover>;
 
 export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Basic popover anchored to a trigger. Keep content focused and lightweight.'
+            }
+        }
+    },
     args: {
         children: [
             <div style={{height: 400}}>
@@ -28,6 +43,30 @@ export const Default: Story = {
                         </div>
                     </PopoverContent>
                 </Popover>
+            </div>
+        ]
+    }
+};
+
+export const Placement: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Control placement via `side` and `align`. Defaults to center alignment.'
+            }
+        }
+    },
+    args: {
+        children: [
+            <div style={{display: 'flex', gap: 12, flexWrap: 'wrap', minHeight: 120}}>
+                {(['top', 'right', 'bottom', 'left'] as const).map(side => (
+                    <Popover key={side}>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline">{side}</Button>
+                        </PopoverTrigger>
+                        <PopoverContent side={side}>From {side}</PopoverContent>
+                    </Popover>
+                ))}
             </div>
         ]
     }

--- a/apps/shade/src/components/ui/sheet.stories.tsx
+++ b/apps/shade/src/components/ui/sheet.stories.tsx
@@ -14,6 +14,14 @@ const meta = {
     title: 'Components / Sheet',
     component: Sheet,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Slide-over panel for lightweight tasks or secondary content. Great for filters, editing contextual data, or multi-step wizards.'
+            }
+        }
+    },
     argTypes: {
         children: {
             table: {
@@ -27,6 +35,13 @@ export default meta;
 type Story = StoryObj<typeof Sheet>;
 
 export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Standard right-side Sheet with header, body, and footer actions.'
+            }
+        }
+    },
     args: {
         children: (
             <>
@@ -52,6 +67,13 @@ export const Default: Story = {
 };
 
 export const SideVariants: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Sheets can open from any side. Choose based on context and available space.'
+            }
+        }
+    },
     args: {
         children: (
             <div className="flex flex-wrap gap-4">

--- a/apps/shade/src/components/ui/tooltip.stories.tsx
+++ b/apps/shade/src/components/ui/tooltip.stories.tsx
@@ -1,11 +1,18 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {Tooltip, TooltipTrigger, TooltipContent} from './tooltip';
-import {TooltipProvider} from '@radix-ui/react-tooltip';
+import {Tooltip, TooltipTrigger, TooltipContent, TooltipProvider} from './tooltip';
 
 const meta = {
     title: 'Components / Tooltip',
     component: Tooltip,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Brief, non-interactive label shown on hover or focus to clarify controls. Keep text short and avoid critical information.'
+            }
+        }
+    },
     decorators: [
         Story => (
             <TooltipProvider>
@@ -26,12 +33,43 @@ export default meta;
 type Story = StoryObj<typeof Tooltip>;
 
 export const Default: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Default tooltip anchored to inline trigger. Appears on hover or focus.'
+            }
+        }
+    },
     args: {
         children: (
             <>
                 <TooltipTrigger>Hover me</TooltipTrigger>
                 <TooltipContent>Tooltip content</TooltipContent>
             </>
+        )
+    }
+};
+
+export const Placement: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use `side` and `align` to control placement when needed.'
+            }
+        }
+    },
+    args: {
+        children: (
+            <div className="flex flex-wrap gap-4">
+                {(['top', 'right', 'bottom', 'left'] as const).map(side => (
+                    <Tooltip key={side}>
+                        <TooltipTrigger className="rounded border px-2 py-1">{side}</TooltipTrigger>
+                        <TooltipContent side={side}>
+                            Tooltip on {side}
+                        </TooltipContent>
+                    </Tooltip>
+                ))}
+            </div>
         )
     }
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2618/document-existing-shade-components

- Modal and dialog components in Shade had poor documentation. Now they all have a detailed usage guide and examples so developers and AI agents would know how to use them.