### PR TITLE
Added stories for Shade utility components

### DIFF
--- a/apps/shade/src/components/ui/accordion.stories.tsx
+++ b/apps/shade/src/components/ui/accordion.stories.tsx
@@ -11,7 +11,14 @@ const meta = {
     title: 'Components / Accordion',
     component: Accordion,
     tags: ['autodocs'],
-    parameters: {}
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Disclosure component for toggling sections of content. Use `type="single"` for one-at-a-time expansion or `type="multiple"` to allow several items open.'
+            }
+        }
+    }
 } satisfies Meta<typeof Accordion>;
 
 export default meta;
@@ -43,6 +50,13 @@ export const Default: Story = {
                 </AccordionContent>
             </AccordionItem>
         ]
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Single mode with collapsible behavior; only one section is expanded at a time.'
+            }
+        }
     }
 };
 
@@ -79,6 +93,13 @@ export const Multiple: Story = {
                 </AccordionContent>
             </AccordionItem>
         ]
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Multiple mode allows several items to be expanded simultaneously.'
+            }
+        }
     }
 };
 
@@ -115,6 +136,38 @@ export const CustomStyling: Story = {
                 </AccordionContent>
             </AccordionItem>
         ]
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Tailor borders, padding, and hover states via `className` on the wrapper and subcomponents.'
+            }
+        }
     }
 };
 
+export const WithDefaultOpen: Story = {
+    args: {
+        type: 'single',
+        defaultValue: 'item-1',
+        children: [
+            <AccordionItem key="item-1" value="item-1">
+                <AccordionTrigger>Opens by default</AccordionTrigger>
+                <AccordionContent>
+                    Use `defaultValue` (uncontrolled) or `value` (controlled) to manage open state.
+                </AccordionContent>
+            </AccordionItem>,
+            <AccordionItem key="item-2" value="item-2">
+                <AccordionTrigger>Second item</AccordionTrigger>
+                <AccordionContent>Closed initially.</AccordionContent>
+            </AccordionItem>
+        ]
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Demonstrates initial open state using `defaultValue`.'
+            }
+        }
+    }
+};

--- a/apps/shade/src/components/ui/icon.stories.tsx
+++ b/apps/shade/src/components/ui/icon.stories.tsx
@@ -3,9 +3,17 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 
 const meta = {
-    title: 'Components / Icons',
-    component: Icon.Close,
+    title: 'Components / Custom icons',
+    component: Icon.Typography,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Custom SVG icons auto-generated from `src/assets/icons`. Import via `Icon.<Name>` and adjust with `size` and `className`.'
+            }
+        }
+    },
     argTypes: {
         size: {
             control: 'select',
@@ -13,10 +21,10 @@ const meta = {
             defaultValue: 'md'
         }
     }
-} satisfies Meta<typeof Icon.Close>;
+} satisfies Meta<typeof Icon.Typography>;
 
 export default meta;
-type Story = StoryObj<typeof Icon.Close>;
+type Story = StoryObj<typeof Icon.Typography>;
 
 export const IconGallery = {
     render: (args: Story['args']) => {
@@ -48,5 +56,53 @@ export const IconGallery = {
                 })}
             </div>
         );
+    }
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex flex-col items-center gap-1">
+                <Icon.Typography size="sm" />
+                <span className="text-xs text-muted-foreground">sm</span>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+                <Icon.Typography size="md" />
+                <span className="text-xs text-muted-foreground">md</span>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+                <Icon.Typography size="lg" />
+                <span className="text-xs text-muted-foreground">lg</span>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+                <Icon.Typography size="xl" />
+                <span className="text-xs text-muted-foreground">xl</span>
+            </div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Choose from `sm`, `md`, `lg`, `xl` sizes or override via Tailwind classes.'
+            }
+        }
+    }
+};
+
+export const ColorsAndClasses: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <Icon.Typography className="text-foreground" />
+            <Icon.Typography className="text-muted-foreground" />
+            <Icon.Typography className="text-emerald-500" />
+            <Icon.Typography className="text-rose-500" />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Style with `className` to change color via Tailwind (e.g., `text-muted-foreground`, `text-emerald-500`).'
+            }
+        }
     }
 };

--- a/apps/shade/src/components/ui/lucide-icon.stories.tsx
+++ b/apps/shade/src/components/ui/lucide-icon.stories.tsx
@@ -3,13 +3,13 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {Smile} from 'lucide-react';
 
 const meta = {
-    title: 'Experimental / Lucide icons',
+    title: 'Components / Icons',
     component: Smile,
     tags: ['autodocs'],
     parameters: {
         docs: {
             description: {
-                component: 'Note: right now we are experimenting whether we should switch to Lucide Icons instead of Streamline. Read the [Lucide Icons docs](https://lucide.dev/guide/packages/lucide-react) to learn more about it.'
+                component: 'Shade uses Lucide Icons by default, following the standard in ShadCN/UI. To learn how to use them, read the [Lucide Icons docs](https://lucide.dev/guide/packages/lucide-react). \n\nIn Ghost apps you can\'t directly reference icons as you would normally in ShadCN/UI, instead you need to use the `LucideIcon` component, e.g. `<LucideIcon.Smile size="20" />`.'
             }
         }
     }

--- a/apps/shade/src/components/ui/separator.stories.tsx
+++ b/apps/shade/src/components/ui/separator.stories.tsx
@@ -1,6 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {Separator} from './separator';
-import React from 'react';
 
 const meta = {
     title: 'Components / Separator',

--- a/apps/shade/src/components/ui/separator.stories.tsx
+++ b/apps/shade/src/components/ui/separator.stories.tsx
@@ -1,15 +1,84 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {Separator} from './separator';
+import React from 'react';
 
 const meta = {
     title: 'Components / Separator',
     component: Separator,
-    tags: ['autodocs']
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'A thin rule used to group and divide content. Supports horizontal or vertical orientation and can be decorative or semantic for accessibility.'
+            }
+        }
+    }
 } satisfies Meta<typeof Separator>;
 
 export default meta;
 type Story = StoryObj<typeof Separator>;
 
-export const Default: Story = {
-    args: {}
+export const Horizontal: Story = {
+    args: {},
+    parameters: {
+        docs: {
+            description: {
+                story: 'Default horizontal separator spanning the container width.'
+            }
+        }
+    }
+};
+
+export const WithLabel: Story = {
+    render: args => (
+        <div className="space-y-4">
+            <div className="text-sm text-muted-foreground">Section title</div>
+            <Separator {...args} />
+            <div className="text-sm">Content below the labeled section.</div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Common usage: separate a labeled section from following content.'
+            }
+        }
+    }
+};
+
+export const Vertical: Story = {
+    render: args => (
+        <div className="flex items-center gap-4">
+            <span>Item A</span>
+            <Separator className="h-6" orientation="vertical" {...args} />
+            <span>Item B</span>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Vertical orientation for inline grouping (e.g., toolbar items). Adjust height with Tailwind classes.'
+            }
+        }
+    }
+};
+
+export const NonDecorative: Story = {
+    args: {
+        decorative: false
+    },
+    render: args => (
+        <div>
+            <div className="text-sm">Semantic divider (exposed to assistive tech)</div>
+            <Separator aria-label="Content divider" {...args} />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Set `decorative=false` when the separator conveys meaning. Include an accessible label.'
+            }
+        }
+    }
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2618/document-existing-shade-components

- The utility type components in Shade (Accordion, Icon, LucideIcon, Separator) had poor documentation. Now they all have a detailed usage guide and examples so developers and AI agents would know how to use them.