### PR TITLE
Fixed reply count double increment bug in ActivityPub

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/admin-x-activitypub/src/hooks/use-activity-pub-queries.ts
@@ -533,7 +533,7 @@ function updateReplyCache(queryClient: QueryClient, id: string, delta: number) {
 function updateReplyCacheOnce(queryClient: QueryClient, id: string, delta: number) {
     // Update reply chain cache (used by Note.tsx and Reader.tsx)
     const replyChainQueryKey = QUERY_KEYS.replyChain(null);
-    queryClient.setQueriesData(replyChainQueryKey, (current?: ReplyChainResponse) => {
+    queryClient.setQueriesData({queryKey: replyChainQueryKey, exact: false}, (current?: ReplyChainResponse) => {
         if (!current) {
             return current;
         }

--- a/apps/admin-x-activitypub/src/views/Feed/Note.tsx
+++ b/apps/admin-x-activitypub/src/views/Feed/Note.tsx
@@ -46,14 +46,8 @@ const Note = () => {
 
     const object = currentPost?.object;
 
-    const [replyCount, setReplyCount] = useState(object?.replyCount ?? 0);
+    const replyCount = object?.replyCount ?? 0;
     const [hasScrolledToPost, setHasScrolledToPost] = useState(false);
-
-    useEffect(() => {
-        if (object?.replyCount !== undefined) {
-            setReplyCount(object.replyCount);
-        }
-    }, [object?.replyCount]);
 
     useEffect(() => {
         if (postRef.current && threadParents.length > 0 && !hasScrolledToPost) {
@@ -146,12 +140,8 @@ const Note = () => {
         );
     }
 
-    function handleReplyCountChange(increment: number) {
-        setReplyCount((current: number) => current + increment);
-    }
-
     function handleDelete() {
-        handleReplyCountChange(-1);
+        // Reply count will be updated via cache invalidation
     }
 
     function toggleChain(chainId: string) {
@@ -258,8 +248,6 @@ const Note = () => {
                                     />
                                     <APReplyBox
                                         object={object}
-                                        onReply={() => handleReplyCountChange(1)}
-                                        onReplyError={() => handleReplyCountChange(-1)}
                                     />
                                     <FeedItemDivider />
                                     <div ref={repliesRef}>

--- a/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/admin-x-activitypub/src/views/Inbox/components/Reader.tsx
@@ -450,13 +450,7 @@ export const Reader: React.FC<ReaderProps> = ({
     const actor = activityData?.actor;
     const authors = activityData?.object?.metadata?.ghostAuthors;
 
-    const [replyCount, setReplyCount] = useState(object?.replyCount ?? 0);
-
-    useEffect(() => {
-        if (object?.replyCount !== undefined) {
-            setReplyCount(object.replyCount);
-        }
-    }, [object?.replyCount]);
+    const replyCount = object?.replyCount ?? 0;
 
     useEffect(() => {
         // Only set up infinite scroll if pagination is supported
@@ -501,12 +495,8 @@ export const Reader: React.FC<ReaderProps> = ({
         };
     }, [hasMoreChildren, isLoadingMoreTopLevelReplies, loadMoreChildren]);
 
-    function handleReplyCountChange(increment: number) {
-        setReplyCount((current: number) => current + increment);
-    }
-
     function handleDelete() {
-        handleReplyCountChange(-1);
+        // Reply count will be updated via cache invalidation
     }
 
     function toggleChain(chainId: string) {
@@ -879,7 +869,6 @@ export const Reader: React.FC<ReaderProps> = ({
                                                 object={object}
                                                 repostCount={object.repostCount ?? 0}
                                                 onLikeClick={onLikeClick}
-                                                onReplyCountChange={handleReplyCountChange}
                                             />
                                         </div>
                                     </div>
@@ -890,8 +879,6 @@ export const Reader: React.FC<ReaderProps> = ({
                                     <div className='mx-auto w-full border-t border-black/[8%] dark:border-gray-950' style={{maxWidth: currentGridWidth}}>
                                         <APReplyBox
                                             object={object}
-                                            onReply={() => handleReplyCountChange(1)}
-                                            onReplyError={() => handleReplyCountChange(-1)}
                                         />
                                         <FeedItemDivider />
                                     </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2621/reply-count-increases-by-two-on-both-posts-and-notes

- Removed redundant reply handlers that were triggering from both FeedItemStats and APReplyBox
- Replaced manual state management with direct cache-based rendering
- Removed unnecessary useEffect that was syncing reply count from two sources
- Fixed cache updates with `exact: false` to update all reply chain queries (e.g. ['reply_chain', 'post-123'])