### PR TITLE
🐛 Fixed duplicate posts in tag archives with identical publish dates

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -19,10 +19,10 @@ const messages = {
 
 /**
  * Selects all allowed columns for the given frame.
- * 
+ *
  * NOTE: This doesn't stop them from being FETCHED, just returned in the response. This causes
  *   the output serializer to remove them from the data object before returning.
- * 
+ *
  * NOTE: This is only intended for the Content API. We need these fields within Admin API responses.
  *
  * @param {Object} frame - The frame object.
@@ -37,10 +37,10 @@ function removeSourceFormats(frame) {
 
 /**
  * Selects all allowed columns for the given frame.
- * 
+ *
  * This removes the lexical and mobiledoc columns from the query. This is a performance improvement as we never intend
  *  to expose those columns in the content API and they are very large datasets to be passing around and de/serializing.
- * 
+ *
  * NOTE: This is only intended for the Content API. We need these fields within Admin API responses.
  *
  * @param {Object} frame - The frame object.
@@ -97,7 +97,9 @@ function setDefaultOrder(frame) {
     }
 
     if (!frame.options.order && !frame.options.autoOrder) {
-        frame.options.order = 'published_at desc';
+        // use id as fallback to ensure consistent ordering across pages when posts
+        // have the same published_at timestamp
+        frame.options.order = 'published_at desc, id desc';
     }
 }
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -102,6 +102,33 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             frame.options.formats.should.containEql('plaintext');
         });
 
+        it('adds default order when no order is specified', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {}
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.order.should.eql('published_at desc, id desc');
+        });
+
+        it('keeps order when it is specified', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    order: 'updated_at desc',
+                    context: {}
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.order.should.eql('updated_at desc');
+        });
+
         describe('Content API', function () {
             it('selects all columns from the posts schema but mobiledoc and lexical when no columns are specified', function () {
                 const apiConfig = {};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1145

- our posts API input serializer was setting the default ordering to `published_at DESC` but that causes problems when posts have identical published_at dates because there's no consistency across page requests
- added `id DESC` as a fallback order to make the secondary ordering for tie-break explicit so page boundaries don't drift

Testing the impact of the ordering change on SQL query planning for the query used on a tag archive showed no discernible difference...

With just `published_at DESC`:
```
mysql> explain select id,uuid,title,slug,html,comment_id,plaintext,feature_image,featured,type,status,locale,visibility,email_recipient_filter,created_at,updated_at,published_at,published_by,custom_excerpt,codeinjection_head,codeinjection_foot,custom_template,canonical_url,newsletter_id,show_title_and_feature_image from `posts` where (`posts`.`status` = 'published' and ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = 'sky-blue-planner-583' and `tags`.`visibility` = 'public')) and `posts`.`type` = 'post')) order by `posts`.`published_at` DESC limit 5 \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: tags
   partitions: NULL
         type: const
possible_keys: PRIMARY,tags_slug_unique
          key: tags_slug_unique
      key_len: 766
          ref: const
         rows: 1
     filtered: 100.00
        Extra: Using temporary; Using filesort
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: posts_tags
   partitions: NULL
         type: ref
possible_keys: posts_tags_tag_id_foreign,posts_tags_post_id_tag_id_index
          key: posts_tags_tag_id_foreign
      key_len: 98
          ref: const
         rows: 6
     filtered: 100.00
        Extra: Start temporary
*************************** 3. row ***************************
           id: 1
  select_type: SIMPLE
        table: posts
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY,posts_type_status_updated_at_index
          key: PRIMARY
      key_len: 98
          ref: ghost.posts_tags.post_id
         rows: 1
     filtered: 100.00
        Extra: Using where; End temporary
3 rows in set, 1 warning (0.00 sec)

explain analyze ...
-> Limit: 5 row(s)  (actual time=0.436..0.441 rows=5 loops=1)
    -> Sort row IDs: posts.published_at DESC, limit input to 5 row(s) per chunk  (actual time=0.436..0.439 rows=5 loops=1)
        -> Table scan on <temporary>  (cost=6.37..8.52 rows=6) (actual time=0.404..0.41 rows=5 loops=1)
            -> Temporary table  (cost=5.94..5.94 rows=6) (actual time=0.396..0.396 rows=5 loops=1)
                -> Remove duplicate posts rows using temporary table (weedout)  (cost=5.34 rows=6) (actual time=0.161..0.302 rows=5 loops=1)
                    -> Nested loop inner join  (cost=5.34 rows=6) (actual time=0.152..0.283 rows=5 loops=1)
                        -> Index lookup on posts_tags using posts_tags_tag_id_foreign (tag_id='000000001c7709cab88be228')  (cost=2.1 rows=6) (actual time=0.102..0.111 rows=6 loops=1)
                        -> Filter: ((posts.`type` = 'post') and (posts.`status` = 'published'))  (cost=0.457 rows=1) (actual time=0.0277..0.0279 rows=0.833 loops=6)
                            -> Single-row index lookup on posts using PRIMARY (id=posts_tags.post_id)  (cost=0.457 rows=1) (actual time=0.0259..0.026 rows=1 loops=6)
```

With `published_at DESC, id DESC`:
```
mysql> explain select id,uuid,title,slug,html,comment_id,plaintext,feature_image,featured,type,status,locale,visibility,email_recipient_filter,created_at,updated_at,published_at,published_by,custom_excerpt,codeinjection_head,codeinjection_foot,custom_template,canonical_url,newsletter_id,show_title_and_feature_image from `posts` where (`posts`.`status` = 'published' and ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = 'sky-blue-planner-583' and `tags`.`visibility` = 'public')) and `posts`.`type` = 'post')) order by `posts`.`published_at` DESC, `posts`.`id` DESC limit 5 \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: tags
   partitions: NULL
         type: const
possible_keys: PRIMARY,tags_slug_unique
          key: tags_slug_unique
      key_len: 766
          ref: const
         rows: 1
     filtered: 100.00
        Extra: Using temporary; Using filesort
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: posts_tags
   partitions: NULL
         type: ref
possible_keys: posts_tags_tag_id_foreign,posts_tags_post_id_tag_id_index
          key: posts_tags_tag_id_foreign
      key_len: 98
          ref: const
         rows: 6
     filtered: 100.00
        Extra: Start temporary
*************************** 3. row ***************************
           id: 1
  select_type: SIMPLE
        table: posts
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY,posts_type_status_updated_at_index
          key: PRIMARY
      key_len: 98
          ref: ghost.posts_tags.post_id
         rows: 1
     filtered: 100.00
        Extra: Using where; End temporary
3 rows in set, 1 warning (0.00 sec)

explain analyze ...
-> Limit: 5 row(s)  (actual time=0.416..0.42 rows=5 loops=1)
    -> Sort row IDs: posts.published_at DESC, posts.id DESC, limit input to 5 row(s) per chunk  (actual time=0.404..0.406 rows=5 loops=1)
        -> Table scan on <temporary>  (cost=6.37..8.52 rows=6) (actual time=0.374..0.38 rows=5 loops=1)
            -> Temporary table  (cost=5.94..5.94 rows=6) (actual time=0.367..0.367 rows=5 loops=1)
                -> Remove duplicate posts rows using temporary table (weedout)  (cost=5.34 rows=6) (actual time=0.16..0.289 rows=5 loops=1)
                    -> Nested loop inner join  (cost=5.34 rows=6) (actual time=0.152..0.272 rows=5 loops=1)
                        -> Index lookup on posts_tags using posts_tags_tag_id_foreign (tag_id='000000001c7709cab88be228')  (cost=2.1 rows=6) (actual time=0.107..0.116 rows=6 loops=1)
                        -> Filter: ((posts.`type` = 'post') and (posts.`status` = 'published'))  (cost=0.457 rows=1) (actual time=0.0251..0.0253 rows=0.833 loops=6)
                            -> Single-row index lookup on posts using PRIMARY (id=posts_tags.post_id)  (cost=0.457 rows=1) (actual time=0.0236..0.0237 rows=1 loops=6)
```