### PR TITLE
🐛 Fixed Analytics settings not updating after plan changes

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -123,10 +123,12 @@ export default class GhBillingIframe extends Component {
             try {
                 // React Query v5+
                 window.adminXQueryClient.invalidateQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
+                window.adminXQueryClient.invalidateQueries({queryKey: ['SettingsResponseType']}).catch(() => {});
             } catch (_) {
                 // TODO: remove this fallback when Admin-X-Settings updates to React Query v5+ (@tanstack/react-query)
                 // React Query v4 fallback
                 window.adminXQueryClient.invalidateQueries(['ConfigResponseType']).catch(() => {});
+                window.adminXQueryClient.invalidateQueries(['SettingsResponseType']).catch(() => {});
             }
         }
 


### PR DESCRIPTION
closes [BAE-492](https://linear.app/ghost/issue/BAE-492/limit-changes-requires-a-page-refresh-to-be-reflected-in-admin) ref https://github.com/TryGhost/Ghost/pull/24879

With #24879 we fixed that Ghost Admin-X wouldn't update the config data after a plan change in the Billing App, leading to features being unavailble that shouldn't be unless a page refresh is done and the cached data is fetched fresh. Analytics also relies on the settings being updated after a change.

This commit invalidates the settings data after we receive a subscription update information from the Billing App, forcing stale settings data to be refreshed.

Due to the nature of billing integrations, this needs to be verified on staging environments with actual subscription changes.