### PR TITLE
Added OKLAB/OKLCH support for comments dark-mode detection

### DIFF
--- a/apps/comments-ui/src/components/content-box.test.jsx
+++ b/apps/comments-ui/src/components/content-box.test.jsx
@@ -1,5 +1,4 @@
 import ContentBox from './content-box';
-import React from 'react';
 import {AppContext} from '../app-context';
 import {ROOT_DIV_ID} from '../utils/constants';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
@@ -141,5 +140,69 @@ describe('ContentBox', () => {
         expect(section).toHaveClass('dark');
 
         window.getComputedStyle = originalGetComputedStyle;
+    });
+
+    describe('oklab/oklch color parsing', () => {
+        const originalGetComputedStyle = window.getComputedStyle;
+
+        afterEach(() => {
+            window.getComputedStyle = originalGetComputedStyle;
+        });
+
+        it.each([
+            {
+                color: 'oklab(0.7 0 0)',
+                description: 'oklab with high lightness (>0.6)',
+                expectedDark: true
+            },
+            {
+                color: 'oklab(0.5 0 0)',
+                description: 'oklab with low lightness (<0.6)',
+                expectedDark: false
+            },
+            {
+                color: 'oklch(0.8 0.1 120)',
+                description: 'oklch with high lightness (>0.6)',
+                expectedDark: true
+            },
+            {
+                color: 'oklch(0.4 0.1 240)',
+                description: 'oklch with low lightness (<0.6)',
+                expectedDark: false
+            },
+            {
+                color: 'oklab(none 0.5 0.2)',
+                description: 'oklab with "none" lightness',
+                expectedDark: false
+            },
+            {
+                color: 'oklch(none 0.1 180)',
+                description: 'oklch with "none" lightness',
+                expectedDark: false
+            }
+        ])('correctly handles $description using 0.6 threshold', ({color, expectedDark}) => {
+            window.getComputedStyle = vi.fn().mockImplementation((element) => {
+                if (element === rootDiv.parentElement) {
+                    return {
+                        getPropertyValue: (prop) => {
+                            if (prop === 'color') {
+                                return color;
+                            }
+                            return '';
+                        }
+                    };
+                }
+                return originalGetComputedStyle(element);
+            });
+
+            const {container} = contextualRender(<ContentBox done={true} />);
+            const section = container.querySelector('section');
+
+            if (expectedDark) {
+                expect(section).toHaveClass('dark');
+            } else {
+                expect(section).not.toHaveClass('dark');
+            }
+        });
     });
 });


### PR DESCRIPTION
closes [ONC-1155](https://linear.app/ghost/issue/ONC-1155/oss-issue-comments-module-fails-to-detect-dark-mode-if-parent-color-is)

Our old detection works great for all colorspaces that are based on RGB (e.g. hex colours, RGBA, RGB, etc), but not on alternative colorspaces that are retained in the computed style. OKLAB & OKLCH use a perceived luminance value that doesn't need the contrast function to work out how contrasty they are against white.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves dark-mode detection in `ContentBox` to handle non-RGB computed colors.
> 
> - Adds `colorStringToLuminance` and `rgbToLuminance` helpers and updates `contrast` to work with luminance values
> - Extends detection logic to parse `oklab`/`oklch` colors and use a simple L>0.6 threshold; retains RGB path using sRGB luminance + contrast
> - Expands tests to cover `oklab`/`oklch` cases (including `none` lightness), and verifies class toggling accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c78e52f9e5ea7043c88d38bfe5bc8cda67aecc04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->