### PR TITLE
🎨 Added auto-open of labs settings when searched

### DIFF
--- a/apps/admin-x-settings/src/components/TopLevelGroup.tsx
+++ b/apps/admin-x-settings/src/components/TopLevelGroup.tsx
@@ -9,7 +9,7 @@ interface TopLevelGroupProps extends Omit<SettingGroupProps, 'isVisible' | 'high
 }
 
 const TopLevelGroup: React.FC<TopLevelGroupProps> = ({keywords, navid, children, ...props}) => {
-    const {checkVisible, noResult} = useSearch();
+    const {checkVisible, noResult, registerSearchTarget, unregisterSearchTarget} = useSearch();
     const {route} = useRouting();
     const [highlight, setHighlight] = useState(false);
     const {ref} = useScrollSection(navid);
@@ -21,6 +21,15 @@ const TopLevelGroup: React.FC<TopLevelGroupProps> = ({keywords, navid, children,
             return () => clearTimeout(timer);
         }
     }, [route, navid]);
+
+    // Register this group as a searchable target for auto-open detection
+    useEffect(() => {
+        if (navid) {
+            registerSearchTarget(navid, keywords);
+            return () => unregisterSearchTarget(navid);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [navid, JSON.stringify(keywords)]);
 
     const hasImageChild = React.Children.toArray(children).some(
         child => React.isValidElement(child) && child.type === 'img'

--- a/apps/admin-x-settings/src/components/providers/SettingsAppProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/SettingsAppProvider.tsx
@@ -49,7 +49,11 @@ const SettingsAppContext = createContext<SettingsAppContextType>({
         checkVisible: () => true,
         highlightKeywords: () => '',
         noResult: false,
-        setNoResult: () => {}
+        setNoResult: () => {},
+        autoOpenTarget: null,
+        setAutoOpenTarget: () => {},
+        registerSearchTarget: () => {},
+        unregisterSearchTarget: () => {}
     },
     sortingState: []
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-201

Searching for labs settings required an extra click to open the panel which is annoying when it's the only panel shown. Added auto-open/close for the panel when it's the only one shown.

- Extend search service with autoOpenTarget and target registry (register/unregister)
- Compute single visible target from registered groups + current filter
- Register each TopLevelGroup (navid + keywords) for DRY search participation
- Simplify Sidebar to only compute noResult (remove brittle per-section detection)
- Update Labs to react to autoOpenTarget and preserve manual Open/Close with override reset on filter change
