### PR TITLE
Updated CI.yml to ignore unimportant labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,14 @@ jobs:
   job_setup:
     name: Setup
     runs-on: ubuntu-latest
+    # Having certain parts of our huge CI workflow run on a specific label is an anti-pattern.
+    # Long term, we want to get away from this by having all of our tests run on every PR, and have the staging deploy either be automatic or a different workflow
+    # This logic skips the entire workflow if triggered by a label that doesn't contain "test" or "deploy" - there's nothing new to do in that case
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      contains(github.event.label.name, 'test') ||
+      contains(github.event.label.name, 'deploy')
     timeout-minutes: 15
     env:
       IS_MAIN: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
- We have a hack/workaround/anti-pattern with using the labels browser-tests and deploy-to-staging to trigger some parts of our CI/CD workflow
- The ideal would be to have the workflow be consistent
- As we start to use labels on PRs more for organisation, this triggers unnecessary workflow runs
- To calm this down a bit, we skip the workflow if the label doesn't contain the words test or deploy
- Catching our two existing labels and probably catches any future similar labels


