### PR TITLE
Removed label actions from triggering CI-docker

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -2,7 +2,7 @@ name: CI (Docker)
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   push:
     # Ref: GHA Filter pattern syntax: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
     # Run on pushes to main, release branches, and previous/future major version branches


### PR DESCRIPTION
- CI-docker is meant to be our new, improved, 12-factor, CI process
- We only had label/unlabel on our old CI workflow as a workaround / anti-pattern to solve other problems (like not wanting to run browser tests on every run) that this CI pipeline should not have
- Therefore, this pipeline should NOT run on label/unlabel as we want it to be clean and not full of anti-patterns!

