### PR TITLE
Updated post filter for admin search

### DIFF
--- a/ghost/admin/app/components/gh-search-input.hbs
+++ b/ghost/admin/app/components/gh-search-input.hbs
@@ -17,7 +17,10 @@
             }}
             as |name select|
         >
-            {{highlighted-text name.title select.searchText}}
+            <div class="gh-nav-search-option">
+                <div>{{highlighted-text name.title select.searchText}}</div>
+                <div class="gh-nav-search-label">Draft</div>
+            </div>
         </PowerSelect>
     </div>
 </div>

--- a/ghost/admin/app/components/gh-search-input.hbs
+++ b/ghost/admin/app/components/gh-search-input.hbs
@@ -19,7 +19,9 @@
         >
             <div class="gh-nav-search-option">
                 <div>{{highlighted-text name.title select.searchText}}</div>
-                <div class="gh-nav-search-label">Draft</div>
+                {{#if (or (eq name.status "draft") (eq name.status "scheduled"))}}
+                    <div class="gh-nav-search-label {{if (eq name.status "draft") "draft"}} {{if (eq name.status "scheduled") "scheduled"}}">{{capitalize name.status}}</div>
+                {{/if}}
             </div>
         </PowerSelect>
     </div>

--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -46,13 +46,30 @@ export default class SearchProviderBasicService extends Service {
         const results = [];
 
         SEARCHABLES.forEach((searchable) => {
-            const matchedContent = this.content.filter((item) => {
+            let matchedContent = this.content.filter((item) => {
                 const normalizedTitle = item.title.toString().toLowerCase();
                 return (
                     item.groupName === searchable.name &&
                     normalizedTitle.indexOf(normalizedTerm) >= 0
                 );
             });
+
+            // Sort posts/pages by status priority (scheduled > draft > published > sent)
+            if (searchable.model === 'post' || searchable.model === 'page') {
+                const statusPriority = {
+                    scheduled: 1,
+                    draft: 2,
+                    published: 3,
+                    sent: 4
+                };
+
+                matchedContent.sort((a, b) => {
+                    const aPriority = statusPriority[a.status] || 5;
+                    const bPriority = statusPriority[b.status] || 5;
+
+                    return aPriority - bPriority;
+                });
+            }
 
             if (!isEmpty(matchedContent)) {
                 results.push({

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -89,6 +89,23 @@ export default class SearchProviderFlexService extends Service {
                 });
             });
 
+            // Sort posts/pages by status priority (scheduled > draft > published > sent)
+            if (searchable.model === 'post' || searchable.model === 'page') {
+                const statusPriority = {
+                    scheduled: 1,
+                    draft: 2,
+                    published: 3,
+                    sent: 4
+                };
+
+                groupResults.sort((a, b) => {
+                    const aPriority = statusPriority[a.status] || 5;
+                    const bPriority = statusPriority[b.status] || 5;
+
+                    return aPriority - bPriority;
+                });
+            }
+
             if (!isEmpty(groupResults)) {
                 results.push({
                     groupName: searchable.name,

--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -207,7 +207,8 @@
 
 .ember-power-select-group .ember-power-select-option .highlight {
     display: inline;
-    background: #fff6b8;
+    font-weight: 600;
+    text-decoration: underline;
     border-radius: 1px;
     color: color-mod(var(--darkgrey) l(-10%));
     pointer-events: none;

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -481,6 +481,25 @@ body:not(.gh-body-fullscreen) .gh-viewport {
     height: auto;
 }
 
+.gh-nav-search-modal .gh-nav-search-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.gh-nav-search-modal .gh-nav-search-label {
+    /* flex-grow: 1; */
+    background: rgba(236, 22, 111, 0.1);
+    color: var(--pink);
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.1px;
+    white-space: nowrap;
+    padding: 1px 3px;
+    border-radius: 5px;
+}
+
 @media (max-width: 800px) {
     .gh-nav-search {
         min-width: 220px;

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -479,6 +479,8 @@ body:not(.gh-body-fullscreen) .gh-viewport {
 
 .modal-content .gh-nav-search-modal .ember-power-select-option {
     height: auto;
+    margin: 0 10px;
+    border-radius: 9px;
 }
 
 .gh-nav-search-modal .gh-nav-search-option {
@@ -488,16 +490,22 @@ body:not(.gh-body-fullscreen) .gh-viewport {
 }
 
 .gh-nav-search-modal .gh-nav-search-label {
-    /* flex-grow: 1; */
-    background: rgba(236, 22, 111, 0.1);
-    color: var(--pink);
     font-size: 1.2rem;
-    text-transform: uppercase;
     font-weight: 600;
     letter-spacing: 0.1px;
     white-space: nowrap;
-    padding: 1px 3px;
+    padding: 1px 8px;
     border-radius: 5px;
+}
+
+.gh-nav-search-modal .gh-nav-search-label.draft {
+    background: rgba(236, 22, 111, 0.1);
+    color: var(--pink);
+}
+
+.gh-nav-search-modal .gh-nav-search-label.scheduled {
+    background: rgba(48, 207, 67, 0.1);
+    color: var(--green);
 }
 
 @media (max-width: 800px) {

--- a/ghost/admin/app/utils/search.js
+++ b/ghost/admin/app/utils/search.js
@@ -1,0 +1,66 @@
+export const SEARCHABLES = [
+    {
+        name: 'Staff',
+        model: 'user',
+        pathField: 'slug',
+        idField: 'slug',
+        titleField: 'name',
+        index: ['name']
+    },
+    {
+        name: 'Tags',
+        model: 'tag',
+        pathField: 'slug',
+        idField: 'slug',
+        titleField: 'name',
+        index: ['name']
+    },
+    {
+        name: 'Posts',
+        model: 'post',
+        pathField: 'id',
+        idField: 'id',
+        titleField: 'title',
+        index: ['title']
+    },
+    {
+        name: 'Pages',
+        model: 'page',
+        pathField: 'id',
+        idField: 'id',
+        titleField: 'title',
+        index: ['title']
+    }
+];
+
+const STATUS_PRIORITY = {
+    scheduled: 1,
+    draft: 2,
+    published: 3,
+    sent: 4
+};
+
+export function sortSearchResultsByStatus(results, model) {
+    if (model === 'post' || model === 'page') {
+        results.sort((a, b) => {
+            const aPriority = STATUS_PRIORITY[a.status] || 5;
+            const bPriority = STATUS_PRIORITY[b.status] || 5;
+            return aPriority - bPriority;
+        });
+    }
+    return results;
+}
+
+export function createSearchResult(searchable, item) {
+    const idField = searchable.idField || searchable.pathField;
+
+    return {
+        id: `${searchable.model}.${item[idField]}`,
+        url: item.url,
+        title: item[searchable.titleField],
+        groupName: searchable.name,
+        status: item.status,
+        visibility: item.visibility,
+        publishedAt: item.published_at
+    };
+}

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -117,7 +117,11 @@ suites.forEach((suite) => {
             // correct results are found
             const options = findAll('.ember-power-select-option');
             expect(options, 'number of search results').to.have.length(4);
-            expect(options.map(el => el.textContent.trim())).to.deep.equal(['First user', 'First tag', 'First post', 'First page']);
+            // Get the title text from the first div child within each option (ignoring status labels)
+            expect(options.map((el) => {
+                const titleDiv = el.querySelector('.gh-nav-search-option > div:first-child');
+                return titleDiv ? titleDiv.textContent.trim() : el.textContent.trim();
+            })).to.deep.equal(['First user', 'First tag', 'First post', 'First page']);
 
             // first item is selected
             expect(options[0]).to.have.attribute('aria-current', 'true');
@@ -211,7 +215,11 @@ suites.forEach((suite) => {
             // correct results are found
             const options = findAll('.ember-power-select-option');
             expect(options, 'number of search results').to.have.length(4);
-            expect(options.map(el => el.textContent.trim())).to.deep.equal(['First user', 'First tag', 'First post', 'First page']);
+            // Get the title text from the first div child within each option (ignoring status labels)
+            expect(options.map((el) => {
+                const titleDiv = el.querySelector('.gh-nav-search-option > div:first-child');
+                return titleDiv ? titleDiv.textContent.trim() : el.textContent.trim();
+            })).to.deep.equal(['First user', 'First tag', 'First post', 'First page']);
 
             // first item is selected
             expect(options[0]).to.have.attribute('aria-current', 'true');

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -15,7 +15,7 @@ const controller = {
         },
         query() {
             const options = {
-                filter: 'type:post',
+                filter: 'type:post+status:[draft,published,scheduled,sent]',
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'url', 'title', 'status', 'published_at', 'visibility']
@@ -34,7 +34,7 @@ const controller = {
         },
         query() {
             const options = {
-                filter: 'type:page',
+                filter: 'type:page+status:[draft,published,scheduled]',
                 limit: '10000',
                 order: 'updated_at DESC',
                 columns: ['id', 'url', 'title', 'status', 'published_at', 'visibility']

--- a/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/search-index.test.js.snap
@@ -43,6 +43,14 @@ Object {
       "url": Any<String>,
       "visibility": Any<String>,
     },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
   ],
 }
 `;
@@ -51,7 +59,7 @@ exports[`Search Index API fetchPages should return a list of pages 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "926",
+  "content-length": "1112",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -63,6 +71,22 @@ Object {
 exports[`Search Index API fetchPosts should return a list of posts 1: [body] 1`] = `
 Object {
   "posts": Array [
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
+    Object {
+      "id": Any<String>,
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "status": Any<String>,
+      "title": Any<String>,
+      "url": Any<String>,
+      "visibility": Any<String>,
+    },
     Object {
       "id": Any<String>,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -172,7 +196,7 @@ exports[`Search Index API fetchPosts should return a list of posts 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2313",
+  "content-length": "2677",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/search-index.test.js
+++ b/ghost/core/test/e2e-api/admin/search-index.test.js
@@ -29,7 +29,7 @@ describe('Search Index API', function () {
                     etag: anyEtag
                 })
                 .matchBodySnapshot({
-                    posts: new Array(11).fill(searchIndexPostMatcher)
+                    posts: new Array(13).fill(searchIndexPostMatcher)
                 });
 
             // Explicitly double-check that expensive fields are not included
@@ -60,7 +60,7 @@ describe('Search Index API', function () {
                     etag: anyEtag
                 })
                 .matchBodySnapshot({
-                    pages: new Array(5).fill(searchIndexPageMatcher)
+                    pages: new Array(6).fill(searchIndexPageMatcher)
                 });
 
             // Explicitly double-check that expensive fields are not included


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2508/
ref https://linear.app/ghost/issue/PROD-2308/
- updated filter for search-index query to use all statuses
- added labels for draft and scheduled

Admin search was using the default post model filter, which is status:published. Given the user is in admin, they should be able to see all results.