### PR TITLE
🐛 Fixed whitespace in names breaking member CSV imports

### DIFF
--- a/ghost/core/core/server/services/members/importer/MembersCSVImporter.js
+++ b/ghost/core/core/server/services/members/importer/MembersCSVImporter.js
@@ -150,9 +150,13 @@ module.exports = class MembersCSVImporter {
                 // Members created in the future will not appear in admin members list
                 // Refs https://github.com/TryGhost/Team/issues/2793
                 const createdAt = moment(row.created_at).isAfter(moment()) ? moment().toDate() : row.created_at;
+
+                // Trim whitespace from name and convert to null if empty
+                const memberName = row.name && row.name.trim() ? row.name.trim() : null;
+
                 const memberValues = {
                     email: row.email,
-                    name: row.name,
+                    name: memberName,
                     note: row.note,
                     subscribed: row.subscribed,
                     created_at: createdAt,
@@ -179,7 +183,8 @@ module.exports = class MembersCSVImporter {
                     }
 
                     // Don't overwrite name or note if they are blank in the file
-                    if (!row.name) {
+                    // Use the processed memberName instead of raw row.name
+                    if (!memberName) {
                         memberValues.name = existingMember.name;
                     }
                     if (!row.note) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1564

- When importing members via CSV, names containing only whitespace (spaces, tabs, etc.) were being stored as empty strings instead of null, causing weird UI issues
- Added validation during import to trim whitespace from member names and convert whitespace-only names to null
- This prevents bad data from entering the database rather than only handling it on the UI side