### PR TITLE
Added `{uniqueid}` email replacement variable

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -39,6 +39,10 @@ const features: Feature[] = [{
     title: 'UTM tracking',
     description: 'Enables UTM tracking for web traffic and member attribution',
     flag: 'utmTracking'
+}, {
+    title: 'Email Unique ID',
+    description: 'Enables {uniqueid} variable in emails for unique image URLs to bypass ESP image caching',
+    flag: 'emailUniqueid'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -93,7 +93,8 @@ module.exports = {
             },
             feature: {
                 contentVisibility: labs.isSet('contentVisibility'),
-                emailCustomization: true // force on until Koenig has been bumped
+                emailCustomization: true, // force on until Koenig has been bumped
+                emailUniqueid: labs.isSet('emailUniqueid')
             },
             nodeRenderers: this.customNodeRenderers
         }, userOptions);

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -774,6 +774,13 @@ class EmailRenderer {
                     return this.createUnsubscribeUrl(member.uuid, {newsletterUuid});
                 },
                 required: true // Used in email headers
+            },
+            // Unique ID used for ad images to bypass ESP image proxies
+            {
+                id: 'uniqueid',
+                getValue: () => {
+                    return crypto.randomUUID();
+                }
             }
         ];
 

--- a/ghost/core/core/server/services/koenig/node-renderers/html-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/html-renderer.js
@@ -1,6 +1,7 @@
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {renderEmptyContainer} = require('../render-utils/render-empty-container');
 const {renderWithVisibility} = require('../render-utils/visibility');
+const {wrapReplacementStrings} = require('../render-utils/replacement-strings');
 
 function renderHtmlNode(node, options = {}) {
     addCreateDocumentOption(options);
@@ -12,7 +13,13 @@ function renderHtmlNode(node, options = {}) {
         return renderEmptyContainer(document);
     }
 
-    const wrappedHtml = `\n<!--kg-card-begin: html-->\n${html}\n<!--kg-card-end: html-->\n`;
+    // Wrap replacement strings like {uniqueid} with %% for email processing
+    // Only wrap if emailUniqueid labs flag is enabled
+    let processedHtml = html;
+    if (options.feature?.emailUniqueid) {
+        processedHtml = wrapReplacementStrings(html);
+    }
+    const wrappedHtml = `\n<!--kg-card-begin: html-->\n${processedHtml}\n<!--kg-card-end: html-->\n`;
 
     const textarea = document.createElement('textarea');
     textarea.value = wrappedHtml;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -49,7 +49,8 @@ const PRIVATE_FEATURES = [
     'emailCustomization',
     'membersSigninOTC',
     'tagsX',
-    'utmTracking'
+    'utmTracking',
+    'emailUniqueid'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -17,6 +17,7 @@ Object {
       "customFonts": true,
       "editorExcerpt": true,
       "emailCustomization": true,
+      "emailUniqueid": true,
       "explore": true,
       "i18n": true,
       "importMemberTier": true,

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -353,6 +353,69 @@ describe('Email renderer', function () {
             const memberHmac = crypto.createHmac('sha256', getMembersValidationKey()).update(member.uuid).digest('hex');
             assert.equal(replacements[1].getValue(member), memberHmac);
         });
+
+        it('returns uniqueid replacement', function () {
+            const html = 'Hello %%{uniqueid}%%,';
+            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
+            assert.equal(replacements.length, 2);
+            assert.equal(replacements[0].token.toString(), '/%%\\{uniqueid\\}%%/g');
+            assert.equal(replacements[0].id, 'uniqueid');
+
+            // Should return a valid UUID
+            const uniqueId = replacements[0].getValue(member);
+            assert.ok(uniqueId);
+            assert.equal(typeof uniqueId, 'string');
+            // UUID v4 format check (8-4-4-4-12 hexadecimal characters)
+            assert.ok(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(uniqueId));
+        });
+
+        it('returns different uniqueid values for different calls', function () {
+            const html = 'Hello %%{uniqueid}%%,';
+            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
+
+            const uniqueId1 = replacements[0].getValue(member);
+            const uniqueId2 = replacements[0].getValue(member);
+
+            // Each call should return a different UUID
+            assert.notEqual(uniqueId1, uniqueId2);
+        });
+
+        it('handles multiple uniqueid instances in same email', function () {
+            const html = 'Hello %%{uniqueid}%% and %%{uniqueid}%%';
+            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
+            assert.equal(replacements.length, 2); // uniqueid + list_unsubscribe
+            assert.equal(replacements[0].token.toString(), '/%%\\{uniqueid\\}%%/g');
+            assert.equal(replacements[0].id, 'uniqueid');
+
+            // Should still be recognized as a single replacement definition
+            const uniqueIdReplacements = replacements.filter(r => r.id === 'uniqueid');
+            assert.equal(uniqueIdReplacements.length, 1);
+        });
+
+        it('does not call uniqueid getValue when not used in email content', function () {
+            // Spy on crypto.randomUUID to verify it's not called
+            const randomUUIDSpy = sinon.spy(crypto, 'randomUUID');
+
+            const html = 'Hello %%{first_name}%%, welcome to our newsletter!';
+            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
+
+            // Should only have first_name and list_unsubscribe replacements
+            assert.equal(replacements.length, 2);
+
+            // Verify uniqueid is not included in replacements
+            const uniqueIdReplacements = replacements.filter(r => r.id === 'uniqueid');
+            assert.equal(uniqueIdReplacements.length, 0);
+
+            // Call getValue on all replacements to simulate actual usage
+            replacements.forEach((replacement) => {
+                replacement.getValue(member);
+            });
+
+            // Verify crypto.randomUUID was never called since uniqueid wasn't used
+            assert.equal(randomUUIDSpy.callCount, 0);
+
+            randomUUIDSpy.restore();
+        });
     });
 
     describe('buildReplacementDefinitions with locales', function () {

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/html-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/html-renderer.test.js
@@ -57,5 +57,48 @@ describe('services/koenig/node-renderers/html-renderer', function () {
             const result = renderForEmail(getTestData({html: ''}));
             assert.equal(result.html, '');
         });
+
+        it('wraps uniqueid replacement strings when emailUniqueid feature is enabled', function () {
+            const htmlWithUniqueId = '<img src="https://ads.example.com/banner.jpg?id={uniqueid}" alt="Ad">';
+            const result = renderForEmail(getTestData({html: htmlWithUniqueId}), {
+                feature: {emailUniqueid: true}
+            });
+
+            assert.ok(result.html.includes('%%{uniqueid}%%'));
+            assert.ok(!result.html.includes('>{uniqueid}<')); // Should not have unwrapped version
+            assert.ok(result.html.includes('kg-card-begin: html'));
+        });
+
+        it('does not wrap uniqueid replacement strings when emailUniqueid feature is disabled', function () {
+            const htmlWithUniqueId = '<img src="https://ads.example.com/banner.jpg?id={uniqueid}" alt="Ad">';
+            const result = renderForEmail(getTestData({html: htmlWithUniqueId}), {
+                feature: {emailUniqueid: false}
+            });
+
+            assert.ok(!result.html.includes('%%{uniqueid}%%'));
+            assert.ok(result.html.includes('{uniqueid}'));
+            assert.ok(result.html.includes('kg-card-begin: html'));
+        });
+
+        it('does not wrap uniqueid replacement strings when feature object is missing', function () {
+            const htmlWithUniqueId = '<img src="https://ads.example.com/banner.jpg?id={uniqueid}" alt="Ad">';
+            const result = renderForEmail(getTestData({html: htmlWithUniqueId}));
+
+            assert.ok(!result.html.includes('%%{uniqueid}%%'));
+            assert.ok(result.html.includes('{uniqueid}'));
+            assert.ok(result.html.includes('kg-card-begin: html'));
+        });
+
+        it('wraps multiple replacement strings when emailUniqueid feature is enabled', function () {
+            const htmlWithMultiple = '<img src="https://ads.example.com/banner.jpg?id={uniqueid}&name={first_name}" alt="Ad">';
+            const result = renderForEmail(getTestData({html: htmlWithMultiple}), {
+                feature: {emailUniqueid: true}
+            });
+
+            assert.ok(result.html.includes('%%{uniqueid}%%'));
+            assert.ok(result.html.includes('%%{first_name}%%'));
+            assert.ok(!result.html.includes('>{uniqueid}<'));
+            assert.ok(!result.html.includes('>{first_name}<'));
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2643/

- when inserting ad images into HTML cards for newsletters it's useful to have a unique identifier so that the ad can't be cached by ESP image cache proxies which can result in stale ads being served and inability to track number of impressions
- added the ability to use `{uniqueid}` inside of HTML cards for cache-bypassing unique URLs, e.g. `https://myadserver.com/my-email-campaign/?seed={uniqueid}`
- the value is completely random and different per recipient and newsletter send so can't be used for any member identification or tracking, it's usage is specifically to help with image caching problems
