### PR TITLE
🐛 Fixed Esc key not closing post preview 

### DIFF
--- a/e2e/helpers/pages/admin/PostEditorPage.ts
+++ b/e2e/helpers/pages/admin/PostEditorPage.ts
@@ -73,7 +73,7 @@ export class PostPreviewModal {
         }
 
         // Wait for script injection to complete (we have a 500ms setTimeout in browser.js)
-        await this.page.waitForTimeout(600);
+        await this.page.waitForTimeout(1000);
 
         // Return the content locators
         return {

--- a/e2e/helpers/pages/admin/PostEditorPage.ts
+++ b/e2e/helpers/pages/admin/PostEditorPage.ts
@@ -145,24 +145,4 @@ export class PostEditorPage extends AdminPage {
     async getStatus(): Promise<string> {
         return await this.statusText.textContent() || '';
     }
-
-    // Helper method to test ESC key functionality
-    async testEscapeKey(): Promise<void> {
-        // First try normal keyboard press
-        await this.page.keyboard.press('Escape');
-
-        // Also dispatch event directly to the document to bypass iframe focus issues
-        await this.page.evaluate(() => {
-            const event = new KeyboardEvent('keydown', {
-                key: 'Escape',
-                code: 'Escape',
-                keyCode: 27,
-                which: 27,
-                bubbles: true,
-                cancelable: true
-            });
-            document.dispatchEvent(event);
-            window.dispatchEvent(event);
-        });
-    }
 }

--- a/e2e/helpers/pages/admin/PostEditorPage.ts
+++ b/e2e/helpers/pages/admin/PostEditorPage.ts
@@ -1,0 +1,168 @@
+import {Page, Locator} from '@playwright/test';
+import {AdminPage} from './AdminPage';
+
+export class PostPreviewModal {
+    private readonly page: Page;
+    readonly modal: Locator;
+    readonly header: Locator;
+    readonly closeButton: Locator;
+    readonly iframe: Locator;
+    readonly webTabButton: Locator;
+    readonly emailTabButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.modal = page.getByRole('banner').filter({hasText: 'Preview'});
+        this.header = this.modal.getByRole('heading', {name: 'Preview'});
+        this.closeButton = this.modal.getByRole('button', {name: 'Close'});
+        this.iframe = page.locator('iframe[title*="preview"]');
+        this.webTabButton = this.modal.getByRole('button', {name: 'Web'});
+        this.emailTabButton = this.modal.getByRole('button', {name: 'Email'});
+    }
+
+    async waitForVisible(): Promise<void> {
+        await this.modal.waitFor({state: 'visible'});
+        await this.header.waitFor({state: 'visible'});
+    }
+
+    async waitForHidden(): Promise<void> {
+        await this.modal.waitFor({state: 'hidden'});
+    }
+
+    async close(): Promise<void> {
+        await this.closeButton.click();
+        await this.waitForHidden();
+    }
+
+    async isVisible(): Promise<boolean> {
+        return await this.modal.isVisible();
+    }
+
+    async clickInIframe(): Promise<void> {
+        await this.iframe.click();
+    }
+
+    async isIframeFocused(): Promise<boolean> {
+        // Check if iframe has focus by checking if it has the 'active' attribute or class
+        await this.iframe.waitFor({state: 'visible'});
+
+        // We can check if the iframe is focused by evaluating focus state
+        return await this.page.evaluate(() => {
+            const iframeElement = document.querySelector('iframe[title*="preview"]');
+            return document.activeElement === iframeElement;
+        });
+    }
+}
+
+export class PostEditorPage extends AdminPage {
+    readonly titleInput: Locator;
+    readonly contentInput: Locator;
+    readonly previewButton: Locator;
+    readonly publishButton: Locator;
+    readonly settingsButton: Locator;
+    readonly addFeatureImageButton: Locator;
+    readonly wordCount: Locator;
+    readonly statusText: Locator;
+    readonly previewModal: PostPreviewModal;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/editor/post/';
+
+        // Initialize locators
+        this.titleInput = page.getByRole('textbox', {name: 'Post title'});
+        this.contentInput = page.getByRole('textbox').nth(1); // Second textbox is content
+        this.previewButton = page.getByRole('button', {name: 'Preview'});
+        this.publishButton = page.getByRole('button', {name: /Publish/});
+        this.settingsButton = page.getByRole('button', {name: 'Settings'});
+        this.addFeatureImageButton = page.getByRole('button', {name: 'Add feature image'});
+        this.wordCount = page.locator('[class*="word-count"], [data-test*="word-count"]').first();
+        this.statusText = page.locator('[class*="status"], [data-test*="status"]').first();
+
+        // Initialize preview modal
+        this.previewModal = new PostPreviewModal(page);
+    }
+
+    async goto(): Promise<void> {
+        await this.page.goto(this.pageUrl);
+        await this.titleInput.waitFor({state: 'visible'});
+    }
+
+    async gotoExistingPost(postId: string): Promise<void> {
+        await this.page.goto(`/ghost/#/editor/post/${postId}`);
+        await this.titleInput.waitFor({state: 'visible'});
+    }
+
+    async createNewPost(title: string, content?: string): Promise<void> {
+        await this.goto();
+        await this.fillTitle(title);
+
+        if (content) {
+            await this.fillContent(content);
+        }
+
+        // Wait for post to be saved automatically
+        await this.waitForSave();
+    }
+
+    async fillTitle(title: string): Promise<void> {
+        await this.titleInput.fill(title);
+        // Tab to trigger save
+        await this.titleInput.press('Tab');
+    }
+
+    async fillContent(content: string): Promise<void> {
+        await this.contentInput.fill(content);
+    }
+
+    async openPreview(): Promise<void> {
+        await this.previewButton.click();
+        await this.previewModal.waitForVisible();
+    }
+
+    async waitForSave(): Promise<void> {
+        // Wait for the "Saving..." text to appear and then disappear
+        await this.page.waitForFunction(() => {
+            const statusElement = document.querySelector('[class*="status"], [data-test*="status"]');
+            return statusElement && statusElement.textContent?.includes('Saved');
+        }, {timeout: 10000});
+    }
+
+    async waitForPreviewButtonVisible(): Promise<void> {
+        await this.previewButton.waitFor({state: 'visible'});
+    }
+
+    async isPreviewButtonVisible(): Promise<boolean> {
+        return await this.previewButton.isVisible();
+    }
+
+    async getWordCount(): Promise<number> {
+        const text = await this.wordCount.textContent();
+        const match = text?.match(/(\d+)\s+words?/);
+        return match ? parseInt(match[1]) : 0;
+    }
+
+    async getStatus(): Promise<string> {
+        return await this.statusText.textContent() || '';
+    }
+
+    // Helper method to test ESC key functionality
+    async testEscapeKey(): Promise<void> {
+        // First try normal keyboard press
+        await this.page.keyboard.press('Escape');
+
+        // Also dispatch event directly to the document to bypass iframe focus issues
+        await this.page.evaluate(() => {
+            const event = new KeyboardEvent('keydown', {
+                key: 'Escape',
+                code: 'Escape',
+                keyCode: 27,
+                which: 27,
+                bubbles: true,
+                cancelable: true
+            });
+            document.dispatchEvent(event);
+            window.dispatchEvent(event);
+        });
+    }
+}

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -9,3 +9,4 @@ export * from './analytics/post-analytics/PostAnalyticsWebTrafficPage';
 export * from './LoginPage';
 export * from './AdminPage';
 export * from './MembersPage';
+export * from './PostEditorPage';

--- a/e2e/tests/admin/PostPreview.test.ts
+++ b/e2e/tests/admin/PostPreview.test.ts
@@ -10,7 +10,7 @@ test.describe('Post Preview Modal', () => {
         postFactory = createPostFactory(page);
     });
 
-    test('ESC key closes preview modal when iframe has focus', async ({page}) => {
+    test('closes preview modal with ESC key when iframe has focus', async ({page}) => {
         // Create a test post
         const post = await postFactory.create({
             title: 'Test Post for ESC Key',
@@ -29,16 +29,15 @@ test.describe('Post Preview Modal', () => {
         const iframeFocused = await postEditorPage.previewModal.isIframeFocused();
         expect(iframeFocused).toBe(true);
 
-        // Test ESC key functionality
-        await postEditorPage.testEscapeKey();
-        await page.waitForTimeout(500);
+        // Press ESC key - implementation should handle it regardless of iframe focus
+        await page.keyboard.press('Escape');
 
         // Verify modal is closed
-        const modalStillVisible = await postEditorPage.previewModal.isVisible();
-        expect(modalStillVisible).toBe(false);
+        await postEditorPage.previewModal.waitForHidden();
+        expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
 
-    test('ESC key closes preview modal without iframe focus', async ({page}) => {
+    test('closes preview modal with ESC key when modal header has focus', async ({page}) => {
         const post = await postFactory.create({
             title: 'Test Post for ESC Key Baseline',
             status: 'draft'
@@ -54,16 +53,15 @@ test.describe('Post Preview Modal', () => {
         // Click on modal header to ensure focus is not on iframe
         await postEditorPage.previewModal.header.click();
 
-        // Test ESC key
-        await postEditorPage.testEscapeKey();
-        await page.waitForTimeout(500);
+        // Press ESC key to close modal
+        await page.keyboard.press('Escape');
 
         // Verify modal is closed
-        const modalClosed = await postEditorPage.previewModal.isVisible();
-        expect(modalClosed).toBe(false);
+        await postEditorPage.previewModal.waitForHidden();
+        expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
 
-    test('Close button works as fallback', async ({page}) => {
+    test('closes preview modal using close button', async ({page}) => {
         const post = await postFactory.create({
             title: 'Test Post for Close Button',
             status: 'draft'
@@ -79,8 +77,7 @@ test.describe('Post Preview Modal', () => {
         // Use close button
         await postEditorPage.previewModal.close();
 
-        // Verify modal is closed
-        const modalClosed = await postEditorPage.previewModal.isVisible();
-        expect(modalClosed).toBe(false);
+        // Verify modal is closed (close() method already waits for hidden)
+        expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
 });

--- a/e2e/tests/admin/PostPreview.test.ts
+++ b/e2e/tests/admin/PostPreview.test.ts
@@ -1,0 +1,86 @@
+import {test, expect} from '../../helpers/playwright';
+import {PostEditorPage} from '../../helpers/pages/admin';
+import {createPostFactory} from '../../data-factory';
+import type {PostFactory} from '../../data-factory';
+
+test.describe('Post Preview Modal', () => {
+    let postFactory: PostFactory;
+
+    test.beforeEach(async ({page}) => {
+        postFactory = createPostFactory(page);
+    });
+
+    test('ESC key closes preview modal when iframe has focus', async ({page}) => {
+        // Create a test post
+        const post = await postFactory.create({
+            title: 'Test Post for ESC Key',
+            status: 'draft'
+        });
+
+        const postEditorPage = new PostEditorPage(page);
+        await postEditorPage.gotoExistingPost(post.id);
+
+        // Open preview modal
+        await postEditorPage.openPreview();
+        expect(await postEditorPage.previewModal.isVisible()).toBe(true);
+
+        // Click inside the iframe to focus it
+        await postEditorPage.previewModal.clickInIframe();
+        const iframeFocused = await postEditorPage.previewModal.isIframeFocused();
+        expect(iframeFocused).toBe(true);
+
+        // Test ESC key functionality
+        await postEditorPage.testEscapeKey();
+        await page.waitForTimeout(500);
+
+        // Verify modal is closed
+        const modalStillVisible = await postEditorPage.previewModal.isVisible();
+        expect(modalStillVisible).toBe(false);
+    });
+
+    test('ESC key closes preview modal without iframe focus', async ({page}) => {
+        const post = await postFactory.create({
+            title: 'Test Post for ESC Key Baseline',
+            status: 'draft'
+        });
+
+        const postEditorPage = new PostEditorPage(page);
+        await postEditorPage.gotoExistingPost(post.id);
+
+        // Open preview modal
+        await postEditorPage.openPreview();
+        expect(await postEditorPage.previewModal.isVisible()).toBe(true);
+
+        // Click on modal header to ensure focus is not on iframe
+        await postEditorPage.previewModal.header.click();
+
+        // Test ESC key
+        await postEditorPage.testEscapeKey();
+        await page.waitForTimeout(500);
+
+        // Verify modal is closed
+        const modalClosed = await postEditorPage.previewModal.isVisible();
+        expect(modalClosed).toBe(false);
+    });
+
+    test('Close button works as fallback', async ({page}) => {
+        const post = await postFactory.create({
+            title: 'Test Post for Close Button',
+            status: 'draft'
+        });
+
+        const postEditorPage = new PostEditorPage(page);
+        await postEditorPage.gotoExistingPost(post.id);
+
+        // Open preview modal
+        await postEditorPage.openPreview();
+        expect(await postEditorPage.previewModal.isVisible()).toBe(true);
+
+        // Use close button
+        await postEditorPage.previewModal.close();
+
+        // Verify modal is closed
+        const modalClosed = await postEditorPage.previewModal.isVisible();
+        expect(modalClosed).toBe(false);
+    });
+});

--- a/e2e/tests/admin/PostPreview.test.ts
+++ b/e2e/tests/admin/PostPreview.test.ts
@@ -11,28 +11,22 @@ test.describe('Post Preview Modal', () => {
     });
 
     test('closes preview modal with ESC key when iframe has focus', async ({page}) => {
-        // Create a test post
         const post = await postFactory.create({
             title: 'Test Post for ESC Key',
             status: 'draft'
         });
 
         const postEditorPage = new PostEditorPage(page);
-        await postEditorPage.gotoExistingPost(post.id);
+        await postEditorPage.gotoPost(post.id);
 
-        // Open preview modal
         await postEditorPage.openPreview();
         expect(await postEditorPage.previewModal.isVisible()).toBe(true);
 
-        // Click inside the iframe to focus it
-        await postEditorPage.previewModal.clickInIframe();
-        const iframeFocused = await postEditorPage.previewModal.isIframeFocused();
-        expect(iframeFocused).toBe(true);
+        const postContent = await postEditorPage.previewModal.getPostContent();
+        await postContent.image().click();
 
-        // Press ESC key - implementation should handle it regardless of iframe focus
         await page.keyboard.press('Escape');
 
-        // Verify modal is closed
         await postEditorPage.previewModal.waitForHidden();
         expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
@@ -44,19 +38,15 @@ test.describe('Post Preview Modal', () => {
         });
 
         const postEditorPage = new PostEditorPage(page);
-        await postEditorPage.gotoExistingPost(post.id);
+        await postEditorPage.gotoPost(post.id);
 
-        // Open preview modal
         await postEditorPage.openPreview();
         expect(await postEditorPage.previewModal.isVisible()).toBe(true);
 
-        // Click on modal header to ensure focus is not on iframe
         await postEditorPage.previewModal.header.click();
 
-        // Press ESC key to close modal
         await page.keyboard.press('Escape');
 
-        // Verify modal is closed
         await postEditorPage.previewModal.waitForHidden();
         expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
@@ -68,16 +58,13 @@ test.describe('Post Preview Modal', () => {
         });
 
         const postEditorPage = new PostEditorPage(page);
-        await postEditorPage.gotoExistingPost(post.id);
+        await postEditorPage.gotoPost(post.id);
 
-        // Open preview modal
         await postEditorPage.openPreview();
         expect(await postEditorPage.previewModal.isVisible()).toBe(true);
 
-        // Use close button
         await postEditorPage.previewModal.close();
 
-        // Verify modal is closed (close() method already waits for hidden)
         expect(await postEditorPage.previewModal.isVisible()).toBe(false);
     });
 });

--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -102,6 +102,7 @@
                     @previewUrl={{this.browserPreviewUrl}}
                     @skipAnimation={{this.skipAnimation}}
                     @mobile={{eq this.previewSize "mobile"}}
+                    @closeModal={{@close}}
                 />
             {{else}}
                 <Editor::Modals::Preview::Email

--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -112,6 +112,7 @@
                     @skipAnimation={{this.skipAnimation}}
                     @savePostTask={{@data.saveTask}}
                     @mobile={{eq this.previewSize "mobile"}}
+                    @closeModal={{@close}}
                 />
             {{/if}}
         {{/let}}

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -1,8 +1,8 @@
 /* global key */
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
-import {inject as service} from '@ember/service';
 import {run} from '@ember/runloop';
+import {inject as service} from '@ember/service';
 
 export default class ModalPostPreviewBrowserComponent extends Component {
     @service modals;

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -1,175 +1,27 @@
-/* global key */
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
-import {run} from '@ember/runloop';
-import {inject as service} from '@ember/service';
 
 export default class ModalPostPreviewBrowserComponent extends Component {
-    @service modals;
-
-    iframeElement = null;
-
-    constructor() {
-        super(...arguments);
-        // Start listening for escape immediately
-        this.setupGlobalEscapeHandler();
-    }
-
-    setupGlobalEscapeHandler() {
-        // Create a single unified handler
+    @action
+    setupPreview() {
+        // Set up escape handler when iframe loads
         this.escapeHandler = (e) => {
-            // Check if this component is still active and has the modal open
-            if (!this.isDestroyed && !this.isDestroying) {
-                if (e.key === 'Escape' || e.keyCode === 27 || e.which === 27) {
-                    // Check if our modal is currently open
-                    const modalElement = document.querySelector('.gh-post-preview-modal');
-                    if (modalElement) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        e.stopImmediatePropagation();
-
-                        // Use run.next to ensure we're in the Ember run loop
-                        run.next(this, () => {
-                            this.closeModal();
-                        });
-
-                        return false;
-                    }
-                }
+            if (e.key === 'Escape' && this.args.closeModal) {
+                e.preventDefault();
+                this.args.closeModal();
             }
         };
 
-        // Add handler with maximum priority on multiple targets
-        const options = {capture: true, passive: false};
-        window.addEventListener('keydown', this.escapeHandler, options);
-        window.addEventListener('keyup', this.escapeHandler, options);
-        document.addEventListener('keydown', this.escapeHandler, options);
-        document.addEventListener('keyup', this.escapeHandler, options);
-    }
-
-    @action
-    setupPreview(event) {
-        this.iframeElement = event.target;
-
-        // Re-attach handlers to ensure they have priority
-        this.reinforceEscapeHandler();
-
-        // Try to inject into iframe as well
-        setTimeout(() => {
-            this.injectIframeHandler();
-        }, 100);
-    }
-
-    reinforceEscapeHandler() {
-        // Remove and re-add to ensure we're at the front of the queue
-        const options = {capture: true, passive: false};
-
-        window.removeEventListener('keydown', this.escapeHandler, options);
-        document.removeEventListener('keydown', this.escapeHandler, options);
-
-        window.addEventListener('keydown', this.escapeHandler, options);
-        document.addEventListener('keydown', this.escapeHandler, options);
-
-        // Also override keymaster if it exists
-        if (typeof key !== 'undefined') {
-            key.unbind('escape');
-            key('escape', () => {
-                this.closeModal();
-                return false;
-            });
-        }
-    }
-
-    injectIframeHandler() {
-        if (!this.iframeElement) {
-            return;
-        }
-
-        try {
-            const iframeDoc = this.iframeElement.contentDocument;
-            const iframeWin = this.iframeElement.contentWindow;
-
-            if (iframeDoc && iframeWin) {
-                // Create handler for inside iframe
-                const iframeEscapeHandler = (e) => {
-                    if (e.key === 'Escape' || e.keyCode === 27) {
-                        e.preventDefault();
-                        e.stopPropagation();
-
-                        // Trigger escape on parent window
-                        const escapeEvent = new KeyboardEvent('keydown', {
-                            key: 'Escape',
-                            keyCode: 27,
-                            which: 27,
-                            code: 'Escape',
-                            bubbles: true,
-                            cancelable: true
-                        });
-
-                        window.dispatchEvent(escapeEvent);
-                    }
-                };
-
-                // Add to iframe's window and document
-                iframeWin.addEventListener('keydown', iframeEscapeHandler, true);
-                iframeDoc.addEventListener('keydown', iframeEscapeHandler, true);
-
-                // Store for cleanup
-                this.iframeHandlers = {
-                    win: iframeWin,
-                    doc: iframeDoc,
-                    handler: iframeEscapeHandler
-                };
-            }
-        } catch (e) {
-            // Ignore cross-origin errors
-            console.debug('Could not inject iframe handler:', e.message);
-        }
-    }
-
-    closeModal() {
-        // Try multiple methods to close
-        if (this.args.closeModal && typeof this.args.closeModal === 'function') {
-            this.args.closeModal();
-        } else if (this.modals && this.modals.top && this.modals.top.close) {
-            this.modals.top.close();
-        } else {
-            // Last resort: find and click the close button
-            const closeButton = document.querySelector('.gh-post-preview-modal button.gh-btn-editor') ||
-                               document.querySelector('button[class*="close"]') ||
-                               Array.from(document.querySelectorAll('button')).find(btn => btn.textContent.trim() === 'Close');
-            if (closeButton) {
-                closeButton.click();
-            }
-        }
+        // Add listener with capture to intercept before iframe traps it
+        document.addEventListener('keydown', this.escapeHandler, true);
     }
 
     willDestroy() {
         super.willDestroy(...arguments);
 
-        // Clean up all event listeners
-        const options = {capture: true, passive: false};
-
+        // Clean up the event listener
         if (this.escapeHandler) {
-            window.removeEventListener('keydown', this.escapeHandler, options);
-            window.removeEventListener('keyup', this.escapeHandler, options);
-            document.removeEventListener('keydown', this.escapeHandler, options);
-            document.removeEventListener('keyup', this.escapeHandler, options);
-        }
-
-        // Clean up iframe handlers
-        if (this.iframeHandlers) {
-            try {
-                this.iframeHandlers.win.removeEventListener('keydown', this.iframeHandlers.handler, true);
-                this.iframeHandlers.doc.removeEventListener('keydown', this.iframeHandlers.handler, true);
-            } catch (e) {
-                // Ignore
-            }
-        }
-
-        // Restore keymaster if we modified it
-        if (typeof key !== 'undefined') {
-            key.unbind('escape');
+            document.removeEventListener('keydown', this.escapeHandler, true);
         }
     }
 }

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -39,8 +39,13 @@ export default class ModalPostPreviewBrowserComponent extends Component {
                     const iframeDoc = this.iframe.contentWindow.document;
                     if (iframeDoc && iframeDoc.body) {
                         const script = iframeDoc.createElement('script');
+                        // Add a data attribute to identify our injected script
+                        script.setAttribute('data-ghost-preview-escape-handler', 'true');
                         script.innerHTML = `
                             (function() {
+                                // Mark that the escape handler is ready
+                                window.ghostPreviewEscapeHandlerReady = true;
+
                                 // Listen for escape key and post message to parent
                                 document.addEventListener('keydown', function(e) {
                                     if (e.key === 'Escape') {

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -3,25 +3,74 @@ import {action} from '@ember/object';
 
 export default class ModalPostPreviewBrowserComponent extends Component {
     @action
-    setupPreview() {
-        // Set up escape handler when iframe loads
-        this.escapeHandler = (e) => {
-            if (e.key === 'Escape' && this.args.closeModal) {
-                e.preventDefault();
-                this.args.closeModal();
+    setupPreview(event) {
+        // Get iframe from the event target
+        const iframe = event.target;
+
+        // Store iframe reference
+        this.iframe = iframe;
+
+        // Listen for messages from the iframe
+        this.messageHandler = (messageEvent) => {
+            // Check if message is from our iframe
+            if (messageEvent.source === this.iframe?.contentWindow && messageEvent.data?.type === 'escapeKeyPressed') {
+                // Create and dispatch a new keyboard event on the parent document
+                // This ensures the modal service's handler will catch it
+                const escapeEvent = new KeyboardEvent('keydown', {
+                    key: 'Escape',
+                    code: 'Escape',
+                    keyCode: 27,
+                    bubbles: true,
+                    cancelable: true
+                });
+                document.dispatchEvent(escapeEvent);
             }
         };
 
-        // Add listener with capture to intercept before iframe traps it
-        document.addEventListener('keydown', this.escapeHandler, true);
+        // Add message listener to parent window
+        window.addEventListener('message', this.messageHandler);
+
+        // Inject script into iframe to listen for escape key and post message
+        // We need to wait a bit for the iframe document to be ready
+        setTimeout(() => {
+            if (this.iframe && this.iframe.contentWindow) {
+                try {
+                    // Check if the document is ready
+                    const iframeDoc = this.iframe.contentWindow.document;
+                    if (iframeDoc && iframeDoc.body) {
+                        const script = iframeDoc.createElement('script');
+                        script.innerHTML = `
+                            (function() {
+                                // Listen for escape key and post message to parent
+                                document.addEventListener('keydown', function(e) {
+                                    if (e.key === 'Escape') {
+                                        window.parent.postMessage({ type: 'escapeKeyPressed' }, '*');
+                                    }
+                                }, true);
+
+                                // Also listen on window to catch all events
+                                window.addEventListener('keydown', function(e) {
+                                    if (e.key === 'Escape') {
+                                        window.parent.postMessage({ type: 'escapeKeyPressed' }, '*');
+                                    }
+                                }, true);
+                            })();
+                        `;
+                        iframeDoc.body.appendChild(script);
+                    }
+                } catch (e) {
+                    // Cross-origin or other access issues, ignore
+                }
+            }
+        }, 500); // Wait for iframe content to fully load
     }
 
     willDestroy() {
         super.willDestroy(...arguments);
 
-        // Clean up the event listener
-        if (this.escapeHandler) {
-            document.removeEventListener('keydown', this.escapeHandler, true);
+        // Clean up the message listener
+        if (this.messageHandler) {
+            window.removeEventListener('message', this.messageHandler);
         }
     }
 }

--- a/ghost/admin/app/components/editor/modals/preview/browser.js
+++ b/ghost/admin/app/components/editor/modals/preview/browser.js
@@ -1,24 +1,175 @@
+/* global key */
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {run} from '@ember/runloop';
 
 export default class ModalPostPreviewBrowserComponent extends Component {
-    escapePressHandler = null;
-    
-    @action
-    setupPreview() {
-        // Set up a handler on the document
-        this.escapePressHandler = (e) => {
-            if (e.key === 'Escape') {
-                // Only handle if we have a modal to close
-                if (this.args.closeModal) {
-                    // Prevent the default behavior
-                    e.preventDefault();
-                    e.stopPropagation();
+    @service modals;
 
-                    // Close the modal directly without creating a new event
-                    this.args.closeModal();
+    iframeElement = null;
+
+    constructor() {
+        super(...arguments);
+        // Start listening for escape immediately
+        this.setupGlobalEscapeHandler();
+    }
+
+    setupGlobalEscapeHandler() {
+        // Create a single unified handler
+        this.escapeHandler = (e) => {
+            // Check if this component is still active and has the modal open
+            if (!this.isDestroyed && !this.isDestroying) {
+                if (e.key === 'Escape' || e.keyCode === 27 || e.which === 27) {
+                    // Check if our modal is currently open
+                    const modalElement = document.querySelector('.gh-post-preview-modal');
+                    if (modalElement) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        e.stopImmediatePropagation();
+
+                        // Use run.next to ensure we're in the Ember run loop
+                        run.next(this, () => {
+                            this.closeModal();
+                        });
+
+                        return false;
+                    }
                 }
             }
         };
+
+        // Add handler with maximum priority on multiple targets
+        const options = {capture: true, passive: false};
+        window.addEventListener('keydown', this.escapeHandler, options);
+        window.addEventListener('keyup', this.escapeHandler, options);
+        document.addEventListener('keydown', this.escapeHandler, options);
+        document.addEventListener('keyup', this.escapeHandler, options);
+    }
+
+    @action
+    setupPreview(event) {
+        this.iframeElement = event.target;
+
+        // Re-attach handlers to ensure they have priority
+        this.reinforceEscapeHandler();
+
+        // Try to inject into iframe as well
+        setTimeout(() => {
+            this.injectIframeHandler();
+        }, 100);
+    }
+
+    reinforceEscapeHandler() {
+        // Remove and re-add to ensure we're at the front of the queue
+        const options = {capture: true, passive: false};
+
+        window.removeEventListener('keydown', this.escapeHandler, options);
+        document.removeEventListener('keydown', this.escapeHandler, options);
+
+        window.addEventListener('keydown', this.escapeHandler, options);
+        document.addEventListener('keydown', this.escapeHandler, options);
+
+        // Also override keymaster if it exists
+        if (typeof key !== 'undefined') {
+            key.unbind('escape');
+            key('escape', () => {
+                this.closeModal();
+                return false;
+            });
+        }
+    }
+
+    injectIframeHandler() {
+        if (!this.iframeElement) {
+            return;
+        }
+
+        try {
+            const iframeDoc = this.iframeElement.contentDocument;
+            const iframeWin = this.iframeElement.contentWindow;
+
+            if (iframeDoc && iframeWin) {
+                // Create handler for inside iframe
+                const iframeEscapeHandler = (e) => {
+                    if (e.key === 'Escape' || e.keyCode === 27) {
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        // Trigger escape on parent window
+                        const escapeEvent = new KeyboardEvent('keydown', {
+                            key: 'Escape',
+                            keyCode: 27,
+                            which: 27,
+                            code: 'Escape',
+                            bubbles: true,
+                            cancelable: true
+                        });
+
+                        window.dispatchEvent(escapeEvent);
+                    }
+                };
+
+                // Add to iframe's window and document
+                iframeWin.addEventListener('keydown', iframeEscapeHandler, true);
+                iframeDoc.addEventListener('keydown', iframeEscapeHandler, true);
+
+                // Store for cleanup
+                this.iframeHandlers = {
+                    win: iframeWin,
+                    doc: iframeDoc,
+                    handler: iframeEscapeHandler
+                };
+            }
+        } catch (e) {
+            // Ignore cross-origin errors
+            console.debug('Could not inject iframe handler:', e.message);
+        }
+    }
+
+    closeModal() {
+        // Try multiple methods to close
+        if (this.args.closeModal && typeof this.args.closeModal === 'function') {
+            this.args.closeModal();
+        } else if (this.modals && this.modals.top && this.modals.top.close) {
+            this.modals.top.close();
+        } else {
+            // Last resort: find and click the close button
+            const closeButton = document.querySelector('.gh-post-preview-modal button.gh-btn-editor') ||
+                               document.querySelector('button[class*="close"]') ||
+                               Array.from(document.querySelectorAll('button')).find(btn => btn.textContent.trim() === 'Close');
+            if (closeButton) {
+                closeButton.click();
+            }
+        }
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+
+        // Clean up all event listeners
+        const options = {capture: true, passive: false};
+
+        if (this.escapeHandler) {
+            window.removeEventListener('keydown', this.escapeHandler, options);
+            window.removeEventListener('keyup', this.escapeHandler, options);
+            document.removeEventListener('keydown', this.escapeHandler, options);
+            document.removeEventListener('keyup', this.escapeHandler, options);
+        }
+
+        // Clean up iframe handlers
+        if (this.iframeHandlers) {
+            try {
+                this.iframeHandlers.win.removeEventListener('keydown', this.iframeHandlers.handler, true);
+                this.iframeHandlers.doc.removeEventListener('keydown', this.iframeHandlers.handler, true);
+            } catch (e) {
+                // Ignore
+            }
+        }
+
+        // Restore keymaster if we modified it
+        if (typeof key !== 'undefined') {
+            key.unbind('escape');
+        }
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1208/
  - Fixed ESC key not closing post preview modal when iframe has focus
  - Added event listener with capture phase to intercept ESC before iframe traps it
  - Added @closeModal prop to preview browser component
  - Added E2E tests to verify ESC key works with and without iframe focus