### PR TITLE
🐛 Fixed {{date}} helper rendering English for zh, zh-Hant, and pa locales

### DIFF
--- a/ghost/core/core/frontend/helpers/date.js
+++ b/ghost/core/core/frontend/helpers/date.js
@@ -46,7 +46,13 @@ module.exports = function (...attrs) {
     // Documentation: http://momentjs.com/docs/#/i18n/
     // Locales: https://github.com/moment/moment/tree/develop/locale
     if (locale && locale.match('^[^/\\\\]*$') !== null) {
-        dateMoment.locale(locale);
+        let momentLocale = locale;
+        if (locale === 'zh-Hant') {
+            momentLocale = 'zh-tw';
+        } else if (locale === 'zh') {
+            momentLocale = 'zh-cn';
+        }
+        dateMoment.locale(momentLocale);
     }
 
     if (timeago) {

--- a/ghost/core/core/frontend/helpers/date.js
+++ b/ghost/core/core/frontend/helpers/date.js
@@ -46,13 +46,20 @@ module.exports = function (...attrs) {
     // Documentation: http://momentjs.com/docs/#/i18n/
     // Locales: https://github.com/moment/moment/tree/develop/locale
     if (locale && locale.match('^[^/\\\\]*$') !== null) {
-        let momentLocale = locale;
-        if (locale === 'zh-Hant') {
-            momentLocale = 'zh-tw';
-        } else if (locale === 'zh') {
-            momentLocale = 'zh-cn';
+        // Moment ships region-specific locales (e.g. zh-cn, zh-tw, pa-in) for some
+        // languages where Ghost's i18n uses a bare or script-tagged code (zh, zh-Hant, pa).
+        // Maximize the locale to find the most likely regional variant, and let moment
+        // pick the first candidate it has a locale for.
+        const candidates = [locale];
+        try {
+            const maximized = new Intl.Locale(locale).maximize();
+            if (maximized.region) {
+                candidates.push(`${maximized.language}-${maximized.region}`, maximized.language);
+            }
+        } catch (e) {
+            // Invalid locale tag - moment will fall back to the default locale
         }
-        dateMoment.locale(momentLocale);
+        dateMoment.locale(candidates);
     }
 
     if (timeago) {

--- a/ghost/core/test/unit/frontend/helpers/date.test.js
+++ b/ghost/core/test/unit/frontend/helpers/date.test.js
@@ -116,6 +116,44 @@ describe('{{date}} helper', function () {
         });
     });
 
+    it('resolves i18n locales to regional moment locales', function () {
+        const testDate = '2014-11-20T01:28:58.593-04:00';
+        const timezone = 'Europe/Dublin';
+        const format = 'll';
+
+        // Ghost i18n locale -> moment locale that should be used for rendering
+        const expectations = {
+            zh: 'zh-cn',
+            'zh-Hant': 'zh-tw',
+            pa: 'pa-in',
+            en: 'en',
+            fr: 'fr',
+            kz: 'en', // not shipped by moment, falls back to the default locale
+            'not-a-real-locale-tag': 'en' // invalid tag, falls back to the default locale
+        };
+
+        Object.keys(expectations).forEach(function (locale) {
+            const context = {
+                hash: {format},
+                data: {
+                    site: {
+                        timezone,
+                        locale
+                    }
+                }
+            };
+
+            const rendered = date.call({published_at: testDate}, context);
+
+            assertExists(rendered);
+            assert.equal(
+                String(rendered),
+                moment(testDate).tz(timezone).locale(expectations[locale]).format(format),
+                `locale "${locale}" should render as moment locale "${expectations[locale]}"`
+            );
+        });
+    });
+
     it('creates properly formatted time ago date strings', function () {
         const testDates = [
             '2013-12-31T23:58:58.593+02:00',


### PR DESCRIPTION
Fixes #24783 
I have implemented the fix suggested in #24783.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map Chinese i18n locales ('zh', 'zh-Hant') to Moment.js equivalents ('zh-cn', 'zh-tw') in `core/frontend/helpers/date.js` when setting date locale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e17c2b60ca77394863c34de54651fa7142e29ab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->