### PR TITLE
Fixed analytics settings not updating after plan changes

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -33,6 +33,8 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     setIsWebAnalyticsLimited(true);
                 }
             });
+        } else {
+            setIsWebAnalyticsLimited(false);
         }
     }, [limiter]);
 

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -46,7 +46,7 @@ export default class GhBillingIframe extends Component {
             }
 
             if (event.data?.subscription) {
-                this._handleSubscriptionUpdate(event.data);
+                await this._handleSubscriptionUpdate(event.data);
             }
         }
     }
@@ -122,13 +122,13 @@ export default class GhBillingIframe extends Component {
         if (window?.adminXQueryClient?.invalidateQueries && typeof window.adminXQueryClient.invalidateQueries === 'function') {
             try {
                 // React Query v5+
-                window.adminXQueryClient.invalidateQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
-                window.adminXQueryClient.invalidateQueries({queryKey: ['SettingsResponseType']}).catch(() => {});
+                window.adminXQueryClient.refetchQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
+                window.adminXQueryClient.refetchQueries({queryKey: ['SettingsResponseType']}).catch(() => {});
             } catch (_) {
                 // TODO: remove this fallback when Admin-X-Settings updates to React Query v5+ (@tanstack/react-query)
                 // React Query v4 fallback
-                window.adminXQueryClient.invalidateQueries(['ConfigResponseType']).catch(() => {});
-                window.adminXQueryClient.invalidateQueries(['SettingsResponseType']).catch(() => {});
+                window.adminXQueryClient.refetchQueries(['ConfigResponseType']).catch(() => {});
+                window.adminXQueryClient.refetchQueries(['SettingsResponseType']).catch(() => {});
             }
         }
 


### PR DESCRIPTION
closes [BAE-492](https://linear.app/ghost/issue/BAE-492/limit-changes-requires-a-page-refresh-to-be-reflected-in-admin) 
ref #24879 
ref 16237e18757b434434e348840b25d34a698fb45c

When users upgraded or downgraded their subscription plan, the analytics settings in Admin-X Settings remained stale until a manual page refresh. This prevented users from immediately accessing newly available features like Web Analytics after upgrading their plan. The issue occurred because React Query was using `invalidateQueries` which respects the 5-minute staleTime, preventing immediate refetch of settings data, and the Analytics component's `isWebAnalyticsLimited` state was never reset when limits were removed. Fixed by using `refetchQueries` instead of `invalidateQueries` to force immediate data refresh regardless of staleTime, and adding proper state reset logic when limits are no longer active. Users now have immediate access to newly available features after plan changes without requiring page refreshes.