### PR TITLE
✨Added Settings to Admin search

### DIFF
--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -13,12 +13,13 @@ interface AppProps {
     officialThemes: OfficialTheme[];
     zapierTemplates: ZapierTemplate[];
     upgradeStatus?: UpgradeStatusType;
+    initialSearchQuery?: string;
 }
 
-function App({framework, designSystem, officialThemes, zapierTemplates, upgradeStatus}: AppProps) {
+function App({framework, designSystem, officialThemes, zapierTemplates, upgradeStatus, initialSearchQuery}: AppProps) {
     return (
         <FrameworkProvider {...framework}>
-            <SettingsAppProvider officialThemes={officialThemes} upgradeStatus={upgradeStatus} zapierTemplates={zapierTemplates}>
+            <SettingsAppProvider officialThemes={officialThemes} upgradeStatus={upgradeStatus} zapierTemplates={zapierTemplates} initialSearchQuery={initialSearchQuery}>
                 {/* NOTE: we need to have an extra NiceModal.Provider here because the one inside DesignSystemApp
                     is loaded too late for possible modals in RoutingProvider, and it's quite hard to change it at
                     this point */}

--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -19,7 +19,7 @@ interface AppProps {
 function App({framework, designSystem, officialThemes, zapierTemplates, upgradeStatus, initialSearchQuery}: AppProps) {
     return (
         <FrameworkProvider {...framework}>
-            <SettingsAppProvider officialThemes={officialThemes} upgradeStatus={upgradeStatus} zapierTemplates={zapierTemplates} initialSearchQuery={initialSearchQuery}>
+            <SettingsAppProvider initialSearchQuery={initialSearchQuery} officialThemes={officialThemes} upgradeStatus={upgradeStatus} zapierTemplates={zapierTemplates}>
                 {/* NOTE: we need to have an extra NiceModal.Provider here because the one inside DesignSystemApp
                     is loaded too late for possible modals in RoutingProvider, and it's quite hard to change it at
                     this point */}

--- a/apps/admin-x-settings/src/components/providers/SettingsAppProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/SettingsAppProvider.tsx
@@ -58,10 +58,13 @@ const SettingsAppContext = createContext<SettingsAppContextType>({
     sortingState: []
 });
 
-type SettingsAppProviderProps = Omit<SettingsAppContextType, 'search'> & {children: ReactNode};
+type SettingsAppProviderProps = Omit<SettingsAppContextType, 'search'> & {
+    children: ReactNode;
+    initialSearchQuery?: string;
+};
 
-const SettingsAppProvider: React.FC<SettingsAppProviderProps> = ({children, ...props}) => {
-    const search = useSearchService();
+const SettingsAppProvider: React.FC<SettingsAppProviderProps> = ({children, initialSearchQuery, ...props}) => {
+    const search = useSearchService(initialSearchQuery);
 
     // a few sane defaults for keeping a sorting state
     const [sortingState, setSortingState] = useState<Sorting[]>([{

--- a/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
@@ -9,7 +9,7 @@ import SearchableSection from '../../SearchableSection';
 
 export const searchKeywords = {
     integrations: ['advanced', 'integrations', 'zapier', 'slack', 'unsplash', 'first promoter', 'firstpromoter', 'pintura', 'disqus', 'analytics', 'ulysses', 'typeform', 'buffer', 'plausible', 'github', 'webhooks'],
-    migrationtools: ['import', 'export', 'migrate', 'substack', 'substack', 'migration', 'medium', 'wordpress', 'wp', 'squarespace'],
+    migrationtools: ['import', 'export', 'migrate', 'substack', 'substack', 'migration', 'medium', 'wordpress', 'wp', 'squarespace', 'import/export','import export'],
     codeInjection: ['advanced', 'code injection', 'head', 'footer'],
     labs: ['advanced', 'labs', 'alpha', 'private', 'beta', 'flag', 'routes', 'redirect', 'translation', 'editor', 'portal'],
     history: ['advanced', 'history', 'log', 'events', 'user events', 'staff', 'audit', 'action'],

--- a/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/GrowthSettings.tsx
@@ -12,7 +12,7 @@ export const searchKeywords = {
     network: ['growth', 'network', 'activitypub', 'blog', 'fediverse', 'sharing'],
     explore: ['ghost explore', 'explore', 'growth', 'share', 'list', 'listing'],
     recommendations: ['growth', 'recommendations', 'recommend', 'blogroll'],
-    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
+    embedSignupForm: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up', 'signup forms', 'sign up forms'],
     offers: ['growth', 'offers', 'discounts', 'coupons', 'promotions']
 };
 

--- a/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
@@ -11,8 +11,8 @@ import {useGlobalData} from '../../providers/GlobalDataProvider';
 export const searchKeywords = {
     access: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email'],
     tiers: ['membership', 'tiers', 'payment', 'paid', 'stripe'],
-    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address'],
-    tips: ['growth', 'tips', 'donations', 'one time', 'payment']
+    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address', 'signup portal'],
+    tips: ['growth', 'tips', 'donations', 'one time', 'payment', 'tips & donations', 'tips and donations']
 };
 
 const MembershipSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/utils/search.tsx
+++ b/apps/admin-x-settings/src/utils/search.tsx
@@ -19,8 +19,8 @@ export interface SearchService {
     isOnlyVisibleComponent: (id: ComponentId) => boolean;
 }
 
-const useSearchService = () => {
-    const [filter, setFilter] = useState('');
+const useSearchService = (initialFilter?: string) => {
+    const [filter, setFilter] = useState(initialFilter || '');
     const [noResult, setNoResult] = useState(false);
     const registeredComponents = useRef<Map<ComponentId, string[]>>(new Map());
     const [visibleComponents, setVisibleComponents] = useState<Set<ComponentId>>(new Set());

--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -190,6 +190,7 @@ export default class AdminXSettings extends AdminXComponent {
     additionalProps = () => ({
         officialThemes,
         zapierTemplates,
-        upgradeStatus: this.upgradeStatus
+        upgradeStatus: this.upgradeStatus,
+        initialSearchQuery: this.args.searchQuery || ''
     });
 }

--- a/ghost/admin/app/components/gh-search-input.js
+++ b/ghost/admin/app/components/gh-search-input.js
@@ -34,6 +34,14 @@ export default class GhSearchInputComponent extends Component {
             let id = selected.id.replace('tag.', '');
             this.router.transitionTo('tag', id);
         }
+
+        if (selected.groupName === 'Settings') {
+            // Navigate to the main settings page with search query
+            // The search title will be passed as a query parameter
+            this.router.transitionTo('settings-x.settings-x', {
+                queryParams: {search: selected.title}
+            });
+        }
     }
 
     @action

--- a/ghost/admin/app/components/gh-search-input.js
+++ b/ghost/admin/app/components/gh-search-input.js
@@ -38,7 +38,7 @@ export default class GhSearchInputComponent extends Component {
         if (selected.groupName === 'Settings') {
             // Navigate to the main settings page with search query
             // The search title will be passed as a query parameter
-            this.router.transitionTo('settings-x.settings-x', {
+            this.router.transitionTo('settings-x', {
                 queryParams: {search: selected.title}
             });
         }

--- a/ghost/admin/app/controllers/settings-x.js
+++ b/ghost/admin/app/controllers/settings-x.js
@@ -2,10 +2,14 @@ import AboutModal from '../components/modals/settings/about';
 import Controller from '@ember/controller';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
 
 export default class SettingsController extends Controller {
     @service modals;
     @service upgradeStatus;
+
+    queryParams = ['search'];
+    @tracked search = '';
 
     @action
     openAbout() {

--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus, processSearchableResponse} from '../utils/search';
+import {SEARCHABLES, createSearchResult, processSearchableResponse, sortSearchResultsByStatus} from '../utils/search';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';

--- a/ghost/admin/app/services/search-provider-basic.js
+++ b/ghost/admin/app/services/search-provider-basic.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus, processSearchableResponse} from '../utils/search';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -63,7 +63,11 @@ export default class SearchProviderBasicService extends Service {
         try {
             const response = await this.ajax.request(url, {data: query});
 
-            const items = response[pluralize(searchable.model)].map(
+            // Use centralized function to process the response
+            const processedItems = processSearchableResponse(searchable, response);
+
+            // Convert to search results
+            const items = processedItems.map(
                 item => createSearchResult(searchable, item)
             );
 

--- a/ghost/admin/app/services/search-provider-flex.js
+++ b/ghost/admin/app/services/search-provider-flex.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import {default as Flexsearch} from 'flexsearch';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {SEARCHABLES, createSearchResult, processSearchableResponse, sortSearchResultsByStatus} from '../utils/search';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -83,7 +83,11 @@ export default class SearchProviderFlexService extends Service {
         try {
             const response = await this.ajax.request(url, {data: query});
 
-            response[pluralize(searchable.model)].forEach((item) => {
+            // Use centralized function to process the response
+            const processedItems = processSearchableResponse(searchable, response);
+
+            // Add items to the index
+            processedItems.forEach((item) => {
                 this.indexes[searchable.model].add(item);
             });
         } catch (error) {

--- a/ghost/admin/app/templates/settings-x.hbs
+++ b/ghost/admin/app/templates/settings-x.hbs
@@ -1,1 +1,1 @@
-<AdminX::Settings />
+<AdminX::Settings @searchQuery={{this.search}} />

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/search-index.js
@@ -137,5 +137,15 @@ module.exports = {
         frame.response = {
             users
         };
+    },
+
+    async fetchSettings(models, apiConfig, frame) {
+        debug('fetchSettings');
+
+        // Settings are already in the correct format from the controller
+        // Just pass them through
+        frame.response = {
+            settings: models.data
+        };
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -382,6 +382,7 @@ module.exports = function apiRoutes() {
     router.get('/search-index/pages', mw.authAdminApi, http(api.searchIndex.fetchPages));
     router.get('/search-index/tags', mw.authAdminApi, http(api.searchIndex.fetchTags));
     router.get('/search-index/users', mw.authAdminApi, http(api.searchIndex.fetchUsers));
+    router.get('/search-index/settings', mw.authAdminApi, http(api.searchIndex.fetchSettings));
 
     return router;
 };

--- a/ghost/core/core/shared/settings-search-index.js
+++ b/ghost/core/core/shared/settings-search-index.js
@@ -1,0 +1,232 @@
+/**
+ * Settings Search Index
+ * Centralized configuration for searchable settings sections
+ * Used by both the admin search and admin-x-settings apps
+ */
+
+const SETTINGS_SEARCH_INDEX = {
+    general: {
+        titleAndDescription: {
+            title: 'Title & description',
+            path: 'general',
+            navid: 'general',
+            keywords: ['general', 'title and description', 'site title', 'site description', 'title & description']
+        },
+        timeZone: {
+            title: 'Timezone',
+            path: 'timezone',
+            navid: 'timezone',
+            keywords: ['general', 'time', 'date', 'site timezone', 'time zone']
+        },
+        publicationLanguage: {
+            title: 'Publication language',
+            path: 'publication-language',
+            navid: 'publication-language',
+            keywords: ['general', 'publication language', 'locale']
+        },
+        users: {
+            title: 'Staff',
+            path: 'staff',
+            navid: 'staff',
+            keywords: ['general', 'users and permissions', 'roles', 'staff', 'invite people', 'contributors', 'editors', 'authors', 'administrators']
+        },
+        metadata: {
+            title: 'Meta data',
+            path: 'metadata',
+            navid: 'metadata',
+            keywords: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data', 'twitter card', 'structured data', 'rich cards', 'x card', 'social', 'facebook card']
+        },
+        socialAccounts: {
+            title: 'Social accounts',
+            path: 'social-accounts',
+            navid: 'social-accounts',
+            keywords: ['general', 'social accounts', 'facebook', 'twitter', 'structured data', 'rich cards']
+        },
+        lockSite: {
+            title: 'Make this site private',
+            path: 'locksite',
+            navid: 'locksite',
+            keywords: ['general', 'password protection', 'lock site', 'make this site private']
+        },
+        analytics: {
+            title: 'Analytics',
+            path: 'analytics',
+            navid: 'analytics',
+            keywords: ['membership', 'analytics', 'tracking', 'privacy', 'membership']
+        }
+    },
+    site: {
+        design: {
+            title: 'Design & branding',
+            path: 'design',
+            navid: 'design',
+            keywords: ['site', 'logo', 'cover', 'colors', 'fonts', 'background', 'themes', 'appearance', 'style', 'design & branding', 'design and branding']
+        },
+        theme: {
+            title: 'Theme',
+            path: 'theme',
+            navid: 'theme',
+            keywords: ['theme', 'template', 'upload']
+        },
+        navigation: {
+            title: 'Navigation',
+            path: 'navigation',
+            navid: 'navigation',
+            keywords: ['site', 'navigation', 'menus', 'primary', 'secondary', 'links']
+        },
+        announcementBar: {
+            title: 'Announcement bar',
+            path: 'announcement-bar',
+            navid: 'announcement-bar',
+            keywords: ['site', 'announcement bar', 'important', 'banner']
+        }
+    },
+    membership: {
+        access: {
+            title: 'Access',
+            path: 'members',
+            navid: 'members',
+            keywords: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting', 'signup', 'sign up', 'spam', 'filters', 'prevention', 'prevent', 'block', 'domains', 'email']
+        },
+        tiers: {
+            title: 'Tiers',
+            path: 'tiers',
+            navid: 'tiers',
+            keywords: ['membership', 'tiers', 'payment', 'paid', 'stripe']
+        },
+        portal: {
+            title: 'Signup portal',
+            path: 'portal',
+            navid: 'portal',
+            keywords: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address', 'signup portal']
+        },
+        tips: {
+            title: 'Tips & donations',
+            path: 'tips-and-donations',
+            navid: 'tips-and-donations',
+            keywords: ['growth', 'tips', 'donations', 'one time', 'payment', 'tips & donations', 'tips and donations']
+        }
+    },
+    growth: {
+        network: {
+            title: 'Network',
+            path: 'network',
+            navid: 'network',
+            keywords: ['growth', 'network', 'activitypub', 'blog', 'fediverse', 'sharing']
+        },
+        explore: {
+            title: 'Ghost Explore',
+            path: 'explore',
+            navid: 'explore',
+            keywords: ['ghost explore', 'explore', 'growth', 'share', 'list', 'listing']
+        },
+        recommendations: {
+            title: 'Recommendations',
+            path: 'recommendations',
+            navid: 'recommendations',
+            keywords: ['growth', 'recommendations', 'recommend', 'blogroll']
+        },
+        embedSignupForm: {
+            title: 'Signup forms',
+            path: 'embed-signup-form',
+            navid: 'embed-signup-form',
+            keywords: ['growth', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up', 'signup forms', 'sign up forms']
+        },
+        offers: {
+            title: 'Offers',
+            path: 'offers',
+            navid: 'offers',
+            keywords: ['growth', 'offers', 'discounts', 'coupons', 'promotions']
+        }
+    },
+    email: {
+        enableNewsletters: {
+            title: 'Newsletters',
+            path: 'enable-newsletters',
+            navid: 'enable-newsletters',
+            keywords: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off']
+        },
+        newsletters: {
+            title: 'Newsletters',
+            path: 'newsletters',
+            navid: 'newsletters',
+            keywords: ['newsletters', 'emails', 'design', 'customization']
+        },
+        defaultRecipients: {
+            title: 'Default recipients',
+            path: 'default-recipients',
+            navid: 'default-recipients',
+            keywords: ['newsletters', 'default recipients', 'emails']
+        },
+        mailgun: {
+            title: 'Mailgun',
+            path: 'mailgun',
+            navid: 'mailgun',
+            keywords: ['mailgun', 'emails', 'newsletters']
+        }
+    },
+    advanced: {
+        integrations: {
+            title: 'Integrations',
+            path: 'integrations',
+            navid: 'integrations',
+            keywords: ['advanced', 'integrations', 'zapier', 'slack', 'unsplash', 'first promoter', 'firstpromoter', 'pintura', 'disqus', 'analytics', 'ulysses', 'typeform', 'buffer', 'plausible', 'github', 'webhooks']
+        },
+        migrationtools: {
+            title: 'Import/Export',
+            path: 'migration',
+            navid: 'migration',
+            keywords: ['import', 'export', 'migrate', 'substack', 'substack', 'migration', 'medium', 'wordpress', 'wp', 'squarespace', 'import/export', 'import export']
+        },
+        codeInjection: {
+            title: 'Code injection',
+            path: 'code-injection',
+            navid: 'code-injection',
+            keywords: ['advanced', 'code injection', 'head', 'footer']
+        },
+        labs: {
+            title: 'Labs',
+            path: 'labs',
+            navid: 'labs',
+            keywords: ['advanced', 'labs', 'alpha', 'private', 'beta', 'flag', 'routes', 'redirect', 'translation', 'editor', 'portal']
+        },
+        history: {
+            title: 'History',
+            path: 'history',
+            navid: 'history',
+            keywords: ['advanced', 'history', 'log', 'events', 'user events', 'staff', 'audit', 'action']
+        },
+        dangerzone: {
+            title: 'Danger zone',
+            path: 'dangerzone',
+            navid: 'dangerzone',
+            keywords: ['danger', 'danger zone', 'delete', 'content', 'delete all content', 'delete site']
+        }
+    }
+};
+
+/**
+ * Flattens the settings index into a searchable array format
+ * @returns {Array} Array of settings with id, title, path, section, and keywords
+ */
+function flattenSettingsIndex() {
+    const settings = [];
+
+    Object.entries(SETTINGS_SEARCH_INDEX).forEach(([sectionKey, section]) => {
+        Object.entries(section).forEach(([settingKey, setting]) => {
+            settings.push({
+                id: `setting.${sectionKey}.${settingKey}`,
+                title: setting.title,
+                path: setting.path,
+                section: sectionKey,
+                keywords: setting.keywords
+            });
+        });
+    });
+
+    return settings;
+}
+
+module.exports = {
+    flattenSettingsIndex
+};


### PR DESCRIPTION
ref [BER-2658](https://linear.app/ghost/issue/BER-2658/)

* updated admin search to index settings
* added search endpoint for settings
* passed through query param to Settings to allow opening the app w/ a specific search term

This PR allows users to search specific settings via keywords in Ghost Admin in order to open up the Settings app with the specified keyword. By passing through the keyword, we generally end up opening the Settings app filtered down to one component which is ideal. We don't launch/open the component in this change, though past changes allow for adding that to each component as desired.

NOTE: This PR does create an area of dual maintenance. We maintain the list of keywords in Ghost Admin for this search instead of also using the keywords in the Settings app. This is NOT ideal, but trying to provide these to both was excessive given the current design with the Ember shell. As we're looking to get rid of Ember, this feels like an ok decision in order to simplify this set of changes. Once we have a singular app, we can *much* more easily maintain this in one spot.