### PR TITLE
Allowed proxied domains for app preview servers

### DIFF
--- a/apps/announcement-bar/vite.config.mjs
+++ b/apps/announcement-bar/vite.config.mjs
@@ -1,14 +1,12 @@
+/* eslint-env node */
 import {resolve} from 'path';
 import fs from 'fs/promises';
 
 import {defineConfig} from 'vitest/config';
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import reactPlugin from '@vitejs/plugin-react';
 import svgrPlugin from 'vite-plugin-svgr';
 
 import pkg from './package.json';
-
-import {SUPPORTED_LOCALES} from '@tryghost/i18n';
 
 export default defineConfig((config) => {
     const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
@@ -17,25 +15,20 @@ export default defineConfig((config) => {
         logLevel: process.env.CI ? 'info' : 'warn',
         clearScreen: false,
         define: {
-            'process.env.NODE_ENV': JSON.stringify(config.mode),
-            REACT_APP_VERSION: JSON.stringify(process.env.npm_package_version)
+            'process.env.NODE_ENV': JSON.stringify(config.mode)
         },
         preview: {
             host: '0.0.0.0',
-            port: 4175,
-            cors: true
-        },
-        server: {
-            port: 5368
+            allowedHosts: true, // allows domain-name proxies to the preview server
+            port: 4177
         },
         plugins: [
-            cssInjectedByJsPlugin(),
             reactPlugin(),
             svgrPlugin()
         ],
         esbuild: {
             loader: 'jsx',
-            include: [/src\/.*\.jsx?$/, /__mocks__\/.*\.jsx?$/],
+            include: /src\/.*\.jsx?$/,
             exclude: []
         },
         optimizeDeps: {
@@ -59,22 +52,12 @@ export default defineConfig((config) => {
             reportCompressedSize: false,
             minify: true,
             sourcemap: true,
-            cssCodeSplit: false,
+            cssCodeSplit: true,
             lib: {
                 entry: resolve(__dirname, 'src/index.js'),
                 formats: ['umd'],
                 name: pkg.name,
                 fileName: format => `${outputFileName}.min.js`
-            },
-            rollupOptions: {
-                output: {
-                    manualChunks: false
-                }
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/portal.json`)
             }
         },
         test: {

--- a/apps/comments-ui/tsconfig.node.json
+++ b/apps/comments-ui/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "package.json"]
+  "include": ["vite.config.mts", "package.json"]
 }

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -21,11 +21,16 @@ export default (function viteConfig() {
         },
         preview: {
             host: '0.0.0.0',
-            port: 6174
+            allowedHosts: true, // allows domain-name proxies to the preview server
+            port: 7173,
+            cors: true
+        },
+        server: {
+            port: 5368
         },
         build: {
-            outDir: resolve(__dirname, 'umd'),
             reportCompressedSize: false,
+            outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
             minify: true,
             sourcemap: true,
@@ -48,14 +53,14 @@ export default (function viteConfig() {
             commonjsOptions: {
                 include: [/ghost/, /node_modules/],
                 dynamicRequireRoot: '../../',
-                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/signup-form.json`)
+                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/comments.json`)
             }
         },
         test: {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
-            setupFiles: './test/test-setup.js',
-            include: ['./test/unit/*'],
+            setupFiles: './src/setupTests.ts',
+            include: ['src/**/*.test.jsx', 'src/**/*.test.js', 'src/**/*.test.ts', 'src/**/*.test.tsx'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
                 minThreads: 1,

--- a/apps/signup-form/tsconfig.node.json
+++ b/apps/signup-form/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "package.json"]
+  "include": ["vite.config.mts", "package.json"]
 }

--- a/apps/signup-form/vite.config.mts
+++ b/apps/signup-form/vite.config.mts
@@ -21,15 +21,12 @@ export default (function viteConfig() {
         },
         preview: {
             host: '0.0.0.0',
-            port: 7173,
-            cors: true
-        },
-        server: {
-            port: 5368
+            allowedHosts: true, // allows domain-name proxies to the preview server
+            port: 6174
         },
         build: {
-            reportCompressedSize: false,
             outDir: resolve(__dirname, 'umd'),
+            reportCompressedSize: false,
             emptyOutDir: true,
             minify: true,
             sourcemap: true,
@@ -52,14 +49,14 @@ export default (function viteConfig() {
             commonjsOptions: {
                 include: [/ghost/, /node_modules/],
                 dynamicRequireRoot: '../../',
-                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/comments.json`)
+                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/signup-form.json`)
             }
         },
         test: {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
-            setupFiles: './src/setupTests.ts',
-            include: ['src/**/*.test.jsx', 'src/**/*.test.js', 'src/**/*.test.ts', 'src/**/*.test.tsx'],
+            setupFiles: './test/test-setup.js',
+            include: ['./test/unit/*'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
                 minThreads: 1,

--- a/apps/sodo-search/vite.config.mjs
+++ b/apps/sodo-search/vite.config.mjs
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import {resolve} from 'path';
 import fs from 'fs/promises';
 
@@ -6,7 +7,7 @@ import reactPlugin from '@vitejs/plugin-react';
 import svgrPlugin from 'vite-plugin-svgr';
 
 import pkg from './package.json';
-
+import {SUPPORTED_LOCALES} from '@tryghost/i18n';
 export default defineConfig((config) => {
     const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
 
@@ -18,7 +19,8 @@ export default defineConfig((config) => {
         },
         preview: {
             host: '0.0.0.0',
-            port: 4177
+            allowedHosts: true, // allows domain-name proxies to the preview server
+            port: 4178
         },
         plugins: [
             reactPlugin(),
@@ -46,8 +48,8 @@ export default defineConfig((config) => {
         },
         build: {
             outDir: resolve(__dirname, 'umd'),
-            emptyOutDir: true,
             reportCompressedSize: false,
+            emptyOutDir: true,
             minify: true,
             sourcemap: true,
             cssCodeSplit: true,
@@ -56,6 +58,11 @@ export default defineConfig((config) => {
                 formats: ['umd'],
                 name: pkg.name,
                 fileName: format => `${outputFileName}.min.js`
+            },
+            commonjsOptions: {
+                include: [/ghost/, /node_modules/],
+                dynamicRequireRoot: '../../',
+                dynamicRequireTargets: SUPPORTED_LOCALES.map(locale => `../../ghost/i18n/locales/${locale}/search.json`)
             }
         },
         test: {


### PR DESCRIPTION
no issue

- added `allowedHosts: true` so any domain can be proxied to the preview server
  - previously if you tried to proxy a domain to one of the preview servers it would error and ask you to add the specific domain in the `allowedHosts` config
  - allows for dev setups using HTTPS and real domains to satisfy Safari's stricter security requirements
- switched from `.js -> .mjs` and `.ts -> .mts` to resolve CJS deprecation warnings on dev startup

---

Example setup:
- Ghost proxy: https://dev.mydomain.com -> http://myip:2368
  - config: `portal.url = https://portal-dev.mydomain.com/portal.min.js`
- Portal proxy: https://portal-dev.mydomain.com -> http://myip:4175

Using `yarn dev --portal` doesn't work in general for Safari if your main Ghost site is HTTPS as it forces the portal URL to http://localhost:4175 so Safari won't load it with a "Mixed content" error (it doesn't have a built-in localhost bypass like Chrome).

An alternative is a local Caddy proxy of `https://localhost:4176` to `http://localhost:4175` and using `yarn dev --portal --https` but then it's harder to test split front-end/admin domains locally or use your dev server across devices for mobile testing.