### PR TITLE
Mount Ember app inside new admin shell

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -16,6 +16,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="ember-app"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -6,6 +6,8 @@ import {
 } from "@tryghost/admin-x-framework";
 import { ShadeApp } from "@tryghost/shade";
 import { routes } from "./routes.tsx";
+import { EmberProvider } from "./ember-bridge/EmberProvider.tsx";
+import EmberRoot from "./ember-bridge/EmberRoot.tsx";
 
 const framework = {
     ghostVersion: "",
@@ -26,17 +28,20 @@ const framework = {
 function App() {
     return (
         <AppProvider>
-            <FrameworkProvider {...framework}>
-                <RouterProvider prefix={"/"} routes={routes}>
-                    <ShadeApp
-                        className="shade-admin"
-                        darkMode={false}
-                        fetchKoenigLexical={null}
-                    >
-                        <Outlet />
-                    </ShadeApp>
-                </RouterProvider>
-            </FrameworkProvider>
+            <EmberProvider>
+                <FrameworkProvider {...framework}>
+                    <RouterProvider prefix={"/"} routes={routes}>
+                        <ShadeApp
+                            className="shade-admin"
+                            darkMode={false}
+                            fetchKoenigLexical={null}
+                        >
+                            <Outlet />
+                            <EmberRoot />
+                        </ShadeApp>
+                    </RouterProvider>
+                </FrameworkProvider>
+            </EmberProvider>
         </AppProvider>
     );
 }

--- a/apps/admin/src/ember-bridge/EmberContext.ts
+++ b/apps/admin/src/ember-bridge/EmberContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+export interface EmberContextType {
+    isFallbackPresent: boolean;
+    registerFallback: () => void;
+    unregisterFallback: () => void;
+}
+
+export const EmberContext = createContext<EmberContextType | undefined>(
+    undefined
+);
+
+export function useEmberContext() {
+    const context = useContext(EmberContext);
+    if (context === undefined) {
+        throw new Error("useEmberContext must be used within an EmberProvider");
+    }
+    return context;
+}

--- a/apps/admin/src/ember-bridge/EmberFallback.tsx
+++ b/apps/admin/src/ember-bridge/EmberFallback.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useEmberContext } from './EmberContext';
+
+
+/**
+ * EmberFallback component that registers itself with the EmberContext.
+ * When this component is mounted, it signals that the Ember app should be shown.
+ * When unmounted, it unregisters itself.
+ */
+export default function EmberFallback() {
+  const { registerFallback, unregisterFallback } = useEmberContext();
+
+  useEffect(() => {
+    registerFallback();
+    return () => {
+      unregisterFallback();
+    };
+  }, [registerFallback, unregisterFallback]);
+
+  return null;
+}

--- a/apps/admin/src/ember-bridge/EmberProvider.tsx
+++ b/apps/admin/src/ember-bridge/EmberProvider.tsx
@@ -1,0 +1,31 @@
+import { useState, useCallback, type ReactNode } from "react";
+import { EmberContext, type EmberContextType } from "./EmberContext";
+
+
+interface EmberProviderProps {
+    children: ReactNode;
+}
+
+export function EmberProvider({ children }: EmberProviderProps) {
+    const [fallbackCount, setFallbackCount] = useState(0);
+
+    const registerFallback = useCallback(() => {
+        setFallbackCount((prev) => prev + 1);
+    }, []);
+
+    const unregisterFallback = useCallback(() => {
+        setFallbackCount((prev) => Math.max(0, prev - 1));
+    }, []);
+
+    const isFallbackPresent = fallbackCount > 0;
+
+    const value: EmberContextType = {
+        isFallbackPresent,
+        registerFallback,
+        unregisterFallback,
+    };
+
+    return (
+        <EmberContext.Provider value={value}>{children}</EmberContext.Provider>
+    );
+}

--- a/apps/admin/src/ember-bridge/EmberRoot.tsx
+++ b/apps/admin/src/ember-bridge/EmberRoot.tsx
@@ -1,0 +1,30 @@
+import React, { useLayoutEffect, useRef } from "react";
+import { useEmberContext } from "./EmberContext";
+
+function EmberRoot() {
+    const ref = useRef<HTMLDivElement>(null);
+    const { isFallbackPresent } = useEmberContext();
+
+    useLayoutEffect(() => {
+        if (ref.current) {
+            const app = document.getElementById("ember-app");
+            if (app) {
+                ref.current.appendChild(app);
+            } else {
+                throw new Error("Ember app not found");
+            }
+        }
+        return () => {
+            const app = document.getElementById("ember-app");
+            if (app) {
+                document.body.appendChild(app);
+            } else {
+                throw new Error("Ember app not found");
+            }
+        };
+    }, []);
+
+    return <div ref={ref} hidden={!isFallbackPresent}></div>;
+}
+
+export default React.memo(EmberRoot);

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,18 +1,1 @@
 @import "@tryghost/shade/styles.css";
-
-body {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas: "react ember";
-  width: 100%;
-  height: 100%;
-}
-
-#root { 
-    grid-area: react;
-}
-
-.gh-app {
-    position: static !important;
-    grid-area: ember;
-}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -5,6 +5,6 @@ import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
-      <App />
+        <App />
     </StrictMode>
 );

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -4,13 +4,14 @@ import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider
 import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
 import { routes as statsRoutes, APP_ROUTE_PREFIX as statsAppRoutePrefix } from "@tryghost/stats/src/routes";
 import { routes as activityPubRoutes, APP_ROUTE_PREFIX as activityPubAppRoutePrefix } from "@tryghost/activitypub/src/routes";
+import EmberFallback from "./ember-bridge/EmberFallback";
 
 export const routes: RouteObject[] = [
     {
         path: "/",
         element: <div>Hello World</div>
     },
-    ...postRoutes[0].children!,
+    ...postRoutes[0].children!.filter(route => route.path !== "*"),
     {
         path: `${statsAppRoutePrefix}`,
         element: <GlobalDataProvider><Outlet /></GlobalDataProvider>,
@@ -37,6 +38,6 @@ export const routes: RouteObject[] = [
     },
     {
         path: "*",
-        element: <div>404</div>
+        Component: EmberFallback
     }
 ];

--- a/ghost/admin/app/app.js
+++ b/ghost/admin/app/app.js
@@ -13,6 +13,8 @@ moment.updateLocale('en', {
     }
 });
 
+const rootElement = document.getElementById('ember-app');
+
 const App = Application.extend({
     Resolver,
     modulePrefix: config.modulePrefix,
@@ -24,7 +26,11 @@ const App = Application.extend({
         touchmove: null,
         touchend: null,
         touchcancel: null
-    }
+    },
+
+    ...(rootElement ? {
+        rootElement: '#ember-app'
+    } : {})
 });
 
 // TODO: remove once the validations refactor is complete


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-2604/mount-ember-app-inside-new-admin-shell

This PR introduces a way for us to manage Ember app visibility. The `EmberRoot` component effectively mounts the original Ember app inside our React-based admin shell and layout. This is done by moving the Ember app DOM sub-tree into the shell app that is managed by React, and ensuring that the Ember root component never re-renders. 

The visibility of the Ember app is then managed via a fallback component and signaling through context. This lets us toggle the visibility of the Ember app by rendering the `EmberFallback` component anywhere within the react app.

The way this is set up together with the router means that when there are no matching routes in the React app, we fall back to the Ember app.

In order to enable moving around the Ember app, I've tweaked the Ember app bootstrap so that if it detects a DOM node with the ID `ember-app` it renders into that DOM node rather than the body. This way, we're effectively rendering the React and Ember apps side by side, even though we're mounting the Ember app within React. 