### PR TITLE
Added prevention to closing magic link popup

### DIFF
--- a/apps/portal/src/components/PopupModal.js
+++ b/apps/portal/src/components/PopupModal.js
@@ -103,8 +103,8 @@ class PopupContent extends React.Component {
     }
 
     handlePopupClose(e) {
-        const {page} = this.context;
-        if (hasMode(['preview']) || page === 'magiclink') {
+        const {page, otcRef} = this.context;
+        if (hasMode(['preview']) || (otcRef && page === 'magiclink')) {
             return;
         }
         if (e.target === e.currentTarget) {

--- a/apps/portal/src/components/PopupModal.js
+++ b/apps/portal/src/components/PopupModal.js
@@ -103,7 +103,8 @@ class PopupContent extends React.Component {
     }
 
     handlePopupClose(e) {
-        if (hasMode(['preview'])) {
+        const {page} = this.context;
+        if (hasMode(['preview']) || page === 'magiclink') {
             return;
         }
         if (e.target === e.currentTarget) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2664/prevent-otc-input-modal-from-dismissing-on-outside-click

- Clicking anywhere outside of the  magic link confirmation modal dismissed it. That was fine when it was just a magic link, but now with the OTC input it needs to stick around since there's no way to get it back.