### PR TITLE
Removed temporary fallback values from analytics

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -26,10 +26,6 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const siteUrl = globalData?.url as string | undefined;
     const siteIcon = globalData?.icon as string | undefined;
 
-    // TEMPORARY: For testing levernews.com direct traffic grouping
-    // Remove this line when done testing
-    const testingSiteUrl = siteUrl || 'https://levernews.com';
-
     let containerClass = 'flex flex-col items-stretch gap-8';
     let cardClass = '';
     if (!appSettings?.paidMembersEnabled) {
@@ -132,7 +128,7 @@ const Growth: React.FC<postAnalyticsProps> = () => {
                             data={postReferrers}
                             mode="growth"
                             siteIcon={siteIcon}
-                            siteUrl={testingSiteUrl}
+                            siteUrl={siteUrl}
                         />
                     </div>
                 }

--- a/apps/posts/src/views/PostAnalytics/Web/Web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/Web.tsx
@@ -111,10 +111,6 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const siteUrl = globalData?.url as string | undefined;
     const siteIcon = globalData?.icon as string | undefined;
 
-    // TEMPORARY: For testing levernews.com direct traffic grouping
-    // Remove this line when done testing
-    const testingSiteUrl = siteUrl || 'https://levernews.com';
-
     // Memoize the processed locations data with percentages
     const processedLocationsData = useMemo<ProcessedLocationData[]>(() => {
         const processed = locationsData?.map(row => ({
@@ -172,7 +168,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
                                     data={sourcesData as BaseSourceData[] | null}
                                     range={chartRange}
                                     siteIcon={siteIcon}
-                                    siteUrl={testingSiteUrl}
+                                    siteUrl={siteUrl}
                                     totalVisitors={totalSourcesVisits}
                                 />
                             </div>


### PR DESCRIPTION
no ref

- In the Growth and Web pages of posts analytics there was a hardcoded fallback value for site URLs.