### PR TITLE
Released @tryghost/portal v2.54.0

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.53.3",
+  "version": "2.54.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -212,7 +212,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.53"
+        "version": "2.54"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2537

Changelog for v2.53.3 -> 2.54.0:

- Added OTC input for sign in

(note: minor version bump to avoid impacting beta users of the OTC feature right away)