### PR TITLE
Added OTC support for custom sign-in forms

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -108,7 +108,7 @@ export default class App extends React.Component {
                 site: contextState.site,
                 member: contextState.member,
                 labs: contextState.labs,
-                onAction: contextState.onAction
+                doAction: contextState.doAction
             });
         }
     }

--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -106,7 +106,9 @@ export default class App extends React.Component {
             handleDataAttributes({
                 siteUrl,
                 site: contextState.site,
-                member: contextState.member
+                member: contextState.member,
+                labs: contextState.labs,
+                onAction: contextState.onAction
             });
         }
     }

--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -108,7 +108,8 @@ export default class App extends React.Component {
                 site: contextState.site,
                 member: contextState.member,
                 labs: contextState.labs,
-                doAction: contextState.doAction
+                doAction: contextState.doAction,
+                captureException: Sentry.captureException
             });
         }
     }

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -124,6 +124,27 @@ async function signin({data, api, state}) {
     }
 }
 
+function startSigninOTCFromCustomForm({data, state}) {
+    const email = (data?.email || '').trim();
+    const otcRef = data?.otcRef;
+
+    if (!otcRef) {
+        return {};
+    }
+
+    return {
+        showPopup: true,
+        page: 'magiclink',
+        lastPage: 'signin',
+        otcRef,
+        pageData: {
+            ...(state.pageData || {}),
+            email
+        },
+        popupNotification: null
+    };
+}
+
 async function verifyOTC({data, api, state}) {
     const {t} = state;
 
@@ -620,6 +641,7 @@ const Actions = {
     back,
     signout,
     signin,
+    startSigninOTCFromCustomForm,
     verifyOTC,
     signup,
     updateSubscription,

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -16,7 +16,7 @@ function handleError(error, form, errorEl, t) {
 }
 
 export async function formSubmitHandler(
-    {event, form, errorEl, siteUrl, submitHandler, labs = {}, onAction},
+    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction},
     t = str => str
 ) {
     form.removeEventListener('submit', submitHandler);
@@ -101,9 +101,9 @@ export async function formSubmitHandler(
 
             form.classList.add('success');
             const otcRef = responseBody?.otc_ref;
-            if (otcRef && typeof onAction === 'function') {
+            if (otcRef && typeof doAction === 'function') {
                 try {
-                    await onAction('startSigninOTCFromCustomForm', {
+                    await doAction('startSigninOTCFromCustomForm', {
                         email: (email || '').trim(),
                         otcRef
                     });
@@ -206,7 +206,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     });
 }
 
-export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, onAction} = {}) {
+export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doAction} = {}) {
     const i18nLanguage = site.locale || 'en';
     const i18n = i18nLib(i18nLanguage, 'portal');
     const t = i18n.t;
@@ -217,7 +217,7 @@ export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, onA
     Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'), function (form) {
         let errorEl = form.querySelector('[data-members-error]');
         function submitHandler(event) {
-            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, onAction}, t);
+            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction}, t);
         }
         form.addEventListener('submit', submitHandler);
     });

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -90,6 +90,8 @@ export async function formSubmitHandler(
         form.addEventListener('submit', submitHandler);
         form.classList.remove('loading');
         if (magicLinkRes.ok) {
+            form.classList.add('success');
+
             let responseBody;
             if (wantsOTC) {
                 try {
@@ -99,7 +101,6 @@ export async function formSubmitHandler(
                 }
             }
 
-            form.classList.add('success');
             const otcRef = responseBody?.otc_ref;
             if (otcRef && typeof doAction === 'function') {
                 try {

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -16,7 +16,7 @@ function handleError(error, form, errorEl, t) {
 }
 
 export async function formSubmitHandler(
-    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction},
+    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction, captureException},
     t = str => str
 ) {
     form.removeEventListener('submit', submitHandler);
@@ -104,13 +104,14 @@ export async function formSubmitHandler(
             const otcRef = responseBody?.otc_ref;
             if (otcRef && typeof doAction === 'function') {
                 try {
-                    await doAction('startSigninOTCFromCustomForm', {
+                    doAction('startSigninOTCFromCustomForm', {
                         email: (email || '').trim(),
                         otcRef
                     });
                 } catch (actionError) {
                     // eslint-disable-next-line no-console
                     console.error(actionError);
+                    captureException?.(actionError);
                 }
             }
         } else {
@@ -207,7 +208,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     });
 }
 
-export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doAction} = {}) {
+export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doAction, captureException} = {}) {
     const i18nLanguage = site.locale || 'en';
     const i18n = i18nLib(i18nLanguage, 'portal');
     const t = i18n.t;
@@ -218,7 +219,7 @@ export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doA
     Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'), function (form) {
         let errorEl = form.querySelector('[data-members-error]');
         function submitHandler(event) {
-            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction}, t);
+            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction, captureException}, t);
         }
         form.addEventListener('submit', submitHandler);
     });

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -180,7 +180,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     });
 }
 
-export function handleDataAttributes({siteUrl, site, member}) {
+export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, onAction} = {}) {
     const i18nLanguage = site.locale || 'en';
     const i18n = i18nLib(i18nLanguage, 'portal');
     const t = i18n.t;
@@ -191,7 +191,7 @@ export function handleDataAttributes({siteUrl, site, member}) {
     Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'), function (form) {
         let errorEl = form.querySelector('[data-members-error]');
         function submitHandler(event) {
-            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler}, t);
+            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, onAction}, t);
         }
         form.addEventListener('submit', submitHandler);
     });

--- a/apps/portal/src/tests/actions.test.js
+++ b/apps/portal/src/tests/actions.test.js
@@ -1,0 +1,43 @@
+import ActionHandler from '../actions';
+
+describe('startSigninOTCFromCustomForm action', () => {
+    test('opens magic link popup with otcRef', async () => {
+        const state = {
+            pageData: {existing: 'data'}
+        };
+        const result = await ActionHandler({
+            action: 'startSigninOTCFromCustomForm',
+            data: {
+                email: ' test@example.com ',
+                otcRef: 'ref-123'
+            },
+            state,
+            api: {}
+        });
+
+        expect(result).toMatchObject({
+            showPopup: true,
+            page: 'magiclink',
+            lastPage: 'signin',
+            otcRef: 'ref-123',
+            pageData: {
+                existing: 'data',
+                email: 'test@example.com'
+            },
+            popupNotification: null
+        });
+    });
+
+    test('returns empty object when otcRef missing', async () => {
+        const result = await ActionHandler({
+            action: 'startSigninOTCFromCustomForm',
+            data: {
+                email: 'test@example.com'
+            },
+            state: {},
+            api: {}
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -167,6 +167,54 @@ describe('Member Data attributes:', () => {
             });
             expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });
+
+        test('requests OTC magic link and opens Portal when flagged', async () => {
+            const {event, form, errorEl, siteUrl, submitHandler} = getMockData();
+            form.dataset.membersForm = 'signin';
+            form.dataset.membersOtc = 'true';
+
+            const originalQuerySelector = event.target.querySelector;
+            event.target.querySelector = jest.fn((selector) => {
+                if (selector === 'input[data-members-email]') {
+                    return {value: ' jamie@example.com '};
+                }
+                return originalQuerySelector(selector);
+            });
+
+            const labs = {membersSigninOTC: true};
+            const onAction = jest.fn(() => Promise.resolve());
+
+            const json = async () => ({otc_ref: 'otc_test_ref'});
+            window.fetch.mockImplementation((url, options = {}) => {
+                if (url.includes('send-magic-link')) {
+                    return Promise.resolve({
+                        ok: true,
+                        json,
+                        clone: () => ({json})
+                    });
+                }
+
+                if (url.includes('integrity-token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        text: async () => 'testtoken'
+                    });
+                }
+
+                return Promise.resolve({ok: true});
+            });
+
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, labs, onAction});
+
+            const magicLinkCall = window.fetch.mock.calls.find(([fetchUrl]) => fetchUrl.includes('send-magic-link'));
+            const requestBody = JSON.parse(magicLinkCall[1].body);
+            expect(requestBody.includeOTC).toBe(true);
+            expect(onAction).toHaveBeenCalledWith('startSigninOTCFromCustomForm', {
+                email: 'jamie@example.com',
+                otcRef: 'otc_test_ref'
+            });
+            expect(form.classList.add).toHaveBeenCalledWith('success');
+        });
     });
 
     describe('data-members-plan', () => {

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -182,7 +182,7 @@ describe('Member Data attributes:', () => {
             });
 
             const labs = {membersSigninOTC: true};
-            const onAction = jest.fn(() => Promise.resolve());
+            const doAction = jest.fn(() => Promise.resolve());
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
             window.fetch.mockImplementation((url, options = {}) => {
@@ -204,12 +204,12 @@ describe('Member Data attributes:', () => {
                 return Promise.resolve({ok: true});
             });
 
-            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, labs, onAction});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, labs, doAction});
 
             const magicLinkCall = window.fetch.mock.calls.find(([fetchUrl]) => fetchUrl.includes('send-magic-link'));
             const requestBody = JSON.parse(magicLinkCall[1].body);
             expect(requestBody.includeOTC).toBe(true);
-            expect(onAction).toHaveBeenCalledWith('startSigninOTCFromCustomForm', {
+            expect(doAction).toHaveBeenCalledWith('startSigninOTCFromCustomForm', {
                 email: 'jamie@example.com',
                 otcRef: 'otc_test_ref'
             });

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -185,7 +185,7 @@ describe('Member Data attributes:', () => {
             const doAction = jest.fn(() => Promise.resolve());
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
-            window.fetch.mockImplementation((url, options = {}) => {
+            window.fetch.mockImplementation((url) => {
                 if (url.includes('send-magic-link')) {
                     return Promise.resolve({
                         ok: true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2573

- adds One-Time Code (OTC) support for custom sign-in forms embedded in Ghost themes. When a custom form is configured with `data-members-otc="true"` the Portal popup will open automatically to collect the OTC after the magic link email is sent
