### PR TITLE
Updated OTC flow to use uuid

### DIFF
--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -23,7 +23,7 @@ const messages = {
  * @typedef {Object} TokenProvider<T, D>
  * @prop {(data: D) => Promise<T>} create
  * @prop {(token: T, options?: TokenValidateOptions) => Promise<D>} validate
- * @prop {(token: T) => Promise<string | null>} [getIdByToken]
+ * @prop {(token: T) => Promise<string | null>} [getRefByToken]
  * @prop {(otcRef: string, tokenValue: T) => string} [deriveOTC]
  */
 
@@ -108,7 +108,7 @@ class MagicLink {
         let otcRef = null;
         if (this.labsService?.isSet('membersSigninOTC') && otc) {
             try {
-                otcRef = await this.getIdFromToken(token);
+                otcRef = await this.getRefFromToken(token);
             } catch (err) {
                 this.sentry?.captureException?.(err);
                 otcRef = null;
@@ -135,17 +135,17 @@ class MagicLink {
     }
 
     /**
-     * getIdFromToken
+     * getRefFromToken
      *
-     * @param {Token} token - The token to get the id from
-     * @returns {Promise<string|null>} id - The id of the token
+     * @param {Token} token - The token to get the ref from
+     * @returns {Promise<string|null>} ref - The ref of the token
      */
-    async getIdFromToken(token) {
-        if (typeof this.tokenProvider.getIdByToken !== 'function') {
+    async getRefFromToken(token) {
+        if (typeof this.tokenProvider.getRefByToken !== 'function') {
             return null;
         }
 
-        const id = await this.tokenProvider.getIdByToken(token);
+        const id = await this.tokenProvider.getRefByToken(token);
         return id;
     }
 
@@ -156,7 +156,7 @@ class MagicLink {
      * @returns {Promise<string|null>} otc - The otc of the token
      */
     async getOTCFromToken(token) {
-        const tokenId = await this.getIdFromToken(token);
+        const tokenId = await this.getRefFromToken(token);
 
         if (!tokenId || typeof this.tokenProvider.deriveOTC !== 'function') {
             return null;

--- a/ghost/core/core/server/services/members/SingleUseTokenProvider.js
+++ b/ghost/core/core/server/services/members/SingleUseTokenProvider.js
@@ -193,7 +193,7 @@ class SingleUseTokenProvider {
         }
 
         try {
-            const model = await this.model.findOne({id: otcRef});
+            const model = await this.model.findOne({uuid: otcRef});
 
             if (!model) {
                 return false;
@@ -208,16 +208,16 @@ class SingleUseTokenProvider {
     }
 
     /**
-     * @method getIdByToken
-     * Retrieves the ID associated with a given token.
+     * @method getRefByToken
+     * Retrieves the ref associated with a given token.
      *
      * @param {string} token - The token to look up.
-     * @returns {Promise<string|null>} The ID if found, or null if not found or on error.
+     * @returns {Promise<string|null>} The ref if found, or null if not found or on error.
      */
-    async getIdByToken(token) {
+    async getRefByToken(token) {
         try {
             const model = await this.model.findOne({token});
-            return model ? model.get('id') : null;
+            return model ? model.get('uuid') : null;
         } catch (err) {
             return null;
         }
@@ -232,7 +232,7 @@ class SingleUseTokenProvider {
      */
     async getTokenByRef(ref) {
         try {
-            const model = await this.model.findOne({id: ref});
+            const model = await this.model.findOne({uuid: ref});
             return model ? model.get('token') : null;
         } catch (err) {
             return null;
@@ -300,7 +300,7 @@ class SingleUseTokenProvider {
                 return false;
             }
 
-            const tokenId = await this.getIdByToken(token);
+            const tokenId = await this.getRefByToken(token);
             if (!tokenId) {
                 return false;
             }

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -425,7 +425,7 @@ describe('sendMagicLink', function () {
                         .expectStatus(201)
                         .expect(({body}) => {
                             Object.keys(body).should.eql(['otc_ref']);
-                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9]{24}$/);
+                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9-]{36}$/);
                         });
                 });
 
@@ -444,7 +444,7 @@ describe('sendMagicLink', function () {
                         .expectStatus(201)
                         .expect(({body}) => {
                             should.exist(body.otc_ref);
-                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9]{24}$/);
+                            body.otc_ref.should.be.a.String().and.match(/^[a-f0-9-]{36}$/);
                         });
                 });
             });

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -32,7 +32,7 @@ describe('MagicLink', function () {
     beforeEach(function () {
         mockSingleUseTokenProvider = {
             create: sandbox.stub().resolves('mock-token'),
-            getIdByToken: sandbox.stub().resolves('test-token-id-123'),
+            getRefByToken: sandbox.stub().resolves('test-token-ref-123'),
             deriveOTC: sandbox.stub().returns('654321')
         };
     });
@@ -131,7 +131,7 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
+            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
         });
 
         it('should not return otcRef when labsService flag is disabled', async function () {
@@ -152,7 +152,7 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
+            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
         });
 
         it('should not return otcRef when labsService is not provided', async function () {
@@ -170,12 +170,12 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
+            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
         });
 
-        it('should work when tokenProvider does not have getIdByToken method', async function () {
-            // No getIdByToken method
-            delete mockSingleUseTokenProvider.getIdByToken;
+        it('should work when tokenProvider does not have getRefByToken method', async function () {
+            // No getRefByToken method
+            delete mockSingleUseTokenProvider.getRefByToken;
 
             const labsService = {
                 isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
@@ -198,8 +198,8 @@ describe('MagicLink', function () {
             assert(options.transporter.sendMail.calledOnce);
         });
 
-        it('should return otcRef as null when getIdByToken resolves to null', async function () {
-            mockSingleUseTokenProvider.getIdByToken.resolves(null);
+        it('should return otcRef as null when getRefByToken resolves to null', async function () {
+            mockSingleUseTokenProvider.getRefByToken.resolves(null);
 
             const labsService = {
                 isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
@@ -218,9 +218,9 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            // deriveOTC is only possible with a token so it's skipped if getIdByToken returns null
+            // deriveOTC is only possible with a token so it's skipped if getRefByToken returns null
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
-            assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
         });
 
         it('should include OTC when includeOTC is true and labs flag is enabled', async function () {
@@ -241,10 +241,10 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert(mockSingleUseTokenProvider.getIdByToken.calledTwice);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledTwice);
             assert(mockSingleUseTokenProvider.deriveOTC.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-id-123', 'mock-token'));
-            assert.equal(result.otcRef, 'test-token-id-123');
+            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-ref-123', 'mock-token'));
+            assert.equal(result.otcRef, 'test-token-ref-123');
 
             // Verify OTC is passed to email content functions
             assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
@@ -270,7 +270,7 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
+            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
             assert.equal(result.otcRef, null);
 
@@ -297,7 +297,7 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert(mockSingleUseTokenProvider.getIdByToken.notCalled);
+            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
             assert.equal(result.otcRef, null);
         });
@@ -361,20 +361,20 @@ describe('MagicLink', function () {
         });
     });
 
-    describe('#getIdFromToken', function () {
-        it('should return token ID when tokenProvider has getIdByToken method', async function () {
+    describe('#getRefFromToken', function () {
+        it('should return token ref when tokenProvider has getRefByToken method', async function () {
             const service = new MagicLink(buildOptions());
-            const tokenId = await service.getIdFromToken('mock-token');
+            const tokenId = await service.getRefFromToken('mock-token');
 
-            assert.equal(tokenId, 'test-token-id-123');
-            assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
-            assert(mockSingleUseTokenProvider.getIdByToken.calledWith('mock-token'));
+            assert.equal(tokenId, 'test-token-ref-123');
+            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledWith('mock-token'));
         });
 
-        it('should return null when tokenProvider lacks getIdByToken method', async function () {
-            delete mockSingleUseTokenProvider.getIdByToken;
+        it('should return null when tokenProvider lacks getRefByToken method', async function () {
+            delete mockSingleUseTokenProvider.getRefByToken;
             const service = new MagicLink(buildOptions());
-            const tokenId = await service.getIdFromToken('mock-token');
+            const tokenId = await service.getRefFromToken('mock-token');
 
             assert.equal(tokenId, null);
         });
@@ -386,13 +386,13 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, '654321');
-            assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
             assert(mockSingleUseTokenProvider.deriveOTC.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-id-123', 'mock-token'));
+            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-ref-123', 'mock-token'));
         });
 
-        it('should return null when tokenProvider lacks getIdByToken method', async function () {
-            delete mockSingleUseTokenProvider.getIdByToken;
+        it('should return null when tokenProvider lacks getRefByToken method', async function () {
+            delete mockSingleUseTokenProvider.getRefByToken;
             const service = new MagicLink(buildOptions());
             const otc = await service.getOTCFromToken('mock-token');
 
@@ -406,16 +406,16 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, null);
-            assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
         });
 
-        it('should return null when getIdByToken returns null', async function () {
-            mockSingleUseTokenProvider.getIdByToken.resolves(null);
+        it('should return null when getRefByToken returns null', async function () {
+            mockSingleUseTokenProvider.getRefByToken.resolves(null);
             const service = new MagicLink(buildOptions());
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, null);
-            assert(mockSingleUseTokenProvider.getIdByToken.calledOnce);
+            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
             assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2493

- uses `token.uuid` as the ref for OTC generation and verification instead of `token.id`
- modifies methods like `getIdByToken` to names like `getRefByToken` so the implementation detail doesn't need to be known by callers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches OTC to use `uuid` as the reference and renames token lookup from `getIdByToken` to `getRefByToken`, updating providers, MagicLink, and tests.
> 
> - **Auth/OTC flow**:
>   - Use `uuid` as OTC reference instead of numeric `id` in `SingleUseTokenProvider` (lookups now by `uuid`).
>   - Rename methods: `getIdByToken` -> `getRefByToken`; `MagicLink#getIdFromToken` -> `getRefFromToken` and update internal calls (`getOTCFromToken`).
>   - Update OTC derivation/verification to use `uuid` (`verifyOTC`, `_validateOTCVerificationHash`, `getTokenByRef`).
> - **Tests**:
>   - Adjust unit/e2e tests to `getRefByToken` and `getRefFromToken` APIs and expectations.
>   - Update OTC ref format assertions from 24-hex to UUID v4-style `^[a-f0-9-]{36}$`.
>   - Modify fixtures to include `uuid` and update all OTC derivation calls to pass `uuid`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa4e63c95e3b0e5fc561238c3dc9459bd5d91083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->