### PR TITLE
Implement email based SSO with oauth2

### DIFF
--- a/ghost/admin/app/styles/layouts/auth.css
+++ b/ghost/admin/app/styles/layouts/auth.css
@@ -164,6 +164,31 @@
     box-shadow: 0 0 0 3px rgba(48,207,67,.25);
 }
 
+.sso-or {
+    margin-top: 10px;
+    margin-bottom: -30px;
+    text-align: center;
+    color: #abb4be;
+    display: flex;
+    align-items: center;
+    text-align: center;
+}
+
+.sso-or::before,
+.sso-or::after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid #abb4be;
+}
+
+.sso-or:not(:empty)::before {
+    margin-right: .25em;
+}
+
+.sso-or:not(:empty)::after {
+    margin-left: .25em;
+}
+
 /* Email notification */
 /* ---------------------------------------------------------- */
 

--- a/ghost/admin/app/templates/signin.hbs
+++ b/ghost/admin/app/templates/signin.hbs
@@ -73,6 +73,19 @@
                         @type="submit"
                         @useAccentColor={{true}}
                         data-test-button="sign-in" />
+
+                    {{#if this.ssoEnabled}}
+                        <div class="sso-or">or</div>
+
+                        <GhTaskButton
+                            @buttonText="Sign in using SSO &rarr;"
+                            @task={{this.ssoInitiate}}
+                            @showSuccess={{false}}
+                            @class="login gh-btn gh-btn-login gh-btn-block gh-btn-icon"
+                            @type="submit"
+                            @useAccentColor={{true}}
+                            data-test-button="sign-in" />
+                    {{/if}}
                 </form>
 
                 <p class="{{if this.flowErrors "main-error" "main-notification"}}" data-test-flow-notification>{{if this.flowErrors this.flowErrors this.flowNotification}}&nbsp;</p>

--- a/ghost/admin/app/templates/signin.hbs
+++ b/ghost/admin/app/templates/signin.hbs
@@ -82,7 +82,7 @@
                             @task={{this.ssoInitiate}}
                             @showSuccess={{false}}
                             @class="login gh-btn gh-btn-login gh-btn-block gh-btn-icon"
-                            @type="submit"
+                            @type="button"
                             @useAccentColor={{true}}
                             data-test-button="sign-in" />
                     {{/if}}

--- a/ghost/admin/app/templates/signin.hbs
+++ b/ghost/admin/app/templates/signin.hbs
@@ -84,7 +84,7 @@
                             @class="login gh-btn gh-btn-login gh-btn-block gh-btn-icon"
                             @type="button"
                             @useAccentColor={{true}}
-                            data-test-button="sign-in" />
+                            data-test-button="sign-in-sso" />
                     {{/if}}
                 </form>
 

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -176,6 +176,7 @@
   "dependencies": {
     "i18n-iso-countries": "7.14.0",
     "lru-cache": "6.0.0",
+    "openid-client": "^6.8.0",
     "path-browserify": "1.0.1",
     "webpack": "5.101.3"
   },

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -29,6 +29,10 @@ module.exports = {
         return require('./session');
     },
 
+    get sso() {
+        return require('./sso');
+    },
+
     get schedules() {
         return apiFramework.pipeline(require('./schedules'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/sso.js
+++ b/ghost/core/core/server/api/endpoints/sso.js
@@ -29,6 +29,8 @@ const server = configSSO && configSSO.server || '';
 const clientId = configSSO && configSSO.clientId || '';
 const clientSecret = configSSO && configSSO.clientSecret || '';
 
+const localRedirectURI = `${config.get('url')}/ghost/api/admin/sso/redirect`;
+
 const ssoEnabled = !!(type === 'oauth' && server && clientId && clientSecret);
 const ssoConfig = ssoEnabled
     ? client.discovery(new URL(server), clientId, clientSecret)
@@ -53,7 +55,7 @@ const controller = {
             }
 
             const parameters = {
-                redirect_uri: 'http://localhost:2368/ghost/api/admin/sso/redirect',
+                redirect_uri: localRedirectURI,
                 scope: 'openid email',
                 state: client.randomState()
             };

--- a/ghost/core/core/server/api/endpoints/sso.js
+++ b/ghost/core/core/server/api/endpoints/sso.js
@@ -1,0 +1,132 @@
+const tpl = require('@tryghost/tpl');
+const errors = require('@tryghost/errors');
+const models = require('../../models');
+const auth = require('../../services/auth');
+const config = require('../../../shared/config');
+
+const client = require('openid-client');
+
+const messages = {
+    noUserWithEnteredEmailAddr: 'There is no user with that email address.',
+    accountSuspended: 'Your account was suspended.',
+    accountLocked: 'Your account was locked.',
+    misconfiguration: 'SSO was misconfigured, notify admins.'
+};
+
+const sessionDuration = 60 * 60; // 1hr in secs
+const abortCookieName = 'ghost-admin-sso-error';
+const abort = error => Promise.resolve(
+    async function sessionMiddleware(req, res, next) {
+        res.cookie(abortCookieName, error, {maxAge: sessionDuration});
+        res.redirect('/ghost');
+        next();
+    }
+);
+
+const configSSO = config.get('sso');
+const type = configSSO && configSSO.type || '';
+const server = configSSO && configSSO.server || '';
+const clientId = configSSO && configSSO.clientId || '';
+const clientSecret = configSSO && configSSO.clientSecret || '';
+
+const ssoEnabled = !!(type === 'oauth' && server && clientId && clientSecret);
+const ssoConfig = ssoEnabled
+    ? client.discovery(new URL(server), clientId, clientSecret)
+    : Promise.resolve(undefined);
+
+const ssoDisabledReturn = Promise.resolve(
+    async function sessionMiddleware(req, res, next) {
+        res.redirect('/ghost');
+        next();
+    }
+);
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    enabled() {
+        return {ssoEnabled};
+    },
+    init() {
+        return ssoConfig.then((sso) => {
+            if (!sso) {
+                return ssoDisabledReturn;
+            }
+
+            const parameters = {
+                redirect_uri: 'http://localhost:2368/ghost/api/admin/sso/redirect',
+                scope: 'openid email',
+                state: client.randomState()
+            };
+
+            const redirectURI = client.buildAuthorizationUrl(sso, parameters);
+
+            return Promise.resolve(function sessionMiddleware(req, res, next) {
+                res.redirect(redirectURI);
+                next();
+            });
+        });
+    },
+    redirect(frame) {
+        const query = frame.original.query;
+        const {code, state} = query;
+        if (!code || !state) {
+            return Promise.reject(new errors.UnauthorizedError({
+                message: 'Invalid parameters!'
+            }));
+        }
+
+        return ssoConfig.then((sso) => { 
+            if (!config) {
+                return ssoDisabledReturn;
+            }
+
+            const currentUrl = new URL(`${frame.original.url.secure ? 'https://' : 'http://'}${frame.original.url.host}${frame.original.url.pathname}`);
+            for (const [key, value] of Object.entries(query)) {
+                currentUrl.searchParams.append(key, value);
+            }
+
+            return client.authorizationCodeGrant(sso, currentUrl, {
+                expectedState: state
+            }).then((tokens) => {
+                return client.fetchUserInfo(sso, tokens.access_token, tokens.claims().sub).then((userInfo) => {
+                    if (!userInfo || !userInfo.email) {
+                        return abort(tpl(messages.noUserWithEnteredEmailAddr));
+                    }
+
+                    return models.User.getByEmail(userInfo.email).then((user) => {
+                        if (!user) {
+                            return abort(tpl(messages.noUserWithEnteredEmailAddr));
+                        }
+        
+                        if (user.isLocked()) {
+                            return abort(tpl(messages.accountLocked));
+                        }
+        
+                        if (user.isInactive()) {
+                            return abort(tpl(messages.accountSuspended));
+                        }
+
+                        return Promise.resolve(async function sessionMiddleware(req, res, next) {
+                            req.brute.reset(async function (err) {
+                                if (err) {
+                                    return next(err);
+                                }
+                                req.user = user;
+                                req.skipVerification = true;
+                                req.skipResponse = true;
+            
+                                await auth.session.createSession(req, res, next);
+                                res.cookie(abortCookieName, '', {maxAge: sessionDuration});
+                                res.redirect('/ghost');
+                            });
+                        });
+                    });
+                });
+            }).catch(() => {
+                return abort(tpl(messages.misconfiguration));
+            });
+        });
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/services/auth/session/middleware.js
+++ b/ghost/core/core/server/services/auth/session/middleware.js
@@ -11,7 +11,9 @@ function SessionMiddleware({sessionService}) {
 
             const isVerified = await sessionService.isVerifiedSession(req, res);
             if (isVerified) {
-                res.sendStatus(201);
+                if (!req.skipResponse) {
+                    res.sendStatus(201);
+                }
             } else {
                 await sessionService.sendAuthCodeToUser(req, res);
                 throw new errors.NoPermissionError({

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -256,6 +256,20 @@ module.exports = function apiRoutes() {
     router.post('/session/verify', shared.middleware.brute.sendVerificationCode, http(api.session.sendVerification));
     router.put('/session/verify', shared.middleware.brute.userVerification, http(api.session.verify));
 
+    // ## SSO
+    router.get('/sso',
+        http(api.sso.enabled)
+    );
+    router.get('/sso/init',
+        shared.middleware.brute.globalBlock,
+        http(api.sso.init)
+    );
+    router.get('/sso/redirect',
+        shared.middleware.brute.globalBlock,
+        shared.middleware.brute.userLogin,
+        http(api.sso.redirect)
+    );
+
     // ## Identity
     router.get('/identities', mw.authAdminApi, http(api.identities.read));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22704,6 +22704,11 @@ jose@^4.15.4:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
   integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
+jose@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.0.tgz#96285365689d16f2845a353964d2284bf19f464c"
+  integrity sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==
+
 jpeg-js@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
@@ -25972,6 +25977,11 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
+oauth4webapi@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-3.8.2.tgz#500d1979038c14656f3f24ff1eb501ff3993115b"
+  integrity sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==
+
 object-assign@4.1.1, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -26192,6 +26202,14 @@ open@^8.0.4, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openid-client@^6.8.0:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-6.8.1.tgz#0e6dd3c1e9c98771ebf387b793ce9f626791a924"
+  integrity sha512-VoYT6enBo6Vj2j3Q5Ec0AezS+9YGzQo1f5Xc42lreMGlfP4ljiXPKVDvCADh+XHCV/bqPu/wWSiCVXbJKvrODw==
+  dependencies:
+    jose "^6.1.0"
+    oauth4webapi "^3.8.2"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
Greetings! I have been using Ghost internally for a while now and I'm decently happy with it. However, the lack of proper SSO keeps me from properly integrating it with the rest of my online services. Seeing a lot of community members agree with this and respecting the fact that Ghost's core developers might not have the time for such a feature, I decided to step in and implement it myself. Remember, SSO isn't an "enhancement" or anything, it's a core security feature that a lot of people (including me) depend on.

This is a pretty bare-bones implementation and is perfectly backwards compatible, with no changes unless SSO is manually enabled in the config. Even then, the code changes are minimal and the new API endpoints don't get in the way of anything important. I'm not that familiar with this codebase, but I tried my best to adhere to the general programming style. I also couldn't find any place to add documentation so the new config entry works as follows:
```json
{
    "...": "whatever other entries",

    "sso": {
        "type": "oauth",
        "server": "https://sso.example.com/.well-known/openid-configuration",
        "clientId": "client_id",
        "clientSecret": "client_secret"
    },
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional Admin SSO via OAuth2/OpenID with new `/sso` endpoints, sign-in UI button/flow, and session handling to support redirect-based login.
> 
> - **Backend**:
>   - **SSO Endpoints**: Add `GET /sso` (enabled), `GET /sso/init` (authorize redirect), `GET /sso/redirect` (callback) in `core/server/web/api/endpoints/admin/routes.js` backed by `core/server/api/endpoints/sso.js`.
>   - **OpenID/OAuth Flow**: Use `openid-client` discovery and auth code grant; resolve user by email; create verified session; surface errors via `ghost-admin-sso-error` cookie.
>   - **Session Middleware**: In `core/server/services/auth/session/middleware.js`, respect `req.skipResponse` to avoid sending `201` when redirecting.
>   - **API Index**: Expose `sso` controller in `core/server/api/endpoints/index.js`.
> - **Frontend**:
>   - **Sign-in Controller** (`admin/app/controllers/signin.js`): Fetch `sso` enabled flag, read/clear error cookie, add `ssoInitiate` task to hit `api('sso','init')`.
>   - **Template** (`admin/app/templates/signin.hbs`): When `ssoEnabled`, show SSO button and divider.
>   - **Styles** (`admin/app/styles/layouts/auth.css`): Add `.sso-or` divider styles.
> - **Dependencies**:
>   - Add `openid-client` (and transitive `jose`, `oauth4webapi`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e04b6d19dcfbe2060ed9e5de9c5c52c925e3567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->