### PR TITLE
Renamed `onAction` to `doAction` in Portal

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -980,7 +980,7 @@ export default class App extends React.Component {
             scrollbarWidth,
             labs,
             otcRef,
-            onAction: (_action, data) => this.dispatchAction(_action, data)
+            doAction: (_action, data) => this.dispatchAction(_action, data)
         };
     }
 

--- a/apps/portal/src/AppContext.js
+++ b/apps/portal/src/AppContext.js
@@ -8,7 +8,7 @@ const AppContext = React.createContext({
     lastPage: '',
     brandColor: '',
     pageData: {},
-    onAction: (action, data) => {
+    doAction: (action, data) => {
         return {action, data};
     },
     t: () => {},

--- a/apps/portal/src/components/Notification.js
+++ b/apps/portal/src/components/Notification.js
@@ -221,7 +221,7 @@ export default class Notification extends React.Component {
             deleteParams.push('stripe');
         }
         clearURLParams(deleteParams);
-        this.context.onAction('refreshMemberData');
+        this.context.doAction('refreshMemberData');
         this.setState({
             active: false
         });

--- a/apps/portal/src/components/PopupModal.js
+++ b/apps/portal/src/components/PopupModal.js
@@ -72,7 +72,7 @@ class PopupContent extends React.Component {
         // If focused on input field, only allow close if no value entered
         const allowClose = eventTargetTag !== 'INPUT' || (eventTargetTag === 'INPUT' && !event?.target?.value);
         if (allowClose) {
-            this.context.onAction('closePopup');
+            this.context.doAction('closePopup');
         }
     }
 
@@ -108,7 +108,7 @@ class PopupContent extends React.Component {
             return;
         }
         if (e.target === e.currentTarget) {
-            this.context.onAction('closePopup');
+            this.context.doAction('closePopup');
         }
     }
 
@@ -260,7 +260,7 @@ export default class PopupModal extends React.Component {
     handlePopupClose(e) {
         e.preventDefault();
         if (e.target === e.currentTarget) {
-            this.context.onAction('closePopup');
+            this.context.doAction('closePopup');
         }
     }
 

--- a/apps/portal/src/components/TriggerButton.js
+++ b/apps/portal/src/components/TriggerButton.js
@@ -166,18 +166,18 @@ class TriggerButtonContent extends React.Component {
         const {showPopup, member, site} = this.context;
 
         if (showPopup) {
-            this.context.onAction('closePopup');
+            this.context.doAction('closePopup');
             return;
         }
 
         if (member) {
-            this.context.onAction('openPopup', {page: 'accountHome'});
+            this.context.doAction('openPopup', {page: 'accountHome'});
             return;
         }
 
         if (isSigninAllowed({site})) {
             const page = isInviteOnly({site}) || !hasAvailablePrices({site}) ? 'signin' : 'signup';
-            this.context.onAction('openPopup', {page});
+            this.context.doAction('openPopup', {page});
             return;
         }
     }
@@ -231,7 +231,7 @@ export default class TriggerButton extends React.Component {
     componentDidMount() {
         window.addEventListener('resize', this.handleResize);
         this.handleResize();
-        
+
         setTimeout(() => {
             if (this.buttonRef.current) {
                 const iframeElement = this.buttonRef.current.node;

--- a/apps/portal/src/components/common/CloseButton.js
+++ b/apps/portal/src/components/common/CloseButton.js
@@ -6,7 +6,7 @@ export default class CloseButton extends React.Component {
     static contextType = AppContext;
 
     closePopup = () => {
-        this.context.onAction('closePopup');
+        this.context.doAction('closePopup');
     };
 
     render() {

--- a/apps/portal/src/components/common/NewsletterManagement.js
+++ b/apps/portal/src/components/common/NewsletterManagement.js
@@ -7,11 +7,11 @@ import {getSiteNewsletters, hasMemberGotEmailSuppression} from '../../utils/help
 import ActionButton from '../common/ActionButton';
 
 function AccountHeader() {
-    const {brandColor, lastPage, onAction, t} = useContext(AppContext);
+    const {brandColor, lastPage, doAction, t} = useContext(AppContext);
     return (
         <header className='gh-portal-detail-header'>
             <BackButton brandColor={brandColor} hidden={!lastPage} onClick={() => {
-                onAction('back');
+                doAction('back');
             }} />
             <h3 className='gh-portal-main-title'>{t('Email preferences')}</h3>
         </header>
@@ -49,7 +49,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
 }
 
 function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableCommentNotifications}) {
-    const {t, onAction} = useContext(AppContext);
+    const {t, doAction} = useContext(AppContext);
     const isChecked = !!enableCommentNotifications;
 
     if (!isCommentsEnabled) {
@@ -58,7 +58,7 @@ function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableC
 
     const handleToggle = async (e, checked) => {
         await updateCommentNotifications(checked);
-        onAction('showPopupNotification', {
+        doAction('showPopupNotification', {
             action: 'updated:success',
             message: t('Comment preferences updated.')
         });
@@ -117,7 +117,7 @@ export default function NewsletterManagement({
     isCommentsEnabled,
     enableCommentNotifications
 }) {
-    const {brandColor, onAction, member, site, t} = useContext(AppContext);
+    const {brandColor, doAction, member, site, t} = useContext(AppContext);
     const isDisabled = !subscribedNewsletters?.length && ((isCommentsEnabled && !enableCommentNotifications) || !isCommentsEnabled);
     const EmptyNotification = () => {
         return null;
@@ -177,7 +177,7 @@ export default function NewsletterManagement({
                         <span className="gh-portal-footer-secondary-light">{t('Not receiving emails?')}</span>
                         <button
                             className="gh-portal-btn-text gh-email-faq-page-button"
-                            onClick={() => onAction('switchPage', {page: 'emailReceivingFAQ', pageData: {direct: false}})}
+                            onClick={() => doAction('switchPage', {page: 'emailReceivingFAQ', pageData: {direct: false}})}
                         >
                             {/* eslint-disable-next-line i18next/no-literal-string */}
                             {t('Get help')} <span className="right-arrow">&rarr;</span>

--- a/apps/portal/src/components/common/PopupNotification.js
+++ b/apps/portal/src/components/common/PopupNotification.js
@@ -71,12 +71,12 @@ export default class PopupNotification extends React.Component {
             if (type === 'stripe:billing-update') {
                 clearURLParams(['stripe']);
             }
-            this.context.onAction('clearPopupNotification');
+            this.context.doAction('clearPopupNotification');
         }
     }
 
     closeNotification() {
-        this.context.onAction('clearPopupNotification');
+        this.context.doAction('clearPopupNotification');
     }
 
     componentDidUpdate() {

--- a/apps/portal/src/components/common/SiteTitleBackButton.js
+++ b/apps/portal/src/components/common/SiteTitleBackButton.js
@@ -14,7 +14,7 @@ export default class SiteTitleBackButton extends React.Component {
                         if (this.props.onBack) {
                             this.props.onBack();
                         } else {
-                            this.context.onAction('closePopup');
+                            this.context.doAction('closePopup');
                         }
                     }}>
                     {/* eslint-disable-next-line i18next/no-literal-string */}

--- a/apps/portal/src/components/pages/AccountEmailPage.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.js
@@ -5,7 +5,7 @@ import NewsletterManagement from '../common/NewsletterManagement';
 import Interpolate from '@doist/react-interpolate';
 
 export default function AccountEmailPage() {
-    const {member, onAction, site, t, pageData} = useContext(AppContext);
+    const {member, doAction, site, t, pageData} = useContext(AppContext);
     let newsletterUuid;
     let action;
     if (pageData) {
@@ -19,11 +19,11 @@ export default function AccountEmailPage() {
     // Redirect to signin page if member is not available
     useEffect(() => {
         if (!member) {
-            onAction('switchPage', {
+            doAction('switchPage', {
                 page: 'signin'
             });
         }
-    }, [member, onAction]);
+    }, [member, doAction]);
 
     // this results in an infinite loop, needs to run only once...
     useEffect(() => {
@@ -33,7 +33,7 @@ export default function AccountEmailPage() {
             const remainingNewsletterSubscriptions = member?.newsletters.filter(n => n.uuid !== newsletterUuid);
             setSubscribedNewsletters(remainingNewsletterSubscriptions);
             setHasInteracted(false); // this shows the dialog
-            onAction('updateNewsletterPreference', {newsletters: remainingNewsletterSubscriptions});
+            doAction('updateNewsletterPreference', {newsletters: remainingNewsletterSubscriptions});
         }
     }, []);
 
@@ -56,11 +56,11 @@ export default function AccountEmailPage() {
         const unsubscribedNewsletter = siteNewsletters?.find((d) => {
             return d.uuid === pageData.newsletterUuid;
         });
-    
+
         if (!unsubscribedNewsletter) {
             return null;
         }
-    
+
         const hideClassName = hasInteracted ? 'gh-portal-hide' : '';
         return (
             <>
@@ -93,18 +93,18 @@ export default function AccountEmailPage() {
             subscribedNewsletters={subscribedNewsletters}
             updateSubscribedNewsletters={(updatedNewsletters) => {
                 setSubscribedNewsletters(updatedNewsletters);
-                onAction('updateNewsletterPreference', {newsletters: updatedNewsletters});
-                onAction('showPopupNotification', {
+                doAction('updateNewsletterPreference', {newsletters: updatedNewsletters});
+                doAction('showPopupNotification', {
                     action: 'updated:success',
                     message: t('Email preferences updated.')
                 });
             }}
             updateCommentNotifications={async (enabled) => {
-                onAction('updateNewsletterPreference', {enableCommentNotifications: enabled});
+                doAction('updateNewsletterPreference', {enableCommentNotifications: enabled});
             }}
             unsubscribeAll={() => {
                 setSubscribedNewsletters([]);
-                onAction('showPopupNotification', {
+                doAction('showPopupNotification', {
                     action: 'updated:success',
                     message: t(`Unsubscribed from all emails.`)
                 });
@@ -112,7 +112,7 @@ export default function AccountEmailPage() {
                 if (commentsEnabled) {
                     data.enableCommentNotifications = false;
                 }
-                onAction('updateNewsletterPreference', data);
+                doAction('updateNewsletterPreference', data);
             }}
             isPaidMember={isPaidMember({member})}
             isCommentsEnabled={commentsEnabled !== 'off'}

--- a/apps/portal/src/components/pages/AccountEmailPage.test.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.test.js
@@ -3,7 +3,7 @@ import {render, fireEvent} from '../../utils/test-utils';
 import AccountEmailPage from './AccountEmailPage';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, context, ...utils} = render(
+    const {mockDoActionFn, context, ...utils} = render(
         <AccountEmailPage />,
         {
             overrideContext: {
@@ -17,7 +17,7 @@ const setup = (overrides) => {
     return {
         unsubscribeAllBtn,
         closeBtn,
-        mockOnActionFn,
+        mockDoActionFn,
         context,
         ...utils
     };
@@ -43,7 +43,7 @@ describe('Account Email Page', () => {
         const siteData = getSiteData({
             newsletters: newsletterData
         });
-        const {mockOnActionFn, unsubscribeAllBtn, getAllByRole} = setup({site: siteData, member: getMemberData({newsletters: newsletterData})});
+        const {mockDoActionFn, unsubscribeAllBtn, getAllByRole} = setup({site: siteData, member: getMemberData({newsletters: newsletterData})});
         let checkboxes = getAllByRole('checkbox');
         let newsletter1Checkbox = checkboxes[0];
         let newsletter2Checkbox = checkboxes[1];
@@ -52,9 +52,9 @@ describe('Account Email Page', () => {
         expect(newsletter2Checkbox).toBeChecked();
 
         fireEvent.click(unsubscribeAllBtn);
-        expect(mockOnActionFn).toHaveBeenCalledTimes(2);
-        expect(mockOnActionFn).toHaveBeenCalledWith('showPopupNotification', {action: 'updated:success', message: 'Unsubscribed from all emails.'});
-        expect(mockOnActionFn).toHaveBeenLastCalledWith('updateNewsletterPreference', {newsletters: [], enableCommentNotifications: false});
+        expect(mockDoActionFn).toHaveBeenCalledTimes(2);
+        expect(mockDoActionFn).toHaveBeenCalledWith('showPopupNotification', {action: 'updated:success', message: 'Unsubscribed from all emails.'});
+        expect(mockDoActionFn).toHaveBeenLastCalledWith('updateNewsletterPreference', {newsletters: [], enableCommentNotifications: false});
 
         checkboxes = getAllByRole('checkbox');
         expect(checkboxes).toHaveLength(3);
@@ -77,26 +77,26 @@ describe('Account Email Page', () => {
         const siteData = getSiteData({
             newsletters: newsletterData
         });
-        const {mockOnActionFn, getAllByTestId, getAllByRole} = setup({site: siteData, member: getMemberData({newsletters: newsletterData})});
+        const {mockDoActionFn, getAllByTestId, getAllByRole} = setup({site: siteData, member: getMemberData({newsletters: newsletterData})});
         let checkboxes = getAllByRole('checkbox');
         let newsletter1Checkbox = checkboxes[0];
         // each newsletter should have the checked class (this is how we know they're enabled/subscribed to)
         expect(newsletter1Checkbox).toBeChecked();
         let subscriptionToggles = getAllByTestId('switch-input');
         fireEvent.click(subscriptionToggles[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {newsletters: [{id: newsletterData[1].id}]});
+        expect(mockDoActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {newsletters: [{id: newsletterData[1].id}]});
         fireEvent.click(subscriptionToggles[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {newsletters: [{id: newsletterData[1].id}, {id: newsletterData[0].id}]});
+        expect(mockDoActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {newsletters: [{id: newsletterData[1].id}, {id: newsletterData[0].id}]});
     });
 
     test('can update comment notifications', async () => {
         const siteData = getSiteData();
-        const {mockOnActionFn, getAllByTestId} = setup({site: siteData, member: getMemberData()});
+        const {mockDoActionFn, getAllByTestId} = setup({site: siteData, member: getMemberData()});
         let subscriptionToggles = getAllByTestId('switch-input');
         fireEvent.click(subscriptionToggles[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {enableCommentNotifications: true});
+        expect(mockDoActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {enableCommentNotifications: true});
         fireEvent.click(subscriptionToggles[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {enableCommentNotifications: false});
+        expect(mockDoActionFn).toHaveBeenCalledWith('updateNewsletterPreference', {enableCommentNotifications: false});
     });
 
     test('displays help for members with email suppressions', async () => {
@@ -114,8 +114,8 @@ describe('Account Email Page', () => {
         const siteData = getSiteData({
             newsletters: newsletterData
         });
-        const {mockOnActionFn} = setup({site: siteData, member: null});
-        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
+        const {mockDoActionFn} = setup({site: siteData, member: null});
+        expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
     });
 
     test('newsletters are not visible when newsletters are disabled on the site but has comments enabled', async () => {
@@ -125,7 +125,7 @@ describe('Account Email Page', () => {
             editorDefaultEmailRecipients: 'disabled',
             member: getMemberData({newsletters: newsletterData})
         });
-        
+
         const {getAllByTestId, getByText} = setup({site: siteData});
         const unsubscribeBtns = getAllByTestId(`toggle-wrapper`);
 

--- a/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.js
+++ b/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.js
@@ -13,11 +13,11 @@ export default class AccountHomePage extends React.Component {
         const {member, site} = this.context;
 
         if (!isSigninAllowed({site})) {
-            this.context.onAction('signout');
+            this.context.doAction('signout');
         }
 
         if (!member) {
-            this.context.onAction('switchPage', {
+            this.context.doAction('switchPage', {
                 page: 'signin',
                 pageData: {
                     redirect: window.location.href // This includes the search/fragment of the URL (#/portal/account) which is missing from the default referer header
@@ -28,7 +28,7 @@ export default class AccountHomePage extends React.Component {
 
     handleSignout(e) {
         e.preventDefault();
-        this.context.onAction('signout');
+        this.context.doAction('signout');
     }
 
     render() {
@@ -44,7 +44,7 @@ export default class AccountHomePage extends React.Component {
             <div className='gh-portal-account-wrapper'>
                 <AccountMain />
                 <AccountFooter
-                    onClose={() => this.context.onAction('closePopup')}
+                    onClose={() => this.context.doAction('closePopup')}
                     handleSignout={e => this.handleSignout(e)}
                     supportAddress={supportAddress}
                     t={t}

--- a/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.test.js
+++ b/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.test.js
@@ -4,7 +4,7 @@ import {site} from '../../../utils/fixtures';
 import {getSiteData, getNewslettersData} from '../../../utils/fixtures-generator';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <AccountHomePage />,
         {
             overrideContext: {
@@ -15,7 +15,7 @@ const setup = (overrides) => {
     const logoutBtn = utils.queryByRole('button', {name: 'logout'});
     return {
         logoutBtn,
-        mockOnActionFn,
+        mockDoActionFn,
         utils
     };
 };
@@ -30,14 +30,14 @@ describe('Account Home Page', () => {
     });
 
     test('can call signout', () => {
-        const {mockOnActionFn, logoutBtn} = setup();
+        const {mockDoActionFn, logoutBtn} = setup();
 
         fireEvent.click(logoutBtn);
-        expect(mockOnActionFn).toHaveBeenCalledWith('signout');
+        expect(mockDoActionFn).toHaveBeenCalledWith('signout');
     });
 
     test('can show Manage button for few newsletters', () => {
-        const {mockOnActionFn, utils} = setup({site: site});
+        const {mockDoActionFn, utils} = setup({site: site});
 
         expect(utils.queryByText('Update your preferences')).toBeInTheDocument();
         expect(utils.queryByText('You\'re currently not receiving emails')).not.toBeInTheDocument();
@@ -46,7 +46,7 @@ describe('Account Home Page', () => {
         expect(manageBtn).toBeInTheDocument();
 
         fireEvent.click(manageBtn);
-        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {lastPage: 'accountHome', page: 'accountEmail'});
+        expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {lastPage: 'accountHome', page: 'accountEmail'});
     });
 
     test('hides Newsletter toggle if newsletters are disabled', () => {

--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountActions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountActions.js
@@ -23,11 +23,11 @@ const shouldShowEmailNewsletterAction = (site) => {
 };
 
 const AccountActions = () => {
-    const {member, onAction, site, t} = useContext(AppContext);
+    const {member, doAction, site, t} = useContext(AppContext);
     const {name, email} = member;
 
     const openEditProfile = () => {
-        onAction('switchPage', {
+        doAction('switchPage', {
             page: 'accountProfile',
             lastPage: 'accountHome'
         });

--- a/apps/portal/src/components/pages/AccountHomePage/components/ContinueSubscriptionButton.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/ContinueSubscriptionButton.js
@@ -5,7 +5,7 @@ import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
 
 const ContinueSubscriptionButton = () => {
-    const {member, onAction, action, brandColor, t} = useContext(AppContext);
+    const {member, doAction, action, brandColor, t} = useContext(AppContext);
     const subscription = getMemberSubscription({member});
     if (!subscription) {
         return null;
@@ -35,7 +35,7 @@ const ContinueSubscriptionButton = () => {
             <CancelNotice />
             <ActionButton
                 onClick={() => {
-                    onAction('continueSubscription', {
+                    doAction('continueSubscription', {
                         subscriptionId: subscription.id
                     });
                 }}

--- a/apps/portal/src/components/pages/AccountHomePage/components/EmailNewsletterAction.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/EmailNewsletterAction.js
@@ -4,7 +4,7 @@ import {getSiteNewsletters, hasMemberGotEmailSuppression} from '../../../../util
 import {useContext} from 'react';
 
 function EmailNewsletterAction() {
-    const {member, site, onAction, t} = useContext(AppContext);
+    const {member, site, doAction, t} = useContext(AppContext);
     let {newsletters} = member;
 
     const subscribed = !!newsletters?.length;
@@ -13,7 +13,7 @@ function EmailNewsletterAction() {
         e.preventDefault();
         const siteNewsletters = getSiteNewsletters({site});
         const subscribedNewsletters = !member?.newsletters?.length ? siteNewsletters : [];
-        onAction('updateNewsletterPreference', {newsletters: subscribedNewsletters});
+        doAction('updateNewsletterPreference', {newsletters: subscribedNewsletters});
     };
 
     return (
@@ -22,7 +22,7 @@ function EmailNewsletterAction() {
                 <h3>{t('Email newsletter')}</h3>
                 <p>{label} {hasMemberGotEmailSuppression({member}) && subscribed && <button
                     className='gh-portal-btn-text gh-email-faq-page-button'
-                    onClick={() => onAction('switchPage', {page: 'emailReceivingFAQ', lastPage: 'accountHome'})}
+                    onClick={() => doAction('switchPage', {page: 'emailReceivingFAQ', lastPage: 'accountHome'})}
                 >
                     {t('Not receiving emails?')}
                 </button>}</p>

--- a/apps/portal/src/components/pages/AccountHomePage/components/EmailPreferencesAction.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/EmailPreferencesAction.js
@@ -14,7 +14,7 @@ function DisabledEmailNotice({t}) {
 }
 
 function EmailPreferencesAction() {
-    const {onAction, member, t, site} = useContext(AppContext);
+    const {doAction, member, t, site} = useContext(AppContext);
 
     const emailSuppressed = isEmailSuppressed({member});
     const hasNewslettersEnabled = hasNewsletterSendingEnabled({site});
@@ -39,7 +39,7 @@ function EmailPreferencesAction() {
             <button
                 className="gh-portal-btn gh-portal-btn-list"
                 onClick={() => {
-                    onAction('switchPage', {
+                    doAction('switchPage', {
                         page,
                         lastPage: 'accountHome'
                     });

--- a/apps/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
@@ -6,17 +6,17 @@ import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag
 import {useContext} from 'react';
 
 const PaidAccountActions = () => {
-    const {member, site, onAction, t} = useContext(AppContext);
+    const {member, site, doAction, t} = useContext(AppContext);
 
     const onEditBilling = () => {
         const subscription = getMemberSubscription({member});
-        onAction('editBilling', {subscriptionId: subscription.id});
+        doAction('editBilling', {subscriptionId: subscription.id});
     };
 
     const openUpdatePlan = () => {
         const {is_stripe_configured: isStripeConfigured} = site;
         if (isStripeConfigured) {
-            onAction('switchPage', {
+            doAction('switchPage', {
                 page: 'accountPlan',
                 lastPage: 'accountHome'
             });

--- a/apps/portal/src/components/pages/AccountHomePage/components/SubscribeButton.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/SubscribeButton.js
@@ -4,7 +4,7 @@ import {isSignupAllowed, hasAvailablePrices} from '../../../../utils/helpers';
 import {useContext} from 'react';
 
 const SubscribeButton = () => {
-    const {site, action, brandColor, onAction, t} = useContext(AppContext);
+    const {site, action, brandColor, doAction, t} = useContext(AppContext);
 
     if (!isSignupAllowed({site}) || !hasAvailablePrices({site})) {
         return null;
@@ -12,7 +12,7 @@ const SubscribeButton = () => {
     const isRunning = ['checkoutPlan:running'].includes(action);
 
     const openPlanPage = () => {
-        onAction('switchPage', {
+        doAction('switchPage', {
             page: 'accountPlan',
             lastPage: 'accountHome'
         });

--- a/apps/portal/src/components/pages/AccountPlanPage.js
+++ b/apps/portal/src/components/pages/AccountPlanPage.js
@@ -313,7 +313,7 @@ export default class AccountPlanPage extends React.Component {
     componentDidMount() {
         const {member} = this.context;
         if (!member) {
-            this.context.onAction('switchPage', {
+            this.context.doAction('switchPage', {
                 page: 'signin'
             });
         }
@@ -349,14 +349,14 @@ export default class AccountPlanPage extends React.Component {
 
     handleSignout(e) {
         e.preventDefault();
-        this.context.onAction('signout');
+        this.context.doAction('signout');
     }
 
     onBack() {
         if (this.state.showConfirmation) {
             this.cancelConfirmPage();
         } else {
-            this.context.onAction('back');
+            this.context.doAction('back');
         }
     }
 
@@ -369,7 +369,7 @@ export default class AccountPlanPage extends React.Component {
     }
 
     onPlanCheckout(e, priceId) {
-        const {onAction, member} = this.context;
+        const {doAction, member} = this.context;
         let {confirmationPlan, selectedPlan} = this.state;
         if (priceId) {
             selectedPlan = priceId;
@@ -380,10 +380,10 @@ export default class AccountPlanPage extends React.Component {
             const subscription = getMemberSubscription({member});
             const subscriptionId = subscription ? subscription.id : '';
             if (subscriptionId) {
-                onAction('updateSubscription', {plan: confirmationPlan.name, planId: confirmationPlan.id, subscriptionId, cancelAtPeriodEnd: false});
+                doAction('updateSubscription', {plan: confirmationPlan.name, planId: confirmationPlan.id, subscriptionId, cancelAtPeriodEnd: false});
             }
         } else {
-            onAction('checkoutPlan', {plan: selectedPlan});
+            doAction('checkoutPlan', {plan: selectedPlan});
         }
     }
 
@@ -434,7 +434,7 @@ export default class AccountPlanPage extends React.Component {
         if (!subscription) {
             return null;
         }
-        this.context.onAction('cancelSubscription', {
+        this.context.doAction('cancelSubscription', {
             subscriptionId: subscription.id,
             cancelAtPeriodEnd: true,
             cancellationReason: reason

--- a/apps/portal/src/components/pages/AccountPlanPage.test.js
+++ b/apps/portal/src/components/pages/AccountPlanPage.test.js
@@ -3,7 +3,7 @@ import {render, fireEvent} from '../../utils/test-utils';
 import AccountPlanPage from './AccountPlanPage';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, context, ...utils} = render(
+    const {mockDoActionFn, context, ...utils} = render(
         <AccountPlanPage />,
         {
             overrideContext: {
@@ -20,14 +20,14 @@ const setup = (overrides) => {
         yearlyCheckboxEl,
         continueBtn,
         chooseBtns,
-        mockOnActionFn,
+        mockDoActionFn,
         context,
         ...utils
     };
 };
 
 const customSetup = (overrides) => {
-    const {mockOnActionFn, context, ...utils} = render(
+    const {mockDoActionFn, context, ...utils} = render(
         <AccountPlanPage />,
         {
             overrideContext: {
@@ -37,7 +37,7 @@ const customSetup = (overrides) => {
     );
 
     return {
-        mockOnActionFn,
+        mockDoActionFn,
         context,
         ...utils
     };
@@ -56,7 +56,7 @@ describe('Account Plan Page', () => {
         const siteData = getSiteData({
             products: getProductsData({numOfProducts: 1})
         });
-        const {mockOnActionFn, monthlyCheckboxEl, yearlyCheckboxEl, queryAllByRole} = setup({site: siteData});
+        const {mockDoActionFn, monthlyCheckboxEl, yearlyCheckboxEl, queryAllByRole} = setup({site: siteData});
         const continueBtn = queryAllByRole('button', {name: 'Continue'});
 
         fireEvent.click(monthlyCheckboxEl);
@@ -64,7 +64,7 @@ describe('Account Plan Page', () => {
         fireEvent.click(yearlyCheckboxEl);
         expect(yearlyCheckboxEl.className).toEqual('gh-portal-btn active');
         fireEvent.click(continueBtn[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('checkoutPlan', {plan: siteData.products[0].yearlyPrice.id});
+        expect(mockDoActionFn).toHaveBeenCalledWith('checkoutPlan', {plan: siteData.products[0].yearlyPrice.id});
     });
 
     test('can cancel subscription for member on hidden tier', async () => {

--- a/apps/portal/src/components/pages/AccountProfilePage.js
+++ b/apps/portal/src/components/pages/AccountProfilePage.js
@@ -22,7 +22,7 @@ export default class AccountProfilePage extends React.Component {
     componentDidMount() {
         const {member} = this.context;
         if (!member) {
-            this.context.onAction('switchPage', {
+            this.context.doAction('switchPage', {
                 page: 'signin'
             });
         }
@@ -30,11 +30,11 @@ export default class AccountProfilePage extends React.Component {
 
     handleSignout(e) {
         e.preventDefault();
-        this.context.onAction('signout');
+        this.context.doAction('signout');
     }
 
     onBack() {
-        this.context.onAction('back');
+        this.context.doAction('back');
     }
 
     onProfileSave(e) {
@@ -47,8 +47,8 @@ export default class AccountProfilePage extends React.Component {
             const {email, name, errors} = this.state;
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
             if (!hasFormErrors) {
-                this.context.onAction('clearPopupNotification');
-                this.context.onAction('updateProfile', {email, name});
+                this.context.doAction('clearPopupNotification');
+                this.context.doAction('updateProfile', {email, name});
             }
         });
     }

--- a/apps/portal/src/components/pages/AccountProfilePage.test.js
+++ b/apps/portal/src/components/pages/AccountProfilePage.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '../../utils/test-utils';
 import AccountProfilePage from './AccountProfilePage';
 
 const setup = () => {
-    const {mockOnActionFn, context, ...utils} = render(
+    const {mockDoActionFn, context, ...utils} = render(
         <AccountProfilePage />
     );
     const emailInputEl = utils.getByLabelText(/email/i);
@@ -12,7 +12,7 @@ const setup = () => {
         emailInputEl,
         nameInputEl,
         saveBtn,
-        mockOnActionFn,
+        mockDoActionFn,
         context,
         ...utils
     };
@@ -28,10 +28,10 @@ describe('Account Profile Page', () => {
     });
 
     test('can call save', () => {
-        const {mockOnActionFn, saveBtn, context} = setup();
+        const {mockDoActionFn, saveBtn, context} = setup();
 
         fireEvent.click(saveBtn);
         const {email, name} = context.member;
-        expect(mockOnActionFn).toHaveBeenCalledWith('updateProfile', {email, name});
+        expect(mockDoActionFn).toHaveBeenCalledWith('updateProfile', {email, name});
     });
 });

--- a/apps/portal/src/components/pages/EmailReceivingFAQ.js
+++ b/apps/portal/src/components/pages/EmailReceivingFAQ.js
@@ -6,7 +6,7 @@ import {getDefaultNewsletterSender, getSupportAddress} from '../../utils/helpers
 import Interpolate from '@doist/react-interpolate';
 
 export default function EmailReceivingPage() {
-    const {brandColor, onAction, site, lastPage, member, t, pageData} = useContext(AppContext);
+    const {brandColor, doAction, site, lastPage, member, t, pageData} = useContext(AppContext);
 
     const supportAddressEmail = getSupportAddress({site});
     const supportAddress = `mailto:${supportAddressEmail}`;
@@ -19,9 +19,9 @@ export default function EmailReceivingPage() {
                 {!directAccess &&
                     <BackButton brandColor={brandColor} onClick={() => {
                         if (!lastPage) {
-                            onAction('switchPage', {page: 'accountEmail', lastPage: 'accountHome'});
+                            doAction('switchPage', {page: 'accountEmail', lastPage: 'accountHome'});
                         } else {
-                            onAction('switchPage', {page: 'accountHome'});
+                            doAction('switchPage', {page: 'accountHome'});
                         }
                     }} />
                 }
@@ -40,7 +40,7 @@ export default function EmailReceivingPage() {
                         string={t(`The email address we have for you is {memberEmail} — if that's not correct, you can update it in your <button>account settings area</button>.`)}
                         mapping={{
                             memberEmail: <strong>{member.email}</strong>,
-                            button: <button className="gh-portal-btn-text" onClick={() => onAction('switchPage', {lastPage: 'emailReceivingFAQ', page: 'accountProfile'})}/>
+                            button: <button className="gh-portal-btn-text" onClick={() => doAction('switchPage', {lastPage: 'emailReceivingFAQ', page: 'accountProfile'})}/>
                         }}
                     />
                 </p>

--- a/apps/portal/src/components/pages/EmailSuppressedPage.js
+++ b/apps/portal/src/components/pages/EmailSuppressedPage.js
@@ -7,44 +7,44 @@ import ActionButton from '../../components/common/ActionButton';
 import {ReactComponent as EmailDeliveryFailedIcon} from '../../images/icons/email-delivery-failed.svg';
 
 export default function EmailSuppressedPage() {
-    const {brandColor, lastPage, onAction, action, site, t} = useContext(AppContext);
+    const {brandColor, lastPage, doAction, action, site, t} = useContext(AppContext);
 
     useEffect(() => {
         if (['removeEmailFromSuppressionList:success'].includes(action)) {
-            onAction('refreshMemberData');
+            doAction('refreshMemberData');
         }
 
         if (['removeEmailFromSuppressionList:failed', 'refreshMemberData:failed'].includes(action)) {
-            onAction('back');
+            doAction('back');
         }
 
         if (['refreshMemberData:success'].includes(action)) {
             const showEmailPreferences = hasMultipleNewsletters({site}) || hasCommentsEnabled({site});
             if (showEmailPreferences) {
-                onAction('switchPage', {
+                doAction('switchPage', {
                     page: 'accountEmail',
                     lastPage: 'accountHome'
                 });
-                onAction('showPopupNotification', {
+                doAction('showPopupNotification', {
                     message: t('You have been successfully resubscribed')
                 });
             } else {
-                onAction('back');
+                doAction('back');
             }
         }
-    }, [action, onAction, site, t]);
+    }, [action, doAction, site, t]);
 
     const isRunning = ['removeEmailFromSuppressionList:running', 'refreshMemberData:running'].includes(action);
 
     const handleSubmit = () => {
-        onAction('removeEmailFromSuppressionList');
+        doAction('removeEmailFromSuppressionList');
     };
 
     return (
         <div className="gh-email-suppressed-page">
             <header className='gh-portal-detail-header'>
                 <BackButton brandColor={brandColor} hidden={!lastPage} onClick={() => {
-                    onAction('back');
+                    doAction('back');
                 }} />
                 <CloseButton />
             </header>

--- a/apps/portal/src/components/pages/EmailSuppressedPage.test.js
+++ b/apps/portal/src/components/pages/EmailSuppressedPage.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '../../utils/test-utils';
 import EmailSuppressedPage from './EmailSuppressedPage';
 
 const setup = () => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <EmailSuppressedPage />
     );
     const resubscribeBtn = utils.queryByRole('button', {name: 'Re-enable emails'});
@@ -11,7 +11,7 @@ const setup = () => {
     return {
         resubscribeBtn,
         title,
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };
@@ -24,9 +24,9 @@ describe('Email Suppressed Page', () => {
     });
 
     test('can call resubscribe button', () => {
-        const {mockOnActionFn, resubscribeBtn} = setup();
+        const {mockDoActionFn, resubscribeBtn} = setup();
 
         fireEvent.click(resubscribeBtn);
-        expect(mockOnActionFn).toHaveBeenCalledWith('removeEmailFromSuppressionList');
+        expect(mockDoActionFn).toHaveBeenCalledWith('removeEmailFromSuppressionList');
     });
 });

--- a/apps/portal/src/components/pages/EmailSuppressionFAQ.js
+++ b/apps/portal/src/components/pages/EmailSuppressionFAQ.js
@@ -5,7 +5,7 @@ import CloseButton from '../../components/common/CloseButton';
 import {getSupportAddress} from '../../utils/helpers';
 
 export default function EmailSuppressedPage() {
-    const {brandColor, onAction, site, t, pageData} = useContext(AppContext);
+    const {brandColor, doAction, site, t, pageData} = useContext(AppContext);
 
     const supportAddress = `mailto:${getSupportAddress({site})}`;
     const directAccess = (pageData && pageData.direct) || false;
@@ -15,7 +15,7 @@ export default function EmailSuppressedPage() {
             {!directAccess &&
                 <header className='gh-portal-detail-header'>
                     <BackButton brandColor={brandColor} onClick={() => {
-                        onAction('switchPage', {page: 'emailSuppressed', lastPage: 'accountHome'});
+                        doAction('switchPage', {page: 'emailSuppressed', lastPage: 'accountHome'});
                     }} />
                     <CloseButton />
                 </header>

--- a/apps/portal/src/components/pages/FeedbackPage.js
+++ b/apps/portal/src/components/pages/FeedbackPage.js
@@ -170,7 +170,7 @@ export const FeedbackPageStyles = `
 `;
 
 function ErrorPage({error}) {
-    const {onAction, t} = useContext(AppContext);
+    const {doAction, t} = useContext(AppContext);
 
     return (
         <div className='gh-portal-content gh-portal-feedback with-footer'>
@@ -185,7 +185,7 @@ function ErrorPage({error}) {
             <ActionButton
                 style={{width: '100%'}}
                 retry={false}
-                onClick = {() => onAction('closePopup')}
+                onClick = {() => doAction('closePopup')}
                 disabled={false}
                 brandColor='#000000'
                 label={t('Close')}
@@ -198,7 +198,7 @@ function ErrorPage({error}) {
 }
 
 const ConfirmDialog = ({onConfirm, loading, initialScore}) => {
-    const {onAction, brandColor, t} = useContext(AppContext);
+    const {doAction, brandColor, t} = useContext(AppContext);
     const [score, setScore] = useState(initialScore);
 
     const stopPropagation = (event) => {
@@ -206,7 +206,7 @@ const ConfirmDialog = ({onConfirm, loading, initialScore}) => {
     };
 
     const close = () => {
-        onAction('closePopup');
+        doAction('closePopup');
     };
 
     const submit = async (event) => {
@@ -276,7 +276,7 @@ const LoadingFeedbackView = ({action, score}) => {
 };
 
 const ConfirmFeedback = ({positive}) => {
-    const {onAction, brandColor, t} = useContext(AppContext);
+    const {doAction, brandColor, t} = useContext(AppContext);
 
     const icon = positive ? <ThumbUpIcon /> : <ThumbDownIcon />;
 
@@ -292,7 +292,7 @@ const ConfirmFeedback = ({positive}) => {
             <ActionButton
                 style={{width: '100%'}}
                 retry={false}
-                onClick = {() => onAction('closePopup')}
+                onClick = {() => doAction('closePopup')}
                 disabled={false}
                 brandColor={brandColor}
                 label={t('Close')}

--- a/apps/portal/src/components/pages/FeedbackPage.test.js
+++ b/apps/portal/src/components/pages/FeedbackPage.test.js
@@ -3,7 +3,7 @@ import {render} from '../../utils/test-utils';
 import FeedbackPage from './FeedbackPage';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <FeedbackPage />,
         {
             overrideContext: {
@@ -12,7 +12,7 @@ const setup = (overrides) => {
         }
     );
     return {
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -65,18 +65,18 @@ export default class MagicLinkPage extends React.Component {
     getTranslatedDescription({lastPage, otcRef, submittedEmailOrInbox}) {
         const descriptionConfig = this.getDescriptionConfig(submittedEmailOrInbox);
         const normalizedPage = (lastPage === 'signup' || lastPage === 'signin') ? lastPage : 'signin';
-        
+
         if (normalizedPage === 'signup') {
             return descriptionConfig.signup;
         }
-        
+
         return otcRef ? descriptionConfig.signin.withOTC : descriptionConfig.signin.withoutOTC;
     }
 
     renderFormHeader() {
         const {t, otcRef, pageData, lastPage} = this.context;
         const submittedEmailOrInbox = pageData?.email ? pageData.email : t('your inbox');
-        
+
         const popupTitle = t(`Now check your email!`);
         const popupDescription = this.getTranslatedDescription({
             lastPage,
@@ -102,7 +102,7 @@ export default class MagicLinkPage extends React.Component {
             <>
                 <div
                     style={{color: '#1d1d1d', fontWeight: 'bold', cursor: 'pointer'}}
-                    onClick={() => this.context.onAction('switchPage', {page: 'signin'})}
+                    onClick={() => this.context.doAction('switchPage', {page: 'signin'})}
                 >
                     {t('Back to Log in')}
                 </div>
@@ -111,7 +111,7 @@ export default class MagicLinkPage extends React.Component {
     }
 
     handleClose() {
-        this.context.onAction('closePopup');
+        this.context.doAction('closePopup');
     }
 
     renderCloseButton() {
@@ -153,7 +153,7 @@ export default class MagicLinkPage extends React.Component {
             const {redirect} = this.context.pageData ?? {};
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
             if (!hasFormErrors && otcRef) {
-                this.context.onAction('verifyOTC', {otc, otcRef, redirect});
+                this.context.doAction('verifyOTC', {otc, otcRef, redirect});
             }
         }
         );

--- a/apps/portal/src/components/pages/MagicLinkPage.test.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.test.js
@@ -12,7 +12,7 @@ const setupTest = (options = {}) => {
         ...contextOverrides
     } = options;
 
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <MagicLinkPage />,
         {
             overrideContext: {
@@ -25,7 +25,7 @@ const setupTest = (options = {}) => {
     );
 
     return {
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };
@@ -67,12 +67,12 @@ describe('MagicLinkPage', () => {
         });
 
         test('calls close popup action when close button clicked', () => {
-            const {getByRole, mockOnActionFn} = setupTest();
+            const {getByRole, mockDoActionFn} = setupTest();
             const closeBtn = getByRole('button', {name: 'Close'});
 
             fireEvent.click(closeBtn);
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('closePopup');
+            expect(mockDoActionFn).toHaveBeenCalledWith('closePopup');
         });
     });
 
@@ -179,20 +179,20 @@ describe('MagicLinkPage', () => {
         });
 
         test('validation blocks submission and allows valid submission', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest();
+            const {mockDoActionFn, ...testUtils} = setupOTCTest();
             const submitButton = testUtils.getByRole('button', {name: 'Continue'});
             const otcInput = testUtils.getByLabelText(OTC_LABEL_REGEX);
 
             // empty submission should be blocked
             fireEvent.click(submitButton);
 
-            expect(mockOnActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
+            expect(mockDoActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
 
             // valid submission should proceed
             fireEvent.change(otcInput, {target: {value: '123456'}});
             fireEvent.click(submitButton);
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                 otc: '123456',
                 otcRef: 'test-otc-ref'
             });
@@ -221,36 +221,36 @@ describe('MagicLinkPage', () => {
 
     describe('OTC form submission', () => {
         test('submits via button click', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest();
+            const {mockDoActionFn, ...testUtils} = setupOTCTest();
 
             fillAndSubmitOTC(testUtils, '123456', 'button');
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                 otc: '123456',
                 otcRef: 'test-otc-ref'
             });
         });
 
         test('submits via Enter key', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest();
+            const {mockDoActionFn, ...testUtils} = setupOTCTest();
 
             fillAndSubmitOTC(testUtils, '654321', 'enter');
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                 otc: '654321',
                 otcRef: 'test-otc-ref'
             });
         });
 
         test('handles different valid OTC formats', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest();
+            const {mockDoActionFn, ...testUtils} = setupOTCTest();
             const testCodes = ['000000', '123456', '999999'];
 
             testCodes.forEach((code) => {
-                mockOnActionFn.mockClear();
+                mockDoActionFn.mockClear();
                 fillAndSubmitOTC(testUtils, code);
 
-                expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+                expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                     otc: code,
                     otcRef: 'test-otc-ref'
                 });
@@ -285,22 +285,22 @@ describe('MagicLinkPage', () => {
         });
 
         test('button click is blocked during loading state', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest({action: 'verifyOTC:running'});
+            const {mockDoActionFn, ...testUtils} = setupOTCTest({action: 'verifyOTC:running'});
             const loadingButton = testUtils.getByRole('button');
             const otcInput = testUtils.getByLabelText(OTC_LABEL_REGEX);
 
             fireEvent.change(otcInput, {target: {value: '123456'}});
             fireEvent.click(loadingButton);
 
-            expect(mockOnActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
+            expect(mockDoActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
         });
 
         test('Enter key submission is blocked during loading state', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest({action: 'verifyOTC:running'});
+            const {mockDoActionFn, ...testUtils} = setupOTCTest({action: 'verifyOTC:running'});
 
             fillAndSubmitOTC(testUtils, '123456', 'enter');
 
-            expect(mockOnActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
+            expect(mockDoActionFn).not.toHaveBeenCalledWith('verifyOTC', expect.anything());
         });
 
         test('validation works during error state', () => {
@@ -326,7 +326,7 @@ describe('MagicLinkPage', () => {
         });
 
         test('supports multiple submission attempts with different values', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest();
+            const {mockDoActionFn, ...testUtils} = setupOTCTest();
             const otcInput = testUtils.getByLabelText(OTC_LABEL_REGEX);
             const submitButton = testUtils.getByRole('button', {name: 'Continue'});
 
@@ -336,12 +336,12 @@ describe('MagicLinkPage', () => {
             fireEvent.change(otcInput, {target: {value: '222222'}});
             fireEvent.click(submitButton);
 
-            expect(mockOnActionFn).toHaveBeenCalledTimes(2);
-            expect(mockOnActionFn).toHaveBeenNthCalledWith(1, 'verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledTimes(2);
+            expect(mockDoActionFn).toHaveBeenNthCalledWith(1, 'verifyOTC', {
                 otc: '111111',
                 otcRef: 'test-otc-ref'
             });
-            expect(mockOnActionFn).toHaveBeenNthCalledWith(2, 'verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenNthCalledWith(2, 'verifyOTC', {
                 otc: '222222',
                 otcRef: 'test-otc-ref'
             });
@@ -350,13 +350,13 @@ describe('MagicLinkPage', () => {
 
     describe('redirect parameter handling', () => {
         test('passes redirect parameter from pageData to verifyOTC action', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest({
+            const {mockDoActionFn, ...testUtils} = setupOTCTest({
                 pageData: {redirect: 'https://example.com/custom-redirect'}
             });
 
             fillAndSubmitOTC(testUtils, '123456');
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                 otc: '123456',
                 otcRef: 'test-otc-ref',
                 redirect: 'https://example.com/custom-redirect'
@@ -364,13 +364,13 @@ describe('MagicLinkPage', () => {
         });
 
         test('verifyOTC action works without redirect parameter', () => {
-            const {mockOnActionFn, ...testUtils} = setupOTCTest({
+            const {mockDoActionFn, ...testUtils} = setupOTCTest({
                 pageData: {} // no redirect
             });
 
             fillAndSubmitOTC(testUtils, '123456');
 
-            expect(mockOnActionFn).toHaveBeenCalledWith('verifyOTC', {
+            expect(mockDoActionFn).toHaveBeenCalledWith('verifyOTC', {
                 otc: '123456',
                 otcRef: 'test-otc-ref',
                 redirect: undefined

--- a/apps/portal/src/components/pages/NewsletterSelectionPage.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.js
@@ -64,7 +64,7 @@ function NewsletterPrefs({subscribedNewsletters, setSubscribedNewsletters}) {
 }
 
 export default function NewsletterSelectionPage({pageData, onBack}) {
-    const {brandColor, site, onAction, action, t} = useContext(AppContext);
+    const {brandColor, site, doAction, action, t} = useContext(AppContext);
     const siteNewsletters = getSiteNewsletters({site});
     const defaultNewsletters = siteNewsletters.filter((d) => {
         return d.subscribe_on_signup;
@@ -111,7 +111,7 @@ export default function NewsletterSelectionPage({pageData, onBack}) {
                                     };
                                 });
                                 const {name, email, plan, phonenumber, offerId} = pageData;
-                                onAction('signup', {name, email, plan, phonenumber, newsletters, offerId});
+                                doAction('signup', {name, email, plan, phonenumber, newsletters, offerId});
                             }}
                             brandColor={brandColor}
                             label={label}

--- a/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
@@ -26,7 +26,7 @@ const mockNewsletters = [
 ];
 
 const setup = () => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <NewsletterSelectionPage
             pageData={{
                 name: 'Test User',
@@ -48,7 +48,7 @@ const setup = () => {
     return {
         title,
         continueBtn,
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };
@@ -80,12 +80,12 @@ describe('NewsletterSelectionPage', () => {
         expect(lockIcon).toBeInTheDocument();
     });
 
-    test('calls onAction with signup data when continue is clicked', async () => {
-        const {continueBtn, mockOnActionFn} = setup();
+    test('calls doAction with signup data when continue is clicked', async () => {
+        const {continueBtn, mockDoActionFn} = setup();
 
         fireEvent.click(continueBtn);
 
-        expect(mockOnActionFn).toHaveBeenCalledWith('signup', {
+        expect(mockDoActionFn).toHaveBeenCalledWith('signup', {
             name: 'Test User',
             email: 'test@example.com',
             plan: 'free',
@@ -96,7 +96,7 @@ describe('NewsletterSelectionPage', () => {
     });
 
     test('allows selecting multiple free newsletters', async () => {
-        const {getAllByTestId, continueBtn, mockOnActionFn} = setup();
+        const {getAllByTestId, continueBtn, mockDoActionFn} = setup();
 
         // Find and click the switch for the additional free newsletter
         const switches = getAllByTestId('switch-input');
@@ -106,7 +106,7 @@ describe('NewsletterSelectionPage', () => {
         fireEvent.click(continueBtn);
 
         // Verify both newsletters are included
-        expect(mockOnActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
+        expect(mockDoActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
             newsletters: expect.arrayContaining([
                 {name: 'Free Newsletter', id: '1'},
                 {name: 'Another Free Newsletter', id: '3'}
@@ -115,7 +115,7 @@ describe('NewsletterSelectionPage', () => {
     });
 
     test('allows deselecting default newsletter', async () => {
-        const {getAllByTestId, continueBtn, mockOnActionFn} = setup();
+        const {getAllByTestId, continueBtn, mockDoActionFn} = setup();
 
         // Find and click the switch for the default newsletter
         const switches = getAllByTestId('switch-input');
@@ -125,7 +125,7 @@ describe('NewsletterSelectionPage', () => {
         fireEvent.click(continueBtn);
 
         // Verify no newsletters are included
-        expect(mockOnActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
+        expect(mockDoActionFn).toHaveBeenCalledWith('signup', expect.objectContaining({
             newsletters: []
         }));
     });

--- a/apps/portal/src/components/pages/OfferPage.js
+++ b/apps/portal/src/components/pages/OfferPage.js
@@ -284,7 +284,7 @@ export default class OfferPage extends React.Component {
                 errors: this.getFormErrors(state)
             };
         }, () => {
-            const {onAction} = this.context;
+            const {doAction} = this.context;
             const {name, email, phonenumber, errors} = this.state;
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
             if (!hasFormErrors) {
@@ -302,7 +302,7 @@ export default class OfferPage extends React.Component {
                         errors: {}
                     });
                 } else {
-                    onAction('signup', signupData);
+                    doAction('signup', signupData);
                     this.setState({
                         errors: {}
                     });
@@ -416,14 +416,14 @@ export default class OfferPage extends React.Component {
         if (member) {
             return null;
         }
-        const {brandColor, onAction, t} = this.context;
+        const {brandColor, doAction, t} = this.context;
         return (
             <div className='gh-portal-signup-message'>
                 <div>{t('Already a member?')}</div>
                 <button
                     className='gh-portal-btn gh-portal-btn-link'
                     style={{color: brandColor}}
-                    onClick={() => onAction('switchPage', {page: 'signin'})}
+                    onClick={() => doAction('switchPage', {page: 'signin'})}
                 >
                     <span>{t('Sign in')}</span>
                 </button>

--- a/apps/portal/src/components/pages/RecommendationsPage.js
+++ b/apps/portal/src/components/pages/RecommendationsPage.js
@@ -186,7 +186,7 @@ const openTab = (url) => {
 };
 
 const RecommendationItem = (recommendation) => {
-    const {t, onAction, member, site} = useContext(AppContext);
+    const {t, doAction, member, site} = useContext(AppContext);
     const {title, url, description, favicon, one_click_subscribe: oneClickSubscribe, featured_image: featuredImage} = recommendation;
     const allowOneClickSubscribe = member && oneClickSubscribe;
     const [subscribed, setSubscribed] = useState(false);
@@ -217,7 +217,7 @@ const RecommendationItem = (recommendation) => {
         openTab(refUrl);
 
         if (!clicked) {
-            onAction('trackRecommendationClicked', {recommendationId: recommendation.id});
+            doAction('trackRecommendationClicked', {recommendationId: recommendation.id});
             setClicked(true);
         }
     }, [refUrl, recommendation.id, clicked]);
@@ -225,11 +225,11 @@ const RecommendationItem = (recommendation) => {
     const oneClickSubscribeHandler = useCallback(async () => {
         try {
             setLoading(true);
-            await onAction('oneClickSubscribe', {
+            await doAction('oneClickSubscribe', {
                 siteUrl: url,
                 throwErrors: true
             });
-            onAction('trackRecommendationSubscribed', {recommendationId: recommendation.id});
+            doAction('trackRecommendationSubscribed', {recommendationId: recommendation.id});
             setSubscribed(true);
         } catch (_) {
             // Open portal signup page
@@ -239,7 +239,7 @@ const RecommendationItem = (recommendation) => {
             openTab(signupUrl);
 
             if (!clicked) {
-                onAction('trackRecommendationClicked', {recommendationId: recommendation.id});
+                doAction('trackRecommendationClicked', {recommendationId: recommendation.id});
                 setClicked(true);
             }
         }
@@ -279,7 +279,7 @@ const RecommendationItem = (recommendation) => {
 };
 
 const RecommendationsPage = () => {
-    const {api, site, pageData, t, onAction} = useContext(AppContext);
+    const {api, site, pageData, t, doAction} = useContext(AppContext);
     const {title, icon} = site;
     const {recommendations_enabled: recommendationsEnabled = false} = site;
     const [recommendations, setRecommendations] = useState(null);
@@ -324,12 +324,12 @@ const RecommendationsPage = () => {
 
     const heading = pageData && pageData.signup ? t('Welcome to {siteTitle}', {siteTitle: title, interpolation: {escapeValue: false}}) : t('Recommendations');
 
-    /* Possible cases: 
+    /* Possible cases:
     - no recommendations found - subhead says no recommendations are available.
     - recommendations found - show generic message
     - recommendations found and user just signed up - show specific message
     */
-   
+
     let subheading;
     if (recommendationsEnabled && recommendations && recommendations.length > 0) {
         if (pageData && pageData.signup) {
@@ -363,7 +363,7 @@ const RecommendationsPage = () => {
                         <span>{t('Show all')}</span>
                     </button>}
                     {(pageData && pageData.signup) && <button className='gh-portal-btn gh-portal-center gh-portal-btn-link gh-portal-btn-recommendations-later' style={{width: '100%'}} onClick={showAllRecommendations}>
-                        <span onClick={() => onAction('closePopup')}>{t('Maybe later')}</span>
+                        <span onClick={() => doAction('closePopup')}>{t('Maybe later')}</span>
                     </button>}
                 </footer>
             )}

--- a/apps/portal/src/components/pages/SigninPage.js
+++ b/apps/portal/src/components/pages/SigninPage.js
@@ -22,7 +22,7 @@ export default class SigninPage extends React.Component {
     componentDidMount() {
         const {member} = this.context;
         if (member) {
-            this.context.onAction('switchPage', {
+            this.context.doAction('switchPage', {
                 page: 'accountHome'
             });
         }
@@ -43,7 +43,7 @@ export default class SigninPage extends React.Component {
             const {redirect} = this.context.pageData ?? {};
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
             if (!hasFormErrors) {
-                this.context.onAction('signin', {email, phonenumber, redirect, token});
+                this.context.doAction('signin', {email, phonenumber, redirect, token});
             }
         });
     }
@@ -126,7 +126,7 @@ export default class SigninPage extends React.Component {
                     data-test-button='signup-switch'
                     className='gh-portal-btn gh-portal-btn-link'
                     style={{color: brandColor}}
-                    onClick={() => this.context.onAction('switchPage', {page: 'signup'})}
+                    onClick={() => this.context.doAction('switchPage', {page: 'signup'})}
                 >
                     <span>{t('Sign up')}</span>
                 </button>

--- a/apps/portal/src/components/pages/SigninPage.test.js
+++ b/apps/portal/src/components/pages/SigninPage.test.js
@@ -3,7 +3,7 @@ import SigninPage from './SigninPage';
 import {getSiteData} from '../../utils/fixtures-generator';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <SigninPage />,
         {
             overrideContext: {
@@ -29,7 +29,7 @@ const setup = (overrides) => {
         emailInput,
         submitButton,
         signupButton,
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };
@@ -44,20 +44,20 @@ describe('SigninPage', () => {
     });
 
     test('can call signin action with email', () => {
-        const {emailInput, submitButton, mockOnActionFn} = setup();
+        const {emailInput, submitButton, mockDoActionFn} = setup();
 
         fireEvent.change(emailInput, {target: {value: 'member@example.com'}});
         expect(emailInput).toHaveValue('member@example.com');
 
         fireEvent.click(submitButton);
-        expect(mockOnActionFn).toHaveBeenCalledWith('signin', {email: 'member@example.com'});
+        expect(mockDoActionFn).toHaveBeenCalledWith('signin', {email: 'member@example.com'});
     });
 
     test('can call swithPage for signup', () => {
-        const {signupButton, mockOnActionFn} = setup();
+        const {signupButton, mockDoActionFn} = setup();
 
         fireEvent.click(signupButton);
-        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signup'});
+        expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {page: 'signup'});
     });
 
     describe('when members are disabled', () => {

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -361,7 +361,7 @@ class SignupPage extends React.Component {
     componentDidMount() {
         const {member} = this.context;
         if (member) {
-            this.context.onAction('switchPage', {
+            this.context.doAction('switchPage', {
                 page: 'accountHome'
             });
         }
@@ -406,7 +406,7 @@ class SignupPage extends React.Component {
                 errors: this.getFormErrors(state)
             };
         }, () => {
-            const {site, onAction} = this.context;
+            const {site, doAction} = this.context;
             const {name, email, plan, phonenumber, token, errors} = this.state;
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
 
@@ -430,7 +430,7 @@ class SignupPage extends React.Component {
                     this.setState({
                         errors: {}
                     });
-                    onAction('signup', {name, email, phonenumber, plan, token});
+                    doAction('signup', {name, email, phonenumber, plan, token});
                 }
             }
         });
@@ -662,7 +662,7 @@ class SignupPage extends React.Component {
     }
 
     renderLoginMessage() {
-        const {brandColor, onAction, t} = this.context;
+        const {brandColor, doAction, t} = this.context;
         return (
             <div>
                 {this.renderFreeTrialMessage()}
@@ -673,7 +673,7 @@ class SignupPage extends React.Component {
                         data-testid='signin-switch'
                         className='gh-portal-btn gh-portal-btn-link'
                         style={{color: brandColor}}
-                        onClick={() => onAction('switchPage', {page: 'signin'})}
+                        onClick={() => doAction('switchPage', {page: 'signin'})}
                     >
                         <span>{t('Sign in')}</span>
                     </button>
@@ -884,7 +884,7 @@ class SignupPage extends React.Component {
                                     showNewsletterSelection: false
                                 });
                             } else {
-                                this.context.onAction('closePopup');
+                                this.context.doAction('closePopup');
                             }
                         }}
                     />

--- a/apps/portal/src/components/pages/SignupPage.test.js
+++ b/apps/portal/src/components/pages/SignupPage.test.js
@@ -3,7 +3,7 @@ import {render, fireEvent, getByTestId, queryByTestId} from '../../utils/test-ut
 import SignupPage from './SignupPage';
 
 const setup = (overrides) => {
-    const {mockOnActionFn, ...utils} = render(
+    const {mockDoActionFn, ...utils} = render(
         <SignupPage />,
         {
             overrideContext: {
@@ -38,7 +38,7 @@ const setup = (overrides) => {
         chooseButton,
         signinButton,
         freeTrialMessage,
-        mockOnActionFn,
+        mockDoActionFn,
         ...utils
     };
 };
@@ -55,7 +55,7 @@ describe('SignupPage', () => {
     });
 
     test('can call signup action with name, email and plan', () => {
-        const {nameInput, emailInput, chooseButton, mockOnActionFn} = setup();
+        const {nameInput, emailInput, chooseButton, mockDoActionFn} = setup();
         const nameVal = 'J Smith';
         const emailVal = 'jsmith@example.com';
         const planVal = 'free';
@@ -66,14 +66,14 @@ describe('SignupPage', () => {
         expect(emailInput).toHaveValue(emailVal);
 
         fireEvent.click(chooseButton[0]);
-        expect(mockOnActionFn).toHaveBeenCalledWith('signup', {email: emailVal, name: nameVal, plan: planVal});
+        expect(mockDoActionFn).toHaveBeenCalledWith('signup', {email: emailVal, name: nameVal, plan: planVal});
     });
 
     test('can call swithPage for signin', () => {
-        const {signinButton, mockOnActionFn} = setup();
+        const {signinButton, mockDoActionFn} = setup();
 
         fireEvent.click(signinButton);
-        expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
+        expect(mockDoActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
     });
 
     test('renders free trial message', () => {

--- a/apps/portal/src/components/pages/SupportError.js
+++ b/apps/portal/src/components/pages/SupportError.js
@@ -25,7 +25,7 @@ export const TipsAndDonationsErrorStyle = `
 `;
 
 const SupportError = ({error}) => {
-    const {onAction, t} = useContext(AppContext);
+    const {doAction, t} = useContext(AppContext);
     const errorTitle = t('Sorry, that didn’t work.');
     const errorMessage = error || t('There was an error processing your payment. Please try again.');
     const buttonLabel = t('Close');
@@ -46,7 +46,7 @@ const SupportError = ({error}) => {
             <ActionButton
                 style={{width: '100%'}}
                 retry={true}
-                onClick = {() => onAction('closePopup')}
+                onClick = {() => doAction('closePopup')}
                 disabled={false}
                 brandColor='#000000'
                 label={buttonLabel}

--- a/apps/portal/src/components/pages/SupportSuccess.js
+++ b/apps/portal/src/components/pages/SupportSuccess.js
@@ -33,7 +33,7 @@ export const TipsAndDonationsSuccessStyle = `
 `;
 
 const SupportSuccess = () => {
-    const {onAction, brandColor, site, t} = useContext(AppContext);
+    const {doAction, brandColor, site, t} = useContext(AppContext);
     const successTitle = t('Thank you for your support');
     const successDescription = t('To continue to stay up to date, subscribe to {publication} below.', {publication: site?.title});
     const buttonLabel = t('Sign up');
@@ -51,7 +51,7 @@ const SupportSuccess = () => {
             <ActionButton
                 style={{width: '100%'}}
                 retry={false}
-                onClick = {() => onAction('switchPage', {page: 'signup'})}
+                onClick = {() => doAction('switchPage', {page: 'signup'})}
                 disabled={false}
                 brandColor={brandColor}
                 label={buttonLabel}
@@ -67,7 +67,7 @@ const SupportSuccess = () => {
                     data-testid='signin-switch'
                     className='gh-portal-btn gh-portal-btn-link'
                     style={{color: brandColor}}
-                    onClick={() => onAction('switchPage', {page: 'signin'})}
+                    onClick={() => doAction('switchPage', {page: 'signin'})}
                 >
                     <span>{t('Sign in')}</span>
                 </button>

--- a/apps/portal/src/components/pages/UnsubscribePage.js
+++ b/apps/portal/src/components/pages/UnsubscribePage.js
@@ -42,7 +42,7 @@ async function updateMemberNewsletters({api, memberUuid, key, newsletters, enabl
 // NOTE: This modal is available even if not logged in, but because it's possible to also be logged in while making modifications,
 //  we need to update the member data in the context if logged in.
 export default function UnsubscribePage() {
-    const {site, api, pageData, member: loggedInMember, onAction, t} = useContext(AppContext);
+    const {site, api, pageData, member: loggedInMember, doAction, t} = useContext(AppContext);
     // member is the member data fetched from the API based on the uuid and its state is limited to just this modal, not all of Portal
     const [member, setMember] = useState();
     const [loading, setLoading] = useState(true);
@@ -60,7 +60,7 @@ export default function UnsubscribePage() {
 
     const updateNewsletters = async (newsletters) => {
         if (loggedInMember) {
-            onAction('updateNewsletterPreference', {newsletters});
+            doAction('updateNewsletterPreference', {newsletters});
         } else {
             await updateMemberNewsletters({api, memberUuid: pageData.uuid, key: pageData.key, newsletters});
         }
@@ -69,20 +69,20 @@ export default function UnsubscribePage() {
             action: `updated:success`,
             message: t('Email preferences updated.')
         };
-        onAction('showPopupNotification', notification);
+        doAction('showPopupNotification', notification);
     };
 
     const updateCommentNotifications = async (enabled) => {
         let updatedData;
         if (loggedInMember) {
             // when we have a member logged in, we need to update the newsletters in the context
-            await onAction('updateNewsletterPreference', {enableCommentNotifications: enabled});
+            await doAction('updateNewsletterPreference', {enableCommentNotifications: enabled});
             updatedData = {...loggedInMember, enable_comment_notifications: enabled};
         } else {
             updatedData = await updateMemberNewsletters({api, memberUuid: pageData.uuid, key: pageData.key, enableCommentNotifications: enabled});
         }
         setMember(updatedData);
-        onAction('showPopupNotification', {
+        doAction('showPopupNotification', {
             action: 'updated:success',
             message: t('Comment preferences updated.')
         });
@@ -91,7 +91,7 @@ export default function UnsubscribePage() {
     const unsubscribeAll = async () => {
         let updatedMember;
         if (loggedInMember) {
-            await onAction('updateNewsletterPreference', {newsletters: [], enableCommentNotifications: false});
+            await doAction('updateNewsletterPreference', {newsletters: [], enableCommentNotifications: false});
             updatedMember = {...loggedInMember};
             updatedMember.newsletters = [];
             updatedMember.enable_comment_notifications = false;
@@ -100,7 +100,7 @@ export default function UnsubscribePage() {
         }
         setSubscribedNewsletters([]);
         setMember(updatedMember);
-        onAction('showPopupNotification', {
+        doAction('showPopupNotification', {
             action: 'updated:success',
             message: t(`Unsubscribed from all emails.`)
         });
@@ -165,7 +165,7 @@ export default function UnsubscribePage() {
                 <ActionButton
                     style={{width: '100%'}}
                     retry={false}
-                    onClick = {() => onAction('closePopup')}
+                    onClick = {() => doAction('closePopup')}
                     disabled={false}
                     brandColor='#000000'
                     label={t('Close')}

--- a/apps/portal/src/utils/test-utils.js
+++ b/apps/portal/src/utils/test-utils.js
@@ -16,7 +16,7 @@ const setupProvider = (context) => {
 };
 
 const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
-    const mockOnActionFn = jest.fn().mockResolvedValue(undefined);
+    const mockDoActionFn = jest.fn().mockResolvedValue(undefined);
 
     // Hardcode the locale to 'en' for testing
     const {t} = require('@tryghost/i18n')('en');
@@ -27,7 +27,7 @@ const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
         action: 'init:success',
         brandColor: testSite.accent_color,
         page: 'signup',
-        onAction: mockOnActionFn,
+        doAction: mockDoActionFn,
         t,
         ...overrideContext
     };
@@ -35,17 +35,17 @@ const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
     return {
         ...utils,
         context,
-        mockOnActionFn
+        mockDoActionFn
     };
 };
 
 export const appRender = (ui, {options = {}} = {}) => {
-    const mockOnActionFn = jest.fn();
+    const mockDoActionFn = jest.fn();
 
     const utils = render(ui, options);
     return {
         ...utils,
-        mockOnActionFn
+        mockDoActionFn
     };
 };
 


### PR DESCRIPTION
no issue

- `onAction` naming was confusing as it sounds like an event handler function rather than something that triggers an action itself
- renamed to `doAction` to better represent it's use-case