### PR TITLE
Added Sender header to prevent Outlook from adding "on behalf of" text

### DIFF
--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -67,7 +67,8 @@ module.exports = class MailgunClient {
                 subject: messageContent.subject,
                 html: messageContent.html,
                 text: messageContent.plaintext,
-                'recipient-variables': JSON.stringify(recipientData)
+                'recipient-variables': JSON.stringify(recipientData),
+                'h:Sender': message.from
             };
 
             // Do we have a custom List-Unsubscribe header set?
@@ -348,9 +349,9 @@ module.exports = class MailgunClient {
     /**
      * Returns the configured target delivery window in seconds
      * Ghost will attempt to deliver emails evenly distributed over this window
-     * 
+     *
      * Defaults to 0 (no delay) if not set
-     * 
+     *
      * @returns {number}
      */
     getTargetDeliveryWindow() {

--- a/ghost/core/core/server/services/mail/GhostMailer.js
+++ b/ghost/core/core/server/services/mail/GhostMailer.js
@@ -68,7 +68,10 @@ function createMessage(message) {
         ...message,
         ...addresses,
         generateTextFromHTML,
-        encoding
+        encoding,
+        headers: {
+            Sender: addresses.from
+        }
     };
 }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -1829,6 +1829,9 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost's Test Site\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": false,
+  "headers": Object {
+    "Sender": "\\"Ghost's Test Site\\" <noreply@127.0.0.1>",
+  },
   "replyTo": null,
   "subject": "🙌 Complete your sign up to Ghost's Test Site!",
   "to": "member_getting_confirmation@test.com",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -2089,6 +2089,9 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost\\" <noreply@sendingdomain.com>",
   "generateTextFromHTML": false,
+  "headers": Object {
+    "Sender": "\\"Ghost\\" <noreply@sendingdomain.com>",
+  },
   "replyTo": null,
   "subject": "Verify email address",
   "to": "hello@acme.com",
@@ -3289,6 +3292,9 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost\\" <default@email.com>",
   "generateTextFromHTML": false,
+  "headers": Object {
+    "Sender": "\\"Ghost\\" <default@email.com>",
+  },
   "replyTo": null,
   "subject": "Verify email address",
   "to": "hello@acme.com",

--- a/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
+++ b/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
@@ -238,6 +238,9 @@ Object {
   "encoding": "base64",
   "from": "\\"Ghost\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "headers": Object {
+    "Sender": "\\"Ghost\\" <noreply@127.0.0.1>",
+  },
   "replyTo": null,
   "subject": "👍 New recommendation: Other Ghost Site",
   "to": "jbloggs@example.com",
@@ -706,6 +709,9 @@ Object {
   "encoding": "base64",
   "from": "\\"Ghost\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "headers": Object {
+    "Sender": "\\"Ghost\\" <noreply@127.0.0.1>",
+  },
   "replyTo": null,
   "subject": "👍 New recommendation: Other Ghost Site",
   "to": "jbloggs@example.com",

--- a/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
@@ -249,6 +249,9 @@ Object {
   "encoding": "base64",
   "from": "\\"a test blog\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "headers": Object {
+    "Sender": "\\"a test blog\\" <noreply@127.0.0.1>",
+  },
   "replyTo": null,
   "subject": "Your New Ghost Site",
   "to": "test@example.com",
@@ -535,6 +538,9 @@ Object {
   "encoding": "base64",
   "from": "\\"a test blog\\" <noreply@127.0.0.1>",
   "generateTextFromHTML": true,
+  "headers": Object {
+    "Sender": "\\"a test blog\\" <noreply@127.0.0.1>",
+  },
   "replyTo": null,
   "subject": "Your New Ghost Site",
   "to": "test@example.com",

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -192,6 +192,9 @@ Object {
   "forceTextContent": true,
   "from": "\\"Ghost at 127.0.0.1\\" <noreply@example.com>",
   "generateTextFromHTML": false,
+  "headers": Object {
+    "Sender": "\\"Ghost at 127.0.0.1\\" <noreply@example.com>",
+  },
   "replyTo": null,
   "subject": "Verify email address",
   "to": "support@example.com",


### PR DESCRIPTION
ref [BAE-552](https://linear.app/ghost/issue/BAE-552/adjust-on-behalf-of-and-via-that-displays-in-some-mail-clients)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `Sender` header to all outgoing emails (transactional and Mailgun bulk) and updates tests accordingly.
> 
> - **Email sending**:
>   - `core/server/services/mail/GhostMailer.js`: include `headers: { Sender: <from> }` on transactional messages.
>   - `core/server/services/lib/MailgunClient.js`: add Mailgun header `h:Sender` set to `message.from` in bulk payload.
> - **Tests**:
>   - Update snapshots to expect the new `Sender`/`h:Sender` headers in email metadata across members, newsletters, recommendations, authentication, and settings verification flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f94831f2d9e210174c3b7d96d209b54ce8209d19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->