### PR TITLE
🐛 Fixed settings changes not reflected in Billing App

### DIFF
--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -92,6 +92,13 @@ export default class BillingService extends Service {
         }
     }
 
+    sendUpdateLimits() {
+        // Send Billing app message to fetch fresh limit usage
+        this.getBillingIframe().contentWindow.postMessage({
+            query: 'limitUpdate'
+        }, '*');
+    }
+
     // Controls billing window modal visibility and sync of the URL visible in browser
     // and the URL opened on the iframe. It is responsible to non user triggered iframe opening,
     // for example: by entering "/pro" route in the URL or using history navigation (back and forward)
@@ -126,6 +133,7 @@ export default class BillingService extends Service {
         window.location.hash = childRoute || '/pro';
 
         this.sendRouteUpdate();
+        this.sendUpdateLimits();
 
         this.router.transitionTo(childRoute || '/pro');
     }


### PR DESCRIPTION
ref [BAE-544](https://linear.app/ghost/issue/BAE-544/settings-changes-not-reflected-in-billing-app)

When users changed settings in Ghost Admin (like disabling Stripe), the Billing App didn't reflect these changes immediately. This caused errors when attempting actions that depended on the current settings state, such as downgrading from Publisher to Starter after disabling Stripe. Users had to manually refresh the page to see the updated state. We added a `sendUpdateLimits()` method that sends a message to the Billing iframe to fetch fresh limit usage data, and we now call this method whenever the billing modal is opened. This ensures the Billing App always shows the current settings state without requiring a manual refresh, providing a seamless experience when making plan changes after modifying settings.

co-authored with @sam-lord 
