### PR TITLE
Fixed inconsistent prop capitalization in Portal

### DIFF
--- a/apps/portal/src/components/common/ActionButton.js
+++ b/apps/portal/src/components/common/ActionButton.js
@@ -84,7 +84,7 @@ const Styles = ({brandColor, disabled, style = {}, isPrimary}) => {
 function ActionButton({
     label, onClick, disabled = false, retry = false,
     brandColor, isRunning, isPrimary = true, isDestructive = false, classes = '',
-    style = {}, tabindex = undefined, dataTestId
+    style = {}, tabIndex = undefined, dataTestId
 }) {
     let Style = Styles({disabled, retry, brandColor, style, isPrimary});
 
@@ -103,7 +103,7 @@ function ActionButton({
     }
     const loaderClassName = isPrimary ? 'gh-portal-loadingicon' : 'gh-portal-loadingicon dark';
     return (
-        <button className={className} style={Style.button} onClick={e => onClick(e)} disabled={disabled} type='submit' tabIndex={tabindex} data-test-button={dataTestId}>
+        <button className={className} style={Style.button} onClick={e => onClick(e)} disabled={disabled} type='submit' tabIndex={tabIndex} data-test-button={dataTestId}>
             {isRunning ? <LoaderIcon className={loaderClassName} /> : label}
         </button>
     );

--- a/apps/portal/src/components/common/InputField.js
+++ b/apps/portal/src/components/common/InputField.js
@@ -94,8 +94,8 @@ function InputField({
     onChange = () => {},
     onBlur = () => {},
     onKeyDown = () => {},
-    tabindex,
-    maxlength,
+    tabIndex,
+    maxLength,
     autoFocus,
     errorMessage
 }) {
@@ -113,25 +113,25 @@ function InputField({
         disabled = true;
     }
 
-    let autocomplete = '';
-    let autocorrect = '';
-    let autocapitalize = '';
+    let autoComplete = '';
+    let autoCorrect = '';
+    let autoCapitalize = '';
     let inputMode;
     let pattern;
     switch (id) {
     case 'input-email':
-        autocomplete = 'off';
-        autocorrect = 'off';
-        autocapitalize = 'off';
+        autoComplete = 'off';
+        autoCorrect = 'off';
+        autoCapitalize = 'off';
         break;
     case 'input-name':
-        autocomplete = 'off';
-        autocorrect = 'off';
+        autoComplete = 'off';
+        autoCorrect = 'off';
         break;
     case 'input-otc':
-        autocomplete = 'one-time-code';
-        autocorrect = 'off';
-        autocapitalize = 'off';
+        autoComplete = 'one-time-code';
+        autoCorrect = 'off';
+        autoCapitalize = 'off';
         inputMode = 'numeric';
         pattern = '[0-9]*';
         placeholder ??= '• • • • • •';
@@ -164,11 +164,11 @@ function InputField({
                 onKeyDown={e => onKeyDown(e, name)}
                 onBlur={e => onBlur(e, name)}
                 disabled={disabled}
-                tabIndex={tabindex}
-                maxLength={maxlength}
-                autoComplete={autocomplete}
-                autoCorrect={autocorrect}
-                autoCapitalize={autocapitalize}
+                tabIndex={tabIndex}
+                maxLength={maxLength}
+                autoComplete={autoComplete}
+                autoCorrect={autoCorrect}
+                autoCapitalize={autoCapitalize}
                 aria-label={label}
                 inputMode={inputMode}
                 pattern={pattern}

--- a/apps/portal/src/components/common/InputForm.js
+++ b/apps/portal/src/components/common/InputForm.js
@@ -19,7 +19,7 @@ const FormInput = ({field, onChange, onBlur = () => { }, onKeyDown = () => {}}) 
                 onKeyDown={onKeyDown}
                 onChange={e => onChange(e, field)}
                 onBlur={e => onBlur(e, field)}
-                tabIndex={field.tabindex}
+                tabIndex={field.tabIndex}
                 errorMessage={field.errorMessage}
                 autoFocus={field.autoFocus}
             />

--- a/apps/portal/src/components/pages/FeedbackPage.js
+++ b/apps/portal/src/components/pages/FeedbackPage.js
@@ -190,7 +190,7 @@ function ErrorPage({error}) {
                 brandColor='#000000'
                 label={t('Close')}
                 isRunning={false}
-                tabindex='3'
+                tabIndex={3}
                 classes={'sticky bottom'}
             />
         </div>
@@ -255,7 +255,7 @@ const ConfirmDialog = ({onConfirm, loading, initialScore}) => {
                 brandColor={brandColor}
                 label={t('Submit feedback')}
                 isRunning={loading}
-                tabindex="3"
+                tabIndex={3}
             />
             <CloseButton close={() => close(false)} />
         </div>
@@ -297,7 +297,7 @@ const ConfirmFeedback = ({positive}) => {
                 brandColor={brandColor}
                 label={t('Close')}
                 isRunning={false}
-                tabindex='3'
+                tabIndex={3}
                 classes={'sticky bottom'}
             />
         </div>

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -191,7 +191,7 @@ export default class MagicLinkPage extends React.Component {
                         label={t('Code')}
                         errorMessage={errors.otc || ''}
                         autoFocus={false}
-                        maxlength={6}
+                        maxLength={6}
                         onChange={e => this.handleInputChange(e, {name: OTC_FIELD_NAME})}
                     />
                 </section>

--- a/apps/portal/src/components/pages/OfferPage.js
+++ b/apps/portal/src/components/pages/OfferPage.js
@@ -187,7 +187,7 @@ export default class OfferPage extends React.Component {
                 name: 'email',
                 disabled: !!member,
                 required: true,
-                tabindex: 2,
+                tabIndex: 2,
                 errorMessage: errors.email || ''
             }
         ];
@@ -209,7 +209,7 @@ export default class OfferPage extends React.Component {
                 name: 'name',
                 disabled: !!member,
                 required: true,
-                tabindex: 1,
+                tabIndex: 1,
                 errorMessage: errors.name || ''
             });
         }
@@ -405,7 +405,7 @@ export default class OfferPage extends React.Component {
                 brandColor={brandColor}
                 label={label}
                 isRunning={isRunning}
-                tabindex='3'
+                tabIndex={3}
                 classes={'sticky bottom'}
             />
         );

--- a/apps/portal/src/components/pages/SigninPage.js
+++ b/apps/portal/src/components/pages/SigninPage.js
@@ -85,8 +85,8 @@ export default class SigninPage extends React.Component {
                 label: 'Phone number',
                 name: 'phonenumber',
                 required: false,
-                tabindex: -1,
-                autocomplete: 'off',
+                tabIndex: -1,
+                autoComplete: 'off',
                 hidden: true
             }
         ];

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -502,7 +502,7 @@ class SignupPage extends React.Component {
                 label: t('Email'),
                 name: 'email',
                 required: true,
-                tabindex: 2,
+                tabIndex: 2,
                 errorMessage: errors.email || ''
             },
             {
@@ -513,8 +513,8 @@ class SignupPage extends React.Component {
                 label: t('Phone number'),
                 name: 'phonenumber',
                 required: false,
-                tabindex: -1,
-                autocomplete: 'off',
+                tabIndex: -1,
+                autoComplete: 'off',
                 hidden: true
             }
         ];
@@ -528,7 +528,7 @@ class SignupPage extends React.Component {
                 label: t('Name'),
                 name: 'name',
                 required: true,
-                tabindex: 1,
+                tabIndex: 1,
                 errorMessage: errors.name || ''
             });
         }
@@ -621,7 +621,7 @@ class SignupPage extends React.Component {
                 brandColor={brandColor}
                 label={label}
                 isRunning={isRunning}
-                tabIndex='3'
+                tabIndex={3}
             />
         );
     }

--- a/apps/portal/src/components/pages/SupportError.js
+++ b/apps/portal/src/components/pages/SupportError.js
@@ -52,7 +52,7 @@ const SupportError = ({error}) => {
                 label={buttonLabel}
                 isDestructive={true}
                 isRunning={false}
-                tabindex='3'
+                tabIndex={3}
                 classes={'sticky bottom'}
             />
         </div>

--- a/apps/portal/src/components/pages/SupportSuccess.js
+++ b/apps/portal/src/components/pages/SupportSuccess.js
@@ -56,7 +56,7 @@ const SupportSuccess = () => {
                 brandColor={brandColor}
                 label={buttonLabel}
                 isRunning={false}
-                tabindex='3'
+                tabIndex={3}
                 classes={'sticky bottom'}
             />
 

--- a/apps/portal/src/components/pages/UnsubscribePage.js
+++ b/apps/portal/src/components/pages/UnsubscribePage.js
@@ -170,7 +170,7 @@ export default function UnsubscribePage() {
                     brandColor='#000000'
                     label={t('Close')}
                     isRunning={false}
-                    tabindex='3'
+                    tabIndex={3}
                     classes={'sticky bottom'}
                 />
             </div>


### PR DESCRIPTION
no issue

- React uses camelCase prop names for HTML attributes but some of Portal's components had partially inconsistent casing resulting in both incorrect usage in the app and incorrect AI review recommendations
- updated prop usage to always use the same camelCase as React rather than the lowercase HTML equivalent
