### PR TITLE
Added `autoComplete` prop/field passthrough in Portal

### DIFF
--- a/apps/portal/src/components/common/InputField.js
+++ b/apps/portal/src/components/common/InputField.js
@@ -97,6 +97,7 @@ function InputField({
     tabIndex,
     maxLength,
     autoFocus,
+    autoComplete = '',
     errorMessage
 }) {
     const fieldNode = useRef(null);
@@ -113,7 +114,6 @@ function InputField({
         disabled = true;
     }
 
-    let autoComplete = '';
     let autoCorrect = '';
     let autoCapitalize = '';
     let inputMode;

--- a/apps/portal/src/components/common/InputField.test.js
+++ b/apps/portal/src/components/common/InputField.test.js
@@ -1,14 +1,15 @@
 import {render, fireEvent} from '@testing-library/react';
 import InputField from './InputField';
 
-const setup = () => {
+const setup = (props = {}) => {
     const mockOnChangeFn = jest.fn();
-    const props = {
+    props = {
         name: 'test-input',
         label: 'Test Input',
         value: '',
         placeholder: 'Test placeholder',
-        onChange: mockOnChangeFn
+        onChange: mockOnChangeFn,
+        ...props
     };
     const utils = render(
         <InputField {...props} />
@@ -33,5 +34,15 @@ describe('InputField', () => {
         fireEvent.change(inputEl, {target: {value: 'Test'}});
 
         expect(mockOnChangeFn).toHaveBeenCalled();
+    });
+
+    test('does not include autoComplete attribute value if not provided', () => {
+        const {inputEl} = setup();
+        expect(inputEl).toHaveAttribute('autoComplete', '');
+    });
+
+    test('applies autoComplete prop correctly', () => {
+        const {inputEl} = setup({autoComplete: 'off'});
+        expect(inputEl).toHaveAttribute('autoComplete', 'off');
     });
 });

--- a/apps/portal/src/components/common/InputForm.js
+++ b/apps/portal/src/components/common/InputForm.js
@@ -22,6 +22,7 @@ const FormInput = ({field, onChange, onBlur = () => { }, onKeyDown = () => {}}) 
                 tabIndex={field.tabIndex}
                 errorMessage={field.errorMessage}
                 autoFocus={field.autoFocus}
+                autoComplete={field.autoComplete}
             />
         </>
     );


### PR DESCRIPTION
no issue

- `autoComplete='off'` was used in our honeypot fields but it was never applied because the `<InputForm>` and `<InputField>` components didn't pass/accept an `autoComplete` prop
