### PR TITLE
Bumped Portal to 2.54

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -212,7 +212,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.53"
+        "version": "2.54"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/25010

- updated default URL so Ghost will use the newly published version
