### PR TITLE
🎨 Hide What's new banner during onboarding

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/footer-banner.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer-banner.hbs
@@ -1,6 +1,6 @@
 {{#if this.showReferralInvite}}
-    <div class="gh-sidebar-banner gh-referral-toast">
-        <button class="gh-sidebar-banner-close" type="button" {{on "click" this.dismissReferralInvite}}>&#xd7;</button>
+    <div class="gh-sidebar-banner gh-referral-toast" data-test-toast="referral">
+        <button class="gh-sidebar-banner-close" type="button" data-test-button="close-referral" {{on "click" this.dismissReferralInvite}}>&#xd7;</button>
         <a href="https://referrals.ghost.org/?ref=admin" target="_blank" rel="noopener noreferrer">
             <strong>You qualify for our invite-only referral program.</strong>
             <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
@@ -11,16 +11,16 @@
 
 {{#if (and this.showWhatsNew this.whatsNew.hasNew)}}
     {{#let (get this.whatsNew.entries "0") as |entry|}}
-    <div class="gh-sidebar-banner gh-whatsnew-toast">
-        <button class="gh-sidebar-banner-close" type="button" {{on "click" this.dismissWhatsNewToast}}>&#xd7;</button>
+    <div class="gh-sidebar-banner gh-whatsnew-toast" data-test-toast="whats-new">
+        <button class="gh-sidebar-banner-close" type="button" data-test-button="close-whats-new" {{on "click" this.dismissWhatsNewToast}}>&#xd7;</button>
         <a class="gh-sidebar-banner-container" href={{entry.url}} target="_blank" rel="noopener noreferrer" {{on "click" (fn this.openFeaturedWhatsNew entry.url)}}>
             <div class="gh-sidebar-banner-head">
                 {{svg-jar "sparkle-fill" class="gh-sidebar-banner-icon gh-whatsnew-banner-icon"}}
-                <span class="gh-sidebar-banner-subhead">What’s new?</span>
+                <span class="gh-sidebar-banner-subhead" data-test-whats-new="subhead">What's new?</span>
             </div>
-            <div class="gh-sidebar-banner-msg">{{entry.title}}</div>
+            <div class="gh-sidebar-banner-msg" data-test-whats-new="title">{{entry.title}}</div>
             {{#if entry.custom_excerpt}}
-                <div class="gh-sidebar-banner-details">{{entry.custom_excerpt}}</div>
+                <div class="gh-sidebar-banner-details" data-test-whats-new="description">{{entry.custom_excerpt}}</div>
             {{/if}}
         </a>
     </div>

--- a/ghost/admin/app/components/gh-nav-menu/footer-banner.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer-banner.js
@@ -48,7 +48,7 @@ export default class FooterBanner extends Component {
     }
 
     get showWhatsNew() {
-        return !this.showReferralInvite && this.whatsNew.hasNewFeatured;
+        return !this.showReferralInvite && this.whatsNew.shouldShowFeaturedBanner;
     }
 
     @task

--- a/ghost/admin/app/services/whats-new.js
+++ b/ghost/admin/app/services/whats-new.js
@@ -50,6 +50,10 @@ export default Service.extend({
         return latestEntry.featured;
     }),
 
+    shouldShowFeaturedBanner: computed('hasNewFeatured', function () {
+        return this.hasNewFeatured;
+    }),
+
     seen: action(function () {
         this.updateLastSeen.perform();
     }),

--- a/ghost/admin/app/services/whats-new.js
+++ b/ghost/admin/app/services/whats-new.js
@@ -8,6 +8,7 @@ import {task} from 'ember-concurrency';
 export default Service.extend({
     session: service(),
     store: service(),
+    onboarding: service(),
     response: null,
 
     entries: null,
@@ -50,8 +51,8 @@ export default Service.extend({
         return latestEntry.featured;
     }),
 
-    shouldShowFeaturedBanner: computed('hasNewFeatured', function () {
-        return this.hasNewFeatured;
+    shouldShowFeaturedBanner: computed('hasNewFeatured', 'onboarding.isChecklistShown', function () {
+        return this.hasNewFeatured && !this.onboarding.isChecklistShown;
     }),
 
     seen: action(function () {

--- a/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
+++ b/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
@@ -194,4 +194,53 @@ describe('Integration: Component: gh-nav-menu/footer-banner', function () {
 
         expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
     });
+
+    it('uses shouldShowFeaturedBanner from whatsNew service', async function () {
+        this.owner.register('service:whatsNew', Service.extend({
+            hasNew: true,
+            hasNewFeatured: true,
+            shouldShowFeaturedBanner: false, // Override to false
+            entries: [{
+                title: 'Test Feature',
+                url: 'https://ghost.org/changelog/test',
+                custom_excerpt: 'Test description',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: true
+            }],
+            seen() {}
+        }));
+
+        this.owner.register('service:session', Service.extend({
+            user: {
+                isAdmin: false
+            }
+        }));
+
+        this.owner.register('service:dashboardStats', Service.extend({
+            currentMRR: 0,
+            loadMrrStats() {
+                return Promise.resolve();
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            accessibility: {
+                referralInviteDismissed: false
+            }
+        }));
+
+        this.owner.register('service:membersUtils', Service.extend({
+            isStripeEnabled: false
+        }));
+
+        this.owner.register('service:modals', Service.extend({}));
+        this.owner.register('service:settings', Service.extend({
+            stripeConnectLivemode: false
+        }));
+
+        await render(hbs`<GhNavMenu::FooterBanner />`);
+
+        // Should NOT show banner because shouldShowFeaturedBanner=false
+        expect(find('.gh-whatsnew-toast'), 'what\'s new banner respects shouldShowFeaturedBanner').to.not.exist;
+    });
 });

--- a/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
+++ b/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
@@ -8,239 +8,150 @@ import {setupRenderingTest} from 'ember-mocha';
 describe('Integration: Component: gh-nav-menu/footer-banner', function () {
     setupRenderingTest();
 
-    it('shows what\'s new banner when hasNewFeatured is true and referral invite is not showing', async function () {
+    // Composable fixture fragments
+    const hasNewFeature = {
+        hasNewFeature: true,
+        shouldShowFeaturedBanner: true,
+        featuredEntry: {
+            title: 'Test Feature',
+            url: 'https://ghost.org/changelog/test',
+            custom_excerpt: 'Test description',
+            published_at: '2024-12-01T00:00:00.000Z',
+            featured: true
+        }
+    };
+
+    const noNewFeature = {
+        hasNewFeature: false
+    };
+
+    const shouldNotShowFeaturedBanner = {
+        shouldShowFeaturedBanner: false
+    };
+
+    const eligibleForReferral = {
+        isAdmin: true,
+        currentMRR: 10100,
+        isStripeEnabled: true,
+        stripeConnectLivemode: true,
+        referralInviteDismissed: false
+    };
+
+    const notEligibleForReferral = {
+        currentMRR: 0,
+        isStripeEnabled: false,
+        stripeConnectLivemode: false
+    };
+
+    const defaultFixture = {
+        ...noNewFeature,
+        ...shouldNotShowFeaturedBanner,
+        ...notEligibleForReferral
+    };
+
+    const setup = function (fixtures = {}) {
+        const config = {
+            ...defaultFixture,
+            ...fixtures
+        };
+
+        // Build whatsNew.entries based on configuration
+        let entries = [];
+        if (config.hasNewFeature && config.featuredEntry) {
+            entries = [config.featuredEntry];
+        }
+
         this.owner.register('service:whatsNew', Service.extend({
-            hasNew: true,
-            hasNewFeatured: true,
-            entries: [{
-                title: 'Test Feature',
-                url: 'https://ghost.org/changelog/test',
-                custom_excerpt: 'Test description',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: true
-            }],
-            seen() {}
+            seen() {},
+            init() {
+                this._super(...arguments);
+                this.entries = entries;
+            },
+            hasNew: config.hasNewFeature,
+            hasNewFeatured: config.hasNewFeature,
+            shouldShowFeaturedBanner: config.shouldShowFeaturedBanner
         }));
 
         this.owner.register('service:session', Service.extend({
-            user: {
-                isAdmin: false
+            init() {
+                this._super(...arguments);
+                this.user = {
+                    isAdmin: config.isAdmin
+                };
             }
         }));
 
         this.owner.register('service:dashboardStats', Service.extend({
-            currentMRR: 0,
             loadMrrStats() {
                 return Promise.resolve();
-            }
+            },
+            currentMRR: config.currentMRR
         }));
 
         this.owner.register('service:feature', Service.extend({
-            accessibility: {
-                referralInviteDismissed: false
+            init() {
+                this._super(...arguments);
+                this.accessibility = {
+                    referralInviteDismissed: config.referralInviteDismissed
+                };
             }
         }));
 
         this.owner.register('service:membersUtils', Service.extend({
-            isStripeEnabled: false
+            isStripeEnabled: config.isStripeEnabled
         }));
 
         this.owner.register('service:modals', Service.extend({}));
+
         this.owner.register('service:settings', Service.extend({
-            stripeConnectLivemode: false
+            stripeConnectLivemode: config.stripeConnectLivemode
         }));
+
+        this.set('hasThemeErrors', config.hasThemeErrors);
+    };
+
+    it('shows what\'s new banner when hasNewFeatured is true and referral invite is not showing', async function () {
+        setup.call(this, {...hasNewFeature, ...notEligibleForReferral});
 
         await render(hbs`<GhNavMenu::FooterBanner />`);
 
-        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is visible').to.exist;
-        expect(find('.gh-whatsnew-toast')).to.contain.text('What\'s new?');
-        expect(find('.gh-whatsnew-toast')).to.contain.text('Test Feature');
-        expect(find('.gh-whatsnew-toast')).to.contain.text('Test description');
+        expect(find('[data-test-toast="whats-new"]'), 'what\'s new banner is visible').to.exist;
+        expect(find('[data-test-whats-new="subhead"]'), 'subhead element exists').to.exist;
+        expect(find('[data-test-whats-new="subhead"]').textContent).to.match(/What.s new\?/);
+        expect(find('[data-test-whats-new="title"]')).to.contain.text(hasNewFeature.featuredEntry.title);
+        expect(find('[data-test-whats-new="description"]')).to.contain.text(hasNewFeature.featuredEntry.custom_excerpt);
     });
 
     it('hides what\'s new banner when hasNewFeatured is false', async function () {
-        this.owner.register('service:whatsNew', Service.extend({
-            hasNew: true,
-            hasNewFeatured: false,
-            entries: [{
-                title: 'Non-featured Update',
-                url: 'https://ghost.org/changelog/test',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: false
-            }],
-            seen() {}
-        }));
-
-        this.owner.register('service:session', Service.extend({
-            user: {
-                isAdmin: false
-            }
-        }));
-
-        this.owner.register('service:dashboardStats', Service.extend({
-            currentMRR: 0,
-            loadMrrStats() {
-                return Promise.resolve();
-            }
-        }));
-
-        this.owner.register('service:feature', Service.extend({
-            accessibility: {
-                referralInviteDismissed: false
-            }
-        }));
-
-        this.owner.register('service:membersUtils', Service.extend({
-            isStripeEnabled: false
-        }));
-
-        this.owner.register('service:modals', Service.extend({}));
-        this.owner.register('service:settings', Service.extend({
-            stripeConnectLivemode: false
-        }));
+        setup.call(this, {...noNewFeature, ...notEligibleForReferral});
 
         await render(hbs`<GhNavMenu::FooterBanner />`);
 
-        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+        expect(find('[data-test-toast="whats-new"]'), 'what\'s new banner is hidden').to.not.exist;
     });
 
     it('hides what\'s new banner when referral invite is showing (priority)', async function () {
-        this.owner.register('service:whatsNew', Service.extend({
-            hasNew: true,
-            hasNewFeatured: true,
-            entries: [{
-                title: 'Test Feature',
-                url: 'https://ghost.org/changelog/test',
-                custom_excerpt: 'Test description',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: true
-            }],
-            seen() {}
-        }));
+        setup.call(this, {...hasNewFeature, ...eligibleForReferral});
 
-        this.owner.register('service:session', Service.extend({
-            user: {
-                isAdmin: true
-            }
-        }));
+        await render(hbs`<GhNavMenu::FooterBanner />`);
 
-        this.owner.register('service:dashboardStats', Service.extend({
-            currentMRR: 10100, // $101 MRR
-            loadMrrStats() {
-                return Promise.resolve();
-            }
-        }));
-
-        this.owner.register('service:feature', Service.extend({
-            accessibility: {
-                referralInviteDismissed: false
-            }
-        }));
-
-        this.owner.register('service:membersUtils', Service.extend({
-            isStripeEnabled: true
-        }));
-
-        this.owner.register('service:modals', Service.extend({}));
-        this.owner.register('service:settings', Service.extend({
-            stripeConnectLivemode: true
-        }));
-
-        this.set('hasThemeErrors', false);
-
-        await render(hbs`<GhNavMenu::FooterBanner @hasThemeErrors={{this.hasThemeErrors}} />`);
-
-        expect(find('.gh-referral-toast'), 'referral banner is visible').to.exist;
-        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+        expect(find('[data-test-toast="referral"]'), 'referral banner is visible').to.exist;
+        expect(find('[data-test-toast="whats-new"]'), 'what\'s new banner is hidden').to.not.exist;
     });
 
     it('hides what\'s new banner when hasNew is false', async function () {
-        this.owner.register('service:whatsNew', Service.extend({
-            hasNew: false,
-            hasNewFeatured: false,
-            entries: [],
-            seen() {}
-        }));
-
-        this.owner.register('service:session', Service.extend({
-            user: {
-                isAdmin: false
-            }
-        }));
-
-        this.owner.register('service:dashboardStats', Service.extend({
-            currentMRR: 0,
-            loadMrrStats() {
-                return Promise.resolve();
-            }
-        }));
-
-        this.owner.register('service:feature', Service.extend({
-            accessibility: {
-                referralInviteDismissed: false
-            }
-        }));
-
-        this.owner.register('service:membersUtils', Service.extend({
-            isStripeEnabled: false
-        }));
-
-        this.owner.register('service:modals', Service.extend({}));
-        this.owner.register('service:settings', Service.extend({
-            stripeConnectLivemode: false
-        }));
+        setup.call(this, {...noNewFeature, ...notEligibleForReferral});
 
         await render(hbs`<GhNavMenu::FooterBanner />`);
 
-        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+        expect(find('[data-test-toast="whats-new"]'), 'what\'s new banner is hidden').to.not.exist;
     });
 
     it('uses shouldShowFeaturedBanner from whatsNew service', async function () {
-        this.owner.register('service:whatsNew', Service.extend({
-            hasNew: true,
-            hasNewFeatured: true,
-            shouldShowFeaturedBanner: false, // Override to false
-            entries: [{
-                title: 'Test Feature',
-                url: 'https://ghost.org/changelog/test',
-                custom_excerpt: 'Test description',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: true
-            }],
-            seen() {}
-        }));
-
-        this.owner.register('service:session', Service.extend({
-            user: {
-                isAdmin: false
-            }
-        }));
-
-        this.owner.register('service:dashboardStats', Service.extend({
-            currentMRR: 0,
-            loadMrrStats() {
-                return Promise.resolve();
-            }
-        }));
-
-        this.owner.register('service:feature', Service.extend({
-            accessibility: {
-                referralInviteDismissed: false
-            }
-        }));
-
-        this.owner.register('service:membersUtils', Service.extend({
-            isStripeEnabled: false
-        }));
-
-        this.owner.register('service:modals', Service.extend({}));
-        this.owner.register('service:settings', Service.extend({
-            stripeConnectLivemode: false
-        }));
+        setup.call(this, {...hasNewFeature, ...shouldNotShowFeaturedBanner, ...notEligibleForReferral});
 
         await render(hbs`<GhNavMenu::FooterBanner />`);
 
-        // Should NOT show banner because shouldShowFeaturedBanner=false
-        expect(find('.gh-whatsnew-toast'), 'what\'s new banner respects shouldShowFeaturedBanner').to.not.exist;
+        expect(find('[data-test-toast="whats-new"]'), 'what\'s new banner respects shouldShowFeaturedBanner').to.not.exist;
     });
 });

--- a/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
+++ b/ghost/admin/tests/integration/components/gh-nav-menu/footer-banner-test.js
@@ -1,0 +1,197 @@
+import Service from '@ember/service';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, render} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+
+describe('Integration: Component: gh-nav-menu/footer-banner', function () {
+    setupRenderingTest();
+
+    it('shows what\'s new banner when hasNewFeatured is true and referral invite is not showing', async function () {
+        this.owner.register('service:whatsNew', Service.extend({
+            hasNew: true,
+            hasNewFeatured: true,
+            entries: [{
+                title: 'Test Feature',
+                url: 'https://ghost.org/changelog/test',
+                custom_excerpt: 'Test description',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: true
+            }],
+            seen() {}
+        }));
+
+        this.owner.register('service:session', Service.extend({
+            user: {
+                isAdmin: false
+            }
+        }));
+
+        this.owner.register('service:dashboardStats', Service.extend({
+            currentMRR: 0,
+            loadMrrStats() {
+                return Promise.resolve();
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            accessibility: {
+                referralInviteDismissed: false
+            }
+        }));
+
+        this.owner.register('service:membersUtils', Service.extend({
+            isStripeEnabled: false
+        }));
+
+        this.owner.register('service:modals', Service.extend({}));
+        this.owner.register('service:settings', Service.extend({
+            stripeConnectLivemode: false
+        }));
+
+        await render(hbs`<GhNavMenu::FooterBanner />`);
+
+        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is visible').to.exist;
+        expect(find('.gh-whatsnew-toast')).to.contain.text('What\'s new?');
+        expect(find('.gh-whatsnew-toast')).to.contain.text('Test Feature');
+        expect(find('.gh-whatsnew-toast')).to.contain.text('Test description');
+    });
+
+    it('hides what\'s new banner when hasNewFeatured is false', async function () {
+        this.owner.register('service:whatsNew', Service.extend({
+            hasNew: true,
+            hasNewFeatured: false,
+            entries: [{
+                title: 'Non-featured Update',
+                url: 'https://ghost.org/changelog/test',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: false
+            }],
+            seen() {}
+        }));
+
+        this.owner.register('service:session', Service.extend({
+            user: {
+                isAdmin: false
+            }
+        }));
+
+        this.owner.register('service:dashboardStats', Service.extend({
+            currentMRR: 0,
+            loadMrrStats() {
+                return Promise.resolve();
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            accessibility: {
+                referralInviteDismissed: false
+            }
+        }));
+
+        this.owner.register('service:membersUtils', Service.extend({
+            isStripeEnabled: false
+        }));
+
+        this.owner.register('service:modals', Service.extend({}));
+        this.owner.register('service:settings', Service.extend({
+            stripeConnectLivemode: false
+        }));
+
+        await render(hbs`<GhNavMenu::FooterBanner />`);
+
+        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+    });
+
+    it('hides what\'s new banner when referral invite is showing (priority)', async function () {
+        this.owner.register('service:whatsNew', Service.extend({
+            hasNew: true,
+            hasNewFeatured: true,
+            entries: [{
+                title: 'Test Feature',
+                url: 'https://ghost.org/changelog/test',
+                custom_excerpt: 'Test description',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: true
+            }],
+            seen() {}
+        }));
+
+        this.owner.register('service:session', Service.extend({
+            user: {
+                isAdmin: true
+            }
+        }));
+
+        this.owner.register('service:dashboardStats', Service.extend({
+            currentMRR: 10100, // $101 MRR
+            loadMrrStats() {
+                return Promise.resolve();
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            accessibility: {
+                referralInviteDismissed: false
+            }
+        }));
+
+        this.owner.register('service:membersUtils', Service.extend({
+            isStripeEnabled: true
+        }));
+
+        this.owner.register('service:modals', Service.extend({}));
+        this.owner.register('service:settings', Service.extend({
+            stripeConnectLivemode: true
+        }));
+
+        this.set('hasThemeErrors', false);
+
+        await render(hbs`<GhNavMenu::FooterBanner @hasThemeErrors={{this.hasThemeErrors}} />`);
+
+        expect(find('.gh-referral-toast'), 'referral banner is visible').to.exist;
+        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+    });
+
+    it('hides what\'s new banner when hasNew is false', async function () {
+        this.owner.register('service:whatsNew', Service.extend({
+            hasNew: false,
+            hasNewFeatured: false,
+            entries: [],
+            seen() {}
+        }));
+
+        this.owner.register('service:session', Service.extend({
+            user: {
+                isAdmin: false
+            }
+        }));
+
+        this.owner.register('service:dashboardStats', Service.extend({
+            currentMRR: 0,
+            loadMrrStats() {
+                return Promise.resolve();
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            accessibility: {
+                referralInviteDismissed: false
+            }
+        }));
+
+        this.owner.register('service:membersUtils', Service.extend({
+            isStripeEnabled: false
+        }));
+
+        this.owner.register('service:modals', Service.extend({}));
+        this.owner.register('service:settings', Service.extend({
+            stripeConnectLivemode: false
+        }));
+
+        await render(hbs`<GhNavMenu::FooterBanner />`);
+
+        expect(find('.gh-whatsnew-toast'), 'what\'s new banner is hidden').to.not.exist;
+    });
+});

--- a/ghost/admin/tests/unit/services/whats-new-test.js
+++ b/ghost/admin/tests/unit/services/whats-new-test.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import moment from 'moment-timezone';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
@@ -7,96 +6,139 @@ import {setupTest} from 'ember-mocha';
 describe('Unit: Service: whats-new', function () {
     setupTest();
 
+    // Composable fixture fragments
+    const seenRecently = {
+        lastSeenDate: '2024-12-01T00:00:00.000Z'
+    };
+
+    const seenLongAgo = {
+        lastSeenDate: '2024-01-01T00:00:00.000Z'
+    };
+
+    const neverSeen = {
+        lastSeenDate: null
+    };
+
+    const newEntry = {
+        entries: [{
+            title: 'New Feature',
+            published_at: '2024-12-01T00:00:00.000Z',
+            featured: false
+        }]
+    };
+
+    const oldEntry = {
+        entries: [{
+            title: 'Old Feature',
+            published_at: '2024-01-01T00:00:00.000Z',
+            featured: false
+        }]
+    };
+
+    const newFeaturedEntry = {
+        entries: [{
+            title: 'Featured Update',
+            published_at: '2024-12-01T00:00:00.000Z',
+            featured: true
+        }]
+    };
+
+    const oldFeaturedEntry = {
+        entries: [{
+            title: 'Old Featured Update',
+            published_at: '2024-01-01T00:00:00.000Z',
+            featured: true
+        }]
+    };
+
+    const noEntries = {
+        entries: []
+    };
+
+    const onboardingInactive = {
+        isChecklistShown: null,
+        checklistState: null
+    };
+
+    const onboardingActive = {
+        isChecklistShown: true,
+        checklistState: 'started'
+    };
+
+    const onboardingComplete = {
+        isChecklistShown: false,
+        checklistState: 'completed'
+    };
+
+    const defaultFixture = {
+        ...neverSeen,
+        ...noEntries,
+        ...onboardingInactive
+    };
+
+    const setup = function (fixtures = {}) {
+        const config = {
+            ...defaultFixture,
+            ...fixtures
+        };
+
+        // Build accessibility JSON
+        const accessibility = {};
+        if (config.lastSeenDate !== null) {
+            accessibility.whatsNew = {
+                lastSeenDate: config.lastSeenDate
+            };
+        }
+        if (config.checklistState !== null) {
+            accessibility.onboarding = {
+                checklistState: config.checklistState
+            };
+        }
+
+        const mockUser = {
+            accessibility: JSON.stringify(accessibility)
+        };
+
+        this.owner.register('service:session', Service.extend({
+            user: mockUser
+        }));
+
+        this.owner.register('service:store', Service.extend({}));
+
+        if (config.isChecklistShown !== null) {
+            this.owner.register('service:onboarding', Service.extend({
+                isChecklistShown: config.isChecklistShown
+            }));
+        }
+
+        const service = this.owner.lookup('service:whats-new');
+        service.set('_user', mockUser);
+        service.set('entries', config.entries);
+
+        return service;
+    };
+
     describe('hasNew', function () {
         it('returns false when no entries exist', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-01-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', []);
+            const service = setup.call(this, {...seenLongAgo, ...noEntries});
 
             expect(service.hasNew).to.be.false;
         });
 
         it('returns true when latest entry is newer than lastSeenDate', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-01-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', [{
-                title: 'New Feature',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: false
-            }]);
+            const service = setup.call(this, {...seenLongAgo, ...newEntry});
 
             expect(service.hasNew).to.be.true;
         });
 
         it('returns false when latest entry is older than lastSeenDate', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-12-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('_user', mockUser);
-            service.set('entries', [{
-                title: 'Old Feature',
-                published_at: '2024-01-01T00:00:00.000Z',
-                featured: false
-            }]);
+            const service = setup.call(this, {...seenRecently, ...oldEntry});
 
             expect(service.hasNew).to.be.false;
         });
 
         it('defaults to 2019-01-01 when no lastSeenDate exists', function () {
-            const mockUser = {
-                accessibility: '{}'
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', [{
-                title: 'Recent Feature',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: false
-            }]);
+            const service = setup.call(this, {...neverSeen, ...newEntry});
 
             expect(service.hasNew).to.be.true;
         });
@@ -104,96 +146,43 @@ describe('Unit: Service: whats-new', function () {
 
     describe('hasNewFeatured', function () {
         it('returns true when hasNew is true and latest entry is featured', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-01-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', [{
-                title: 'Featured Update',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: true
-            }]);
+            const service = setup.call(this, {...seenLongAgo, ...newFeaturedEntry});
 
             expect(service.hasNewFeatured).to.be.true;
         });
 
         it('returns false when hasNew is false', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-12-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('_user', mockUser);
-            service.set('entries', [{
-                title: 'Old Featured Update',
-                published_at: '2024-01-01T00:00:00.000Z',
-                featured: true
-            }]);
+            const service = setup.call(this, {...seenRecently, ...oldFeaturedEntry});
 
             expect(service.hasNewFeatured).to.be.false;
         });
 
         it('returns false when hasNew is true but entry is not featured', function () {
-            const mockUser = {
-                accessibility: JSON.stringify({
-                    whatsNew: {
-                        lastSeenDate: '2024-01-01T00:00:00.000Z'
-                    }
-                })
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', [{
-                title: 'Non-featured Update',
-                published_at: '2024-12-01T00:00:00.000Z',
-                featured: false
-            }]);
+            const service = setup.call(this, {...seenLongAgo, ...newEntry});
 
             expect(service.hasNewFeatured).to.be.false;
         });
 
         it('returns false when entries array is empty', function () {
-            const mockUser = {
-                accessibility: '{}'
-            };
-
-            this.owner.register('service:session', Service.extend({
-                user: mockUser
-            }));
-
-            this.owner.register('service:store', Service.extend({}));
-
-            const service = this.owner.lookup('service:whats-new');
-            service.set('entries', []);
+            const service = setup.call(this, {...neverSeen, ...noEntries});
 
             expect(service.hasNewFeatured).to.be.false;
+        });
+    });
+
+    describe('shouldShowFeaturedBanner', function () {
+        it('returns false when onboarding checklist is shown', function () {
+            const service = setup.call(this, {...newFeaturedEntry, ...onboardingActive});
+
+            expect(service.hasNewFeatured).to.be.true; // Would normally show
+            expect(service.shouldShowFeaturedBanner).to.be.false; // But hidden during onboarding
+        });
+
+        it('returns true when onboarding checklist is not shown', function () {
+            const service = setup.call(this, {...seenLongAgo, ...newFeaturedEntry, ...onboardingComplete});
+
+            expect(service.hasNewFeatured).to.be.true;
+            expect(service.shouldShowFeaturedBanner).to.be.true; // Shows after onboarding
         });
     });
 });

--- a/ghost/admin/tests/unit/services/whats-new-test.js
+++ b/ghost/admin/tests/unit/services/whats-new-test.js
@@ -1,0 +1,199 @@
+import Service from '@ember/service';
+import moment from 'moment-timezone';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Service: whats-new', function () {
+    setupTest();
+
+    describe('hasNew', function () {
+        it('returns false when no entries exist', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-01-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', []);
+
+            expect(service.hasNew).to.be.false;
+        });
+
+        it('returns true when latest entry is newer than lastSeenDate', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-01-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', [{
+                title: 'New Feature',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: false
+            }]);
+
+            expect(service.hasNew).to.be.true;
+        });
+
+        it('returns false when latest entry is older than lastSeenDate', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-12-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('_user', mockUser);
+            service.set('entries', [{
+                title: 'Old Feature',
+                published_at: '2024-01-01T00:00:00.000Z',
+                featured: false
+            }]);
+
+            expect(service.hasNew).to.be.false;
+        });
+
+        it('defaults to 2019-01-01 when no lastSeenDate exists', function () {
+            const mockUser = {
+                accessibility: '{}'
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', [{
+                title: 'Recent Feature',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: false
+            }]);
+
+            expect(service.hasNew).to.be.true;
+        });
+    });
+
+    describe('hasNewFeatured', function () {
+        it('returns true when hasNew is true and latest entry is featured', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-01-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', [{
+                title: 'Featured Update',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: true
+            }]);
+
+            expect(service.hasNewFeatured).to.be.true;
+        });
+
+        it('returns false when hasNew is false', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-12-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('_user', mockUser);
+            service.set('entries', [{
+                title: 'Old Featured Update',
+                published_at: '2024-01-01T00:00:00.000Z',
+                featured: true
+            }]);
+
+            expect(service.hasNewFeatured).to.be.false;
+        });
+
+        it('returns false when hasNew is true but entry is not featured', function () {
+            const mockUser = {
+                accessibility: JSON.stringify({
+                    whatsNew: {
+                        lastSeenDate: '2024-01-01T00:00:00.000Z'
+                    }
+                })
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', [{
+                title: 'Non-featured Update',
+                published_at: '2024-12-01T00:00:00.000Z',
+                featured: false
+            }]);
+
+            expect(service.hasNewFeatured).to.be.false;
+        });
+
+        it('returns false when entries array is empty', function () {
+            const mockUser = {
+                accessibility: '{}'
+            };
+
+            this.owner.register('service:session', Service.extend({
+                user: mockUser
+            }));
+
+            this.owner.register('service:store', Service.extend({}));
+
+            const service = this.owner.lookup('service:whats-new');
+            service.set('entries', []);
+
+            expect(service.hasNewFeatured).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
## Why this change?

When setting up a brand new Ghost site, the "What's new" featured banner appears in the sidebar during onboarding. This creates a confusing user experience because:
- Everything is new on a brand new site
- The banner distracts from the onboarding checklist
- Users haven't experienced the baseline yet, so "what's new" has no context

Ref https://linear.app/ghost/issue/DES-1155/hide-whats-new-for-brand-new-sites

## What does this change do?

Hides the "What's new" featured banner while the onboarding checklist is active. Once a user completes or dismisses onboarding, the banner will appear normally if there are new featured updates.

**Technical implementation:**

The `whatsNew` service now encapsulates the concern of deciding if we should show the notification or not, instead of the component itself checking the various conditions on when the notification should be shown.

`whatsNew` then uses the `onboarding` service to check if the Site is currently going through the onboarding checklist or not.

## Why is this needed?

Creates a cleaner, more focused onboarding experience without competing notifications.

## Implementation approach

This PR uses a 3-stage commit strategy:
1. **Baseline tests** - Validates existing behaviour before changes
2. **Refactor** - Moves logic to service layer (no behaviour change)
3. **Feature** - Adds onboarding check with new tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the "What's new" sidebar banner while onboarding is active by moving visibility logic to `whats-new` service, adding test selectors, and introducing unit/integration tests.
> 
> - **Admin UI**
>   - **Banner visibility**: `gh-nav-menu/footer-banner.js` now uses `whatsNew.shouldShowFeaturedBanner` instead of `hasNewFeatured` to show the banner.
>   - **Test selectors**: Add `data-test-*` attributes to `gh-nav-menu/footer-banner.hbs` for referral and what's new banners/elements.
> - **Service: `whats-new`**
>   - Add `onboarding` service dependency and new computed `shouldShowFeaturedBanner` to hide featured banner when `onboarding.isChecklistShown` is true.
> - **Tests**
>   - New integration tests for `gh-nav-menu/footer-banner` covering referral priority and banner visibility rules.
>   - New unit tests for `whats-new` service covering `hasNew`, `hasNewFeatured`, and `shouldShowFeaturedBanner`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3703894be2a5df2fe34570f729488b364aa98cef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->