### PR TITLE
Added utm_ columns to events tables

### DIFF
--- a/ghost/core/core/server/data/migrations/utils/schema.js
+++ b/ghost/core/core/server/data/migrations/utils/schema.js
@@ -11,7 +11,7 @@ const {createNonTransactionalMigration, createTransactionalMigration} = require(
  *
  * @returns {Migration}
  */
-function createAddColumnMigration(table, column, columnDefinition) {
+function createAddColumnMigration(table, column, columnDefinition, options = {}) {
     return createNonTransactionalMigration(
         // up
         commands.createColumnMigration({
@@ -20,7 +20,8 @@ function createAddColumnMigration(table, column, columnDefinition) {
             dbIsInCorrectState: hasColumn => hasColumn === true,
             operation: commands.addColumn,
             operationVerb: 'Adding',
-            columnDefinition
+            columnDefinition,
+            options
         }),
         // down
         commands.createColumnMigration({
@@ -29,7 +30,8 @@ function createAddColumnMigration(table, column, columnDefinition) {
             dbIsInCorrectState: hasColumn => hasColumn === false,
             operation: commands.dropColumn,
             operationVerb: 'Removing',
-            columnDefinition
+            columnDefinition,
+            options
         })
     );
 }
@@ -41,7 +43,7 @@ function createAddColumnMigration(table, column, columnDefinition) {
  *
  * @returns {Migration}
  */
-function createDropColumnMigration(table, column, columnDefinition) {
+function createDropColumnMigration(table, column, columnDefinition, options = {}) {
     return createNonTransactionalMigration(
         // up
         commands.createColumnMigration({
@@ -49,7 +51,9 @@ function createDropColumnMigration(table, column, columnDefinition) {
             column,
             dbIsInCorrectState: hasColumn => hasColumn === false,
             operation: commands.dropColumn,
-            operationVerb: 'Removing'
+            operationVerb: 'Removing',
+            columnDefinition,
+            options
         }),
         // down
         commands.createColumnMigration({
@@ -58,7 +62,8 @@ function createDropColumnMigration(table, column, columnDefinition) {
             dbIsInCorrectState: hasColumn => hasColumn === true,
             operation: commands.addColumn,
             operationVerb: 'Adding',
-            columnDefinition
+            columnDefinition,
+            options
         })
     );
 }

--- a/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
@@ -2,23 +2,23 @@ const {combineNonTransactionalMigrations, createAddColumnMigration} = require('.
 
 module.exports = combineNonTransactionalMigrations(
     // members_created_events
-    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
 
     // members_subscription_created_events
-    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
 
     // donation_payment_events
-    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
-    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true})
+    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'})
 );

--- a/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
@@ -1,60 +1,24 @@
-const logging = require('@tryghost/logging');
-const {createTransactionalMigration} = require('../../utils');
+const {combineNonTransactionalMigrations, createAddColumnMigration} = require('../../utils');
 
-const tables = [
-    'members_created_events',
-    'members_subscription_created_events',
-    'donation_payment_events'
-];
+module.exports = combineNonTransactionalMigrations(
+    // members_created_events
+    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}),
 
-const utmColumns = [
-    {name: 'utm_source', definition: {type: 'string', maxlength: 191, nullable: true}},
-    {name: 'utm_medium', definition: {type: 'string', maxlength: 191, nullable: true}},
-    {name: 'utm_campaign', definition: {type: 'string', maxlength: 191, nullable: true}},
-    {name: 'utm_term', definition: {type: 'string', maxlength: 191, nullable: true}},
-    {name: 'utm_content', definition: {type: 'string', maxlength: 191, nullable: true}}
-];
+    // members_subscription_created_events
+    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}),
 
-module.exports = createTransactionalMigration(
-    async function up(knex) {
-        // we should allow for loops because we want sequential execution
-        // eslint-disable-next-line no-restricted-syntax
-        for (const table of tables) {
-            logging.info(`Adding UTM columns to ${table}`);
-
-            // eslint-disable-next-line no-restricted-syntax
-            for (const column of utmColumns) {
-                const hasColumn = await knex.schema.hasColumn(table, column.name);
-                if (!hasColumn) {
-                    logging.info(`Adding column ${column.name} to ${table}`);
-                    await knex.schema.table(table, function (t) {
-                        t.string(column.name, column.definition.maxlength).nullable();
-                    });
-                } else {
-                    logging.warn(`Column ${column.name} already exists in ${table} - skipping`);
-                }
-            }
-        }
-    },
-
-    async function down(knex) {
-        // we should allow for loops because we want sequential execution
-        // eslint-disable-next-line no-restricted-syntax
-        for (const table of tables) {
-            logging.info(`Removing UTM columns from ${table}`);
-
-            // eslint-disable-next-line no-restricted-syntax
-            for (const column of utmColumns) {
-                const hasColumn = await knex.schema.hasColumn(table, column.name);
-                if (hasColumn) {
-                    logging.info(`Dropping column ${column.name} from ${table}`);
-                    await knex.schema.table(table, function (t) {
-                        t.dropColumn(column.name);
-                    });
-                } else {
-                    logging.warn(`Column ${column.name} does not exist in ${table} - skipping`);
-                }
-            }
-        }
-    }
+    // donation_payment_events
+    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}),
+    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true})
 );

--- a/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
@@ -2,23 +2,23 @@ const {combineNonTransactionalMigrations, createAddColumnMigration} = require('.
 
 module.exports = combineNonTransactionalMigrations(
     // members_created_events
-    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
 
     // members_subscription_created_events
-    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
 
     // donation_payment_events
-    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
-    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'})
+    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true}, {algorithm: 'auto'})
 );

--- a/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
@@ -1,0 +1,60 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+const tables = [
+    'members_created_events',
+    'members_subscription_created_events',
+    'donation_payment_events'
+];
+
+const utmColumns = [
+    {name: 'utm_source', definition: {type: 'string', maxlength: 191, nullable: true}},
+    {name: 'utm_medium', definition: {type: 'string', maxlength: 191, nullable: true}},
+    {name: 'utm_campaign', definition: {type: 'string', maxlength: 191, nullable: true}},
+    {name: 'utm_term', definition: {type: 'string', maxlength: 191, nullable: true}},
+    {name: 'utm_content', definition: {type: 'string', maxlength: 191, nullable: true}}
+];
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        // we should allow for loops because we want sequential execution
+        // eslint-disable-next-line no-restricted-syntax
+        for (const table of tables) {
+            logging.info(`Adding UTM columns to ${table}`);
+
+            // eslint-disable-next-line no-restricted-syntax
+            for (const column of utmColumns) {
+                const hasColumn = await knex.schema.hasColumn(table, column.name);
+                if (!hasColumn) {
+                    logging.info(`Adding column ${column.name} to ${table}`);
+                    await knex.schema.table(table, function (t) {
+                        t.string(column.name, column.definition.maxlength).nullable();
+                    });
+                } else {
+                    logging.warn(`Column ${column.name} already exists in ${table} - skipping`);
+                }
+            }
+        }
+    },
+
+    async function down(knex) {
+        // we should allow for loops because we want sequential execution
+        // eslint-disable-next-line no-restricted-syntax
+        for (const table of tables) {
+            logging.info(`Removing UTM columns from ${table}`);
+
+            // eslint-disable-next-line no-restricted-syntax
+            for (const column of utmColumns) {
+                const hasColumn = await knex.schema.hasColumn(table, column.name);
+                if (hasColumn) {
+                    logging.info(`Dropping column ${column.name} from ${table}`);
+                    await knex.schema.table(table, function (t) {
+                        t.dropColumn(column.name);
+                    });
+                } else {
+                    logging.warn(`Column ${column.name} does not exist in ${table} - skipping`);
+                }
+            }
+        }
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.2/2025-09-30-14-28-09-add-utm-fields.js
@@ -2,23 +2,23 @@ const {combineNonTransactionalMigrations, createAddColumnMigration} = require('.
 
 module.exports = combineNonTransactionalMigrations(
     // members_created_events
-    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
 
     // members_subscription_created_events
-    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('members_subscription_created_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
 
     // donation_payment_events
-    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'}),
-    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'inplace'})
+    createAddColumnMigration('donation_payment_events', 'utm_source', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_medium', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_campaign', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_term', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'}),
+    createAddColumnMigration('donation_payment_events', 'utm_content', {type: 'string', maxlength: 191, nullable: true, algorithm: 'auto'})
 );

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -96,6 +96,7 @@ function dropNullable(tableName, column, transaction = db.knex) {
  * @param {string} column
  * @param {import('knex').Knex.Transaction} [transaction]
  * @param {object} columnSpec
+ * @param {'inplace'|'copy'} [columnSpec.algorithm] - MySQL only: 'inplace' (online DDL) or 'copy' (default, legacy DDL)
  */
 async function addColumn(tableName, column, transaction = db.knex, columnSpec) {
     const addColumnBuilder = transaction.schema.table(tableName, function (table) {
@@ -113,8 +114,10 @@ async function addColumn(tableName, column, transaction = db.knex, columnSpec) {
         let sql = sqlQuery.sql;
 
         if (DatabaseInfo.isMySQL(transaction)) {
+            // Allow overriding the algorithm via columnSpec
+            const algorithm = columnSpec?.algorithm || 'copy';
             // Guard against an ending semicolon
-            sql = sql.replace(/;\s*$/, '') + ', algorithm=copy';
+            sql = sql.replace(/;\s*$/, '') + `, algorithm=${algorithm}`;
         }
 
         await transaction.raw(sql);
@@ -148,8 +151,10 @@ async function dropColumn(tableName, column, transaction = db.knex, columnSpec =
         let sql = sqlQuery.sql;
 
         if (DatabaseInfo.isMySQL(transaction)) {
+            // Allow overriding the algorithm via columnSpec
+            const algorithm = columnSpec?.algorithm || 'copy';
             // Guard against an ending semicolon
-            sql = sql.replace(/;\s*$/, '') + ', algorithm=copy';
+            sql = sql.replace(/;\s*$/, '') + `, algorithm=${algorithm}`;
         }
 
         await transaction.raw(sql);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -535,6 +535,11 @@ module.exports = {
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        utm_source: {type: 'string', maxlength: 191, nullable: true},
+        utm_medium: {type: 'string', maxlength: 191, nullable: true},
+        utm_campaign: {type: 'string', maxlength: 191, nullable: true},
+        utm_term: {type: 'string', maxlength: 191, nullable: true},
+        utm_content: {type: 'string', maxlength: 191, nullable: true},
         source: {
             type: 'string', maxlength: 50, nullable: false, validations: {
                 isIn: [['member', 'import', 'system', 'api', 'admin']]
@@ -715,6 +720,11 @@ module.exports = {
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        utm_source: {type: 'string', maxlength: 191, nullable: true},
+        utm_medium: {type: 'string', maxlength: 191, nullable: true},
+        utm_campaign: {type: 'string', maxlength: 191, nullable: true},
+        utm_term: {type: 'string', maxlength: 191, nullable: true},
+        utm_content: {type: 'string', maxlength: 191, nullable: true},
         batch_id: {type: 'string', maxlength: 24, nullable: true}
     },
     offer_redemptions: {
@@ -756,6 +766,11 @@ module.exports = {
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        utm_source: {type: 'string', maxlength: 191, nullable: true},
+        utm_medium: {type: 'string', maxlength: 191, nullable: true},
+        utm_campaign: {type: 'string', maxlength: 191, nullable: true},
+        utm_term: {type: 'string', maxlength: 191, nullable: true},
+        utm_content: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         donation_message: {type: 'string', maxlength: 255, nullable: true} // https://docs.stripe.com/payments/checkout/custom-fields
     },

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -525,6 +525,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        // attribution values from ghost-history (member attribution tracking script)
         attribution_id: {type: 'string', maxlength: 24, nullable: true, index: true},
         attribution_type: {
             type: 'string', maxlength: 50, nullable: true, validations: {
@@ -532,9 +533,11 @@ module.exports = {
             }
         },
         attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+        // referrer values from browser, processed by our referrerParser library
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        // raw values from URL query parameters
         utm_source: {type: 'string', maxlength: 191, nullable: true},
         utm_medium: {type: 'string', maxlength: 191, nullable: true},
         utm_campaign: {type: 'string', maxlength: 191, nullable: true},
@@ -710,6 +713,7 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
+        // attribution values from ghost-history (member attribution tracking script)
         attribution_id: {type: 'string', maxlength: 24, nullable: true, index: true},
         attribution_type: {
             type: 'string', maxlength: 50, nullable: true, validations: {
@@ -717,9 +721,11 @@ module.exports = {
             }
         },
         attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+        // referrer values from browser, processed by our referrerParser library
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        // raw values from URL query parameters
         utm_source: {type: 'string', maxlength: 191, nullable: true},
         utm_medium: {type: 'string', maxlength: 191, nullable: true},
         utm_campaign: {type: 'string', maxlength: 191, nullable: true},
@@ -756,6 +762,7 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
         amount: {type: 'integer', nullable: false},
         currency: {type: 'string', maxlength: 50, nullable: false},
+        // attribution values from ghost-history (member attribution tracking script)
         attribution_id: {type: 'string', maxlength: 24, nullable: true},
         attribution_type: {
             type: 'string', maxlength: 50, nullable: true, validations: {
@@ -763,9 +770,11 @@ module.exports = {
             }
         },
         attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+        // referrer values from browser, processed by our referrerParser library
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        // raw values from URL query parameters
         utm_source: {type: 'string', maxlength: 191, nullable: true},
         utm_medium: {type: 'string', maxlength: 191, nullable: true},
         utm_campaign: {type: 'string', maxlength: 191, nullable: true},

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -22699,7 +22699,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "17706",
+  "content-length": "17979",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -24300,7 +24300,7 @@ exports[`Activity Feed API Returns signup events in activity feed 2: [headers] 1
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "21127",
+  "content-length": "21855",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -386,7 +386,7 @@ exports[`Members API - member attribution Returns sign up attributions of all ty
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8230",
+  "content-length": "8685",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -6125,7 +6125,7 @@ exports[`Members API Can subscribe to a newsletter 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5336",
+  "content-length": "5427",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -7305,7 +7305,7 @@ exports[`Members API can change the email address 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1118",
+  "content-length": "1209",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '526d04f5d3321f1ce1399acd4acb75c7';
+    const currentSchemaHash = '3071f336e59e2ff87f1336caf5dfaed6';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = '17f64e5c9cd6075f6939903439dce56c';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2689/
ref https://github.com/TryGhost/Ghost/commit/d8e58b53d0984c198c2a6e12bd73b44356aab350
ref https://github.com/TryGhost/Ghost/commit/2bfd8f8b7ec1f487c92b8497955f573bbd14f422
- added utm_ related fields to members_created_events, members_subscription_created_events, and donation_payment_events
- updated schema
- updated migration `createAddColumnMigration` to not force `algorithm=copy` (added 'auto' option)

This PR contains the migrations necessary to store the utm_ parameters we are adding tracking for. As they are another element of member attribution, they've been added to the tables that already have member attribution tracking: members_created_events, members_subscription_created_events, and donation_payment_events.

The columns added are for all of the utm_ fields: utm_campaign, utm_term, utm_content, utm_medium, utm_source.

We already have referrer_medium and referrer_source, but these are 'processed' fields that do not directly correspond to utm_ fields, so we've added the additional column. At some point, it may be worth consolidating.

__NOTE__: W/r to migrations (see refs above), we had found in investigating changing this migration to use our helpers instead of manually creating the trx and column changes that the performance was _awful_. We traced this back to the use of `algorithm=copy` which, to the best of our knowledge, was useful for the purposes of migrations on the `posts` table due to the very large `long` fields (lexical, mobiledoc, etc). This algorithm forces a copy of the table prior to acting on it, which on a table like `members_created_events` with a sample 2M rows, was incredibly slow (60-250s) vs. letting the sql engine do it's thing (2-3s). 

It seems likely that many of our migrations could actually be improved by letting the sql optimizer create its own plan (although clearly this was not true for posts). While we have some ideas on how to programmatically handle this, it feels safest to add a new param to allow for specifying the algorithm; this is currently ONLY used in adding and dropping a column, so those were the two places updated.