### PR TITLE
Updated new paid member newsletter handling

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -381,7 +381,10 @@ module.exports = class RouterController {
                 attribution: {
                     id: options.metadata.attribution_id ?? null,
                     type: options.metadata.attribution_type ?? null,
-                    url: options.metadata.attribution_url ?? null
+                    url: options.metadata.attribution_url ?? null,
+                    referrerSource: options.metadata.referrer_source ?? null,
+                    referrerMedium: options.metadata.referrer_medium ?? null,
+                    referrerUrl: options.metadata.referrer_url ?? null
                 }
             };
 
@@ -390,6 +393,15 @@ module.exports = class RouterController {
             if (options.newsletters) {
                 tokenData.newsletters = options.newsletters;
             }
+
+            // Remove attribution from metadata that goes to Stripe
+            // since we're passing it through the token instead
+            delete options.metadata.attribution_id;
+            delete options.metadata.attribution_type;
+            delete options.metadata.attribution_url;
+            delete options.metadata.referrer_source;
+            delete options.metadata.referrer_medium;
+            delete options.metadata.referrer_url;
 
             options.successUrl = await this._magicLinkService.getMagicLink({
                 tokenData,

--- a/ghost/core/core/server/services/stripe/StripeService.js
+++ b/ghost/core/core/server/services/stripe/StripeService.js
@@ -99,6 +99,9 @@ module.exports = class StripeService {
             get staffServiceEmails(){
                 return staffService.api.emails;
             },
+            getTokenDataFromMagicLinkToken(token){
+                return membersService.api.getTokenDataFromMagicLinkToken(token);
+            },
             sendSignupEmail(email){
                 return membersService.api.sendEmailWithMagicLink({
                     email,

--- a/ghost/core/core/server/services/stripe/services/webhook/CheckoutSessionEventService.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/CheckoutSessionEventService.js
@@ -185,7 +185,7 @@ module.exports = class CheckoutSessionEventService {
             const metadataName = _.get(session, 'metadata.name');
 
             // Get newsletter and attribution data from the magic link token in success_url
-            let newsletters = [];
+            let newsletters = null;
             let attribution = null;
 
             try {
@@ -198,7 +198,10 @@ module.exports = class CheckoutSessionEventService {
                         const tokenData = await this.deps.getTokenDataFromMagicLinkToken(token);
 
                         if (tokenData) {
-                            newsletters = tokenData.newsletters || [];
+                            // Preserve the distinction between undefined (use defaults) and [] (opted out)
+                            if ('newsletters' in tokenData) {
+                                newsletters = tokenData.newsletters;
+                            }
                             attribution = tokenData.attribution || null;
                         }
                     }

--- a/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
@@ -176,3 +176,19 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Create Stripe Checkout Session Token-based data handling Handles missing token data gracefully 1: [body] 1`] = `
+Object {
+  "url": "https://site.com",
+}
+`;
+
+exports[`Create Stripe Checkout Session Token-based data handling Handles missing token data gracefully 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-type": "application/json",
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/CheckoutSessionEventService.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/CheckoutSessionEventService.test.js
@@ -634,7 +634,6 @@ describe('CheckoutSessionEventService', function () {
             assert.deepEqual(memberData.newsletters, [{id: 1, name: 'Newsletter'}]);
         });
 
-
         it('should handle token retrieval errors gracefully', async function () {
             api.getCustomer.resolves(customer);
             memberRepository.get.resolves(null);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-939/
ref https://github.com/TryGhost/Ghost/pull/23302 (initial spike)

Previously, we were using Stripe's metadata field to pass the newsletter subscription selection. Stripe has a limit of 500 characters for each key's value, so it was plausible to hit this limit with a dozen or so newsletters. This failed silently by not respecting members' selections when signing up.

With free member creation flows, we set the newsletter data as part of the magic token we generate and send to require email validation. As we're already generating a magic link for the success url (redirect) following the Stripe checkout completion, we can simply parse this for the token and access the newsletter data without having to pass it to Stripe.

In other words, we effectively use the tokens table as a 'pending member'. And by changing our handling here, we align on a single approach for how we handle sign up data.

As a note, the token field allows up to 2000 characters, so even after the other data we pack in there and base64url encoding, we have ample headroom over the previous Stripe metadata handling, as our other fields are reasonably small.

----

Coauthored by @cmraible 