### PR TITLE
Created page hit promise before visiting home page

### DIFF
--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -10,8 +10,9 @@ test.describe('Ghost Admin - Analytics Overview', () => {
     test('records visitor when homepage is visited', async ({page, browser, baseURL}) => {
         await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
             const homePage = new HomePage(publicPage);
+            const pageHitRequest = homePage.waitForPageHitRequest();
             await homePage.goto();
-            await homePage.waitForPageHitRequest();
+            await pageHitRequest;
         });
 
         const analyticsOverviewPage = new AnalyticsOverviewPage(page);


### PR DESCRIPTION
Just testing this out for now. 

It seems the `waitForPageHitRequest` is flaky — works in CI and on my machine, but not on others. Suspect there is a race condition where the request finishes before we are able to create the promise.