### PR TITLE
Cleaned up unused `MembersConfigProvider.getAuthSecret()`

### DIFF
--- a/ghost/core/core/server/services/members/MembersConfigProvider.js
+++ b/ghost/core/core/server/services/members/MembersConfigProvider.js
@@ -1,6 +1,5 @@
 const logging = require('@tryghost/logging');
 const {URL} = require('url');
-const crypto = require('crypto');
 const createKeypair = require('keypair');
 
 class MembersConfigProvider {
@@ -40,20 +39,6 @@ class MembersConfigProvider {
      */
     isStripeConnected() {
         return this._settingsHelpers.isStripeConnected();
-    }
-
-    getAuthSecret() {
-        const hexSecret = this._settingsCache.get('members_email_auth_secret');
-        if (!hexSecret) {
-            logging.warn('Could not find members_email_auth_secret, using dynamically generated secret');
-            return crypto.randomBytes(64);
-        }
-        const secret = Buffer.from(hexSecret, 'hex');
-        if (secret.length < 64) {
-            logging.warn('members_email_auth_secret not large enough (64 bytes), using dynamically generated secret');
-            return crypto.randomBytes(64);
-        }
-        return secret;
     }
 
     getAllowSelfSignup() {

--- a/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
@@ -9,7 +9,6 @@ const HALF_HOUR_MS = 30 * 60 * 1000;
 
 describe('SingleUseTokenProvider', function () {
     let tokenProvider;
-    let mockMembersConfig;
     let mockModel;
     const testAuthSecret = 'a'.repeat(128);
 
@@ -20,10 +19,6 @@ describe('SingleUseTokenProvider', function () {
     };
 
     beforeEach(function () {
-        mockMembersConfig = {
-            getAuthSecret: sinon.stub().returns(testAuthSecret)
-        };
-
         mockModel = {
             add: sinon.stub(),
             findOne: sinon.stub(),
@@ -36,7 +31,7 @@ describe('SingleUseTokenProvider', function () {
             validityPeriod: DAY_MS,
             validityPeriodAfterUsage: HOUR_MS,
             maxUsageCount: 7,
-            secret: mockMembersConfig.getAuthSecret()
+            secret: testAuthSecret
         });
     });
 


### PR DESCRIPTION
no issue

- the method is unused so keeping it around just adds confusion
- cleaned up a test mock that was mocking usage unnecessarily/without matching real usage
