### PR TITLE
Refactor CSS for publish menu responsiveness and style

### DIFF
--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -966,6 +966,10 @@
     padding: 16px 24px 16px 24px;
 }
 
+.modal-post-success .modal-body h2 {
+    overflow-wrap: anywhere;
+}
+
 .modal-post-success .modal-body p {
     font-size: 1.6rem;
     line-height: 1.5em;


### PR DESCRIPTION

When we publish our post and if the title is is Single word and long such as (pneumonoultramicroscopicsilicovolcanoconiosis) the title gets out or the card because there was no css to handle the title (mainly the overflow css)

<img width="1920" height="1080" alt="Screenshot (361)" src="https://github.com/user-attachments/assets/65e91cf9-4a00-4b1d-b98b-ea3c5f0a06be" />
<img width="1920" height="1080" alt="Screenshot (364)" src="https://github.com/user-attachments/assets/b3df9a37-3c6f-4e9e-8b2c-3787a40f1e5f" />

### After adding the css for this it looks like this

<img width="1920" height="1080" alt="Screenshot (365)" src="https://github.com/user-attachments/assets/edf46f9e-91dc-4f8c-96f7-f90dccb1b2b5" />


- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds word-wrapping to long titles in the publish success modal and adjusts mobile/header spacing; includes minor style cleanups.
> 
> - **Styles (Admin)**:
>   - **Publish Success Modal**: Add wrapping for long titles (`.modal-post-success .modal-body h2`) to prevent overflow.
>   - **Responsive Header**: Add `padding-right` to `.gh-publish-header` at `<=1024px` and `margin-right` to `.gh-publish-header .mobile` at `<=500px`.
>   - **Bookmark Card**: Split `.gh-post-bookmark-title` `line-height` and `line-clamp` into separate declarations.
> - **Cleanup**: Normalize selector combinator spacing, gradients, keyframe formatting, and box-shadow values across `publishmenu.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d56f09d160428dc85c271188b1ac5ec6467c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->