### PR TITLE
🎨 Changed "What's new" toast to be hidden for new users.

### DIFF
--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -1,5 +1,6 @@
 const validator = require('@tryghost/validator');
 const ObjectId = require('bson-objectid').default;
+const moment = require('moment-timezone');
 const ghostBookshelf = require('./base');
 const baseUtils = require('./base/utils');
 const limitService = require('../services/limits');
@@ -201,6 +202,19 @@ User = ghostBookshelf.Model.extend({
                     columnKey: 'name'
                 })
             });
+        }
+
+        // Initialize accessibility.whatsNew for new users
+        if (options.method === 'insert' && !options.importing) {
+            const existingValue = this.get('accessibility');
+            const accessibility = existingValue ? JSON.parse(existingValue) : {};
+
+            const today = moment.utc().startOf('day').toISOString();
+
+            accessibility.whatsNew ??= {};
+            accessibility.whatsNew.lastSeenDate ??= today;
+
+            this.set('accessibility', JSON.stringify(accessibility));
         }
 
         // If the user's email is set & has changed & we are not importing

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -386,7 +386,7 @@ exports[`Members API - member attribution Returns sign up attributions of all ty
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8230",
+  "content-length": "8290",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
@@ -647,7 +647,7 @@ exports[`Pages API Convert can convert a mobiledoc page to lexical 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4325",
+  "content-length": "4445",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -753,7 +753,7 @@ exports[`Pages API Convert can convert a mobiledoc page to lexical 4: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4325",
+  "content-length": "4445",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -947,7 +947,7 @@ exports[`Pages API Copy Can copy a page 3: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4119",
+  "content-length": "4239",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1053,7 +1053,7 @@ exports[`Pages API Create Can create a page with html 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4349",
+  "content-length": "4469",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1333,7 +1333,7 @@ exports[`Pages API Update Access Visibility is set to tiers Saves only paid tier
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3754",
+  "content-length": "3874",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1438,7 +1438,7 @@ exports[`Pages API Update Can modify show_title_and_feature_image property 2: [h
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4120",
+  "content-length": "4240",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -197,7 +197,7 @@ exports[`Posts API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "11256",
+  "content-length": "11496",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -766,7 +766,7 @@ exports[`Posts API Can browse with formats 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "14054",
+  "content-length": "14294",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -874,7 +874,7 @@ exports[`Posts API Convert can convert a mobiledoc post to lexical 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4362",
+  "content-length": "4482",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -983,7 +983,7 @@ exports[`Posts API Convert can convert a mobiledoc post to lexical 4: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4362",
+  "content-length": "4482",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1089,7 +1089,7 @@ exports[`Posts API Copy Can copy a post 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4154",
+  "content-length": "4274",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1198,7 +1198,7 @@ exports[`Posts API Create Can create a post with html 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4384",
+  "content-length": "4504",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1307,7 +1307,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4396",
+  "content-length": "4516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1416,7 +1416,7 @@ exports[`Posts API Create Can create a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4212",
+  "content-length": "4332",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1524,7 +1524,7 @@ exports[`Posts API Create invalidates preview cache when updating a draft post 1
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4182",
+  "content-length": "4302",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2100,7 +2100,7 @@ exports[`Posts API Update Access Visibility is set to tiers Saves only paid tier
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3787",
+  "content-length": "3907",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2209,7 +2209,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4347",
+  "content-length": "4467",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2318,7 +2318,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4344",
+  "content-length": "4464",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2427,7 +2427,7 @@ exports[`Posts API Update Can update a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4157",
+  "content-length": "4277",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2536,7 +2536,7 @@ exports[`Posts API Update Can update a post with mobiledoc 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4154",
+  "content-length": "4274",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
@@ -27,7 +27,7 @@ exports[`User API Can edit user roles by name 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -74,7 +74,7 @@ exports[`User API Can edit user roles by name 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1052",
+  "content-length": "1112",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -87,7 +87,7 @@ exports[`User API Can edit user with empty roles data and does not change the ro
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -134,7 +134,7 @@ exports[`User API Can edit user with empty roles data and does not change the ro
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1115",
+  "content-length": "1175",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -157,7 +157,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -195,7 +195,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -233,7 +233,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -271,7 +271,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -309,7 +309,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -347,7 +347,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -385,7 +385,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -423,7 +423,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -468,7 +468,7 @@ exports[`User API Can include user roles 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8483",
+  "content-length": "8963",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -491,7 +491,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -528,7 +528,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -565,7 +565,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -609,7 +609,7 @@ exports[`User API Can paginate users 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2856",
+  "content-length": "3036",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -692,7 +692,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -729,7 +729,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -766,7 +766,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -803,7 +803,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -840,7 +840,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -877,7 +877,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -914,7 +914,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -951,7 +951,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -995,7 +995,7 @@ exports[`User API Can request all users ordered by id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "7124",
+  "content-length": "7604",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1008,7 +1008,7 @@ exports[`User API Can retrieve a user by email 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1052,7 +1052,7 @@ exports[`User API Can retrieve a user by email 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "881",
+  "content-length": "941",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1065,7 +1065,7 @@ exports[`User API Can retrieve a user by id 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1113,7 +1113,7 @@ exports[`User API Can retrieve a user by id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1127",
+  "content-length": "1187",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1126,7 +1126,7 @@ exports[`User API Can retrieve a user by slug 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1170,7 +1170,7 @@ exports[`User API Can retrieve a user by slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "881",
+  "content-length": "941",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1183,7 +1183,7 @@ exports[`User API Can transfer ownership to admin user 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1230,7 +1230,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1315,7 +1315,7 @@ exports[`User API Does not trigger cache invalidation when a private attribute o
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1359,7 +1359,7 @@ exports[`User API Does not trigger cache invalidation when a private attribute o
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "950",
+  "content-length": "1010",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1372,7 +1372,7 @@ exports[`User API Does not trigger cache invalidation when no attribute on a use
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1416,7 +1416,7 @@ exports[`User API Does not trigger cache invalidation when no attribute on a use
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "982",
+  "content-length": "1042",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1429,7 +1429,7 @@ exports[`User API Does trigger cache invalidation when a social link on a user h
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1473,7 +1473,7 @@ exports[`User API Does trigger cache invalidation when a social link on a user h
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "982",
+  "content-length": "1042",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1487,7 +1487,7 @@ exports[`User API can edit a user 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1531,7 +1531,7 @@ exports[`User API can edit a user 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "949",
+  "content-length": "1009",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1545,7 +1545,7 @@ exports[`User API can edit a user fetched from the API 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1590,7 +1590,7 @@ exports[`User API can edit a user fetched from the API 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1059",
+  "content-length": "1119",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1603,7 +1603,7 @@ exports[`User API can edit a user fetched from the API 3: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1648,7 +1648,7 @@ exports[`User API can edit a user fetched from the API 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1052",
+  "content-length": "1112",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
@@ -16,7 +16,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -75,7 +75,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -186,7 +186,7 @@ Object {
     "previous": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -272,7 +272,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -346,7 +346,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -507,7 +507,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -581,7 +581,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -742,7 +742,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -816,7 +816,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -976,7 +976,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1050,7 +1050,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1210,7 +1210,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1284,7 +1284,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1445,7 +1445,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1519,7 +1519,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1724,7 +1724,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1798,7 +1798,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1943,7 +1943,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2017,7 +2017,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2177,7 +2177,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2251,7 +2251,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -16,7 +16,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -78,7 +78,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -188,7 +188,7 @@ Object {
     "previous": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -273,7 +273,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -349,7 +349,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -508,7 +508,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -605,7 +605,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -766,7 +766,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -842,7 +842,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1001,7 +1001,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1077,7 +1077,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1236,7 +1236,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1312,7 +1312,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1472,7 +1472,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1569,7 +1569,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1774,7 +1774,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1871,7 +1871,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2016,7 +2016,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2113,7 +2113,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2273,7 +2273,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2349,7 +2349,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,

--- a/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
@@ -4,7 +4,7 @@ exports[`Authentication API Blog setup complete setup 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": null,
       "bluesky": null,
       "comment_notifications": true,
@@ -48,7 +48,7 @@ exports[`Authentication API Blog setup complete setup 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "853",
+  "content-length": "913",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -293,7 +293,7 @@ exports[`Authentication API Blog setup complete setup with default theme 1: [bod
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": null,
       "bluesky": null,
       "comment_notifications": true,
@@ -337,7 +337,7 @@ exports[`Authentication API Blog setup complete setup with default theme 2: [hea
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "853",
+  "content-length": "913",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -597,7 +597,7 @@ exports[`Authentication API Blog setup update setup 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"whatsNew\\":{\\"lastSeenDate\\":\\"2025-10-02T00:00:00.000Z\\"}}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -641,7 +641,7 @@ exports[`Authentication API Blog setup update setup 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "924",
+  "content-length": "984",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
## Why this change?

When setting up a brand new Ghost site, the "What's new" featured banner appears in the sidebar during onboarding. This creates a confusing user experience because:
- Everything is new on a brand new site
- The banner distracts from the onboarding checklist
- Users haven't experienced the baseline yet, so "what's new" has no context

Ref https://linear.app/ghost/issue/DES-1155/hide-whats-new-for-brand-new-sites

## What does this change do?

This change-set sets the newly created User's "last seen" news date with the date that they were created, such that they'll only see "What's new" toasts when newer information is available.

Once a new update is available, the "What's new" toast re-appears, regardless of their onboarding status.

## Technical Implementation

This works by setting the `user.accessibility` column (which is where the `whatsNew.lastSeenDate` is stored) with a default value of today's date.

Formerly this column was `null` by default, and is updated by the frontend as the User changes their settings or dismisses the "What's new" toast. Now it will always have a value by default, which is why the snapshots had to be updated in all cases when there's a new User setup. This is a notable change in behaviour that needs to be considered in this review.

We intentionally made the smallest change that improves the onboarding experience. The current TEXT blob stored in user.accessibility is not ideal for typed/structured data, and we have documented a follow-up to revisit this pattern in more depth. See [ENG-2552](https://linear.app/ghost/issue/ENG-2552/refactor-usersaccessibility-json-blob-pattern)
 for options to refactor the JSON-blob approach and consider a more structured model for accessibility preferences and “What’s new” state.

## Comparison with the [Frontend approach](https://github.com/TryGhost/Ghost/pull/25014)

The benefits of setting this state in the backend for new Users is that we get the same effect of hiding the "What's new" toast without any need to change the frontend or manage any frontend state (such as triggering `whatsNew.seen()`). This has the additional benefit of simplifying the Ember -> React migration as its one less bit of logic in the Ember components which will have to be migrated to React.

The drawback of this approach is that now User's have a non-null `accessibility` value by default which requires many test snapshot updates and we have "What's new" logic baked into the User model logic which is coupling what was formerly a "user preferences" frontend concern with data model logic.