### PR TITLE
Made `t` a requirable function in Portal

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
+import i18n from './utils/i18n';
 import TriggerButton from './components/TriggerButton';
 import Notification from './components/Notification';
 import PopupModal from './components/PopupModal';
@@ -14,8 +15,6 @@ import ActionHandler from './actions';
 import './App.css';
 import {hasRecommendations, allowCompMemberUpgrade, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {handleDataAttributes} from './data-attributes';
-
-import i18nLib from '@tryghost/i18n';
 
 const DEV_MODE_DATA = {
     showPopup: true,
@@ -198,7 +197,7 @@ export default class App extends React.Component {
             // Fetch data from API, links, preview, dev sources
             const {site, member, page, showPopup, popupNotification, lastPage, pageQuery, pageData} = await this.fetchData();
             const i18nLanguage = this.props.siteI18nEnabled ? this.props.locale || site.locale || 'en' : 'en';
-            const i18n = i18nLib(i18nLanguage, 'portal');
+            i18n.changeLanguage(i18nLanguage);
 
             const state = {
                 site,

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -118,7 +118,7 @@ async function signin({data, api, state}) {
             action: 'signin:failed',
             popupNotification: createPopupNotification({
                 type: 'signin:failed', autoHide: false, closeable: true, state, status: 'error',
-                message: chooseBestErrorMessage(e, t('Failed to log in, please try again'), t)
+                message: chooseBestErrorMessage(e, t('Failed to log in, please try again'))
             })
         };
     }
@@ -168,7 +168,7 @@ async function verifyOTC({data, api, state}) {
             action: 'verifyOTC:failed',
             popupNotification: createPopupNotification({
                 type: 'verifyOTC:failed', autoHide: false, closeable: true, state, status: 'error',
-                message: chooseBestErrorMessage(e, t('Failed to verify code, please try again'), t)
+                message: chooseBestErrorMessage(e, t('Failed to verify code, please try again'))
             })
         };
     }
@@ -202,7 +202,7 @@ async function signup({data, state, api}) {
         };
     } catch (e) {
         const {t} = state;
-        const message = chooseBestErrorMessage(e, t('Failed to sign up, please try again'), t);
+        const message = chooseBestErrorMessage(e, t('Failed to sign up, please try again'));
         return {
             action: 'signup:failed',
             popupNotification: createPopupNotification({
@@ -553,7 +553,7 @@ async function updateProfile({data, state, api}) {
         let message = '';
 
         if (emailUpdate.error) {
-            message = chooseBestErrorMessage(emailUpdate.error, t('Failed to send verification email'), t);
+            message = chooseBestErrorMessage(emailUpdate.error, t('Failed to send verification email'));
         } else {
             message = t('Check your inbox to verify email update');
         }

--- a/apps/portal/src/components/pages/FeedbackPage.js
+++ b/apps/portal/src/components/pages/FeedbackPage.js
@@ -321,7 +321,7 @@ export default function FeedbackPage() {
             await sendFeedback({siteUrl: site.url, uuid, key, postId, score: selectedScore}, api);
             setScore(selectedScore);
         } catch (e) {
-            const text = chooseBestErrorMessage(e, t('There was a problem submitting your feedback. Please try again a little later.'), t);
+            const text = chooseBestErrorMessage(e, t('There was a problem submitting your feedback. Please try again a little later.'));
             setError(text);
         }
         setLoading(false);

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -12,7 +12,7 @@ function displayErrorIfElementExists(errorEl, message) {
 function handleError(error, form, errorEl, t) {
     form.classList.add('error');
     const defaultMessage = t('There was an error sending the email, please try again');
-    displayErrorIfElementExists(errorEl, chooseBestErrorMessage(error, defaultMessage, t));
+    displayErrorIfElementExists(errorEl, chooseBestErrorMessage(error, defaultMessage));
 }
 
 export async function formSubmitHandler(
@@ -116,7 +116,7 @@ export async function formSubmitHandler(
             }
         } else {
             const e = await HumanReadableError.fromApiResponse(magicLinkRes);
-            const errorMessage = chooseBestErrorMessage(e, t('Failed to send magic link email'), t);
+            const errorMessage = chooseBestErrorMessage(e, t('Failed to send magic link email'));
             displayErrorIfElementExists(errorEl, errorMessage);
             form.classList.add('error'); // Ensure error state is set here
         }

--- a/apps/portal/src/tests/errors.test.js
+++ b/apps/portal/src/tests/errors.test.js
@@ -1,58 +1,60 @@
 import {HumanReadableError, chooseBestErrorMessage} from '../utils/errors';
+import {vi} from 'vitest';
+
+vi.mock('@tryghost/i18n', () => {
+    const mockT = vi.fn((message, params) => {
+        if (params?.number) {
+            return `translated ${message.replace('{number}', params.number)}`;
+        }
+        return `translated ${message}`;
+    });
+
+    return {
+        default: vi.fn(() => ({
+            t: mockT
+        }))
+    };
+});
 
 describe('error messages are set correctly', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     test('handles 400 error without defaultMessage', async () => {
-        function t(message) {
-            return 'translated ' + message;
-        }
         const error = new Response('{"errors":[{"message":"This is a 400 error"}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
-        expect(chooseBestErrorMessage(humanReadableError, null, t)).toEqual('translated This is a 400 error');
+        expect(chooseBestErrorMessage(humanReadableError, null)).toEqual('translated This is a 400 error');
     });
 
     test('handles an error with defaultMessage not a special message', async () => {
-        function t(message) {
-            return 'translated ' + message;
-        }
         const error = new Response('{"errors":[{"message":"This is a 400 error"}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
         // note that the default message is passed in already-translated.
-        expect(chooseBestErrorMessage(humanReadableError, 'translated default message', t)).toEqual('translated default message');
+        expect(chooseBestErrorMessage(humanReadableError, 'translated default message')).toEqual('translated default message');
     });
 
     test('handles an error with defaultMessage that is a special message', async () => {
-        function t(message) {
-            return 'translated ' + message;
-        }
         const error = new Response('{"errors":[{"message":"Too many attempts try again in {number} minutes."}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
-        expect(chooseBestErrorMessage(humanReadableError, 'this is the default message', t)).toEqual('translated Too many attempts try again in {number} minutes.');
+        expect(chooseBestErrorMessage(humanReadableError, 'this is the default message')).toEqual('translated Too many attempts try again in {number} minutes.');
     });
 
     test('handles an error when the message has a number', async () => {
-        function t(message, {number: number}) {
-            return 'translated ' + message + ' ' + number;
-        }
         const error = new Response('{"errors":[{"message":"Too many attempts try again in 10 minutes."}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
-        expect(chooseBestErrorMessage(humanReadableError, 'this is the default message', t)).toEqual('translated Too many attempts try again in {number} minutes. 10');
+        expect(chooseBestErrorMessage(humanReadableError, 'this is the default message')).toEqual('translated Too many attempts try again in 10 minutes.');
     });
 
     test('handles a 500 error', async () => {
-        function t(message) {
-            return 'translated ' + message;
-        }
         const error = new Response('{"errors":[{"message":"This is a 500 error"}]}', {status: 500});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
-        expect(chooseBestErrorMessage(humanReadableError, null, t)).toEqual('translated A server error occurred');
+        expect(chooseBestErrorMessage(humanReadableError, null)).toEqual('translated A server error occurred');
     });
 
     test('gets the magic link error message correctly', async () => {
-        function t(message) {
-            return 'translated ' + message;
-        }
         const error = new Response('{"errors":[{"message":"Failed to send magic link email"}]}', {status: 400});
         const humanReadableError = await HumanReadableError.fromApiResponse(error);
-        expect(chooseBestErrorMessage(humanReadableError, null, t)).toEqual('translated Failed to send magic link email');
+        expect(chooseBestErrorMessage(humanReadableError, null)).toEqual('translated Failed to send magic link email');
     });
 });

--- a/apps/portal/src/utils/errors.js
+++ b/apps/portal/src/utils/errors.js
@@ -1,3 +1,5 @@
+import {t} from './i18n';
+
 export class HumanReadableError extends Error {
     /**
      * Returns whether this response from the server is a human readable error and should be shown to the user.
@@ -31,7 +33,7 @@ export const specialMessages = [];
  * Many "alreadyTranslatedDefaultMessages" are pretty vague, so we want to replace them with a more specific message
  * whenever one is available.
  */
-export function chooseBestErrorMessage(error, alreadyTranslatedDefaultMessage, t) {
+export function chooseBestErrorMessage(error, alreadyTranslatedDefaultMessage) {
     const translateMessage = (message, number = null) => {
         if (number) {
             return t(message, {number});

--- a/apps/portal/src/utils/i18n.js
+++ b/apps/portal/src/utils/i18n.js
@@ -1,0 +1,7 @@
+import i18nLib from '@tryghost/i18n';
+
+const i18n = i18nLib('en', 'portal');
+
+export const t = i18n.t.bind(i18n);
+
+export default i18n;


### PR DESCRIPTION
no issue

- we were running into situations where we wanted to use `t` in library code but because it only existed in React context it meant a lot of prop-drilling and arg passing
- extracted `i18n` and `t` setup to `utils/i18n.js` so that it can be imported anywhere within Portal without needing to be passed around
- updated `App.initSetup` to change the language from the default 'en' once we've fetched the site details
- updated `errors` util tests to mock the required `t` rather than a `t` argument
