### PR TITLE
Bumped default @tryghost/portal version to 2.55

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -212,7 +212,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.54"
+        "version": "2.55"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/02eed58ee4645a732dc245bde0edce77807ca92f

- activates latest Portal version inside Ghost
