### PR TITLE
Added polyfill for TailwindCSS v4 migration

### DIFF
--- a/apps/shade/src/styles/tailwind-v4-polyfill.css
+++ b/apps/shade/src/styles/tailwind-v4-polyfill.css
@@ -1,0 +1,33 @@
+/* TailwindCSS v4 Polyfill - Temporary utilities for v4 classes not available in v3 */
+/* This file will be removed after upgrading to TailwindCSS v4 */
+
+/* Shadow utilities */
+.shadow-xs {
+    box-shadow: 0 0 1px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.03), 0 8px 10px -12px rgba(0,0,0,.1);
+}
+
+/* Drop shadow utilities */
+.drop-shadow-xs {
+    filter: drop-shadow(0 1px 1px rgb(0 0 0 / 0.05));
+}
+
+/* Blur utilities */
+.blur-xs {
+    filter: blur(2px);
+}
+
+/* Backdrop blur utilities */
+.backdrop-blur-xs {
+    backdrop-filter: blur(2px);
+}
+
+/* Border radius utilities */
+.rounded-xs {
+    border-radius: 0.125rem; /* 2px */
+}
+
+/* Outline utilities */
+.outline-hidden {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+}

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -4,6 +4,9 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+/* TailwindCSS v4 polyfill - temporary utilities for v4 classes not available in v3 */
+@import "./src/styles/tailwind-v4-polyfill.css";
+
 @import url(https://fonts.bunny.net/css?family=cardo:400,700);
 @import url(https://fonts.bunny.net/css?family=manrope:300,500,700);
 @import url(https://fonts.bunny.net/css?family=merriweather:300,700);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2642/upgrade-tailwindcss-to-v4

This PR is part of migrating to TailwindCSS v4 in reasonable small chunks. The core idea is that first we'd update the classnames according to the [TWCSS v4 upgrade guide](https://tailwindcss.com/docs/upgrade-guide) without actually changing TWCSS to v4. This would mean that we'd need a (seemingly small) CSS file that adds classes in v3 that exist in v4 (but not in v3). It allows us to update Shade and app classes one app at a time and once that's done we can update TWCSS to v4 and all classes would be already up to date by then.

This PR is the first step in this: it creates temporary CSS utilities to support TailwindCSS v4 classnames while maintaining v3 compatibility. This polyfill includes:

    - shadow-xs, drop-shadow-xs (v4 shadow scale)
    - blur-xs, backdrop-blur-xs (v4 blur scale)
    - rounded-xs (v4 border radius scale)
    - outline-hidden (v4 outline utility)

The polyfill will be removed after upgrading to TailwindCSS v4.