### PR TITLE
Added missing auto* field attrs to redesigned OTC input

### DIFF
--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -202,10 +202,13 @@ export default class MagicLinkPage extends React.Component {
                                 type="text"
                                 value={this.state.otc}
                                 inputMode="numeric"
-                                pattern="[0-9]*"
-                                aria-label={t('Code')}
-                                autoFocus={false}
                                 maxLength={6}
+                                pattern="[0-9]*"
+                                autoComplete="one-time-code"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                                autoFocus={true}
+                                aria-label={t('Code')}
                                 onChange={e => this.handleInputChange(e, {name: OTC_FIELD_NAME})}
                             />
                         </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2706/

- fields were on the previous version but were lost during the redesign/alpha flag git shuffle
