### PR TITLE
Updated Shade classnames to support TWCSS v4

### DIFF
--- a/apps/shade/src/components/features/color-picker/color-picker.tsx
+++ b/apps/shade/src/components/features/color-picker/color-picker.tsx
@@ -247,7 +247,7 @@ export const ColorPickerHue = ({
             <Slider.Track className="relative my-0.5 h-3 w-full grow rounded-full bg-[linear-gradient(90deg,#FF0000,#FFFF00,#00FF00,#00FFFF,#0000FF,#FF00FF,#FF0000)]">
                 <Slider.Range className="absolute h-full" />
             </Slider.Track>
-            <Slider.Thumb className="block size-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+            <Slider.Thumb className="focus-visible:outline-hidden block size-4 rounded-full border border-primary/50 bg-background shadow-sm transition-colors focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
         </Slider.Root>
     );
 };
@@ -273,7 +273,7 @@ export const ColorPickerAlpha = ({
                 <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent to-black/50 dark:to-white/50" />
                 <Slider.Range className="absolute h-full rounded-full bg-transparent" />
             </Slider.Track>
-            <Slider.Thumb className="block size-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+            <Slider.Thumb className="focus-visible:outline-hidden block size-4 rounded-full border border-primary/50 bg-background shadow-sm transition-colors focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
         </Slider.Root>
     );
 };

--- a/apps/shade/src/components/features/post_share_modal/post-share-modal.stories.tsx
+++ b/apps/shade/src/components/features/post_share_modal/post-share-modal.stories.tsx
@@ -109,7 +109,7 @@ export const CopyLinkDemo: Story = {
             const [isOpen, setIsOpen] = useState(false);
 
             return (
-                <div className="space-y-4">
+                <div className="gap-4">
                     <PostShareModal
                         author="Jane Smith"
                         defaultOpen={isOpen}
@@ -141,7 +141,7 @@ export const PostSuccess: Story = {
             const [isOpen, setIsOpen] = useState(false);
 
             return (
-                <div className="space-y-4">
+                <div className="gap-4">
                     <PostShareModal
                         author="Jane Smith"
                         defaultOpen={isOpen}

--- a/apps/shade/src/components/ui/alert-dialog.tsx
+++ b/apps/shade/src/components/ui/alert-dialog.tsx
@@ -52,7 +52,7 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col space-y-2 text-center sm:text-left',
+            'flex flex-col gap-2 text-center sm:text-left',
             className
         )}
         {...props}
@@ -66,7 +66,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 [&>button]:min-w-20',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2 [&>button]:min-w-20',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/badge.tsx
+++ b/apps/shade/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import {cn} from '@/lib/utils';
 
 const badgeVariants = cva(
-    'inline-flex items-center rounded-sm border px-1.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+    'focus:outline-hidden inline-flex items-center rounded-sm border px-1.5 text-xs font-semibold transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2',
     {
         variants: {
             variant: {

--- a/apps/shade/src/components/ui/button.tsx
+++ b/apps/shade/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import {ChevronDown} from 'lucide-react';
 import {cn} from '@/lib/utils';
 
 const buttonVariants = cva(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:stroke-[1.5px]',
+    'focus-visible:outline-hidden inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:stroke-[1.5px]',
     {
         variants: {
             variant: {

--- a/apps/shade/src/components/ui/card.tsx
+++ b/apps/shade/src/components/ui/card.tsx
@@ -40,7 +40,7 @@ const Card = React.forwardRef<
 Card.displayName = 'Card';
 
 const cardHeaderVariants = cva(
-    'flex flex-col space-y-1.5',
+    'flex flex-col gap-1.5',
     {
         variants: {
             variant: {

--- a/apps/shade/src/components/ui/chart.tsx
+++ b/apps/shade/src/components/ui/chart.tsx
@@ -49,7 +49,7 @@ React.ComponentProps<'div'> & {
             <div
                 ref={ref}
                 className={cn(
-                    'flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke=\'#ccc\']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke=\'#fff\']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke=\'#ccc\']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted  [&_.recharts-reference-line_[stroke=\'#ccc\']]:stroke-border [&_.recharts-sector[stroke=\'#fff\']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none',
+                    'flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke=\'#ccc\']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke=\'#fff\']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke=\'#ccc\']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted  [&_.recharts-reference-line_[stroke=\'#ccc\']]:stroke-border [&_.recharts-sector[stroke=\'#fff\']]:stroke-transparent [&_.recharts-sector]:outline-hidden [&_.recharts-surface]:outline-hidden',
                     className
                 )}
                 data-chart={chartId}

--- a/apps/shade/src/components/ui/data-list.stories.tsx
+++ b/apps/shade/src/components/ui/data-list.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
                 <DataListRow>
                     <DataListBar />
                     <DataListItemContent>
-                        <div className='flex items-center space-x-4 overflow-hidden'>
+                        <div className='flex items-center gap-4 overflow-hidden'>
                             <div>🇺🇸</div>
                             <div className='truncate font-medium'>
                                 Clean Monochrome Workspace in Düsseldorf, Germany A Designer’s Dual Apple Studio Display Workspace in Canada
@@ -47,7 +47,7 @@ export const Default: Story = {
                         width: '93%'
                     }} />
                     <DataListItemContent>
-                        <div className='flex items-center space-x-4 overflow-hidden'>
+                        <div className='flex items-center gap-4 overflow-hidden'>
                             <div>🇺🇸</div>
                             <div className='truncate font-medium'>
                                 No percentage value, no animation
@@ -64,7 +64,7 @@ export const Default: Story = {
                         width: '74%'
                     }} />
                     <DataListItemContent>
-                        <div className='flex items-center space-x-4 overflow-hidden'>
+                        <div className='flex items-center gap-4 overflow-hidden'>
                             <div className='flex items-center gap-3 truncate'>
                                 <div>🏴‍☠️</div>
                                 <div className='overflow-hidden'>
@@ -100,7 +100,7 @@ export const WithoutHeader: Story = {
                 <DataListRow>
                     <DataListBar style={{width: '100%'}} />
                     <DataListItemContent>
-                        <div className='flex items-center space-x-4 overflow-hidden'>
+                        <div className='flex items-center gap-4 overflow-hidden'>
                             <div>🏆</div>
                             <div className='truncate font-medium'>
                                 Top Performer
@@ -115,7 +115,7 @@ export const WithoutHeader: Story = {
                 <DataListRow>
                     <DataListBar style={{width: '80%'}} />
                     <DataListItemContent>
-                        <div className='flex items-center space-x-4 overflow-hidden'>
+                        <div className='flex items-center gap-4 overflow-hidden'>
                             <div>🥈</div>
                             <div className='truncate font-medium'>
                                 Second Place

--- a/apps/shade/src/components/ui/dialog.tsx
+++ b/apps/shade/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
             <DialogPrimitive.Content
                 ref={ref}
                 className={cn(
-                    'fixed left-[50%] top-[8vmin] z-50 grid w-full max-w-lg translate-x-[-50%] gap-6 bg-background dark:bg-[#101114] p-6 shadow-lg duration-200 transform-gpu data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 sm:rounded-lg outline-none',
+                    'fixed left-[50%] top-[8vmin] z-50 grid w-full max-w-lg translate-x-[-50%] gap-6 bg-background dark:bg-[#101114] p-6 shadow-lg duration-200 transform-gpu data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 sm:rounded-lg outline-hidden',
                     className
                 )}
                 {...props}
@@ -55,7 +55,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col space-y-1.5 text-center sm:text-left',
+            'flex flex-col gap-1.5 text-center sm:text-left',
             className
         )}
         {...props}
@@ -69,7 +69,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 sm:items-end [&_button]:min-w-20',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2 sm:items-end [&_button]:min-w-20',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/dropdown-menu.tsx
+++ b/apps/shade/src/components/ui/dropdown-menu.tsx
@@ -26,7 +26,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     <DropdownMenuPrimitive.SubTrigger
         ref={ref}
         className={cn(
-            'flex cursor-default gap-2 select-none hover:bg-accent items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+            'flex cursor-default gap-2 select-none hover:bg-accent items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
             inset && 'pl-8',
             className
         )}
@@ -87,7 +87,7 @@ const DropdownMenuItem = React.forwardRef<
     <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(
-            'relative flex cursor-default select-none cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+            'relative flex cursor-default select-none cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
             inset && 'pl-8',
             className
         )}
@@ -104,7 +104,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
         ref={ref}
         checked={checked}
         className={cn(
-            'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             className
         )}
         {...props}
@@ -127,7 +127,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     <DropdownMenuPrimitive.RadioItem
         ref={ref}
         className={cn(
-            'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/empty-indicator.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.tsx
@@ -32,11 +32,11 @@ interface EmptyIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const EmptyIndicator = React.forwardRef<HTMLDivElement, EmptyIndicatorProps>(({children, className, title, description, actions, ...props}, ref) => {
     return (
-        <div ref={ref} className={cn('flex flex-col items-center justify-center space-y-3 text-center', className)} {...props}>
+        <div ref={ref} className={cn('flex flex-col items-center justify-center gap-3 text-center', className)} {...props}>
             <EmptyBadge>
                 {children}
             </EmptyBadge>
-            <div className='max-w-[320px] space-y-1.5'>
+            <div className='max-w-[320px] gap-1.5'>
                 <h3 className='text-pretty text-sm font-medium tracking-normal text-foreground'>
                     {title}
                 </h3>

--- a/apps/shade/src/components/ui/form.stories.tsx
+++ b/apps/shade/src/components/ui/form.stories.tsx
@@ -49,7 +49,7 @@ const DefaultFormComponent = () => {
     return (
         <div style={{padding: '24px', maxWidth: '400px'}}>
             <Form {...form}>
-                <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+                <form className="gap-6" onSubmit={form.handleSubmit(onSubmit)}>
                     <FormField
                         control={form.control}
                         name="name"
@@ -138,7 +138,7 @@ const WithErrorsFormComponent = () => {
     return (
         <div style={{padding: '24px', maxWidth: '400px'}}>
             <Form {...form}>
-                <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+                <form className="gap-6" onSubmit={form.handleSubmit(onSubmit)}>
                     <FormField
                         control={form.control}
                         name="name"

--- a/apps/shade/src/components/ui/form.tsx
+++ b/apps/shade/src/components/ui/form.tsx
@@ -78,7 +78,7 @@ const FormItem = React.forwardRef<
 
     return (
         <FormItemContext.Provider value={{id}}>
-            <div ref={ref} className={cn('space-y-2', className)} {...props} />
+            <div ref={ref} className={cn('gap-2', className)} {...props} />
         </FormItemContext.Provider>
     );
 });

--- a/apps/shade/src/components/ui/input.tsx
+++ b/apps/shade/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
             <input
                 ref={ref}
                 className={cn(
-                    'flex h-9 w-full rounded-md border border-transparent bg-gray-150 dark:bg-gray-900 px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:bg-transparent focus-visible:border-green focus-visible:shadow-[0_0_0_2px_rgba(48,207,67,.25)] disabled:cursor-not-allowed disabled:opacity-50',
+                    'flex h-9 w-full rounded-md border border-transparent bg-gray-150 dark:bg-gray-900 px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:bg-transparent focus-visible:border-green focus-visible:shadow-[0_0_0_2px_rgba(48,207,67,.25)] disabled:cursor-not-allowed disabled:opacity-50',
                     className
                 )}
                 type={type}

--- a/apps/shade/src/components/ui/label.stories.tsx
+++ b/apps/shade/src/components/ui/label.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story = {
 
 export const WithInput: Story = {
     render: () => (
-        <div className="space-y-2">
+        <div className="gap-2">
             <Label htmlFor="email">Email address</Label>
             <Input id="email" placeholder="Enter your email..." type="email" />
         </div>
@@ -56,7 +56,7 @@ export const WithInput: Story = {
 
 export const Required: Story = {
     render: () => (
-        <div className="space-y-2">
+        <div className="gap-2">
             <Label htmlFor="password">
                 Password <span className="text-red-500">*</span>
             </Label>
@@ -74,7 +74,7 @@ export const Required: Story = {
 
 export const Disabled: Story = {
     render: () => (
-        <div className="space-y-2">
+        <div className="gap-2">
             <Label htmlFor="disabled-input">Disabled field</Label>
             <Input id="disabled-input" placeholder="This field is disabled..." disabled />
         </div>

--- a/apps/shade/src/components/ui/pagemenu.tsx
+++ b/apps/shade/src/components/ui/pagemenu.tsx
@@ -153,7 +153,7 @@ const PageMenu = React.forwardRef<HTMLDivElement, PageMenuProps>(
                             <DropdownMenuTrigger asChild>
                                 <Button
                                     className={cn(
-                                        'h-[30px] flex-shrink-0 px-3 py-2',
+                                        'h-[30px] shrink-0 px-3 py-2',
                                         selectedHiddenItem && 'bg-accent text-accent-foreground'
                                     )}
                                     variant="ghost"

--- a/apps/shade/src/components/ui/popover.stories.tsx
+++ b/apps/shade/src/components/ui/popover.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
                     </PopoverTrigger>
                     <PopoverContent align="start" className="w-80">
                         <div className="grid gap-4">
-                            <div className="space-y-2">
+                            <div className="gap-2">
                                 <h4 className="font-medium leading-none">Dimensions</h4>
                                 <p className="text-sm text-muted-foreground">Set the dimensions for the layer.</p>
                             </div>

--- a/apps/shade/src/components/ui/popover.tsx
+++ b/apps/shade/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
         ref={ref}
         align={align}
         className={cn(
-            'z-50 rounded-md bg-white dark:bg-gray-950 p-5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 rounded-md bg-white dark:bg-gray-950 p-5 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className
         )}
         sideOffset={sideOffset}

--- a/apps/shade/src/components/ui/select.tsx
+++ b/apps/shade/src/components/ui/select.tsx
@@ -18,7 +18,7 @@ const SelectTrigger = React.forwardRef<
     <SelectPrimitive.Trigger
         ref={ref}
         className={cn(
-            'flex h-[34px] w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent hover:bg-accent px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+            'flex h-[34px] w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent hover:bg-accent px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
             className
         )}
         {...props}
@@ -117,7 +117,7 @@ const SelectItem = React.forwardRef<
     <SelectPrimitive.Item
         ref={ref}
         className={cn(
-            'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/separator.stories.tsx
+++ b/apps/shade/src/components/ui/separator.stories.tsx
@@ -31,7 +31,7 @@ export const Horizontal: Story = {
 
 export const WithLabel: Story = {
     render: args => (
-        <div className="space-y-4">
+        <div className="gap-4">
             <div className="text-sm text-muted-foreground">Section title</div>
             <Separator {...args} />
             <div className="text-sm">Content below the labeled section.</div>

--- a/apps/shade/src/components/ui/sheet.tsx
+++ b/apps/shade/src/components/ui/sheet.tsx
@@ -84,7 +84,7 @@ const SheetHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col space-y-1 text-center sm:text-left',
+            'flex flex-col gap-1 text-center sm:text-left',
             className
         )}
         {...props}
@@ -98,7 +98,7 @@ const SheetFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2',
             className
         )}
         {...props}

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -439,7 +439,7 @@ const SidebarGroupLabel = React.forwardRef<
         <Comp
             ref={ref}
             className={cn(
-                'duration-200 flex shrink-0 items-center rounded-md px-3 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+                'duration-200 flex shrink-0 items-center rounded-md px-3 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
                 'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
                 `h-${SIDEBAR_MENU_HEIGHT}`,
                 className
@@ -461,7 +461,7 @@ const SidebarGroupAction = React.forwardRef<
         <Comp
             ref={ref}
             className={cn(
-                'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+                'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
                 // Increases the hit area of the button on mobile.
                 'after:absolute after:-inset-2 after:md:hidden',
                 'group-data-[collapsible=icon]:hidden',
@@ -514,7 +514,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = 'SidebarMenuItem';
 
 const sidebarMenuButtonVariants = cva(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md px-3 py-2 text-left text-md font-medium text-gray-800 outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-semibold data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+    'peer/menu-button outline-hidden flex w-full items-center gap-2 overflow-hidden rounded-md px-3 py-2 text-left text-md font-medium text-gray-800 ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-semibold data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
     {
         variants: {
             variant: {
@@ -607,7 +607,7 @@ React.ComponentProps<'button'> & {
         <Comp
             ref={ref}
             className={cn(
-                'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
+                'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
                 // Increases the hit area of the button on mobile.
                 'after:absolute after:-inset-2 after:md:hidden',
                 'peer-data-[size=sm]/menu-button:top-1',
@@ -721,7 +721,7 @@ React.ComponentProps<'a'> & {
         <Comp
             ref={ref}
             className={cn(
-                'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-3 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+                'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-3 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
                 'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
                 size === 'sm' && 'text-xs',
                 size === 'md' && 'text-sm',

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -84,7 +84,7 @@ const TabsList = React.forwardRef<
 TabsList.displayName = TabsPrimitive.List.displayName;
 
 const tabsTriggerVariants = cva(
-    'inline-flex items-center justify-center whitespace-nowrap px-3 py-1 ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground [&_svg]:size-4 [&_svg]:shrink-0',
+    'focus-visible:outline-hidden inline-flex items-center justify-center whitespace-nowrap px-3 py-1 ring-offset-background transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground [&_svg]:size-4 [&_svg]:shrink-0',
     {
         variants: {
             variant: {
@@ -132,7 +132,7 @@ const TabsTriggerCount: React.FC<TabsTriggerCountProps> = ({className = '', chil
 TabsTriggerCount.displayName = 'TabsTriggerCount';
 
 const tabsContentVariants = cva(
-    'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+    'focus-visible:outline-hidden ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
     {
         variants: {
             variant: {

--- a/apps/shade/src/components/ui/textarea.tsx
+++ b/apps/shade/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<
         <textarea
             ref={ref}
             className={cn(
-                'flex min-h-[80px] w-full rounded-md border border-transparent bg-gray-150 dark:bg-gray-900 px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:bg-transparent focus-visible:border-green focus-visible:shadow-[0_0_0_2px_rgba(48,207,67,.25)] disabled:cursor-not-allowed disabled:opacity-50',
+                'flex min-h-[80px] w-full rounded-md border border-transparent bg-gray-150 dark:bg-gray-900 px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:bg-transparent focus-visible:border-green focus-visible:shadow-[0_0_0_2px_rgba(48,207,67,.25)] disabled:cursor-not-allowed disabled:opacity-50',
                 className
             )}
             {...props}

--- a/apps/shade/src/components/ui/toggle.tsx
+++ b/apps/shade/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import {cn} from '@/lib/utils';
 
 const toggleVariants = cva(
-    'inline-flex items-center justify-center gap-2 rounded-sm text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm dark:hover:bg-background [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:stroke-[1.5px]',
+    'focus-visible:outline-hidden inline-flex items-center justify-center gap-2 rounded-sm text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-xs dark:hover:bg-background [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:stroke-[1.5px]',
     {
         variants: {
             variant: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2642/upgrade-tailwindcss-to-v4

This PR is part of migrating to TailwindCSS v4 in reasonable small chunks. The core idea is that first we'd update the classnames according to the [TWCSS v4 upgrade guide](https://tailwindcss.com/docs/upgrade-guide) without actually changing TWCSS to v4. This would mean that we'd need a (seemingly small) CSS file that adds classes in v3 that exist in v4 (but not in v3). It allows us to update Shade and app classes one app at a time and once that's done we can update TWCSS to v4 and all classes would be already up to date by then.

This PR updates Shade classnames to be forward compatible with TailwindCSS V4.
