### PR TITLE
Added stats utm endpoints with fixture data

### DIFF
--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -514,7 +514,7 @@ const controller = {
         },
         options: [
             'order',
-            'limit', 
+            'limit',
             'date_from',
             'date_to',
             'timezone',
@@ -540,6 +540,42 @@ const controller = {
         },
         async query(frame) {
             return await statsService.api.getTopSourcesWithRange(frame.options);
+        }
+    },
+    utmGrowth: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'utm_type',
+            'order',
+            'limit',
+            'date_from',
+            'date_to',
+            'timezone',
+            'post_id'
+        ],
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        cache: statsService.cache,
+        generateCacheKeyData(frame) {
+            return {
+                method: 'utmGrowth',
+                options: {
+                    utm_type: frame.options.utm_type,
+                    order: frame.options.order,
+                    limit: frame.options.limit,
+                    date_from: frame.options.date_from,
+                    date_to: frame.options.date_to,
+                    timezone: frame.options.timezone,
+                    post_id: frame.options.post_id
+                }
+            };
+        },
+        async query(frame) {
+            return await statsService.api.getUtmGrowthStats(frame.options);
         }
     }
 

--- a/ghost/core/core/server/services/stats/ReferrersStatsService.js
+++ b/ghost/core/core/server/services/stats/ReferrersStatsService.js
@@ -645,7 +645,7 @@ module.exports.normalizeSource = normalizeSource;
  * @typedef {object} UtmGrowthStat
  * @type {Object}
  * @property {string} utm_value - The UTM parameter value (e.g., 'google', 'facebook')
- * @property {string} utm_type - The UTM parameter type ('source', 'medium', 'campaign')
+ * @property {string} utm_type - The UTM parameter type ('utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content')
  * @property {number} free_members - Count of free member signups
  * @property {number} paid_members - Count of paid member conversions
  * @property {number} mrr - Total MRR from this UTM parameter (in cents)

--- a/ghost/core/core/server/services/stats/ReferrersStatsService.js
+++ b/ghost/core/core/server/services/stats/ReferrersStatsService.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const errors = require('@tryghost/errors');
 
 // Import centralized date utilities
 const {getDateBoundaries, applyDateFilter} = require('./utils/date-utils');
@@ -473,7 +474,9 @@ class ReferrersStatsService {
         // Validate utm_type is a valid UTM field
         const validUtmFields = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
         if (!validUtmFields.includes(utmField)) {
-            throw new Error(`Invalid utm_type: ${utmField}. Must be one of: ${validUtmFields.join(', ')}`);
+            throw new errors.BadRequestError({
+                message: `Invalid utm_type: ${utmField}. Must be one of: ${validUtmFields.join(', ')}`
+            });
         }
 
         // Fixture data; will replace with real data once members service is wired up fully

--- a/ghost/core/core/server/services/stats/StatsService.js
+++ b/ghost/core/core/server/services/stats/StatsService.js
@@ -245,6 +245,23 @@ class StatsService {
     }
 
     /**
+     * Get UTM growth stats broken down by UTM field (fixture data)
+     * Can be filtered by post using post_id parameter
+     * @param {Object} options
+     * @param {string} [options.utm_type='utm_source'] - Which UTM field to group by ('utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content')
+     * @param {string} [options.order='free_members desc'] - Sort order
+     * @param {number} [options.limit=50] - Maximum number of results (ignored when filtering by post)
+     * @param {string} [options.date_from] - Start date in YYYY-MM-DD format (not yet implemented for fixtures)
+     * @param {string} [options.date_to] - End date in YYYY-MM-DD format (not yet implemented for fixtures)
+     * @param {string} [options.timezone] - Timezone to use for date interpretation (not yet implemented for fixtures)
+     * @param {string} [options.post_id] - Optional filter by post ID
+     * @returns {Promise<{data: import('./ReferrersStatsService').UtmGrowthStat[], meta: {}}>}
+     */
+    async getUtmGrowthStats(options = {}) {
+        return this.referrers.getUtmGrowthStats(options);
+    }
+
+    /**
      * @param {object} deps
      *
      * @returns {StatsService}

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -165,6 +165,7 @@ module.exports = function apiRoutes() {
     router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
     router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
     router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
+    router.get('/stats/utm-growth', mw.authAdminApi, http(api.stats.utmGrowth));
     router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));
     router.post('/stats/posts-member-counts', mw.authAdminApi, http(api.stats.postsMemberCounts));
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2717/
- add new utm endpoint, /stats/utm-growth, accepting a param for the utm return field
- added fixture data for new endpoint until fully wired up

This set of changes adds a new endpoint, /stats/utm-growth, that returns fixture data until we're able to fully wire up the members service to the backend. This effectively unlocks the frontend design from being dependent on the backend support.

The stats endpoint is intended to be used like `/stats/utm-growth?post_id={id}&utm_type=utm_source`. Post is optional; the only required field is utm_type.