### PR TITLE
Fixed waiting logic in e2e test global setup

### DIFF
--- a/e2e/helpers/environment/DockerCompose.ts
+++ b/e2e/helpers/environment/DockerCompose.ts
@@ -58,7 +58,7 @@ export class DockerCompose {
      * Returns null if no containers are found.
      */
     async getContainersStatus(): Promise<ContainerStatusItem[] | null> {
-        const command = `docker compose -f ${this.composeFilePath} -p ${this.projectName} ps --format json`;
+        const command = `docker compose -f ${this.composeFilePath} -p ${this.projectName} ps -a --format json`;
         const output = execSync(command, {encoding: 'utf-8'}).trim();
         if (!output) {
             return null;


### PR DESCRIPTION
In the e2e global setup, we have some custom logic to wait for all docker compose services to:
- be in a healthy state, if they have a health check configured
- exit with code 0 otherwise

There was an error in this check causing it to only check containers that are running, thus ignoring any containers which may have exited with code 1. This fixes that, so if a container exits with code 1, the global setup will fail and output a much clearer error message describing what went wrong.