### PR TITLE
Added local configuration files to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,6 @@ compose.yml
 !.docker/**/*entrypoint.sh
 
 ghost/core/core/built/admin
+
+# Ignore local config files (.json and .jsonc)
+ghost/core/config.local.json*


### PR DESCRIPTION
Previously any local configuration files at `ghost/core/config.local.json` would be copied into the container, leading to inconsistencies between the container built in CI and any containers built locally. These configuration files are gitignored but not dockerignored currently.

This removes the config files from any docker builds, which should help ensure local builds run the same as they do in CI. 