### PR TITLE
Fixed local build files overriding docker files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "docker:dev:analytics": "docker compose --profile analytics up -d --wait",
     "docker:dev:analytics:stop": "docker compose --profile analytics down",
     "docker:dev:analytics:logs": "docker compose --profile analytics logs -f",
-    "docker:build": "yarn docker:clean && docker compose --profile all build",
+    "docker:build": "yarn docker:clean && yarn build:clean && docker compose --profile all build",
     "docker:clean": "echo \"Deleting node_modules volumes...\" && docker compose --profile all down --remove-orphans && docker volume ls -q -f name=ghost_node_modules | xargs -I{} docker volume rm {}",
     "docker:shell": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost /bin/bash",
     "docker:mysql": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up mysql -d --wait && docker compose exec mysql mysql -u root -proot ghost",


### PR DESCRIPTION
no refs

When running Ghost locally in docker for development, your local files are mounted into the built container. If you have any stale build outputs for any apps locally, these stale files will override the correct build files in the Docker container, which can lead to unexpected behavior that is counterintuitive and difficult to debug, leading to a general experience of "flakiness" with Docker.

This change attempts to improve this by deleting all local build outputs before building the docker container, such that running `yarn docker:build` should always result in a completely fresh build of everything, even after mounting your local files into the container.