### PR TITLE
Added UTM fields to Ghost member attribution service

### DIFF
--- a/ghost/core/core/server/services/member-attribution/AttributionBuilder.js
+++ b/ghost/core/core/server/services/member-attribution/AttributionBuilder.js
@@ -7,6 +7,11 @@
  * @prop {string|null} referrerSource
  * @prop {string|null} referrerMedium
  * @prop {string|null} referrerUrl
+ * @prop {string|null} utmSource
+ * @prop {string|null} utmMedium
+ * @prop {string|null} utmCampaign
+ * @prop {string|null} utmTerm
+ * @prop {string|null} utmContent
  */
 
 class Attribution {
@@ -21,9 +26,14 @@ class Attribution {
      * @param {string|null} [data.referrerSource]
      * @param {string|null} [data.referrerMedium]
      * @param {string|null} [data.referrerUrl]
+     * @param {string|null} [data.utmSource]
+     * @param {string|null} [data.utmMedium]
+     * @param {string|null} [data.utmCampaign]
+     * @param {string|null} [data.utmTerm]
+     * @param {string|null} [data.utmContent]
      */
     constructor({
-        id, url, type, referrerSource, referrerMedium, referrerUrl
+        id, url, type, referrerSource, referrerMedium, referrerUrl, utmSource, utmMedium, utmCampaign, utmTerm, utmContent
     }, {urlTranslator}) {
         this.id = id;
         this.url = url;
@@ -31,6 +41,11 @@ class Attribution {
         this.referrerSource = referrerSource;
         this.referrerMedium = referrerMedium;
         this.referrerUrl = referrerUrl;
+        this.utmSource = utmSource;
+        this.utmMedium = utmMedium;
+        this.utmCampaign = utmCampaign;
+        this.utmTerm = utmTerm;
+        this.utmContent = utmContent;
 
         /**
          * @private
@@ -57,7 +72,12 @@ class Attribution {
                     title: null,
                     referrerSource: this.referrerSource,
                     referrerMedium: this.referrerMedium,
-                    referrerUrl: this.referrerUrl
+                    referrerUrl: this.referrerUrl,
+                    utmSource: this.utmSource,
+                    utmMedium: this.utmMedium,
+                    utmCampaign: this.utmCampaign,
+                    utmTerm: this.utmTerm,
+                    utmContent: this.utmContent
                 };
             }
             return {
@@ -67,7 +87,12 @@ class Attribution {
                 title: this.#urlTranslator.getUrlTitle(this.url),
                 referrerSource: this.referrerSource,
                 referrerMedium: this.referrerMedium,
-                referrerUrl: this.referrerUrl
+                referrerUrl: this.referrerUrl,
+                utmSource: this.utmSource,
+                utmMedium: this.utmMedium,
+                utmCampaign: this.utmCampaign,
+                utmTerm: this.utmTerm,
+                utmContent: this.utmContent
             };
         }
 
@@ -80,7 +105,12 @@ class Attribution {
             title: model.get('title') ?? model.get('name') ?? this.#urlTranslator.getUrlTitle(this.url),
             referrerSource: this.referrerSource,
             referrerMedium: this.referrerMedium,
-            referrerUrl: this.referrerUrl
+            referrerUrl: this.referrerUrl,
+            utmSource: this.utmSource,
+            utmMedium: this.utmMedium,
+            utmCampaign: this.utmCampaign,
+            utmTerm: this.utmTerm,
+            utmContent: this.utmContent
         };
     }
 
@@ -118,14 +148,19 @@ class AttributionBuilder {
     /**
      * Creates an Attribution object with the dependencies injected
      */
-    build({id, url, type, referrerSource, referrerMedium, referrerUrl}) {
+    build({id, url, type, referrerSource, referrerMedium, referrerUrl, utmSource, utmMedium, utmCampaign, utmTerm, utmContent}) {
         return new Attribution({
             id,
             url,
             type,
             referrerSource,
             referrerMedium,
-            referrerUrl
+            referrerUrl,
+            utmSource,
+            utmMedium,
+            utmCampaign,
+            utmTerm,
+            utmContent
         }, {urlTranslator: this.urlTranslator});
     }
 
@@ -142,14 +177,24 @@ class AttributionBuilder {
                 type: null,
                 referrerSource: null,
                 referrerMedium: null,
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         }
 
         const referrerData = this.referrerTranslator.getReferrerDetails(history) || {
             referrerSource: null,
             referrerMedium: null,
-            referrerUrl: null
+            referrerUrl: null,
+            utmSource: null,
+            utmMedium: null,
+            utmCampaign: null,
+            utmTerm: null,
+            utmContent: null
         };
 
         // Start at the end. Return the first post we find
@@ -194,10 +239,10 @@ class AttributionBuilder {
 
         // We only have history items without a path that have invalid ids
         return this.build({
-            ...referrerData,
             id: null,
             url: null,
-            type: null
+            type: null,
+            ...referrerData
         });
     }
 }

--- a/ghost/core/core/server/services/member-attribution/README.md
+++ b/ghost/core/core/server/services/member-attribution/README.md
@@ -43,20 +43,8 @@ graph TD
 #### 1. **MemberAttributionService** (`MemberAttributionService.js`)
 Main service interface that coordinates all attribution logic.
 
-**Responsibilities:**
-- Convert URL history arrays into attribution objects
-- Handle attribution from Ghost framework context (API, Admin, Import)
-- Retrieve stored attribution for members and subscriptions
-- Add post attribution tracking parameters to URLs
-
 #### 2. **AttributionBuilder** (`AttributionBuilder.js`)
-
 Converts URL history into attribution resources using the "Last Post Algorithm™️".
-
-**Responsibilities:**
-- Parse URL history and extract the most relevant attribution
-- Build `Attribution` objects with all relevant data
-- Fetch resource models (posts, pages, tags, authors) to enrich attribution
 
 **Key Classes:**
 - `Attribution`: Represents attribution data with methods to fetch and enrich resources
@@ -65,157 +53,17 @@ Converts URL history into attribution resources using the "Last Post Algorithm�
 #### 3. **UrlHistory** (`UrlHistory.js`)
 Validated container for URL history arrays from the frontend.
 
-**Responsibilities:**
-- Validate history structure and data types
-- Filter expired entries (older than 24 hours)
-- Provide iterable interface (newest to oldest)
-
 #### 4. **UrlTranslator** (`UrlTranslator.js`)
 Translates between URLs and Ghost resources.
-
-**Responsibilities:**
-- Convert paths to resource types and IDs using the URL service
-- Fetch resource models by ID and type
-- Handle subdirectory path conversions
-- Generate resource URLs
-
-**Supported Resources:**
-- Posts (`type: 'post'`)
-- Pages (`type: 'page'`)
-- Tags (`type: 'tag'`)
-- Authors (`type: 'author'`)
-- Generic URLs (`type: 'url'`)
 
 #### 5. **ReferrerTranslator** (`ReferrerTranslator.js`)
 Parses referrer information into source and medium classifications.
 
-**Responsibilities:**
-- Use `@tryghost/referrer-parser` to identify known referrer sources
-- Extract UTM parameters from history
-- Filter out internal and blocked referrers (e.g., checkout.stripe.com)
-- Default to "Direct" when no referrer is found
-
 #### 6. **OutboundLinkTagger** (`OutboundLinkTagger.js`)
 Adds `?ref=` parameters to external links in newsletters.
 
-**Responsibilities:**
-- Tag outbound links with site domain or newsletter name
-- Skip links that already have attribution parameters
-- Handle blocked domains that don't support ref parameters
-- Process HTML content to add tags to all external links
-
 #### 7. **Frontend Script** (`member-attribution.js`)
 Browser-side script that captures visitor journey in sessionStorage.
-
-**Responsibilities:**
-- Track page visits in sessionStorage (`ghost-history` key)
-- Parse and store referrer information and UTM parameters
-- Handle attribution query parameters (`attribution_id`, `attribution_type`)
-- Maintain history limit (15 items) and expiry (24 hours)
-- Clean up URL by removing attribution params after capturing
-
-## Data Flow
-
-### 1. Visitor Journey Tracking (Frontend)
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Browser
-    participant Script as member-attribution.js
-    participant Storage as sessionStorage
-
-    User->>Browser: Visits page
-    Browser->>Script: Page load
-    Script->>Script: Capture current path
-    Script->>Script: Extract referrer URL
-    Script->>Script: Parse UTM parameters
-    Script->>Script: Check attribution query params
-    Script->>Storage: Store as URLHistory array
-```
-
-### 2. Member Signup (Backend)
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant MAS as MemberAttributionService
-    participant UH as UrlHistory
-    participant AB as AttributionBuilder
-    participant UT as UrlTranslator
-    participant RT as ReferrerTranslator
-    participant Attr as Attribution
-    participant DB as MemberCreatedEvent
-
-    Client->>MAS: Signup with URLHistory
-    MAS->>UH: create(history)
-    UH->>UH: Validate & filter expired
-    UH-->>MAS: Validated history
-    MAS->>AB: getAttribution(history)
-
-    loop For each history item (newest first)
-        AB->>UT: getResourceDetails(item)
-        UT-->>AB: Resource type & ID
-        AB->>AB: Find last post or first resource
-    end
-
-    AB->>RT: getReferrerDetails(history)
-    RT-->>AB: Referrer source, medium, UTM data
-    AB->>Attr: build(resource + referrer data)
-    Attr->>Attr: fetchResource()
-    Attr-->>AB: Enriched attribution
-    AB-->>MAS: Attribution object
-
-    MAS->>DB: Store attribution data
-    Note over DB: attribution_id, attribution_type,<br/>attribution_url, referrer_source,<br/>referrer_medium, referrer_url,<br/>utm_source, utm_medium, etc.
-```
-
-### 3. Attribution Retrieval
-
-```mermaid
-sequenceDiagram
-    participant API
-    participant MAS as MemberAttributionService
-    participant DB as MemberCreatedEvent
-    participant AB as AttributionBuilder
-    participant Attr as Attribution
-
-    API->>MAS: getMemberCreatedAttribution(memberId)
-    MAS->>DB: Load event by member_id
-    DB-->>MAS: Event with attribution data
-    MAS->>AB: build(stored attribution)
-    AB->>Attr: Create Attribution instance
-    Attr->>Attr: fetchResource()
-    Note over Attr: Loads current title & URL<br/>from Post/Page/Tag/Author
-    Attr-->>MAS: AttributionResource
-    MAS-->>API: Return attribution with title & URL
-```
-
-### 4. Newsletter Link Tagging
-
-```mermaid
-sequenceDiagram
-    participant Email as Newsletter Service
-    participant OLT as OutboundLinkTagger
-    participant LR as LinkReplacer
-
-    Email->>OLT: addToHtml(html, newsletter)
-    OLT->>LR: replace(html, callback)
-
-    loop For each link in HTML
-        LR->>OLT: Check if external link
-        alt Is external & not blocked
-            OLT->>OLT: addToUrl(url, newsletter)
-            Note over OLT: Appends ?ref=site-domain<br/>or ?ref=newsletter-name-newsletter
-            OLT-->>LR: Modified URL
-        else Is internal or blocked
-            OLT-->>LR: Original URL
-        end
-    end
-
-    LR-->>OLT: Modified HTML
-    OLT-->>Email: HTML with tagged links
-```
 
 ## Attribution Types
 

--- a/ghost/core/core/server/services/member-attribution/README.md
+++ b/ghost/core/core/server/services/member-attribution/README.md
@@ -1,0 +1,253 @@
+# Member Attribution Service
+
+The Member Attribution Service tracks how members discover and sign up to a Ghost site. It captures attribution data (source pages, referrer information, UTM parameters) and associates it with member signup and subscription events.
+
+## Features
+
+### Core Attribution Tracking
+- **Page Attribution**: Tracks which pages (posts, pages, authors, tags) visitors viewed before becoming members
+- **Referrer Attribution**: Identifies external sources (search engines, social media, direct links) that brought visitors to the site
+- **UTM Parameter Tracking**: Captures UTM campaign parameters (source, medium, campaign, term, content) for marketing attribution
+- **Last Post Algorithm**: Prioritizes the last post viewed in the visitor's journey as the primary attribution source
+
+### Attribution Sources
+- **Content Attribution**: Posts, pages, authors, and tags visited by members
+- **External Referrers**: Tracks referrer sources like Google, Facebook, Twitter, etc. using `@tryghost/referrer-parser`
+- **Manual Creation**: Tracks members created via Admin UI, API, or import tools
+- **Integration Attribution**: Associates members created via integrations with the integration name
+- **Newsletter Links**: Adds attribution tracking to outbound links in newsletters with `?ref=` parameters
+
+### Settings
+- **Member Source Tracking**: Can be enabled/disabled via `members_track_sources` setting
+- **Outbound Link Tagging**: Can be enabled/disabled via `outbound_link_tagging` setting
+
+## Architecture
+
+### Component Overview
+
+```mermaid
+graph TD
+    A[Frontend Browser<br/>member-attribution.js<br/>Captures URL history in session] -->|URLHistory Array| B[MemberAttributionService<br/>Main service interface<br/>Coordinates attribution logic]
+
+    B --> C[AttributionBuilder<br/>Converts URLHistory into Attribution objects<br/>Implements Last Post Algorithm]
+    B --> D[UrlTranslator<br/>Converts paths to resource IDs and types<br/>Fetches Post/Page/Tag/Author models]
+    B --> E[ReferrerTranslator<br/>Parses referrer URLs to identify sources<br/>Extracts UTM parameters]
+    B --> F[OutboundLinkTagger<br/>Adds ?ref parameters to external links]
+
+    C --> D
+    C --> E
+```
+
+### Components
+
+#### 1. **MemberAttributionService** (`MemberAttributionService.js`)
+Main service interface that coordinates all attribution logic.
+
+**Responsibilities:**
+- Convert URL history arrays into attribution objects
+- Handle attribution from Ghost framework context (API, Admin, Import)
+- Retrieve stored attribution for members and subscriptions
+- Add post attribution tracking parameters to URLs
+
+#### 2. **AttributionBuilder** (`AttributionBuilder.js`)
+
+Converts URL history into attribution resources using the "Last Post Algorithm™️".
+
+**Responsibilities:**
+- Parse URL history and extract the most relevant attribution
+- Build `Attribution` objects with all relevant data
+- Fetch resource models (posts, pages, tags, authors) to enrich attribution
+
+**Key Classes:**
+- `Attribution`: Represents attribution data with methods to fetch and enrich resources
+- `AttributionBuilder`: Factory for creating `Attribution` instances
+
+#### 3. **UrlHistory** (`UrlHistory.js`)
+Validated container for URL history arrays from the frontend.
+
+**Responsibilities:**
+- Validate history structure and data types
+- Filter expired entries (older than 24 hours)
+- Provide iterable interface (newest to oldest)
+
+#### 4. **UrlTranslator** (`UrlTranslator.js`)
+Translates between URLs and Ghost resources.
+
+**Responsibilities:**
+- Convert paths to resource types and IDs using the URL service
+- Fetch resource models by ID and type
+- Handle subdirectory path conversions
+- Generate resource URLs
+
+**Supported Resources:**
+- Posts (`type: 'post'`)
+- Pages (`type: 'page'`)
+- Tags (`type: 'tag'`)
+- Authors (`type: 'author'`)
+- Generic URLs (`type: 'url'`)
+
+#### 5. **ReferrerTranslator** (`ReferrerTranslator.js`)
+Parses referrer information into source and medium classifications.
+
+**Responsibilities:**
+- Use `@tryghost/referrer-parser` to identify known referrer sources
+- Extract UTM parameters from history
+- Filter out internal and blocked referrers (e.g., checkout.stripe.com)
+- Default to "Direct" when no referrer is found
+
+#### 6. **OutboundLinkTagger** (`OutboundLinkTagger.js`)
+Adds `?ref=` parameters to external links in newsletters.
+
+**Responsibilities:**
+- Tag outbound links with site domain or newsletter name
+- Skip links that already have attribution parameters
+- Handle blocked domains that don't support ref parameters
+- Process HTML content to add tags to all external links
+
+#### 7. **Frontend Script** (`member-attribution.js`)
+Browser-side script that captures visitor journey in sessionStorage.
+
+**Responsibilities:**
+- Track page visits in sessionStorage (`ghost-history` key)
+- Parse and store referrer information and UTM parameters
+- Handle attribution query parameters (`attribution_id`, `attribution_type`)
+- Maintain history limit (15 items) and expiry (24 hours)
+- Clean up URL by removing attribution params after capturing
+
+## Data Flow
+
+### 1. Visitor Journey Tracking (Frontend)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Script as member-attribution.js
+    participant Storage as sessionStorage
+
+    User->>Browser: Visits page
+    Browser->>Script: Page load
+    Script->>Script: Capture current path
+    Script->>Script: Extract referrer URL
+    Script->>Script: Parse UTM parameters
+    Script->>Script: Check attribution query params
+    Script->>Storage: Store as URLHistory array
+```
+
+### 2. Member Signup (Backend)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant MAS as MemberAttributionService
+    participant UH as UrlHistory
+    participant AB as AttributionBuilder
+    participant UT as UrlTranslator
+    participant RT as ReferrerTranslator
+    participant Attr as Attribution
+    participant DB as MemberCreatedEvent
+
+    Client->>MAS: Signup with URLHistory
+    MAS->>UH: create(history)
+    UH->>UH: Validate & filter expired
+    UH-->>MAS: Validated history
+    MAS->>AB: getAttribution(history)
+
+    loop For each history item (newest first)
+        AB->>UT: getResourceDetails(item)
+        UT-->>AB: Resource type & ID
+        AB->>AB: Find last post or first resource
+    end
+
+    AB->>RT: getReferrerDetails(history)
+    RT-->>AB: Referrer source, medium, UTM data
+    AB->>Attr: build(resource + referrer data)
+    Attr->>Attr: fetchResource()
+    Attr-->>AB: Enriched attribution
+    AB-->>MAS: Attribution object
+
+    MAS->>DB: Store attribution data
+    Note over DB: attribution_id, attribution_type,<br/>attribution_url, referrer_source,<br/>referrer_medium, referrer_url,<br/>utm_source, utm_medium, etc.
+```
+
+### 3. Attribution Retrieval
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant MAS as MemberAttributionService
+    participant DB as MemberCreatedEvent
+    participant AB as AttributionBuilder
+    participant Attr as Attribution
+
+    API->>MAS: getMemberCreatedAttribution(memberId)
+    MAS->>DB: Load event by member_id
+    DB-->>MAS: Event with attribution data
+    MAS->>AB: build(stored attribution)
+    AB->>Attr: Create Attribution instance
+    Attr->>Attr: fetchResource()
+    Note over Attr: Loads current title & URL<br/>from Post/Page/Tag/Author
+    Attr-->>MAS: AttributionResource
+    MAS-->>API: Return attribution with title & URL
+```
+
+### 4. Newsletter Link Tagging
+
+```mermaid
+sequenceDiagram
+    participant Email as Newsletter Service
+    participant OLT as OutboundLinkTagger
+    participant LR as LinkReplacer
+
+    Email->>OLT: addToHtml(html, newsletter)
+    OLT->>LR: replace(html, callback)
+
+    loop For each link in HTML
+        LR->>OLT: Check if external link
+        alt Is external & not blocked
+            OLT->>OLT: addToUrl(url, newsletter)
+            Note over OLT: Appends ?ref=site-domain<br/>or ?ref=newsletter-name-newsletter
+            OLT-->>LR: Modified URL
+        else Is internal or blocked
+            OLT-->>LR: Original URL
+        end
+    end
+
+    LR-->>OLT: Modified HTML
+    OLT-->>Email: HTML with tagged links
+```
+
+## Attribution Types
+
+The service supports these attribution types:
+
+| Type     | Description                              | Has ID | Resource Model |
+|----------|------------------------------------------|--------|----------------|
+| `post`   | Blog post                                | ✓      | Post           |
+| `page`   | Static page                              | ✓      | Post           |
+| `author` | Author page                              | ✓      | User           |
+| `tag`    | Tag page                                 | ✓      | Tag            |
+| `url`    | Generic URL (no specific resource)       | ✗      | None           |
+| `null`   | No attribution (tracking disabled/empty) | ✗      | None           |
+
+## Internal Context Sources
+
+When members are created through Ghost's internal systems:
+
+| Context      | referrerSource        | referrerMedium  |
+|--------------|-----------------------|-----------------|
+| `import`     | Imported              | Member Importer |
+| `admin`      | Created manually      | Ghost Admin     |
+| `api`        | Created via API       | Admin API       |
+| `integration`| Integration: {name}   | Admin API       |
+
+## Testing
+
+Tests are located in:
+- `test/unit/server/services/member-attribution/attribution.test.js`
+- `test/unit/server/services/member-attribution/history.test.js`
+- `test/unit/server/services/member-attribution/service.test.js`
+- `test/unit/server/services/member-attribution/url-translator.test.js`
+- `test/unit/server/services/member-attribution/referrer-translator.test.js`
+- `test/unit/server/services/member-attribution/outbound-link-tagger.test.js`
+- `test/e2e-server/services/member-attribution.test.js`

--- a/ghost/core/core/server/services/member-attribution/ReferrerTranslator.js
+++ b/ghost/core/core/server/services/member-attribution/ReferrerTranslator.js
@@ -3,6 +3,11 @@
  * @prop {string|null} [referrerSource]
  * @prop {string|null} [referrerMedium]
  * @prop {string|null} [referrerUrl]
+ * @prop {string|null} [utmSource]
+ * @prop {string|null} [utmMedium]
+ * @prop {string|null} [utmCampaign]
+ * @prop {string|null} [utmTerm]
+ * @prop {string|null} [utmContent]
  */
 
 const {ReferrerParser} = require('@tryghost/referrer-parser');
@@ -36,8 +41,35 @@ class ReferrerTranslator {
             return {
                 referrerSource: null,
                 referrerMedium: null,
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             };
+        }
+
+        // Look for UTM parameters first (most recent entry with UTM data)
+        let utmData = {
+            utmSource: null,
+            utmMedium: null,
+            utmCampaign: null,
+            utmTerm: null,
+            utmContent: null
+        };
+
+        for (const item of history) {
+            if (item.utmSource || item.utmMedium || item.utmCampaign || item.utmTerm || item.utmContent) {
+                utmData = {
+                    utmSource: item.utmSource || null,
+                    utmMedium: item.utmMedium || null,
+                    utmCampaign: item.utmCampaign || null,
+                    utmTerm: item.utmTerm || null,
+                    utmContent: item.utmContent || null
+                };
+                break;
+            }
         }
 
         for (const item of history) {
@@ -53,7 +85,8 @@ class ReferrerTranslator {
                 return {
                     referrerSource,
                     referrerMedium,
-                    referrerUrl
+                    referrerUrl,
+                    ...utmData
                 };
             }
         }
@@ -61,7 +94,8 @@ class ReferrerTranslator {
         return {
             referrerSource: 'Direct',
             referrerMedium: null,
-            referrerUrl: null
+            referrerUrl: null,
+            ...utmData
         };
     }
 

--- a/ghost/core/core/server/services/member-attribution/ReferrerTranslator.js
+++ b/ghost/core/core/server/services/member-attribution/ReferrerTranslator.js
@@ -50,7 +50,9 @@ class ReferrerTranslator {
             };
         }
 
-        // Look for UTM parameters first (most recent entry with UTM data)
+        // Look for UTM parameters (earliest entry with UTM data)
+        // Note: history is ordered newest-to-oldest, so we want the LAST match
+        // This captures the original campaign source rather than subsequent navigations
         let utmData = {
             utmSource: null,
             utmMedium: null,
@@ -59,6 +61,7 @@ class ReferrerTranslator {
             utmContent: null
         };
 
+        // In finding the 'campaign' that got the user here, we want the earliest entry with UTM data
         for (const item of history) {
             if (item.utmSource || item.utmMedium || item.utmCampaign || item.utmTerm || item.utmContent) {
                 utmData = {
@@ -68,10 +71,10 @@ class ReferrerTranslator {
                     utmTerm: item.utmTerm || null,
                     utmContent: item.utmContent || null
                 };
-                break;
             }
         }
 
+        // In finding the 'content' that got the user to sign up, we want the latest entry with referrer data
         for (const item of history) {
             let refUrl = this.getUrlFromStr(item.referrerUrl);
             if (refUrl?.hostname === 'checkout.stripe.com') {

--- a/ghost/core/core/server/services/member-attribution/UrlHistory.js
+++ b/ghost/core/core/server/services/member-attribution/UrlHistory.js
@@ -6,6 +6,11 @@
  * @prop {string} [referrerSource]
  * @prop {string} [referrerMedium]
  * @prop {string} [referrerUrl]
+ * @prop {string} [utmSource]
+ * @prop {string} [utmMedium]
+ * @prop {string} [utmCampaign]
+ * @prop {string} [utmTerm]
+ * @prop {string} [utmContent]
  * @prop {number} time
  */
 

--- a/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
@@ -38,7 +38,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -62,7 +67,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
-                referrerUrl: 'ghost.org'
+                referrerUrl: 'ghost.org',
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -86,7 +96,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
-                referrerUrl: 'admin.example.com'
+                referrerUrl: 'admin.example.com',
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -110,7 +125,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'publisher weekly newsletter',
                 referrerMedium: 'Email',
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -134,7 +154,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Ghost.org',
                 referrerMedium: 'Ghost Network',
-                referrerUrl: 'ghost.org'
+                referrerUrl: 'ghost.org',
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -158,7 +183,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Twitter',
                 referrerMedium: 'social',
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -172,7 +202,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Facebook',
                 referrerMedium: 'social',
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -202,7 +237,12 @@ describe('ReferrerTranslator', function () {
                 ])).eql({
                     referrerSource: 'Google Product Search',
                     referrerMedium: 'search',
-                    referrerUrl: 'google.ac'
+                    referrerUrl: 'google.ac',
+                    utmSource: null,
+                    utmMedium: null,
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
                 });
             });
 
@@ -226,7 +266,12 @@ describe('ReferrerTranslator', function () {
                 ])).eql({
                     referrerSource: 'Twitter',
                     referrerMedium: 'social',
-                    referrerUrl: 't.co'
+                    referrerUrl: 't.co',
+                    utmSource: null,
+                    utmMedium: null,
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
                 });
             });
         });
@@ -251,7 +296,12 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'sample.com',
                 referrerMedium: null,
-                referrerUrl: 'sample.com'
+                referrerUrl: 'sample.com',
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -259,7 +309,12 @@ describe('ReferrerTranslator', function () {
             should(translator.getReferrerDetails([])).eql({
                 referrerSource: null,
                 referrerMedium: null,
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
             });
         });
 
@@ -273,7 +328,183 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 referrerSource: 'Direct',
                 referrerMedium: null,
-                referrerUrl: null
+                referrerUrl: null,
+                utmSource: null,
+                utmMedium: null,
+                utmCampaign: null,
+                utmTerm: null,
+                utmContent: null
+            });
+        });
+
+        describe('UTM parameter extraction', function () {
+            it('extracts all UTM parameters from first history entry with UTM data', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'google',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'newsletter',
+                        utmMedium: 'email',
+                        utmCampaign: 'spring_sale',
+                        utmTerm: 'running_shoes',
+                        utmContent: 'header_link'
+                    },
+                    {
+                        referrerSource: 'twitter',
+                        referrerMedium: null,
+                        referrerUrl: null
+                    }
+                ])).eql({
+                    referrerSource: 'Google',
+                    referrerMedium: 'unknown',
+                    referrerUrl: null,
+                    utmSource: 'newsletter',
+                    utmMedium: 'email',
+                    utmCampaign: 'spring_sale',
+                    utmTerm: 'running_shoes',
+                    utmContent: 'header_link'
+                });
+            });
+
+            it('extracts partial UTM parameters (only utmSource)', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'facebook',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'twitter_campaign'
+                    }
+                ])).eql({
+                    referrerSource: 'Facebook',
+                    referrerMedium: 'social',
+                    referrerUrl: null,
+                    utmSource: 'twitter_campaign',
+                    utmMedium: null,
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
+                });
+            });
+
+            it('extracts partial UTM parameters (source and campaign)', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: null,
+                        referrerMedium: null,
+                        referrerUrl: 'https://t.co/',
+                        utmSource: 'instagram',
+                        utmCampaign: 'summer_promo'
+                    }
+                ])).eql({
+                    referrerSource: 'Twitter',
+                    referrerMedium: 'social',
+                    referrerUrl: 't.co',
+                    utmSource: 'instagram',
+                    utmMedium: null,
+                    utmCampaign: 'summer_promo',
+                    utmTerm: null,
+                    utmContent: null
+                });
+            });
+
+            it('uses first entry with UTM data when multiple entries have UTM', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'google',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'first_source',
+                        utmCampaign: 'first_campaign'
+                    },
+                    {
+                        referrerSource: 'twitter',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'second_source',
+                        utmCampaign: 'second_campaign'
+                    }
+                ])).eql({
+                    referrerSource: 'Google',
+                    referrerMedium: 'unknown',
+                    referrerUrl: null,
+                    utmSource: 'first_source',
+                    utmMedium: null,
+                    utmCampaign: 'first_campaign',
+                    utmTerm: null,
+                    utmContent: null
+                });
+            });
+
+            it('returns null UTM values when no history entries contain UTM data', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'twitter',
+                        referrerMedium: null,
+                        referrerUrl: null
+                    },
+                    {
+                        referrerSource: 'facebook',
+                        referrerMedium: null,
+                        referrerUrl: null
+                    }
+                ])).eql({
+                    referrerSource: 'Twitter',
+                    referrerMedium: 'social',
+                    referrerUrl: null,
+                    utmSource: null,
+                    utmMedium: null,
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
+                });
+            });
+
+            it('extracts UTM from later entry when earlier entries have no UTM', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'twitter',
+                        referrerMedium: null,
+                        referrerUrl: null
+                    },
+                    {
+                        referrerSource: 'facebook',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'delayed_utm',
+                        utmMedium: 'social_media'
+                    }
+                ])).eql({
+                    referrerSource: 'Twitter',
+                    referrerMedium: 'social',
+                    referrerUrl: null,
+                    utmSource: 'delayed_utm',
+                    utmMedium: 'social_media',
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
+                });
+            });
+
+            it('combines Ghost referrer with UTM parameters', async function () {
+                should(translator.getReferrerDetails([
+                    {
+                        referrerSource: 'ghost-explore',
+                        referrerMedium: null,
+                        referrerUrl: null,
+                        utmSource: 'partner_site',
+                        utmCampaign: 'q1_2024'
+                    }
+                ])).eql({
+                    referrerSource: 'Ghost Explore',
+                    referrerMedium: 'Ghost Network',
+                    referrerUrl: null,
+                    utmSource: 'partner_site',
+                    utmMedium: null,
+                    utmCampaign: 'q1_2024',
+                    utmTerm: null,
+                    utmContent: null
+                });
             });
         });
     });

--- a/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
@@ -338,7 +338,7 @@ describe('ReferrerTranslator', function () {
         });
 
         describe('UTM parameter extraction', function () {
-            it('extracts all UTM parameters from most recent history entry with UTM data', async function () {
+            it('extracts all UTM parameters', async function () {
                 should(translator.getReferrerDetails([
                     {
                         referrerSource: 'google',

--- a/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
@@ -338,7 +338,7 @@ describe('ReferrerTranslator', function () {
         });
 
         describe('UTM parameter extraction', function () {
-            it('extracts all UTM parameters from first history entry with UTM data', async function () {
+            it('extracts all UTM parameters from most recent history entry with UTM data', async function () {
                 should(translator.getReferrerDetails([
                     {
                         referrerSource: 'google',
@@ -408,29 +408,29 @@ describe('ReferrerTranslator', function () {
                 });
             });
 
-            it('uses first entry with UTM data when multiple entries have UTM', async function () {
+            it('uses earliest entry with UTM data when multiple entries have UTM', async function () {
                 should(translator.getReferrerDetails([
                     {
                         referrerSource: 'google',
                         referrerMedium: null,
                         referrerUrl: null,
-                        utmSource: 'first_source',
-                        utmCampaign: 'first_campaign'
+                        utmSource: 'recent_source',
+                        utmCampaign: 'recent_campaign'
                     },
                     {
                         referrerSource: 'twitter',
                         referrerMedium: null,
                         referrerUrl: null,
-                        utmSource: 'second_source',
-                        utmCampaign: 'second_campaign'
+                        utmSource: 'earliest_source',
+                        utmCampaign: 'earliest_campaign'
                     }
                 ])).eql({
                     referrerSource: 'Google',
                     referrerMedium: 'unknown',
                     referrerUrl: null,
-                    utmSource: 'first_source',
+                    utmSource: 'earliest_source',
                     utmMedium: null,
-                    utmCampaign: 'first_campaign',
+                    utmCampaign: 'earliest_campaign',
                     utmTerm: null,
                     utmContent: null
                 });
@@ -460,7 +460,7 @@ describe('ReferrerTranslator', function () {
                 });
             });
 
-            it('extracts UTM from later entry when earlier entries have no UTM', async function () {
+            it('extracts UTM from earliest entry when more recent entries have no UTM', async function () {
                 should(translator.getReferrerDetails([
                     {
                         referrerSource: 'twitter',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2693/update-member-attribution-service-to-pass-through-utm-data
- updated `AttributionBuilder`, `ReferrerTranslator` classes to pass through UTM fields

Since adding the UTM fields to the frontend scripts (member-attribution and ghost-stats), we need to update the backend services to actual utilize the fields. This service is used by the `MemberBREADService`, which lies between Stripe and the Events.