### PR TITLE
Added UTM fields to Member and Donation events

### DIFF
--- a/ghost/core/core/server/services/donations/DonationPaymentEvent.ts
+++ b/ghost/core/core/server/services/donations/DonationPaymentEvent.ts
@@ -13,6 +13,11 @@ export class DonationPaymentEvent {
     referrerSource: string | null;
     referrerMedium: string | null;
     referrerUrl: string | null;
+    utmSource: string | null;
+    utmMedium: string | null;
+    utmCampaign: string | null;
+    utmTerm: string | null;
+    utmContent: string | null;
 
     constructor(data: Omit<DonationPaymentEvent, 'timestamp'>, timestamp: Date) {
         this.timestamp = timestamp;
@@ -30,6 +35,11 @@ export class DonationPaymentEvent {
         this.referrerSource = data.referrerSource;
         this.referrerMedium = data.referrerMedium;
         this.referrerUrl = data.referrerUrl;
+        this.utmSource = data.utmSource;
+        this.utmMedium = data.utmMedium;
+        this.utmCampaign = data.utmCampaign;
+        this.utmTerm = data.utmTerm;
+        this.utmContent = data.utmContent;
     }
 
     static create(data: Omit<DonationPaymentEvent, 'timestamp'>, timestamp?: Date) {

--- a/ghost/core/core/server/services/members-events/EventStorage.js
+++ b/ghost/core/core/server/services/members-events/EventStorage.js
@@ -35,6 +35,11 @@ class EventStorage {
                 referrer_source: attribution?.referrerSource ?? null,
                 referrer_medium: attribution?.referrerMedium ?? null,
                 referrer_url: attribution?.referrerUrl ?? null,
+                utm_source: attribution?.utmSource ?? null,
+                utm_medium: attribution?.utmMedium ?? null,
+                utm_campaign: attribution?.utmCampaign ?? null,
+                utm_term: attribution?.utmTerm ?? null,
+                utm_content: attribution?.utmContent ?? null,
                 batch_id: event.data.batchId ?? null
             });
         });
@@ -52,6 +57,11 @@ class EventStorage {
                 referrer_source: attribution?.referrerSource ?? null,
                 referrer_medium: attribution?.referrerMedium ?? null,
                 referrer_url: attribution?.referrerUrl ?? null,
+                utm_source: attribution?.utmSource ?? null,
+                utm_medium: attribution?.utmMedium ?? null,
+                utm_campaign: attribution?.utmCampaign ?? null,
+                utm_term: attribution?.utmTerm ?? null,
+                utm_content: attribution?.utmContent ?? null,
                 batch_id: event.data.batchId ?? null
             });
         });

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -2170,6 +2170,58 @@ describe('Members API', function () {
             });
         });
 
+        it('Creates a SubscriptionCreatedEvent with UTM parameters', async function () {
+            const attribution = {
+                id: null,
+                url: '/',
+                type: 'url',
+                referrerSource: 'google',
+                referrerMedium: 'cpc',
+                referrerUrl: 'google.com',
+                utmSource: 'newsletter',
+                utmMedium: 'email',
+                utmCampaign: 'spring_sale',
+                utmTerm: 'ghost_pro',
+                utmContent: 'header_link'
+            };
+
+            const absoluteUrl = urlUtils.createUrl('/', true);
+
+            const member = await testWithAttribution(attribution, {
+                id: null,
+                url: absoluteUrl,
+                type: 'url',
+                title: 'homepage',
+                referrer_source: 'Google',
+                referrer_medium: 'cpc',
+                referrer_url: 'google.com'
+            });
+
+            // Verify UTM parameters are stored in SubscriptionCreatedEvent
+            const subscriptionModel = await getSubscription(member.subscriptions[0].id);
+            await assertMemberEvents({
+                eventType: 'SubscriptionCreatedEvent',
+                memberId: member.id,
+                asserts: [
+                    {
+                        member_id: member.id,
+                        subscription_id: subscriptionModel.id,
+                        attribution_id: null,
+                        attribution_url: absoluteUrl,
+                        attribution_type: 'url',
+                        referrer_source: 'Google',
+                        referrer_medium: 'cpc',
+                        referrer_url: 'google.com',
+                        utm_source: 'newsletter',
+                        utm_medium: 'email',
+                        utm_campaign: 'spring_sale',
+                        utm_term: 'ghost_pro',
+                        utm_content: 'header_link'
+                    }
+                ]
+            });
+        });
+
         it('The customer.subscription.created webhook should set the attribution metadata', async function () {
             // set up all necessary resources
             const customer_id = createStripeID('cust');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2880/
ref https://github.com/TryGhost/Ghost/commit/2ea046c3e88aafea6d8544aafde9e5f473cc5012
- updated event storage to pass along UTM fields to the Ghost database

The Ghost db contains `utm_*` columns (see migration above) in various events tables. This PR wires up the data flow so that the real data coming from the frontend scripts actually reaches the database.