### PR TITLE
Updated Portal to use imported `t` function everywhere

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -208,7 +208,6 @@ export default class App extends React.Component {
                 showPopup,
                 pageData,
                 popupNotification,
-                t: i18n.t,
                 dir: i18n.dir() || 'ltr',
                 action: 'init:success',
                 initStatus: 'success',

--- a/apps/portal/src/AppContext.js
+++ b/apps/portal/src/AppContext.js
@@ -11,7 +11,6 @@ const AppContext = React.createContext({
     doAction: (action, data) => {
         return {action, data};
     },
-    t: () => {},
     dir: 'ltr'
 
 });

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -1,6 +1,7 @@
 import setupGhostApi from './utils/api';
 import {chooseBestErrorMessage} from './utils/errors';
 import {createPopupNotification, getMemberEmail, getMemberName, getProductCadenceFromPrice, removePortalLinkFromUrl, getRefDomain} from './utils/helpers';
+import {t} from './utils/i18n';
 
 function switchPage({data, state}) {
     return {
@@ -67,7 +68,6 @@ async function signout({api, state}) {
             action: 'signout:success'
         };
     } catch (e) {
-        const {t} = state;
         return {
             action: 'signout:failed',
             popupNotification: createPopupNotification({
@@ -79,7 +79,7 @@ async function signout({api, state}) {
 }
 
 async function signin({data, api, state}) {
-    const {t, labs} = state;
+    const {labs} = state;
 
     const includeOTC = labs?.membersSigninOTC ? true : undefined;
 
@@ -146,8 +146,6 @@ function startSigninOTCFromCustomForm({data, state}) {
 }
 
 async function verifyOTC({data, api, state}) {
-    const {t} = state;
-
     try {
         const integrityToken = await api.member.getIntegrityToken();
         const response = await api.member.verifyOTC({...data, integrityToken});
@@ -201,7 +199,6 @@ async function signup({data, state, api}) {
             }
         };
     } catch (e) {
-        const {t} = state;
         const message = chooseBestErrorMessage(e, t('Failed to sign up, please try again'));
         return {
             action: 'signup:failed',
@@ -229,7 +226,6 @@ async function checkoutPlan({data, state, api}) {
             }
         });
     } catch (e) {
-        const {t} = state;
         return {
             action: 'checkoutPlan:failed',
             popupNotification: createPopupNotification({
@@ -241,7 +237,6 @@ async function checkoutPlan({data, state, api}) {
 }
 
 async function updateSubscription({data, state, api}) {
-    const {t} = state;
     try {
         const {plan, planId, subscriptionId, cancelAtPeriodEnd} = data;
         const {tierId, cadence} = getProductCadenceFromPrice({site: state?.site, priceId: planId});
@@ -290,7 +285,6 @@ async function cancelSubscription({data, state, api}) {
             member: member
         };
     } catch (e) {
-        const {t} = state;
         return {
             action: 'cancelSubscription:failed',
             popupNotification: createPopupNotification({
@@ -315,7 +309,6 @@ async function continueSubscription({data, state, api}) {
             member: member
         };
     } catch (e) {
-        const {t} = state;
         return {
             action: 'continueSubscription:failed',
             popupNotification: createPopupNotification({
@@ -330,7 +323,6 @@ async function editBilling({data, state, api}) {
     try {
         await api.member.editBilling(data);
     } catch (e) {
-        const {t} = state;
         return {
             action: 'editBilling:failed',
             popupNotification: createPopupNotification({
@@ -382,7 +374,6 @@ async function updateNewsletterPreference({data, state, api}) {
             member
         };
     } catch (e) {
-        const {t} = state;
         return {
             action: 'updateNewsletterPref:failed',
             popupNotification: createPopupNotification({
@@ -395,7 +386,6 @@ async function updateNewsletterPreference({data, state, api}) {
 }
 
 async function removeEmailFromSuppressionList({state, api}) {
-    const {t} = state;
     try {
         await api.member.deleteSuppression();
         const action = 'removeEmailFromSuppressionList:success';
@@ -419,7 +409,6 @@ async function removeEmailFromSuppressionList({state, api}) {
 }
 
 async function updateNewsletter({data, state, api}) {
-    const {t} = state;
     try {
         const {subscribed} = data;
         const member = await api.member.update({subscribed});
@@ -512,7 +501,6 @@ async function refreshMemberData({state, api}) {
 }
 
 async function updateProfile({data, state, api}) {
-    const {t} = state;
     const [dataUpdate, emailUpdate] = await Promise.all([updateMemberData({data, state, api}), updateMemberEmail({data, state, api})]);
     if (dataUpdate && emailUpdate) {
         if (emailUpdate.success) {

--- a/apps/portal/src/components/common/BackButton.js
+++ b/apps/portal/src/components/common/BackButton.js
@@ -1,6 +1,5 @@
-import {useContext} from 'react';
-import AppContext from '../../AppContext';
 import {ReactComponent as LeftArrowIcon} from '../../images/icons/arrow-left.svg';
+import {t} from '../../utils/i18n';
 
 export const BackButtonStyles = `
     .gh-portal-btn-back,
@@ -52,8 +51,6 @@ export const BackButtonStyles = `
 `;
 
 function ActionButton({label = null, hidden = false, onClick}) {
-    const {t} = useContext(AppContext);
-
     if (hidden) {
         return null;
     }

--- a/apps/portal/src/components/common/NewsletterManagement.js
+++ b/apps/portal/src/components/common/NewsletterManagement.js
@@ -5,9 +5,10 @@ import {useContext} from 'react';
 import Switch from '../common/Switch';
 import {getSiteNewsletters, hasMemberGotEmailSuppression} from '../../utils/helpers';
 import ActionButton from '../common/ActionButton';
+import {t} from '../../utils/i18n';
 
 function AccountHeader() {
-    const {brandColor, lastPage, doAction, t} = useContext(AppContext);
+    const {brandColor, lastPage, doAction} = useContext(AppContext);
     return (
         <header className='gh-portal-detail-header'>
             <BackButton brandColor={brandColor} hidden={!lastPage} onClick={() => {
@@ -49,7 +50,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
 }
 
 function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableCommentNotifications}) {
-    const {t, doAction} = useContext(AppContext);
+    const {doAction} = useContext(AppContext);
     const isChecked = !!enableCommentNotifications;
 
     if (!isCommentsEnabled) {
@@ -96,8 +97,6 @@ function NewsletterPrefs({subscribedNewsletters, setSubscribedNewsletters, hasNe
 }
 
 function ShowPaidMemberMessage({site, isPaid}) {
-    const {t} = useContext(AppContext);
-
     if (isPaid) {
         return (
             <p style={{textAlign: 'center', marginTop: '12px', marginBottom: '0', color: 'var(--grey6)'}}>{t('Unsubscribing from emails will not cancel your paid subscription to {title}', {title: site?.title})}</p>
@@ -117,7 +116,7 @@ export default function NewsletterManagement({
     isCommentsEnabled,
     enableCommentNotifications
 }) {
-    const {brandColor, doAction, member, site, t} = useContext(AppContext);
+    const {brandColor, doAction, member, site} = useContext(AppContext);
     const isDisabled = !subscribedNewsletters?.length && ((isCommentsEnabled && !enableCommentNotifications) || !isCommentsEnabled);
     const EmptyNotification = () => {
         return null;

--- a/apps/portal/src/components/common/PopupNotification.js
+++ b/apps/portal/src/components/common/PopupNotification.js
@@ -6,6 +6,7 @@ import {ReactComponent as WarningIcon} from '../../images/icons/warning-fill.svg
 import {getSupportAddress} from '../../utils/helpers';
 import {clearURLParams} from '../../utils/notifications';
 import Interpolate from '@doist/react-interpolate';
+import {t} from '../../utils/i18n';
 
 export const PopupNotificationStyles = `
     .gh-portal-popupnotification {
@@ -33,7 +34,7 @@ const CloseButton = ({hide = false, onClose}) => {
     );
 };
 
-const NotificationText = ({message, site, t}) => {
+const NotificationText = ({message, site}) => {
     const supportAddress = getSupportAddress({site});
     const supportAddressMail = `mailto:${supportAddress}`;
     if (message) {
@@ -117,7 +118,7 @@ export default class PopupNotification extends React.Component {
     }
 
     render() {
-        const {popupNotification, site, t} = this.context;
+        const {popupNotification, site} = this.context;
         const {className} = this.state;
         const {type, status, closeable, message} = popupNotification;
         const statusClass = status ? ` ${status}` : '';
@@ -126,7 +127,7 @@ export default class PopupNotification extends React.Component {
         return (
             <div className={`gh-portal-notification gh-portal-popupnotification ${statusClass}${slideClass}`} onAnimationEnd={e => this.onAnimationEnd(e)}>
                 {(status === 'error' ? <WarningIcon className='gh-portal-notification-icon error' alt=''/> : <CheckmarkIcon className='gh-portal-notification-icon success' alt=''/>)}
-                <NotificationText type={type} status={status} message={message} site={site} t={t} />
+                <NotificationText type={type} status={status} message={message} site={site} />
                 <CloseButton hide={!closeable} onClose={e => this.closeNotification(e)}/>
             </div>
         );

--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -5,6 +5,7 @@ import {getCurrencySymbol, getPriceString, getStripeAmount, getMemberActivePrice
 import AppContext from '../../AppContext';
 import calculateDiscount from '../../utils/discount';
 import Interpolate from '@doist/react-interpolate';
+import {t} from '../../utils/i18n';
 
 export const ProductsSectionStyles = () => {
     // const products = getSiteProducts({site});
@@ -580,7 +581,7 @@ function ProductCardAlternatePrice({price}) {
 }
 
 function ProductCardTrialDays({trialDays, discount, selectedInterval}) {
-    const {site, t} = useContext(AppContext);
+    const {site} = useContext(AppContext);
 
     if (hasFreeTrialTier({site})) {
         if (trialDays) {
@@ -603,7 +604,7 @@ function ProductCardTrialDays({trialDays, discount, selectedInterval}) {
 
 function ProductCardPrice({product}) {
     const {selectedInterval} = useContext(ProductsContext);
-    const {t, site} = useContext(AppContext);
+    const {site} = useContext(AppContext);
     const monthlyPrice = product.monthlyPrice;
     const yearlyPrice = product.yearlyPrice;
     const trialDays = product.trial_days;
@@ -653,7 +654,7 @@ function ProductCardPrice({product}) {
 }
 
 function FreeProductCard({products, handleChooseSignup, error}) {
-    const {site, action, t} = useContext(AppContext);
+    const {site, action} = useContext(AppContext);
     const {selectedProduct, setSelectedProduct} = useContext(ProductsContext);
 
     let cardClass = selectedProduct === 'free' ? 'gh-portal-product-card free checked' : 'gh-portal-product-card free';
@@ -736,7 +737,6 @@ function FreeProductCard({products, handleChooseSignup, error}) {
 }
 
 function ProductCardButton({selectedProduct, product, disabled, noOfProducts, trialDays}) {
-    const {t} = useContext(AppContext);
     if (selectedProduct === product.id && disabled) {
         return (
             <LoaderIcon className='gh-portal-loadingicon' />
@@ -839,7 +839,7 @@ function ProductCards({products, selectedInterval, handleChooseSignup, errors}) 
 }
 
 function YearlyDiscount({discount}) {
-    const {site, t} = useContext(AppContext);
+    const {site} = useContext(AppContext);
     const {portal_plans: portalPlans} = site;
 
     if (discount === 0 || !portalPlans.includes('monthly')) {
@@ -862,7 +862,7 @@ function YearlyDiscount({discount}) {
 }
 
 function ProductPriceSwitch({selectedInterval, setSelectedInterval, products}) {
-    const {site, t} = useContext(AppContext);
+    const {site} = useContext(AppContext);
     const {portal_plans: portalPlans} = site;
     const paidProducts = products.filter(product => product.type !== 'free');
 
@@ -944,7 +944,7 @@ function getActiveInterval({portalPlans, portalDefaultPlan, selectedInterval}) {
 }
 
 function ProductsSection({onPlanSelect, products, type = null, handleChooseSignup, errors}) {
-    const {site, member, t} = useContext(AppContext);
+    const {site, member} = useContext(AppContext);
     const {portal_plans: portalPlans, portal_default_plan: portalDefaultPlan} = site;
     const defaultProductId = products.length > 0 ? products[0].id : 'free';
 
@@ -1085,7 +1085,7 @@ function ProductDescription({product}) {
 }
 
 function ChangeProductCard({product, onPlanSelect}) {
-    const {member, site, t} = useContext(AppContext);
+    const {member, site} = useContext(AppContext);
     const {selectedProduct, setSelectedProduct, selectedInterval} = useContext(ProductsContext);
     const cardClass = selectedProduct === product.id ? 'gh-portal-product-card checked' : 'gh-portal-product-card';
     const monthlyPrice = product.monthlyPrice;

--- a/apps/portal/src/components/common/SiteTitleBackButton.js
+++ b/apps/portal/src/components/common/SiteTitleBackButton.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import AppContext from '../../AppContext';
+import {t} from '../../utils/i18n';
 
 export default class SiteTitleBackButton extends React.Component {
     static contextType = AppContext;
 
     render() {
-        const {t} = this.context;
         return (
             <>
                 <button

--- a/apps/portal/src/components/pages/AccountEmailPage.js
+++ b/apps/portal/src/components/pages/AccountEmailPage.js
@@ -3,9 +3,10 @@ import {useContext, useEffect, useState} from 'react';
 import {isPaidMember, getSiteNewsletters, hasNewsletterSendingEnabled} from '../../utils/helpers';
 import NewsletterManagement from '../common/NewsletterManagement';
 import Interpolate from '@doist/react-interpolate';
+import {t} from '../../utils/i18n';
 
 export default function AccountEmailPage() {
-    const {member, doAction, site, t, pageData} = useContext(AppContext);
+    const {member, doAction, site, pageData} = useContext(AppContext);
     let newsletterUuid;
     let action;
     if (pageData) {

--- a/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.js
+++ b/apps/portal/src/components/pages/AccountHomePage/AccountHomePage.js
@@ -32,7 +32,7 @@ export default class AccountHomePage extends React.Component {
     }
 
     render() {
-        const {member, site, t} = this.context;
+        const {member, site} = this.context;
         const supportAddress = getSupportAddress({site});
         if (!member) {
             return null;
@@ -47,7 +47,6 @@ export default class AccountHomePage extends React.Component {
                     onClose={() => this.context.doAction('closePopup')}
                     handleSignout={e => this.handleSignout(e)}
                     supportAddress={supportAddress}
-                    t={t}
                 />
             </div>
         );

--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountActions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountActions.js
@@ -5,6 +5,7 @@ import {hasCommentsEnabled, hasMultipleNewsletters, isEmailSuppressed, hasNewsle
 import PaidAccountActions from './PaidAccountActions';
 import EmailNewsletterAction from './EmailNewsletterAction';
 import EmailPreferencesAction from './EmailPreferencesAction';
+import {t} from '../../../../utils/i18n';
 
 const shouldShowEmailPreferences = (site, member) => {
     return (
@@ -23,7 +24,7 @@ const shouldShowEmailNewsletterAction = (site) => {
 };
 
 const AccountActions = () => {
-    const {member, doAction, site, t} = useContext(AppContext);
+    const {member, doAction, site} = useContext(AppContext);
     const {name, email} = member;
 
     const openEditProfile = () => {

--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountFooter.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountFooter.js
@@ -1,4 +1,6 @@
-const AccountFooter = ({handleSignout, supportAddress = '', t}) => {
+import {t} from '../../../../utils/i18n';
+
+const AccountFooter = ({handleSignout, supportAddress = ''}) => {
     const supportAddressMail = `mailto:${supportAddress}`;
     return (
         <footer className='gh-portal-account-footer'>

--- a/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/AccountWelcome.js
@@ -4,9 +4,10 @@ import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
 
 import SubscribeButton from './SubscribeButton';
+import {t} from '../../../../utils/i18n';
 
 const AccountWelcome = () => {
-    const {member, site, t} = useContext(AppContext);
+    const {member, site} = useContext(AppContext);
     const {is_stripe_configured: isStripeConfigured} = site;
 
     if (!isStripeConfigured || hasOnlyFreePlan({site})) {

--- a/apps/portal/src/components/pages/AccountHomePage/components/ContinueSubscriptionButton.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/ContinueSubscriptionButton.js
@@ -3,9 +3,10 @@ import ActionButton from '../../../common/ActionButton';
 import {getMemberSubscription} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
+import {t} from '../../../../utils/i18n';
 
 const ContinueSubscriptionButton = () => {
-    const {member, doAction, action, brandColor, t} = useContext(AppContext);
+    const {member, doAction, action, brandColor} = useContext(AppContext);
     const subscription = getMemberSubscription({member});
     if (!subscription) {
         return null;

--- a/apps/portal/src/components/pages/AccountHomePage/components/EmailNewsletterAction.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/EmailNewsletterAction.js
@@ -2,9 +2,10 @@ import AppContext from '../../../../AppContext';
 import Switch from '../../../common/Switch';
 import {getSiteNewsletters, hasMemberGotEmailSuppression} from '../../../../utils/helpers';
 import {useContext} from 'react';
+import {t} from '../../../../utils/i18n';
 
 function EmailNewsletterAction() {
-    const {member, site, doAction, t} = useContext(AppContext);
+    const {member, site, doAction} = useContext(AppContext);
     let {newsletters} = member;
 
     const subscribed = !!newsletters?.length;

--- a/apps/portal/src/components/pages/AccountHomePage/components/EmailPreferencesAction.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/EmailPreferencesAction.js
@@ -2,8 +2,9 @@ import AppContext from '../../../../AppContext';
 import {useContext} from 'react';
 import {isEmailSuppressed, hasNewsletterSendingEnabled, hasCommentsEnabled} from '../../../../utils/helpers';
 import {ReactComponent as EmailDeliveryFailedIcon} from '../../../../images/icons/email-delivery-failed.svg';
+import {t} from '../../../../utils/i18n';
 
-function DisabledEmailNotice({t}) {
+function DisabledEmailNotice() {
     return (
         <p className="gh-portal-email-notice">
             <EmailDeliveryFailedIcon className="gh-portal-email-notice-icon" />
@@ -14,7 +15,7 @@ function DisabledEmailNotice({t}) {
 }
 
 function EmailPreferencesAction() {
-    const {doAction, member, t, site} = useContext(AppContext);
+    const {doAction, member, site} = useContext(AppContext);
 
     const emailSuppressed = isEmailSuppressed({member});
     const hasNewslettersEnabled = hasNewsletterSendingEnabled({site});
@@ -25,7 +26,7 @@ function EmailPreferencesAction() {
 
     const renderEmailNotice = () => {
         if (emailSuppressed || hasNewslettersAndCommentsDisabled) {
-            return <DisabledEmailNotice t={t} />;
+            return <DisabledEmailNotice />;
         }
         return <p>{t('Update your preferences')}</p>;
     };

--- a/apps/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
@@ -4,9 +4,10 @@ import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
 import {useContext} from 'react';
+import {t} from '../../../../utils/i18n';
 
 const PaidAccountActions = () => {
-    const {member, site, doAction, t} = useContext(AppContext);
+    const {member, site, doAction} = useContext(AppContext);
 
     const onEditBilling = () => {
         const subscription = getMemberSubscription({member});
@@ -33,7 +34,7 @@ const PaidAccountActions = () => {
             const {amount = 0, currency, interval} = price;
             label = `${Intl.NumberFormat('en', {currency, style: 'currency'}).format(amount / 100)}/${t(interval)}`;
         }
-        let offerLabelStr = getOfferLabel({price, offer, subscriptionStartDate: startDate, t});
+        let offerLabelStr = getOfferLabel({price, offer, subscriptionStartDate: startDate});
         const compExpiry = getCompExpiry({member});
         if (isComplimentary) {
             if (compExpiry) {
@@ -68,7 +69,7 @@ const PaidAccountActions = () => {
                     <p className={oldPriceClassName}>
                         {label}
                     </p>
-                    <FreeTrialLabel subscription={subscription} t={t} />
+                    <FreeTrialLabel subscription={subscription} />
                 </>
             );
         }
@@ -171,7 +172,7 @@ const PaidAccountActions = () => {
     return null;
 };
 
-function FreeTrialLabel({subscription, t}) {
+function FreeTrialLabel({subscription}) {
     if (subscriptionHasFreeTrial({sub: subscription})) {
         const trialEnd = getDateString(subscription.trial_end_at);
         return (
@@ -186,7 +187,7 @@ function FreeTrialLabel({subscription, t}) {
     return null;
 }
 
-function getOfferLabel({offer, price, subscriptionStartDate, t}) {
+function getOfferLabel({offer, price, subscriptionStartDate}) {
     let offerLabel = '';
 
     if (offer?.type === 'trial') {

--- a/apps/portal/src/components/pages/AccountHomePage/components/SubscribeButton.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/SubscribeButton.js
@@ -2,9 +2,10 @@ import AppContext from '../../../../AppContext';
 import ActionButton from '../../../common/ActionButton';
 import {isSignupAllowed, hasAvailablePrices} from '../../../../utils/helpers';
 import {useContext} from 'react';
+import {t} from '../../../../utils/i18n';
 
 const SubscribeButton = () => {
-    const {site, action, brandColor, doAction, t} = useContext(AppContext);
+    const {site, action, brandColor, doAction} = useContext(AppContext);
 
     if (!isSignupAllowed({site}) || !hasAvailablePrices({site})) {
         return null;

--- a/apps/portal/src/components/pages/AccountHomePage/components/UserHeader.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/UserHeader.js
@@ -1,9 +1,10 @@
 import AppContext from '../../../../AppContext';
 import MemberAvatar from '../../../common/MemberGravatar';
 import {useContext} from 'react';
+import {t} from '../../../../utils/i18n';
 
 const UserHeader = () => {
-    const {member, brandColor, t} = useContext(AppContext);
+    const {member, brandColor} = useContext(AppContext);
     const avatar = member.avatar_image;
     return (
         <header className='gh-portal-account-header'>

--- a/apps/portal/src/components/pages/AccountPlanPage.js
+++ b/apps/portal/src/components/pages/AccountPlanPage.js
@@ -7,6 +7,7 @@ import {MultipleProductsPlansSection} from '../common/PlansSection';
 import {getDateString} from '../../utils/date-time';
 import {allowCompMemberUpgrade, formatNumber, getAvailablePrices, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
+import {t} from '../../utils/i18n';
 
 export const AccountPlanPageStyles = `
     .account-plan.full-size .gh-portal-main-title {
@@ -39,7 +40,7 @@ export const AccountPlanPageStyles = `
     }
 `;
 
-function getConfirmationPageTitle({confirmationType, t}) {
+function getConfirmationPageTitle({confirmationType}) {
     if (confirmationType === 'changePlan') {
         return t('Confirm subscription');
     } else if (confirmationType === 'cancel') {
@@ -50,10 +51,10 @@ function getConfirmationPageTitle({confirmationType, t}) {
 }
 
 const Header = ({showConfirmation, confirmationType}) => {
-    const {member, t} = useContext(AppContext);
+    const {member} = useContext(AppContext);
     let title = isPaidMember({member}) ? t('Change plan') : t('Choose a plan');
     if (showConfirmation) {
-        title = getConfirmationPageTitle({confirmationType, t});
+        title = getConfirmationPageTitle({confirmationType});
     }
     return (
         <header className='gh-portal-detail-header'>
@@ -63,7 +64,7 @@ const Header = ({showConfirmation, confirmationType}) => {
 };
 
 const CancelSubscriptionButton = ({member, onCancelSubscription, action, brandColor}) => {
-    const {site, t} = useContext(AppContext);
+    const {site} = useContext(AppContext);
     if (!member.paid) {
         return null;
     }
@@ -109,7 +110,7 @@ const CancelSubscriptionButton = ({member, onCancelSubscription, action, brandCo
 
 // For confirmation flows
 const PlanConfirmationSection = ({plan, type, onConfirm}) => {
-    const {site, action, member, brandColor, t} = useContext(AppContext);
+    const {site, action, member, brandColor} = useContext(AppContext);
     const [reason, setReason] = useState('');
     const subscription = getMemberSubscription({member});
     const isRunning = ['updateSubscription:running', 'checkoutPlan:running', 'cancelSubscription:running'].includes(action);

--- a/apps/portal/src/components/pages/AccountProfilePage.js
+++ b/apps/portal/src/components/pages/AccountProfilePage.js
@@ -6,6 +6,7 @@ import CloseButton from '../common/CloseButton';
 import BackButton from '../common/BackButton';
 import InputForm from '../common/InputForm';
 import {ValidateInputForm} from '../../utils/form';
+import {t} from '../../utils/i18n';
 
 export default class AccountProfilePage extends React.Component {
     static contextType = AppContext;
@@ -41,7 +42,7 @@ export default class AccountProfilePage extends React.Component {
         e.preventDefault();
         this.setState((state) => {
             return {
-                errors: ValidateInputForm({fields: this.getInputFields({state}), t: this.context.t})
+                errors: ValidateInputForm({fields: this.getInputFields({state})})
             };
         }, () => {
             const {email, name, errors} = this.state;
@@ -54,8 +55,6 @@ export default class AccountProfilePage extends React.Component {
     }
 
     renderSaveButton() {
-        const {t} = this.context;
-
         const isRunning = (this.context.action === 'updateProfile:running');
         let label = t('Save');
         if (this.context.action === 'updateProfile:failed') {
@@ -76,8 +75,6 @@ export default class AccountProfilePage extends React.Component {
     }
 
     renderDeleteAccountButton() {
-        const {t} = this.context;
-
         return (
             <div style={{cursor: 'pointer', color: 'red'}} role='button'>{t('Delete account')}</div>
         );
@@ -92,8 +89,6 @@ export default class AccountProfilePage extends React.Component {
     }
 
     renderHeader() {
-        const {t} = this.context;
-
         return (
             <header className='gh-portal-detail-header'>
                 <BackButton brandColor={this.context.brandColor} hidden={!this.context.lastPage} onClick={e => this.onBack(e)} />
@@ -134,8 +129,6 @@ export default class AccountProfilePage extends React.Component {
     }
 
     getInputFields({state, fieldNames}) {
-        const {t} = this.context;
-
         const errors = state.errors || {};
         const fields = [
             {

--- a/apps/portal/src/components/pages/EmailReceivingFAQ.js
+++ b/apps/portal/src/components/pages/EmailReceivingFAQ.js
@@ -4,9 +4,10 @@ import BackButton from '../../components/common/BackButton';
 import CloseButton from '../../components/common/CloseButton';
 import {getDefaultNewsletterSender, getSupportAddress} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
+import {t} from '../../utils/i18n';
 
 export default function EmailReceivingPage() {
-    const {brandColor, doAction, site, lastPage, member, t, pageData} = useContext(AppContext);
+    const {brandColor, doAction, site, lastPage, member, pageData} = useContext(AppContext);
 
     const supportAddressEmail = getSupportAddress({site});
     const supportAddress = `mailto:${supportAddressEmail}`;

--- a/apps/portal/src/components/pages/EmailSuppressedPage.js
+++ b/apps/portal/src/components/pages/EmailSuppressedPage.js
@@ -5,9 +5,10 @@ import CloseButton from '../../components/common/CloseButton';
 import BackButton from '../../components/common/BackButton';
 import ActionButton from '../../components/common/ActionButton';
 import {ReactComponent as EmailDeliveryFailedIcon} from '../../images/icons/email-delivery-failed.svg';
+import {t} from '../../utils/i18n';
 
 export default function EmailSuppressedPage() {
-    const {brandColor, lastPage, doAction, action, site, t} = useContext(AppContext);
+    const {brandColor, lastPage, doAction, action, site} = useContext(AppContext);
 
     useEffect(() => {
         if (['removeEmailFromSuppressionList:success'].includes(action)) {

--- a/apps/portal/src/components/pages/EmailSuppressionFAQ.js
+++ b/apps/portal/src/components/pages/EmailSuppressionFAQ.js
@@ -3,9 +3,10 @@ import {useContext} from 'react';
 import BackButton from '../../components/common/BackButton';
 import CloseButton from '../../components/common/CloseButton';
 import {getSupportAddress} from '../../utils/helpers';
+import {t} from '../../utils/i18n';
 
 export default function EmailSuppressedPage() {
-    const {brandColor, doAction, site, t, pageData} = useContext(AppContext);
+    const {brandColor, doAction, site, pageData} = useContext(AppContext);
 
     const supportAddress = `mailto:${getSupportAddress({site})}`;
     const directAccess = (pageData && pageData.direct) || false;

--- a/apps/portal/src/components/pages/FeedbackPage.js
+++ b/apps/portal/src/components/pages/FeedbackPage.js
@@ -8,6 +8,7 @@ import {chooseBestErrorMessage} from '../../utils/errors';
 import ActionButton from '../common/ActionButton';
 import CloseButton from '../common/CloseButton';
 import LoadingPage from './LoadingPage';
+import {t} from '../../utils/i18n';
 
 export const FeedbackPageStyles = `
     .gh-portal-feedback {
@@ -170,7 +171,7 @@ export const FeedbackPageStyles = `
 `;
 
 function ErrorPage({error}) {
-    const {doAction, t} = useContext(AppContext);
+    const {doAction} = useContext(AppContext);
 
     return (
         <div className='gh-portal-content gh-portal-feedback with-footer'>
@@ -198,7 +199,7 @@ function ErrorPage({error}) {
 }
 
 const ConfirmDialog = ({onConfirm, loading, initialScore}) => {
-    const {doAction, brandColor, t} = useContext(AppContext);
+    const {doAction, brandColor} = useContext(AppContext);
     const [score, setScore] = useState(initialScore);
 
     const stopPropagation = (event) => {
@@ -276,7 +277,7 @@ const LoadingFeedbackView = ({action, score}) => {
 };
 
 const ConfirmFeedback = ({positive}) => {
-    const {doAction, brandColor, t} = useContext(AppContext);
+    const {doAction, brandColor} = useContext(AppContext);
 
     const icon = positive ? <ThumbUpIcon /> : <ThumbDownIcon />;
 
@@ -305,7 +306,7 @@ const ConfirmFeedback = ({positive}) => {
 };
 
 export default function FeedbackPage() {
-    const {site, pageData, member, t, api} = useContext(AppContext);
+    const {site, pageData, member, api} = useContext(AppContext);
     const {uuid, key, postId, score: initialScore} = pageData;
     const [score, setScore] = useState(initialScore);
     const positive = score === 1;

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -5,6 +5,7 @@ import AppContext from '../../AppContext';
 import {ReactComponent as EnvelopeIcon} from '../../images/icons/envelope.svg';
 
 import InputField from '../common/InputField';
+import {t} from '../../utils/i18n';
 
 export const MagicLinkStyles = `
     .gh-portal-icon-envelope {
@@ -44,7 +45,6 @@ export default class MagicLinkPage extends React.Component {
      * @returns {Object} Configuration object with message templates for signin/signup scenarios
      */
     getDescriptionConfig(submittedEmailOrInbox) {
-        const {t} = this.context;
         return {
             signin: {
                 withOTC: t('An email has been sent to {submittedEmailOrInbox}. Click the link inside or enter your code below.', {submittedEmailOrInbox}),
@@ -74,7 +74,7 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderFormHeader() {
-        const {t, otcRef, pageData, lastPage} = this.context;
+        const {otcRef, pageData, lastPage} = this.context;
         const submittedEmailOrInbox = pageData?.email ? pageData.email : t('your inbox');
 
         const popupTitle = t(`Now check your email!`);
@@ -96,8 +96,6 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderLoginMessage() {
-        const {t} = this.context;
-
         return (
             <>
                 <div
@@ -115,8 +113,6 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderCloseButton() {
-        const {t} = this.context;
-
         const label = t('Close');
         return (
             <ActionButton
@@ -139,7 +135,7 @@ export default class MagicLinkPage extends React.Component {
     }
 
     doVerifyOTC() {
-        const {t, labs} = this.context;
+        const {labs} = this.context;
         const missingCodeError = labs?.membersSigninOTCAlpha ? t('Enter code above') : t('Enter code below');
 
         this.setState((state) => {
@@ -179,7 +175,7 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderOTCForm() {
-        const {t, action, labs, otcRef} = this.context;
+        const {action, labs, otcRef} = this.context;
         const errors = this.state.errors || {};
 
         if (!labs?.membersSigninOTC || !otcRef) {

--- a/apps/portal/src/components/pages/NewsletterSelectionPage.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.js
@@ -4,8 +4,9 @@ import Switch from '../common/Switch';
 import {getSiteNewsletters, hasOnlyFreePlan} from '../../utils/helpers';
 import ActionButton from '../common/ActionButton';
 import {ReactComponent as LockIcon} from '../../images/icons/lock.svg';
+import {t} from '../../utils/i18n';
 
-function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribedNewsletters, t}) {
+function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribedNewsletters}) {
     const isChecked = subscribedNewsletters.some((d) => {
         return d.id === newsletter?.id;
     });
@@ -48,7 +49,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
 }
 
 function NewsletterPrefs({subscribedNewsletters, setSubscribedNewsletters}) {
-    const {site, t} = useContext(AppContext);
+    const {site} = useContext(AppContext);
     const newsletters = getSiteNewsletters({site});
     return newsletters.map((newsletter) => {
         return (
@@ -57,14 +58,13 @@ function NewsletterPrefs({subscribedNewsletters, setSubscribedNewsletters}) {
                 newsletter={newsletter}
                 subscribedNewsletters={subscribedNewsletters}
                 setSubscribedNewsletters={setSubscribedNewsletters}
-                t={t}
             />
         );
     });
 }
 
 export default function NewsletterSelectionPage({pageData, onBack}) {
-    const {brandColor, site, doAction, action, t} = useContext(AppContext);
+    const {brandColor, site, doAction, action} = useContext(AppContext);
     const siteNewsletters = getSiteNewsletters({site});
     const defaultNewsletters = siteNewsletters.filter((d) => {
         return d.subscribe_on_signup;

--- a/apps/portal/src/components/pages/OfferPage.js
+++ b/apps/portal/src/components/pages/OfferPage.js
@@ -8,6 +8,7 @@ import {getCurrencySymbol, getProductFromId, hasMultipleProductsFeature, isSameC
 import {ValidateInputForm} from '../../utils/form';
 import {interceptAnchorClicks} from '../../utils/links';
 import NewsletterSelectionPage from './NewsletterSelectionPage';
+import {t} from '../../utils/i18n';
 
 export const OfferPageStyles = () => {
     return `
@@ -169,14 +170,14 @@ export default class OfferPage extends React.Component {
         const checkboxError = checkboxRequired && !state.termsCheckboxChecked;
 
         return {
-            ...ValidateInputForm({fields: this.getInputFields({state}), t: this.context.t}),
+            ...ValidateInputForm({fields: this.getInputFields({state})}),
             checkbox: checkboxError
         };
     }
 
     getInputFields({state, fieldNames}) {
         const {portal_name: portalName} = this.context.site;
-        const {member, t} = this.context;
+        const {member} = this.context;
         const errors = state.errors || {};
         const fields = [
             {
@@ -376,7 +377,7 @@ export default class OfferPage extends React.Component {
     }
 
     renderSubmitButton() {
-        const {action, brandColor, t} = this.context;
+        const {action, brandColor} = this.context;
         const {pageData: offer} = this.context;
         let label = t('Continue');
 
@@ -416,7 +417,7 @@ export default class OfferPage extends React.Component {
         if (member) {
             return null;
         }
-        const {brandColor, doAction, t} = this.context;
+        const {brandColor, doAction} = this.context;
         return (
             <div className='gh-portal-signup-message'>
                 <div>{t('Already a member?')}</div>
@@ -432,7 +433,7 @@ export default class OfferPage extends React.Component {
     }
 
     renderOfferTag() {
-        const {pageData: offer, t} = this.context;
+        const {pageData: offer} = this.context;
 
         if (offer.amount <= 0) {
             return (
@@ -518,7 +519,7 @@ export default class OfferPage extends React.Component {
         return '';
     }
 
-    renderOfferMessage({offer, product, t}) {
+    renderOfferMessage({offer, product}) {
         const offerMessages = {
             forever: t(`{amount} off forever.`, {
                 amount: this.getOffAmount({offer})
@@ -568,7 +569,7 @@ export default class OfferPage extends React.Component {
     }
 
     renderProductLabel({product, offer}) {
-        const {site, t} = this.context;
+        const {site} = this.context;
 
         if (hasMultipleProductsFeature({site})) {
             return (
@@ -611,8 +612,6 @@ export default class OfferPage extends React.Component {
     }
 
     renderProductCard({product, offer, currencyClass, updatedPrice, price, benefits}) {
-        const {t} = this.context;
-
         if (this.state.showNewsletterSelection) {
             return null;
         }
@@ -623,7 +622,7 @@ export default class OfferPage extends React.Component {
                         <h4 className="gh-portal-product-name">{product.name} - {(offer.cadence === 'month' ? t('Monthly') : t('Yearly'))}</h4>
                         {this.renderOldTierPrice({offer, price})}
                         {this.renderUpdatedTierPrice({offer, currencyClass, updatedPrice, price})}
-                        {this.renderOfferMessage({offer, product, price, t})}
+                        {this.renderOfferMessage({offer, product, price})}
                     </div>
                 </div>
 
@@ -648,7 +647,7 @@ export default class OfferPage extends React.Component {
     }
 
     render() {
-        const {pageData: offer, site, t} = this.context;
+        const {pageData: offer, site} = this.context;
         if (!offer) {
             return null;
         }

--- a/apps/portal/src/components/pages/RecommendationsPage.js
+++ b/apps/portal/src/components/pages/RecommendationsPage.js
@@ -8,6 +8,7 @@ import {ReactComponent as LoaderIcon} from '../../images/icons/loader.svg';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/check-circle.svg';
 
 import {getRefDomain} from '../../utils/helpers';
+import {t} from '../../utils/i18n';
 
 export const RecommendationsPageStyles = `
     .gh-portal-recommendations-header .gh-portal-main-title {
@@ -186,7 +187,7 @@ const openTab = (url) => {
 };
 
 const RecommendationItem = (recommendation) => {
-    const {t, doAction, member, site} = useContext(AppContext);
+    const {doAction, member, site} = useContext(AppContext);
     const {title, url, description, favicon, one_click_subscribe: oneClickSubscribe, featured_image: featuredImage} = recommendation;
     const allowOneClickSubscribe = member && oneClickSubscribe;
     const [subscribed, setSubscribed] = useState(false);
@@ -279,7 +280,7 @@ const RecommendationItem = (recommendation) => {
 };
 
 const RecommendationsPage = () => {
-    const {api, site, pageData, t, doAction} = useContext(AppContext);
+    const {api, site, pageData, doAction} = useContext(AppContext);
     const {title, icon} = site;
     const {recommendations_enabled: recommendationsEnabled = false} = site;
     const [recommendations, setRecommendations] = useState(null);

--- a/apps/portal/src/components/pages/SigninPage.js
+++ b/apps/portal/src/components/pages/SigninPage.js
@@ -7,6 +7,7 @@ import InputForm from '../common/InputForm';
 import {ValidateInputForm} from '../../utils/form';
 import {hasAvailablePrices, isSigninAllowed, isSignupAllowed} from '../../utils/helpers';
 import {ReactComponent as InvitationIcon} from '../../images/icons/invitation.svg';
+import {t} from '../../utils/i18n';
 
 export default class SigninPage extends React.Component {
     static contextType = AppContext;
@@ -36,7 +37,7 @@ export default class SigninPage extends React.Component {
     doSignin() {
         this.setState((state) => {
             return {
-                errors: ValidateInputForm({fields: this.getInputFields({state}), t: this.context.t})
+                errors: ValidateInputForm({fields: this.getInputFields({state})})
             };
         }, async () => {
             const {email, phonenumber, errors, token} = this.state;
@@ -63,8 +64,6 @@ export default class SigninPage extends React.Component {
     }
 
     getInputFields({state}) {
-        const {t} = this.context;
-
         const errors = state.errors || {};
         const fields = [
             {
@@ -94,7 +93,7 @@ export default class SigninPage extends React.Component {
     }
 
     renderSubmitButton() {
-        const {action, t} = this.context;
+        const {action} = this.context;
         let retry = false;
         const isRunning = (action === 'signin:running');
         let label = isRunning ? t('Sending login link...') : t('Continue');
@@ -118,7 +117,7 @@ export default class SigninPage extends React.Component {
     }
 
     renderSignupMessage() {
-        const {brandColor, t} = this.context;
+        const {brandColor} = this.context;
         return (
             <div className='gh-portal-signup-message'>
                 <div>{t('Don\'t have an account?')}</div>
@@ -135,7 +134,7 @@ export default class SigninPage extends React.Component {
     }
 
     renderForm() {
-        const {site, t} = this.context;
+        const {site} = this.context;
         const isSignupAvailable = isSignupAllowed({site}) && hasAvailablePrices({site});
 
         if (!isSigninAllowed({site})) {
@@ -189,7 +188,7 @@ export default class SigninPage extends React.Component {
     }
 
     renderSiteTitle() {
-        const {site, t} = this.context;
+        const {site} = this.context;
         const siteTitle = site.title;
 
         if (!isSigninAllowed({site})) {

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -10,6 +10,7 @@ import {ValidateInputForm} from '../../utils/form';
 import {getSiteProducts, getSitePrices, hasAvailablePrices, hasOnlyFreePlan, isInviteOnly, isFreeSignupAllowed, isPaidMembersOnly, freeHasBenefitsOrDescription, hasMultipleNewsletters, hasFreeTrialTier, isSignupAllowed, isSigninAllowed} from '../../utils/helpers';
 import {ReactComponent as InvitationIcon} from '../../images/icons/invitation.svg';
 import {interceptAnchorClicks} from '../../utils/links';
+import {t} from '../../utils/i18n';
 
 export const SignupPageStyles = `
 .gh-portal-back-sitetitle {
@@ -395,7 +396,7 @@ class SignupPage extends React.Component {
         const checkboxError = checkboxRequired && !state.termsCheckboxChecked;
 
         return {
-            ...ValidateInputForm({fields: this.getInputFields({state}), t: this.context.t}),
+            ...ValidateInputForm({fields: this.getInputFields({state})}),
             checkbox: checkboxError
         };
     }
@@ -491,7 +492,7 @@ class SignupPage extends React.Component {
     }
 
     getInputFields({state, fieldNames}) {
-        const {site: {portal_name: portalName}, t} = this.context;
+        const {site: {portal_name: portalName}} = this.context;
 
         const errors = state.errors || {};
         const fields = [
@@ -585,7 +586,7 @@ class SignupPage extends React.Component {
     }
 
     renderSubmitButton() {
-        const {action, site, brandColor, pageQuery, t} = this.context;
+        const {action, site, brandColor, pageQuery} = this.context;
 
         if (isInviteOnly({site}) || !hasAvailablePrices({site, pageQuery})) {
             return null;
@@ -627,7 +628,7 @@ class SignupPage extends React.Component {
     }
 
     renderProducts() {
-        const {site, pageQuery, t} = this.context;
+        const {site, pageQuery} = this.context;
         const products = getSiteProducts({site, pageQuery});
         const errors = this.state.errors || {};
         const priceErrors = {};
@@ -650,7 +651,7 @@ class SignupPage extends React.Component {
     }
 
     renderFreeTrialMessage() {
-        const {site, t, pageQuery} = this.context;
+        const {site, pageQuery} = this.context;
         if (hasFreeTrialTier({site, pageQuery}) && !isInviteOnly({site}) && hasAvailablePrices({site, pageQuery})) {
             return (
                 <p className='gh-portal-free-trial-notification' data-testid="free-trial-notification-text">
@@ -662,7 +663,7 @@ class SignupPage extends React.Component {
     }
 
     renderLoginMessage() {
-        const {brandColor, doAction, t} = this.context;
+        const {brandColor, doAction} = this.context;
         return (
             <div>
                 {this.renderFreeTrialMessage()}
@@ -768,7 +769,6 @@ class SignupPage extends React.Component {
     }
 
     renderPaidMembersOnlyMessage() {
-        const {t} = this.context;
         return (
             <section>
                 <div className='gh-portal-section'>
@@ -785,7 +785,6 @@ class SignupPage extends React.Component {
     }
 
     renderInviteOnlyMessage() {
-        const {t} = this.context;
         return (
             <section>
                 <div className='gh-portal-section'>
@@ -802,7 +801,6 @@ class SignupPage extends React.Component {
     }
 
     renderMembersDisabledMessage() {
-        const {t} = this.context;
         return (
             <section>
                 <div className='gh-portal-section'>

--- a/apps/portal/src/components/pages/SupportError.js
+++ b/apps/portal/src/components/pages/SupportError.js
@@ -4,6 +4,7 @@ import CloseButton from '../common/CloseButton';
 import ActionButton from '../common/ActionButton';
 import {ReactComponent as WarningIcon} from '../../images/icons/warning-outline.svg';
 import * as Sentry from '@sentry/react';
+import {t} from '../../utils/i18n';
 
 export const TipsAndDonationsErrorStyle = `
     .gh-portal-tips-and-donations .gh-tips-and-donations-icon-error {
@@ -25,7 +26,7 @@ export const TipsAndDonationsErrorStyle = `
 `;
 
 const SupportError = ({error}) => {
-    const {doAction, t} = useContext(AppContext);
+    const {doAction} = useContext(AppContext);
     const errorTitle = t('Sorry, that didn’t work.');
     const errorMessage = error || t('There was an error processing your payment. Please try again.');
     const buttonLabel = t('Close');

--- a/apps/portal/src/components/pages/SupportPage.js
+++ b/apps/portal/src/components/pages/SupportPage.js
@@ -3,12 +3,13 @@ import SupportError from './SupportError';
 import LoadingPage from './LoadingPage';
 import setupGhostApi from '../../utils/api';
 import AppContext from '../../AppContext';
+import {t} from '../../utils/i18n';
 
 const SupportPage = () => {
     const [isLoading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [disabledFeatureError, setDisabledFeatureError] = useState(null);
-    const {member, t, site} = useContext(AppContext);
+    const {member, site} = useContext(AppContext);
 
     useEffect(() => {
         async function checkoutDonation() {

--- a/apps/portal/src/components/pages/SupportSuccess.js
+++ b/apps/portal/src/components/pages/SupportSuccess.js
@@ -3,6 +3,7 @@ import AppContext from '../../AppContext';
 import {ReactComponent as ConfettiIcon} from '../../images/icons/confetti.svg';
 import CloseButton from '../common/CloseButton';
 import ActionButton from '../common/ActionButton';
+import {t} from '../../utils/i18n';
 
 export const TipsAndDonationsSuccessStyle = `
     .gh-portal-tips-and-donations .gh-portal-signup-header {
@@ -33,7 +34,7 @@ export const TipsAndDonationsSuccessStyle = `
 `;
 
 const SupportSuccess = () => {
-    const {doAction, brandColor, site, t} = useContext(AppContext);
+    const {doAction, brandColor, site} = useContext(AppContext);
     const successTitle = t('Thank you for your support');
     const successDescription = t('To continue to stay up to date, subscribe to {publication} below.', {publication: site?.title});
     const buttonLabel = t('Sign up');

--- a/apps/portal/src/components/pages/UnsubscribePage.js
+++ b/apps/portal/src/components/pages/UnsubscribePage.js
@@ -7,6 +7,7 @@ import CloseButton from '../common/CloseButton';
 import {ReactComponent as WarningIcon} from '../../images/icons/warning-fill.svg';
 import Interpolate from '@doist/react-interpolate';
 import LoadingPage from './LoadingPage';
+import {t} from '../../utils/i18n';
 
 function SiteLogo() {
     const {site} = useContext(AppContext);
@@ -42,7 +43,7 @@ async function updateMemberNewsletters({api, memberUuid, key, newsletters, enabl
 // NOTE: This modal is available even if not logged in, but because it's possible to also be logged in while making modifications,
 //  we need to update the member data in the context if logged in.
 export default function UnsubscribePage() {
-    const {site, api, pageData, member: loggedInMember, doAction, t} = useContext(AppContext);
+    const {site, api, pageData, member: loggedInMember, doAction} = useContext(AppContext);
     // member is the member data fetched from the API based on the uuid and its state is limited to just this modal, not all of Portal
     const [member, setMember] = useState();
     const [loading, setLoading] = useState(true);

--- a/apps/portal/src/utils/form.js
+++ b/apps/portal/src/utils/form.js
@@ -1,6 +1,7 @@
 import * as Validator from './validator';
+import {t} from './i18n';
 
-export const FormInputError = ({field, t}) => {
+export const FormInputError = ({field}) => {
     if (field.required && !field.value) {
         switch (field.name) {
         case 'name':
@@ -23,14 +24,13 @@ export const FormInputError = ({field, t}) => {
 /**
  * Validate input fields
  * @param {Array} fields
- * @param {Function} t
  * @returns {Object} errors
  */
-export const ValidateInputForm = ({fields, t}) => {
+export const ValidateInputForm = ({fields}) => {
     const errors = {};
     fields.forEach((field) => {
         const name = field.name;
-        const fieldError = FormInputError({field, t});
+        const fieldError = FormInputError({field});
         errors[name] = fieldError;
     });
     return errors;


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/25045

## Summary

This PR refactors the Portal app to standardise on the approach introduced in https://github.com/TryGhost/Ghost/pull/25045. Eliminates prop drilling of the `t` translation function by using a centralized i18n module that can be imported directly where needed.

Previously, the `t` function was initialized in `App.js` and passed through `AppContext` to all components that needed translations. This required threading `t` through many layers of components and made the code more difficult to maintain.

## Changes

- **Created centralized `utils/i18n.js` module** that initializes i18next with English and exports a bound `t` function ([earlier PR](https://github.com/TryGhost/Ghost/pull/25045))
- **Removed `t` from AppContext and App.js state** - no longer needed in context
- **Updated `actions.js`** to import `t` directly instead of extracting from state (removed 15 instances of `const {t} = state`)
- **Updated all Portal components (35+ files)** to import `t` directly:
  - Functional components: Removed `t` from `useContext(AppContext)` destructuring
  - Class components: Replaced `this.context.t` with imported `t` function

## Benefits

- ✅ **Eliminates prop drilling** - No more passing `t` through component trees
- ✅ **Cleaner component signatures** - Components no longer need translation props
- ✅ **Available immediately** - Translation function available from the start (initialized with English), avoiding timing issues with early API requests made before we've fetched site language
- ✅ **Still supports dynamic language switching** - Language can be changed via `i18n.changeLanguage()` in App.js
- ✅ **Improved maintainability** - Easier to add translated strings without modifying component props or function args
- ✅ **Better developer experience** - Just import and use, no need to wire through context