### PR TITLE
Added UTM parameter storage to member events

### DIFF
--- a/ghost/core/core/server/services/donations/DonationBookshelfRepository.ts
+++ b/ghost/core/core/server/services/donations/DonationBookshelfRepository.ts
@@ -23,6 +23,11 @@ type DonationEventModelInstance = BookshelfModelInstance & {
     referrer_source: string | null;
     referrer_medium: string | null;
     referrer_url: string | null;
+    utm_source: string | null;
+    utm_medium: string | null;
+    utm_campaign: string | null;
+    utm_term: string | null;
+    utm_content: string | null;
 }
 type DonationPaymentEventBookshelfModel = BookshelfModel<DonationEventModelInstance>;
 
@@ -47,7 +52,12 @@ export class DonationBookshelfRepository implements DonationRepository {
             attribution_type: event.attributionType,
             referrer_source: event.referrerSource,
             referrer_medium: event.referrerMedium,
-            referrer_url: event.referrerUrl
+            referrer_url: event.referrerUrl,
+            utm_source: event.utmSource,
+            utm_medium: event.utmMedium,
+            utm_campaign: event.utmCampaign,
+            utm_term: event.utmTerm,
+            utm_content: event.utmContent
         });
     }
 }

--- a/ghost/core/core/server/services/donations/DonationPaymentEvent.ts
+++ b/ghost/core/core/server/services/donations/DonationPaymentEvent.ts
@@ -13,6 +13,11 @@ export class DonationPaymentEvent {
     referrerSource: string | null;
     referrerMedium: string | null;
     referrerUrl: string | null;
+    utmSource: string | null;
+    utmMedium: string | null;
+    utmCampaign: string | null;
+    utmTerm: string | null;
+    utmContent: string | null;
 
     constructor(data: Omit<DonationPaymentEvent, 'timestamp'>, timestamp: Date) {
         this.timestamp = timestamp;
@@ -30,6 +35,11 @@ export class DonationPaymentEvent {
         this.referrerSource = data.referrerSource;
         this.referrerMedium = data.referrerMedium;
         this.referrerUrl = data.referrerUrl;
+        this.utmSource = data.utmSource;
+        this.utmMedium = data.utmMedium;
+        this.utmCampaign = data.utmCampaign;
+        this.utmTerm = data.utmTerm;
+        this.utmContent = data.utmContent;
     }
 
     static create(data: Omit<DonationPaymentEvent, 'timestamp'>, timestamp?: Date) {

--- a/ghost/core/core/server/services/members-events/EventStorage.js
+++ b/ghost/core/core/server/services/members-events/EventStorage.js
@@ -35,6 +35,11 @@ class EventStorage {
                 referrer_source: attribution?.referrerSource ?? null,
                 referrer_medium: attribution?.referrerMedium ?? null,
                 referrer_url: attribution?.referrerUrl ?? null,
+                utm_source: attribution?.utmSource ?? null,
+                utm_medium: attribution?.utmMedium ?? null,
+                utm_campaign: attribution?.utmCampaign ?? null,
+                utm_term: attribution?.utmTerm ?? null,
+                utm_content: attribution?.utmContent ?? null,
                 batch_id: event.data.batchId ?? null
             });
         });
@@ -52,6 +57,11 @@ class EventStorage {
                 referrer_source: attribution?.referrerSource ?? null,
                 referrer_medium: attribution?.referrerMedium ?? null,
                 referrer_url: attribution?.referrerUrl ?? null,
+                utm_source: attribution?.utmSource ?? null,
+                utm_medium: attribution?.utmMedium ?? null,
+                utm_campaign: attribution?.utmCampaign ?? null,
+                utm_term: attribution?.utmTerm ?? null,
+                utm_content: attribution?.utmContent ?? null,
                 batch_id: event.data.batchId ?? null
             });
         });

--- a/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with UTM parameters 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": Any<Object>,
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": Any<String>,
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": null,
+      "newsletters": Any<Array>,
+      "note": null,
+      "status": "paid",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "tiers": Any<Array>,
+      "unsubscribe_url": "http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with UTM parameters 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "2621",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with author attribution 1: [body] 1`] = `
 Object {
   "members": Array [
@@ -437,7 +485,7 @@ exports[`Members API Member attribution Returns subscription created attribution
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "7024",
+  "content-length": "7037",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -176,6 +176,57 @@ describe('Members Signin', function () {
         assert(!member, 'Member should not have been created');
     });
 
+    it('Stores UTM parameters in MemberCreatedEvent', async function () {
+        const email = 'member-with-utm@test.com';
+        const attribution = {
+            id: null,
+            url: null,
+            type: null,
+            referrerSource: 'Google',
+            referrerMedium: 'unknown',
+            referrerUrl: null,
+            utmSource: 'newsletter',
+            utmMedium: 'email',
+            utmCampaign: 'spring_sale',
+            utmTerm: 'ghost_pro',
+            utmContent: 'header_link'
+        };
+
+        const magicLink = await membersService.api.getMagicLink(email, 'signup', {attribution});
+        const magicLinkUrl = new URL(magicLink);
+        const token = magicLinkUrl.searchParams.get('token');
+
+        await membersAgent.get(`/?token=${token}&action=signup`)
+            .expectStatus(302)
+            .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
+            .expectHeader('Set-Cookie', /members-ssr.*/);
+
+        const member = await getMemberByEmail(email);
+
+        // Check event created with UTM parameters
+        await assertMemberEvents({
+            eventType: 'MemberCreatedEvent',
+            memberId: member.id,
+            asserts: [
+                {
+                    created_at: member.get('created_at'),
+                    attribution_url: null,
+                    attribution_id: null,
+                    attribution_type: null,
+                    source: 'member',
+                    referrer_source: 'Google',
+                    referrer_medium: 'unknown',
+                    referrer_url: null,
+                    utm_source: 'newsletter',
+                    utm_medium: 'email',
+                    utm_campaign: 'spring_sale',
+                    utm_term: 'ghost_pro',
+                    utm_content: 'header_link'
+                }
+            ]
+        });
+    });
+
     describe('Validity Period', function () {
         let clock;
         let startDate = new Date();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2880/
ref https://github.com/TryGhost/Ghost/commit/2ea046c3e88aafea6d8544aafde9e5f473cc5012
- updated event storage to pass along UTM fields to the Ghost database

The Ghost db contains utm_* columns (see migration above) in various events tables. This PR wires up the data flow so that the real data coming from the frontend scripts actually reaches the database.