### PR TITLE
Updated filter style on React tags list

### DIFF
--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -18,7 +18,7 @@ const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
                 <ToggleGroup data-testid="tags-header-tabs" size='button' type="single" value={currentTab} onValueChange={(newTab) => {
                     navigate(newTab === 'internal' ? '/tags?type=internal' : '/tags');
                 }}>
-                    <ToggleGroupItem aria-label="Internal tags" value="public">
+                    <ToggleGroupItem aria-label="Public tags" value="public">
                         Public tags
                     </ToggleGroupItem>
                     <ToggleGroupItem aria-label="Internal tags" value="internal">

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {Button, Header, PageMenu, PageMenuItem} from '@tryghost/shade';
-import {Link} from '@tryghost/admin-x-framework';
+import {Button, Header, ToggleGroup, ToggleGroupItem} from '@tryghost/shade';
+import {useNavigate} from '@tryghost/admin-x-framework';
 
 interface TagsHeaderProps {
     currentTab?: string;
@@ -8,19 +8,23 @@ interface TagsHeaderProps {
 }
 
 const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
+    const navigate = useNavigate();
+
     return (
         <Header variant="inline-nav">
             <Header.Title>Tags</Header.Title>
 
             <Header.Nav>
-                <PageMenu data-testid="tags-header-tabs" defaultValue={currentTab}>
-                    <PageMenuItem value="public" asChild>
-                        <Link to="/tags">Public tags</Link>
-                    </PageMenuItem>
-                    <PageMenuItem value="internal" asChild>
-                        <Link to="/tags?type=internal">Internal tags</Link>
-                    </PageMenuItem>
-                </PageMenu>
+                <ToggleGroup size='button' type="single" value={currentTab} onValueChange={(newTab) => {
+                    navigate(newTab === 'internal' ? '/tags?type=internal' : '/tags');
+                }}>
+                    <ToggleGroupItem aria-label="Internal tags" value="public">
+                        Public tags
+                    </ToggleGroupItem>
+                    <ToggleGroupItem aria-label="Internal tags" value="internal">
+                        Internal tags
+                    </ToggleGroupItem>
+                </ToggleGroup>
             </Header.Nav>
 
             <Header.Actions>

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -15,7 +15,7 @@ const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
             <Header.Title>Tags</Header.Title>
 
             <Header.Nav>
-                <ToggleGroup size='button' type="single" value={currentTab} onValueChange={(newTab) => {
+                <ToggleGroup data-testid="tags-header-tabs" size='button' type="single" value={currentTab} onValueChange={(newTab) => {
                     navigate(newTab === 'internal' ? '/tags?type=internal' : '/tags');
                 }}>
                     <ToggleGroupItem aria-label="Internal tags" value="public">

--- a/apps/posts/src/views/Tags/components/TagsHeader.tsx
+++ b/apps/posts/src/views/Tags/components/TagsHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Button, Header, ToggleGroup, ToggleGroupItem} from '@tryghost/shade';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {Link} from '@tryghost/admin-x-framework';
 
 interface TagsHeaderProps {
     currentTab?: string;
@@ -8,21 +8,21 @@ interface TagsHeaderProps {
 }
 
 const TagsHeader: React.FC<TagsHeaderProps> = ({currentTab}) => {
-    const navigate = useNavigate();
-
     return (
         <Header variant="inline-nav">
             <Header.Title>Tags</Header.Title>
 
             <Header.Nav>
-                <ToggleGroup data-testid="tags-header-tabs" size='button' type="single" value={currentTab} onValueChange={(newTab) => {
-                    navigate(newTab === 'internal' ? '/tags?type=internal' : '/tags');
-                }}>
-                    <ToggleGroupItem aria-label="Public tags" value="public">
-                        Public tags
+                <ToggleGroup data-testid="tags-header-tabs" size='button' type="single" value={currentTab}>
+                    <ToggleGroupItem aria-label="Public tags" value="public" asChild>
+                        <Link to="/tags">
+                            Public tags
+                        </Link>
                     </ToggleGroupItem>
-                    <ToggleGroupItem aria-label="Internal tags" value="internal">
-                        Internal tags
+                    <ToggleGroupItem aria-label="Internal tags" value="internal" asChild>
+                        <Link to="/tags?type=internal">
+                            Internal tags
+                        </Link>
                     </ToggleGroupItem>
                 </ToggleGroup>
             </Header.Nav>

--- a/apps/shade/src/components/ui/toggle-group.stories.tsx
+++ b/apps/shade/src/components/ui/toggle-group.stories.tsx
@@ -160,6 +160,36 @@ export const WithText: Story = {
     }
 };
 
+const ButtonSizedComponent = () => {
+    const [value, setValue] = useState<string>('preview');
+
+    return (
+        <ToggleGroup size='button' type="single" value={value} onValueChange={(newValue) => {
+            if (newValue) {
+                setValue(newValue);
+            }
+        }}>
+            <ToggleGroupItem aria-label="Preview" value="preview">
+                Preview
+            </ToggleGroupItem>
+            <ToggleGroupItem aria-label="Code" value="code">
+                Code
+            </ToggleGroupItem>
+        </ToggleGroup>
+    );
+};
+
+export const ButtonSized: Story = {
+    render: () => <ButtonSizedComponent />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'Toggle group with text labels instead of icons for clearer meaning.'
+            }
+        }
+    }
+};
+
 const NoSelectionComponent = () => {
     const [value, setValue] = useState<string>('');
 

--- a/apps/shade/src/components/ui/toggle-group.stories.tsx
+++ b/apps/shade/src/components/ui/toggle-group.stories.tsx
@@ -184,7 +184,7 @@ export const ButtonSized: Story = {
     parameters: {
         docs: {
             description: {
-                story: 'Toggle group with text labels instead of icons for clearer meaning.'
+                story: 'Toggle group with button-sized variant for a more prominent appearance, suitable for primary navigation controls.'
             }
         }
     }

--- a/apps/shade/src/components/ui/toggle.tsx
+++ b/apps/shade/src/components/ui/toggle.tsx
@@ -14,7 +14,8 @@ const toggleVariants = cva(
                 default: 'bg-transparent'
             },
             size: {
-                default: 'h-[26px] min-w-[26px] px-2'
+                default: 'h-[26px] min-w-[26px] px-2',
+                button: 'h-[32px] min-w-[32px] px-3'
             }
         },
         defaultVariants: {

--- a/e2e/helpers/pages/admin/tags/TagsPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagsPage.ts
@@ -37,7 +37,7 @@ export class TagsPage extends AdminPage {
     }
 
     async selectTab(tabText: string) {
-        const tab = this.tabs.getByRole('link', {name: tabText});
+        const tab = this.tabs.getByLabel(tabText);
         await tab.click();
     }
 

--- a/e2e/helpers/pages/admin/tags/TagsPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagsPage.ts
@@ -25,7 +25,7 @@ export class TagsPage extends AdminPage {
         this.tagNames = page.locator('[data-test-tag-name]');
 
         this.tabs = page.getByTestId('tags-header-tabs');
-        this.activeTab = this.tabs.locator('[data-state="active"]');
+        this.activeTab = this.tabs.locator('[data-state="on"]');
         this.newTagButton = page.getByRole('link', {name: 'New tag'});
         this.createNewTagButton = this.pageContent.getByRole('link', {name: 'Create a new tag'});
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1216/use-toggle-group-in-tag-list-filter

- Changed the component to a toggle group to filter public/internal tags on the tags list for better UX and design parity with the Ember version.