### PR TITLE
Updated Portal's `data-attributes` file to match `i18n` util pattern

### DIFF
--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import {getCheckoutSessionDataFromPlanAttribute, getUrlHistory} from './utils/helpers';
 import {HumanReadableError, chooseBestErrorMessage} from './utils/errors';
-import i18nLib from '@tryghost/i18n';
+import i18n, {t} from './utils/i18n';
 
 function displayErrorIfElementExists(errorEl, message) {
     if (errorEl) {
@@ -9,15 +9,14 @@ function displayErrorIfElementExists(errorEl, message) {
     }
 }
 
-function handleError(error, form, errorEl, t) {
+function handleError(error, form, errorEl) {
     form.classList.add('error');
     const defaultMessage = t('There was an error sending the email, please try again');
     displayErrorIfElementExists(errorEl, chooseBestErrorMessage(error, defaultMessage));
 }
 
 export async function formSubmitHandler(
-    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction, captureException},
-    t = str => str
+    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction, captureException}
 ) {
     form.removeEventListener('submit', submitHandler);
     event.preventDefault();
@@ -121,14 +120,13 @@ export async function formSubmitHandler(
             form.classList.add('error'); // Ensure error state is set here
         }
     } catch (err) {
-        handleError(err, form, errorEl, t);
+        handleError(err, form, errorEl);
     }
 }
 
 export function planClickHandler({event, el, errorEl, siteUrl, site, member, clickHandler}) {
-    const i18nLanguage = site.locale || 'en';
-    const i18n = i18nLib(i18nLanguage, 'portal');
-    const t = i18n.t;
+    i18n.changeLanguage(site.locale || 'en');
+
     el.removeEventListener('click', clickHandler);
     event.preventDefault();
     let plan = el.dataset.membersPlan;
@@ -209,17 +207,17 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
 }
 
 export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doAction, captureException} = {}) {
-    const i18nLanguage = site.locale || 'en';
-    const i18n = i18nLib(i18nLanguage, 'portal');
-    const t = i18n.t;
     if (!siteUrl) {
         return;
     }
+
+    i18n.changeLanguage(site.locale || 'en');
+
     siteUrl = siteUrl.replace(/\/$/, '');
     Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'), function (form) {
         let errorEl = form.querySelector('[data-members-error]');
         function submitHandler(event) {
-            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction, captureException}, t);
+            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction, captureException});
         }
         form.addEventListener('submit', submitHandler);
     });

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -4,7 +4,17 @@ import {fireEvent, appRender, within} from '../utils/test-utils';
 import setupGhostApi from '../utils/api';
 import * as helpers from '../utils/helpers';
 import {formSubmitHandler, planClickHandler, handleDataAttributes} from '../data-attributes';
-import * as i18nLib from '@tryghost/i18n';
+import i18n from '../utils/i18n';
+import {vi} from 'vitest';
+
+vi.mock('../utils/i18n', () => ({
+    default: {
+        changeLanguage: vi.fn(),
+        dir: vi.fn(),
+        t: vi.fn(str => str)
+    },
+    t: vi.fn(str => str)
+}));
 
 // Mock data
 function getMockData({newsletterQuerySelectorResult = null} = {}) {
@@ -75,6 +85,8 @@ function getMockData({newsletterQuerySelectorResult = null} = {}) {
 
 describe('Member Data attributes:', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
+
         // Mock global fetch
         jest.spyOn(window, 'fetch').mockImplementation((url) => {
             if (url.includes('send-magic-link')) {
@@ -315,17 +327,10 @@ describe('Member Data attributes:', () => {
             // Override the site locale to 'de'
             site.locale = 'de';
 
-            // Mock i18nLib to verify it's called with correct parameters
-            const mockI18n = {
-                t: jest.fn(str => str)
-            };
-            jest.spyOn(i18nLib, 'default').mockImplementation(() => mockI18n);
-
             await planClickHandler({event, errorEl, siteUrl, clickHandler, site, member, el: element});
 
             // Verify i18nLib was called with correct locale
-            expect(i18nLib.default).toHaveBeenCalledWith('de', 'portal');
-            expect(mockI18n.t).toBeDefined();
+            expect(i18n.changeLanguage).toHaveBeenCalledWith('de');
         });
 
         test('allows free member upgrade via direct checkout', async () => {
@@ -455,6 +460,8 @@ const setup = async ({site, member = null, showPopup = true}) => {
 
 describe('Portal Data attributes:', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
+
         // Mock global fetch
         jest.spyOn(window, 'fetch').mockImplementation((url) => {
             if (url.includes('send-magic-link')) {
@@ -718,17 +725,9 @@ describe('Portal Data attributes:', () => {
             // Override the site locale to 'de'
             site.locale = 'de';
 
-            // Mock i18nLib to verify it's called with correct parameters
-            const mockI18n = {
-                t: jest.fn(str => str)
-            };
-            jest.spyOn(i18nLib, 'default').mockImplementation(() => mockI18n);
-
             handleDataAttributes({siteUrl, site, member});
 
-            // Verify i18nLib was called with correct locale
-            expect(i18nLib.default).toHaveBeenCalledWith('de', 'portal');
-            expect(mockI18n.t).toBeDefined();
+            expect(i18n.changeLanguage).toHaveBeenCalledWith('de');
         });
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/25086

- updated data-attributes.js to use the centralized i18n util we've switched to elsewhere in Portal's codebase to have a cleaner `import i18n, {t}` pattern. Removed all instances where t was being passed as a function parameter.
