### PR TITLE
Fetch post count when editing tags

### DIFF
--- a/ghost/admin/app/routes/tag.js
+++ b/ghost/admin/app/routes/tag.js
@@ -25,7 +25,7 @@ export default class TagRoute extends AuthenticatedRoute {
         this._requiresBackgroundRefresh = false;
 
         if (params.tag_slug) {
-            return this.store.queryRecord('tag', {slug: params.tag_slug});
+            return this.store.queryRecord('tag', {slug: params.tag_slug, include: 'count.posts'});
         } else {
             return this.store.createRecord('tag');
         }


### PR DESCRIPTION
Refs https://linear.app/ghost/issue/PROD-2711/port-existing-ember-tests-to-playwright

The post count wont show in the tag deletion confirmation modal if you load the tag editor directly instead of going via the tag list. Ensuring we include the counts for the model retrieval of individual tags resolves this.

Without this in place, the [new E2E tests for the tag editor](https://github.com/TryGhost/Ghost/pull/25098) fail.