### PR TITLE
Removed wait type "networkidle" which is discouraged.

### DIFF
--- a/e2e/.claude/E2E_TEST_WRITING_GUIDE.md
+++ b/e2e/.claude/E2E_TEST_WRITING_GUIDE.md
@@ -95,7 +95,6 @@ export class FeaturePage extends AdminPage {
     // Action methods
     async performAction(): Promise<void> {
         await this.buttonName.click();
-        await this.page.waitForLoadState('networkidle');
     }
 
     async fillForm(data: {field1: string; field2: string}): Promise<void> {
@@ -285,6 +284,7 @@ New factories are added as needed. When you need test data that doesn't have a f
 ❌ **Never put selectors in test files**
 ❌ **Don't write comments** - make code self-documenting instead
 ❌ **Don't use hardcoded waits** (`page.waitForTimeout`)
+❌ **Don't use networkidle in waits** (`page.waitForLoadState('networkidle')`) - rely on web assertions to assess readiness instead
 ❌ **Don't depend on test execution order**
 ❌ **Don't manually log in** - use the pre-authenticated fixture
 ❌ **Avoid CSS/XPath selectors** - use semantic selectors
@@ -296,7 +296,6 @@ New factories are added as needed. When you need test data that doesn't have a f
 
 ```typescript
 // Good - explicit waits
-await page.waitForLoadState('networkidle');
 await element.waitFor({state: 'visible'});
 await page.waitForSelector('[data-test="element"]');
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -55,7 +55,6 @@ export class AnalyticsPage extends AdminPage {
     // Semantic action methods
     async saveSettings() {
         await this.saveButton.click();
-        await this.page.waitForLoadState('networkidle');
     }
 }
 ```
@@ -92,7 +91,6 @@ export class AnalyticsPage extends AdminPage {
 import {PostFactory, UserFactory} from '../data-factory';
 
 const postFactory = createPostFactory(page.request);
-
 const post = await postFactory.create({userId: user.id});
 ```
 
@@ -107,6 +105,7 @@ const post = await postFactory.create({userId: user.id});
 
 ### DON'T ❌
 - Hard-coded waits (`waitForTimeout`)
+- networkidle in waits** (`networkidle`) 
 - Test dependencies (Test B needs Test A)
 - Direct database manipulation
 - Multiple scenarios in one test

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -188,6 +188,9 @@ From the e2e directory:
 # Run all tests
 yarn test
 
+# Debug failed tests (keeps containers)
+PRESERVE_ENV=true yarn test
+
 # Run TypeScript type checking
 yarn test:types
 

--- a/e2e/helpers/pages/BasePage.ts
+++ b/e2e/helpers/pages/BasePage.ts
@@ -27,13 +27,9 @@ export class BasePage {
         }
     }
 
-    async goto(url = null, options?: pageGotoOptions) {
+    async goto(url?: string, options?: pageGotoOptions) {
         const urlToVisit = url || this.pageUrl;
         await this.page.goto(urlToVisit, options);
-    }
-
-    public async waitForPageToFullyLoad() {
-        await this.page.waitForLoadState('networkidle');
     }
 
     async pressKey(key: string) {

--- a/e2e/helpers/pages/admin/settings/SettingsPage.ts
+++ b/e2e/helpers/pages/admin/settings/SettingsPage.ts
@@ -48,7 +48,6 @@ export class SettingsPage extends BasePage {
 
     async goto() {
         await super.goto();
-        await this.page.waitForLoadState('networkidle');
         await this.page.waitForSelector('h5', {timeout: 10000});
     }
 

--- a/e2e/helpers/pages/public/HomePage.ts
+++ b/e2e/helpers/pages/public/HomePage.ts
@@ -14,4 +14,8 @@ export class HomePage extends PublicPage {
         this.title = page.getByRole('heading', {level: 1});
         this.accountButton = page.locator('[data-portal="account"]').first();
     }
+
+    async waitUntilLoaded(): Promise<void> {
+        return this.accountButton.waitFor({state: 'visible'});
+    }
 }

--- a/e2e/helpers/pages/public/PublicPage.ts
+++ b/e2e/helpers/pages/public/PublicPage.ts
@@ -83,7 +83,7 @@ export class PublicPage extends BasePage {
         });
     }
 
-    async goto(url = null, options?: pageGotoOptions): Promise<void> {
+    async goto(url?: string, options?: pageGotoOptions): Promise<void> {
         await this.enableAnalyticsRequests();
         await super.goto(url, options);
     }

--- a/e2e/tests/public/member-signup-types.test.ts
+++ b/e2e/tests/public/member-signup-types.test.ts
@@ -23,7 +23,7 @@ test.describe('Ghost Public - Member Signup - Types', () => {
         const magicLink = extractMagicLink(emailTextBody);
         const publicPage = new PublicPage(page);
         await publicPage.goto(magicLink);
-        await publicPage.waitForPageToFullyLoad();
+        await new HomePage(page).waitUntilLoaded();
     }
 
     test('signed up with magic link - direct', async ({page}) => {

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -13,7 +13,8 @@ test.describe('Ghost Public - Member Signup', () => {
     });
 
     test('signed up with magic link in email', async ({page}) => {
-        await new HomePage(page).goto();
+        const homePage = new HomePage(page);
+        await homePage.goto();
         const {emailAddress} = await signupViaPortal(page);
 
         const message = await emailClient.waitForEmail(emailAddress);
@@ -23,9 +24,8 @@ test.describe('Ghost Public - Member Signup', () => {
         const magicLink = extractMagicLink(emailTextBody);
         const publicPage = new PublicPage(page);
         await publicPage.goto(magicLink);
-        await publicPage.waitForPageToFullyLoad();
+        await homePage.waitUntilLoaded();
 
-        const homePage = new HomePage(page);
         await expect(homePage.accountButton).toBeVisible();
     });
 


### PR DESCRIPTION
Introduced this changed to make sure Playwright wait practices are used, so tests do not generate false positives.
