### PR TITLE
Fixed flaky page hit E2E test

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -334,10 +334,22 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 
+      - name: Check for repeat label
+        id: check-repeat
+        if: github.event_name == 'pull_request'
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | jq -e 'index("repeat-e2e-tests")' > /dev/null; then
+            echo "repeat-flag=--repeat-each=10" >> $GITHUB_OUTPUT
+            echo "::notice::Running tests with --repeat-each=10 due to 'repeat-e2e-tests' label"
+          else
+            echo "repeat-flag=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run e2e tests
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
-        run: yarn test:e2e
+        run: yarn test:e2e ${{ steps.check-repeat.outputs.repeat-flag }}
 
       - name: Upload Playwright artifacts
         if: failure()

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -334,22 +334,10 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 
-      - name: Check for repeat label
-        id: check-repeat
-        if: github.event_name == 'pull_request'
-        run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          if echo "$LABELS" | jq -e 'index("repeat-e2e-tests")' > /dev/null; then
-            echo "repeat-flag=--repeat-each=10" >> $GITHUB_OUTPUT
-            echo "::notice::Running tests with --repeat-each=10 due to 'repeat-e2e-tests' label"
-          else
-            echo "repeat-flag=" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run e2e tests
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
-        run: yarn test:e2e ${{ steps.check-repeat.outputs.repeat-flag }}
+        run: yarn test:e2e
 
       - name: Upload Playwright artifacts
         if: failure()

--- a/e2e/helpers/pages/public/PublicPage.ts
+++ b/e2e/helpers/pages/public/PublicPage.ts
@@ -1,4 +1,4 @@
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, Response} from '@playwright/test';
 import {BasePage, pageGotoOptions} from '../BasePage';
 
 declare global {

--- a/e2e/helpers/pages/public/PublicPage.ts
+++ b/e2e/helpers/pages/public/PublicPage.ts
@@ -88,20 +88,10 @@ export class PublicPage extends BasePage {
         await super.goto(url, options);
     }
 
-    async gotoAndWaitForPageHit(url?: string, options?: pageGotoOptions): Promise<void> {
-        const pageHitPromise = this.pageHitRequestPromise();
-        await this.goto(url, options);
-        await pageHitPromise;
-    }
-
-    pageHitRequestPromise(): Promise<Response> {
-        return this.page.waitForResponse((response) => {
+    async waitForPageHitRequest(): Promise<void> {
+        await this.page.waitForResponse((response) => {
             return response.url().includes('/.ghost/analytics/api/v1/page_hit') && response.request().method() === 'POST';
         }, {timeout: 10000});
-    }
-
-    async waitForPageHitRequest(): Promise<void> {
-        await this.pageHitRequestPromise();
     }
 
     async openPortalViaSubscribeButton(): Promise<void> {

--- a/e2e/helpers/pages/public/PublicPage.ts
+++ b/e2e/helpers/pages/public/PublicPage.ts
@@ -88,10 +88,20 @@ export class PublicPage extends BasePage {
         await super.goto(url, options);
     }
 
-    async waitForPageHitRequest(): Promise<void> {
-        await this.page.waitForResponse((response) => {
+    async gotoAndWaitForPageHit(url?: string, options?: pageGotoOptions): Promise<void> {
+        const pageHitPromise = this.pageHitRequestPromise();
+        await this.goto(url, options);
+        await pageHitPromise;
+    }
+
+    pageHitRequestPromise(): Promise<Response> {
+        return this.page.waitForResponse((response) => {
             return response.url().includes('/.ghost/analytics/api/v1/page_hit') && response.request().method() === 'POST';
         }, {timeout: 10000});
+    }
+
+    async waitForPageHitRequest(): Promise<void> {
+        await this.pageHitRequestPromise();
     }
 
     async openPortalViaSubscribeButton(): Promise<void> {

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -10,8 +10,7 @@ test.describe('Ghost Admin - Analytics Overview', () => {
     test('records visitor when homepage is visited', async ({page, browser, baseURL}) => {
         await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
             const homePage = new HomePage(publicPage);
-            await homePage.goto();
-            await homePage.waitForPageHitRequest();
+            await homePage.gotoAndWaitForPageHit();
         });
 
         const analyticsOverviewPage = new AnalyticsOverviewPage(page);

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -10,7 +10,8 @@ test.describe('Ghost Admin - Analytics Overview', () => {
     test('records visitor when homepage is visited', async ({page, browser, baseURL}) => {
         await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
             const homePage = new HomePage(publicPage);
-            await homePage.gotoAndWaitForPageHit();
+            await homePage.goto();
+            await homePage.waitForPageHitRequest();
         });
 
         const analyticsOverviewPage = new AnalyticsOverviewPage(page);


### PR DESCRIPTION
The "Analytics > Overview > records a visitor when homepage is visited" E2E test has been flaky in CI, timing out waiting for the page hit response to be received when visiting the homepage.

The flakiness was caused by a race condition: it's possible that the page hit request could be completed before the promise to listen for the request is created. This leads to the test timing out waiting for a request that has already happened.

This fixes it by creating the promise _before_ navigating to the homepage, _then_ waiting for the promise to resolve. It does so in a helper function on the `PublicPage` POM so we can reuse this logic for any tests the depend on the page hit request, and avoid making this mistake again in the future.