### PR TITLE
Added step to E2E CI workflow to output command to view test reports

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -413,7 +413,7 @@ jobs:
       - name: View Test Report command
         if: failure()
         run: |
-          echo "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
+          echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
 
       - name: Comment on PR with test report command
         if: failure() && github.event_name == 'pull_request'

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -412,4 +412,4 @@ jobs:
 
       - name: Output command to view report
         run: |
-          echo "::notice::To view the Playwright report locally, run: gh run download ${{ github.run_id }} -n playwright-report -D /tmp/playwright-\$\$ && npx playwright show-report /tmp/playwright-\$\$/playwright-report"
+          echo "::notice::To view the Playwright report locally, run: REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -412,7 +412,7 @@ jobs:
 
       - name: View Test Report command
         run: |
-          echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
+          echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\""
 
       - name: Comment on PR with test report command
         if: github.event_name == 'pull_request'
@@ -424,5 +424,5 @@ jobs:
           To view the Playwright test report locally, run:
 
           \`\`\`bash
-          REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\"
+          REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\"
           \`\`\`"

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -411,12 +411,11 @@ jobs:
           retention-days: 7
 
       - name: View Test Report command
-        if: failure()
         run: |
           echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
 
       - name: Comment on PR with test report command
-        if: failure() && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -410,6 +410,20 @@ jobs:
           path: e2e/all-test-results
           retention-days: 7
 
-      - name: Output command to view report
+      - name: View Test Report command
+        if: failure()
         run: |
-          echo "::notice::To view the Playwright report locally, run: REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
+          echo "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\""
+
+      - name: Comment on PR with test report command
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "## E2E Tests Failed
+
+          To view the Playwright test report locally, run:
+
+          \`\`\`bash
+          REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR/playwright-report\"
+          \`\`\`"

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -28,7 +28,7 @@ test.describe('Ghost Admin - Analytics Overview', () => {
         const visitorsCount = await analyticsOverviewPage.latestPost.visitorsCount();
 
         await expect(analyticsOverviewPage.latestPost.post).toBeVisible();
-        expect(visitorsCount).toContain('9');
+        expect(visitorsCount).toContain('0');
         expect(membersCount).toContain('0');
     });
 

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -17,7 +17,7 @@ test.describe('Ghost Admin - Analytics Overview', () => {
         await analyticsOverviewPage.goto();
         await analyticsOverviewPage.refreshData();
 
-        expect(await analyticsOverviewPage.uniqueVisitors.count()).toBe(1);
+        expect(await analyticsOverviewPage.uniqueVisitors.count()).toBe(9);
     });
 
     test('latest post', async ({page}) => {

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -28,7 +28,7 @@ test.describe('Ghost Admin - Analytics Overview', () => {
         const visitorsCount = await analyticsOverviewPage.latestPost.visitorsCount();
 
         await expect(analyticsOverviewPage.latestPost.post).toBeVisible();
-        expect(visitorsCount).toContain('0');
+        expect(visitorsCount).toContain('9');
         expect(membersCount).toContain('0');
     });
 

--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -17,7 +17,7 @@ test.describe('Ghost Admin - Analytics Overview', () => {
         await analyticsOverviewPage.goto();
         await analyticsOverviewPage.refreshData();
 
-        expect(await analyticsOverviewPage.uniqueVisitors.count()).toBe(9);
+        expect(await analyticsOverviewPage.uniqueVisitors.count()).toBe(1);
     });
 
     test('latest post', async ({page}) => {


### PR DESCRIPTION
When the E2E tests fail, they upload the full playwright test report, including the traces, as a Github Artifact. It also outputs a command that can be copied and run locally to conveniently view the test report in your browser.

This makes a few improvements to this setup:
- Currently if you run the command that is output more than once for the same test run, only the first will succeed. This fixes that.
- It improves the formatting of the command output in the GHA logs
- It added a step that will post the command as a comment on the PR, to make it even more convenient to see what when wrong in the e2e tests