### PR TITLE
Updated Tinybird deployment jobs to only run on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1172,7 +1172,7 @@ jobs:
       job_setup,
       job_tinybird-tests
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1192,7 +1192,7 @@ jobs:
       job_tinybird-tests,
       deploy_tinybird_staging
     ]
-    if: always() && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.deploy_tinybird_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && github.event_name == 'push' && needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.result == 'success' && needs.job_tinybird-tests.result == 'success' && needs.deploy_tinybird_staging.result == 'success' && needs.job_setup.outputs.is_main == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
There is a bug in our Tinybird deploy workflow in CI that allows it to run on commits that have already merged to `main`, potentially leading to stale code being deployed to Tinybird.

This can happen because merged PRs can re-run their workflows in response to e.g. label added events, and since the code is already on the `main` branch, our "is this running on the main branch?" check evaluates to true.

This prevents this from happening by explicitly only running on _pushes_ to the main branch.