### PR TITLE
Merge CI run artifacts for single-pane reporting

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: all-blob-reports
+          path: e2e/all-blob-reports
           pattern: blob-report-*
           merge-multiple: true
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -345,7 +345,7 @@ jobs:
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -354,7 +354,7 @@ jobs:
 
   merge_reports:
     name: Merge Playwright Reports
-    if: ${{ !cancelled() }}
+    if: ${{ always() && !cancelled() }}
     needs: [test_e2e, setup]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -345,16 +345,24 @@ jobs:
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
           path: e2e/blob-report
           retention-days: 1
 
+      - name: Upload test results artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.shardIndex }}
+          path: e2e/test-results
+          retention-days: 7
+
   merge_reports:
     name: Merge Playwright Reports
-    if: always() && needs.test_e2e.result == 'failure'
+    if: always()
     needs: [test_e2e, setup]
     runs-on: ubuntu-latest
     steps:
@@ -377,6 +385,13 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
+      - name: Download test results from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: e2e/all-test-results
+          pattern: test-results-*
+          merge-multiple: true
+
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
         working-directory: e2e
@@ -387,6 +402,13 @@ jobs:
           name: playwright-report
           path: e2e/playwright-report
           retention-days: 14
+
+      - name: Upload merged test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/all-test-results
+          retention-days: 7
 
       - name: Output command to view report
         run: |

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -345,7 +345,7 @@ jobs:
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -353,7 +353,7 @@ jobs:
           retention-days: 1
 
       - name: Upload test results artifacts
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.shardIndex }}
@@ -362,7 +362,7 @@ jobs:
 
   merge_reports:
     name: Merge Playwright Reports
-    if: always()
+    if: always() && needs.test_e2e.result == 'failure'
     needs: [test_e2e, setup]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -345,7 +345,7 @@ jobs:
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ always() && !cancelled() }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -354,7 +354,7 @@ jobs:
 
   merge_reports:
     name: Merge Playwright Reports
-    if: ${{ always() && !cancelled() }}
+    if: always() && needs.test_e2e.result == 'failure'
     needs: [test_e2e, setup]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -344,17 +344,50 @@ jobs:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      - name: Upload Playwright artifacts
-        if: failure()
+      - name: Upload blob report to GitHub Actions Artifacts
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.shardIndex }}
-          path: |
-            e2e/playwright-report/
-            e2e/test-results/
-          retention-days: 7
+          name: blob-report-${{ matrix.shardIndex }}
+          path: e2e/blob-report
+          retention-days: 1
+
+  merge_reports:
+    name: Merge Playwright Reports
+    if: ${{ !cancelled() }}
+    needs: [test_e2e, setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.setup.outputs.dependency_cache_key }}
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        working-directory: e2e
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report
+          retention-days: 14
 
       - name: Output command to view report
-        if: failure()
         run: |
-          echo "::notice::To view the Playwright report locally, run: gh run download ${{ github.run_id }} -n playwright-report-${{ matrix.shardIndex }} -D /tmp/playwright-\$\$ && npx playwright show-report /tmp/playwright-\$\$/playwright-report"
+          echo "::notice::To view the Playwright report locally, run: gh run download ${{ github.run_id }} -n playwright-report -D /tmp/playwright-\$\$ && npx playwright show-report /tmp/playwright-\$\$/playwright-report"

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -22,7 +22,7 @@ const config = {
     retries: 0, // Retries open the door to flaky tests. If the test needs retries, it's not a good test or the app is broken.
     workers: process.env.CI ? 4 : getWorkerCount(),
     fullyParallel: true,
-    reporter: process.env.CI ? [['list', {printSteps: true}], ['html']] : [['list', {printSteps: true}]],
+    reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],
     use: {
         // Base URL will be set dynamically per test via fixture
         baseURL: process.env.GHOST_BASE_URL || 'http://localhost:2368',

--- a/e2e/tests/public/homepage.test.ts
+++ b/e2e/tests/public/homepage.test.ts
@@ -6,7 +6,7 @@ test.describe('Ghost Public - Homepage', () => {
         const homePage = new HomePage(page);
 
         await homePage.goto();
-        await expect(homePage.title).not.toBeVisible();
+        await expect(homePage.title).toBeVisible();
         await expect(homePage.mainSubscribeButton).toBeVisible();
     });
 });

--- a/e2e/tests/public/homepage.test.ts
+++ b/e2e/tests/public/homepage.test.ts
@@ -6,7 +6,7 @@ test.describe('Ghost Public - Homepage', () => {
         const homePage = new HomePage(page);
 
         await homePage.goto();
-        await expect(homePage.title).toBeVisible();
+        await expect(homePage.title).not.toBeVisible();
         await expect(homePage.mainSubscribeButton).toBeVisible();
     });
 });


### PR DESCRIPTION
no_ref

After running tests, separate reports are generated on each shard. Added additional step to merge playwright reports.
