### PR TITLE
Prevent the error screen from flashing on navigation

### DIFF
--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -51,7 +51,16 @@ export const routes: RouteObject[] = [
             },
             {
                 path: 'tags',
-                element: <Tags />
+                children: [
+                    {
+                        index: true,
+                        element: <Tags />
+                    },
+                    {
+                        path: ':tagSlug',
+                        element: null
+                    }
+                ]
             },
 
             // Error handling


### PR DESCRIPTION
Refs https://linear.app/ghost/issue/PROD-2509/release-tags-list

I found a few areas lacking polish when testing things one final time before release. When navigating from the React tag list to the Ember tag editor, the router on the React side will also try to render the same route before it is unmounted. Since there isn't a tag editor in React (yet) the error fallback would render instead. 

Adding an empty placeholder route prevents the error fallback from rendering.