### PR TITLE
Added correct current user prop to the preview card in ActivityPub lists

### DIFF
--- a/apps/admin-x-activitypub/package.json
+++ b/apps/admin-x-activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-x-activitypub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/admin-x-activitypub/src/views/Profile/components/ActorList.tsx
@@ -74,7 +74,7 @@ const ActorList: React.FC<ActorListProps> = ({
 
                             return (
                                 <React.Fragment key={actor.id}>
-                                    <ProfilePreviewHoverCard actor={actor} align='center' isCurrentUser={false} side='left'>
+                                    <ProfilePreviewHoverCard actor={actor} align='center' isCurrentUser={isCurrentUser} side='left'>
                                         <div>
                                             <ActivityItem key={actor.id}
                                                 data-testid="actor-item"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-736/show-profile-preview-on-hover

- the followers/following list items had hardcoded `false` value for the current user which would result in displaying a follow button for the current user
- this fixes the issue by providing correct current user flag to the component