### PR TITLE
Fix list item over state for narrow viewports

### DIFF
--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -93,7 +93,7 @@ function TagsList({
                             <TableRow
                                 key={key}
                                 {...props}
-                                className="relative grid w-full grid-cols-[1fr_5rem] items-center gap-x-4 p-2 md:grid-cols-[1fr_auto_5rem] lg:table-row lg:p-0"
+                                className="relative grid w-full grid-cols-[1fr_5rem] items-center gap-x-4 p-2 hover:bg-muted/50 md:grid-cols-[1fr_auto_5rem] lg:table-row lg:p-0 [&.group:hover_td]:bg-transparent"
                                 data-testid="tag-list-row"
                             >
                                 <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">


### PR DESCRIPTION
Refs https://linear.app/ghost/issue/PROD-2509/release-tags-list

I found a small visual bug with list item hover states that shouldn't block a release. The hover background was applied to individual table cells. Since they are not laid out with a continuous background on narrower viewports the hover highlight would not cover the full width of the row.

Since the default hover highlight uses a transparent background color, applying that same hover effect to the full row caused a stacking effect. Thus, we first need to unset the styling applied by the table cell component, and then apply  our own background to the full row.

The background override uses an arbitrary variant to target all descendants: 
https://tailwindcss.com/docs/hover-focus-and-other-states#using-arbitrary-variants

### Before 
<img width="581" height="104" alt="Screenshot 2025-10-09 at 14 13 58" src="https://github.com/user-attachments/assets/01115734-be90-4343-9ba9-ab9ddf339137" />


### After
<img width="581" height="99" alt="Screenshot 2025-10-09 at 14 13 30" src="https://github.com/user-attachments/assets/ce1bcded-beef-49e7-9f91-f7dd83702a64" />
