### PR TITLE
Moved invalid OTC error inline

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
-import i18n from './utils/i18n';
+import i18n, {t} from './utils/i18n';
+import {chooseBestErrorMessage} from './utils/errors';
 import TriggerButton from './components/TriggerButton';
 import Notification from './components/Notification';
 import PopupModal from './components/PopupModal';
@@ -53,6 +54,7 @@ export default class App extends React.Component {
             page: 'loading',
             showPopup: false,
             action: 'init:running',
+            actionErrorMessage: null,
             initStatus: 'running',
             lastPage: null,
             customSiteUrl: props.customSiteUrl,
@@ -683,7 +685,8 @@ export default class App extends React.Component {
     async dispatchAction(action, data) {
         clearTimeout(this.timeoutId);
         this.setState({
-            action: `${action}:running`
+            action: `${action}:running`,
+            actionErrorMessage: null
         });
         try {
             const updatedState = await ActionHandler({action, data, state: this.state, api: this.GhostApi});
@@ -714,6 +717,7 @@ export default class App extends React.Component {
             });
             this.setState({
                 action: `${action}:failed`,
+                actionErrorMessage: chooseBestErrorMessage(error, t('An unexpected error occured. Please try again or <a>contact support</a> if the error persists.')),
                 popupNotification
             });
         }
@@ -960,13 +964,14 @@ export default class App extends React.Component {
 
     /**Get final App level context from App state*/
     getContextFromState() {
-        const {site, member, action, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, labs, otcRef} = this.state;
+        const {site, member, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, labs, otcRef} = this.state;
         const contextPage = this.getContextPage({site, page, member});
         const contextMember = this.getContextMember({page: contextPage, member, customSiteUrl});
         return {
             api: this.GhostApi,
             site,
             action,
+            actionErrorMessage,
             brandColor: this.getAccentColor(),
             page: contextPage,
             pageQuery,

--- a/apps/portal/src/AppContext.js
+++ b/apps/portal/src/AppContext.js
@@ -5,6 +5,7 @@ const AppContext = React.createContext({
     site: {},
     member: {},
     action: '',
+    actionErrorMessage: null,
     lastPage: '',
     brandColor: '',
     pageData: {},

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -222,24 +222,25 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderOTCForm() {
-        const {action, labs, otcRef} = this.context;
+        const {action, actionErrorMessage, labs, otcRef} = this.context;
         const errors = this.state.errors || {};
 
         if (!labs?.membersSigninOTC || !otcRef) {
             return null;
         }
 
-        // @TODO: action implementation TBD
         const isRunning = (action === 'verifyOTC:running');
         const isError = (action === 'verifyOTC:failed');
+
+        const error = (isError && actionErrorMessage) ? actionErrorMessage : errors.otc;
 
         return (
             <form onSubmit={e => this.handleSubmit(e)}>
                 <section className='gh-portal-section gh-portal-otp'>
-                    <div className={`gh-portal-otp-container ${this.state.isFocused && 'focused'} ${errors.otc && 'error'}`}>
+                    <div className={`gh-portal-otp-container ${this.state.isFocused && 'focused'} ${error && 'error'}`}>
                         <input
                             id={`input-${OTC_FIELD_NAME}`}
-                            className={`gh-portal-input ${this.state.otc && 'entry'} ${errors.otc && 'error'}`}
+                            className={`gh-portal-input ${this.state.otc && 'entry'} ${error && 'error'}`}
                             placeholder='––––––'
                             name={OTC_FIELD_NAME}
                             type="text"
@@ -257,9 +258,9 @@ export default class MagicLinkPage extends React.Component {
                             onBlur={() => this.setState({isFocused: false})}
                         />
                     </div>
-                    {errors.otc &&
+                    {error &&
                         <div className="gh-portal-otp-error">
-                            {errors.otc}
+                            {error}
                         </div>
                     }
                 </section>

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -107,10 +107,10 @@ export async function formSubmitHandler(
                         email: (email || '').trim(),
                         otcRef
                     });
-                } catch (actionError) {
+                } catch (e) {
                     // eslint-disable-next-line no-console
-                    console.error(actionError);
-                    captureException?.(actionError);
+                    console.error(e);
+                    captureException?.(e);
                 }
             }
         } else {

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -242,9 +242,9 @@ describe('Member Data attributes:', () => {
             });
 
             const labs = {membersSigninOTC: true};
-            const actionError = new Error('failed to start OTC sign-in');
+            const actionErrorMessage = new Error('failed to start OTC sign-in');
             const doAction = vi.fn(() => {
-                throw actionError;
+                throw actionErrorMessage;
             });
             const captureException = vi.fn();
             const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -275,8 +275,8 @@ describe('Member Data attributes:', () => {
                 email: 'jamie@example.com',
                 otcRef: 'otc_test_ref'
             });
-            expect(captureException).toHaveBeenCalledWith(actionError);
-            expect(consoleSpy).toHaveBeenCalledWith(actionError);
+            expect(captureException).toHaveBeenCalledWith(actionErrorMessage);
+            expect(consoleSpy).toHaveBeenCalledWith(actionErrorMessage);
             expect(form.classList.add).toHaveBeenCalledWith('success');
 
             consoleSpy.mockRestore();

--- a/apps/portal/src/utils/errors.js
+++ b/apps/portal/src/utils/errors.js
@@ -16,12 +16,14 @@ export class HumanReadableError extends Error {
                 }
             } catch (e) {
                 // Failed to decode: ignore
-                return false;
+                return undefined;
             }
         }
         if (res.status === 500) {
             return new HumanReadableError('A server error occurred');
         }
+
+        return undefined;
     }
 }
 
@@ -64,6 +66,7 @@ export function chooseBestErrorMessage(error, alreadyTranslatedDefaultMessage) {
             t('Signups from this email domain are currently restricted.');
             t('Too many sign-up attempts, try again later');
             t('Memberships from this email domain are currently restricted.');
+            t('Invalid verification code');
         }
     };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2706

When an invalid OTC was entered, we were showing a notification popup that was inconsistent with the inline validation error design and had spatial dissociation with the form the user is interacting with. Moving error display inline required a method of surfacing errors from within dispatched in a way that allowed the calling-components to access them.

- added `actionErrorMessage` to App context
  - actions should return this state property rather than `popupNotification` when inline error display is desired
  - when set, should be a plain string
- updated `verifyOTC` action to set `actionError` instead of `popupNotification`
- updated `MagicLinkPage` to use `actionError` to display an inline error state on verification failure to match error design when no code was entered
- refactored `HumanReadableError.fromApiResponse` so it always returns an instance or `undefined` to match the declared return type