### PR TITLE
Revert "Added a way to run tests on multiple shards in CI"

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -286,14 +286,9 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
   test_e2e:
-    name: E2E Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: E2E Tests
     runs-on: ubuntu-latest
     needs: [build, setup]
-    strategy:
-      fail-fast: false
-      matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -342,13 +337,13 @@ jobs:
       - name: Run e2e tests
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
-        run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: yarn test:e2e
 
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.shardIndex }}
+          name: playwright-report
           path: |
             e2e/playwright-report/
             e2e/test-results/
@@ -357,4 +352,4 @@ jobs:
       - name: Output command to view report
         if: failure()
         run: |
-          echo "::notice::To view the Playwright report locally, run: gh run download ${{ github.run_id }} -n playwright-report-${{ matrix.shardIndex }} -D /tmp/playwright-\$\$ && npx playwright show-report /tmp/playwright-\$\$/playwright-report"
+          echo "::notice::To view the Playwright report locally, run: gh run download ${{ github.run_id }} -n playwright-report -D /tmp/playwright-\$\$ && npx playwright show-report /tmp/playwright-\$\$/playwright-report"


### PR DESCRIPTION
Reverted TryGhost/Ghost#25102. Introduced sharding to speed up tests, but it seems it generates too much load on CI process.

(**sidenote** : it seems it was GH issue - degradation in performance)