### PR TITLE
Completed Jest to Vitest migration in Portal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -32,8 +32,19 @@
   },
   "eslintConfig": {
     "env": {
-      "browser": true,
-      "jest": true
+      "browser": true
+    },
+    "globals": {
+      "vi": "readonly",
+      "describe": "readonly",
+      "it": "readonly",
+      "test": "readonly",
+      "expect": "readonly",
+      "beforeEach": "readonly",
+      "afterEach": "readonly",
+      "beforeAll": "readonly",
+      "afterAll": "readonly",
+      "require": "readonly"
     },
     "parserOptions": {
       "sourceType": "module",
@@ -70,23 +81,16 @@
       "last 1 safari version"
     ]
   },
-  "jest": {
-    "coverageReporters": [
-      "cobertura",
-      "text-summary",
-      "html"
-    ]
-  },
   "devDependencies": {
     "@babel/eslint-parser": "7.28.4",
     "@doist/react-interpolate": "2.2.1",
     "@sentry/react": "7.120.4",
-    "@testing-library/jest-dom": "5.17.0",
+    "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "12.1.5",
     "@tryghost/i18n": "0.0.0",
     "@vitejs/plugin-react": "4.7.0",
-    "@vitest/coverage-v8": "1.6.1",
-    "@vitest/ui": "1.6.1",
+    "@vitest/coverage-v8": "3.2.4",
+    "@vitest/ui": "3.2.4",
     "concurrently": "8.2.2",
     "cross-fetch": "4.1.0",
     "eslint-plugin-i18next": "6.1.3",
@@ -96,6 +100,6 @@
     "vite": "5.4.20",
     "vite-plugin-css-injected-by-js": "3.5.2",
     "vite-plugin-svgr": "3.3.0",
-    "vitest": "1.6.1"
+    "vitest": "3.2.4"
   }
 }

--- a/apps/portal/src/components/common/ActionButton.test.js
+++ b/apps/portal/src/components/common/ActionButton.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '@testing-library/react';
 import ActionButton from './ActionButton';
 
 const setup = () => {
-    const mockOnClickFn = jest.fn();
+    const mockOnClickFn = vi.fn();
     const props = {
         label: 'Test Action Button', onClick: mockOnClickFn, disabled: false
     };

--- a/apps/portal/src/components/common/InputField.test.js
+++ b/apps/portal/src/components/common/InputField.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '@testing-library/react';
 import InputField from './InputField';
 
 const setup = () => {
-    const mockOnChangeFn = jest.fn();
+    const mockOnChangeFn = vi.fn();
     const props = {
         name: 'test-input',
         label: 'Test Input',

--- a/apps/portal/src/components/common/Switch.test.js
+++ b/apps/portal/src/components/common/Switch.test.js
@@ -2,7 +2,7 @@ import {render, fireEvent} from '@testing-library/react';
 import Switch from './Switch';
 
 const setup = () => {
-    const mockOnToggle = jest.fn();
+    const mockOnToggle = vi.fn();
     const props = {
         onToggle: mockOnToggle,
         label: 'Test Switch',

--- a/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
+++ b/apps/portal/src/components/pages/NewsletterSelectionPage.test.js
@@ -55,7 +55,7 @@ const setup = () => {
 
 describe('NewsletterSelectionPage', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
     });
 
     test('renders', () => {

--- a/apps/portal/src/setupTests.js
+++ b/apps/portal/src/setupTests.js
@@ -1,20 +1,10 @@
-import {afterEach, expect} from 'vitest';
+import {afterEach} from 'vitest';
 import {cleanup} from '@testing-library/react';
 import {fetch} from 'cross-fetch';
-import matchers from '@testing-library/jest-dom/matchers';
-
-// TODO: remove this once we're switched `jest` to `vi` in code
-// eslint-disable-next-line no-undef
-globalThis.jest = vi;
+import '@testing-library/jest-dom/vitest';
 
 // eslint-disable-next-line no-undef
 globalThis.fetch = fetch;
 
 // Add the cleanup function for React testing library
 afterEach(cleanup);
-
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-expect.extend(matchers);

--- a/apps/portal/src/tests/App.test.js
+++ b/apps/portal/src/tests/App.test.js
@@ -17,7 +17,7 @@ describe('App', function () {
         document.body.appendChild(link);
 
         const ghostApi = setupGhostApi({siteUrl: 'http://example.com'});
-        ghostApi.init = jest.fn(() => {
+        ghostApi.init = vi.fn(() => {
             return Promise.resolve({
                 site: FixtureSite.singleTier.basic,
                 member: FixtureMember.free

--- a/apps/portal/src/tests/EmailSubscriptionsFlow.test.js
+++ b/apps/portal/src/tests/EmailSubscriptionsFlow.test.js
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 const setup = async ({site, member = null, newsletters}, loggedOut = false) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member: loggedOut ? null : member,
@@ -14,20 +14,20 @@ const setup = async ({site, member = null, newsletters}, loggedOut = false) => {
         });
     });
 
-    ghostApi.member.update = jest.fn(({newsletters: newNewsletters}) => {
+    ghostApi.member.update = vi.fn(({newsletters: newNewsletters}) => {
         return Promise.resolve({
             newsletters: newNewsletters,
             enable_comment_notifications: false
         });
     });
 
-    ghostApi.member.newsletters = jest.fn(() => {
+    ghostApi.member.newsletters = vi.fn(() => {
         return Promise.resolve({
             newsletters
         });
     });
 
-    ghostApi.member.updateNewsletters = jest.fn(({uuid: memberUuid, newsletters: newNewsletters, enableCommentNotifications}) => {
+    ghostApi.member.updateNewsletters = vi.fn(({uuid: memberUuid, newsletters: newNewsletters, enableCommentNotifications}) => {
         return Promise.resolve({
             uuid: memberUuid,
             newsletters: newNewsletters,

--- a/apps/portal/src/tests/FeedbackFlow.test.js
+++ b/apps/portal/src/tests/FeedbackFlow.test.js
@@ -11,13 +11,13 @@ const postId = posts[0].id;
 
 const setup = async (site = siteData, member = memberData, loggedOut = false, api = {}) => {
     const ghostApi = setupGhostApi({siteUrl: site.url});
-    ghostApi.init = api?.init || jest.fn(() => {
+    ghostApi.init = api?.init || vi.fn(() => {
         return Promise.resolve({
             site,
             member: loggedOut ? null : member
         });
     });
-    ghostApi.feedback.add = api?.add || jest.fn(() => {
+    ghostApi.feedback.add = api?.add || vi.fn(() => {
         return Promise.resolve({
             feedback: [
                 {
@@ -137,7 +137,7 @@ describe('Feedback Submission Flow', () => {
                 writable: true
             });
             const mockApi = {
-                add: jest.fn(() => {
+                add: vi.fn(() => {
                     return Promise.reject(new Error('Failed to submit feedback'));
                 })
             };

--- a/apps/portal/src/tests/SigninFlow.test.js
+++ b/apps/portal/src/tests/SigninFlow.test.js
@@ -7,22 +7,22 @@ const OTC_LABEL_REGEX = /Code/i;
 
 const setup = async ({site, member = null, labs = {}}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve('testtoken');
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -63,22 +63,22 @@ const setup = async ({site, member = null, labs = {}}) => {
 
 const multiTierSetup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve(`testtoken`);
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -169,7 +169,7 @@ describe('Signin', () => {
             });
 
             // Mock sendMagicLink to return otc_ref for OTC flow
-            ghostApi.member.sendMagicLink = jest.fn(() => {
+            ghostApi.member.sendMagicLink = vi.fn(() => {
                 return Promise.resolve({success: true, otc_ref: 'test-otc-ref-123'});
             });
 
@@ -403,7 +403,7 @@ describe('Signin', () => {
 });
 
 describe('OTC Integration Flow', () => {
-    const locationAssignMock = jest.fn();
+    const locationAssignMock = vi.fn();
 
     beforeEach(() => {
         const mockLocation = new URL('https://portal.localhost/#/portal/signin');
@@ -416,13 +416,13 @@ describe('OTC Integration Flow', () => {
 
     afterEach(() => {
         window.location = realLocation;
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
         locationAssignMock.mockReset();
     });
 
     const setupOTCFlow = async ({site, otcRef = 'test-otc-ref-123', returnOtcRef = true}) => {
         const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-        ghostApi.init = jest.fn(() => {
+        ghostApi.init = vi.fn(() => {
             return Promise.resolve({
                 site,
                 member: null
@@ -430,17 +430,17 @@ describe('OTC Integration Flow', () => {
         });
 
         // Mock sendMagicLink to return otcRef for OTC flow or fallback
-        ghostApi.member.sendMagicLink = jest.fn(() => {
+        ghostApi.member.sendMagicLink = vi.fn(() => {
             return returnOtcRef
                 ? Promise.resolve({success: true, otc_ref: otcRef})
                 : Promise.resolve({success: true});
         });
 
-        ghostApi.member.getIntegrityToken = jest.fn(() => {
+        ghostApi.member.getIntegrityToken = vi.fn(() => {
             return Promise.resolve('testtoken');
         });
 
-        ghostApi.member.verifyOTC = jest.fn(() => {
+        ghostApi.member.verifyOTC = vi.fn(() => {
             return Promise.resolve({
                 redirectUrl: 'https://example.com/welcome'
             });

--- a/apps/portal/src/tests/SignupFlow.test.js
+++ b/apps/portal/src/tests/SignupFlow.test.js
@@ -8,28 +8,28 @@ const deepClone = obj => JSON.parse(JSON.stringify(obj));
 
 const offerSetup = async ({site, member = null, offer}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site: deepClone(site),
             member: member ? deepClone(member) : null
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve(`testtoken`);
     });
 
-    ghostApi.site.offer = jest.fn(() => {
+    ghostApi.site.offer = vi.fn(() => {
         return Promise.resolve({
             offers: [offer]
         });
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -82,22 +82,22 @@ const offerSetup = async ({site, member = null, offer}) => {
 
 const setup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site: deepClone(site),
             member: member ? deepClone(member) : null
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve(`testtoken`);
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -141,22 +141,22 @@ const setup = async ({site, member = null}) => {
 
 const multiTierSetup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site: deepClone(site),
             member: member ? deepClone(member) : null
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve(`testtoken`);
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 

--- a/apps/portal/src/tests/UpgradeFlow.test.js
+++ b/apps/portal/src/tests/UpgradeFlow.test.js
@@ -5,24 +5,24 @@ import setupGhostApi from '../utils/api.js';
 
 const offerSetup = async ({site, member = null, offer}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.site.offer = jest.fn(() => {
+    ghostApi.site.offer = vi.fn(() => {
         return Promise.resolve({
             offers: [offer]
         });
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -72,18 +72,18 @@ const offerSetup = async ({site, member = null, offer}) => {
 
 const setup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -127,18 +127,18 @@ const setup = async ({site, member = null}) => {
 
 const multiTierSetup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -29,12 +29,12 @@ function getMockData({newsletterQuerySelectorResult = null} = {}) {
     const clickHandler = () => {};
 
     const form = {
-        removeEventListener: jest.fn(),
-        classList: {remove: jest.fn(), add: jest.fn()},
+        removeEventListener: vi.fn(),
+        classList: {remove: vi.fn(), add: vi.fn()},
         dataset: {membersForm: 'signup'},
-        addEventListener: jest.fn()
+        addEventListener: vi.fn()
     };
-    jest.spyOn(form.classList, 'add');
+    vi.spyOn(form.classList, 'add');
 
     const element = {
         removeEventListener: () => {},
@@ -88,7 +88,7 @@ describe('Member Data attributes:', () => {
         vi.clearAllMocks();
 
         // Mock global fetch
-        jest.spyOn(window, 'fetch').mockImplementation((url) => {
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
             if (url.includes('send-magic-link')) {
                 return Promise.resolve({
                     ok: true,
@@ -127,7 +127,7 @@ describe('Member Data attributes:', () => {
 
         // Mock global Stripe
         window.Stripe = () => {};
-        jest.spyOn(window, 'Stripe').mockImplementation(() => {
+        vi.spyOn(window, 'Stripe').mockImplementation(() => {
             return {
                 redirectToCheckout: () => {
                     return Promise.resolve({});
@@ -136,7 +136,7 @@ describe('Member Data attributes:', () => {
         });
 
         // Mock url history method
-        jest.spyOn(helpers, 'getUrlHistory').mockImplementation(() => {
+        vi.spyOn(helpers, 'getUrlHistory').mockImplementation(() => {
             return [{
                 path: '/blog/',
                 refMedium: null,
@@ -147,13 +147,13 @@ describe('Member Data attributes:', () => {
         });
 
         // Mock window.location
-        let locationMock = jest.fn();
+        let locationMock = vi.fn();
         delete window.location;
         window.location = {assign: locationMock};
         window.location.href = (new URL('https://portal.localhost')).href;
     });
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
     describe('data-members-form', () => {
         test('allows free signup', async () => {
@@ -186,7 +186,7 @@ describe('Member Data attributes:', () => {
             form.dataset.membersOtc = 'true';
 
             const originalQuerySelector = event.target.querySelector;
-            event.target.querySelector = jest.fn((selector) => {
+            event.target.querySelector = vi.fn((selector) => {
                 if (selector === 'input[data-members-email]') {
                     return {value: ' jamie@example.com '};
                 }
@@ -194,7 +194,7 @@ describe('Member Data attributes:', () => {
             });
 
             const labs = {membersSigninOTC: true};
-            const doAction = jest.fn(() => Promise.resolve());
+            const doAction = vi.fn(() => Promise.resolve());
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
             window.fetch.mockImplementation((url) => {
@@ -234,7 +234,7 @@ describe('Member Data attributes:', () => {
             form.dataset.membersOtc = 'true';
 
             const originalQuerySelector = event.target.querySelector;
-            event.target.querySelector = jest.fn((selector) => {
+            event.target.querySelector = vi.fn((selector) => {
                 if (selector === 'input[data-members-email]') {
                     return {value: ' jamie@example.com '};
                 }
@@ -243,11 +243,11 @@ describe('Member Data attributes:', () => {
 
             const labs = {membersSigninOTC: true};
             const actionError = new Error('failed to start OTC sign-in');
-            const doAction = jest.fn(() => {
+            const doAction = vi.fn(() => {
                 throw actionError;
             });
-            const captureException = jest.fn();
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const captureException = vi.fn();
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
             window.fetch.mockImplementation((url) => {
@@ -429,18 +429,18 @@ describe('Member Data attributes:', () => {
 
 const setup = async ({site, member = null, showPopup = true}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -463,7 +463,7 @@ describe('Portal Data attributes:', () => {
         vi.clearAllMocks();
 
         // Mock global fetch
-        jest.spyOn(window, 'fetch').mockImplementation((url) => {
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
             if (url.includes('send-magic-link')) {
                 return Promise.resolve({
                     ok: true,
@@ -495,7 +495,7 @@ describe('Portal Data attributes:', () => {
 
         // Mock global Stripe
         window.Stripe = () => {};
-        jest.spyOn(window, 'Stripe').mockImplementation(() => {
+        vi.spyOn(window, 'Stripe').mockImplementation(() => {
             return {
                 redirectToCheckout: () => {
                     return Promise.resolve({});
@@ -504,14 +504,14 @@ describe('Portal Data attributes:', () => {
         });
 
         // Mock window.location
-        let locationMock = jest.fn();
+        let locationMock = vi.fn();
         delete window.location;
         window.location = {assign: locationMock};
         window.location.href = (new URL('https://portal.localhost')).href;
         window.location.hash = '';
     });
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
     describe('data-portal', () => {
         test('opens default portal page', async () => {

--- a/apps/portal/src/tests/portal-links.test.js
+++ b/apps/portal/src/tests/portal-links.test.js
@@ -6,22 +6,22 @@ import {fireEvent} from '@testing-library/react';
 
 const setup = async ({site, member = null, showPopup = true}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
-    ghostApi.init = jest.fn(() => {
+    ghostApi.init = vi.fn(() => {
         return Promise.resolve({
             site,
             member
         });
     });
 
-    ghostApi.member.sendMagicLink = jest.fn(() => {
+    ghostApi.member.sendMagicLink = vi.fn(() => {
         return Promise.resolve('success');
     });
 
-    ghostApi.member.getIntegrityToken = jest.fn(() => {
+    ghostApi.member.getIntegrityToken = vi.fn(() => {
         return Promise.resolve('testtoken');
     });
 
-    ghostApi.member.checkoutPlan = jest.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(() => {
         return Promise.resolve();
     });
 
@@ -42,7 +42,7 @@ const setup = async ({site, member = null, showPopup = true}) => {
 describe('Portal Data links:', () => {
     beforeEach(() => {
         // Mock global fetch
-        jest.spyOn(window, 'fetch').mockImplementation((url) => {
+        vi.spyOn(window, 'fetch').mockImplementation((url) => {
             if (url.includes('send-magic-link')) {
                 return Promise.resolve({
                     ok: true,
@@ -74,7 +74,7 @@ describe('Portal Data links:', () => {
 
         // Mock global Stripe
         window.Stripe = () => {};
-        jest.spyOn(window, 'Stripe').mockImplementation(() => {
+        vi.spyOn(window, 'Stripe').mockImplementation(() => {
             return {
                 redirectToCheckout: () => {
                     return Promise.resolve({});
@@ -83,13 +83,13 @@ describe('Portal Data links:', () => {
         });
 
         // Mock window.location
-        let locationMock = jest.fn();
+        let locationMock = vi.fn();
         delete window.location;
         window.location = {assign: locationMock};
         window.location.href = (new URL('https://portal.localhost')).href;
     });
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
         window.location.hash = '';
     });
     describe('#/portal', () => {

--- a/apps/portal/src/utils/helpers.test.js
+++ b/apps/portal/src/utils/helpers.test.js
@@ -431,16 +431,16 @@ describe('Helpers - ', () => {
 
     describe('getUrlHistory', () => {
         beforeEach(() => {
-            jest.spyOn(console, 'warn').mockImplementation(() => {
+            vi.spyOn(console, 'warn').mockImplementation(() => {
                 // don't log for these tests
             });
         });
         afterEach(() => {
-            jest.restoreAllMocks();
+            vi.restoreAllMocks();
         });
 
         test('returns valid history ', () => {
-            jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify([
+            vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify([
                 {
                     path: '/',
                     time: 0
@@ -452,14 +452,14 @@ describe('Helpers - ', () => {
         });
 
         test('ignores invalid history ', () => {
-            jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('invalid');
+            vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('invalid');
             const urlHistory = getUrlHistory();
             expect(sessionStorage.getItem).toHaveBeenCalled();
             expect(urlHistory).toBeUndefined();
         });
 
         test('doesn\'t throw if sessionStorage is disabled', () => {
-            jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
                 throw new Error('SessionStorage disabled');
             });
             const urlHistory = getUrlHistory();

--- a/apps/portal/src/utils/test-utils.js
+++ b/apps/portal/src/utils/test-utils.js
@@ -16,7 +16,7 @@ const setupProvider = (context) => {
 };
 
 const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
-    const mockDoActionFn = jest.fn().mockResolvedValue(undefined);
+    const mockDoActionFn = vi.fn().mockResolvedValue(undefined);
 
     // Hardcode the locale to 'en' for testing
     const {t} = require('@tryghost/i18n')('en');
@@ -40,7 +40,7 @@ const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
 };
 
 export const appRender = (ui, {options = {}} = {}) => {
-    const mockDoActionFn = jest.fn();
+    const mockDoActionFn = vi.fn();
 
     const utils = render(ui, options);
     return {

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -83,7 +83,10 @@ export default defineConfig((config) => {
             globals: true,
             environment: 'jsdom',
             setupFiles: './src/setupTests.js',
-            testTimeout: 10000
+            testTimeout: 10000,
+            coverage: {
+                reporter: ['cobertura', 'text-summary', 'html']
+            }
         }
     };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,14 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@ampproject/remapping@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
+  integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@aws-crypto/sha256-browser@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
@@ -1593,7 +1601,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bcoe/v8-coverage@^1.0.1":
+"@bcoe/v8-coverage@^1.0.1", "@bcoe/v8-coverage@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
@@ -3836,6 +3844,14 @@
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -3866,6 +3882,14 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz#a58d31eaadaf92c6695680b2e1d464a9b8fbf7fc"
   integrity sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.30":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -8168,6 +8192,19 @@
     lodash "^4.17.21"
     redent "^3.0.0"
 
+"@testing-library/jest-dom@6.6.3":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz#26ba906cf928c0f8172e182c6fe214eb4f9f2bd2"
+  integrity sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==
+  dependencies:
+    "@adobe/css-tools" "^4.4.0"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    lodash "^4.17.21"
+    redent "^3.0.0"
+
 "@testing-library/jest-dom@^6.6.3":
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz#697db9424f0d21d8216f1958fa0b1b69b5f43923"
@@ -10138,24 +10175,24 @@
     test-exclude "^6.0.0"
     v8-to-istanbul "^9.1.0"
 
-"@vitest/coverage-v8@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz#47230491ec73aa288a92e36b75c1671b3f741d4e"
-  integrity sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==
+"@vitest/coverage-v8@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz#a2d8d040288c1956a1c7d0a0e2cdcfc7a3319f13"
+  integrity sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==
   dependencies:
-    "@ampproject/remapping" "^2.2.1"
-    "@bcoe/v8-coverage" "^0.2.3"
-    debug "^4.3.4"
+    "@ampproject/remapping" "^2.3.0"
+    "@bcoe/v8-coverage" "^1.0.2"
+    ast-v8-to-istanbul "^0.3.3"
+    debug "^4.4.1"
     istanbul-lib-coverage "^3.2.2"
     istanbul-lib-report "^3.0.1"
-    istanbul-lib-source-maps "^5.0.4"
-    istanbul-reports "^3.1.6"
-    magic-string "^0.30.5"
-    magicast "^0.3.3"
-    picocolors "^1.0.0"
-    std-env "^3.5.0"
-    strip-literal "^2.0.0"
-    test-exclude "^6.0.0"
+    istanbul-lib-source-maps "^5.0.6"
+    istanbul-reports "^3.1.7"
+    magic-string "^0.30.17"
+    magicast "^0.3.5"
+    std-env "^3.9.0"
+    test-exclude "^7.0.1"
+    tinyrainbow "^2.0.0"
 
 "@vitest/expect@1.6.1":
   version "1.6.1"
@@ -10210,7 +10247,7 @@
   dependencies:
     tinyrainbow "^1.2.0"
 
-"@vitest/pretty-format@3.2.4":
+"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
   integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
@@ -10226,6 +10263,15 @@
     p-limit "^5.0.0"
     pathe "^1.1.1"
 
+"@vitest/runner@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
+  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
+  dependencies:
+    "@vitest/utils" "3.2.4"
+    pathe "^2.0.3"
+    strip-literal "^3.0.0"
+
 "@vitest/snapshot@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.1.tgz#90414451a634bb36cd539ccb29ae0d048a8c0479"
@@ -10234,6 +10280,15 @@
     magic-string "^0.30.5"
     pathe "^1.1.1"
     pretty-format "^29.7.0"
+
+"@vitest/snapshot@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
+  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
+  dependencies:
+    "@vitest/pretty-format" "3.2.4"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
 
 "@vitest/spy@1.6.1":
   version "1.6.1"
@@ -10256,18 +10311,18 @@
   dependencies:
     tinyspy "^4.0.3"
 
-"@vitest/ui@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-1.6.1.tgz#e94c42af392ddb47531b2401d8871bc246f1947e"
-  integrity sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==
+"@vitest/ui@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-3.2.4.tgz#df8080537c1dcfeae353b2d3cb3301d9acafe04a"
+  integrity sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==
   dependencies:
-    "@vitest/utils" "1.6.1"
-    fast-glob "^3.3.2"
-    fflate "^0.8.1"
-    flatted "^3.2.9"
-    pathe "^1.1.1"
-    picocolors "^1.0.0"
-    sirv "^2.0.4"
+    "@vitest/utils" "3.2.4"
+    fflate "^0.8.2"
+    flatted "^3.3.3"
+    pathe "^2.0.3"
+    sirv "^3.0.1"
+    tinyglobby "^0.2.14"
+    tinyrainbow "^2.0.0"
 
 "@vitest/utils@1.6.1":
   version "1.6.1"
@@ -11257,6 +11312,15 @@ ast-types@^0.16.1:
   integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
   dependencies:
     tslib "^2.0.1"
+
+ast-v8-to-istanbul@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz#9fba217c272dd8c2615603da5de3e1a460b4b9af"
+  integrity sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.30"
+    estree-walker "^3.0.3"
+    js-tokens "^9.0.1"
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -15574,6 +15638,13 @@ debug@4.3.4:
   dependencies:
     ms "2.1.2"
 
+debug@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@~4.3.1, debug@~4.3.2:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
@@ -18005,7 +18076,7 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
-es-module-lexer@^1.2.1:
+es-module-lexer@^1.2.1, es-module-lexer@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
@@ -18813,6 +18884,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expect-type@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
+  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
+
 expect@29.7.0, expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
@@ -19163,7 +19239,7 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fflate@^0.8.1:
+fflate@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
   integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
@@ -19503,7 +19579,7 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^3.2.9:
+flatted@^3.2.9, flatted@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
@@ -22180,7 +22256,7 @@ istanbul-lib-source-maps@^4.0.0, istanbul-lib-source-maps@^4.0.1:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-lib-source-maps@^5.0.4:
+istanbul-lib-source-maps@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
   integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
@@ -22193,6 +22269,14 @@ istanbul-reports@^3.0.2, istanbul-reports@^3.1.3, istanbul-reports@^3.1.5, istan
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
   integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+istanbul-reports@^3.1.7:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
@@ -24228,7 +24312,7 @@ magic-string@^0.30.0, magic-string@^0.30.1, magic-string@^0.30.17, magic-string@
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-magicast@^0.3.3:
+magicast@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
   integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
@@ -26785,7 +26869,7 @@ pathe@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.1.tgz#1dd31d382b974ba69809adc9a7a347e65d84829a"
   integrity sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==
 
-pathe@^2.0.1:
+pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
@@ -30431,10 +30515,10 @@ sinon@^9.0.0:
     nise "^4.0.4"
     supports-color "^7.1.0"
 
-sirv@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
-  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
+sirv@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
+  integrity sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==
   dependencies:
     "@polka/url" "^1.0.0-next.24"
     mrmime "^2.0.0"
@@ -30923,7 +31007,7 @@ statuses@^2.0.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
-std-env@^3.3.3, std-env@^3.5.0:
+std-env@^3.3.3, std-env@^3.5.0, std-env@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
   integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
@@ -31303,6 +31387,13 @@ strip-literal@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.1.tgz#26906e65f606d49f748454a08084e94190c2e5ad"
   integrity sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==
+  dependencies:
+    js-tokens "^9.0.1"
+
+strip-literal@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
   dependencies:
     js-tokens "^9.0.1"
 
@@ -32003,12 +32094,17 @@ tiny-lr@^2.0.0:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
-tinybench@^2.5.1:
+tinybench@^2.5.1, tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinyglobby@^0.2.12, tinyglobby@^0.2.15:
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
   integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
@@ -32020,6 +32116,11 @@ tinypool@^0.8.3:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
   integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
 
 tinyrainbow@^1.2.0:
   version "1.2.0"
@@ -33279,6 +33380,17 @@ vite-node@1.6.1:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.1"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
 vite-plugin-css-injected-by-js@3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz#1f75d16ad5c05b6b49bf18018099a189ec2e46ad"
@@ -33327,6 +33439,20 @@ vite@7.1.10:
   optionalDependencies:
     fsevents "~2.3.3"
 
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.9.tgz#ba844410e5d0c0f2a4eaf17a52af60ebea322cbf"
+  integrity sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vitest@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.6.1.tgz#b4a3097adf8f79ac18bc2e2e0024c534a7a78d2f"
@@ -33352,6 +33478,35 @@ vitest@1.6.1:
     vite "^5.0.0"
     vite-node "1.6.1"
     why-is-node-running "^2.2.2"
+
+vitest@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
+  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.4"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/pretty-format" "^3.2.4"
+    "@vitest/runner" "3.2.4"
+    "@vitest/snapshot" "3.2.4"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    chai "^5.2.0"
+    debug "^4.4.1"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -33738,7 +33893,7 @@ whoops@~4.1.7:
     clean-stack "~3.0.0"
     mimic-fn "~3.1.0"
 
-why-is-node-running@^2.2.2:
+why-is-node-running@^2.2.2, why-is-node-running@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
   integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==


### PR DESCRIPTION
no issue

Around 3 years ago we switched from `jest` to `vi` but only aliased the global rather than fully completing the switch. This change finishes the migration.

- Upgraded Vitest packages from 1.6.1 to 3.2.4
- Upgraded `@testing-library/jest-dom` from 5.17.0 to 6.6.3 for better Vitest compatibility
- Migrated all test files from `jest.*` to `vi.*` API
- Updated test setup to use modern `@testing-library/jest-dom/vitest` import
- Moved coverage config from package.json to vite.config.mjs
- Updated ESLint config with Vitest-specific globals
- Removed jest compatibility shim from setupTests.js