### PR TITLE
Reduced flakiness of tags e2e tests

### DIFF
--- a/e2e/helpers/pages/admin/tags/TagEditorPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagEditorPage.ts
@@ -63,6 +63,9 @@ export class TagEditorPage extends AdminPage {
 
     async save() {
         await this.saveButton.click();
+        // Wait for the save to complete - button becomes enabled again after save
+        await this.saveButton.waitFor({state: 'visible'});
+        await this.page.waitForLoadState('networkidle');
     }
 
     async deleteTag() {

--- a/e2e/helpers/pages/admin/tags/TagEditorPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagEditorPage.ts
@@ -1,4 +1,4 @@
-import {Locator, Page} from '@playwright/test';
+import {expect, Locator, Page} from '@playwright/test';
 import {AdminPage} from '../AdminPage';
 
 export class TagEditorPage extends AdminPage {
@@ -63,9 +63,10 @@ export class TagEditorPage extends AdminPage {
 
     async save() {
         await this.saveButton.click();
-        // Wait for the save to complete - button becomes enabled again after save
-        await this.saveButton.waitFor({state: 'visible'});
-        await this.page.waitForLoadState('networkidle');
+        // Wait for save to start
+        await this.saveButton.locator('[data-test-task-button-state="running"]').waitFor();
+        // Wait for save to complete
+        await this.saveButton.locator('[data-test-task-button-state="success"]').waitFor();
     }
 
     async deleteTag() {

--- a/e2e/helpers/pages/admin/tags/TagEditorPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagEditorPage.ts
@@ -1,4 +1,4 @@
-import {expect, Locator, Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 import {AdminPage} from '../AdminPage';
 
 export class TagEditorPage extends AdminPage {
@@ -19,7 +19,7 @@ export class TagEditorPage extends AdminPage {
         super(page);
 
         this.pageUrl = '/ghost/#/tags';
-        
+
         this.nameInput = page.locator('[data-test-input="tag-name"]');
         this.slugInput = page.locator('[data-test-input="tag-slug"]');
         this.descriptionInput = page.locator('[data-test-input="tag-description"]');

--- a/e2e/helpers/pages/admin/tags/TagsPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagsPage.ts
@@ -1,5 +1,6 @@
 import {Locator, Page} from '@playwright/test';
 import {AdminPage} from '../AdminPage';
+import {pageGotoOptions} from '../../BasePage';
 
 export class TagsPage extends AdminPage {
     readonly pageContent: Locator;
@@ -49,8 +50,18 @@ export class TagsPage extends AdminPage {
         return this.page.getByRole('link', {name: name, exact: true});
     }
 
+    async goto(url?: string, options?: pageGotoOptions) {
+        await super.goto(url, options);
+        await this.waitForPageToFullyLoad();
+    }
+
     async waitForPageToFullyLoad() {
-        await this.page.waitForURL(this.pageUrl);
+        await this.page.waitForURL(this.pageUrl, {waitUntil: 'domcontentloaded'});
         await this.pageContent.waitFor({state: 'visible'});
+        // Wait for either tag list (when tags exist) or create button (empty state)
+        await Promise.race([
+            this.tagList.waitFor({state: 'visible'}),
+            this.createNewTagButton.waitFor({state: 'visible'})
+        ]);
     }
 }

--- a/e2e/helpers/pages/admin/tags/TagsPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagsPage.ts
@@ -57,11 +57,5 @@ export class TagsPage extends AdminPage {
 
     async waitForPageToFullyLoad() {
         await this.page.waitForURL(this.pageUrl, {waitUntil: 'domcontentloaded'});
-        await this.pageContent.waitFor({state: 'visible'});
-        // Wait for either tag list (when tags exist) or create button (empty state)
-        await Promise.race([
-            this.tagList.waitFor({state: 'visible'}),
-            this.createNewTagButton.waitFor({state: 'visible'})
-        ]);
     }
 }

--- a/e2e/tests/admin/tags/editor.test.ts
+++ b/e2e/tests/admin/tags/editor.test.ts
@@ -12,9 +12,10 @@ test.describe('Ghost Admin - Tags Editor', () => {
         await tagEditor.goBackToTagsList();
         await tagsPage.waitForPageToFullyLoad();
 
-        await expect(tagsPage.getRowByTitle('New tag name')).toBeVisible();
-        await expect(tagsPage.getRowByTitle('New tag name')).toContainText('new-tag-slug');
-        await expect(tagsPage.getRowByTitle('New tag name')).toContainText('0 posts');
+        const newTagRow = tagsPage.getRowByTitle('New tag name');
+        await expect(newTagRow).toBeVisible();
+        await expect(newTagRow).toContainText('new-tag-slug');
+        await expect(newTagRow).toContainText('0 posts');
     });
 
     test('can edit tags', async ({page}) => {
@@ -37,8 +38,9 @@ test.describe('Ghost Admin - Tags Editor', () => {
         await tagEditor.goBackToTagsList();
         await tagsPage.waitForPageToFullyLoad();
 
-        await expect(tagsPage.getRowByTitle('New tag name')).toBeVisible();
-        await expect(tagsPage.getRowByTitle('New tag name')).toContainText('new-tag-slug');
+        const newTagRow = tagsPage.getRowByTitle('New tag name');
+        await expect(newTagRow).toBeVisible();
+        await expect(newTagRow).toContainText('new-tag-slug');
     });
 
     test('does not create duplicates when editing a tag', async ({page}) => {
@@ -47,7 +49,7 @@ test.describe('Ghost Admin - Tags Editor', () => {
         await tagsPage.goto();
 
         await expect(tagsPage.tagListRow).toHaveCount(1);
-        
+
         await tagsPage.getRowByTitle('News').click();
         await tagEditor.fillTagName('Edited Tag Name');
         await tagEditor.save();
@@ -61,7 +63,7 @@ test.describe('Ghost Admin - Tags Editor', () => {
     test('can delete tag without posts', async ({page}) => {
         const tagEditor = new TagEditorPage(page);
         const tagsPage = new TagsPage(page);
-        
+
         await tagEditor.createTag('To be deleted', 'to-be-deleted');
         await tagEditor.goBackToTagsList();
         await tagsPage.waitForPageToFullyLoad();
@@ -72,16 +74,15 @@ test.describe('Ghost Admin - Tags Editor', () => {
         await expect(tagEditor.deleteModal).toBeVisible();
         await tagEditor.confirmDelete();
 
-        await expect(tagEditor.deleteModal).not.toBeVisible();
-        await expect(page).toHaveURL('/ghost/#/tags');
+        await tagsPage.waitForPageToFullyLoad();
         await expect(tagsPage.tagListRow).toHaveCount(1);
     });
 
     test('can delete tags with posts', async ({page}) => {
         const tagsPage = new TagsPage(page);
         const tagEditor = new TagEditorPage(page);
-        await tagsPage.goto();        
-        
+        await tagsPage.goto();
+
         await tagsPage.getRowByTitle('News').click();
         await tagEditor.deleteTag();
 
@@ -89,9 +90,9 @@ test.describe('Ghost Admin - Tags Editor', () => {
         await expect(tagEditor.deleteModalPostsCount).toContainText('1 post');
 
         await tagEditor.confirmDelete();
+        // confirmDelete waits for navigation, now just wait for content to load
+        await tagsPage.pageContent.waitFor({state: 'visible'});
 
-        await expect(tagEditor.deleteModal).not.toBeVisible();
-        await expect(page).toHaveURL('/ghost/#/tags');
         await expect(tagsPage.getRowByTitle('News')).not.toBeVisible();
     });
 
@@ -105,8 +106,7 @@ test.describe('Ghost Admin - Tags Editor', () => {
     });
 
     test('redirects to 404 when tag does not exist', async ({page}) => {
-        const tagEditor = new TagEditorPage(page);
-        await tagEditor.gotoTagBySlug('unknown');
+        await page.goto('/ghost/#/tags/unknown');
 
         await expect(page.getByText('Page not found')).toBeVisible();
     });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/ecb0f3d8f8102e04ad369277bcc9892e20e6552e
- updated tags tests to improve resiliency

A few tests were failing locally. Specifically, the save action was occurring too quickly for the remaining actions in some tests.