### PR TITLE
🐛 Fixed crash during forced upgrade when billing iframe not ready

### DIFF
--- a/ghost/admin/app/services/billing.js
+++ b/ghost/admin/app/services/billing.js
@@ -43,6 +43,10 @@ export default class BillingService extends Service {
         }
     }
 
+    _isBillingIframeLoaded() {
+        return this.getBillingIframe() !== null && this.getBillingIframe().contentWindow;
+    }
+
     getIframeURL() {
         // initiate getting owner user in the background
         this.getOwnerUser();
@@ -81,7 +85,7 @@ export default class BillingService extends Service {
         const action = this.action;
 
         if (action) {
-            if (action === 'checkout') {
+            if (action === 'checkout' && this._isBillingIframeLoaded()) {
                 this.getBillingIframe().contentWindow.postMessage({
                     query: 'routeUpdate',
                     response: this.checkoutRoute
@@ -93,6 +97,10 @@ export default class BillingService extends Service {
     }
 
     sendUpdateLimits() {
+        if (!this._isBillingIframeLoaded()) {
+            return;
+        }
+
         // Send Billing app message to fetch fresh limit usage
         this.getBillingIframe().contentWindow.postMessage({
             query: 'limitUpdate'


### PR DESCRIPTION
closes [BAE-544](https://linear.app/ghost/issue/BAE-544/settings-changes-not-reflected-in-billing-app)

When `hostSettings.forceUpgrade` was enabled, the application attempted to open the billing window immediately during initialization by calling `billing.openBillingWindow()`. This triggered `sendUpdateLimits()` which tried to access the billing iframe's `contentWindow` before the iframe element was inserted into the DOM, causing a crash that broke the entire Ember admin application. Added a guard clause in `sendUpdateLimits()` to check if the billing iframe exists and has a valid `contentWindow` before attempting to send postMessages. This ensures the app loads gracefully during forceUpgrade flows while still sending limit updates during normal runtime when the iframe is ready.
