### PR TITLE
Updated tags list to use empty indicator component

### DIFF
--- a/apps/posts/src/views/Tags/Tags.tsx
+++ b/apps/posts/src/views/Tags/Tags.tsx
@@ -3,7 +3,7 @@ import TagsContent from './components/TagsContent';
 import TagsHeader from './components/TagsHeader';
 import TagsLayout from './components/TagsLayout';
 import TagsList from './components/TagsList';
-import {Button, LoadingIndicator, LucideIcon} from '@tryghost/shade';
+import {Button, EmptyIndicator, LoadingIndicator, LucideIcon} from '@tryghost/shade';
 import {useBrowseTags} from '@tryghost/admin-x-framework/api/tags';
 import {useLocation} from '@tryghost/admin-x-framework';
 
@@ -46,14 +46,17 @@ const Tags: React.FC = () => {
                         </Button>
                     </div>
                 ) : !data?.tags.length ? (
-                    <div className="mb-16 flex h-full flex-col items-center justify-center gap-8">
-                        <LucideIcon.Tags className="-mb-4 size-16 text-muted-foreground" strokeWidth={1} />
-                        <h2 className="text-xl font-medium">
-                            Start organizing your content
-                        </h2>
-                        <Button asChild>
-                            <a href="#/tags/new">Create a new tag</a>
-                        </Button>
+                    <div className="flex h-full items-center justify-center">
+                        <EmptyIndicator
+                            actions={
+                                <Button asChild>
+                                    <a href="#/tags/new">Create a new tag</a>
+                                </Button>
+                            }
+                            title="Start organizing your content"
+                        >
+                            <LucideIcon.Tags />
+                        </EmptyIndicator>
                     </div>
                 ) : (
                     <TagsList

--- a/apps/shade/src/components/ui/empty-indicator.stories.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.stories.tsx
@@ -83,3 +83,46 @@ export const CompactCopy: Story = {
     }
 };
 
+export const TitleOnly: Story = {
+    args: {
+        title: 'No results found'
+    },
+    render: args => (
+        <EmptyIndicator {...args}>
+            <Inbox />
+        </EmptyIndicator>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use title-only when the context is self-explanatory and no additional description is needed.'
+            }
+        }
+    }
+};
+
+export const TitleWithAction: Story = {
+    args: {
+        title: 'No members yet',
+        actions: (
+            <>
+                <Button>
+                    <Plus /> Add member
+                </Button>
+            </>
+        )
+    },
+    render: args => (
+        <EmptyIndicator {...args}>
+            <Inbox />
+        </EmptyIndicator>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Combine a title with actions when the next step is clear without needing additional explanation.'
+            }
+        }
+    }
+};
+

--- a/apps/shade/src/components/ui/empty-indicator.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.tsx
@@ -40,9 +40,11 @@ const EmptyIndicator = React.forwardRef<HTMLDivElement, EmptyIndicatorProps>(({c
                 <h3 className='text-pretty text-md font-medium tracking-normal text-foreground'>
                     {title}
                 </h3>
-                <p className='text-pretty text-sm leading-tight text-muted-foreground'>
-                    {description}
-                </p>
+                {description &&
+                    <p className='text-pretty text-sm leading-tight text-muted-foreground'>
+                        {description}
+                    </p>
+                }
             </div>
             {actions && (
                 <div className='mt-4 flex items-center gap-2'>

--- a/apps/shade/src/components/ui/empty-indicator.tsx
+++ b/apps/shade/src/components/ui/empty-indicator.tsx
@@ -37,7 +37,7 @@ const EmptyIndicator = React.forwardRef<HTMLDivElement, EmptyIndicatorProps>(({c
                 {children}
             </EmptyBadge>
             <div className='max-w-[320px] space-y-1.5'>
-                <h3 className='text-pretty text-sm font-medium tracking-normal text-foreground'>
+                <h3 className='text-pretty text-md font-medium tracking-normal text-foreground'>
                     {title}
                 </h3>
                 <p className='text-pretty text-sm leading-tight text-muted-foreground'>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2565/use-emptyindicator-for-tag-list-blank-state

- Updated the React tags screen to use the Empty indicator component from Shade instead of a custom implementation when there are no tags.
