### PR TITLE
Updated reading_time related code to improve clarity

### DIFF
--- a/ghost/core/core/frontend/helpers/reading_time.js
+++ b/ghost/core/core/frontend/helpers/reading_time.js
@@ -13,18 +13,18 @@
 const {checks} = require('../services/data');
 const {SafeString} = require('../services/handlebars');
 
-const {readingTime: calculateReadingTime} = require('@tryghost/helpers');
+const {readingTime: calculateAndFormatReadingTime} = require('@tryghost/helpers');
 
 module.exports = function reading_time(options) {// eslint-disable-line camelcase
     options = options || {};
     options.hash = options.hash || {};
+    const possiblyPost = this;
 
     // only calculate reading time for posts
-    if (!checks.isPost(this)) {
+    if (!checks.isPost(possiblyPost)) {
         return null;
     }
 
-    let readingTime = calculateReadingTime(this, options.hash);
-
+    const readingTime = calculateAndFormatReadingTime(possiblyPost, options.hash);
     return new SafeString(readingTime);
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js
@@ -8,11 +8,17 @@ const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
  * @returns {void} - modifies attrs
  */
 module.exports.forPost = (options, model, attrs) => {
+    // requested via `columns`
     const columnsIncludesCustomExcerpt = options.columns?.includes('custom_excerpt');
     const columnsIncludesExcerpt = options.columns?.includes('excerpt');
     const columnsIncludesPlaintext = options.columns?.includes('plaintext');
     const columnsIncludesReadingTime = options.columns?.includes('reading_time');
+
+    // requested via `formats`
     const formatsIncludesPlaintext = options.formats?.includes('plaintext');
+
+    // no columns requested
+    const noColumnsRequested = !Object.prototype.hasOwnProperty.call(options, 'columns');
 
     // 1. Gets excerpt from post's plaintext. If custom_excerpt exists, it overrides the excerpt but the key remains excerpt.
     if (columnsIncludesExcerpt) {
@@ -32,7 +38,6 @@ module.exports.forPost = (options, model, attrs) => {
         }
     }
 
-    // 2. Displays plaintext if requested via `columns` or `formats`
     if (columnsIncludesPlaintext || formatsIncludesPlaintext) {
         let plaintext = model.get('plaintext');
         if (plaintext) {
@@ -43,7 +48,7 @@ module.exports.forPost = (options, model, attrs) => {
     }
 
     // 3. Displays excerpt if no columns was requested - specifically needed for the Admin Posts API
-    if (!Object.prototype.hasOwnProperty.call(options, 'columns')) {
+    if (noColumnsRequested) {
         let customExcerpt = model.get('custom_excerpt');
 
         if (customExcerpt !== null) {
@@ -59,7 +64,7 @@ module.exports.forPost = (options, model, attrs) => {
     }
 
     // 4. Add `reading_time` if no columns were requested, or if `reading_time` was requested via `columns`
-    if (!Object.prototype.hasOwnProperty.call(options, 'columns') || columnsIncludesReadingTime) {
+    if (noColumnsRequested || columnsIncludesReadingTime) {
         if (attrs.html) {
             let additionalImages = 0;
 


### PR DESCRIPTION
Added tiny change to the reading time extra argument for posts which is calculated on the fly.

* more descriptive names to make the code easier to understand at a glance
* explicit variables and const declarations to improve readability and maintainability

