### PR TITLE
Enforce kebab-case naming for workspace consistency

### DIFF
--- a/e2e/tests/.eslintrc.js
+++ b/e2e/tests/.eslintrc.js
@@ -6,5 +6,15 @@ module.exports = {
     ],
     rules: {
         'no-console': 'off'
-    }
+    },
+    overrides: [
+        {
+            // Only apply filename rule to files containing 'test' in their name
+            files: ['*test*'],
+            rules: {
+                // Enforce kebab-case (lowercase with hyphens) for test filenames
+                'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', true]
+            }
+        }
+    ]
 };


### PR DESCRIPTION
- Added filename validation rule for files containing 'test' in their name
- Enforces lowercase kebab-case pattern (only lowercase letters, numbers, dots, and hyphens)
- Applied only to test files via ESLint overrides configuration
- Improves consistency across E2E test file naming conventions