### PR TITLE
Added `otc_used_count` column to `tokens` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.4/2025-10-13-10-18-38-add-tokens-otc-used-count-column.js
+++ b/ghost/core/core/server/data/migrations/versions/6.4/2025-10-13-10-18-38-add-tokens-otc-used-count-column.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('tokens', 'otc_used_count', {
+    type: 'integer',
+    nullable: false,
+    unsigned: true,
+    defaultTo: 0
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1,7 +1,7 @@
 /* String Column Sizes Information
  * (From: https://github.com/TryGhost/Ghost/pull/7932)
  * New/Updated column maxlengths should meet these guidlines
- * 
+ *
  * Small strings = length 50
  * Medium strings = length 191
  * Large strings = length 2000 (use soft limits via validation for 191-2000)
@@ -925,7 +925,8 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         first_used_at: {type: 'dateTime', nullable: true},
-        used_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+        used_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        otc_used_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     snippets: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/models/single-use-token.js
+++ b/ghost/core/core/server/models/single-use-token.js
@@ -7,6 +7,7 @@ const SingleUseToken = ghostBookshelf.Model.extend({
     defaults() {
         return {
             used_count: 0,
+            otc_used_count: 0,
             uuid: crypto.randomUUID(),
             token: crypto
                 .randomBytes(192 / 8)

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '3071f336e59e2ff87f1336caf5dfaed6';
+    const currentSchemaHash = 'aa00ea8206673b21837fbcc24897f779';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2502

- magic link tokens allow multiple uses to account for clicks from email scanning tools, these uses increment the `tokens.used_count` column
- we want to separate OTC uses from magic link uses for two reasons
  1. automatic link clickers should not block you from using your OTC by hitting the link too many times
  2. OTC should have tighter restrictions on uses because they don't get used automatically like links
- adding `tokens.otc_used_count` lets us track OTC uses separately from magic link uses
