### PR TITLE
Fixed error in `docker:clean` script

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -100,7 +100,7 @@ services:
     entrypoint: [ "/home/ghost/.docker/development.entrypoint.sh" ]
     working_dir: /home/ghost
     command: [ "node", "/home/ghost/.docker/watch-admin-apps.js" ]
-    profiles: [ split ]
+    profiles: [ split, all ]
     tty: true
     restart: always
     environment:


### PR DESCRIPTION
The `yarn docker:clean` script stops all running services in the docker compose project by using the "all" profile in docker compose, which ensures it stops all services, regardless of which profiles may be enabled locally.

However, the `admin-apps` service was missing the "all" profile so it was being skipped in `yarn docker:clean` and causing an error. This adds the profile to ensure that `yarn docker:clean` succeeds.