### PR TITLE
Added Stripe profile to docker compose

### DIFF
--- a/.docker/development.entrypoint.sh
+++ b/.docker/development.entrypoint.sh
@@ -39,6 +39,17 @@ else
     echo "WARNING: Tinybird not enabled: .env file not found"
 fi
 
+# Configure Stripe webhook secret
+if [ -f /mnt/shared-config/.env.stripe ]; then
+    source /mnt/shared-config/.env.stripe
+    if [ -n "${STRIPE_WEBHOOK_SECRET:-}" ]; then
+        export WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"
+        echo "Stripe webhook secret configured successfully"
+    else
+        echo "WARNING: Stripe webhook secret not found in shared config"
+    fi
+fi
+
 yarn nx reset
 
 # Execute the CMD

--- a/.docker/stripe/entrypoint.sh
+++ b/.docker/stripe/entrypoint.sh
@@ -23,14 +23,19 @@ _term() {
 # Set up signal handlers (POSIX-compliant signal names)
 trap _term TERM INT
 
+# Remove any stale config file from previous runs
+rm -f /mnt/shared-config/.env.stripe
+
 # Check if STRIPE_SECRET_KEY is set
 if [ -z "${STRIPE_SECRET_KEY:-}" ]; then
-    echo "ERROR: STRIPE_SECRET_KEY is not set" >&2
-    echo "" >&2
-    echo "To use the Stripe service, you must set STRIPE_SECRET_KEY in your .env file:" >&2
-    echo "  STRIPE_SECRET_KEY=sk_test_..." >&2
-    echo "" >&2
-    echo "You can find your secret key at: https://dashboard.stripe.com/test/apikeys" >&2
+    echo "================================================================================"
+    echo "ERROR: STRIPE_SECRET_KEY is not set"
+    echo ""
+    echo "To use the Stripe service, you must set STRIPE_SECRET_KEY in your .env file:"
+    echo "  STRIPE_SECRET_KEY=sk_test_..."
+    echo ""
+    echo "You can find your secret key at: https://dashboard.stripe.com/test/apikeys"
+    echo "================================================================================"
     exit 1
 fi
 
@@ -42,8 +47,8 @@ WEBHOOK_SECRET=$(timeout 10s stripe listen --print-secret --api-key "${STRIPE_SE
 
 # Check if we got a timeout
 if [ "$WEBHOOK_SECRET" = "TIMEOUT" ]; then
-    echo "ERROR: Timed out waiting for Stripe CLI (10s)" >&2
-    echo "Please check that your STRIPE_SECRET_KEY is valid" >&2
+    echo "ERROR: Timed out waiting for Stripe CLI (10s)"
+    echo "Please check that your STRIPE_SECRET_KEY is valid"
     exit 1
 fi
 
@@ -51,9 +56,9 @@ fi
 if echo "$WEBHOOK_SECRET" | grep -q "^whsec_"; then
     echo "Successfully fetched webhook secret"
 else
-    echo "ERROR: Failed to fetch Stripe webhook secret" >&2
-    echo "Output: $WEBHOOK_SECRET" >&2
-    echo "Please ensure STRIPE_SECRET_KEY is set in your environment" >&2
+    echo "ERROR: Failed to fetch Stripe webhook secret"
+    echo "Output: $WEBHOOK_SECRET"
+    echo "Please ensure STRIPE_SECRET_KEY is set in your environment"
     exit 1
 fi
 
@@ -72,11 +77,11 @@ if [ $? -eq 0 ]; then
     if [ $? -eq 0 ]; then
         echo "Successfully wrote Stripe configuration to $ENV_FILE"
     else
-        echo "ERROR: Failed to move temporary file to $ENV_FILE" >&2
+        echo "ERROR: Failed to move temporary file to $ENV_FILE"
         exit 1
     fi
 else
-    echo "ERROR: Failed to create temporary configuration file" >&2
+    echo "ERROR: Failed to create temporary configuration file"
     rm -f "$TMP_ENV_FILE"
     exit 1
 fi

--- a/.docker/stripe/entrypoint.sh
+++ b/.docker/stripe/entrypoint.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# Entrypoint script for the Stripe CLI service in compose.yml
+## This script fetches the webhook secret from Stripe CLI and writes it to a shared config file
+## that the Ghost server can read to verify webhook signatures.
+
+# Note: the stripe CLI container is based on alpine, hence `sh` instead of `bash`.
+set -eu
+
+# Initialize child process variable
+child=""
+
+# Handle shutdown signals gracefully.
+_term() {
+    echo "Caught SIGTERM/SIGINT signal, shutting down gracefully..."
+    if [ -n "$child" ]; then
+        kill -TERM "$child" 2>/dev/null || true
+        wait "$child" 2>/dev/null || true
+    fi
+    exit 0
+}
+
+# Set up signal handlers (POSIX-compliant signal names)
+trap _term TERM INT
+
+# Check if STRIPE_SECRET_KEY is set
+if [ -z "${STRIPE_SECRET_KEY:-}" ]; then
+    echo "ERROR: STRIPE_SECRET_KEY is not set" >&2
+    echo "" >&2
+    echo "To use the Stripe service, you must set STRIPE_SECRET_KEY in your .env file:" >&2
+    echo "  STRIPE_SECRET_KEY=sk_test_..." >&2
+    echo "" >&2
+    echo "You can find your secret key at: https://dashboard.stripe.com/test/apikeys" >&2
+    exit 1
+fi
+
+echo "Using STRIPE_SECRET_KEY for authentication"
+
+# Fetch the webhook secret with timeout
+echo "Fetching Stripe webhook secret..."
+WEBHOOK_SECRET=$(timeout 10s stripe listen --print-secret --api-key "${STRIPE_SECRET_KEY}" 2>&1 || echo "TIMEOUT")
+
+# Check if we got a timeout
+if [ "$WEBHOOK_SECRET" = "TIMEOUT" ]; then
+    echo "ERROR: Timed out waiting for Stripe CLI (10s)" >&2
+    echo "Please check that your STRIPE_SECRET_KEY is valid" >&2
+    exit 1
+fi
+
+# Check if we got a valid secret (should start with "whsec_")
+if echo "$WEBHOOK_SECRET" | grep -q "^whsec_"; then
+    echo "Successfully fetched webhook secret"
+else
+    echo "ERROR: Failed to fetch Stripe webhook secret" >&2
+    echo "Output: $WEBHOOK_SECRET" >&2
+    echo "Please ensure STRIPE_SECRET_KEY is set in your environment" >&2
+    exit 1
+fi
+
+# Write the webhook secret to the shared config file
+ENV_FILE="/mnt/shared-config/.env.stripe"
+TMP_ENV_FILE="/mnt/shared-config/.env.stripe.tmp"
+
+echo "Writing Stripe configuration to $ENV_FILE..."
+
+cat > "$TMP_ENV_FILE" << EOF
+STRIPE_WEBHOOK_SECRET=$WEBHOOK_SECRET
+EOF
+
+if [ $? -eq 0 ]; then
+    mv "$TMP_ENV_FILE" "$ENV_FILE"
+    if [ $? -eq 0 ]; then
+        echo "Successfully wrote Stripe configuration to $ENV_FILE"
+    else
+        echo "ERROR: Failed to move temporary file to $ENV_FILE" >&2
+        exit 1
+    fi
+else
+    echo "ERROR: Failed to create temporary configuration file" >&2
+    rm -f "$TMP_ENV_FILE"
+    exit 1
+fi
+
+# Start stripe listen in the background
+echo "Starting Stripe webhook listener forwarding to http://server:2368/members/webhooks/stripe/"
+stripe listen --forward-to http://server:2368/members/webhooks/stripe/ --api-key "${STRIPE_SECRET_KEY}" &
+child=$!
+
+# Wait for the child process
+wait "$child"

--- a/compose.yml
+++ b/compose.yml
@@ -66,6 +66,9 @@ services:
       tb-cli:
         condition: service_completed_successfully
         required: false
+      stripe:
+        condition: service_started
+        required: false
     environment:
       - DEBUG=${DEBUG:-}
       - SSH_AUTH_SOCK=/ssh-agent
@@ -282,6 +285,20 @@ services:
     ports:
       - "1025:1025" # SMTP server
       - "8025:8025" # Web interface
+    restart: always
+
+  stripe:
+    image: stripe/stripe-cli:latest
+    container_name: ghost-stripe
+    profiles: [ stripe, all ]
+    entrypoint: [ "/entrypoint.sh" ]
+    volumes:
+      - ./.docker/stripe/entrypoint.sh:/entrypoint.sh:ro
+      - shared-config:/mnt/shared-config
+    environment:
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
+      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
     restart: always
 
 volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -67,7 +67,7 @@ services:
         condition: service_completed_successfully
         required: false
       stripe:
-        condition: service_started
+        condition: service_healthy
         required: false
     environment:
       - DEBUG=${DEBUG:-}
@@ -299,7 +299,10 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}
-    restart: always
+    healthcheck:
+      test: ["CMD", "test", "-f", "/mnt/shared-config/.env.stripe"]
+      interval: 1s
+      retries: 120
 
 volumes:
   mysql-data: {}


### PR DESCRIPTION
When running or testing any kind of paid membership flows, you need the stripe CLI running somewhere locally to forward webhooks to your locally running instance of Ghost. Historically this has all been done locally, and the `dev.js` script can optionally start the `stripe listen...` command when running `yarn dev`. 

This PR allows for a more docker-native way of working with Stripe locally:
- The `stripe listen` command runs in a dedicated stripe CLI container, using the official stripe CLI docker container
- The `stripe` service retrieves the webhook secret from Stripe, and writes it to a shared config volume
- The `stripe` service then runs the `stripe listen...` command, forwarding the requests to the Ghost instance ("server" in the split profile)
- The `server` (Ghost) service then reads the webhook secret from the shared volume, and uses it to validate the webhooks it receives.