### PR TITLE
Improved loading state of profiles in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Profile/Profile.tsx
+++ b/apps/activitypub/src/views/Profile/Profile.tsx
@@ -156,7 +156,7 @@ const Profile: React.FC<ProfileProps> = ({}) => {
         };
     }) || [];
 
-    const postsTab = isLoadingAccount ? <></> : <PostsTab handle={params.handle || ''} />;
+    const postsTab = <PostsTab handle={params.handle || ''} />;
     const likesTab = <LikesTab />;
     const followingTab = <FollowingTab handle={params.handle || ''} />;
     const followersTab = <FollowersTab handle={params.handle || ''} />;

--- a/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -213,12 +213,14 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                 <a className='inline-flex max-w-full truncate text-[1.5rem] text-gray-800 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-500' href={account?.url} rel='noopener noreferrer' target='_blank'>
                                     <span className='truncate'>{!isLoadingAccount ? account?.handle : <Skeleton className='w-full max-w-56' />}</span>
                                 </a>
-                                <Button className='-ml-1.5 size-6 p-0 text-gray-800 hover:text-gray-900 dark:text-gray-700 dark:hover:text-gray-600' title='Copy handle' variant='link' onClick={handleCopy}>
-                                    {!copied ?
-                                        <LucideIcon.Copy size={16} /> :
-                                        <LucideIcon.Check size={16} />
-                                    }
-                                </Button>
+                                {!isLoadingAccount && (
+                                    <Button className='-ml-1.5 size-6 p-0 text-gray-800 hover:text-gray-900 dark:text-gray-700 dark:hover:text-gray-600' title='Copy handle' variant='link' onClick={handleCopy}>
+                                        {!copied ?
+                                            <LucideIcon.Copy size={16} /> :
+                                            <LucideIcon.Check size={16} />
+                                        }
+                                    </Button>
+                                )}
                                 {account?.followsMe && !isLoadingAccount && (
                                     <Badge className='mt-px whitespace-nowrap' variant='secondary'>Follows you</Badge>
                                 )}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2888/improve-loading-state-of-profile

- hides copy handle button while loading as it was redundant when the handle isn't ready
- displays skeleton loader in posts tab right away instead of waiting for the account data is finished loading