### PR TITLE
Fix race condition in tag editor tests

### DIFF
--- a/e2e/helpers/pages/admin/tags/TagDetailsPage.ts
+++ b/e2e/helpers/pages/admin/tags/TagDetailsPage.ts
@@ -6,6 +6,7 @@ export class TagDetailsPage extends AdminPage {
     readonly slugInput: Locator;
     readonly descriptionInput: Locator;
     readonly saveButton: Locator;
+    readonly saveButtonSuccess: Locator;
     readonly deleteButton: Locator;
     readonly backLink: Locator;
     readonly navMenuItem: Locator;
@@ -13,13 +14,14 @@ export class TagDetailsPage extends AdminPage {
     constructor(page: Page) {
         super(page);
 
-        this.nameInput = page.locator('[data-test-input="tag-name"]');
-        this.slugInput = page.locator('[data-test-input="tag-slug"]');
-        this.descriptionInput = page.locator('[data-test-input="tag-description"]');
-        this.saveButton = page.locator('[data-test-button="save"]');
-        this.deleteButton = page.locator('[data-test-button="delete-tag"]');
+        this.nameInput = page.getByRole('textbox', {name: 'Name'});
+        this.slugInput = page.getByRole('textbox', {name: 'Slug'});
+        this.descriptionInput = page.getByRole('textbox', {name: 'Description'});
+        this.saveButton = page.getByRole('button', {name: 'Save'});
+        this.saveButtonSuccess = page.getByRole('button', {name: 'Saved'});
+        this.deleteButton = page.getByRole('button', {name: 'Delete tag'});
+        
         this.backLink = page.locator('[data-test-link="tags-back"]');
-
         this.navMenuItem = page.locator('[data-test-nav="tags"]');
     }
 
@@ -37,6 +39,7 @@ export class TagDetailsPage extends AdminPage {
 
     async save() {
         await this.saveButton.click();
+        await this.saveButtonSuccess.waitFor({state: 'visible'});
     }
 
     async goBackToTagsList() {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-2894/troubleshoot-flaky-e2e-tests-running-locally

The tag editor in Ember will redirect to the URL for the newly created tag when saving. If we click the back link in the breadcrumbs too soon we introduce a  race condition between the back navigation and the post-save redirect. 

The navigation to the tag list means that the URL assertion will succeed, but  we will have been redirected back to the editor before the list actually  renders. That makes the following assertion fail.

In order to target the saved state of the save button, I needed to use a use a different locator. While changing that I used the opportunity to align the  other locators with what we consider best practice.

