### PR TITLE
Fixed profile hover card infinite loop in activitypub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
+++ b/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
@@ -41,6 +41,9 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
         enabled: shouldFetch && Boolean(targetHandle)
     });
 
+    const isLoading = accountQuery.isFetching || accountQuery.isLoading;
+    const hasLoadingError = accountQuery.error;
+
     const hasCompleteAccountData = accountQuery.data ? (
         typeof accountQuery.data.followerCount === 'number' &&
         typeof accountQuery.data.followingCount === 'number' &&
@@ -52,10 +55,17 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
             return;
         }
 
-        if (!hasCompleteAccountData && !accountQuery.isFetching && !accountQuery.isLoading) {
+        if (!hasCompleteAccountData && !isLoading && !hasLoadingError) {
             accountQuery.refetch({cancelRefetch: false});
         }
-    }, [accountQuery, accountQuery.isFetching, accountQuery.isLoading, accountQuery.refetch, hasCompleteAccountData, shouldFetch, targetHandle]);
+    }, [
+        accountQuery,
+        isLoading,
+        hasLoadingError,
+        hasCompleteAccountData,
+        shouldFetch,
+        targetHandle
+    ]);
 
     if (bypassHover) {
         return <>{children}</>;
@@ -121,9 +131,9 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
                         </div>
                     </div>
                     <div className='flex gap-3 dark:text-gray-300'>
-                        {(accountQuery.isLoading || accountQuery.isFetching) ? (
+                        {isLoading ? (
                             <Skeleton className='h-4 w-32' />
-                        ) : (
+                        ) : !hasLoadingError && (
                             <>
                                 <span>
                                     <span className='font-bold text-black dark:text-white'>{abbreviateNumber(followingCount)}</span>
@@ -136,9 +146,9 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
                             </>
                         )}
                     </div>
-                    {(accountQuery.isLoading || accountQuery.isFetching) ? (
+                    {isLoading ? (
                         <Skeleton className='h-4 w-48' />
-                    ) : bio ? (
+                    ) : !hasLoadingError && bio ? (
                         <div dangerouslySetInnerHTML={{__html: bio}} className='leading-tight dark:text-gray-300 [&_.invisible]:hidden [&_a:hover]:underline [&_a]:text-[#00a4eb]' />
                     ) : null}
                 </div>


### PR DESCRIPTION
no ref

When the profile hover card is displayed it makes a network request to fetch profile data. If the request fails (i.e 404), the `hasCompleteData` variable continues to be set to false, but the effect that loads the data is retriggered causing an infinite loop. This change ensures that the refetch only occurs if there was not previously a loading error