### PR TITLE
Updated docs to make sure to mention that Ghost container needs to be…

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,7 @@ From the repository root:
 # Install dependencies
 yarn
 
-# Build Docker images
+# Build Docker images (to make sure latest changes in Ghost project are tested locally) 
 yarn docker:build
 
 # Run the e2e tests

--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -18,6 +18,7 @@ services:
       start_period: 10s
 
   ghost-migrations:
+    # if not specified this will default to tag of Ghost project
     image: ${GHOST_IMAGE_TAG:-ghost-monorepo:latest}
     pull_policy: never
     working_dir: /home/ghost

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -3,6 +3,7 @@ import path from 'path';
 export const COMPOSE_FILE_PATH = path.resolve(__dirname, '../../compose.yml');
 export const COMPOSE_PROJECT = 'ghost-e2e';
 
+// if not specified this would be the tag of the Ghost project, built at root of the repository
 export const DEFAULT_GHOST_IMAGE = process.env.GHOST_IMAGE_TAG || 'ghost-monorepo';
 export const DEFAULT_WORKDIR = '/home/ghost/ghost/core';
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,6 +10,7 @@
     "build:ts": "tsc --noEmit",
     "docker:build:ghost": "cd .. && docker build -t ghost-monorepo:latest -f .docker/Dockerfile .",
     "prepare": "tsc --noEmit",
+    "pretest": "echo '⚠️ To make sure Ghost project is built with latest changes, run before tests: yarn docker:build (from repository root)'",
     "test": "playwright test --project=main",
     "test:factory": "playwright test --project=factories",
     "test:single": "playwright test --project=main -g",


### PR DESCRIPTION

* Ghost monorepo container needs to be built with latest changes to Ghost. Updated docs to make that clear.