### PR TITLE
Renovate: Reconfigured and fixed schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,13 @@
     ],
     // This reduces PR churn when managing lots of dependencies
     "rebaseWhen": "never",
+    // We have to disable platform based automerge (forcing renovate to do it manually)
+    // as otherwise renovate wont follow our schedule
+    "platformAutomerge": false,
+    "timezone": "Etc/UTC",
     "automergeSchedule": [
-        // Allow automerge From 5pm Friday til midday Monday
-        "* 17-23 * * 5",
-        "* * * * 0,6,",
+        // Allow automerge all weekend: Saturday, Sunday, and Monday morning
+        "* * * * 0,6",
         "* 0-12 * * 1"
     ],
     "ignoreDeps": [


### PR DESCRIPTION
ref INC-197
ref https://linear.app/ghost/issue/ENG-2514/implement-delayed-external-package-updates

- By default renovate will pass auto-merging configured PRs over to the respective platform its running on so that it doesn't have to do it itself
- This in turn though breaks the ability to follow a specific set schedule which is what we want
- This pins the schedule to a specific TZ as otherwise its unclear what TZ the schedule will actually be in and renovate's docs suggest setting a TZ specifically if you want it to follow one
- Finally it moves our schedule to only be weekend + Monday morning to allow any engineers in the US a package free merge experience