### PR TITLE
Added post titles to notifications in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -393,10 +393,10 @@ const Notifications: React.FC = () => {
                                                     (group.type === 'repost' && !group.post?.name && group.post?.content)
                                                 ) && (
                                                     (group.type !== 'reply' && group.type !== 'mention' ?
-                                                        <div
-                                                            dangerouslySetInnerHTML={{__html: stripHtml(group.post?.content || '')}}
-                                                            className='ap-note-content mt-0.5 line-clamp-1 text-pretty text-sm text-gray-700 dark:text-gray-600'
-                                                        /> :
+                                                        <div className='ap-note-content mt-0.5 line-clamp-1 text-pretty text-sm text-gray-700 dark:text-gray-600'>
+                                                            {group.post?.type === 'article' && group.post?.title && <>{group.post.title} &mdash; </>}
+                                                            <span dangerouslySetInnerHTML={{__html: stripHtml(group.post?.content || '')}} />
+                                                        </div> :
                                                         <>
                                                             <div className='mt-2.5 rounded-md bg-gray-100 px-5 py-[14px] group-hover:bg-gray-200 dark:bg-gray-925/30 group-hover:dark:bg-black/40'>
                                                                 <ProfileLinkedContent


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2724/ui-shows-first-sentence-instead-of-post-title-in-notifications

-  Displayed article title at the start of article/post notifications
-  Previously only showed post content, which fit notes but lacked context for articles