### PR TITLE
Added routing support for profile tabs in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
+++ b/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
@@ -6,6 +6,7 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Avatar, AvatarFallback, AvatarImage, Badge, H3, HoverCard, HoverCardContent, HoverCardTrigger, LucideIcon, Skeleton, abbreviateNumber} from '@tryghost/shade';
 import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {useAccountForUser} from '../../hooks/use-activity-pub-queries';
+import {useNavigate} from '@tryghost/admin-x-framework';
 
 type ProfilePreviewHoverCardProps = {
     actor?: ActorProperties | Account | null;
@@ -29,6 +30,7 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
     isCurrentUser = false
 }) => {
     const [shouldFetch, setShouldFetch] = useState(false);
+    const navigate = useNavigate();
 
     let targetHandle = actor?.handle;
     if (!targetHandle && actor && isActorProperties(actor)) {
@@ -82,6 +84,24 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
     const followerCount = typeof displayData?.followerCount === 'number' ? displayData.followerCount : (Number(displayData?.followerCount) || 0);
     const bio = displayData?.bio ? openLinksInNewTab(stripHtml(displayData.bio, ['a'])) : undefined;
 
+    const handleProfileClick = () => {
+        if (displayHandle) {
+            navigate(`/profile/${displayHandle}`);
+        }
+    };
+
+    const handleFollowingClick = () => {
+        if (displayHandle) {
+            navigate(`/profile/${displayHandle}/following`);
+        }
+    };
+
+    const handleFollowersClick = () => {
+        if (displayHandle) {
+            navigate(`/profile/${displayHandle}/followers`);
+        }
+    };
+
     return (
         <HoverCard onOpenChange={setShouldFetch}>
             <HoverCardTrigger asChild>
@@ -89,14 +109,15 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
             </HoverCardTrigger>
             <HoverCardContent
                 align={align}
-                className='w-[320px] rounded-2xl border-0 p-5 text-left text-gray-900 shadow-[0_5px_24px_0px_rgba(0,0,0,0.02),0px_2px_5px_0px_rgba(0,0,0,0.07),0px_0px_1px_0px_rgba(0,0,0,0.25)] outline-none dark:bg-[#101114] dark:shadow-none'
+                className='w-[320px] cursor-default rounded-2xl border-0 p-5 text-left text-gray-900 shadow-[0_5px_24px_0px_rgba(0,0,0,0.02),0px_2px_5px_0px_rgba(0,0,0,0.07),0px_0px_1px_0px_rgba(0,0,0,0.25)] outline-none dark:bg-[#101114] dark:shadow-none'
                 side={side}
                 sideOffset={12}
+                onClick={e => e.stopPropagation()}
             >
                 <div className='flex flex-col gap-2'>
                     <div className='flex flex-col gap-2'>
                         <div className='flex justify-between'>
-                            <Avatar className='size-14'>
+                            <Avatar className='size-14 cursor-pointer' onClick={handleProfileClick}>
                                 {avatarUrl && (
                                     <AvatarImage
                                         alt={displayName}
@@ -120,7 +141,7 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
                                 />
                             )}
                         </div>
-                        <div className='flex flex-col items-start'>
+                        <div className='flex cursor-pointer flex-col items-start' onClick={handleProfileClick}>
                             <H3 className='w-full truncate'>{displayName}</H3>
                             <div className='flex w-full gap-2'>
                                 <span className='truncate text-gray-700 dark:text-gray-600'>{displayHandle}</span>
@@ -135,11 +156,11 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
                             <Skeleton className='h-4 w-32' />
                         ) : !hasLoadingError && (
                             <>
-                                <span>
+                                <span className='cursor-pointer hover:underline' onClick={handleFollowingClick}>
                                     <span className='font-bold text-black dark:text-white'>{abbreviateNumber(followingCount)}</span>
                                     {' '}Following
                                 </span>
-                                <span>
+                                <span className='cursor-pointer hover:underline' onClick={handleFollowersClick}>
                                     <span className='font-bold text-black dark:text-white'>{abbreviateNumber(followerCount)}</span>
                                     {' '}Followers
                                 </span>

--- a/apps/activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
@@ -15,7 +15,7 @@ const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
 
         const linkClass = cn(
             'justify-start text-md font-medium text-gray-800 dark:hover:bg-gray-925/70 dark:text-gray-500 h-9 [&_svg]:size-[18px]',
-            (to && location.pathname === to) && 'bg-gray-100 dark:bg-gray-925/70 dark:text-white text-black font-semibold'
+            (to && (location.pathname === to || location.pathname.startsWith(`${to}/`))) && 'bg-gray-100 dark:bg-gray-925/70 dark:text-white text-black font-semibold'
         );
 
         const badge = count && count > 0 ? (

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -91,17 +91,7 @@ export const routes: CustomRouteObject[] = [
                 pageTitle: 'Profile'
             },
             {
-                path: 'profile/:handle',
-                element: <Profile />,
-                pageTitle: 'Profile'
-            },
-            {
-                path: 'profile/:handle/following',
-                element: <Profile />,
-                pageTitle: 'Profile'
-            },
-            {
-                path: 'profile/:handle/followers',
+                path: 'profile/:handle/:tab?',
                 element: <Profile />,
                 pageTitle: 'Profile'
             },

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -76,7 +76,32 @@ export const routes: CustomRouteObject[] = [
                 pageTitle: 'Profile'
             },
             {
+                path: 'profile/likes',
+                element: <Profile />,
+                pageTitle: 'Profile'
+            },
+            {
+                path: 'profile/following',
+                element: <Profile />,
+                pageTitle: 'Profile'
+            },
+            {
+                path: 'profile/followers',
+                element: <Profile />,
+                pageTitle: 'Profile'
+            },
+            {
                 path: 'profile/:handle',
+                element: <Profile />,
+                pageTitle: 'Profile'
+            },
+            {
+                path: 'profile/:handle/following',
+                element: <Profile />,
+                pageTitle: 'Profile'
+            },
+            {
+                path: 'profile/:handle/followers',
                 element: <Profile />,
                 pageTitle: 'Profile'
             },

--- a/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -38,7 +38,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     followingTab,
     followersTab
 }) => {
-    const params = useParams();
+    const params = useParams<{handle?: string; tab?: string}>();
     const location = useLocation();
     const navigate = useNavigate();
     const {canGoBack} = useNavigationStack();
@@ -46,12 +46,9 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     const basePath = params.handle ? `/profile/${params.handle}` : '/profile';
     const likesEnabled = !params.handle;
 
-    const normalizedPath = location.pathname.replace(/\/+$/, '');
-    const profileIndex = normalizedPath.indexOf('/profile');
-    const suffix = profileIndex >= 0 ? normalizedPath.slice(profileIndex + '/profile'.length) : '';
-    const segments = suffix.split('/').filter(Boolean);
-    const lastSegment = segments[segments.length - 1] || '';
-    const tabSlug = (params.handle && lastSegment === params.handle) ? '' : lastSegment;
+    const tabSlug = params.handle
+        ? (params.tab || '')
+        : (location.pathname.split('/').pop() || '');
 
     const allowedTabs = useMemo<ProfileTab[]>(() => (
         likesEnabled ? ['likes', 'following', 'followers'] : ['following', 'followers']


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2890/link-to-followersfollowing-tab-from-the-preview-card

-  Enabled routing for profile tabs (Posts, Likes, Following, Followers) to preserve state on refresh
-  Added nested route support for active menu highlighting (e.g., /profile/likes now highlights Profile)
-  Linked tabs from profile preview card for direct navigation to Following/Followers