### PR TITLE
Added Auto-Submitted header to prevent automatic replies

### DIFF
--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -68,7 +68,8 @@ module.exports = class MailgunClient {
                 html: messageContent.html,
                 text: messageContent.plaintext,
                 'recipient-variables': JSON.stringify(recipientData),
-                'h:Sender': message.from
+                'h:Sender': message.from,
+                'h:Auto-Submitted': 'auto-generated'
             };
 
             // Do we have a custom List-Unsubscribe header set?


### PR DESCRIPTION
ref [GVA-567](https://linear.app/ghost/issue/GVA-567/adding-the-sender-header-causes-automatic-replies-to-be-sent-back-for)

This should prevent auto-responders (e.g. out-of-office replies) from being sent, which was a regression introduced when we added the Sender header.