### PR TITLE
Removed alpha flag around inline OTC error display

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -145,9 +145,7 @@ function startSigninOTCFromCustomForm({data, state}) {
     };
 }
 
-async function verifyOTC({data, api, state}) {
-    const {labs} = state;
-
+async function verifyOTC({data, api}) {
     const genericErrorMessage = t('Failed to verify code, please try again');
 
     try {
@@ -157,36 +155,16 @@ async function verifyOTC({data, api, state}) {
         if (response.redirectUrl) {
             return window.location.assign(response.redirectUrl);
         } else {
-            if (labs?.membersSigninOTCAlpha) {
-                return {
-                    action: 'verifyOTC:failed',
-                    actionErrorMessage: chooseBestErrorMessage(response.errors?.[0], genericErrorMessage)
-                };
-            } else {
-                return {
-                    action: 'verifyOTC:failed',
-                    popupNotification: createPopupNotification({
-                        type: 'verifyOTC:failed', autoHide: false, closeable: true, state, status: 'error',
-                        message: response.message || t('Invalid verification code')
-                    })
-                };
-            }
+            return {
+                action: 'verifyOTC:failed',
+                actionErrorMessage: chooseBestErrorMessage(response.errors?.[0], genericErrorMessage)
+            };
         }
     } catch (e) {
-        if (labs?.membersSigninOTCAlpha) {
-            return {
-                action: 'verifyOTC:failed',
-                actionErrorMessage: chooseBestErrorMessage(e, genericErrorMessage)
-            };
-        } else {
-            return {
-                action: 'verifyOTC:failed',
-                popupNotification: createPopupNotification({
-                    type: 'verifyOTC:failed', autoHide: false, closeable: true, state, status: 'error',
-                    message: chooseBestErrorMessage(e, genericErrorMessage)
-                })
-            };
-        }
+        return {
+            action: 'verifyOTC:failed',
+            actionErrorMessage: chooseBestErrorMessage(e, genericErrorMessage)
+        };
     }
 }
 

--- a/apps/portal/src/components/pages/MagicLinkPage.test.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.test.js
@@ -33,7 +33,7 @@ const setupTest = (options = {}) => {
 // Helper for OTC-enabled tests
 const setupOTCTest = (options = {}) => {
     return setupTest({
-        labs: {membersSigninOTC: true, membersSigninOTCAlpha: true},
+        labs: {membersSigninOTC: true},
         otcRef: 'test-otc-ref',
         ...options
     });
@@ -87,7 +87,7 @@ describe('MagicLinkPage', () => {
         test('does not render OTC form when conditions not met', () => {
             const scenarios = [
                 {labs: {membersSigninOTC: false}, otcRef: 'test-ref'},
-                {labs: {membersSigninOTC: true, membersSigninOTCAlpha: true}, otcRef: null},
+                {labs: {membersSigninOTC: true}, otcRef: null},
                 {labs: {membersSigninOTC: false}, otcRef: null}
             ];
 
@@ -315,7 +315,7 @@ describe('MagicLinkPage', () => {
     describe('OTC flow edge cases', () => {
         test('does not render form without otcRef even with lab flag', () => {
             const utils = setupTest({
-                labs: {membersSigninOTC: true, membersSigninOTCAlpha: true},
+                labs: {membersSigninOTC: true},
                 otcRef: null
             });
 
@@ -451,18 +451,6 @@ describe('MagicLinkPage', () => {
                 otc: '654321',
                 otcRef: 'test-otc-ref'
             });
-        });
-
-        test('shows actionErrorMessage in non-alpha OTC form variant', () => {
-            const utils = setupTest({
-                labs: {membersSigninOTC: true, membersSigninOTCAlpha: false},
-                otcRef: 'test-otc-ref',
-                action: 'verifyOTC:failed',
-                actionErrorMessage: 'Invalid verification code'
-            });
-
-            // In non-alpha variant, error appears in InputField error message
-            expect(utils.getByText('Invalid verification code')).toBeInTheDocument();
         });
     });
 });

--- a/apps/portal/src/tests/SigninFlow.test.js
+++ b/apps/portal/src/tests/SigninFlow.test.js
@@ -180,7 +180,7 @@ describe('Signin', () => {
             expect(magicLink).toBeInTheDocument();
             const description = await within(popupIframeDocument).findByText(/An email has been sent to jamie@example.com/i);
             expect(description).toBeInTheDocument();
-            
+
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
                 emailType: 'signin',
@@ -558,18 +558,14 @@ describe('OTC Integration Flow', () => {
         const description = await within(popupIframeDocument).findByText(/An email has been sent to jamie@example.com/i);
         expect(description).toBeInTheDocument();
     });
-    
+
     test('OTC verification with invalid code shows error', async () => {
         const {ghostApi, popupIframeDocument} = await setupOTCFlow({
             site: FixtureSite.singleTier.basic
         });
 
         // Mock verifyOTC to return validation error
-        ghostApi.member.verifyOTC.mockResolvedValueOnce({
-            valid: false,
-            success: false,
-            message: 'Invalid verification code'
-        });
+        ghostApi.member.verifyOTC.mockRejectedValueOnce(new Error('Invalid verification code'));
 
         await submitSigninForm(popupIframeDocument, 'jamie@example.com');
         submitOTCForm(popupIframeDocument, '000000');
@@ -606,7 +602,7 @@ describe('OTC Integration Flow', () => {
             });
         });
 
-        const errorNotification = await within(popupIframeDocument).findByText(/Invalid verification code/i);
+        const errorNotification = await within(popupIframeDocument).findByText(/Failed to verify code/i);
         expect(errorNotification).toBeInTheDocument();
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-2706

- removes alpha flag so the inline error is available on the private beta
