### PR TITLE
Add admin deployment job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1203,3 +1203,47 @@ jobs:
           token: ${{ secrets.TINYBIRD_TOKEN }}
           workspace: 'Production'
           slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
+
+  deploy_admin:
+    needs: [
+      job_setup,
+      job_required_tests
+    ]
+    name: Deploy Admin
+    runs-on: ubuntu-latest
+    if: |
+      always()
+      && needs.job_setup.result == 'success'
+      && needs.job_setup.outputs.is_main == 'true'
+      && needs.job_required_tests.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
+      - name: Build Admin
+        env:
+          GHOST_CDN_URL: https://assets.ghost.io/admin-forward/
+        run: yarn nx run admin:build
+      - name: Upload build artifact
+        id: upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-build
+          path: apps/admin/dist
+      - name: Deploy Admin
+        uses: aurelien-baudet/workflow-dispatch@v4
+        with:
+          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          workflow: .github/workflows/deploy-admin.yml
+          ref: 'refs/heads/main' # this is the ref of Ghost-Moya
+          repo: TryGhost/Ghost-Moya
+          inputs: '{"admin_build_artifact_id":"${{ steps.upload-artifacts.outputs.artifact-id }}", "admin_build_artifact_run_id":"${{ github.run_id }}"}'
+          wait-for-completion-timeout: 25m
+          wait-for-completion-interval: 30s


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2900/set-up-github-actions

This is the Github action/workflow part needed to build Ghost in a way that will let us use set up continuous delivery of the new React admin. 

- Build admin on merge to main
- Upload assets to artifact storage
- Trigger Ghost-Moya deploy job (like the canary builds)