### PR TITLE
Set up build step for new admin package

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -2,12 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+
+    <title>Ghost</title>
+
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover" />
+    <meta name="pinterest" content="nopin" />
+
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="application-name" content="Ghost" />
+    <meta name="apple-mobile-web-app-title" content="Ghost" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -24,6 +24,32 @@
     "globals": "16.4.0",
     "typescript": "5.8.3",
     "typescript-eslint": "8.46.1",
-    "vite": "7.1.10"
+     "vite": "7.1.10"
+  },
+  "nx": {
+    "targets": {
+      "build:dev": {
+        "dependsOn": [
+          "build",
+          {
+            "projects": [
+              "ghost-admin"
+            ],
+            "target": "build:dev"
+          }
+        ]
+      },
+      "build": {
+        "dependsOn": [
+          "build",
+          {
+            "projects": [
+              "ghost-admin"
+            ],
+            "target": "build"
+          }
+        ]
+      }
+    }
   }
 }

--- a/apps/admin/tsconfig.node.json
+++ b/apps/admin/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite-ember-assets.ts"]
 }

--- a/apps/admin/vite-ember-assets.ts
+++ b/apps/admin/vite-ember-assets.ts
@@ -1,0 +1,66 @@
+import type {PluginOption, HtmlTagDescriptor} from 'vite';
+import path from 'path';
+import fs from 'fs';
+
+// Vite plugin to extract styles and scripts from Ghost admin index.html
+export function emberAssetsPlugin() {
+    return {
+        name: 'ember-assets',
+        transformIndexHtml: {
+            order: 'post',
+            handler() {
+                // Path to the Ghost admin index.html file
+                const indexPath = path.resolve(__dirname, '../../ghost/admin/dist/index.html');
+                try {
+                    const indexContent = fs.readFileSync(indexPath, 'utf-8');
+                    // Extract stylesheets
+                    const styleRegex = /<link[^>]*rel="stylesheet"[^>]*href="([^"]*)"[^>]*>/g;
+                    const styles: HtmlTagDescriptor[] = [];
+                    let styleMatch;
+                    while ((styleMatch = styleRegex.exec(indexContent)) !== null) {
+                        styles.push({
+                            tag: 'link',
+                            attrs: {
+                                rel: 'stylesheet',
+                                href: '/ghost/' + styleMatch[1]
+                            }
+                        });
+                    }
+                    // Extract scripts
+                    const scriptRegex = /<script[^>]*src="([^"]*)"[^>]*><\/script>/g;
+                    const scripts: HtmlTagDescriptor[] = [];
+                    let scriptMatch;
+                    while ((scriptMatch = scriptRegex.exec(indexContent)) !== null) {
+                        scripts.push({
+                            tag: 'script',
+                            injectTo: 'body',
+                            attrs: {
+                                src: '/ghost/' + scriptMatch[1].replace(/^\/ghost\//, '')
+                            }
+                        });
+                    }
+
+                    // Extract meta tags
+                    const metaRegex = /<meta name="ghost-admin\/config\/environment" content="([^"]*)"[^>]*>/g;
+                    const metaTags: HtmlTagDescriptor[] = [];
+                    let metaMatch;
+                    while ((metaMatch = metaRegex.exec(indexContent)) !== null) {
+                        metaTags.push({
+                            tag: 'meta',
+                            attrs: {
+                                name: 'ghost-admin/config/environment',
+                                content: metaMatch[1]
+                            }
+                        });
+                    }
+
+                    // Generate the virtual module content
+                    return [...styles, ...scripts, ...metaTags];
+                } catch (error) {
+                    console.warn('Failed to read Ghost admin index.html:', error);
+                    return;
+                }
+            }
+        }
+    } as const satisfies PluginOption;
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,6 +1,33 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import { emberAssetsPlugin } from "./vite-ember-assets";
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()]
-})
+    plugins: [react(), emberAssetsPlugin()],
+    server: {
+        proxy: {
+            // Proxy requests to the Ghost Admin API. We need to rewrite the
+            // cookies and headers for the existing security middleware not to
+            // reject the requests. 
+            "^/ghost/api/.*": {
+                changeOrigin: true,
+                cookieDomainRewrite: {
+                    "*": "localhost:2368",
+                },
+                headers: {
+                    Referrer: "http://localhost:2368",
+                },
+                target: "http://localhost:2368",
+            },
+
+            // Proxy requests to the Ghost Admin assets
+            "^/ghost/assets/.*": {
+                target: "http://localhost:2368",
+            },
+            "^/ghost/ember-cli-live-reload.js": {
+                target: "http://localhost:2368",
+            },
+        },
+    },
+});

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -17,7 +17,7 @@ const adminApiProxy = {
 
 // https://vite.dev/config/
 export default defineConfig({
-    base: "/ghost",
+    base: process.env.GHOST_CDN_URL ?? '/ghost',
     plugins: [react(), emberAssetsPlugin()],
     server: {
         proxy: {

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -2,32 +2,39 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { emberAssetsPlugin } from "./vite-ember-assets";
 
+const adminApiProxy = {
+    // Proxy requests to the Ghost Admin API. We need to rewrite the
+    // cookies and headers for the existing security middleware not to
+    // reject the requests.
+    "^/ghost/api/.*": {
+        changeOrigin: true,
+        cookieDomainRewrite: {
+            "*": "localhost:2368",
+        },
+        target: "http://localhost:2368",
+    },
+};
+
 // https://vite.dev/config/
 export default defineConfig({
+    base: "/ghost",
     plugins: [react(), emberAssetsPlugin()],
     server: {
         proxy: {
-            // Proxy requests to the Ghost Admin API. We need to rewrite the
-            // cookies and headers for the existing security middleware not to
-            // reject the requests. 
-            "^/ghost/api/.*": {
-                changeOrigin: true,
-                cookieDomainRewrite: {
-                    "*": "localhost:2368",
-                },
-                headers: {
-                    Referrer: "http://localhost:2368",
-                },
-                target: "http://localhost:2368",
-            },
+            ...adminApiProxy,
 
-            // Proxy requests to the Ghost Admin assets
+            // Proxy requests for Ghost Admin (Ember) assets
             "^/ghost/assets/.*": {
                 target: "http://localhost:2368",
             },
             "^/ghost/ember-cli-live-reload.js": {
                 target: "http://localhost:2368",
             },
+        },
+    },
+    preview: {
+        proxy: {
+            ...adminApiProxy,
         },
     },
 });


### PR DESCRIPTION
This PR adds a Vite plugin that injects the assets needed by the Ember admin app. The plugin extracts the relevant scripts and assets from the `index.html` that's built by Ember and inject those into the index file that Vite generates. 

### Local development 
Running `yarn nx run admin:dev` (or `yarn dev` inside the admin package) will launch a development server that serves the existing Ember admin (for now). This will serve as the container and entrypoint for the new React based app shell.

- Ember `script`, `link` and `meta` tags are injected into the generated html
- All Ember assets requests are proxied to the existing admin server in core, which in turn exposes the output from Ember dev server
- API calls are proxied to the admin API

### Build
Running `yarn nx run admin:build` will build all dependencies, including the Ember admin, and the build the new `@tryghost/admin` package. 

- Ember `script`, `link` and `meta` tags are injected into the generated html
- When building the `@tryghost/admin` package, the plugin will copy all Ember assets to the `dist` folder. 

### Preview
Running `yarn nx run admin:preview` (or `yarn preview` inside the admin package) will launch a preview server for the build output.

- All assets, including the Ember assets, will be served from `dist`
- API calls are still proxied to the admin API

---

Closes https://linear.app/ghost/issue/BER-2902/set-up-new-admin-build-that-include-all-relevant-assets-from-existing