### PR TITLE
Added docker build to pretest command when running e2e tests

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -6,3 +6,5 @@ PRESERVE_ENV=false
 
 # define only if you want custom number of workers for tests to run in parallel locally
 TEST_WORKERS_COUNT=5
+# Skips the docker build pretest command, if you don't need to rebuild the container
+GHOST_E2E_SKIP_BUILD=1

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,9 +15,6 @@ From the repository root:
 # Install dependencies
 yarn
 
-# Build Docker images (to make sure latest changes in Ghost project are tested locally) 
-yarn docker:build
-
 # Run the e2e tests
 yarn test:e2e
 ```

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,7 @@
     "docker:build:ghost": "cd .. && docker build -t ghost-monorepo:latest -f .docker/Dockerfile .",
     "docker:update": "docker compose pull && docker compose up -d --force-recreate",
     "prepare": "tsc --noEmit",
-    "pretest": "echo '⚠️ To make sure Ghost project is built with latest changes, run before tests: yarn docker:build (from repository root)'",
+    "pretest": "(test -n \"$GHOST_E2E_SKIP_BUILD\" || test -n \"$CI\") && echo 'Skipping Docker build (GHOST_E2E_SKIP_BUILD or CI is set)' || docker compose -f ../compose.yml build ghost tb-cli",
     "test": "playwright test --project=main",
     "test:single": "playwright test --project=main -g",
     "test:debug": "playwright test --project=main --headed --timeout=60000 -g",


### PR DESCRIPTION
The E2E tests run against the Ghost docker image. Currently if you make changes to Ghost, you need to manually rebuild the docker image before running the tests again, which is not obvious and annoying to have to run constantly.

This adds the Docker image build as a pretest command, so by default the image will always be rebuilt before running the e2e tests.