### PR TITLE
Updated e2e tests global setup to reuse shared containers between test runs

### DIFF
--- a/e2e/helpers/environment/DockerCompose.ts
+++ b/e2e/helpers/environment/DockerCompose.ts
@@ -167,10 +167,6 @@ export class DockerCompose {
         return output;
     }
 
-    /**
-     * Execute a command in a service container using `docker compose run`.
-     * This runs the command with the service's default entrypoint and environment.
-     */
     execInService(service: string, command: string[]): string {
         const cmdArgs = command.map(arg => `"${arg}"`).join(' ');
         const cmd = `docker compose -f ${this.composeFilePath} -p ${this.projectName} run --rm -T ${service} ${cmdArgs}`;

--- a/e2e/helpers/environment/DockerCompose.ts
+++ b/e2e/helpers/environment/DockerCompose.ts
@@ -168,6 +168,18 @@ export class DockerCompose {
     }
 
     /**
+     * Execute a command in a service container using `docker compose run`.
+     * This runs the command with the service's default entrypoint and environment.
+     */
+    execInService(service: string, command: string[]): string {
+        const cmdArgs = command.map(arg => `"${arg}"`).join(' ');
+        const cmd = `docker compose -f ${this.composeFilePath} -p ${this.projectName} run --rm -T ${service} ${cmdArgs}`;
+        debug('execInService running:', cmd);
+        const output = execSync(cmd, {encoding: 'utf-8'}).toString();
+        return output;
+    }
+
+    /**
      * Find the container for a compose service by label.
      */
     async getContainerForService(service: string): Promise<Container> {

--- a/e2e/helpers/environment/EnvironmentManager.ts
+++ b/e2e/helpers/environment/EnvironmentManager.ts
@@ -70,19 +70,59 @@ export class EnvironmentManager {
     }
 
     /**
+     * Clean up leftover resources from previous test runs
+     * This should be called at the start of globalSetup to ensure a clean slate,
+     * especially after interrupted test runs (e.g. via ctrl+c)
+     *
+     * 1. Clean up leftover test databases (if MySQL is running)
+     * 2. Stop and remove docker-compose services (mysql, tinybird, portal, etc.)
+     * 3. Remove all leftover Ghost containers
+     * 4. Clean up state files
+     */
+    private async cleanupLeftoverResources(): Promise<void> {
+        try {
+            logging.info('Cleaning up leftover resources from previous test runs...');
+
+            // Clean up leftover test databases if MySQL is running
+            await this.mysql.dropAllTestDatabases();
+
+            // Clean up docker compose services (mysql, tinybird, portal, etc.)
+            try {
+                this.dockerCompose.down();
+                debug('Docker compose services cleaned up');
+            } catch (error) {
+                debug('No docker compose services to clean up or cleanup failed:', error);
+            }
+
+            // Clean up leftover Ghost containers
+            await this.ghost.removeAll();
+
+            // Clean up state files
+            this.cleanupStateFiles();
+
+            logging.info('Leftover resources cleaned up successfully');
+        } catch (error) {
+            logging.warn('Failed to clean up some leftover resources:', error);
+            // Don't throw - we want to continue with setup even if cleanup fails
+        }
+    }
+
+    /**
      * Setup shared global environment for tests (i.e. mysql, tinybird, portal)
      * This should be called once before all tests run.
      *
-     * 1. Start docker-compose services (including running Ghost migrations on the default database)
-     * 2. Wait for all services to be ready (healthy or exited with code 0)
-     * 2. Create a MySQL snapshot of the database after migrations, so we can quickly clone from it for each test without re-running migrations
-     * 3. Fetch Tinybird tokens from the tinybird-local service and store in /data/state/tinybird.json
+     * 1. Clean up any leftover resources from previous test runs
+     * 2. Start docker-compose services (including running Ghost migrations on the default database)
+     * 3. Wait for all services to be ready (healthy or exited with code 0)
+     * 4. Create a MySQL snapshot of the database after migrations, so we can quickly clone from it for each test without re-running migrations
+     * 5. Fetch Tinybird tokens from the tinybird-local service and store in /data/state/tinybird.json
      *
      * NOTE: Playwright workers run in their own processes, so each worker gets its own instance of EnvironmentManager.
      * This is why we need to use a shared state file for Tinybird tokens - this.tinybird instance is not shared between workers.
      */
     public async globalSetup(): Promise<void> {
         logging.info('Starting global environment setup...');
+        await this.cleanupLeftoverResources();
         this.dockerCompose.up();
         await this.dockerCompose.waitForAll();
         await this.mysql.createSnapshot();

--- a/e2e/helpers/environment/EnvironmentManager.ts
+++ b/e2e/helpers/environment/EnvironmentManager.ts
@@ -86,19 +86,10 @@ export class EnvironmentManager {
         try {
             logging.info('Cleaning up leftover resources from previous test runs...');
 
-            // Clean up leftover Ghost containers
             await this.ghost.removeAll();
-
-            // Clean up leftover test databases if MySQL is running
             await this.mysql.dropAllTestDatabases();
-
-            // Delete the MySQL snapshot to ensure fresh migrations
             await this.mysql.deleteSnapshot();
-
-            // Recreate the base database to ensure clean migrations
             await this.mysql.recreateBaseDatabase();
-
-            // Truncate Tinybird analytics data to start fresh
             this.tinybird.truncateAnalyticsEvents();
 
             logging.info('Leftover resources cleaned up successfully');

--- a/e2e/helpers/environment/GhostManager.ts
+++ b/e2e/helpers/environment/GhostManager.ts
@@ -165,4 +165,31 @@ export class GhostManager {
             debug('Failed to remove container:', error);
         }
     }
+
+    /** Remove all Ghost containers (used for cleanup of leftover containers from interrupted tests). */
+    async removeAll(): Promise<void> {
+        try {
+            debug('Finding all Ghost containers...');
+            const containers = await this.docker.listContainers({
+                all: true,
+                filters: {
+                    label: ['tryghost/e2e=ghost']
+                }
+            });
+
+            if (containers.length === 0) {
+                debug('No Ghost containers found');
+                return;
+            }
+
+            debug(`Found ${containers.length} Ghost container(s) to remove`);
+            for (const containerInfo of containers) {
+                await this.remove(containerInfo.Id);
+            }
+            debug('All Ghost containers removed');
+        } catch (error) {
+            logging.error('Failed to remove all Ghost containers:', error);
+            // Don't throw - we want to continue with setup even if cleanup fails
+        }
+    }
 }

--- a/e2e/helpers/environment/TinybirdManager.ts
+++ b/e2e/helpers/environment/TinybirdManager.ts
@@ -75,4 +75,19 @@ export class TinybirdManager {
         this.saveState(state);
         logging.info('Tinybird tokens fetched');
     }
+
+    /**
+     * Truncate the analytics_events datasource and cascade to materialized views.
+     * This ensures a clean slate for each test run.
+     */
+    truncateAnalyticsEvents(): void {
+        try {
+            debug('Truncating analytics_events datasource...');
+            this.dockerCompose.execInService('tb-cli', ['tb', 'datasource', 'truncate', 'analytics_events', '--yes', '--cascade']);
+            debug('analytics_events datasource truncated');
+        } catch (error) {
+            debug('Failed to truncate analytics_events (Tinybird may not be running):', error);
+            // Don't throw - we want to continue with setup even if truncate fails
+        }
+    }
 }


### PR DESCRIPTION
Currently the global setup in e2e tests always starts the shared services in `e2e/compose.yml` for every test run, and stops all services in the global teardown. When iterating on tests locally, this is really slow and annoying, driven mostly by Tinybird setup taking ~30s.

This change leaves the shared services (mysql, tinybird, etc) running, and just cleans up their state so the containers can be reused in subsequent test runs without incurring the 30s delay.

It will also cleanup any leftover ghost containers and databases in the global setup, so if any are left running from previous test runs, we won't need to clean them up manually before running the tests again.