### PR TITLE
Fixed scrollbar interaction in the admin settings section

### DIFF
--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -139,7 +139,7 @@ const Sidebar: React.FC = () => {
                     <TextField
                         autoComplete="off"
                         autoCorrect="off"
-                        className='mr-12 flex h-10 w-full items-center rounded-lg border border-transparent bg-white px-[33px] py-1.5 text-[14px] shadow-[0_0_1px_rgba(21,23,26,0.25),0_1px_3px_rgba(0,0,0,0.03),0_8px_10px_-12px_rgba(0,0,0,.1)] transition-colors hover:shadow-sm focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,0.25)] tablet:mr-0 dark:border-transparent dark:bg-grey-925 dark:text-white dark:placeholder:text-grey-800 dark:focus:border-green dark:focus:bg-grey-950'
+                        className='mr-8 flex h-10 w-full items-center rounded-lg border border-transparent bg-white px-[33px] py-1.5 text-[14px] shadow-[0_0_1px_rgba(21,23,26,0.25),0_1px_3px_rgba(0,0,0,0.03),0_8px_10px_-12px_rgba(0,0,0,.1)] transition-colors hover:shadow-sm focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,0.25)] tablet:mr-0 dark:border-transparent dark:bg-grey-925 dark:text-white dark:placeholder:text-grey-800 dark:focus:border-green dark:focus:bg-grey-950'
                         containerClassName='w-100'
                         inputRef={searchInputRef}
                         placeholder="Search settings"

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -13,7 +13,7 @@ const EMPTY_KEYWORDS: string[] = [];
 
 const Page: React.FC<{children: ReactNode}> = ({children}) => {
     return <>
-        <div className='fixed right-0 top-2 z-50 flex justify-end bg-transparent p-8 tablet:fixed tablet:top-0 tablet:px-8' id="done-button-container">
+        <div className='fixed right-0 top-2 z-50 m-8 flex justify-end bg-transparent tablet:fixed tablet:top-0' id="done-button-container">
             <ExitSettingsButton />
         </div>
         <div className="fixed left-0 top-0 flex size-full dark:bg-grey-975" id="admin-x-settings-content">
@@ -80,7 +80,7 @@ const MainContent: React.FC = () => {
     return (
         <Page>
             {loadingModal && <div className={`fixed inset-0 z-40 h-[calc(100vh-55px)] w-[100vw] tablet:h-[100vh] ${topLevelBackdropClasses}`} />}
-            <div className="no-scrollbar fixed inset-x-0 top-0 z-[35] flex-1 basis-[320px] bg-white p-8 tablet:relative tablet:inset-x-auto tablet:top-auto tablet:h-full tablet:overflow-y-scroll tablet:bg-grey-50 tablet:py-0 dark:bg-grey-975 dark:tablet:bg-[#101114]" id="admin-x-settings-sidebar-scroller">
+            <div className="fixed inset-x-0 top-0 z-[35] max-w-[calc(100%-16px)] flex-1 basis-[320px] bg-white p-8 tablet:relative tablet:inset-x-auto tablet:top-auto tablet:h-full tablet:overflow-y-scroll tablet:bg-grey-50 tablet:py-0 dark:bg-grey-975 dark:tablet:bg-[#101114]" id="admin-x-settings-sidebar-scroller">
                 <div className="relative w-full">
                     <Sidebar />
                 </div>


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/25055

This PR improves the layout of the settings section of the admin panel:

1. The main content area now can be fully scrolled by interacting with the scrollbar - even in the top area, where the scrollbar was covered by the wrapper of the "X" button before.
2. The left content area now has a visible scrollbar, so that it can be scrolled by grabbing and dragging the scrollbar.
3. As a drive-by, an issue causing a double scrollbar to appear for the main content on mobile sizes (width < 860px) was also fixed. Now only one scrollbar is visible and fully interactable.

- Before

https://github.com/user-attachments/assets/2d7d69c8-62c9-48b6-8c52-d482d04d0ee4

- After

https://github.com/user-attachments/assets/c4e5f706-06fb-434f-a6b5-10df26989ca3