### PR TITLE
Pinned traffic analytics version in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -191,7 +191,7 @@ services:
 
   analytics:
     profiles: [ analytics, all ]
-    image: ghost/traffic-analytics:1
+    image: ghost/traffic-analytics:1.0.18
     platform: linux/amd64
     command: ["node", "--enable-source-maps", "dist/server.js"]
     entrypoint: [ "/app/entrypoint.sh" ]

--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   caddy:
-    image: caddy:2
+    image: caddy:latest
     ports:
       - "8080:80"
     volumes:

--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
 
   caddy:
-    image: caddy:latest
+    image: caddy:2
     ports:
       - "8080:80"
     volumes:
@@ -52,7 +52,7 @@ services:
         condition: service_healthy
 
   analytics:
-    image: ghost/traffic-analytics:1
+    image: ghost/traffic-analytics:1.0.18
     platform: linux/amd64
     command: ["node", "--enable-source-maps", "dist/server.js"]
     entrypoint: [ "/app/entrypoint.sh" ]


### PR DESCRIPTION
Currently docker compose won't ever pull the latest version if there's already a v1.x.x pulled locally. This can be annoying when working on features that span the analytics service and Ghost, as you may be working against a stale version of the analytics service without realizing it.

By pinning the exact version, this will force docker to pull the latest available as soon as it's updated in the compose file (which renovate should handle for us as new versions are released).