### PR TITLE
✨ Added One-Time-Code flow to member sign-in

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -28,14 +28,6 @@ const features: Feature[] = [{
     description: 'Enables keeping in touch with the new Explore API',
     flag: 'explore'
 }, {
-    title: 'Members sign-in OTC (private beta)',
-    description: 'Enables one-time codes alongside magic links for members signin',
-    flag: 'membersSigninOTC'
-}, {
-    title: 'Members sign-in OTC (internal alpha)',
-    description: 'Testing changes to members sign-in OTC prior to private beta release',
-    flag: 'membersSigninOTCAlpha'
-}, {
     title: 'Tags X',
     description: 'Enables the new Tags UI',
     flag: 'tagsX'

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -79,21 +79,17 @@ async function signout({api, state}) {
 }
 
 async function signin({data, api, state}) {
-    const {labs} = state;
-
-    const includeOTC = labs?.membersSigninOTC ? true : undefined;
-
     try {
         const integrityToken = await api.member.getIntegrityToken();
         const payload = {
             ...data,
             emailType: 'signin',
             integrityToken,
-            ...(includeOTC ? {includeOTC: true} : {})
+            includeOTC: true
         };
         const response = await api.member.sendMagicLink(payload);
 
-        if (includeOTC && response?.otc_ref) {
+        if (response?.otc_ref) {
             return {
                 page: 'magiclink',
                 lastPage: 'signin',

--- a/apps/portal/src/components/pages/MagicLinkPage.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.js
@@ -222,10 +222,10 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderOTCForm() {
-        const {action, actionErrorMessage, labs, otcRef} = this.context;
+        const {action, actionErrorMessage, otcRef} = this.context;
         const errors = this.state.errors || {};
 
-        if (!labs?.membersSigninOTC || !otcRef) {
+        if (!otcRef) {
             return null;
         }
 
@@ -281,8 +281,8 @@ export default class MagicLinkPage extends React.Component {
     }
 
     render() {
-        const {labs, otcRef} = this.context;
-        const showOTCForm = labs?.membersSigninOTC && otcRef;
+        const {otcRef} = this.context;
+        const showOTCForm = !!otcRef;
 
         return (
             <div className='gh-portal-content'>

--- a/apps/portal/src/components/pages/MagicLinkPage.test.js
+++ b/apps/portal/src/components/pages/MagicLinkPage.test.js
@@ -6,7 +6,7 @@ const OTC_ERROR_REGEX = /Enter code/i;
 
 const setupTest = (options = {}) => {
     const {
-        labs = {membersSigninOTC: false},
+        labs = {},
         otcRef = null,
         action = 'init:success',
         ...contextOverrides
@@ -33,7 +33,7 @@ const setupTest = (options = {}) => {
 // Helper for OTC-enabled tests
 const setupOTCTest = (options = {}) => {
     return setupTest({
-        labs: {membersSigninOTC: true},
+        labs: {},
         otcRef: 'test-otc-ref',
         ...options
     });
@@ -77,7 +77,7 @@ describe('MagicLinkPage', () => {
     });
 
     describe('OTC form conditional rendering', () => {
-        test('renders OTC form when lab flag enabled and otcRef exists', () => {
+        test('renders OTC form when otcRef exists', () => {
             const utils = setupOTCTest();
 
             expect(utils.getByLabelText(OTC_LABEL_REGEX)).toBeInTheDocument();
@@ -86,9 +86,7 @@ describe('MagicLinkPage', () => {
 
         test('does not render OTC form when conditions not met', () => {
             const scenarios = [
-                {labs: {membersSigninOTC: false}, otcRef: 'test-ref'},
-                {labs: {membersSigninOTC: true}, otcRef: null},
-                {labs: {membersSigninOTC: false}, otcRef: null}
+                {labs: {}, otcRef: null}
             ];
 
             scenarios.forEach(({labs, otcRef}) => {
@@ -313,9 +311,9 @@ describe('MagicLinkPage', () => {
     });
 
     describe('OTC flow edge cases', () => {
-        test('does not render form without otcRef even with lab flag', () => {
+        test('does not render form without otcRef', () => {
             const utils = setupTest({
-                labs: {membersSigninOTC: true},
+                labs: {},
                 otcRef: null
             });
 

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -16,7 +16,7 @@ function handleError(error, form, errorEl) {
 }
 
 export async function formSubmitHandler(
-    {event, form, errorEl, siteUrl, submitHandler, labs = {}, doAction, captureException}
+    {event, form, errorEl, siteUrl, submitHandler, doAction, captureException}
 ) {
     form.removeEventListener('submit', submitHandler);
     event.preventDefault();
@@ -47,7 +47,7 @@ export async function formSubmitHandler(
         emailType = form.dataset.membersForm;
     }
 
-    const wantsOTC = emailType === 'signin' && form?.dataset?.membersOtc === 'true' && labs?.membersSigninOTC;
+    const wantsOTC = emailType === 'signin' && form?.dataset?.membersOtc === 'true';
 
     form.classList.add('loading');
     const urlHistory = getUrlHistory();

--- a/apps/portal/src/index.js
+++ b/apps/portal/src/index.js
@@ -25,9 +25,6 @@ function getSiteData() {
         const locale = scriptTag.dataset.locale; // not providing a fallback here but will do it within the app.
 
         const labs = {};
-        // NOTE: dataset converts always lowercase dash-attrs to camelCase
-        labs.membersSigninOTC = scriptTag.dataset.membersSigninOtc === 'true';
-        labs.membersSigninOTCAlpha = scriptTag.dataset.membersSigninOtcAlpha === 'true';
 
         return {siteUrl, apiKey, apiUrl, siteI18nEnabled, locale, labs};
     }

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -180,7 +180,7 @@ describe('Member Data attributes:', () => {
             expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });
 
-        test('requests OTC magic link and opens Portal when flagged', async () => {
+        test('requests OTC magic link and opens Portal when flagged with data-members-otc=true', async () => {
             const {event, form, errorEl, siteUrl, submitHandler} = getMockData();
             form.dataset.membersForm = 'signin';
             form.dataset.membersOtc = 'true';
@@ -193,7 +193,7 @@ describe('Member Data attributes:', () => {
                 return originalQuerySelector(selector);
             });
 
-            const labs = {membersSigninOTC: true};
+            const labs = {};
             const doAction = vi.fn(() => Promise.resolve());
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
@@ -241,7 +241,7 @@ describe('Member Data attributes:', () => {
                 return originalQuerySelector(selector);
             });
 
-            const labs = {membersSigninOTC: true};
+            const labs = {};
             const actionErrorMessage = new Error('failed to start OTC sign-in');
             const doAction = vi.fn(() => {
                 throw actionErrorMessage;

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -70,8 +70,6 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
-    @feature('membersSigninOTC') membersSigninOTC;
-    @feature('membersSigninOTCAlpha') membersSigninOTCAlpha;
     @feature('tagsX') tagsX;
     @feature('utmTracking') utmTracking;
 

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -63,9 +63,7 @@ function getMembersHelper(data, frontendKey, excludeList) {
             ghost: urlUtils.getSiteUrl(),
             key: frontendKey,
             api: urlUtils.urlFor('api', {type: 'content'}, true),
-            locale: settingsCache.get('locale') || 'en',
-            'members-signin-otc': labs.isSet('membersSigninOTC'), // html.dataset converts dash-attrs to camelCase
-            'members-signin-otc-alpha': labs.isSet('membersSigninOTCAlpha') // html.dataset converts dash-attrs to camelCase
+            locale: settingsCache.get('locale') || 'en'
         };
         if (colorString) {
             attributes['accent-color'] = colorString;

--- a/ghost/core/core/server/services/lib/magic-link/MagicLink.js
+++ b/ghost/core/core/server/services/lib/magic-link/MagicLink.js
@@ -85,7 +85,7 @@ class MagicLink {
         const url = this.getSigninURL(token, type, options.referrer);
 
         let otc = null;
-        if (this.labsService?.isSet('membersSigninOTC') && options.includeOTC) {
+        if (options.includeOTC) {
             try {
                 otc = await this.getOTCFromToken(token);
             } catch (err) {
@@ -106,7 +106,7 @@ class MagicLink {
         // this if we've successfully generated an OTC to avoid clients showing
         // a token input field when the email doesn't contain an OTC
         let otcRef = null;
-        if (this.labsService?.isSet('membersSigninOTC') && otc) {
+        if (otc) {
             try {
                 otcRef = await this.getRefFromToken(token);
             } catch (err) {

--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -665,7 +665,7 @@ module.exports = class RouterController {
             } else {
                 const signIn = await this._handleSignin(req, normalizedEmail, referrer);
 
-                if (this.labsService.isSet('membersSigninOTC') && signIn.otcRef) {
+                if (signIn.otcRef) {
                     res.writeHead(201, {'Content-Type': 'application/json'});
                     return res.end(JSON.stringify({otc_ref: signIn.otcRef}));
                 }
@@ -790,7 +790,7 @@ module.exports = class RouterController {
 
         let includeOTC = false;
 
-        if (this.labsService.isSet('membersSigninOTC') && (reqIncludeOTC === true || reqIncludeOTC === 'true')) {
+        if (reqIncludeOTC === true || reqIncludeOTC === 'true') {
             includeOTC = true;
         }
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -47,8 +47,6 @@ const PRIVATE_FEATURES = [
     'lexicalIndicators',
     'contentVisibilityAlpha',
     'emailCustomization',
-    'membersSigninOTC',
-    'membersSigninOTCAlpha',
     'tagsX',
     'utmTracking',
     'emailUniqueid'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -23,8 +23,6 @@ Object {
       "importMemberTier": true,
       "lexicalIndicators": true,
       "members": true,
-      "membersSigninOTC": true,
-      "membersSigninOTCAlpha": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
       "tagsX": true,

--- a/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`sendMagicLink OTC With membersSigninOTC flag enabled Rate limiting Will rate limit OTC verification enumeration (IP-based) 1: [body] 1`] = `
+exports[`sendMagicLink OTC Rate limiting Will rate limit OTC verification enumeration (IP-based) 1: [body] 1`] = `
 Object {
   "errors": Array [
     Object {
@@ -36,7 +36,7 @@ Object {
 }
 `;
 
-exports[`sendMagicLink OTC With membersSigninOTC flag enabled Rate limiting Will rate limit OTC verification for specific otcRef 1: [body] 1`] = `
+exports[`sendMagicLink OTC Rate limiting Will rate limit OTC verification for specific otcRef 1: [body] 1`] = `
 Object {
   "errors": Array [
     Object {
@@ -198,7 +198,7 @@ Object {
 }
 `;
 
-exports[`sendMagicLink signin email matches OTC snapshot (membersSigninOTC enabled) 1 1`] = `
+exports[`sendMagicLink signin email matches OTC snapshot 1 1`] = `
 Object {
   "html": "
 <!doctype html>
@@ -391,205 +391,6 @@ Object {
 Your verification code for Ghost: <OTC>
 
 Or use this link to securely sign in:
-
-http://127.0.0.1:2369/members/?token=<TOKEN>&action=signin
-
-For your security, the link will expire in 24 hours time.
-
-See you soon!
-
----
-
-Sent to member1@test.com
-If you did not make this request, you can safely ignore this email.",
-  "to": "member1@test.com",
-}
-`;
-
-exports[`sendMagicLink signin email matches non-OTC snapshot (membersSigninOTC enabled) 1 1`] = `
-Object {
-  "html": "
-<!doctype html>
-<html>
-  <head>
-    <meta name=\\"viewport\\" content=\\"width=device-width\\">
-    <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
-    <title>🔑 Secure sign in link for Ghost</title>
-    <style>
-    /* -------------------------------------
-        RESPONSIVE AND MOBILE FRIENDLY STYLES
-    ------------------------------------- */
-    @media only screen and (max-width: 620px) {
-      table[class=body] h1 {
-        font-size: 28px !important;
-        margin-bottom: 10px !important;
-      }
-      table[class=body] p,
-            table[class=body] ul,
-            table[class=body] ol,
-            table[class=body] td,
-            table[class=body] span,
-            table[class=body] a {
-        font-size: 16px !important;
-      }
-      table[class=body] .wrapper,
-            table[class=body] .article {
-        padding: 10px !important;
-      }
-      table[class=body] .content {
-        padding: 0 !important;
-      }
-      table[class=body] .container {
-        padding: 0 !important;
-        width: 100% !important;
-      }
-      table[class=body] .main {
-        border-left-width: 0 !important;
-        border-radius: 0 !important;
-        border-right-width: 0 !important;
-      }
-      table[class=body] .btn table {
-        width: 100% !important;
-      }
-      table[class=body] .btn a {
-        width: 100% !important;
-      }
-      table[class=body] .img-responsive {
-        height: auto !important;
-        max-width: 100% !important;
-        width: auto !important;
-      }
-      table[class=body] p[class=small],
-      table[class=body] a[class=small] {
-        font-size: 11px !important;
-      }
-    }
-    /* -------------------------------------
-        PRESERVE THESE STYLES IN THE HEAD
-    ------------------------------------- */
-    @media all {
-      .ExternalClass {
-        width: 100%;
-      }
-      .ExternalClass,
-            .ExternalClass p,
-            .ExternalClass span,
-            .ExternalClass font,
-            .ExternalClass td,
-            .ExternalClass div {
-        line-height: 100%;
-      }
-      .recipient-link a {
-        color: inherit !important;
-        font-family: inherit !important;
-        font-size: inherit !important;
-        font-weight: inherit !important;
-        line-height: inherit !important;
-        text-decoration: none !important;
-      }
-      #MessageViewBody a {
-        color: inherit;
-        text-decoration: none;
-        font-size: inherit;
-        font-family: inherit;
-        font-weight: inherit;
-        line-height: inherit;
-      }
-    }
-    hr {
-      border-width: 0;
-      height: 0;
-      margin-top: 34px;
-      margin-bottom: 34px;
-      border-bottom-width: 1px;
-      border-bottom-color: #EEF5F8;
-    }
-    a {
-      color: #3A464C;
-    }
-    </style>
-  </head>
-  <body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
-    <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
-      <tr>
-        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
-        <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;\\">
-          <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;\\">
-
-            <!-- START CENTERED CONTAINER -->
-            <span class=\\"preheader\\" style=\\"color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;\\">Welcome back to Ghost!</span>
-            <!-- SPACING FOR PREVIEW TEXT -->
-            <div style=\\"display:none; max-height:0; overflow:hidden; mso-hide: all;\\" aria-hidden=\\"true\\" role=\\"presentation\\">
-              &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
-            </div>
-            <table class=\\"main\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;\\">
-
-              <!-- START MAIN CONTENT AREA -->
-              <tr>
-                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;\\">
-                  <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
-                    <tr>
-                      <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">
-                        <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 24px; margin: 0; margin-bottom: 15px;\\">Hey there,</p>
-                        <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 24px; margin-bottom: 32px;\\">Welcome back! Use this link to securely sign in to your Ghost account:</p>
-                        <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"btn btn-primary\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;\\">
-                          <tbody>
-                            <tr>
-                              <td align=\\"left\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; padding-bottom: 35px;\\">
-                                <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\\">
-                                  <tbody>
-                                    <tr>
-                                      <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: #FF1A75; border-radius: 5px; text-align: center;\\"> <a href=\\"http://127.0.0.1:2369/members/?token=<TOKEN>&action=signin\\" target=\\"_blank\\" style=\\"display: inline-block; color: #ffffff; background-color: #FF1A75; border: solid 1px #FF1A75; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #FF1A75;\\">Sign in to Ghost</a> </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                        <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 24px; margin: 0; margin-bottom: 11px;\\">For your security, the link will expire in 24 hours time.</p>
-                        <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 24px; margin: 0; margin-bottom: 30px;\\">See you soon!</p>
-                        <hr/>
-                        <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 24px;\\">You can also copy & paste this URL into your browser:</p>
-                        <p style=\\"word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 22px; margin-top:0; color: #3A464C;\\">http://127.0.0.1:2369/members/?token=<TOKEN>&action=signin</p>
-                      </td>
-                    </tr>
-
-                    <!-- START FOOTER -->
-
-                    <tr>
-                      <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 80px;\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 16px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0;\\">If you did not make this request, you can safely ignore this email.</p>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px;\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 16px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0;\\">This message was sent from <a class=\\"small\\" href=\\"http://127.0.0.1:2369/\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">127.0.0.1</a> to <a class=\\"small\\" href=\\"mailto:member1@test.com\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">member1@test.com</a></p>
-                      </td>
-                    </tr>
-
-                    <!-- END FOOTER -->
-                  </table>
-                </td>
-              </tr>
-
-            <!-- END MAIN CONTENT AREA -->
-            </table>
-
-
-          <!-- END CENTERED CONTAINER -->
-          </div>
-        </td>
-        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
-      </tr>
-    </table>
-  </body>
-</html>
-",
-  "subject": "🔑 Secure sign in link for Ghost",
-  "text": "Hey there,
-
-Welcome back! Use this link to securely sign in to your Ghost account:
 
 http://127.0.0.1:2369/members/?token=<TOKEN>&action=signin
 

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -66,7 +66,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -351,7 +351,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -466,7 +466,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2063,7 +2063,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2177,7 +2177,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2292,7 +2292,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2406,7 +2406,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2572,7 +2572,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -2852,7 +2852,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><script async src=\\"https://js.stripe.com/v3/\\"></script>
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><script async src=\\"https://js.stripe.com/v3/\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
@@ -3067,7 +3067,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3234,7 +3234,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3464,7 +3464,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
@@ -3578,7 +3578,7 @@ Object {
 
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" data-members-signin-otc=\\"false\\" data-members-signin-otc-alpha=\\"false\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -20,9 +20,6 @@ describe('MagicLink', function () {
             config: {
                 get: sandbox.stub().resolves()
             },
-            labsService: {
-                isSet: sandbox.stub().returns(false)
-            },
             ...overrides
         };
     }
@@ -104,13 +101,9 @@ describe('MagicLink', function () {
         });
     });
 
-    describe('#sendMagicLink with labsService', function () {
-        it('should not return otcRef when labsService is provided and flag is enabled but includeOTC is not set', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const service = new MagicLink(buildOptions({labsService}));
+    describe('#sendMagicLink with OTC', function () {
+        it('should not return otcRef when includeOTC is not set', async function () {
+            const service = new MagicLink(buildOptions());
 
             const args = {
                 email: 'test@example.com',
@@ -125,54 +118,11 @@ describe('MagicLink', function () {
             assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
         });
 
-        it('should not return otcRef when labsService flag is disabled', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(false)
-            };
-
-            const service = new MagicLink(buildOptions({labsService}));
-
-            const args = {
-                email: 'test@example.com',
-                tokenData: {
-                    id: '420'
-                },
-                includeOTC: true
-            };
-
-            const result = await service.sendMagicLink(args);
-
-            assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
-        });
-
-        it('should not return otcRef when labsService is not provided', async function () {
-            const service = new MagicLink(buildOptions({labsService: undefined}));
-
-            const args = {
-                email: 'test@example.com',
-                tokenData: {
-                    id: '420'
-                },
-                includeOTC: true
-            };
-
-            // Should not throw any errors
-            const result = await service.sendMagicLink(args);
-
-            assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
-        });
-
         it('should work when tokenProvider does not have getRefByToken method', async function () {
             // No getRefByToken method
             delete mockSingleUseTokenProvider.getRefByToken;
 
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const options = buildOptions({labsService});
+            const options = buildOptions();
             const service = new MagicLink(options);
 
             const args = {
@@ -192,11 +142,7 @@ describe('MagicLink', function () {
         it('should return otcRef as null when getRefByToken resolves to null', async function () {
             mockSingleUseTokenProvider.getRefByToken.resolves(null);
 
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const service = new MagicLink(buildOptions({labsService}));
+            const service = new MagicLink(buildOptions());
 
             const args = {
                 email: 'test@example.com',
@@ -214,12 +160,8 @@ describe('MagicLink', function () {
             assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
         });
 
-        it('should include OTC when includeOTC is true and labs flag is enabled', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const options = buildOptions({labsService});
+        it('should include OTC when includeOTC is true', async function () {
+            const options = buildOptions();
             const service = new MagicLink(options);
 
             const args = {
@@ -243,12 +185,8 @@ describe('MagicLink', function () {
             assert(options.getSubject.firstCall.calledWithExactly('signin', '654321'));
         });
 
-        it('should not include OTC when includeOTC is false even if labs flag is enabled', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const options = buildOptions({labsService});
+        it('should not include OTC when includeOTC is false', async function () {
+            const options = buildOptions();
             const service = new MagicLink(options);
 
             const args = {
@@ -271,34 +209,8 @@ describe('MagicLink', function () {
             assert(options.getSubject.firstCall.calledWithExactly('signin', null));
         });
 
-        it('should not include OTC when includeOTC is true but labs flag is disabled', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(false)
-            };
-
-            const service = new MagicLink(buildOptions({labsService}));
-
-            const args = {
-                email: 'test@example.com',
-                tokenData: {
-                    id: '420'
-                },
-                includeOTC: true
-            };
-
-            const result = await service.sendMagicLink(args);
-
-            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
-            assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
-            assert.equal(result.otcRef, null);
-        });
-
         it('should pass OTC to email content functions when OTC is enabled', async function () {
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const options = buildOptions({labsService});
+            const options = buildOptions();
             const service = new MagicLink(options);
 
             const args = {
@@ -324,11 +236,7 @@ describe('MagicLink', function () {
         it('should not include OTC when tokenProvider lacks deriveOTC method', async function () {
             delete mockSingleUseTokenProvider.deriveOTC;
 
-            const labsService = {
-                isSet: sandbox.stub().withArgs('membersSigninOTC').returns(true)
-            };
-
-            const options = buildOptions({labsService});
+            const options = buildOptions();
             const service = new MagicLink(options);
 
             const args = {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
@@ -857,7 +857,7 @@ describe('RouterController', function () {
             });
         });
 
-        describe('membersSigninOTC feature flag', function () {
+        describe('OTC response handling', function () {
             let req, res, handleSigninStub, routerController;
 
             beforeEach(function () {
@@ -880,7 +880,7 @@ describe('RouterController', function () {
                         getAttribution: sinon.stub().resolves({})
                     },
                     labsService: {
-                        isSet: sinon.stub()
+                        isSet: sinon.stub().returns(false)
                     },
                     settingsCache: {
                         get: sinon.stub().returns([])
@@ -901,8 +901,7 @@ describe('RouterController', function () {
                 routerController._handleSignin = handleSigninStub;
             });
 
-            it('should return otc_ref when flag is enabled and otcRef exists', async function () {
-                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+            it('should return otc_ref when otcRef exists', async function () {
                 handleSigninStub.resolves({otcRef: 'test-token-123'});
 
                 await routerController.sendMagicLink(req, res);
@@ -911,18 +910,7 @@ describe('RouterController', function () {
                 res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})).should.be.true();
             });
 
-            it('should not return otc_ref when flag is disabled', async function () {
-                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(false);
-                handleSigninStub.resolves({otcRef: 'test-token-123'});
-
-                await routerController.sendMagicLink(req, res);
-
-                res.writeHead.calledWith(201).should.be.true();
-                res.end.calledWith('Created.').should.be.true();
-            });
-
-            it('should not return otc_ref when flag is enabled but no otcRef', async function () {
-                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+            it('should not return otc_ref when no otcRef', async function () {
                 handleSigninStub.resolves({otcRef: null});
 
                 await routerController.sendMagicLink(req, res);
@@ -931,8 +919,7 @@ describe('RouterController', function () {
                 res.end.calledWith('Created.').should.be.true();
             });
 
-            it('should not return otc_ref when flag is enabled but otcRef is undefined', async function () {
-                routerController.labsService.isSet.withArgs('membersSigninOTC').returns(true);
+            it('should not return otc_ref when otcRef is undefined', async function () {
                 handleSigninStub.resolves({});
 
                 await routerController.sendMagicLink(req, res);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-2520/

- Portal's sign-in flow will now include a one-time-code (OTC) in emails and display a code input form after submitting the standard email sign-in form
  - OTC usage is optional for members, magic links are still included alongside the code
  - reduces sign-in friction in scenarios such as in-app browsers
- custom sign-in forms can opt in to the same OTC flow by adding a `data-members-otc=true"`
  - in this scenario, Portal will open the code input modal once a member submits their email in the custom form
