### PR TITLE
Updated activitypub Bluesky sharing enablement flow

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/api/activitypub.test.ts
+++ b/apps/activitypub/src/api/activitypub.test.ts
@@ -1607,7 +1607,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/enable`]: {
                     async assert(_resource, init) {
                         expect(init?.method).toEqual('POST');
                     },
@@ -1636,7 +1636,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/disable`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/disable`]: {
                     async assert(_resource, init) {
                         expect(init?.method).toEqual('POST');
                     },
@@ -1665,7 +1665,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/confirm-handle`]: {
                     response: JSONResponse({
                         handle: 'foo@bar.baz'
                     })
@@ -1693,7 +1693,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/confirm-handle`]: {
                     response: JSONResponse(null)
                 }
             });
@@ -1719,7 +1719,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/confirm-handle`]: {
                     response: JSONResponse({
                         foo: 'bar'
                     })
@@ -1747,7 +1747,7 @@ describe('ActivityPubAPI', function () {
                         }]
                     })
                 },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                [`https://activitypub.api/.ghost/activitypub/v2/actions/bluesky/confirm-handle`]: {
                     response: JSONResponse({
                         handle: ['foo@bar.baz']
                     })

--- a/apps/activitypub/src/api/activitypub.test.ts
+++ b/apps/activitypub/src/api/activitypub.test.ts
@@ -1608,34 +1608,9 @@ describe('ActivityPubAPI', function () {
                     })
                 },
                 [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
-                    response: JSONResponse({
-                        handle: '@foo@bar.baz'
-                    })
-                }
-            });
-
-            const api = new ActivityPubAPI(
-                new URL('https://activitypub.api'),
-                new URL('https://auth.api'),
-                'index',
-                fakeFetch
-            );
-
-            const result = await api.enableBluesky();
-
-            expect(result).toBe('@foo@bar.baz');
-        });
-
-        test('It returns an empty string if the response is null', async function () {
-            const fakeFetch = Fetch({
-                'https://auth.api/': {
-                    response: JSONResponse({
-                        identities: [{
-                            token: 'fake-token'
-                        }]
-                    })
-                },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('POST');
+                    },
                     response: JSONResponse(null)
                 }
             });
@@ -1647,65 +1622,7 @@ describe('ActivityPubAPI', function () {
                 fakeFetch
             );
 
-            const result = await api.enableBluesky();
-
-            expect(result).toBe('');
-        });
-
-        test('It returns an empty string if the response does not contain a handle property', async function () {
-            const fakeFetch = Fetch({
-                'https://auth.api/': {
-                    response: JSONResponse({
-                        identities: [{
-                            token: 'fake-token'
-                        }]
-                    })
-                },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
-                    response: JSONResponse({
-                        foo: 'bar'
-                    })
-                }
-            });
-
-            const api = new ActivityPubAPI(
-                new URL('https://activitypub.api'),
-                new URL('https://auth.api'),
-                'index',
-                fakeFetch
-            );
-
-            const result = await api.enableBluesky();
-
-            expect(result).toBe('');
-        });
-
-        test('It returns an empty string if the response contains an invalid handle property', async function () {
-            const fakeFetch = Fetch({
-                'https://auth.api/': {
-                    response: JSONResponse({
-                        identities: [{
-                            token: 'fake-token'
-                        }]
-                    })
-                },
-                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/enable`]: {
-                    response: JSONResponse({
-                        handle: ['@foo@bar.baz']
-                    })
-                }
-            });
-
-            const api = new ActivityPubAPI(
-                new URL('https://activitypub.api'),
-                new URL('https://auth.api'),
-                'index',
-                fakeFetch
-            );
-
-            const result = await api.enableBluesky();
-
-            expect(result).toBe('');
+            await api.enableBluesky();
         });
     });
 
@@ -1735,6 +1652,118 @@ describe('ActivityPubAPI', function () {
             );
 
             await api.disableBluesky();
+        });
+    });
+
+    describe('confirmBlueskyHandle', function () {
+        test('It confirms the bluesky handle', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                    response: JSONResponse({
+                        handle: 'foo@bar.baz'
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.confirmBlueskyHandle();
+
+            expect(result).toBe('foo@bar.baz');
+        });
+
+        test('It returns an empty string if the response is null', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                    response: JSONResponse(null)
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.confirmBlueskyHandle();
+
+            expect(result).toBe('');
+        });
+
+        test('It returns an empty string if the response does not contain a handle property', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                    response: JSONResponse({
+                        foo: 'bar'
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.confirmBlueskyHandle();
+
+            expect(result).toBe('');
+        });
+
+        test('It returns an empty string if the response contains an invalid handle property', async function () {
+            const fakeFetch = Fetch({
+                'https://auth.api/': {
+                    response: JSONResponse({
+                        identities: [{
+                            token: 'fake-token'
+                        }]
+                    })
+                },
+                [`https://activitypub.api/.ghost/activitypub/v1/actions/bluesky/confirm-handle`]: {
+                    response: JSONResponse({
+                        handle: ['foo@bar.baz']
+                    })
+                }
+            });
+
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.confirmBlueskyHandle();
+
+            expect(result).toBe('');
         });
     });
 });

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -709,19 +709,19 @@ export class ActivityPubAPI {
     }
 
     async enableBluesky() {
-        const url = new URL('.ghost/activitypub/v1/actions/bluesky/enable', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v2/actions/bluesky/enable', this.apiUrl);
 
         await this.fetchJSON(url, 'POST');
     }
 
     async disableBluesky() {
-        const url = new URL('.ghost/activitypub/v1/actions/bluesky/disable', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v2/actions/bluesky/disable', this.apiUrl);
 
         await this.fetchJSON(url, 'POST');
     }
 
     async confirmBlueskyHandle(): Promise<string> {
-        const url = new URL('.ghost/activitypub/v1/actions/bluesky/confirm-handle', this.apiUrl);
+        const url = new URL('.ghost/activitypub/v2/actions/bluesky/confirm-handle', this.apiUrl);
 
         const json = await this.fetchJSON(url, 'POST');
 

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -26,7 +26,8 @@ export interface Account {
     domainBlockedByMe: boolean;
     attachment: { name: string; value: string }[];
     blueskyEnabled?: boolean;
-    blueskyHandle?: string;
+    blueskyHandleConfirmed?: boolean;
+    blueskyHandle?: string | null;
 }
 
 export type AccountSearchResult = Pick<
@@ -707,8 +708,20 @@ export class ActivityPubAPI {
         return json.fileUrl;
     }
 
-    async enableBluesky(): Promise<string> {
+    async enableBluesky() {
         const url = new URL('.ghost/activitypub/v1/actions/bluesky/enable', this.apiUrl);
+
+        await this.fetchJSON(url, 'POST');
+    }
+
+    async disableBluesky() {
+        const url = new URL('.ghost/activitypub/v1/actions/bluesky/disable', this.apiUrl);
+
+        await this.fetchJSON(url, 'POST');
+    }
+
+    async confirmBlueskyHandle(): Promise<string> {
+        const url = new URL('.ghost/activitypub/v1/actions/bluesky/confirm-handle', this.apiUrl);
 
         const json = await this.fetchJSON(url, 'POST');
 
@@ -717,11 +730,5 @@ export class ActivityPubAPI {
         }
 
         return String(json.handle);
-    }
-
-    async disableBluesky() {
-        const url = new URL('.ghost/activitypub/v1/actions/bluesky/disable', this.apiUrl);
-
-        await this.fetchJSON(url, 'POST');
     }
 }

--- a/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
+++ b/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
@@ -1,7 +1,7 @@
 import APAvatar from '@src/components/global/APAvatar';
 import EditProfile from '@src/views/Preferences/components/EditProfile';
 import Layout from '@src/components/layout';
-import React, {useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,
@@ -22,7 +22,10 @@ import {AlertDialog,
     LucideIcon,
     buttonVariants} from '@tryghost/shade';
 import {toast} from 'sonner';
-import {useAccountForUser, useDisableBlueskyMutationForUser, useEnableBlueskyMutationForUser} from '@hooks/use-activity-pub-queries';
+import {useAccountForUser, useConfirmBlueskyHandleMutationForUser, useDisableBlueskyMutationForUser, useEnableBlueskyMutationForUser} from '@hooks/use-activity-pub-queries';
+
+const CONFIRMATION_INTERVAL = 5000;
+const MAX_CONFIRMATION_RETRIES = 12;
 
 const BlueskySharing: React.FC = () => {
     const {data: account, isLoading: isLoadingAccount} = useAccountForUser('index', 'me');
@@ -30,8 +33,11 @@ const BlueskySharing: React.FC = () => {
     const [copied, setCopied] = useState(false);
     const [isEditingProfile, setIsEditingProfile] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
+    const [handleConfirmed, setHandleConfirmed] = useState(false);
+    const retryCountRef = useRef(0);
     const enableBlueskyMutation = useEnableBlueskyMutationForUser('index');
     const disableBlueskyMutation = useDisableBlueskyMutationForUser('index');
+    const confirmBlueskyHandleMutation = useConfirmBlueskyHandleMutationForUser('index');
     const enabled = account?.blueskyEnabled ?? false;
 
     const handleCopy = async () => {
@@ -64,6 +70,55 @@ const BlueskySharing: React.FC = () => {
             setLoading(false);
         }
     };
+
+    const confirmHandle = useCallback(() => {
+        confirmBlueskyHandleMutation.mutateAsync().then((handle) => {
+            if (handle) {
+                setHandleConfirmed(true);
+            }
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []); // Empty deps - mutations are stable in practice
+
+    useEffect(() => {
+        if (!account?.blueskyEnabled) {
+            setHandleConfirmed(false);
+
+            retryCountRef.current = 0;
+
+            return;
+        }
+
+        if (account?.blueskyHandleConfirmed) {
+            setHandleConfirmed(true);
+
+            retryCountRef.current = 0;
+
+            return;
+        }
+
+        setHandleConfirmed(false);
+        retryCountRef.current = 0;
+
+        const confirmHandleInterval = setInterval(async () => {
+            retryCountRef.current += 1;
+
+            if (retryCountRef.current > MAX_CONFIRMATION_RETRIES) {
+                clearInterval(confirmHandleInterval);
+
+                toast.error('Failed to confirm Bluesky handle');
+
+                await disableBlueskyMutation.mutateAsync();
+
+                return;
+            }
+
+            confirmHandle();
+        }, CONFIRMATION_INTERVAL);
+
+        return () => clearInterval(confirmHandleInterval);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [account?.blueskyEnabled, account?.blueskyHandleConfirmed, confirmHandle]); // disableBlueskyMutation is stable
 
     if (isLoadingAccount) {
         return (
@@ -122,43 +177,51 @@ const BlueskySharing: React.FC = () => {
                     </div> :
                     <>
                         <p className='mt-2 pr-32 text-base'>Your social web profile is now connected to Bluesky, via <a className="text-purple hover:text-purple-600" href="https://fed.brid.gy" rel="noreferrer" target="_blank">Bridgy Fed</a>. Posts are automatically synced after a short delay to complete activation.</p>
-                        <div className='mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 p-8 dark:border-gray-950'>
-                            <div className='relative'>
-                                <APAvatar
-                                    author={
-                                        {
-                                            icon: {
-                                                url: account?.avatarUrl || ''
-                                            },
-                                            name: account?.name || '',
-                                            handle: account?.handle || ''
-                                        }
-                                    }
-                                    size='md'
-                                />
-                                <div className='absolute bottom-0 right-0 z-10 flex size-6 items-center justify-center rounded-full bg-white shadow-xs'>
-                                    <svg height="14" role="img" viewBox="0 0 24 24" width="14" xmlns="http://www.w3.org/2000/svg"><path d="M12 10.8c-1.087 -2.114 -4.046 -6.053 -6.798 -7.995C2.566 0.944 1.561 1.266 0.902 1.565 0.139 1.908 0 3.08 0 3.768c0 0.69 0.378 5.65 0.624 6.479 0.815 2.736 3.713 3.66 6.383 3.364 0.136 -0.02 0.275 -0.039 0.415 -0.056 -0.138 0.022 -0.276 0.04 -0.415 0.056 -3.912 0.58 -7.387 2.005 -2.83 7.078 5.013 5.19 6.87 -1.113 7.823 -4.308 0.953 3.195 2.05 9.271 7.733 4.308 4.267 -4.308 1.172 -6.498 -2.74 -7.078a8.741 8.741 0 0 1 -0.415 -0.056c0.14 0.017 0.279 0.036 0.415 0.056 2.67 0.297 5.568 -0.628 6.383 -3.364 0.246 -0.828 0.624 -5.79 0.624 -6.478 0 -0.69 -0.139 -1.861 -0.902 -2.206 -0.659 -0.298 -1.664 -0.62 -4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z" fill="#0385FF" strokeWidth="1"></path></svg>
-                                </div>
+                        {!handleConfirmed && (
+                            <div className='mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 p-8 dark:border-gray-950'>
+                                <p className='text-base'>Confirming your Bluesky handle...</p>
+                                <LoadingIndicator size='sm' />
                             </div>
-                            <div className='flex grow flex-col items-center'>
-                                <H3>{account?.name || ''}</H3>
-                                <div className='flex items-center gap-1 text-gray-800'>
-                                    <span className='text-lg font-medium'>{account?.blueskyHandle}</span>
-                                    <Button className='size-6 p-0 hover:opacity-80' title='Copy handle' variant='link' onClick={handleCopy}>
-                                        {!copied ?
-                                            <LucideIcon.Copy size={16} /> :
-                                            <LucideIcon.Check size={16} />
+                        )}
+                        {handleConfirmed && (
+                            <div className='mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 p-8 dark:border-gray-950'>
+                                <div className='relative'>
+                                    <APAvatar
+                                        author={
+                                            {
+                                                icon: {
+                                                    url: account?.avatarUrl || ''
+                                                },
+                                                name: account?.name || '',
+                                                handle: account?.handle || ''
+                                            }
                                         }
-                                    </Button>
+                                        size='md'
+                                    />
+                                    <div className='absolute bottom-0 right-0 z-10 flex size-6 items-center justify-center rounded-full bg-white shadow-xs'>
+                                        <svg height="14" role="img" viewBox="0 0 24 24" width="14" xmlns="http://www.w3.org/2000/svg"><path d="M12 10.8c-1.087 -2.114 -4.046 -6.053 -6.798 -7.995C2.566 0.944 1.561 1.266 0.902 1.565 0.139 1.908 0 3.08 0 3.768c0 0.69 0.378 5.65 0.624 6.479 0.815 2.736 3.713 3.66 6.383 3.364 0.136 -0.02 0.275 -0.039 0.415 -0.056 -0.138 0.022 -0.276 0.04 -0.415 0.056 -3.912 0.58 -7.387 2.005 -2.83 7.078 5.013 5.19 6.87 -1.113 7.823 -4.308 0.953 3.195 2.05 9.271 7.733 4.308 4.267 -4.308 1.172 -6.498 -2.74 -7.078a8.741 8.741 0 0 1 -0.415 -0.056c0.14 0.017 0.279 0.036 0.415 0.056 2.67 0.297 5.568 -0.628 6.383 -3.364 0.246 -0.828 0.624 -5.79 0.624 -6.478 0 -0.69 -0.139 -1.861 -0.902 -2.206 -0.659 -0.298 -1.664 -0.62 -4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z" fill="#0385FF" strokeWidth="1"></path></svg>
+                                    </div>
                                 </div>
+                                <div className='flex grow flex-col items-center'>
+                                    <H3>{account?.name || ''}</H3>
+                                    <div className='flex items-center gap-1 text-gray-800'>
+                                        <span className='text-lg font-medium'>{account?.blueskyHandle}</span>
+                                        <Button className='size-6 p-0 hover:opacity-80' title='Copy handle' variant='link' onClick={handleCopy}>
+                                            {!copied ?
+                                                <LucideIcon.Copy size={16} /> :
+                                                <LucideIcon.Check size={16} />
+                                            }
+                                        </Button>
+                                    </div>
+                                </div>
+                                <Button className='mt-2 w-full' size='lg' variant='secondary' asChild>
+                                    <a href={`https://bsky.app/profile/${account?.blueskyHandle?.replace(/^@/, '')}`} rel='noreferrer' target='_blank'>
+                                            Open profile
+                                        <LucideIcon.ExternalLink size={14} strokeWidth={1.25} />
+                                    </a>
+                                </Button>
                             </div>
-                            <Button className='mt-2 w-full' size='lg' variant='secondary' asChild>
-                                <a href={`https://bsky.app/profile/${account?.blueskyHandle?.replace(/^@/, '')}`} rel='noreferrer' target='_blank'>
-                                        Open profile
-                                    <LucideIcon.ExternalLink size={14} strokeWidth={1.25} />
-                                </a>
-                            </Button>
-                        </div>
+                        )}
                     </>
                 }
             </div>

--- a/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
+++ b/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
@@ -177,7 +177,7 @@ const BlueskySharing: React.FC = () => {
                                             Enable Bluesky sharing</> :
                                         <div className='flex items-center gap-2'>
                                             <LoadingIndicator size='sm' />
-                                            <span>Creating handle...</span>
+                                            <span>Enabling Bluesky sharing...</span>
                                         </div>
                                     }
                                 </Button>

--- a/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
+++ b/apps/activitypub/src/views/Preferences/components/BlueskySharing.tsx
@@ -91,8 +91,12 @@ const BlueskySharing: React.FC = () => {
         if (account?.blueskyHandleConfirmed) {
             setHandleConfirmed(true);
             setLoading(false);
+
+            // Only show toast on first confirmation
+            if (retryCountRef.current > 0) {
+                toast.success('Bluesky sharing enabled');
+            }
             retryCountRef.current = 0;
-            toast.success('Bluesky sharing enabled');
 
             return;
         }


### PR DESCRIPTION
ref https://github.com/TryGhost/ActivityPub/pull/1377

We updated the backend implementation of the Bluesky sharing enablement process to include a confirmation step in which the client would prompt the backend to check what handle has been assigned to the Bluesky account generated by Bridgy Fed - This circumvents the need to for us to compute the handle manually and potentially getting it wrong if we compute it in a different way to Bridgy Fed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Bluesky sharing to v2 enable/disable endpoints, add handle confirmation flow with polling, update UI/state, and bump package to 2.0.0.
> 
> - **API**:
>   - Migrate Bluesky endpoints to `v2` (`enable`, `disable`) and add `confirm-handle` endpoint.
>   - Change `enableBluesky()` to no longer return a handle; introduce `confirmBlueskyHandle()` returning a confirmed handle or empty string.
>   - Extend `Account` with `blueskyHandleConfirmed` and make `blueskyHandle` nullable.
> - **Hooks** (`apps/activitypub/src/hooks/use-activity-pub-queries.ts`):
>   - Add `useConfirmBlueskyHandleMutationForUser` and cache updater for Bluesky details.
>   - Update enable/disable mutations to set `{blueskyEnabled, blueskyHandleConfirmed, blueskyHandle}` appropriately and invalidate follows.
> - **UI** (`views/Preferences/components/BlueskySharing.tsx`):
>   - Implement enablement confirmation flow with polling, loading states, success/error toasts, and conditional rendering once handle is confirmed.
>   - Update disable flow and button states; show link to Bluesky profile when confirmed.
> - **Tests** (`src/api/activitypub.test.ts`):
>   - Update Bluesky tests for `v2` endpoints; add tests for handle confirmation and null/invalid responses.
> - **Package**:
>   - Bump `@tryghost/activitypub` version to `2.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c743df50334f6541e64cd7969e1889c2e4a0cac9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->