### PR TITLE
Released @tryghost/portal v2.55.5

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.55.4",
+  "version": "2.55.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changelog for v2.55.4 -> 2.55.5:

- 🐛 [Fixed `data-locale` attribute being overridden by site locale](https://github.com/TryGhost/Ghost/pull/25190)
- [0209eb1](https://github.com/TryGhost/Ghost/commit/0209eb1e6780c15f1678e530936ca6c6bf8079dd)
