### PR TITLE
Removed UTM dropdowns from Analytics Growth pages

### DIFF
--- a/apps/admin-x-framework/src/api/stats.ts
+++ b/apps/admin-x-framework/src/api/stats.ts
@@ -80,19 +80,6 @@ export type PostGrowthStatsResponseType = {
     meta: Meta;
 };
 
-export type UtmGrowthStatItem = {
-    utm_value: string;
-    utm_type: string;
-    free_members: number;
-    paid_members: number;
-    mrr: number;
-};
-
-export type UtmGrowthStatsResponseType = {
-    stats: UtmGrowthStatItem[];
-    meta: Meta;
-};
-
 export type MrrHistoryItem = {
     date: string;
     mrr: number;
@@ -216,7 +203,6 @@ const newsletterStatsDataType = 'NewsletterStatsResponseType';
 const newsletterSubscriberStatsDataType = 'NewsletterSubscriberStatsResponseType';
 
 const postGrowthStatsDataType = 'PostGrowthStatsResponseType';
-const utmGrowthStatsDataType = 'UtmGrowthStatsResponseType';
 const mrrHistoryDataType = 'MrrHistoryResponseType';
 const topPostViewsDataType = 'TopPostViewsResponseType';
 const subscriptionStatsDataType = 'SubscriptionStatsResponseType';
@@ -245,12 +231,6 @@ export const usePostGrowthStats = createQueryWithId<PostGrowthStatsResponseType>
     dataType: postGrowthStatsDataType,
     path: id => `/stats/posts/${id}/growth`
 });
-
-export const useUtmGrowthStats = createQuery<UtmGrowthStatsResponseType>({
-    dataType: utmGrowthStatsDataType,
-    path: '/stats/utm-growth/'
-});
-
 export const useMrrHistory = createQuery<MrrHistoryResponseType>({
     dataType: mrrHistoryDataType,
     path: '/stats/mrr/'

--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -1,16 +1,11 @@
-import React, {useState} from 'react';
+import React from 'react';
 import SourceIcon from '../../components/SourceIcon';
-import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate, useParams} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, UtmCampaignTabs, UtmCampaignType, UtmTabType, cn, formatNumber, getUtmType} from '@tryghost/shade';
+import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate} from '@tryghost/admin-x-framework';
+import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/App';
-import {useGlobalData} from '@src/providers/PostAnalyticsContext';
-import {useUtmGrowthStats} from '@tryghost/admin-x-framework/api/stats';
 
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';
-
-// Number of top sources to show in the preview card
-const TOP_SOURCES_PREVIEW_LIMIT = 10;
 
 interface SourcesTableProps {
     data: ProcessedSourceData[] | null;
@@ -112,72 +107,16 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
 }) => {
     const {appSettings} = useAppContext();
     const navigate = useNavigate();
-    const {data: globalData} = useGlobalData();
-    const {postId} = useParams();
-    const [selectedTab, setSelectedTab] = useState<UtmTabType>('sources');
-    const [selectedCampaign, setSelectedCampaign] = useState<UtmCampaignType>('');
-
-    // Check if UTM tracking is enabled in labs
-    const utmTrackingEnabled = globalData?.labs?.utmTracking || false;
-
-    const shouldFetchUtmData = utmTrackingEnabled
-        && selectedTab === 'campaigns'
-        && !!selectedCampaign
-        && !!postId;
-
-    const utmType = getUtmType(selectedCampaign);
-    const {data: utmData, isFetching: isUtmFetching} = useUtmGrowthStats({
-        searchParams: {
-            utm_type: utmType,
-            post_id: postId || ''
-        },
-        enabled: shouldFetchUtmData
-    });
-
-    // Select and transform the appropriate data based on current view
-    const displayData = React.useMemo(() => {
-        const isShowingCampaigns = selectedTab === 'campaigns' && selectedCampaign;
-
-        if (!isShowingCampaigns) {
-            return data;
-        }
-
-        if (!utmData?.stats) {
-            return null;
-        }
-
-        return utmData.stats.map(item => ({
-            ...item,
-            source: item.utm_value || '(not set)'
-        }));
-    }, [data, utmData, selectedTab, selectedCampaign]);
-
     // Process and group sources data with pre-computed icons and display values
-    const processedData = React.useMemo((): ProcessedSourceData[] => {
-        // UTM campaigns: UTM values are not domains, so don't show icons or links
-        if (selectedTab === 'campaigns' && selectedCampaign && displayData) {
-            return displayData.map(item => ({
-                source: String(item.source || '(not set)'),
-                visits: 0,
-                isDirectTraffic: false,
-                iconSrc: '',
-                displayName: String(item.source || '(not set)'),
-                linkUrl: undefined,
-                free_members: item.free_members || 0,
-                paid_members: item.paid_members || 0,
-                mrr: item.mrr || 0
-            }));
-        }
-
-        // For regular sources, use the standard processing
+    const processedData = React.useMemo(() => {
         return processSources({
-            data: displayData,
+            data,
             mode,
             siteUrl,
             siteIcon,
             defaultSourceIconUrl
         });
-    }, [displayData, siteUrl, siteIcon, mode, defaultSourceIconUrl, selectedTab, selectedCampaign]);
+    }, [data, siteUrl, siteIcon, mode, defaultSourceIconUrl]);
 
     // Extend processed data with percentage values for visits mode
     const extendedData = React.useMemo(() => {
@@ -188,29 +127,25 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
         });
     }, [processedData, totalVisitors, mode]);
 
-    const topSources = extendedData.slice(0, TOP_SOURCES_PREVIEW_LIMIT);
+    const topSources = extendedData.slice(0, 10);
 
-    // Check if original source data has content (for tab visibility)
-    const hasAnySourceData = data && data.length > 0;
-
-    // Generate title and description based on mode, tab, and campaign
-    const cardTitle = selectedTab === 'campaigns' && selectedCampaign ? selectedCampaign : title;
+    // Generate description based on mode and range
     const cardDescription = description || (
         mode === 'growth'
             ? 'Where did your growth come from?'
             : `How readers found your ${range ? 'site' : 'post'}${range && getPeriodText ? ` ${getPeriodText(range)}` : ''}`
     );
 
-    const sheetTitle = selectedTab === 'campaigns' && selectedCampaign ? selectedCampaign : (mode === 'growth' ? 'Sources' : 'Top sources');
+    const sheetTitle = mode === 'growth' ? 'Sources' : 'Top sources';
     const sheetDescription = mode === 'growth'
         ? 'Where did your growth come from?'
         : `How readers found your ${range ? 'site' : 'post'}${range && getPeriodText ? ` ${getPeriodText(range)}` : ''}`;
 
     return (
         <Card className={cn('group/datalist w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]', className)} data-testid='top-sources-card'>
-            {hasAnySourceData &&
+            {topSources.length <= 0 &&
                 <CardHeader>
-                    <CardTitle>{cardTitle}</CardTitle>
+                    <CardTitle>{title}</CardTitle>
                     <CardDescription>{cardDescription}</CardDescription>
                 </CardHeader>
             }
@@ -228,60 +163,33 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
                     >
                         <LucideIcon.Activity />
                     </EmptyIndicator>
+                ) : topSources.length > 0 ? (
+                    <SourcesTable
+                        data={topSources}
+                        defaultSourceIconUrl={defaultSourceIconUrl}
+                        getPeriodText={getPeriodText}
+                        headerStyle='card'
+                        mode={mode}
+                        range={range}
+                    >
+                        <CardHeader>
+                            <CardTitle>{title}</CardTitle>
+                            <CardDescription>{cardDescription}</CardDescription>
+                        </CardHeader>
+                    </SourcesTable>
                 ) : (
-                    <>
-                        {utmTrackingEnabled && mode === 'growth' && hasAnySourceData && (
-                            <>
-                                <div className='mb-4'>
-                                    <UtmCampaignTabs
-                                        selectedCampaign={selectedCampaign}
-                                        selectedTab={selectedTab}
-                                        onCampaignChange={setSelectedCampaign}
-                                        onTabChange={setSelectedTab}
-                                    />
-                                </div>
-                                <Separator />
-                            </>
-                        )}
-                        {(selectedTab === 'campaigns' && selectedCampaign && isUtmFetching) ? (
-                            <SkeletonTable className='mt-3' />
-                        ) : (hasAnySourceData || (selectedTab === 'campaigns' && selectedCampaign)) ? (
-                            <>
-                                {topSources.length > 0 ? (
-                                    <SourcesTable
-                                        data={topSources}
-                                        defaultSourceIconUrl={defaultSourceIconUrl}
-                                        getPeriodText={getPeriodText}
-                                        mode={mode}
-                                        range={range}
-                                    />
-                                ) : (
-                                    <div className='py-20 text-center text-sm text-gray-700' data-testid='empty-sources-indicator'>
-                                        <EmptyIndicator
-                                            className='h-full'
-                                            description={mode === 'growth' && `No data available for this view`}
-                                            title={`No ${selectedTab === 'campaigns' && selectedCampaign ? selectedCampaign.toLowerCase() : 'sources'} data available`}
-                                        >
-                                            <LucideIcon.UserPlus strokeWidth={1.5} />
-                                        </EmptyIndicator>
-                                    </div>
-                                )}
-                            </>
-                        ) : (
-                            <div className='py-20 text-center text-sm text-gray-700' data-testid='empty-sources-indicator'>
-                                <EmptyIndicator
-                                    className='h-full'
-                                    description={mode === 'growth' && `Once someone signs up on this post, sources will show here`}
-                                    title={`No sources data available ${getPeriodText ? getPeriodText(range) : ''}`}
-                                >
-                                    <LucideIcon.UserPlus strokeWidth={1.5} />
-                                </EmptyIndicator>
-                            </div>
-                        )}
-                    </>
+                    <div className='py-20 text-center text-sm text-gray-700'>
+                        <EmptyIndicator
+                            className='h-full'
+                            description={mode === 'growth' && `Once someone signs up on this post, sources will show here`}
+                            title={`No sources data available ${getPeriodText ? getPeriodText(range) : ''}`}
+                        >
+                            <LucideIcon.UserPlus strokeWidth={1.5} />
+                        </EmptyIndicator>
+                    </div>
                 )}
             </CardContent>
-            {extendedData.length > TOP_SOURCES_PREVIEW_LIMIT &&
+            {extendedData.length > 10 &&
                 <CardFooter>
                     <Sheet>
                         <SheetTrigger asChild>

--- a/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/Sources.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useTinybirdQuery} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, UtmCampaignTabs, UtmCampaignType, UtmTabType, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HTable, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, TabType, UtmCampaignTabs, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {getAudienceQueryParam} from '../../components/AudienceSelect';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
@@ -101,8 +101,8 @@ export const Sources: React.FC<SourcesCardProps> = ({
     topSourcesLimit = 10
 }) => {
     const {data: globalData, statsConfig, audience, post, isPostLoading} = useGlobalData();
-    const [selectedTab, setSelectedTab] = useState<UtmTabType>('sources');
-    const [selectedCampaign, setSelectedCampaign] = useState<UtmCampaignType>('');
+    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
+    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
 
     // Check if UTM tracking is enabled in labs
     const utmTrackingEnabled = globalData?.labs?.utmTracking || false;
@@ -132,7 +132,7 @@ export const Sources: React.FC<SourcesCardProps> = ({
     }, [isPostLoading, post, statsConfig?.id, startDate, endDate, timezone, audience]);
 
     // Map campaign types to endpoints
-    const campaignEndpointMap: Record<UtmCampaignType, string> = {
+    const campaignEndpointMap: Record<CampaignType, string> = {
         '': '',
         'UTM sources': 'api_top_utm_sources',
         'UTM mediums': 'api_top_utm_mediums',
@@ -160,7 +160,7 @@ export const Sources: React.FC<SourcesCardProps> = ({
             }
 
             // Map UTM field names to the generic key name
-            const utmKeyMap: Record<UtmCampaignType, string> = {
+            const utmKeyMap: Record<CampaignType, string> = {
                 '': '',
                 'UTM sources': 'utm_source',
                 'UTM mediums': 'utm_medium',

--- a/apps/shade/src/components/features/utm-campaign-tabs/utm-campaign-tabs.tsx
+++ b/apps/shade/src/components/features/utm-campaign-tabs/utm-campaign-tabs.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {TableFilterDropdownTab, TableFilterTab, TableFilterTabs} from '../table-filter-tabs/table-filter-tabs';
 
-export const UTM_CAMPAIGN_TYPES = [
+export type CampaignType = '' | 'UTM sources' | 'UTM mediums' | 'UTM campaigns' | 'UTM contents' | 'UTM terms';
+export type TabType = 'sources' | 'campaigns';
+
+export const CAMPAIGN_TYPES: readonly CampaignType[] = [
     'UTM sources',
     'UTM mediums',
     'UTM campaigns',
@@ -9,69 +12,19 @@ export const UTM_CAMPAIGN_TYPES = [
     'UTM terms'
 ] as const;
 
-export type UtmCampaignType = '' | typeof UTM_CAMPAIGN_TYPES[number];
-export type UtmTabType = 'sources' | 'campaigns';
-
-export const UTM_CAMPAIGN_OPTIONS = UTM_CAMPAIGN_TYPES.map(type => ({
+const CAMPAIGN_OPTIONS = CAMPAIGN_TYPES.map(type => ({
     value: type,
     label: type
 }));
 
-export const UTM_TYPE_MAP = {
-    'UTM sources': 'utm_source',
-    'UTM mediums': 'utm_medium',
-    'UTM campaigns': 'utm_campaign',
-    'UTM contents': 'utm_content',
-    'UTM terms': 'utm_term'
-} as const satisfies Record<typeof UTM_CAMPAIGN_TYPES[number], string>;
-
-export const getUtmType = (campaign: UtmCampaignType): string => {
-    return campaign ? UTM_TYPE_MAP[campaign as Exclude<UtmCampaignType, ''>] || '' : '';
-};
-
-// Component Interfaces
-interface UtmCampaignDropdownProps {
-    selectedCampaign: UtmCampaignType;
-    onCampaignChange: (campaign: UtmCampaignType) => void;
-    placeholder?: string;
-}
-
 interface UtmCampaignTabsProps {
     className?: string;
-    selectedTab: UtmTabType;
-    onTabChange: (tab: UtmTabType) => void;
-    selectedCampaign: UtmCampaignType;
-    onCampaignChange: (campaign: UtmCampaignType) => void;
+    selectedTab: TabType;
+    onTabChange: (tab: TabType) => void;
+    selectedCampaign: CampaignType;
+    onCampaignChange: (campaign: CampaignType) => void;
 }
 
-/**
- * Dropdown component for selecting UTM campaign types.
- * Can be embedded within other tab systems.
- */
-export const UtmCampaignDropdown: React.FC<UtmCampaignDropdownProps> = ({
-    selectedCampaign,
-    onCampaignChange,
-    placeholder = 'Campaigns'
-}) => {
-    const handleCampaignChange = (campaign: string) => {
-        onCampaignChange(campaign as UtmCampaignType);
-    };
-
-    return (
-        <TableFilterDropdownTab
-            options={UTM_CAMPAIGN_OPTIONS}
-            placeholder={placeholder}
-            selectedOption={selectedCampaign}
-            value='campaigns'
-            onOptionChange={handleCampaignChange}
-        />
-    );
-};
-
-/**
- * Complete tab system with Sources and Campaigns (dropdown) tabs.
- * Handles tab switching logic automatically.
- */
 export const UtmCampaignTabs: React.FC<UtmCampaignTabsProps> = ({
     className,
     selectedTab,
@@ -84,7 +37,7 @@ export const UtmCampaignTabs: React.FC<UtmCampaignTabsProps> = ({
         if (tab === 'campaigns' && !selectedCampaign) {
             return;
         }
-        onTabChange(tab as UtmTabType);
+        onTabChange(tab as TabType);
 
         // Clear campaign when switching away
         if (tab !== 'campaigns') {
@@ -93,7 +46,7 @@ export const UtmCampaignTabs: React.FC<UtmCampaignTabsProps> = ({
     };
 
     const handleCampaignChange = (campaign: string) => {
-        onCampaignChange(campaign as UtmCampaignType);
+        onCampaignChange(campaign as CampaignType);
         onTabChange('campaigns');
     };
 
@@ -105,7 +58,7 @@ export const UtmCampaignTabs: React.FC<UtmCampaignTabsProps> = ({
         >
             <TableFilterTab value='sources'>Sources</TableFilterTab>
             <TableFilterDropdownTab
-                options={UTM_CAMPAIGN_OPTIONS}
+                options={CAMPAIGN_OPTIONS}
                 placeholder='Campaigns'
                 selectedOption={selectedCampaign}
                 value='campaigns'

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -50,15 +50,8 @@ export * from './components/layout/view-header';
 // Feature components — Complete functional components (share modal, etc.)
 export {default as PostShareModal} from './components/features/post_share_modal';
 export * from './components/features/table-filter-tabs/table-filter-tabs';
-export {
-    UtmCampaignDropdown,
-    UtmCampaignTabs,
-    UTM_CAMPAIGN_TYPES,
-    UTM_CAMPAIGN_OPTIONS,
-    UTM_TYPE_MAP,
-    getUtmType
-} from './components/features/utm-campaign-tabs/utm-campaign-tabs';
-export type {UtmCampaignType, UtmTabType} from './components/features/utm-campaign-tabs/utm-campaign-tabs';
+export * from './components/features/utm-campaign-tabs/utm-campaign-tabs';
+export type {CampaignType, TabType} from './components/features/utm-campaign-tabs/utm-campaign-tabs';
 
 // Third party components
 export * as Recharts from 'recharts';

--- a/apps/stats/src/utils/content-helpers.ts
+++ b/apps/stats/src/utils/content-helpers.ts
@@ -3,8 +3,7 @@ export const CONTENT_TYPES = {
     POSTS: 'posts',
     PAGES: 'pages',
     POSTS_AND_PAGES: 'posts_and_pages',
-    SOURCES: 'sources',
-    CAMPAIGNS: 'campaigns'
+    SOURCES: 'sources'
 } as const;
 
 export type ContentType = typeof CONTENT_TYPES[keyof typeof CONTENT_TYPES];
@@ -18,8 +17,6 @@ export const getContentTitle = (selectedContentType: ContentType) => {
         return 'Top pages';
     case CONTENT_TYPES.SOURCES:
         return 'Top sources';
-    case CONTENT_TYPES.CAMPAIGNS:
-        return 'Top campaigns';
     default:
         return 'Top content';
     }
@@ -50,9 +47,7 @@ export const getGrowthContentDescription = (selectedContentType: ContentType, ra
         return `Which posts or pages drove the most growth ${getPeriodText(rangeValue)}`;
     case CONTENT_TYPES.SOURCES:
         return `How readers found your site ${getPeriodText(rangeValue)}`;
-    case CONTENT_TYPES.CAMPAIGNS:
-        return `Which campaigns drove the most growth ${getPeriodText(rangeValue)}`;
     default:
         return `Which posts drove the most growth ${getPeriodText(rangeValue)}`;
     }
-};
+}; 

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -1,11 +1,11 @@
 import React, {useState} from 'react';
 import SortButton from '../../components/SortButton';
 import SourceIcon from '../../components/SourceIcon';
-import {Button, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, UtmCampaignType, centsToDollars, formatNumber, getUtmType} from '@tryghost/shade';
+import {Button, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, centsToDollars, formatNumber} from '@tryghost/shade';
 import {getFaviconDomain, getSymbol, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useMrrHistory, useUtmGrowthStats} from '@tryghost/admin-x-framework/api/stats';
+import {useMrrHistory} from '@tryghost/admin-x-framework/api/stats';
 import {useTopSourcesGrowth} from '@src/hooks/useTopSourcesGrowth';
 
 interface ProcessedReferrerData {
@@ -82,7 +82,6 @@ interface GrowthSourcesProps {
     showViewAll?: boolean;
     sortBy?: SourcesOrder;
     setSortBy?: (sortBy: SourcesOrder) => void;
-    selectedCampaign?: UtmCampaignType;
 }
 
 export const GrowthSources: React.FC<GrowthSourcesProps> = ({
@@ -90,8 +89,7 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
     limit = 20,
     showViewAll = false,
     sortBy: externalSortBy,
-    setSortBy: externalSetSortBy,
-    selectedCampaign = ''
+    setSortBy: externalSetSortBy
 }) => {
     const {data: globalData} = useGlobalData();
     const {data: mrrHistoryResponse} = useMrrHistory();
@@ -106,23 +104,8 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
     // Convert our sort format to backend format
     const backendOrderBy = sortBy.replace('free_members', 'signups').replace('paid_members', 'paid_conversions');
 
-    // When showViewAll is true, fetch more data to detect if there are more results than the preview limit
-    // This allows us to show the "View all" footer when processedData.length > limit
-    const fetchLimit = showViewAll ? 100 : limit;
-
-    // Use the new endpoint with server-side sorting and limiting for regular sources
-    const {data: referrersData, isLoading: isSourcesLoading} = useTopSourcesGrowth(range, backendOrderBy, fetchLimit);
-
-    // Get UTM campaign data when a campaign is selected
-    const utmType = getUtmType(selectedCampaign);
-    const {data: utmData, isFetching: isUtmFetching} = useUtmGrowthStats({
-        searchParams: {
-            utm_type: utmType,
-            limit: String(fetchLimit),
-            order: backendOrderBy
-        },
-        enabled: !!selectedCampaign
-    });
+    // Use the new endpoint with server-side sorting and limiting
+    const {data: referrersData, isLoading} = useTopSourcesGrowth(range, backendOrderBy, limit);
 
     // Get site URL for favicon processing
     const siteUrl = globalData?.url as string | undefined;
@@ -150,29 +133,6 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
 
     // Process data for display (no client-side sorting needed since backend handles it)
     const processedData = React.useMemo((): ProcessedReferrerData[] => {
-        // If a campaign is selected, only show UTM data (not regular sources)
-        if (selectedCampaign) {
-            // If we have UTM data and we're not fetching, show it
-            if (utmData?.stats && !isUtmFetching) {
-                // UTM values are campaign identifiers, not domains - don't show icons or links
-                return utmData.stats.map((item) => {
-                    const source = item.utm_value || '(not set)';
-                    return {
-                        source,
-                        free_members: item.free_members,
-                        paid_members: item.paid_members,
-                        mrr: item.mrr,
-                        iconSrc: '',
-                        displayName: source,
-                        linkUrl: undefined
-                    };
-                });
-            }
-            // If fetching or no data yet, return empty array (don't show regular sources)
-            return [];
-        }
-
-        // Default to regular sources data when no campaign is selected
         if (!referrersData?.stats) {
             return [];
         }
@@ -190,15 +150,15 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
 
             return {
                 source,
-                free_members: item.signups,
-                paid_members: item.paid_conversions,
+                free_members: item.signups, // Backend returns 'signups', we map to 'free_members' for display
+                paid_members: item.paid_conversions, // Backend returns 'paid_conversions', we map to 'paid_members' for display
                 mrr: item.mrr,
                 iconSrc,
                 displayName: source,
                 linkUrl
             };
         });
-    }, [referrersData, utmData, selectedCampaign, siteUrl, defaultSourceIconUrl, isUtmFetching]);
+    }, [referrersData, siteUrl]);
 
     const title = 'Top sources';
     const description = `Where did your growth come from ${getPeriodText(range)}`;
@@ -226,20 +186,9 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
         );
     }
 
-    // Show loading state when:
-    // 1. Loading regular sources data and not showing campaigns
-    // 2. Fetching UTM data and showing a campaign
-    const isLoading = (!selectedCampaign && isSourcesLoading && !referrersData) || (!!selectedCampaign && isUtmFetching);
-
     if (isLoading) {
         return (
-            <TableBody>
-                <TableRow className='last:border-none'>
-                    <TableCell className='border-none py-12 group-hover:!bg-transparent' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
-                        <SkeletonTable lines={5} />
-                    </TableCell>
-                </TableRow>
-            </TableBody>
+            <SkeletonTable lines={5} />
         );
     }
 

--- a/apps/stats/src/views/Stats/Web/Web.tsx
+++ b/apps/stats/src/views/Stats/Web/Web.tsx
@@ -7,7 +7,7 @@ import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
 import TopContent from './components/TopContent';
 import WebKPIs, {KpiDataItem} from './components/WebKPIs';
-import {Card, CardContent, UtmCampaignType, UtmTabType, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
+import {CampaignType, Card, CardContent, TabType, formatDuration, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {KpiMetric} from '@src/types/kpi';
 import {Navigate, useAppContext, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
@@ -51,8 +51,8 @@ const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {appSettings} = useAppContext();
-    const [selectedTab, setSelectedTab] = useState<UtmTabType>('sources');
-    const [selectedCampaign, setSelectedCampaign] = useState<UtmCampaignType>('');
+    const [selectedTab, setSelectedTab] = useState<TabType>('sources');
+    const [selectedCampaign, setSelectedCampaign] = useState<CampaignType>('');
     
     // Check if UTM tracking is enabled in labs
     const utmTrackingEnabled = data?.labs?.utmTracking || false;
@@ -95,7 +95,7 @@ const Web: React.FC = () => {
     });
 
     // Map campaign types to endpoints
-    const campaignEndpointMap: Record<UtmCampaignType, string> = {
+    const campaignEndpointMap: Record<CampaignType, string> = {
         '': '',
         'UTM sources': 'api_top_utm_sources',
         'UTM mediums': 'api_top_utm_mediums',
@@ -123,7 +123,7 @@ const Web: React.FC = () => {
             }
             
             // Map UTM field names to the generic key name
-            const utmKeyMap: Record<UtmCampaignType, string> = {
+            const utmKeyMap: Record<CampaignType, string> = {
                 '': '',
                 'UTM sources': 'utm_source',
                 'UTM mediums': 'utm_medium',

--- a/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
+++ b/apps/stats/src/views/Stats/Web/components/SourcesCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
-import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, UtmCampaignTabs, UtmCampaignType, UtmTabType, formatNumber, formatPercentage} from '@tryghost/shade';
+import {Button, CampaignType, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, HTable, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, TabType, UtmCampaignTabs, formatNumber, formatPercentage} from '@tryghost/shade';
 import {getPeriodText} from '@src/utils/chart-helpers';
 
 // Default source icon URL - apps can override this
@@ -75,11 +75,11 @@ interface SourcesCardProps {
     siteIcon?: string;
     defaultSourceIconUrl?: string;
     isLoading: boolean;
-    selectedTab: UtmTabType;
-    selectedCampaign: UtmCampaignType;
+    selectedTab: TabType;
+    selectedCampaign: CampaignType;
     utmTrackingEnabled?: boolean;
-    onTabChange: (tab: UtmTabType) => void;
-    onCampaignChange: (campaign: UtmCampaignType) => void;
+    onTabChange: (tab: TabType) => void;
+    onCampaignChange: (campaign: CampaignType) => void;
 }
 
 export const SourcesCard: React.FC<SourcesCardProps> = ({

--- a/apps/stats/src/views/Stats/components/SourceIcon.tsx
+++ b/apps/stats/src/views/Stats/components/SourceIcon.tsx
@@ -8,11 +8,6 @@ interface SourceIconProps {
 }
 
 const SourceIcon: React.FC<SourceIconProps> = ({defaultSourceIconUrl, displayName, iconSrc}) => {
-    // Don't render an icon if iconSrc is empty (e.g., for UTM campaign values)
-    if (!iconSrc) {
-        return null;
-    }
-
     return (
         <>
             {displayName.trim().toLowerCase().endsWith('newsletter') ? (

--- a/apps/stats/test/unit/utils/content-helpers.test.ts
+++ b/apps/stats/test/unit/utils/content-helpers.test.ts
@@ -8,6 +8,24 @@ import {
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 describe('content-helpers', () => {
+    describe('CONTENT_TYPES constants', () => {
+        it('exports correct content type constants', () => {
+            expect(CONTENT_TYPES.POSTS).toBe('posts');
+            expect(CONTENT_TYPES.PAGES).toBe('pages');
+            expect(CONTENT_TYPES.POSTS_AND_PAGES).toBe('posts_and_pages');
+            expect(CONTENT_TYPES.SOURCES).toBe('sources');
+        });
+
+        it('exports all expected content types', () => {
+            const keys = Object.keys(CONTENT_TYPES);
+            expect(keys).toContain('POSTS');
+            expect(keys).toContain('PAGES');
+            expect(keys).toContain('POSTS_AND_PAGES');
+            expect(keys).toContain('SOURCES');
+            expect(keys).toHaveLength(4);
+        });
+    });
+
     describe('getContentTitle', () => {
         it('returns correct title for posts', () => {
             expect(getContentTitle(CONTENT_TYPES.POSTS)).toBe('Top posts');
@@ -44,7 +62,7 @@ describe('content-helpers', () => {
         it('returns correct description for posts', () => {
             mockGetPeriodText.mockReturnValue('in the last 30 days');
             const result = getContentDescription(CONTENT_TYPES.POSTS, 30, mockGetPeriodText);
-
+            
             expect(result).toBe('Your highest viewed posts in the last 30 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(30);
         });
@@ -52,7 +70,7 @@ describe('content-helpers', () => {
         it('returns correct description for pages', () => {
             mockGetPeriodText.mockReturnValue('in the last 7 days');
             const result = getContentDescription(CONTENT_TYPES.PAGES, 7, mockGetPeriodText);
-
+            
             expect(result).toBe('Your highest viewed pages in the last 7 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(7);
         });
@@ -60,7 +78,7 @@ describe('content-helpers', () => {
         it('returns correct description for posts and pages', () => {
             mockGetPeriodText.mockReturnValue('today');
             const result = getContentDescription(CONTENT_TYPES.POSTS_AND_PAGES, 1, mockGetPeriodText);
-
+            
             expect(result).toBe('Your highest viewed posts or pages today');
             expect(mockGetPeriodText).toHaveBeenCalledWith(1);
         });
@@ -68,7 +86,7 @@ describe('content-helpers', () => {
         it('returns correct description for sources', () => {
             mockGetPeriodText.mockReturnValue('in the last 90 days');
             const result = getContentDescription(CONTENT_TYPES.SOURCES, 90, mockGetPeriodText);
-
+            
             expect(result).toBe('How readers found your site in the last 90 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(90);
         });
@@ -76,7 +94,7 @@ describe('content-helpers', () => {
         it('returns default description for unknown content type', () => {
             mockGetPeriodText.mockReturnValue('(all time)');
             const result = getContentDescription('unknown' as ContentType, 1000, mockGetPeriodText);
-
+            
             expect(result).toBe('Your highest viewed posts or pages (all time)');
             expect(mockGetPeriodText).toHaveBeenCalledWith(1000);
         });
@@ -84,7 +102,7 @@ describe('content-helpers', () => {
         it('handles different range values correctly', () => {
             mockGetPeriodText.mockReturnValue('this year');
             const result = getContentDescription(CONTENT_TYPES.POSTS, -1, mockGetPeriodText);
-
+            
             expect(result).toBe('Your highest viewed posts this year');
             expect(mockGetPeriodText).toHaveBeenCalledWith(-1);
         });
@@ -100,7 +118,7 @@ describe('content-helpers', () => {
         it('returns correct growth description for posts', () => {
             mockGetPeriodText.mockReturnValue('in the last 30 days');
             const result = getGrowthContentDescription(CONTENT_TYPES.POSTS, 30, mockGetPeriodText);
-
+            
             expect(result).toBe('Which posts drove the most growth in the last 30 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(30);
         });
@@ -108,7 +126,7 @@ describe('content-helpers', () => {
         it('returns correct growth description for pages', () => {
             mockGetPeriodText.mockReturnValue('in the last 7 days');
             const result = getGrowthContentDescription(CONTENT_TYPES.PAGES, 7, mockGetPeriodText);
-
+            
             expect(result).toBe('Which pages drove the most growth in the last 7 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(7);
         });
@@ -116,7 +134,7 @@ describe('content-helpers', () => {
         it('returns correct growth description for posts and pages', () => {
             mockGetPeriodText.mockReturnValue('today');
             const result = getGrowthContentDescription(CONTENT_TYPES.POSTS_AND_PAGES, 1, mockGetPeriodText);
-
+            
             expect(result).toBe('Which posts or pages drove the most growth today');
             expect(mockGetPeriodText).toHaveBeenCalledWith(1);
         });
@@ -124,7 +142,7 @@ describe('content-helpers', () => {
         it('returns correct growth description for sources', () => {
             mockGetPeriodText.mockReturnValue('in the last 90 days');
             const result = getGrowthContentDescription(CONTENT_TYPES.SOURCES, 90, mockGetPeriodText);
-
+            
             expect(result).toBe('How readers found your site in the last 90 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(90);
         });
@@ -132,7 +150,7 @@ describe('content-helpers', () => {
         it('returns default growth description for unknown content type', () => {
             mockGetPeriodText.mockReturnValue('(all time)');
             const result = getGrowthContentDescription('unknown' as ContentType, 1000, mockGetPeriodText);
-
+            
             expect(result).toBe('Which posts drove the most growth (all time)');
             expect(mockGetPeriodText).toHaveBeenCalledWith(1000);
         });
@@ -140,7 +158,7 @@ describe('content-helpers', () => {
         it('calls getPeriodText with correct range value', () => {
             mockGetPeriodText.mockReturnValue('test period');
             getGrowthContentDescription(CONTENT_TYPES.POSTS, 123, mockGetPeriodText);
-
+            
             expect(mockGetPeriodText).toHaveBeenCalledWith(123);
             expect(mockGetPeriodText).toHaveBeenCalledTimes(1);
         });

--- a/e2e/helpers/pages/admin/analytics/AnalyticsGrowthPage.ts
+++ b/e2e/helpers/pages/admin/analytics/AnalyticsGrowthPage.ts
@@ -8,8 +8,6 @@ class TopContentCard extends BasePage {
     readonly postsButton: Locator;
     readonly pagesButton: Locator;
     readonly sourcesButton: Locator;
-    readonly campaignsDropdown: Locator;
-    readonly topContentRows: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -19,18 +17,6 @@ class TopContentCard extends BasePage {
         this.postsButton = this.contentCard.getByRole('tab', {name: 'Posts', exact: true});
         this.pagesButton = this.contentCard.getByRole('tab', {name: 'Pages', exact: true});
         this.sourcesButton = this.contentCard.getByRole('tab', {name: 'Sources', exact: true});
-        this.campaignsDropdown = this.contentCard.getByRole('tab', {name: 'Campaigns', exact: true});
-        this.topContentRows = this.contentCard.locator('tbody tr');
-    }
-
-    async openCampaignsDropdown() {
-        // force: true because Radix dropdowns add an overlay button on top of the main button
-        await this.campaignsDropdown.click({force: true});
-    }
-
-    async selectCampaignType(type: 'UTM mediums' | 'UTM sources' | 'UTM campaigns' | 'UTM terms' | 'UTM contents') {
-        const option = this.page.getByRole('menuitem', {name: type});
-        await option.click();
     }
 }
 

--- a/e2e/helpers/pages/admin/analytics/post-analytics/PostAnalyticsGrowthPage.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/PostAnalyticsGrowthPage.ts
@@ -1,38 +1,10 @@
 import {Locator, Page} from '@playwright/test';
-import {BasePage} from '../../../BasePage';
 import {AdminPage} from '../../AdminPage';
-
-class TopSourcesCard extends BasePage {
-    readonly contentCard: Locator;
-    readonly sourcesButton: Locator;
-    readonly campaignsDropdown: Locator;
-    readonly topContentRows: Locator;
-
-    constructor(page: Page) {
-        super(page);
-
-        this.contentCard = page.getByTestId('top-sources-card');
-        this.sourcesButton = this.contentCard.getByRole('tab', {name: 'Sources', exact: true});
-        this.campaignsDropdown = this.contentCard.getByRole('tab', {name: 'Campaigns', exact: true});
-        this.topContentRows = this.contentCard.locator('tbody tr');
-    }
-
-    async openCampaignsDropdown() {
-        // force: true because Radix dropdowns add an overlay button on top of the main button
-        await this.campaignsDropdown.click({force: true});
-    }
-
-    async selectCampaignType(type: 'UTM sources' | 'UTM mediums' | 'UTM campaigns' | 'UTM contents' | 'UTM terms') {
-        const option = this.page.getByRole('menuitem', {name: type});
-        await option.click();
-    }
-}
 
 export class PostAnalyticsGrowthPage extends AdminPage {
     readonly membersCard: Locator;
     readonly viewMemberButton: Locator;
     readonly topSourcesCard: Locator;
-    readonly topContent: TopSourcesCard;
 
     constructor(page: Page) {
         super(page);
@@ -41,6 +13,5 @@ export class PostAnalyticsGrowthPage extends AdminPage {
         this.viewMemberButton = this.membersCard.getByRole('button', {name: 'View member'});
 
         this.topSourcesCard = this.page.getByTestId('top-sources-card');
-        this.topContent = new TopSourcesCard(page);
     }
 }

--- a/e2e/tests/admin/analytics/growth.test.ts
+++ b/e2e/tests/admin/analytics/growth.test.ts
@@ -1,13 +1,7 @@
-import {test, expect, withIsolatedPage} from '../../../helpers/playwright';
+import {test, expect} from '../../../helpers/playwright';
 import {AnalyticsGrowthPage} from '../../../helpers/pages/admin';
-import {signupViaPortal} from '../../../helpers/playwright/flows/signup';
-import {HomePage} from '../../../helpers/pages/public';
-import {extractMagicLink} from '../../../helpers/services/email/utils';
-import {EmailClient, MailhogClient} from '../../../helpers/services/email/MailhogClient';
-import {EmailMessageBody} from '../../../helpers/services/email/EmailMessageBody';
 
 test.describe('Ghost Admin - Growth', () => {
-    const emailClient: EmailClient = new MailhogClient();
     let growthPage: AnalyticsGrowthPage;
 
     test.beforeEach(async ({page}) => {
@@ -39,44 +33,5 @@ test.describe('Ghost Admin - Growth', () => {
 
         await expect(growthPage.topContent.contentCard).toContainText('How readers found your site in the last 30 days');
         await expect(growthPage.topContent.contentCard).toContainText('No conversions');
-    });
-
-    test.describe('Campaigns', function () {
-        test.use({labs: {utmTracking: true}});
-
-        test('empty top content card - campaigns', async () => {
-            await growthPage.topContent.openCampaignsDropdown();
-            await growthPage.topContent.selectCampaignType('UTM campaigns');
-
-            await expect(growthPage.topContent.contentCard).toContainText('Which campaigns drove the most growth in the last 30 days');
-            await expect(growthPage.topContent.contentCard).toContainText('No conversions');
-        });
-
-        test('records free members when UTM campaign is set', async ({browser}) => {
-            const utmCampaign = 'spring-sale';
-
-            // Create a new member via portal with UTM campaign set
-            await withIsolatedPage(browser, {}, async ({page: publicPage}) => {
-                const homePage = new HomePage(publicPage);
-                await homePage.goto(`/?utm_campaign=${utmCampaign}`);
-                const {emailAddress} = await signupViaPortal(publicPage);
-
-                const message = await emailClient.waitForEmail(emailAddress);
-                const emailMessageBodyParts = new EmailMessageBody(message);
-                const emailTextBody = emailMessageBodyParts.getTextContent();
-
-                const magicLink = extractMagicLink(emailTextBody);
-                await publicPage.goto(magicLink);
-                await expect(homePage.accountButton).toBeVisible();
-            });
-
-            // Verify that the member appears in the top content card
-            await growthPage.goto();
-            await growthPage.topContent.openCampaignsDropdown();
-            await growthPage.topContent.selectCampaignType('UTM campaigns');
-            await expect(growthPage.topContent.contentCard).toContainText('Which campaigns drove the most growth in the last 30 days');
-            await expect(growthPage.topContent.topContentRows).toHaveCount(1);
-            await expect(growthPage.topContent.topContentRows.first()).toContainText(`${utmCampaign}+1`);
-        });
     });
 });

--- a/e2e/tests/admin/analytics/post-analytics/growth.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/growth.test.ts
@@ -5,17 +5,8 @@ import {
     PostAnalyticsGrowthPage,
     MembersPage
 } from '../../../../helpers/pages/admin';
-import {withIsolatedPage} from '../../../../helpers/playwright';
-import {extractMagicLink} from '../../../../helpers/services/email/utils';
-import {signupViaPortal} from '../../../../helpers/playwright/flows/signup';
-import {HomePage} from '../../../../helpers/pages/public';
-import {EmailClient, MailhogClient} from '../../../../helpers/services/email/MailhogClient';
-import {EmailMessageBody} from '../../../../helpers/services/email/EmailMessageBody';
-import {createPostFactory} from '../../../../data-factory';
 
 test.describe('Ghost Admin - Post Analytics - Growth', () => {
-    const emailClient: EmailClient = new MailhogClient();
-
     test.beforeEach(async ({page}) => {
         const analyticsOverviewPage = new AnalyticsOverviewPage(page);
         await analyticsOverviewPage.goto();
@@ -45,58 +36,7 @@ test.describe('Ghost Admin - Post Analytics - Growth', () => {
     test('empty top sources card', async ({page}) => {
         const postAnalyticsPageGrowthPage = new PostAnalyticsGrowthPage(page);
 
-        await expect(postAnalyticsPageGrowthPage.topContent.sourcesButton).not.toBeVisible();
-        await expect(postAnalyticsPageGrowthPage.topContent.campaignsDropdown).not.toBeVisible();
         await expect(postAnalyticsPageGrowthPage.topSourcesCard).toContainText('No sources data available');
-    });
-
-    test.describe('Campaigns', function () {
-        test.use({labs: {utmTracking: true}});
-
-        test('empty state top sources card - with UTM tracking enabled', async ({page}) => {
-            const postAnalyticsPageGrowthPage = new PostAnalyticsGrowthPage(page);
-
-            await expect(postAnalyticsPageGrowthPage.topContent.sourcesButton).not.toBeVisible();
-            await expect(postAnalyticsPageGrowthPage.topContent.campaignsDropdown).not.toBeVisible();
-            await expect(postAnalyticsPageGrowthPage.topSourcesCard).toContainText('No sources data available');
-        });
-
-        test('attributes free members to UTM Campaigns', async ({page, browser}) => {
-            const utmCampaign = 'spring-sale';
-
-            const postFactory = createPostFactory(page.request);
-            const post = await postFactory.create({
-                title: 'UTM Campaign Test Post',
-                status: 'published'
-            });
-
-            // Create a new member via portal with UTM campaign set on the specific post
-            await withIsolatedPage(browser, {}, async ({page: publicPage}) => {
-                const homePage = new HomePage(publicPage);
-                await homePage.goto(`/${post.slug}?utm_campaign=${utmCampaign}`);
-                const {emailAddress} = await signupViaPortal(publicPage);
-
-                const message = await emailClient.waitForEmail(emailAddress);
-                const emailMessageBodyParts = new EmailMessageBody(message);
-                const emailTextBody = emailMessageBodyParts.getTextContent();
-
-                const magicLink = extractMagicLink(emailTextBody);
-                await publicPage.goto(magicLink);
-                await expect(homePage.accountButton).toBeVisible();
-            });
-
-            // Verify that the member appears in the campaigns view for this specific post
-            const postAnalyticsGrowthPage = new PostAnalyticsGrowthPage(page);
-            await postAnalyticsGrowthPage.goto(`/ghost/#/posts/analytics/${post.id}/growth`);
-            await postAnalyticsGrowthPage.topContent.openCampaignsDropdown();
-            await postAnalyticsGrowthPage.topContent.selectCampaignType('UTM campaigns');
-
-            await expect(postAnalyticsGrowthPage.topContent.contentCard).toContainText('UTM campaigns');
-            await expect(postAnalyticsGrowthPage.topContent.contentCard).toContainText('Where did your growth come from?');
-            await expect(postAnalyticsGrowthPage.topContent.topContentRows).toHaveCount(1);
-            await expect(postAnalyticsGrowthPage.topContent.topContentRows.first()).toContainText(utmCampaign);
-            await expect(postAnalyticsGrowthPage.topContent.topContentRows.first()).toContainText('+1');
-        });
     });
 });
 


### PR DESCRIPTION
This reverts commit 3c15df68a62b3ffd96cce83b9e01eed36d0e0023.

We've decided to go in a different direction for the UX here after seeing how this works live. There is a lot of noise in the UTM parameters that a real site sees in production, and the current UX doesn't do much to help the user make sense of it.