### PR TITLE
Added tier name truncation in the status column of the members list

### DIFF
--- a/ghost/admin/app/components/members/list-item.hbs
+++ b/ghost/admin/app/components/members/list-item.hbs
@@ -17,7 +17,7 @@
             {{else}}
                 <span class="midlightgrey">-</span>
             {{/if}}
-            <div class="midgrey">{{this.tiers}}</div>
+            <div class="gh-members-list-status-tiers midgrey">{{this.tiers}}</div>
         </LinkTo>
     {{else}}
         <LinkTo @route="member" @model={{@member}} @query={{@query}} class="gh-list-data" data-test-table-data="status">

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -146,6 +146,12 @@ p.gh-members-list-email {
     margin: -2px 0 -1px;
 }
 
+.gh-members-list-status-tiers {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .gh-members-list-open-rate,
 .gh-members-list-geolocation {
     width: 150px;


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/24693

This PR adds some style to better handle long tier names in the status column of the members list (`/ghost/#/members`).
The truncation was already applied in other columns (e.g. for the email address in the member details column), but it was missing for the tier, causing a long tier name to overflow into adjacent columns.

- Before

<img width="1404" height="69" alt="Screenshot from 2025-10-17 08-16-44" src="https://github.com/user-attachments/assets/369d76dd-f487-4d63-bb23-c19687708069" />

- After

<img width="1404" height="69" alt="Screenshot from 2025-10-17 08-15-06" src="https://github.com/user-attachments/assets/4d65a308-66d2-4428-980f-4ef5690af2df" />