### PR TITLE
Improved spacing of the publish page on small screens

### DIFF
--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -231,8 +231,7 @@
         align-items: center;
         height: 64px;
         margin: 0;
-        padding: 0;
-        padding-left: 15px;
+        padding: 0 15px;
         background-color: var(--white);
         border-radius: 0;
     }
@@ -658,8 +657,8 @@
 
 .gh-publish-cta {
     display: flex;
-    width: max-content;
     gap: 3.2rem;
+    width: 100%;
 }
 
 .gh-publish-cta .gh-btn {

--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -348,7 +348,8 @@
 
 @media (max-width: 1024px) {
     .gh-publish-settings-container {
-        padding-top: 10vh;
+        /* clear the 64px fixed mobile header (.gh-publish-header) before the 10vh airy spacing kicks in on taller viewports */
+        padding-top: max(10vh, 6rem);
     }
 }
 
@@ -657,7 +658,8 @@
 
 .gh-publish-cta {
     display: flex;
-    gap: 3.2rem;
+    flex-wrap: wrap;
+    gap: 1.2rem 3.2rem;
     width: 100%;
 }
 
@@ -717,6 +719,8 @@
 
 .gh-publish-cta-secondary {
     display: block;
+    flex-shrink: 0;
+    max-width: 100%;
     overflow: hidden;
     color: var(--midgrey);
     font-weight: 400;
@@ -732,6 +736,13 @@
     color: var(--darkgrey);
     font-size: 1.45rem;
     text-align: left;
+}
+
+/* once the secondary wraps below the button on narrow screens, indent it to align with the button's label text (.gh-btn-large span has 20px inline padding) */
+@media (max-width: 500px) {
+    .gh-publish-cta-secondary {
+        padding-left: 0.5rem;
+    }
 }
 
 .gh-publish-confirmation {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/24898

This PR improves the right spacing of the publish page header, by making it proportional to the left one. It also ensures that the "Back to settings" secondary CTA does not overflow horizontally on very narrow viewports.

- Before

<img width="799" height="987" alt="image" src="https://github.com/user-attachments/assets/88a590a5-842b-46b0-9b27-232e1fcaf067" />

- After

<img width="799" height="987" alt="image" src="https://github.com/user-attachments/assets/bd3f4d87-e470-4d31-b2c1-c1201ee5ddb6" />