### PR TITLE
Moved static url prefixes out of config

### DIFF
--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -22,8 +22,8 @@ const errorHandler = require('@tryghost/mw-error-handler');
 const mw = require('./middleware');
 
 const STATIC_IMAGE_URL_PREFIX = `/${urlUtils.STATIC_IMAGE_URL_PREFIX}`;
-const STATIC_MEDIA_URL_PREFIX = `/${config.getStaticUrlPrefix('media')}`;
-const STATIC_FILES_URL_PREFIX = `/${config.getStaticUrlPrefix('files')}`;
+const STATIC_MEDIA_URL_PREFIX = `/${urlUtils.STATIC_MEDIA_URL_PREFIX}`;
+const STATIC_FILES_URL_PREFIX = `/${urlUtils.STATIC_FILES_URL_PREFIX}`;
 
 let router;
 

--- a/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalFilesStorage.js
@@ -1,6 +1,7 @@
 // # Local File System Storage module
 // The (default) module for storing media, using the local file system
 const config = require('../../../shared/config');
+const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
 const messages = {
@@ -14,7 +15,7 @@ class LocalFilesStorage extends LocalStorageBase {
         super({
             storagePath: config.getContentPath('files'),
             siteUrl: config.getSiteUrl(),
-            staticFileURLPrefix: config.getStaticUrlPrefix('files'),
+            staticFileURLPrefix: urlUtils.STATIC_FILES_URL_PREFIX,
             errorMessages: messages
         });
     }

--- a/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
+++ b/ghost/core/core/server/adapters/storage/LocalMediaStorage.js
@@ -1,6 +1,7 @@
 // # Local File System Media Storage module
 // The (default) module for storing media, using the local file system
 const config = require('../../../shared/config');
+const urlUtils = require('../../../shared/url-utils');
 const LocalStorageBase = require('./LocalStorageBase');
 
 const messages = {
@@ -13,7 +14,7 @@ class LocalMediaStorage extends LocalStorageBase {
     constructor() {
         super({
             storagePath: config.getContentPath('media'),
-            staticFileURLPrefix: config.getStaticUrlPrefix('media'),
+            staticFileURLPrefix: urlUtils.STATIC_MEDIA_URL_PREFIX,
             siteUrl: config.getSiteUrl(),
             errorMessages: messages
         });

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/files.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/files.js
@@ -1,7 +1,8 @@
 const config = require('../../../../../../shared/config');
+const urlUtils = require('../../../../../../shared/url-utils');
 
 function getURL(urlPath) {
-    const media = new RegExp('^' + config.getSubdir() + '/' + config.getStaticUrlPrefix('files'));
+    const media = new RegExp('^' + config.getSubdir() + '/' + urlUtils.STATIC_FILES_URL_PREFIX);
     const absolute = media.test(urlPath) ? true : false;
 
     if (absolute) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/media.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/media.js
@@ -1,7 +1,8 @@
 const config = require('../../../../../../shared/config');
+const urlUtils = require('../../../../../../shared/url-utils');
 
 function getURL(urlPath) {
-    const media = new RegExp('^' + config.getSubdir() + '/' + config.getStaticUrlPrefix('media'));
+    const media = new RegExp('^' + config.getSubdir() + '/' + urlUtils.STATIC_MEDIA_URL_PREFIX);
     const absolute = media.test(urlPath) ? true : false;
 
     if (absolute) {

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -65,25 +65,6 @@ const isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
 };
 
 /**
- * @callback getStaticUrlPrefixFn
- * @param {'images'|'media'|'files'} type
- * @returns {string}
- */
-function getStaticUrlPrefix(type) {
-    switch (type) {
-    case 'images':
-        return 'content/images';
-    case 'media':
-        return 'content/media';
-    case 'files':
-        return 'content/files';
-    default:
-        // eslint-disable-next-line ghost/ghost-custom/no-native-error
-        throw new Error('getStaticUrlPrefix was called with: ' + type);
-    }
-}
-
-/**
  * @callback getContentPathFn
  * @param {string} type - the type of context you want the path for
  * @returns {string}
@@ -120,12 +101,10 @@ const getContentPath = function getContentPath(type) {
  * @typedef ConfigHelpers
  * @property {isPrivacyDisabledFn} isPrivacyDisabled
  * @property {getContentPathFn} getContentPath
- * @property {getStaticUrlPrefixFn} getStaticUrlPrefix
  */
 module.exports.bindAll = (nconf) => {
     nconf.isPrivacyDisabled = isPrivacyDisabled.bind(nconf);
     nconf.getContentPath = getContentPath.bind(nconf);
     nconf.getBackendMountPath = getBackendMountPath.bind(nconf);
     nconf.getFrontendMountPath = getFrontendMountPath.bind(nconf);
-    nconf.getStaticUrlPrefix = getStaticUrlPrefix.bind(nconf);
 };

--- a/ghost/core/core/shared/url-utils.js
+++ b/ghost/core/core/shared/url-utils.js
@@ -2,7 +2,6 @@ const UrlUtils = require('@tryghost/url-utils');
 const config = require('./config');
 
 const BASE_API_PATH = '/ghost/api';
-
 const urlUtils = new UrlUtils({
     getSubdir: config.getSubdir,
     getSiteUrl: config.getSiteUrl,
@@ -14,3 +13,6 @@ const urlUtils = new UrlUtils({
 
 module.exports = urlUtils;
 module.exports.BASE_API_PATH = BASE_API_PATH;
+module.exports.STATIC_IMAGE_URL_PREFIX = 'content/images';
+module.exports.STATIC_MEDIA_URL_PREFIX = 'content/media';
+module.exports.STATIC_FILES_URL_PREFIX = 'content/files';

--- a/ghost/core/test/unit/shared/config/helpers.test.js
+++ b/ghost/core/test/unit/shared/config/helpers.test.js
@@ -51,18 +51,4 @@ describe('vhost utils', function () {
             configUtils.config.getFrontendMountPath().should.eql(/.*/);
         });
     });
-
-    describe('getStaticUrlPrefix', function () {
-        it('should return the correct static url prefix', function () {
-            configUtils.config.getStaticUrlPrefix('images').should.eql('content/images');
-            configUtils.config.getStaticUrlPrefix('media').should.eql('content/media');
-            configUtils.config.getStaticUrlPrefix('files').should.eql('content/files');
-        });
-
-        it('should throw an error if the type is not valid', function () {
-            (function () {
-                configUtils.config.getStaticUrlPrefix('invalid');
-            }).should.throw('getStaticUrlPrefix was called with: invalid');
-        });
-    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1524

We are already reading the static url prefix for images from url-utils
and we're going to be updating url-utils to be performing logic based on
these constants. The idea here is to consolidate our usage and transfer
ownership of the constants to url-utils. For now we are setting this in
Ghost with `module.exports =` but that is temporary until the package
has been updated to export these values itself.