### PR TITLE
Fixed STATIC_IMAGE_URL_PREFIX assignment

### DIFF
--- a/ghost/core/core/shared/url-utils.js
+++ b/ghost/core/core/shared/url-utils.js
@@ -13,6 +13,5 @@ const urlUtils = new UrlUtils({
 
 module.exports = urlUtils;
 module.exports.BASE_API_PATH = BASE_API_PATH;
-module.exports.STATIC_IMAGE_URL_PREFIX = 'content/images';
 module.exports.STATIC_MEDIA_URL_PREFIX = 'content/media';
 module.exports.STATIC_FILES_URL_PREFIX = 'content/files';


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/7a619f05 ref https://linear.app/ghost/issue/PRO-1524

This is a `getter` on the UrlUtils class and cannot be overriden.
