### PR TITLE
Fixed running Ember tests locally on :4200/tests/

### DIFF
--- a/ghost/admin/app/services/onboarding.js
+++ b/ghost/admin/app/services/onboarding.js
@@ -70,7 +70,9 @@ export default class OnboardingService extends Service {
     }
 
     @action
-    async completeChecklist() {
+    async completeChecklist(event) {
+        event?.preventDefault();
+
         const settings = this.settings;
 
         settings.checklistState = 'completed';
@@ -79,7 +81,9 @@ export default class OnboardingService extends Service {
     }
 
     @action
-    async dismissChecklist() {
+    async dismissChecklist(event) {
+        event?.preventDefault();
+
         const settings = this.settings;
 
         settings.checklistState = 'dismissed';

--- a/ghost/admin/tests/index.html
+++ b/ghost/admin/tests/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <base href="{{rootURL}}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Ghost Tests</title>
     <meta name="description" content="">


### PR DESCRIPTION
no issue

- at some point in the not too distant past the chunked JS files output by `ember-auto-import` started to be included in the `tests/index.html` file with no leading `/` resulting in 404s and an empty tests screen
- for CI tests the build runs in the `test` env so our conditional in `ember-cli-build.js` to set `publicAssetURL` to `undefined` and let auto-import do it's thing worked
- for local browser tests when running `yarn dev`, `ember-cli-build.js` is only run in the "dev" env so `publicAssetURL` was always set to the relative `assets/` path which is necessary for dev environments to work in subdirectory setups
- the fix was to add `<base href="{{rootURL}}">` to the tests `index.html` template so any relative `src` attributes are interpreted by the browser as being relative to `/` rather than `/tests/` when not set
