### PR TITLE
Fixed flaky tiers update browser test

### DIFF
--- a/ghost/core/test/e2e-browser/admin/tiers.spec.js
+++ b/ghost/core/test/e2e-browser/admin/tiers.spec.js
@@ -102,6 +102,7 @@ test.describe('Admin', () => {
             });
 
             await test.step('Check yearly price and description', async () => {
+                await portalFrame.locator('[data-test-button="switch-yearly"]').click();
                 await expect(portalTierCard.locator('.amount').first()).toHaveText(updatedYearlyPrice);
                 await expect(portalTierCard.locator('.gh-portal-product-description').first()).toHaveText(updatedDescription);
             });


### PR DESCRIPTION
no issue

- this test sometimes failed locally because it opened on the Monthly prices but the test assumed it would open on Yearly
- updated test to click "Yearly" before checking the yearly price as the test is only concerned about seeing updated prices reflect on the front-end, not which ones will be shown by default
