### PR TITLE
Resolve CSS specificity conflicts between Ember and React apps

### DIFF
--- a/apps/shade/preflight.css
+++ b/apps/shade/preflight.css
@@ -1,4 +1,4 @@
-.shade {
+:where(.shade) {
     /*
     1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
     2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)

--- a/ghost/admin/app/styles/patterns/global.css
+++ b/ghost/admin/app/styles/patterns/global.css
@@ -629,11 +629,18 @@ input[type="image"] {
     position: relative;
 }
 
+
 .show {
+    display: block;
+}
+.ember-application .show {
     display: block !important;
 }
 
 .hidden {
+    display: none;
+}
+.ember-application .hidden {
     visibility: hidden !important;
     display: none !important;
 }


### PR DESCRIPTION
**Ref:** https://linear.app/ghost/issue/BER-2914/resolve-css-specificity-conflict

This PR fixes CSS specificity conflicts that occur when the Ember admin app and React apps (using the shade design system) are hosted together in the admin shell. 

Specifically:
1. Tailwind utility classes for visibility did not work in React apps due to `!important` rules from Ember
2. Visual regressions in the Ember app when mounted in the shell due to competing CSS resets

### Changes

#### 1. Scoped show and hidden classes to the Ember app

- The usage of `!important` in the base Ember stylesheet was breaking Tailwind utility classes for visibility in React apps
- By scoping these classes to `.ember-application`, the Tailwind utilities work as expected outside of Ember
- This doesn't affect existing Ember behavior since the increased specificity doesn't matter given the `!important` flag

#### 2. Reduced specificity of the shade CSS reset

- When the shade CSS reset is applied to the admin shell, it affects the mounted Ember app
- Since the shade reset differs from Ember's reset, this caused visual regressions when comparing the Ember app in the shell vs. standalone
- Reducing the shade reset's specificity allows the Ember base stylesheet to take precedence
- The specificity is still high enough to prevent the opposite issue when React apps are hosted within Ember
