### PR TITLE
Fixed open events in transactional emails

### DIFF
--- a/ghost/core/core/server/services/mail/GhostMailer.js
+++ b/ghost/core/core/server/services/mail/GhostMailer.js
@@ -135,7 +135,7 @@ module.exports = class GhostMailer {
             if (tags.length > 0) {
                 messageToSend['o:tag'] = tags;
             }
-            if (settingsCache.get('emailTrackOpens')) {
+            if (settingsCache.get('email_track_opens')) {
                 messageToSend['o:tracking-opens'] = true;
             }
         }

--- a/ghost/core/test/unit/server/services/mail/GhostMailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/GhostMailer.test.js
@@ -336,7 +336,7 @@ describe('Mail: Ghostmailer', function () {
             configUtils.set({
                 hostSettings: {siteId: '123123'}
             });
-            sandbox.stub(settingsCache, 'get').withArgs('emailTrackOpens').returns(true);
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(true);
 
             mailer = new mail.GhostMailer();
             // Mock the state to simulate Mailgun transport
@@ -360,7 +360,7 @@ describe('Mail: Ghostmailer', function () {
             configUtils.set({
                 hostSettings: {siteId: '123123'}
             });
-            sandbox.stub(settingsCache, 'get').withArgs('emailTrackOpens').returns(false);
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(false);
 
             mailer = new mail.GhostMailer();
             mailer.state.usingMailgun = true;
@@ -383,7 +383,7 @@ describe('Mail: Ghostmailer', function () {
             configUtils.set({
                 hostSettings: {} // No siteId
             });
-            sandbox.stub(settingsCache, 'get').withArgs('emailTrackOpens').returns(true);
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(true);
 
             mailer = new mail.GhostMailer();
             mailer.state.usingMailgun = true;


### PR DESCRIPTION
ref [GVA-383](https://linear.app/ghost/issue/GVA-383/adding-open-rate-to-transactional-emails-sent-by-ghost)

Used incorrect setting in initial commit, I was more focused on making sure we didn't enable this by accident. Confirmed all settings correct, and the tags are being set :-) 