### PR TITLE
Fall back to Ember for auth

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,48 +1,16 @@
-import {
-    FrameworkProvider,
-    Outlet,
-    RouterProvider,
-    AppProvider,
-} from "@tryghost/admin-x-framework";
-import { ShadeApp } from "@tryghost/shade";
-import { routes } from "./routes.tsx";
-import { EmberProvider } from "./ember-bridge/EmberProvider.tsx";
-import EmberRoot from "./ember-bridge/EmberRoot.tsx";
-
-const framework = {
-    ghostVersion: "",
-    externalNavigate: () => {},
-    unsplashConfig: {
-        Authorization: "",
-        "Accept-Version": "",
-        "Content-Type": "",
-        "App-Pragma": "",
-        "X-Unsplash-Cache": true,
-    },
-    sentryDSN: null,
-    onUpdate: () => {},
-    onInvalidate: () => {},
-    onDelete: () => {},
-};
+import { Outlet } from "@tryghost/admin-x-framework";
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { EmberProvider, EmberFallback, EmberRoot, EmberAuthSync } from "./ember-bridge";
 
 function App() {
+    const { data: currentUser } = useCurrentUser();
+
     return (
-        <AppProvider>
-            <EmberProvider>
-                <FrameworkProvider {...framework}>
-                    <RouterProvider prefix={"/"} routes={routes}>
-                        <ShadeApp
-                            className="shade-admin"
-                            darkMode={false}
-                            fetchKoenigLexical={null}
-                        >
-                            <Outlet />
-                            <EmberRoot />
-                        </ShadeApp>
-                    </RouterProvider>
-                </FrameworkProvider>
-            </EmberProvider>
-        </AppProvider>
+        <EmberProvider>
+            {currentUser ? <Outlet /> : <EmberFallback />}
+            <EmberRoot />
+            <EmberAuthSync />
+        </EmberProvider>
     );
 }
 

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,15 +1,15 @@
 import { Outlet } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
-import { EmberProvider, EmberFallback, EmberRoot, EmberAuthSync } from "./ember-bridge";
+import { EmberProvider, EmberFallback, EmberRoot, useEmberAuthSync } from "./ember-bridge";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
+    useEmberAuthSync();
 
     return (
         <EmberProvider>
             {currentUser ? <Outlet /> : <EmberFallback />}
             <EmberRoot />
-            <EmberAuthSync />
         </EmberProvider>
     );
 }

--- a/apps/admin/src/ember-bridge/EmberAuthSync.tsx
+++ b/apps/admin/src/ember-bridge/EmberAuthSync.tsx
@@ -16,11 +16,8 @@ const isAuthRoute = (path: string) => {
     return AUTH_ROUTES.has(cleanPath);
 };
 
-/**
- * Component that monitors route changes and invalidates React Query caches
- * when navigating away from authentication routes in Ember
- */
-export function EmberAuthSync() {
+
+export function useEmberAuthSync() {
     const location = useLocation();
     const queryClient = useQueryClient();
     const previousPathRef = useRef<string | null>(null);
@@ -37,6 +34,4 @@ export function EmberAuthSync() {
         // Update the previous path reference
         previousPathRef.current = currentPath;
     }, [location, queryClient]);
-
-    return null;
 }

--- a/apps/admin/src/ember-bridge/EmberAuthSync.tsx
+++ b/apps/admin/src/ember-bridge/EmberAuthSync.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useRef } from 'react';
-import { useLocation } from '@tryghost/admin-x-framework';
-import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from "react";
+import { useLocation } from "@tryghost/admin-x-framework";
+import { useQueryClient } from "@tanstack/react-query";
 
-/**
- * Helper function to check if a path is an authentication-related route
- */
-const isAuthRoute = (path: string): boolean => {
-    return path.startsWith('/setup') ||
-           path.startsWith('/signin') ||
-           path.startsWith('/signout') ||
-           path.startsWith('/signup') ||
-           path.startsWith('/reset');
+const AUTH_ROUTES = new Set(["setup", "signin", "signout", "signup", "reset"]);
+
+const isAuthRoute = (path: string) => {
+    if (!path) {
+        return false;
+    }
+    
+    // Remove leading slash and extract the first path segment
+    // Also strip any query params or hash fragments
+    const cleanPath = path.replace(/^\//, '').split(/[/?#]/)[0];
+    
+    return AUTH_ROUTES.has(cleanPath);
 };
 
 /**
@@ -37,4 +40,3 @@ export function EmberAuthSync() {
 
     return null;
 }
-

--- a/apps/admin/src/ember-bridge/EmberAuthSync.tsx
+++ b/apps/admin/src/ember-bridge/EmberAuthSync.tsx
@@ -5,10 +5,6 @@ import { useQueryClient } from "@tanstack/react-query";
 const AUTH_ROUTES = new Set(["setup", "signin", "signout", "signup", "reset"]);
 
 const isAuthRoute = (path: string) => {
-    if (!path) {
-        return false;
-    }
-    
     // Remove leading slash and extract the first path segment
     // Also strip any query params or hash fragments
     const cleanPath = path.replace(/^\//, '').split(/[/?#]/)[0];

--- a/apps/admin/src/ember-bridge/EmberAuthSync.tsx
+++ b/apps/admin/src/ember-bridge/EmberAuthSync.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from '@tryghost/admin-x-framework';
+import { useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Helper function to check if a path is an authentication-related route
+ */
+const isAuthRoute = (path: string): boolean => {
+    return path.startsWith('/setup') ||
+           path.startsWith('/signin') ||
+           path.startsWith('/signout') ||
+           path.startsWith('/signup') ||
+           path.startsWith('/reset');
+};
+
+/**
+ * Component that monitors route changes and invalidates React Query caches
+ * when navigating away from authentication routes in Ember
+ */
+export function EmberAuthSync() {
+    const location = useLocation();
+    const queryClient = useQueryClient();
+    const previousPathRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        const currentPath = location.pathname;
+        const previousPath = previousPathRef.current;
+
+        // If we're navigating away from an auth route, invalidate all caches
+        if (previousPath && isAuthRoute(previousPath) && !isAuthRoute(currentPath)) {
+            void queryClient.invalidateQueries();
+        }
+
+        // Update the previous path reference
+        previousPathRef.current = currentPath;
+    }, [location, queryClient]);
+
+    return null;
+}
+

--- a/apps/admin/src/ember-bridge/EmberFallback.tsx
+++ b/apps/admin/src/ember-bridge/EmberFallback.tsx
@@ -7,7 +7,7 @@ import { useEmberContext } from './EmberContext';
  * When this component is mounted, it signals that the Ember app should be shown.
  * When unmounted, it unregisters itself.
  */
-export default function EmberFallback() {
+export function EmberFallback() {
   const { registerFallback, unregisterFallback } = useEmberContext();
 
   useEffect(() => {

--- a/apps/admin/src/ember-bridge/EmberRoot.tsx
+++ b/apps/admin/src/ember-bridge/EmberRoot.tsx
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useRef } from "react";
 import { useEmberContext } from "./EmberContext";
 
-function EmberRoot() {
+export const EmberRoot = React.memo(function EmberRoot() {
     const ref = useRef<HTMLDivElement>(null);
     const { isFallbackPresent } = useEmberContext();
 
@@ -25,6 +25,4 @@ function EmberRoot() {
     }, []);
 
     return <div ref={ref} hidden={!isFallbackPresent}></div>;
-}
-
-export default React.memo(EmberRoot);
+});

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -1,0 +1,5 @@
+export { EmberRoot } from "./EmberRoot";
+export { EmberProvider } from "./EmberProvider";
+export { useEmberContext } from "./EmberContext";
+export { EmberFallback } from "./EmberFallback";
+export { EmberAuthSync } from "./EmberAuthSync";

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -2,4 +2,4 @@ export { EmberRoot } from "./EmberRoot";
 export { EmberProvider } from "./EmberProvider";
 export { useEmberContext } from "./EmberContext";
 export { EmberFallback } from "./EmberFallback";
-export { EmberAuthSync } from "./EmberAuthSync";
+export { useEmberAuthSync } from "./EmberAuthSync";

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,9 +2,45 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import {
+    FrameworkProvider,
+    RouterProvider,
+    AppProvider,
+} from "@tryghost/admin-x-framework";
+import { ShadeApp } from "@tryghost/shade";
+
+import { routes } from "./routes.tsx";
+
+const framework = {
+    ghostVersion: "",
+    externalNavigate: () => {},
+    unsplashConfig: {
+        Authorization: "",
+        "Accept-Version": "",
+        "Content-Type": "",
+        "App-Pragma": "",
+        "X-Unsplash-Cache": true,
+    },
+    sentryDSN: null,
+    onUpdate: () => {},
+    onInvalidate: () => {},
+    onDelete: () => {},
+};
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
-        <App />
+        <AppProvider>
+            <FrameworkProvider {...framework}>
+                <RouterProvider prefix={"/"} routes={routes}>
+                    <ShadeApp
+                        className="shade-admin"
+                        darkMode={true}
+                        fetchKoenigLexical={null}
+                    >
+                        <App />
+                    </ShadeApp>
+                </RouterProvider>
+            </FrameworkProvider>
+        </AppProvider>
     </StrictMode>
 );

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -34,7 +34,7 @@ createRoot(document.getElementById("root")!).render(
                 <RouterProvider prefix={"/"} routes={routes}>
                     <ShadeApp
                         className="shade-admin"
-                        darkMode={true}
+                        darkMode={false}
                         fetchKoenigLexical={null}
                     >
                         <App />

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -4,7 +4,7 @@ import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider
 import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
 import { routes as statsRoutes, APP_ROUTE_PREFIX as statsAppRoutePrefix } from "@tryghost/stats/src/routes";
 import { routes as activityPubRoutes, APP_ROUTE_PREFIX as activityPubAppRoutePrefix } from "@tryghost/activitypub/src/routes";
-import EmberFallback from "./ember-bridge/EmberFallback";
+import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
     {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2917/fall-back-to-ember-for-authentication

If we can't fetch the current user, fall back to displaying the Ember app so that it can handle authentication for us. Once the user navigates away from any known auth route, refetch the user so that we're up to date on the React side.

This is a temporary solution to handle auth until we bridge the Ember state properly or re-implement auth on the React side.
