### PR TITLE
Removed default feature image from post factory

### DIFF
--- a/e2e/data-factory/factories/post-factory.ts
+++ b/e2e/data-factory/factories/post-factory.ts
@@ -12,7 +12,7 @@ export interface Post {
     html: string;
     comment_id: string;
     plaintext: string;
-    feature_image: string;
+    feature_image: string | null;
     featured: boolean;
     type: string;
     status: 'draft' | 'published' | 'scheduled';
@@ -50,7 +50,7 @@ export class PostFactory extends Factory<Partial<Post>, Post> {
             html: `<p>${content}</p>`,
             comment_id: generateId(),
             plaintext: content,
-            feature_image: `https://picsum.photos/800/600?random=${Math.random()}`,
+            feature_image: null,
             featured: faker.datatype.boolean(),
             type: 'post',
             status: 'draft',


### PR DESCRIPTION
- Changed feature_image from random picsum.photos URL for factories
- Removed external dependencies in E2E tests, that prevents potential timeouts from external image service