### PR TITLE
Rework tag list hover highlight to resolve issue in Safari

### DIFF
--- a/apps/posts/src/views/Tags/components/TagsList.tsx
+++ b/apps/posts/src/views/Tags/components/TagsList.tsx
@@ -62,7 +62,7 @@ function TagsList({
     });
 
     return (
-        <div ref={parentRef}>
+        <div ref={parentRef} className="overflow-hidden">
             <Table
                 className="flex table-fixed flex-col lg:table"
                 data-testid="tags-list"
@@ -93,15 +93,17 @@ function TagsList({
                             <TableRow
                                 key={key}
                                 {...props}
-                                className="relative grid w-full grid-cols-[1fr_5rem] items-center gap-x-4 p-2 hover:bg-muted/50 md:grid-cols-[1fr_auto_5rem] lg:table-row lg:p-0 [&.group:hover_td]:bg-transparent"
+                                className="grid w-full grid-cols-[1fr_5rem] items-center gap-x-4 p-2 hover:bg-muted/50 md:grid-cols-[1fr_auto_5rem] lg:table-row lg:p-0 [&.group:hover_td]:bg-transparent"
                                 data-testid="tag-list-row"
                             >
-                                <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">
+                                <TableCell className="static col-start-1 col-end-1 row-start-1 row-end-1 flex min-w-0 flex-col p-0 md:relative lg:table-cell lg:w-1/2 lg:p-4 xl:w-3/5">
                                     <a
-                                        className="block truncate pb-1 text-lg font-medium before:absolute before:inset-0 before:z-10"
+                                        className="before:absolute before:left-0 before:top-0 before:z-10 before:h-full before:w-[100vw]"
                                         href={`#/tags/${item.slug}`}
                                     >
-                                        {item.name}
+                                        <span className="block truncate pb-1 text-lg font-medium">
+                                            {item.name}
+                                        </span>
                                     </a>
                                     <span className="block truncate text-muted-foreground">
                                         {item.description}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/ONC-1226/editing-tags-sometimes-doesnt-load-the-correct-tag-you-clicked-on

Safari doesn't support containment of content within table rows. This means the way we had implementing clickable table rows breaks, but only in Safari. 

The new version relies on the table row height to contain the height of the clickable pseudo element and an outer overflow-hidden outside of the table to prevent the rows from growing out of bounds.

For narrow screens where we don't rely on table rendering, we instead use the  table row that then acts as a block element to contain the click area. 

Adapted from this community discussion:
https://github.com/tailwindlabs/tailwindcss/discussions/3502#discussioncomment-12350921
