### PR TITLE
Fixed `ember-basic-dropdown` based components erroring inside React shell

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -17,6 +17,7 @@
   <body>
     <div id="root"></div>
     <div id="ember-app"></div>
+    <div id="ember-basic-dropdown-wormhole"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
no issue

When Ember is hosted inside the React shell and renders into `<div id="ember-app">` instead of `<body>`, any ember-basic-dropdown based components would error with "Assertion Failed: You cannot pass a null or undefined destination element to in-element" and put the Ember app into a crashed state that required a refresh.

- added the default wormhole element to the React app shell's HTML so `ember-basic-dropdown` doesn't pass `null` into `{{in-element}}` when Ember has a customized root element
