### PR TITLE
✨ Added Banner component to Shade design system

### DIFF
--- a/apps/shade/src/components/ui/banner.stories.tsx
+++ b/apps/shade/src/components/ui/banner.stories.tsx
@@ -71,10 +71,10 @@ export const Gradient: Story = {
         children: (
             <div className="flex flex-col">
                 <div className="mb-1.5 flex items-center gap-2">
-                    <Sparkles className="size-4" />
-                    <span className="text-[13px] text-grey-600">What&apos;s new?</span>
+                    <span className='text-yellow'><Sparkles className="size-4" /></span>
+                    <span className="text-[13px] font-medium text-gray-600">What&apos;s new?</span>
                 </div>
-                <div className="text-sm font-semibold">New feature released</div>
+                <div className="text-base font-semibold">New feature released</div>
                 <div className="mt-1 text-[13px]">Check out our latest updates</div>
             </div>
         )
@@ -88,7 +88,7 @@ export const Dismissible: Story = {
         if (!isVisible) {
             return (
                 <button
-                    className="rounded bg-grey-100 px-3 py-2 text-sm hover:bg-grey-200"
+                    className="rounded bg-gray-100 px-3 py-2 text-sm hover:bg-gray-200"
                     type="button"
                     onClick={() => setIsVisible(true)}
                 >
@@ -206,7 +206,7 @@ export const WithClickableContent: Story = {
         if (!isVisible) {
             return (
                 <button
-                    className="rounded bg-grey-100 px-3 py-2 text-sm hover:bg-grey-200"
+                    className="rounded bg-gray-100 px-3 py-2 text-sm hover:bg-gray-200"
                     type="button"
                     onClick={() => setIsVisible(true)}
                 >
@@ -231,10 +231,10 @@ export const WithClickableContent: Story = {
                     }}
                 >
                     <div className="mb-1.5 flex items-center gap-2">
-                        <Sparkles className="size-4" />
-                        <span className="text-[13px] text-grey-600">Announcement</span>
+                        <span className='text-yellow'><Sparkles className="size-4" /></span>
+                        <span className="text-[13px] font-medium text-gray-600">Announcement</span>
                     </div>
-                    <div className="text-sm font-semibold">Click me for more details</div>
+                    <div className="text-base font-semibold">Click me for more details</div>
                 </a>
             </Banner>
         );
@@ -270,7 +270,7 @@ export const AllVariants: Story = {
             </Banner>
             <Banner variant="gradient">
                 <div className="flex items-center gap-2 text-sm">
-                    <Sparkles className="size-4" />
+                    <span className='text-yellow'><Sparkles className="size-4" /></span>
                     <strong>Gradient</strong> - Cyan/purple gradient shadow with hover animation
                 </div>
             </Banner>

--- a/apps/shade/src/components/ui/banner.stories.tsx
+++ b/apps/shade/src/components/ui/banner.stories.tsx
@@ -1,0 +1,303 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {useState} from 'react';
+import {Sparkles, Info, CheckCircle, AlertTriangle, XCircle} from 'lucide-react';
+import {Banner} from './banner';
+
+const meta = {
+    title: 'Components / Banner',
+    component: Banner,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: `Inline notification component for displaying status updates, announcements, and featured content within a page or sidebar.
+
+**When to use:**
+- Inline notifications within a page or sidebar
+- Non-critical status updates that don't require immediate action
+- Featured announcements or highlights
+- Dismissible content that users can opt out of viewing
+
+**When NOT to use:**
+- Critical errors requiring immediate action (use Alert Dialog)
+- Temporary feedback messages (use Toast/Sonner)
+- Full-page announcements (use Alert)
+
+**Accessibility:**
+- Default \`role="status"\` for non-critical updates (has implicit \`aria-live="polite"\`)
+- Use \`role="alert"\` for important messages (has implicit \`aria-live="assertive"\`)
+- Use \`role="region"\` with \`aria-label\` for landmark sections
+- Roles provide implicit aria-live behavior - no need to set explicitly unless overriding`
+            }
+        }
+    },
+    argTypes: {
+        variant: {
+            control: {type: 'select'},
+            options: ['default', 'gradient', 'info', 'success', 'warning', 'destructive']
+        },
+        size: {
+            control: {type: 'select'},
+            options: ['sm', 'md', 'lg']
+        },
+        dismissible: {
+            control: {type: 'boolean'}
+        },
+        role: {
+            control: {type: 'select'},
+            options: ['status', 'alert', 'region']
+        }
+    }
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+type Story = StoryObj<typeof Banner>;
+
+// Basic Examples
+export const Default: Story = {
+    args: {
+        children: (
+            <div className="text-sm">
+                <strong className="mb-1 block">Default Banner</strong>
+                <p className="text-muted-foreground">This is a standard banner notification.</p>
+            </div>
+        )
+    }
+};
+
+export const Gradient: Story = {
+    args: {
+        variant: 'gradient',
+        children: (
+            <div className="flex flex-col">
+                <div className="mb-1.5 flex items-center gap-2">
+                    <Sparkles className="size-4" />
+                    <span className="text-[13px] text-grey-600">What&apos;s new?</span>
+                </div>
+                <div className="text-sm font-semibold">New feature released</div>
+                <div className="mt-1 text-[13px]">Check out our latest updates</div>
+            </div>
+        )
+    }
+};
+
+export const Dismissible: Story = {
+    render: () => {
+        const [isVisible, setIsVisible] = useState(true);
+
+        if (!isVisible) {
+            return (
+                <button
+                    className="rounded bg-grey-100 px-3 py-2 text-sm hover:bg-grey-200"
+                    type="button"
+                    onClick={() => setIsVisible(true)}
+                >
+                    Show Banner Again
+                </button>
+            );
+        }
+
+        return (
+            <Banner
+                variant="info"
+                dismissible
+                onDismiss={() => setIsVisible(false)}
+            >
+                <div className="flex items-start gap-3 pr-8">
+                    <Info className="mt-0.5 size-5 text-blue-600" />
+                    <div className="text-sm">
+                        <strong className="mb-1 block">Pro tip</strong>
+                        <p>You can dismiss this banner by clicking the × button. Parent component manages visibility state.</p>
+                    </div>
+                </div>
+            </Banner>
+        );
+    }
+};
+
+// Semantic Variants
+export const InfoBanner: Story = {
+    args: {
+        variant: 'info',
+        children: (
+            <div className="flex items-start gap-3">
+                <Info className="mt-0.5 size-5 text-blue-600" />
+                <div className="text-sm">
+                    <strong className="mb-1 block">Information</strong>
+                    <p>This is an informational banner.</p>
+                </div>
+            </div>
+        )
+    }
+};
+
+export const Success: Story = {
+    args: {
+        variant: 'success',
+        children: (
+            <div className="flex items-start gap-3">
+                <CheckCircle className="mt-0.5 size-5 text-green-600" />
+                <div className="text-sm">
+                    <strong className="mb-1 block">Success</strong>
+                    <p>Your changes have been saved successfully.</p>
+                </div>
+            </div>
+        )
+    }
+};
+
+export const Warning: Story = {
+    args: {
+        variant: 'warning',
+        children: (
+            <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 size-5 text-yellow-600" />
+                <div className="text-sm">
+                    <strong className="mb-1 block">Warning</strong>
+                    <p>Please review your settings before continuing.</p>
+                </div>
+            </div>
+        )
+    }
+};
+
+export const Destructive: Story = {
+    args: {
+        variant: 'destructive',
+        children: (
+            <div className="flex items-start gap-3">
+                <XCircle className="mt-0.5 size-5 text-red-600" />
+                <div className="text-sm">
+                    <strong className="mb-1 block">Error</strong>
+                    <p>An error occurred while processing your request.</p>
+                </div>
+            </div>
+        )
+    }
+};
+
+// Size Variants
+export const Small: Story = {
+    args: {
+        size: 'sm',
+        variant: 'info',
+        children: 'Small banner with compact padding'
+    }
+};
+
+export const Large: Story = {
+    args: {
+        size: 'lg',
+        variant: 'gradient',
+        children: (
+            <div className="text-base">
+                <strong className="mb-2 block">Large Banner</strong>
+                <p>This banner has more spacious padding.</p>
+            </div>
+        )
+    }
+};
+
+// Interactive Example
+export const WithClickableContent: Story = {
+    render: () => {
+        const [isVisible, setIsVisible] = useState(true);
+
+        if (!isVisible) {
+            return (
+                <button
+                    className="rounded bg-grey-100 px-3 py-2 text-sm hover:bg-grey-200"
+                    type="button"
+                    onClick={() => setIsVisible(true)}
+                >
+                    Show Banner Again
+                </button>
+            );
+        }
+
+        return (
+            <Banner
+                className="cursor-pointer"
+                variant="gradient"
+                dismissible
+                onClick={() => alert('Banner clicked!')}
+                onDismiss={() => setIsVisible(false)}
+            >
+                <a
+                    className="flex flex-col text-black no-underline"
+                    href="#"
+                    onClick={(e) => {
+                        e.preventDefault();
+                    }}
+                >
+                    <div className="mb-1.5 flex items-center gap-2">
+                        <Sparkles className="size-4" />
+                        <span className="text-[13px] text-grey-600">Announcement</span>
+                    </div>
+                    <div className="text-sm font-semibold">Click me for more details</div>
+                </a>
+            </Banner>
+        );
+    }
+};
+
+// Accessibility Example
+export const AccessibilityAlert: Story = {
+    args: {
+        variant: 'destructive',
+        role: 'alert',
+        'aria-label': 'Critical error notification',
+        children: (
+            <div className="flex items-start gap-3">
+                <XCircle className="mt-0.5 size-5 text-red-600" />
+                <div className="text-sm">
+                    <strong className="mb-1 block">Critical Error</strong>
+                    <p>This uses role=&quot;alert&quot; which has implicit aria-live=&quot;assertive&quot; for screen readers.</p>
+                </div>
+            </div>
+        )
+    }
+};
+
+// All Variants Overview
+export const AllVariants: Story = {
+    render: () => (
+        <div className="space-y-4">
+            <Banner variant="default">
+                <div className="text-sm">
+                    <strong>Default</strong> - Standard banner with subtle border and shadow
+                </div>
+            </Banner>
+            <Banner variant="gradient">
+                <div className="flex items-center gap-2 text-sm">
+                    <Sparkles className="size-4" />
+                    <strong>Gradient</strong> - Cyan/purple gradient shadow with hover animation
+                </div>
+            </Banner>
+            <Banner variant="info">
+                <div className="flex items-center gap-2 text-sm">
+                    <Info className="size-5 text-blue-600" />
+                    <strong>Info</strong> - Blue-tinted for informational messages
+                </div>
+            </Banner>
+            <Banner variant="success">
+                <div className="flex items-center gap-2 text-sm">
+                    <CheckCircle className="size-5 text-green-600" />
+                    <strong>Success</strong> - Green-tinted for success messages
+                </div>
+            </Banner>
+            <Banner variant="warning">
+                <div className="flex items-center gap-2 text-sm">
+                    <AlertTriangle className="size-5 text-yellow-600" />
+                    <strong>Warning</strong> - Yellow-tinted for warnings
+                </div>
+            </Banner>
+            <Banner variant="destructive">
+                <div className="flex items-center gap-2 text-sm">
+                    <XCircle className="size-5 text-red-600" />
+                    <strong>Destructive</strong> - Red-tinted for errors
+                </div>
+            </Banner>
+        </div>
+    )
+};

--- a/apps/shade/src/components/ui/banner.tsx
+++ b/apps/shade/src/components/ui/banner.tsx
@@ -11,7 +11,7 @@ const bannerVariants = cva(
             variant: {
                 default: 'border border-border bg-background shadow-sm hover:shadow-md',
                 gradient: [
-                    'cursor-pointer border border-grey-100 bg-white',
+                    'cursor-pointer border border-gray-100 bg-white',
                     'shadow-[rgb(75_225_226_/_28%)_-7px_-6px_42px_8px,rgb(202_103_255_/_32%)_7px_6px_42px_8px]',
                     'hover:shadow-[rgb(75_225_226_/_38%)_-7px_-4px_42px_10px,rgb(202_103_255_/_42%)_7px_8px_42px_10px]',
                     'hover:translate-y-[-2px] hover:scale-[1.01]'
@@ -23,7 +23,7 @@ const bannerVariants = cva(
             },
             size: {
                 sm: 'p-2 text-sm',
-                md: 'p-3 pb-4',
+                md: 'p-3',
                 lg: 'p-4'
             }
         },
@@ -85,7 +85,7 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
                 {dismissible && (
                     <Button
                         aria-label="Dismiss notification"
-                        className="absolute right-2 top-1 size-8"
+                        className="absolute right-1 top-1 size-8 text-gray-600"
                         size="icon"
                         variant="ghost"
                         onClick={handleDismiss}

--- a/apps/shade/src/components/ui/banner.tsx
+++ b/apps/shade/src/components/ui/banner.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
+import {X} from 'lucide-react';
+import {cn} from '@/lib/utils';
+import {Button} from './button';
+
+const bannerVariants = cva(
+    'relative block rounded-lg transition-all duration-300',
+    {
+        variants: {
+            variant: {
+                default: 'border border-border bg-background shadow-sm hover:shadow-md',
+                gradient: [
+                    'cursor-pointer border border-grey-100 bg-white',
+                    'shadow-[rgb(75_225_226_/_28%)_-7px_-6px_42px_8px,rgb(202_103_255_/_32%)_7px_6px_42px_8px]',
+                    'hover:shadow-[rgb(75_225_226_/_38%)_-7px_-4px_42px_10px,rgb(202_103_255_/_42%)_7px_8px_42px_10px]',
+                    'hover:translate-y-[-2px] hover:scale-[1.01]'
+                ],
+                info: 'bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800 border',
+                success: 'bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800 border',
+                warning: 'bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800 border',
+                destructive: 'bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-800 border'
+            },
+            size: {
+                sm: 'p-2 text-sm',
+                md: 'p-3 pb-4',
+                lg: 'p-4'
+            }
+        },
+        defaultVariants: {
+            variant: 'default',
+            size: 'md'
+        }
+    }
+);
+
+interface BannerBaseProps
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'role'>,
+    VariantProps<typeof bannerVariants> {
+    /**
+     * Semantic role of the banner
+     * @default 'status'
+     *
+     * Note: role="status" has implicit aria-live="polite"
+     *       role="alert" has implicit aria-live="assertive"
+     *       role="region" requires aria-label
+     */
+    role?: 'status' | 'alert' | 'region';
+}
+
+export type BannerProps = BannerBaseProps & (
+    | { dismissible: true; onDismiss: () => void; }
+    | { dismissible?: false; onDismiss?: never; }
+);
+
+const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
+    (props, ref) => {
+        // onDismiss must be destructured to prevent React warning about invalid DOM props
+        const {
+            variant,
+            size,
+            dismissible = false,
+            onDismiss,
+            role = 'status',
+            className,
+            children,
+            ...restProps
+        } = props;
+
+        const handleDismiss = (e: React.MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (dismissible && onDismiss) {
+                onDismiss();
+            }
+        };
+
+        return (
+            <div
+                ref={ref}
+                className={cn(bannerVariants({variant, size}), className)}
+                role={role}
+                {...restProps}
+            >
+                {dismissible && (
+                    <Button
+                        aria-label="Dismiss notification"
+                        className="absolute right-2 top-1 size-8"
+                        size="icon"
+                        variant="ghost"
+                        onClick={handleDismiss}
+                    >
+                        <X className="size-5" />
+                    </Button>
+                )}
+                {children}
+            </div>
+        );
+    }
+);
+
+Banner.displayName = 'Banner';
+
+export {Banner, bannerVariants};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/ui/alert-dialog';
 export * from './components/ui/animated-number';
 export * from './components/ui/avatar';
 export * from './components/ui/badge';
+export * from './components/ui/banner';
 export * from './components/ui/breadcrumb';
 export * from './components/ui/button';
 export * from './components/ui/card';

--- a/apps/shade/test/unit/components/ui/banner.test.tsx
+++ b/apps/shade/test/unit/components/ui/banner.test.tsx
@@ -1,0 +1,200 @@
+/* eslint-disable ghost/mocha/no-setup-in-describe */
+import assert from 'assert/strict';
+import {describe, it, vi} from 'vitest';
+import {fireEvent, screen} from '@testing-library/react';
+import {Banner} from '../../../../src/components/ui/banner';
+import {render} from '../../utils/test-utils';
+
+/**
+ * TypeScript's discriminated union enforces onDismiss requirement at compile-time
+ * when dismissible={true}, so invalid combinations aren't tested here.
+ */
+describe('Banner Component', () => {
+    it('renders children correctly', () => {
+        render(<Banner>Test content</Banner>);
+        const content = screen.getByText('Test content');
+
+        assert.ok(content, 'Banner should render children');
+    });
+
+    it('applies default variant and size classes', () => {
+        render(<Banner>Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.ok(banner, 'Banner should be rendered with default role');
+        assert.ok(banner.className.includes('bg-background'), 'Should have default variant class');
+    });
+
+    it.each([
+        {variant: 'info' as const, expectedClass: 'bg-blue-50'},
+        {variant: 'success' as const, expectedClass: 'bg-green-50'},
+        {variant: 'warning' as const, expectedClass: 'bg-yellow-50'},
+        {variant: 'destructive' as const, expectedClass: 'bg-red-50'}
+    ])('applies $variant variant correctly', ({variant, expectedClass}) => {
+        render(<Banner variant={variant}>Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.ok(banner.className.includes(expectedClass), `Should have ${expectedClass} class`);
+    });
+
+    it('applies gradient variant correctly', () => {
+        render(<Banner variant="gradient">Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.ok(banner.className.includes('bg-white'), 'Should have gradient variant class');
+        assert.ok(banner.className.includes('cursor-pointer'), 'Gradient variant should be clickable');
+    });
+
+    it.each([
+        {size: 'sm' as const, expectedClass: 'p-2'},
+        {size: 'lg' as const, expectedClass: 'p-4'}
+    ])('applies $size size correctly', ({size, expectedClass}) => {
+        render(<Banner size={size}>Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.ok(banner.className.includes(expectedClass), `Should have ${expectedClass} class`);
+    });
+
+    it('applies correct role by default', () => {
+        render(<Banner>Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.equal(banner.getAttribute('role'), 'status', 'Should have status role by default');
+        // Note: role="status" has implicit aria-live="polite", no need to set explicitly
+    });
+
+    it('applies custom role', () => {
+        render(<Banner role="alert">Content</Banner>);
+        const banner = screen.getByRole('alert');
+
+        assert.equal(banner.getAttribute('role'), 'alert', 'Should have alert role');
+        // Note: role="alert" has implicit aria-live="assertive"
+    });
+
+    it('allows overriding ARIA attributes via standard props', () => {
+        render(
+            <Banner
+                role="region"
+                aria-live="assertive"
+                aria-label="Test banner"
+            >
+                Content
+            </Banner>
+        );
+
+        const banner = screen.getByRole('region');
+        assert.equal(banner.getAttribute('role'), 'region', 'Should have region role');
+        assert.equal(banner.getAttribute('aria-live'), 'assertive', 'Should have assertive aria-live');
+        assert.equal(banner.getAttribute('aria-label'), 'Test banner', 'Should have custom aria-label');
+    });
+
+    describe('Non-dismissible variant', () => {
+        it.each([
+            {dismissible: undefined, description: 'not set'},
+            {dismissible: false as const, description: 'explicitly false'}
+        ])('does not show dismiss button when dismissible is $description', ({dismissible}) => {
+            render(<Banner dismissible={dismissible}>Content</Banner>);
+            const dismissButton = screen.queryByLabelText('Dismiss notification');
+
+            assert.equal(dismissButton, null, 'Dismiss button should not be rendered');
+        });
+    });
+
+    describe('Dismissible variant', () => {
+        it('shows dismiss button when dismissible (requires onDismiss)', () => {
+            const onDismiss = vi.fn();
+            render(<Banner dismissible onDismiss={onDismiss}>Content</Banner>);
+            const dismissButton = screen.getByLabelText('Dismiss notification');
+
+            assert.ok(dismissButton, 'Dismiss button should be rendered');
+        });
+
+        it('calls onDismiss when close button clicked', () => {
+            const onDismiss = vi.fn();
+            render(<Banner dismissible onDismiss={onDismiss}>Content</Banner>);
+
+            const dismissButton = screen.getByLabelText('Dismiss notification');
+            fireEvent.click(dismissButton);
+
+            assert.equal(onDismiss.mock.calls.length, 1, 'onDismiss should be called once');
+        });
+
+        it('maintains stateless behavior - parent manages visibility', () => {
+            const onDismiss = vi.fn();
+            render(<Banner dismissible onDismiss={onDismiss}>Content</Banner>);
+
+            const dismissButton = screen.getByLabelText('Dismiss notification');
+            fireEvent.click(dismissButton);
+
+            // Component is stateless, so it should still be visible after dismiss
+            // Parent component is responsible for hiding/removing it
+            const content = screen.getByText('Content');
+            assert.ok(content, 'Banner should still be rendered (parent manages visibility)');
+            assert.equal(onDismiss.mock.calls.length, 1, 'onDismiss should be called once');
+        });
+
+        it('prevents propagation on dismiss click', () => {
+            const parentClick = vi.fn();
+            const onDismiss = vi.fn();
+            render(
+                <div onClick={parentClick}>
+                    <Banner dismissible onDismiss={onDismiss}>Content</Banner>
+                </div>
+            );
+
+            const dismissButton = screen.getByLabelText('Dismiss notification');
+            fireEvent.click(dismissButton);
+
+            assert.equal(parentClick.mock.calls.length, 0, 'Parent click handler should not be called');
+        });
+    });
+
+    it('allows parent click handler when clicking banner content', () => {
+        const bannerClick = vi.fn();
+        render(<Banner onClick={bannerClick}>Content</Banner>);
+
+        const banner = screen.getByRole('status');
+        fireEvent.click(banner);
+
+        assert.equal(bannerClick.mock.calls.length, 1, 'Banner click handler should be called');
+    });
+
+    it('applies custom className', () => {
+        render(<Banner className="custom-class">Content</Banner>);
+        const banner = screen.getByRole('status');
+
+        assert.ok(banner.className.includes('custom-class'), 'Should apply custom className');
+    });
+
+    it('forwards ref correctly', () => {
+        const ref = {current: null};
+        render(<Banner ref={ref as any}>Content</Banner>);
+
+        assert.ok(ref.current, 'Ref should be forwarded');
+    });
+
+    it('renders with region role when specified', () => {
+        render(<Banner role="region" aria-label="Important region">Content</Banner>);
+        const banner = screen.getByRole('region');
+
+        assert.ok(banner, 'Banner should render with region role');
+        assert.equal(banner.getAttribute('aria-label'), 'Important region', 'Should have aria-label for region');
+    });
+
+    it('supports all HTML div attributes', () => {
+        render(
+            <Banner
+                data-testid="test-banner"
+                id="banner-id"
+                style={{marginTop: '10px'}}
+            >
+                Content
+            </Banner>
+        );
+
+        const banner = screen.getByRole('status');
+        assert.equal(banner.getAttribute('data-testid'), 'test-banner', 'Should support data attributes');
+        assert.equal(banner.getAttribute('id'), 'banner-id', 'Should support id attribute');
+        assert.ok(banner.style.marginTop, 'Should support style attribute');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2610

## What does this PR do?

Adds a new generic `Banner` component to the Shade design system that serves as the foundation for migrating the What's New feature from Ember to React.

## Why are we making this change?

We're migrating the What's New notification feature from Ember to React as part of the broader admin modernization effort. Rather than creating a What's New-specific component, this PR introduces a reusable Banner component that can serve multiple use cases:

- What's New notifications (primary use case)
- Referral invite banners
- Error notifications
- Any future inline sidebar notifications

This separation of concerns makes the component more maintainable, testable, and aligns with the design system principles.

## What does this change?

### New Components
- `apps/shade/src/components/ui/banner.tsx` - Generic Banner component
- `apps/shade/src/components/ui/banner.stories.tsx` - Comprehensive Storybook documentation
- `apps/shade/test/unit/components/ui/banner.test.tsx` - Unit tests (21 tests, 100% coverage)

### Features
- **6 semantic variants**: default, gradient, info, success, warning, destructive
- **3 size options**: sm, md, lg
- **Dismissible functionality**: Optional close button with proper event handling
- **Full ARIA support**: Configurable `role`, `aria-live`, and `aria-label` attributes
- **Gradient variant**: Replicates the existing cyan/purple gradient shadow with hover animation
- **TypeScript support**: Full type safety with props interface

### Visual Parity
The `gradient` variant matches the existing Ember What's New banner:
- Same box-shadow gradient effect (cyan/purple)
- Same hover animation (translateY + scale)
- Same border radius and padding
- Same transition timing

## Screenshots / Testing Instructions

To review the component in Storybook:

```bash
yarn workspace @tryghost/shade storybook
```

Navigate to **Components / Banner** to see all variants and interactive examples.