### PR TITLE
Replaced MailHog with MailPit 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -277,10 +277,10 @@ services:
     ports:
       - 9091:9091
 
-  mailhog:
-    image: mailhog/mailhog:latest
+  mailpit:
+    image: axllent/mailpit
     platform: linux/amd64
-    container_name: ghost-mailhog
+    container_name: ghost-mailpit
     profiles: [ ghost, split, all ]
     ports:
       - "1025:1025" # SMTP server

--- a/ghost/core/core/shared/config/env/config.development.docker.json
+++ b/ghost/core/core/shared/config/env/config.development.docker.json
@@ -12,7 +12,7 @@
         "from": "test@example.com",
         "transport": "SMTP",
         "options": {
-            "host": "mailhog",
+            "host": "mailpit",
             "port": 1025
         }
     },


### PR DESCRIPTION
- MailPit is actively maintained while MailHog is deprecated
- Updated Docker Compose and development configuration