### PR TITLE
Added indexes to members created events and subscription created events

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
@@ -1,0 +1,28 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+const {commands} = require('../../../schema');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding index on members_created_events.batch_id');
+        await commands.addIndex('members_created_events', ['batch_id'], knex);
+
+        logging.info('Adding index on members_created_events.source');
+        await commands.addIndex('members_created_events', ['source'], knex);
+
+        logging.info('Adding index on members_subscription_created_events.batch_id');
+        await commands.addIndex('members_subscription_created_events', ['batch_id'], knex);
+    },
+    async function down(knex) {
+        logging.info('Dropping index on members_subscription_created_events.batch_id');
+        await commands.dropIndex('members_subscription_created_events', ['batch_id'], knex);
+
+        logging.info('Dropping index on members_created_events.source');
+        await commands.dropIndex('members_created_events', ['source'], knex);
+
+        logging.info('Dropping index on members_created_events.batch_id');
+        await commands.dropIndex('members_created_events', ['batch_id'], knex);
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
@@ -1,6 +1,3 @@
-// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
-
-const logging = require('@tryghost/logging');
 const {createTransactionalMigration} = require('../../utils');
 const {commands} = require('../../../schema');
 

--- a/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/6.6/2025-10-23-01-37-17-add-indicies-to-members-created-events.js
@@ -6,23 +6,13 @@ const {commands} = require('../../../schema');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
-        logging.info('Adding index on members_created_events.batch_id');
         await commands.addIndex('members_created_events', ['batch_id'], knex);
-
-        logging.info('Adding index on members_created_events.source');
         await commands.addIndex('members_created_events', ['source'], knex);
-
-        logging.info('Adding index on members_subscription_created_events.batch_id');
         await commands.addIndex('members_subscription_created_events', ['batch_id'], knex);
     },
     async function down(knex) {
-        logging.info('Dropping index on members_subscription_created_events.batch_id');
         await commands.dropIndex('members_subscription_created_events', ['batch_id'], knex);
-
-        logging.info('Dropping index on members_created_events.source');
         await commands.dropIndex('members_created_events', ['source'], knex);
-
-        logging.info('Dropping index on members_created_events.batch_id');
         await commands.dropIndex('members_created_events', ['batch_id'], knex);
     }
 );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-712/improve-performance-of-verificationtrigger-queries

The `VerificationTrigger` service runs a few queries on the `members_created_events` and `members_subscription_created_events` tables for each new member added via the Admin API, which are particularly slow (upwards of 40 seconds in some cases). The queries are currently using temporary tables and two full table scans.

This commit adds appropriate indexes to these tables to improve the performance of these queries, and remove the temporary tables + full table scans. 