### PR TITLE
Fixed Tinybird port conflict in e2e tests

### DIFF
--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -80,9 +80,9 @@ services:
     platform: linux/amd64
     stop_grace_period: 2s
     ports:
-      - "7181:7181"
+      - "7182:7181" # Use 7182 on host to avoid conflicts with root compose.yml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7181/v0/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:7182/v0/health" ]
       interval: 1s
       timeout: 5s
       retries: 120

--- a/e2e/helpers/environment/GhostManager.ts
+++ b/e2e/helpers/environment/GhostManager.ts
@@ -67,7 +67,7 @@ export class GhostManager {
                 TB_HOST: `http://${TB.LOCAL_HOST}:${TB.PORT}`,
                 TB_LOCAL_HOST: TB.LOCAL_HOST,
                 tinybird__stats__endpoint: `http://${TB.LOCAL_HOST}:${TB.PORT}`,
-                tinybird__stats__endpointBrowser: 'http://localhost:7181',
+                tinybird__stats__endpointBrowser: `http://localhost:${TB.HOST_PORT}`,
                 tinybird__tracker__endpoint: 'http://localhost:8080/.ghost/analytics/api/v1/page_hit',
                 tinybird__tracker__datasource: 'analytics_events',
                 tinybird__workspaceId: tinybirdState.workspaceId,

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -19,6 +19,7 @@ export const MYSQL = {
 export const TB = {
     LOCAL_HOST: 'tinybird-local',
     PORT: 7181,
+    HOST_PORT: 7182,
     CLI_ENV_PATH: '/mnt/shared-config/.env.tinybird'
 };
 


### PR DESCRIPTION
The Tinybird service in e2e/compose.yml uses the same hostport as the Tinybird service in compose.yml, which leads to a port conflict when running both.

This changes the host port for Tinybird in the e2e tests to 7182 to avoid the conflict.