### PR TITLE
Extract analytics provider logic to factory pattern (PR 3 of 4)

### DIFF
--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const {createAnalyticsProviders} = require('./analytics-provider-factory');
 
 class EmailAnalyticsServiceWrapper {
     init() {
@@ -9,7 +10,6 @@ class EmailAnalyticsServiceWrapper {
         const EmailAnalyticsService = require('./EmailAnalyticsService');
         const EmailEventStorage = require('../email-service/EmailEventStorage');
         const EmailEventProcessor = require('../email-service/EmailEventProcessor');
-        const MailgunProvider = require('./EmailAnalyticsProviderMailgun');
         const {EmailRecipientFailure, EmailSpamComplaintEvent, Email} = require('../../models');
         const StartEmailAnalyticsJobEvent = require('./events/StartEmailAnalyticsJobEvent');
         const domainEvents = require('@tryghost/domain-events');
@@ -47,9 +47,7 @@ class EmailAnalyticsServiceWrapper {
             config,
             settings,
             eventProcessor,
-            providers: [
-                new MailgunProvider({config, settings})
-            ],
+            providers: createAnalyticsProviders(config, settings),
             queries,
             domainEvents,
             prometheusClient

--- a/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
+++ b/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
@@ -1,0 +1,68 @@
+const logging = require('@tryghost/logging');
+
+/**
+ * Resolves the analytics provider based on email provider configuration
+ *
+ * Analytics providers are tied to email providers. If a bulk email provider
+ * doesn't have analytics support, this returns null and analytics features
+ * are disabled for that provider.
+ *
+ * @param {Object} config - Configuration service
+ * @returns {string|null} The analytics provider name or null if unsupported
+ */
+function resolveAnalyticsProvider(config) {
+    const emailProvider = config.get('bulkEmail:provider');
+
+    // Only use default for undefined or empty string
+    const provider = (emailProvider === undefined || emailProvider === '') ? 'mailgun' : emailProvider;
+
+    // Map email providers to their analytics implementations
+    const analyticsProviderMap = {
+        'mailgun': 'mailgun'
+        // Future providers can be added here:
+        // 'ses': 'ses',
+        // 'sendgrid': 'sendgrid'
+    };
+
+    const analyticsProvider = analyticsProviderMap[provider];
+
+    if (!analyticsProvider && provider !== null && provider !== false && provider !== 0) {
+        logging.warn(`No analytics provider available for email provider: ${provider}`);
+    } else if (!analyticsProvider) {
+        logging.warn(`No analytics provider available for email provider: ${emailProvider}`);
+    }
+
+    return analyticsProvider || null;
+}
+
+/**
+ * Creates analytics providers array for the EmailAnalyticsService
+ *
+ * @param {Object} config - Configuration service
+ * @param {Object} settings - Settings cache
+ * @returns {Array} Array of analytics provider instances
+ */
+function createAnalyticsProviders(config, settings) {
+    const provider = resolveAnalyticsProvider(config);
+
+    if (!provider) {
+        // Return empty array - analytics will be disabled
+        return [];
+    }
+
+    if (provider === 'mailgun') {
+        const MailgunProvider = require('./EmailAnalyticsProviderMailgun');
+        return [
+            new MailgunProvider({config, settings})
+        ];
+    }
+
+    // This should never be reached due to validation, but keeping for safety
+    logging.error(`Analytics provider '${provider}' is not implemented`);
+    return [];
+}
+
+module.exports = {
+    resolveAnalyticsProvider,
+    createAnalyticsProviders
+};

--- a/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
+++ b/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
@@ -26,10 +26,8 @@ function resolveAnalyticsProvider(config) {
 
     const analyticsProvider = analyticsProviderMap[provider];
 
-    if (!analyticsProvider && provider !== null && provider !== false && provider !== 0) {
+    if (!analyticsProvider) {
         logging.warn(`No analytics provider available for email provider: ${provider}`);
-    } else if (!analyticsProvider) {
-        logging.warn(`No analytics provider available for email provider: ${emailProvider}`);
     }
 
     return analyticsProvider || null;

--- a/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
+++ b/ghost/core/core/server/services/email-analytics/analytics-provider-factory.js
@@ -18,7 +18,7 @@ function resolveAnalyticsProvider(config) {
 
     // Map email providers to their analytics implementations
     const analyticsProviderMap = {
-        'mailgun': 'mailgun'
+        mailgun: 'mailgun'
         // Future providers can be added here:
         // 'ses': 'ses',
         // 'sendgrid': 'sendgrid'

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -258,6 +258,7 @@
     "parse-prometheus-text-format": "1.1.1",
     "postcss": "8.5.6",
     "postcss-cli": "11.0.1",
+    "proxyquire": "2.1.3",
     "rewire": "8.0.0",
     "should": "13.2.3",
     "sinon": "18.0.1",

--- a/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
@@ -1,0 +1,259 @@
+const should = require('should');
+const sinon = require('sinon');
+
+/**
+ * Tests for analytics-provider-factory module
+ *
+ * These tests execute the ACTUAL production code from analytics-provider-factory.js,
+ * following the same pattern as PR2's email-provider-factory tests.
+ */
+describe('Analytics Provider Factory', function () {
+    let sandbox;
+    let factory;
+    let mockConfig;
+    let mockSettings;
+    let loggingStub;
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+
+        // Reset the module cache to get a fresh instance
+        delete require.cache[require.resolve('../../../../../core/server/services/email-analytics/analytics-provider-factory')];
+
+        // Create logging stub before requiring the module
+        loggingStub = {
+            warn: sandbox.stub(),
+            error: sandbox.stub()
+        };
+
+        // Use proxyquire to inject the logging stub
+        const proxyquire = require('proxyquire').noPreserveCache();
+        factory = proxyquire('../../../../../core/server/services/email-analytics/analytics-provider-factory', {
+            '@tryghost/logging': loggingStub
+        });
+
+        // Create mocks for dependencies
+        mockConfig = {
+            get: sandbox.stub()
+        };
+
+        mockSettings = {
+            get: sandbox.stub()
+        };
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        // Clean up module cache
+        delete require.cache[require.resolve('../../../../../core/server/services/email-analytics/analytics-provider-factory')];
+    });
+
+    describe('resolveAnalyticsProvider', function () {
+        it('should export resolveAnalyticsProvider function', function () {
+            should.exist(factory.resolveAnalyticsProvider);
+            factory.resolveAnalyticsProvider.should.be.a.Function();
+        });
+
+        it('returns mailgun analytics for mailgun email provider', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            const result = factory.resolveAnalyticsProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            mockConfig.get.calledOnce.should.be.true();
+            mockConfig.get.calledWith('bulkEmail:provider').should.be.true();
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns mailgun analytics when no provider configured (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(undefined);
+
+            const result = factory.resolveAnalyticsProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns mailgun analytics for empty string (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('');
+
+            const result = factory.resolveAnalyticsProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns null for unknown email providers and logs warning', function () {
+            const unsupportedProviders = ['sendgrid', 'ses', 'postmark', 'smtp', 'brevo', 'resend'];
+
+            unsupportedProviders.forEach((provider) => {
+                mockConfig.get.reset();
+                loggingStub.warn.reset();
+                mockConfig.get.withArgs('bulkEmail:provider').returns(provider);
+
+                const result = factory.resolveAnalyticsProvider(mockConfig);
+
+                should.equal(result, null);
+                loggingStub.warn.calledOnce.should.be.true();
+                loggingStub.warn.calledWith(`No analytics provider available for email provider: ${provider}`).should.be.true();
+            });
+        });
+
+        it('returns null for false value and logs warning', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(false);
+
+            const result = factory.resolveAnalyticsProvider(mockConfig);
+
+            should.equal(result, null);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('returns null for 0 value and logs warning', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(0);
+
+            const result = factory.resolveAnalyticsProvider(mockConfig);
+
+            should.equal(result, null);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+    });
+
+    describe('createAnalyticsProviders', function () {
+        let MailgunProviderStub;
+        let mailgunProviderInstance;
+
+        beforeEach(function () {
+            // Create instance that will be returned
+            mailgunProviderInstance = {
+                fetchLatest: sandbox.stub(),
+                fetchMissing: sandbox.stub()
+            };
+
+            // Create constructor stub
+            MailgunProviderStub = sandbox.stub().returns(mailgunProviderInstance);
+        });
+
+        it('should export createAnalyticsProviders function', function () {
+            should.exist(factory.createAnalyticsProviders);
+            factory.createAnalyticsProviders.should.be.a.Function();
+        });
+
+        it('creates MailgunProvider for mailgun config', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            // Use proxyquire to inject the MailgunProvider stub
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-analytics/analytics-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './EmailAnalyticsProviderMailgun': MailgunProviderStub
+            });
+
+            const result = factoryWithMocks.createAnalyticsProviders(mockConfig, mockSettings);
+
+            // Verify MailgunProvider was created with correct config
+            MailgunProviderStub.calledOnce.should.be.true();
+            MailgunProviderStub.calledWith({
+                config: mockConfig,
+                settings: mockSettings
+            }).should.be.true();
+
+            // Result should be array with the provider instance
+            result.should.be.an.Array();
+            result.length.should.equal(1);
+            result[0].should.equal(mailgunProviderInstance);
+        });
+
+        it('creates MailgunProvider when provider is not configured (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(undefined);
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-analytics/analytics-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './EmailAnalyticsProviderMailgun': MailgunProviderStub
+            });
+
+            const result = factoryWithMocks.createAnalyticsProviders(mockConfig, mockSettings);
+
+            MailgunProviderStub.calledOnce.should.be.true();
+            result.should.be.an.Array();
+            result.length.should.equal(1);
+            result[0].should.equal(mailgunProviderInstance);
+        });
+
+        it('returns empty array for unsupported providers', function () {
+            const unsupportedProviders = ['sendgrid', 'ses', 'postmark'];
+
+            unsupportedProviders.forEach((provider) => {
+                mockConfig.get.reset();
+                loggingStub.warn.reset();
+                mockConfig.get.withArgs('bulkEmail:provider').returns(provider);
+
+                const result = factory.createAnalyticsProviders(mockConfig, mockSettings);
+
+                result.should.be.an.Array();
+                result.length.should.equal(0);
+                loggingStub.warn.calledOnce.should.be.true();
+            });
+        });
+
+        it('returns empty array and logs warning for null provider', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(null);
+
+            const result = factory.createAnalyticsProviders(mockConfig, mockSettings);
+
+            result.should.be.an.Array();
+            result.length.should.equal(0);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('handles empty string as mailgun default', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('');
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-analytics/analytics-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './EmailAnalyticsProviderMailgun': MailgunProviderStub
+            });
+
+            const result = factoryWithMocks.createAnalyticsProviders(mockConfig, mockSettings);
+
+            MailgunProviderStub.calledOnce.should.be.true();
+            result.should.be.an.Array();
+            result.length.should.equal(1);
+        });
+    });
+
+    describe('Integration with EmailAnalyticsServiceWrapper', function () {
+        it('can be required and used by EmailAnalyticsServiceWrapper', function () {
+            const {createAnalyticsProviders, resolveAnalyticsProvider} = factory;
+
+            should.exist(createAnalyticsProviders);
+            should.exist(resolveAnalyticsProvider);
+            createAnalyticsProviders.should.be.a.Function();
+            resolveAnalyticsProvider.should.be.a.Function();
+
+            // Verify the functions have the expected signatures
+            createAnalyticsProviders.length.should.equal(2); // expects 2 parameters
+            resolveAnalyticsProvider.length.should.equal(1); // expects 1 parameter
+        });
+
+        it('returns array format expected by EmailAnalyticsService', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const MailgunProviderStub = sandbox.stub().returns({test: 'provider'});
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-analytics/analytics-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './EmailAnalyticsProviderMailgun': MailgunProviderStub
+            });
+
+            const result = factoryWithMocks.createAnalyticsProviders(mockConfig, mockSettings);
+
+            // EmailAnalyticsService expects an array in the 'providers' field
+            result.should.be.an.Array();
+            result.forEach(provider => {
+                provider.should.be.an.Object();
+            });
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
@@ -242,7 +242,7 @@ describe('Analytics Provider Factory', function () {
 
             // EmailAnalyticsService expects an array in the 'providers' field
             result.should.be.an.Array();
-            result.forEach(provider => {
+            result.forEach((provider) => {
                 provider.should.be.an.Object();
             });
         });

--- a/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/analytics-provider-factory.test.js
@@ -17,9 +17,6 @@ describe('Analytics Provider Factory', function () {
     beforeEach(function () {
         sandbox = sinon.createSandbox();
 
-        // Reset the module cache to get a fresh instance
-        delete require.cache[require.resolve('../../../../../core/server/services/email-analytics/analytics-provider-factory')];
-
         // Create logging stub before requiring the module
         loggingStub = {
             warn: sandbox.stub(),
@@ -44,8 +41,6 @@ describe('Analytics Provider Factory', function () {
 
     afterEach(function () {
         sandbox.restore();
-        // Clean up module cache
-        delete require.cache[require.resolve('../../../../../core/server/services/email-analytics/analytics-provider-factory')];
     });
 
     describe('resolveAnalyticsProvider', function () {
@@ -231,10 +226,6 @@ describe('Analytics Provider Factory', function () {
             should.exist(resolveAnalyticsProvider);
             createAnalyticsProviders.should.be.a.Function();
             resolveAnalyticsProvider.should.be.a.Function();
-
-            // Verify the functions have the expected signatures
-            createAnalyticsProviders.length.should.equal(2); // expects 2 parameters
-            resolveAnalyticsProvider.length.should.equal(1); // expects 1 parameter
         });
 
         it('returns array format expected by EmailAnalyticsService', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19284,6 +19284,14 @@ filesize@^6.1.0:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.4.0.tgz#914f50471dd66fdca3cefe628bd0cde4ef769bcd"
   integrity sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -21862,6 +21870,11 @@ is-object@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-0.1.2.tgz#00efbc08816c33cfc4ac8251d132e10dc65098d7"
   integrity sha512-GkfZZlIZtpkFrqyAXPQSRBMsaHAw+CgoKe2HXAkjd/sfoI9+hS8PT4wg2rJxdQyUKr7N2vHJbg7/jQtE5l5vBQ==
+
+is-object@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
 is-path-inside@^3.0.3:
   version "3.0.3"
@@ -24642,7 +24655,7 @@ meow@^10.1.5:
     type-fest "^1.2.2"
     yargs-parser "^20.2.9"
 
-merge-descriptors@1.0.3:
+merge-descriptors@1.0.3, merge-descriptors@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
@@ -25254,6 +25267,11 @@ module-details-from-path@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==
 
 moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33, moment-timezone@^0.5.48:
   version "0.5.45"
@@ -28411,6 +28429,15 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxyquire@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Summary

Third of 4 incremental PRs to establish an email provider adapter pattern. This PR extracts analytics provider logic to a testable factory module, enabling provider-specific analytics implementations.

## 📋 Foundation Plan: PRs 1-4

| PR | Description | Status |
|----|-------------|--------|
| **1** | Extract provider creation | [#25244](https://github.com/TryGhost/Ghost/pull/25244) |
| **2** | Factory pattern for providers | [#25246](https://github.com/TryGhost/Ghost/pull/25246) |
| **3** | **Analytics provider factory (this PR)** | [#25247](https://github.com/TryGhost/Ghost/pull/25247) |
| **4** | Suppression provider factory | [#25248](https://github.com/TryGhost/Ghost/pull/25248) |

**After PR4:** ✅ Foundation complete - Mailgun runs entirely through adapters

## 📝 This PR (3 of 4): Analytics Provider Factory

### What Changes
- Extracts analytics provider selection to factory module
- Maps email providers to analytics implementations
- Returns empty array for providers without analytics

### Key Design
Analytics is optional - providers without analytics gracefully degrade by returning an empty array.

### Code Pattern
```
// Before: Hardcoded in EmailAnalyticsServiceWrapper
providers: [new MailgunProvider({config, settings})]

// After: Factory determines provider
providers: createAnalyticsProviders(config, settings)
```

### Testing
- ✅ 15 new tests with comprehensive edge cases
- ✅ Consistent default handling with PR2

### Key Design Decisions
1. **Returns array**: Compatible with EmailAnalyticsService expectations
2. **Empty array for unsupported**: Analytics optional, gracefully disabled
3. **Warnings not errors**: Logs but doesn't fail
4. **Smart defaults**: Only undefined/empty default to mailgun

### Running Tests
```bash
cd ghost/core
npx mocha test/unit/server/services/email-analytics/analytics-provider-factory.test.js
```