### PR TITLE
Extract suppression provider logic to factory (PR 4 of 4 - Foundation Complete)

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -1,15 +1,6 @@
 const models = require('../../models');
 const configService = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
-const MailgunClient = require('../lib/MailgunClient');
-const MailgunEmailSuppressionList = require('./MailgunEmailSuppressionList');
+const {createSuppressionProvider} = require('./suppression-provider-factory');
 
-const mailgunClient = new MailgunClient({
-    config: configService,
-    settings: settingsCache
-});
-
-module.exports = new MailgunEmailSuppressionList({
-    Suppression: models.Suppression,
-    apiClient: mailgunClient
-});
+module.exports = createSuppressionProvider(configService, settingsCache, models);

--- a/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
@@ -18,7 +18,7 @@ function resolveSuppressionProvider(config) {
 
     // Map email providers to their suppression implementations
     const suppressionProviderMap = {
-        'mailgun': 'mailgun'
+        mailgun: 'mailgun'
         // Future providers can be added here:
         // 'ses': 'ses',
         // 'sendgrid': 'sendgrid'

--- a/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
@@ -1,0 +1,69 @@
+const logging = require('@tryghost/logging');
+
+/**
+ * Resolves the suppression list provider based on email provider configuration
+ *
+ * Suppression list providers are tied to email providers. If a bulk email provider
+ * doesn't have suppression list support, this returns null and a fallback implementation
+ * (InMemoryEmailSuppressionList) is used.
+ *
+ * @param {Object} config - Configuration service
+ * @returns {string|null} The suppression provider name or null if unsupported
+ */
+function resolveSuppressionProvider(config) {
+    const emailProvider = config.get('bulkEmail:provider');
+
+    // Only use default for undefined or empty string
+    const provider = (emailProvider === undefined || emailProvider === '') ? 'mailgun' : emailProvider;
+
+    // Map email providers to their suppression implementations
+    const suppressionProviderMap = {
+        'mailgun': 'mailgun'
+        // Future providers can be added here:
+        // 'ses': 'ses',
+        // 'sendgrid': 'sendgrid'
+    };
+
+    const suppressionProvider = suppressionProviderMap[provider];
+
+    if (!suppressionProvider && provider !== null && provider !== false && provider !== 0) {
+        logging.warn(`No suppression list provider available for email provider: ${provider}`);
+    } else if (!suppressionProvider) {
+        logging.warn(`No suppression list provider available for email provider: ${emailProvider}`);
+    }
+
+    return suppressionProvider || null;
+}
+
+/**
+ * Creates suppression list provider instance
+ *
+ * @param {Object} config - Configuration service
+ * @param {Object} settings - Settings cache
+ * @param {Object} models - Ghost models
+ * @returns {Object} Suppression list provider instance
+ */
+function createSuppressionProvider(config, settings, models) {
+    const provider = resolveSuppressionProvider(config);
+
+    if (provider === 'mailgun') {
+        const MailgunClient = require('../lib/MailgunClient');
+        const MailgunEmailSuppressionList = require('./MailgunEmailSuppressionList');
+
+        const mailgunClient = new MailgunClient({config, settings});
+
+        return new MailgunEmailSuppressionList({
+            Suppression: models.Suppression,
+            apiClient: mailgunClient
+        });
+    }
+
+    // Fallback to in-memory implementation for unsupported providers
+    const InMemoryEmailSuppressionList = require('./InMemoryEmailSuppressionList');
+    return new InMemoryEmailSuppressionList();
+}
+
+module.exports = {
+    resolveSuppressionProvider,
+    createSuppressionProvider
+};

--- a/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
+++ b/ghost/core/core/server/services/email-suppression-list/suppression-provider-factory.js
@@ -26,10 +26,8 @@ function resolveSuppressionProvider(config) {
 
     const suppressionProvider = suppressionProviderMap[provider];
 
-    if (!suppressionProvider && provider !== null && provider !== false && provider !== 0) {
+    if (!suppressionProvider) {
         logging.warn(`No suppression list provider available for email provider: ${provider}`);
-    } else if (!suppressionProvider) {
-        logging.warn(`No suppression list provider available for email provider: ${emailProvider}`);
     }
 
     return suppressionProvider || null;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -258,6 +258,7 @@
     "parse-prometheus-text-format": "1.1.1",
     "postcss": "8.5.6",
     "postcss-cli": "11.0.1",
+    "proxyquire": "2.1.3",
     "rewire": "8.0.0",
     "should": "13.2.3",
     "sinon": "18.0.1",

--- a/ghost/core/test/unit/server/services/email-suppression-list/suppression-provider-factory.test.js
+++ b/ghost/core/test/unit/server/services/email-suppression-list/suppression-provider-factory.test.js
@@ -1,0 +1,341 @@
+const should = require('should');
+const sinon = require('sinon');
+
+/**
+ * Tests for suppression-provider-factory module
+ *
+ * These tests execute the ACTUAL production code from suppression-provider-factory.js,
+ * following the same pattern as PR2's email-provider-factory and PR3's analytics-provider-factory tests.
+ */
+describe('Suppression Provider Factory', function () {
+    let sandbox;
+    let factory;
+    let mockConfig;
+    let mockSettings;
+    let mockModels;
+    let loggingStub;
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+
+        // Create logging stub before requiring the module
+        loggingStub = {
+            warn: sandbox.stub(),
+            error: sandbox.stub()
+        };
+
+        // Use proxyquire to inject the logging stub
+        const proxyquire = require('proxyquire').noPreserveCache();
+        factory = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+            '@tryghost/logging': loggingStub
+        });
+
+        // Create mocks for dependencies
+        mockConfig = {
+            get: sandbox.stub()
+        };
+
+        mockSettings = {
+            get: sandbox.stub()
+        };
+
+        mockModels = {
+            Suppression: {
+                findOne: sandbox.stub(),
+                findAll: sandbox.stub(),
+                add: sandbox.stub(),
+                destroy: sandbox.stub()
+            }
+        };
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('resolveSuppressionProvider', function () {
+        it('should export resolveSuppressionProvider function', function () {
+            should.exist(factory.resolveSuppressionProvider);
+            factory.resolveSuppressionProvider.should.be.a.Function();
+        });
+
+        it('returns mailgun for mailgun email provider', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            mockConfig.get.calledOnce.should.be.true();
+            mockConfig.get.calledWith('bulkEmail:provider').should.be.true();
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns mailgun when no provider configured (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(undefined);
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns mailgun for empty string (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('');
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, 'mailgun');
+            loggingStub.warn.called.should.be.false();
+        });
+
+        it('returns null for unknown email providers and logs warning', function () {
+            const unsupportedProviders = ['sendgrid', 'ses', 'postmark', 'smtp', 'brevo', 'resend'];
+
+            unsupportedProviders.forEach((provider) => {
+                mockConfig.get.reset();
+                loggingStub.warn.reset();
+                mockConfig.get.withArgs('bulkEmail:provider').returns(provider);
+
+                const result = factory.resolveSuppressionProvider(mockConfig);
+
+                should.equal(result, null);
+                loggingStub.warn.calledOnce.should.be.true();
+                loggingStub.warn.calledWith(`No suppression list provider available for email provider: ${provider}`).should.be.true();
+            });
+        });
+
+        it('returns null for false value and logs warning', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(false);
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, null);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('returns null for 0 value and logs warning', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(0);
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, null);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('returns null for null value and logs warning', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(null);
+
+            const result = factory.resolveSuppressionProvider(mockConfig);
+
+            should.equal(result, null);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+    });
+
+    describe('createSuppressionProvider', function () {
+        let MailgunClientStub;
+        let MailgunEmailSuppressionListStub;
+        let InMemoryEmailSuppressionListStub;
+        let mailgunClientInstance;
+        let mailgunSuppressionInstance;
+        let inMemorySuppressionInstance;
+
+        beforeEach(function () {
+            // Create instances that will be returned
+            mailgunClientInstance = {
+                removeBounce: sandbox.stub(),
+                removeComplaint: sandbox.stub(),
+                removeUnsubscribe: sandbox.stub()
+            };
+
+            mailgunSuppressionInstance = {
+                getSuppressionData: sandbox.stub(),
+                getBulkSuppressionData: sandbox.stub(),
+                removeEmail: sandbox.stub(),
+                init: sandbox.stub()
+            };
+
+            inMemorySuppressionInstance = {
+                getSuppressionData: sandbox.stub(),
+                getBulkSuppressionData: sandbox.stub(),
+                removeEmail: sandbox.stub(),
+                init: sandbox.stub()
+            };
+
+            // Create constructor stubs
+            MailgunClientStub = sandbox.stub().returns(mailgunClientInstance);
+            MailgunEmailSuppressionListStub = sandbox.stub().returns(mailgunSuppressionInstance);
+            InMemoryEmailSuppressionListStub = sandbox.stub().returns(inMemorySuppressionInstance);
+        });
+
+        it('should export createSuppressionProvider function', function () {
+            should.exist(factory.createSuppressionProvider);
+            factory.createSuppressionProvider.should.be.a.Function();
+        });
+
+        it('creates MailgunEmailSuppressionList for mailgun config', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                '../lib/MailgunClient': MailgunClientStub,
+                './MailgunEmailSuppressionList': MailgunEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            // Verify MailgunClient was created with correct config
+            MailgunClientStub.calledOnce.should.be.true();
+            MailgunClientStub.calledWith({
+                config: mockConfig,
+                settings: mockSettings
+            }).should.be.true();
+
+            // Verify MailgunEmailSuppressionList was created
+            MailgunEmailSuppressionListStub.calledOnce.should.be.true();
+            MailgunEmailSuppressionListStub.calledWith({
+                Suppression: mockModels.Suppression,
+                apiClient: mailgunClientInstance
+            }).should.be.true();
+
+            // Result should be the suppression list instance
+            result.should.equal(mailgunSuppressionInstance);
+        });
+
+        it('creates MailgunEmailSuppressionList when provider is not configured (default)', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(undefined);
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                '../lib/MailgunClient': MailgunClientStub,
+                './MailgunEmailSuppressionList': MailgunEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            MailgunClientStub.calledOnce.should.be.true();
+            MailgunEmailSuppressionListStub.calledOnce.should.be.true();
+            result.should.equal(mailgunSuppressionInstance);
+        });
+
+        it('returns InMemoryEmailSuppressionList for unsupported providers', function () {
+            const unsupportedProviders = ['sendgrid', 'ses', 'postmark'];
+
+            unsupportedProviders.forEach((provider) => {
+                mockConfig.get.reset();
+                loggingStub.warn.reset();
+                mockConfig.get.withArgs('bulkEmail:provider').returns(provider);
+
+                const proxyquire = require('proxyquire').noPreserveCache();
+                const InMemoryStub = sandbox.stub().returns(inMemorySuppressionInstance);
+                const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                    '@tryghost/logging': loggingStub,
+                    './InMemoryEmailSuppressionList': InMemoryStub
+                });
+
+                const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+                InMemoryStub.calledOnce.should.be.true();
+                result.should.equal(inMemorySuppressionInstance);
+                loggingStub.warn.calledOnce.should.be.true();
+            });
+        });
+
+        it('returns InMemoryEmailSuppressionList and logs warning for null provider', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(null);
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './InMemoryEmailSuppressionList': InMemoryEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            InMemoryEmailSuppressionListStub.calledOnce.should.be.true();
+            result.should.equal(inMemorySuppressionInstance);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('handles empty string as mailgun default', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('');
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                '../lib/MailgunClient': MailgunClientStub,
+                './MailgunEmailSuppressionList': MailgunEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            MailgunClientStub.calledOnce.should.be.true();
+            MailgunEmailSuppressionListStub.calledOnce.should.be.true();
+            result.should.equal(mailgunSuppressionInstance);
+        });
+
+        it('returns InMemoryEmailSuppressionList for false value', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(false);
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './InMemoryEmailSuppressionList': InMemoryEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            InMemoryEmailSuppressionListStub.calledOnce.should.be.true();
+            result.should.equal(inMemorySuppressionInstance);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+
+        it('returns InMemoryEmailSuppressionList for 0 value', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns(0);
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                './InMemoryEmailSuppressionList': InMemoryEmailSuppressionListStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            InMemoryEmailSuppressionListStub.calledOnce.should.be.true();
+            result.should.equal(inMemorySuppressionInstance);
+            loggingStub.warn.calledOnce.should.be.true();
+        });
+    });
+
+    describe('Integration with service.js', function () {
+        it('can be required and used by service.js', function () {
+            const {createSuppressionProvider, resolveSuppressionProvider} = factory;
+
+            should.exist(createSuppressionProvider);
+            should.exist(resolveSuppressionProvider);
+            createSuppressionProvider.should.be.a.Function();
+            resolveSuppressionProvider.should.be.a.Function();
+        });
+
+        it('returns instance format expected by service consumers', function () {
+            mockConfig.get.withArgs('bulkEmail:provider').returns('mailgun');
+
+            const proxyquire = require('proxyquire').noPreserveCache();
+            const MailgunClientStub = sandbox.stub().returns({});
+            const MailgunSuppressionStub = sandbox.stub().returns({test: 'instance'});
+            const factoryWithMocks = proxyquire('../../../../../core/server/services/email-suppression-list/suppression-provider-factory', {
+                '@tryghost/logging': loggingStub,
+                '../lib/MailgunClient': MailgunClientStub,
+                './MailgunEmailSuppressionList': MailgunSuppressionStub
+            });
+
+            const result = factoryWithMocks.createSuppressionProvider(mockConfig, mockSettings, mockModels);
+
+            // Service expects a single instance, not an array
+            result.should.be.an.Object();
+            result.should.not.be.an.Array();
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -19284,6 +19284,14 @@ filesize@^6.1.0:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.4.0.tgz#914f50471dd66fdca3cefe628bd0cde4ef769bcd"
   integrity sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -21862,6 +21870,11 @@ is-object@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-0.1.2.tgz#00efbc08816c33cfc4ac8251d132e10dc65098d7"
   integrity sha512-GkfZZlIZtpkFrqyAXPQSRBMsaHAw+CgoKe2HXAkjd/sfoI9+hS8PT4wg2rJxdQyUKr7N2vHJbg7/jQtE5l5vBQ==
+
+is-object@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
 is-path-inside@^3.0.3:
   version "3.0.3"
@@ -24642,7 +24655,7 @@ meow@^10.1.5:
     type-fest "^1.2.2"
     yargs-parser "^20.2.9"
 
-merge-descriptors@1.0.3:
+merge-descriptors@1.0.3, merge-descriptors@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
@@ -25254,6 +25267,11 @@ module-details-from-path@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==
 
 moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33, moment-timezone@^0.5.48:
   version "0.5.45"
@@ -28411,6 +28429,15 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxyquire@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Summary

**🎉 Foundation Complete!** Fourth and final PR establishing the email provider adapter pattern. This PR extracts suppression list provider logic to a testable factory module, completing the abstraction of all Mailgun-specific code.

## 📋 Foundation Series Complete

| PR | Description | Status |
|----|-------------|--------|
| **1** | Extract provider creation | [#25244](https://github.com/TryGhost/Ghost/pull/25244) |
| **2** | Factory pattern for providers | [#25246](https://github.com/TryGhost/Ghost/pull/25246) |
| **3** | Analytics provider factory| [#25247](https://github.com/TryGhost/Ghost/pull/25247) |
| **4** | **Suppression provider factory (this PR)** | [#25248](https://github.com/TryGhost/Ghost/pull/25248) |

**🚀 Result:** All Mailgun-specific code now extracted to factories. Ready for alternative providers!

## 🎯 Why This Matters

The suppression list was the last piece hardcoded to Mailgun in `service.js`. With this PR:
- ✅ All three email services (sending, analytics, suppression) now use factories
- ✅ Provider selection is centralized through `bulkEmail:provider` config
- ✅ New providers can be added without modifying service initialization
- ✅ **Foundation complete - ready for Amazon SES implementation**

## 📝 This PR (4 of 4): Suppression Provider Factory - Foundation Complete! 🎉

### What Changes
- Extracts suppression list provider to factory module
- Simplifies service.js from 15 to 6 lines
- Returns InMemoryEmailSuppressionList for unsupported providers

### Key Design
Unlike analytics, suppression is required - we return InMemory implementation as safe fallback rather than null.

### Code Pattern
```
// Before: Hardcoded in service.js
module.exports = new MailgunEmailSuppressionList({...});

// After: Factory determines provider
module.exports = createSuppressionProvider(config, settings, models);
```

### Testing
- ✅ 18 new tests - all passed first try
- ✅ Foundation complete: 48 total new tests across series

### Key Design Decision: InMemory Fallback
Unlike analytics (which returns empty array), suppression returns InMemory implementation:
- Suppression is required functionality (member API depends on it)
- InMemory provides safe no-op behavior
- Prevents null pointer exceptions
- Already exists for testing purposes

### Running Tests
```bash
cd ghost/core
npx mocha test/unit/server/services/email-suppression-list/suppression-provider-factory.test.js

# Results: 18 passing (81ms) ✅
```

## 🏆 Foundation Achievement Complete

With this PR, we've completed the email provider adapter foundation:

### What's Been Accomplished (PRs 1-4)
1. **Email Provider Factory** - Selects and creates email sending providers
2. **Analytics Provider Factory** - Maps providers to analytics implementations  
3. **Suppression Provider Factory** - Handles provider-specific suppression lists
4. **All tests passing** - 48 new tests added across the foundation