### PR TITLE
Added email provider base class for adapter system (Phase 1: Email Adapter Foundation 1/4)

### DIFF
--- a/ghost/core/core/server/adapters/email/EmailProviderBase.js
+++ b/ghost/core/core/server/adapters/email/EmailProviderBase.js
@@ -1,3 +1,5 @@
+const errors = require('@tryghost/errors');
+
 /**
  * Base class for email provider adapters
  *
@@ -36,11 +38,9 @@ class EmailProviderBase {
      * @param {Object} [options] - Send options
      * @param {boolean} [options.clickTrackingEnabled] - Enable click tracking
      * @param {boolean} [options.openTrackingEnabled] - Enable open tracking
-     * @returns {Promise<Object>} Send result with provider message ID
      * @returns {Promise<{id: string}>} Object containing the provider's message ID
      */
     async send() {
-        const errors = require('@tryghost/errors');
         throw new errors.IncorrectUsageError({
             message: 'send() must be implemented by email provider adapter'
         });

--- a/ghost/core/core/server/adapters/email/EmailProviderBase.js
+++ b/ghost/core/core/server/adapters/email/EmailProviderBase.js
@@ -1,0 +1,50 @@
+/**
+ * Base class for email provider adapters
+ *
+ * Email provider adapters handle sending bulk emails through various email service providers.
+ * All email provider adapters must extend this base class and implement the required methods.
+ *
+ * @abstract
+ */
+class EmailProviderBase {
+    /**
+     * @param {Object} config - Provider-specific configuration
+     */
+    constructor(config) {
+        Object.defineProperty(this, 'requiredFns', {
+            value: ['send'],
+            writable: false
+        });
+
+        /**
+         * Provider configuration
+         * @type {Object}
+         */
+        this.config = config || {};
+    }
+
+    /**
+     * Send an email
+     *
+     * @abstract
+     * @param {Object} data - Email data
+     * @param {string} data.subject - Email subject
+     * @param {string} data.html - Email HTML content
+     * @param {string} data.plaintext - Email plain text content
+     * @param {Object[]} data.recipients - Array of recipient objects
+     * @param {string} data.recipients[].email - Recipient email address
+     * @param {Object} [options] - Send options
+     * @param {boolean} [options.clickTrackingEnabled] - Enable click tracking
+     * @param {boolean} [options.openTrackingEnabled] - Enable open tracking
+     * @returns {Promise<Object>} Send result with provider message ID
+     * @returns {Promise<{id: string}>} Object containing the provider's message ID
+     */
+    async send() {
+        const errors = require('@tryghost/errors');
+        throw new errors.IncorrectUsageError({
+            message: 'send() must be implemented by email provider adapter'
+        });
+    }
+}
+
+module.exports = EmailProviderBase;

--- a/ghost/core/core/server/adapters/email/EmailProviderBase.js
+++ b/ghost/core/core/server/adapters/email/EmailProviderBase.js
@@ -40,7 +40,7 @@ class EmailProviderBase {
      * @param {boolean} [options.openTrackingEnabled] - Enable open tracking
      * @returns {Promise<{id: string}>} Object containing the provider's message ID
      */
-    async send() {
+    async send(data, options) {
         throw new errors.IncorrectUsageError({
             message: 'send() must be implemented by email provider adapter'
         });

--- a/ghost/core/core/server/services/adapter-manager/index.js
+++ b/ghost/core/core/server/services/adapter-manager/index.js
@@ -21,7 +21,7 @@ adapterManager.registerAdapter('email', require('../../adapters/email/EmailProvi
 module.exports = {
     /**
      *
-     * @param {String} name - one of 'storage', 'scheduling', 'sso', 'cache' etc. Or can contain a "resource" extension like "storage:image"
+     * @param {String} name - one of 'storage', 'scheduling', 'sso', 'cache', 'email' etc. Or can contain a "resource" extension like "storage:image"
      * @returns {Object} instance of an adapter
      */
     getAdapter(name) {

--- a/ghost/core/core/server/services/adapter-manager/index.js
+++ b/ghost/core/core/server/services/adapter-manager/index.js
@@ -16,6 +16,7 @@ adapterManager.registerAdapter('storage', require('ghost-storage-base'));
 adapterManager.registerAdapter('scheduling', require('../../adapters/scheduling/scheduling-base'));
 adapterManager.registerAdapter('sso', require('../../adapters/sso/SSOBase'));
 adapterManager.registerAdapter('cache', require('@tryghost/adapter-base-cache'));
+adapterManager.registerAdapter('email', require('../../adapters/email/EmailProviderBase'));
 
 module.exports = {
     /**

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -32,6 +32,11 @@
             "settings": {},
             "imageSizes": {},
             "gscan": {}
+        },
+        "email": {
+            "active": "mailgun",
+            "mailgun": {},
+            "ses": {}
         }
     },
     "storage": {

--- a/ghost/core/test/unit/server/adapters/email/EmailProviderBase.test.js
+++ b/ghost/core/test/unit/server/adapters/email/EmailProviderBase.test.js
@@ -1,0 +1,78 @@
+const should = require('should');
+const EmailProviderBase = require('../../../../../core/server/adapters/email/EmailProviderBase');
+
+describe('EmailProviderBase', function () {
+    describe('constructor', function () {
+        it('sets requiredFns property', function () {
+            const base = new EmailProviderBase({});
+
+            should.exist(base.requiredFns);
+            base.requiredFns.should.be.an.Array();
+            base.requiredFns.should.containEql('send');
+        });
+
+        it('stores config', function () {
+            const config = {domain: 'test.com', apiKey: 'key-123'};
+            const base = new EmailProviderBase(config);
+
+            should.exist(base.config);
+            base.config.should.equal(config);
+        });
+
+        it('handles missing config', function () {
+            const base = new EmailProviderBase();
+
+            should.exist(base.config);
+            base.config.should.eql({});
+        });
+    });
+
+    describe('send method', function () {
+        it('is defined', function () {
+            const base = new EmailProviderBase({});
+
+            base.send.should.be.a.Function();
+        });
+
+        it('throws error when not implemented', async function () {
+            const base = new EmailProviderBase({});
+            const emailData = {
+                subject: 'Test',
+                html: '<p>Test</p>',
+                plaintext: 'Test',
+                recipients: [{email: 'test@example.com'}]
+            };
+
+            await base.send(emailData).should.be.rejected();
+        });
+
+        it('throws error with descriptive message', async function () {
+            const base = new EmailProviderBase({});
+
+            try {
+                await base.send({});
+                should.fail('Should have thrown an error');
+            } catch (error) {
+                error.message.should.match(/send\(\) must be implemented by email provider adapter/);
+            }
+        });
+    });
+
+    describe('integration with AdapterManager', function () {
+        it('can be required by AdapterManager', function () {
+            // This test verifies the module exports correctly
+            const BaseClass = require('../../../../../core/server/adapters/email/EmailProviderBase');
+
+            should.exist(BaseClass);
+            BaseClass.should.be.a.Function();
+        });
+
+        it('can be instantiated', function () {
+            const BaseClass = require('../../../../../core/server/adapters/email/EmailProviderBase');
+            const instance = new BaseClass({});
+
+            should.exist(instance);
+            instance.should.be.instanceOf(EmailProviderBase);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/adapters/email/EmailProviderBase.test.js
+++ b/ghost/core/test/unit/server/adapters/email/EmailProviderBase.test.js
@@ -58,9 +58,8 @@ describe('EmailProviderBase', function () {
         });
     });
 
-    describe('integration with AdapterManager', function () {
-        it('can be required by AdapterManager', function () {
-            // This test verifies the module exports correctly
+    describe('module exports', function () {
+        it('can be required', function () {
             const BaseClass = require('../../../../../core/server/adapters/email/EmailProviderBase');
 
             should.exist(BaseClass);


### PR DESCRIPTION
## Summary

**Phase 1: Email Adapter Foundation (1/4)**

Creates the base email provider adapter class to enable pluggable email providers. This establishes the foundation for supporting multiple email services (Mailgun, SES, Postmark, SendGrid) while maintaining backward compatibility.

**Phase 1:** 📍[PR1](https://github.com/TryGhost/Ghost/pull/25250) → [PR2](https://github.com/TryGhost/Ghost/pull/25251) → [PR3](https://github.com/TryGhost/Ghost/pull/25252) → [PR4](https://github.com/TryGhost/Ghost/pull/25253)

**Phase 2:** [PR5](https://github.com/TryGhost/Ghost/pull/25367) → [PR6](https://github.com/TryGhost/Ghost/pull/25365) → [PR7](https://github.com/TryGhost/Ghost/pull/25366)

---

## Context

This PR series addresses [#22771#issuecomment-2793035710](https://github.com/TryGhost/Ghost/pull/22771#issuecomment-2793035710) to add support for alternative email providers.

Following @ErisDS's guidance:
> "Make the smallest change you can find that moves the codebase towards having mailgun bulk mail be an adapter, rather than built-in"

## Changes

- Introduces `EmailProviderBase` adapter class with immutable contract enforcement
- Registers `email` adapter type in AdapterManager
- Adds email adapter configuration to defaults
- Includes unit tests for base class contract

The base class requires implementations to provide a `send()` method and validates this contract through AdapterManager.

**Next:** PR2 refactors Mailgun to use this adapter pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce base email provider adapter and wire it into the adapter manager with default config and tests.
> 
> - **Backend**
>   - **Email**
>     - Add `EmailProviderBase` adapter class with `send` contract and config handling in `core/server/adapters/email/EmailProviderBase.js`.
>     - Register `email` adapter type in `core/server/services/adapter-manager/index.js`.
>     - Extend `core/shared/config/defaults.json` with `adapters.email` defaults (`active: "mailgun"`, `mailgun`, `ses`).
> - **Tests**
>   - Add unit tests for `EmailProviderBase` covering construction and `send` not-implemented error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f58b630929f6425af30f98b93f08d8a1f7593919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
