### PR TITLE
🐛 Fixed outdated dashboard links in design and profile modals

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -210,7 +210,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         if (canAccessSettings(currentUser)) {
             updateRoute('staff');
         } else {
-            updateRoute({isExternal: true, route: 'dashboard'});
+            updateRoute({isExternal: true, route: 'analytics'});
         }
     }, [currentUser, updateRoute]);
 

--- a/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
@@ -202,7 +202,7 @@ const DesignModal: React.FC = () => {
     return <PreviewModalContent
         afterClose={() => {
             if (refParam === 'setup') {
-                window.location.hash = '/analytics/';
+                updateRoute({isExternal: true, route: 'analytics'});
             } else {
                 updateRoute('design');
             }

--- a/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
@@ -202,7 +202,7 @@ const DesignModal: React.FC = () => {
     return <PreviewModalContent
         afterClose={() => {
             if (refParam === 'setup') {
-                window.location.hash = '/dashboard/';
+                window.location.hash = '/analytics/';
             } else {
                 updateRoute('design');
             }


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-690

- We retired the dashboard route in favor of analytics, but it was missed in a few places
- This PR updates it in the design modal that shows up during site setup, as well as for users with permissions below admin
- Now when those modals are closed they'll be redirected to /analytics instead of /dashboard (in the case of low-permission users, it actually falls back to something other than /analytics. For contributors, for example, it falls back to /posts. But that's elsewhere in the code)
- Not user visible since /dashboard was redirecting to /analytics anyway, but more correct
- in DesignModal, also switches from `window.location.hash` to `updateRoute`
- Considered creating a constant for routes, but that seems like a larger lift than this ticket was meant for


---

Location of fix in DesignModal:
![redir](https://github.com/user-attachments/assets/7240743c-732e-4ec6-a7cc-9fd5563a625a)

Location of fix in UserDetailModal (click "your profile" then close):
<img width="300" height="792" alt="Screenshot 2025-10-27 at 8 47 52 AM" src="https://github.com/user-attachments/assets/5775c2c5-7d6e-4352-8126-166898e66592" />
