### PR TITLE
🐛 Fixed growth table loading state showing empty instead of skeleton

### DIFF
--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -53,7 +53,7 @@ const Growth: React.FC = () => {
     const {isLoading, chartData, totals, currencySymbol, subscriptionData} = useGrowthStats(range);
 
     // Get growth data with post_type filtering - only call when not on Sources tab
-    const {data: topPostsData} = useTopPostsStatsWithRange(
+    const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsStatsWithRange(
         range,
         sortBy as TopPostsOrder,
         selectedContentType as 'posts' | 'pages' | 'posts_and_pages'
@@ -120,6 +120,7 @@ const Growth: React.FC = () => {
     }, [topPostsData, sortBy]);
 
     const isPageLoading = isLoading;
+    const isTableLoading = isLoading || isTopPostsLoading;
 
     return (
         <StatsLayout>
@@ -139,7 +140,7 @@ const Growth: React.FC = () => {
                         />
                     </CardContent>
                 </Card>
-                {isPageLoading ?
+                {isTableLoading ?
                     <Card className='min-h-[460px]'>
                         <CardHeader>
                             <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -1,21 +1,21 @@
 import DateRangeSelect from '../components/DateRangeSelect';
 import GrowthKPIs from './components/GrowthKPIs';
 import GrowthSources from './components/GrowthSources';
-import React, { useMemo, useState } from 'react';
+import React, {useMemo, useState} from 'react';
 import SortButton from '../components/SortButton';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
-import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber } from '@tryghost/shade';
-import { CONTENT_TYPES, ContentType, getContentTitle, getGrowthContentDescription } from '@src/utils/content-helpers';
-import { getClickHandler } from '@src/utils/url-helpers';
-import { getPeriodText } from '@src/utils/chart-helpers';
-import { useAppContext } from '@src/App';
-import { useGlobalData } from '@src/providers/GlobalDataProvider';
-import { useGrowthStats } from '@src/hooks/useGrowthStats';
-import { useNavigate, useSearchParams } from '@tryghost/admin-x-framework';
-import { useTopPostsStatsWithRange } from '@src/hooks/useTopPostsStatsWithRange';
-import type { TopPostStatItem } from '@tryghost/admin-x-framework/api/stats';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {CONTENT_TYPES, ContentType, getContentTitle, getGrowthContentDescription} from '@src/utils/content-helpers';
+import {getClickHandler} from '@src/utils/url-helpers';
+import {getPeriodText} from '@src/utils/chart-helpers';
+import {useAppContext} from '@src/App';
+import {useGlobalData} from '@src/providers/GlobalDataProvider';
+import {useGrowthStats} from '@src/hooks/useGrowthStats';
+import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
+import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
+import type {TopPostStatItem} from '@tryghost/admin-x-framework/api/stats';
 
 // Type for unified content data that combines top content with growth metrics
 interface UnifiedGrowthContentData {
@@ -39,21 +39,21 @@ type SourcesOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc' | 'so
 type UnifiedSortOrder = TopPostsOrder | SourcesOrder;
 
 const Growth: React.FC = () => {
-    const { range, site } = useGlobalData();
+    const {range, site} = useGlobalData();
     const navigate = useNavigate();
     const [sortBy, setSortBy] = useState<UnifiedSortOrder>('free_members desc');
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
     const [searchParams] = useSearchParams();
-    const { appSettings } = useAppContext();
+    const {appSettings} = useAppContext();
 
     // Get the initial tab from URL search parameters
     const initialTab = searchParams.get('tab') || 'total-members';
 
     // Get stats from custom hook once
-    const { isLoading, chartData, totals, currencySymbol, subscriptionData } = useGrowthStats(range);
+    const {isLoading, chartData, totals, currencySymbol, subscriptionData} = useGrowthStats(range);
 
     // Get growth data with post_type filtering - only call when not on Sources tab
-    const { data: topPostsData, isLoading: isTopPostsLoading } = useTopPostsStatsWithRange(
+    const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsStatsWithRange(
         range,
         sortBy as TopPostsOrder,
         selectedContentType as 'posts' | 'pages' | 'posts_and_pages'
@@ -204,7 +204,7 @@ const Growth: React.FC = () => {
                                                 <TableCell className='border-none py-12 group-hover:!bg-transparent' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
                                                     <EmptyIndicator
                                                         actions={
-                                                            <Button variant='outline' onClick={() => navigate('/settings/analytics', { crossApp: true })}>
+                                                            <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
                                                                 Open settings
                                                             </Button>
                                                         }

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -197,7 +197,11 @@ const Growth: React.FC = () => {
                                 :
                                 <TableBody>
                                     {isTableLoading ? (
-                                        <Skeleton containerClassName='block pt-2 space-y-2' count={5} maxWidth={75} randomize />
+                                        <TableRow className='last:border-none'>
+                                            <TableCell className='border-none py-2' colSpan={1}>
+                                                <Skeleton containerClassName='space-y-2' count={5} maxWidth={75} randomize />
+                                            </TableCell>
+                                        </TableRow>
                                     ) : (
                                         !appSettings?.analytics.membersTrackSources ? (
                                             <TableRow className='last:border-none'>

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -1,21 +1,21 @@
 import DateRangeSelect from '../components/DateRangeSelect';
 import GrowthKPIs from './components/GrowthKPIs';
 import GrowthSources from './components/GrowthSources';
-import React, {useMemo, useState} from 'react';
+import React, { useMemo, useState } from 'react';
 import SortButton from '../components/SortButton';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber} from '@tryghost/shade';
-import {CONTENT_TYPES, ContentType, getContentTitle, getGrowthContentDescription} from '@src/utils/content-helpers';
-import {getClickHandler} from '@src/utils/url-helpers';
-import {getPeriodText} from '@src/utils/chart-helpers';
-import {useAppContext} from '@src/App';
-import {useGlobalData} from '@src/providers/GlobalDataProvider';
-import {useGrowthStats} from '@src/hooks/useGrowthStats';
-import {useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
-import {useTopPostsStatsWithRange} from '@src/hooks/useTopPostsStatsWithRange';
-import type {TopPostStatItem} from '@tryghost/admin-x-framework/api/stats';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber } from '@tryghost/shade';
+import { CONTENT_TYPES, ContentType, getContentTitle, getGrowthContentDescription } from '@src/utils/content-helpers';
+import { getClickHandler } from '@src/utils/url-helpers';
+import { getPeriodText } from '@src/utils/chart-helpers';
+import { useAppContext } from '@src/App';
+import { useGlobalData } from '@src/providers/GlobalDataProvider';
+import { useGrowthStats } from '@src/hooks/useGrowthStats';
+import { useNavigate, useSearchParams } from '@tryghost/admin-x-framework';
+import { useTopPostsStatsWithRange } from '@src/hooks/useTopPostsStatsWithRange';
+import type { TopPostStatItem } from '@tryghost/admin-x-framework/api/stats';
 
 // Type for unified content data that combines top content with growth metrics
 interface UnifiedGrowthContentData {
@@ -39,21 +39,21 @@ type SourcesOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc' | 'so
 type UnifiedSortOrder = TopPostsOrder | SourcesOrder;
 
 const Growth: React.FC = () => {
-    const {range, site} = useGlobalData();
+    const { range, site } = useGlobalData();
     const navigate = useNavigate();
     const [sortBy, setSortBy] = useState<UnifiedSortOrder>('free_members desc');
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
     const [searchParams] = useSearchParams();
-    const {appSettings} = useAppContext();
+    const { appSettings } = useAppContext();
 
     // Get the initial tab from URL search parameters
     const initialTab = searchParams.get('tab') || 'total-members';
 
     // Get stats from custom hook once
-    const {isLoading, chartData, totals, currencySymbol, subscriptionData} = useGrowthStats(range);
+    const { isLoading, chartData, totals, currencySymbol, subscriptionData } = useGrowthStats(range);
 
     // Get growth data with post_type filtering - only call when not on Sources tab
-    const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsStatsWithRange(
+    const { data: topPostsData, isLoading: isTopPostsLoading } = useTopPostsStatsWithRange(
         range,
         sortBy as TopPostsOrder,
         selectedContentType as 'posts' | 'pages' | 'posts_and_pages'
@@ -140,79 +140,71 @@ const Growth: React.FC = () => {
                         />
                     </CardContent>
                 </Card>
-                {isTableLoading ?
-                    <Card className='min-h-[460px]'>
-                        <CardHeader>
-                            <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>
-                            <CardDescription>{getGrowthContentDescription(selectedContentType, range, getPeriodText)}</CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <SkeletonTable lines={5} />
-                        </CardContent>
-                    </Card>
-                    :
-                    <Card className='w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]' data-testid='top-content-card'>
-                        <CardHeader>
-                            <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>
-                            <CardDescription>{getGrowthContentDescription(selectedContentType, range, getPeriodText)}</CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <Table>
-                                <TableHeader>
-                                    <TableRow className='[&>th]:h-auto [&>th]:pb-2 [&>th]:pt-0'>
-                                        <TableHead className='min-w-[320px] pl-0'>
-                                            <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
-                                                setSelectedContentType(value as ContentType);
-                                            }}>
-                                                <TabsList>
-                                                    <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
-                                                    <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
-                                                    <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
-                                                    <TabsTrigger value={CONTENT_TYPES.SOURCES}>Sources</TabsTrigger>
-                                                </TabsList>
-                                            </Tabs>
-                                        </TableHead>
-                                        <TableHead className='w-[140px] text-right'>
-                                            {appSettings?.paidMembersEnabled ?
-                                                <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='free_members desc'>
+                <Card className='w-full overflow-x-auto' data-testid='top-content-card'>
+                    <CardHeader>
+                        <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>
+                        <CardDescription>{getGrowthContentDescription(selectedContentType, range, getPeriodText)}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow className='[&>th]:h-auto [&>th]:pb-2 [&>th]:pt-0'>
+                                    <TableHead className='min-w-[320px] pl-0'>
+                                        <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
+                                            setSelectedContentType(value as ContentType);
+                                        }}>
+                                            <TabsList>
+                                                <TabsTrigger value={CONTENT_TYPES.POSTS_AND_PAGES}>Posts & pages</TabsTrigger>
+                                                <TabsTrigger value={CONTENT_TYPES.POSTS}>Posts</TabsTrigger>
+                                                <TabsTrigger value={CONTENT_TYPES.PAGES}>Pages</TabsTrigger>
+                                                <TabsTrigger value={CONTENT_TYPES.SOURCES}>Sources</TabsTrigger>
+                                            </TabsList>
+                                        </Tabs>
+                                    </TableHead>
+                                    <TableHead className='w-[140px] text-right'>
+                                        {appSettings?.paidMembersEnabled ?
+                                            <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='free_members desc'>
                                                 Free members
-                                                </SortButton>
-                                                :
-                                                <>Free members</>
-                                            }
-                                        </TableHead>
-                                        {appSettings?.paidMembersEnabled &&
+                                            </SortButton>
+                                            :
+                                            <>Free members</>
+                                        }
+                                    </TableHead>
+                                    {appSettings?.paidMembersEnabled &&
                                         <>
                                             <TableHead className='w-[140px] text-right'>
                                                 <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='paid_members desc'>
-                                                Paid members
+                                                    Paid members
                                                 </SortButton>
                                             </TableHead>
                                             <TableHead className='w-[140px] text-right'>
                                                 <SortButton activeSortBy={sortBy} setSortBy={setSortBy} sortBy='mrr desc'>
-                                                MRR impact
+                                                    MRR impact
                                                 </SortButton>
                                             </TableHead>
                                         </>
-                                        }
-                                    </TableRow>
-                                </TableHeader>
-                                {selectedContentType === CONTENT_TYPES.SOURCES ?
-                                    <GrowthSources
-                                        limit={20}
-                                        range={range}
-                                        setSortBy={(newSortBy: SourcesOrder) => setSortBy(newSortBy)}
-                                        showViewAll={true}
-                                        sortBy={sortBy as SourcesOrder}
-                                    />
-                                    :
-                                    <TableBody>
-                                        {!appSettings?.analytics.membersTrackSources ? (
+                                    }
+                                </TableRow>
+                            </TableHeader>
+                            {selectedContentType === CONTENT_TYPES.SOURCES ?
+                                <GrowthSources
+                                    limit={20}
+                                    range={range}
+                                    setSortBy={(newSortBy: SourcesOrder) => setSortBy(newSortBy)}
+                                    showViewAll={true}
+                                    sortBy={sortBy as SourcesOrder}
+                                />
+                                :
+                                <TableBody>
+                                    {isTableLoading ? (
+                                        <SkeletonTable className='pt-2' lines={5} />
+                                    ) : (
+                                        !appSettings?.analytics.membersTrackSources ? (
                                             <TableRow className='last:border-none'>
                                                 <TableCell className='border-none py-12 group-hover:!bg-transparent' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
                                                     <EmptyIndicator
                                                         actions={
-                                                            <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
+                                                            <Button variant='outline' onClick={() => navigate('/settings/analytics', { crossApp: true })}>
                                                                 Open settings
                                                             </Button>
                                                         }
@@ -251,14 +243,14 @@ const Growth: React.FC = () => {
                                                         {(post.free_members > 0 && '+')}{formatNumber(post.free_members)}
                                                     </TableCell>
                                                     {appSettings?.paidMembersEnabled &&
-                                                    <>
-                                                        <TableCell className='text-right font-mono text-sm'>
-                                                            {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
-                                                        </TableCell>
-                                                        <TableCell className='text-right font-mono text-sm'>
-                                                            {(post.mrr > 0 && '+')}{currencySymbol}{centsToDollars(post.mrr).toFixed(0)}
-                                                        </TableCell>
-                                                    </>
+                                                        <>
+                                                            <TableCell className='text-right font-mono text-sm'>
+                                                                {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
+                                                            </TableCell>
+                                                            <TableCell className='text-right font-mono text-sm'>
+                                                                {(post.mrr > 0 && '+')}{currencySymbol}{centsToDollars(post.mrr).toFixed(0)}
+                                                            </TableCell>
+                                                        </>
                                                     }
                                                 </TableRow>
                                             ))
@@ -273,13 +265,13 @@ const Growth: React.FC = () => {
                                                     </EmptyIndicator>
                                                 </TableCell>
                                             </TableRow>
-                                        )}
-                                    </TableBody>
-                                }
-                            </Table>
-                        </CardContent>
-                    </Card>
-                }
+                                        )
+                                    )}
+                                </TableBody>
+                            }
+                        </Table>
+                    </CardContent>
+                </Card>
             </StatsView>
         </StatsLayout>
     );

--- a/apps/stats/src/views/Stats/Growth/Growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/Growth.tsx
@@ -6,7 +6,7 @@ import SortButton from '../components/SortButton';
 import StatsHeader from '../layout/StatsHeader';
 import StatsLayout from '../layout/StatsLayout';
 import StatsView from '../layout/StatsView';
-import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber} from '@tryghost/shade';
+import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Tabs, TabsList, TabsTrigger, centsToDollars, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {CONTENT_TYPES, ContentType, getContentTitle, getGrowthContentDescription} from '@src/utils/content-helpers';
 import {getClickHandler} from '@src/utils/url-helpers';
 import {getPeriodText} from '@src/utils/chart-helpers';
@@ -197,7 +197,7 @@ const Growth: React.FC = () => {
                                 :
                                 <TableBody>
                                     {isTableLoading ? (
-                                        <SkeletonTable className='pt-2' lines={5} />
+                                        <Skeleton containerClassName='block pt-2 space-y-2' count={5} maxWidth={75} randomize />
                                     ) : (
                                         !appSettings?.analytics.membersTrackSources ? (
                                             <TableRow className='last:border-none'>

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -188,7 +188,7 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
 
     if (isLoading) {
         return (
-            <SkeletonTable lines={5} />
+            <SkeletonTable className='pt-2' lines={5} />
         );
     }
 

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -188,7 +188,13 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
 
     if (isLoading) {
         return (
-            <Skeleton containerClassName='block pt-2 space-y-2' count={5} maxWidth={75} randomize />
+            <TableBody>
+                <TableRow className='last:border-none'>
+                    <TableCell className='border-none py-2' colSpan={1}>
+                        <Skeleton containerClassName='space-y-2' count={5} maxWidth={75} randomize />
+                    </TableCell>
+                </TableRow>
+            </TableBody>
         );
     }
 

--- a/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/GrowthSources.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import SortButton from '../../components/SortButton';
 import SourceIcon from '../../components/SourceIcon';
-import {Button, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, centsToDollars, formatNumber} from '@tryghost/shade';
+import {Button, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Skeleton, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, centsToDollars, formatNumber} from '@tryghost/shade';
 import {getFaviconDomain, getSymbol, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/GlobalDataProvider';
@@ -188,7 +188,7 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
 
     if (isLoading) {
         return (
-            <SkeletonTable className='pt-2' lines={5} />
+            <Skeleton containerClassName='block pt-2 space-y-2' count={5} maxWidth={75} randomize />
         );
     }
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-706

- Table loading state was being driven by the `isPageLoading` variable that comes from calling `useGrowthStats`, but the data for the growth table in particular (instead of the chart) comes from `useTopPostsStatsWithRange`
- This PR updates the table loading state so that it's toggled whenever data is fetched for the table itself
- Makes it so the header row doesn't disappear during loading
- Adds a bit of padding above the skeleton for both posts/pages and source table. Note there's a bit of tweaking left to do so that the skeleton is full width (so the columns line up)
- Makes the table full width


<img width="300" height="711" alt="Screenshot 2025-11-11 at 6 21 51 PM" src="https://github.com/user-attachments/assets/4dea1324-5b1c-4c00-84d3-251149786605" />
<img width="300" height="1024" alt="Screenshot 2025-11-11 at 6 58 30 PM" src="https://github.com/user-attachments/assets/17852735-5e86-4709-8869-2f1e79b7ec6a" />


