### PR TITLE
Ber 2916 remove activiytpub router basepath

### DIFF
--- a/apps/activitypub/src/components/global/BackButton.tsx
+++ b/apps/activitypub/src/components/global/BackButton.tsx
@@ -24,7 +24,7 @@ const BackButton: React.FC<BackButtonProps> = ({className, onClick}) => {
                 if (previousPath) {
                     navigate(-1);
                 } else {
-                    navigate('/');
+                    navigate('/network');
                 }
             }}
         >

--- a/apps/activitypub/src/components/layout/Onboarding/Step1.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step1.tsx
@@ -41,7 +41,7 @@ const Step1: React.FC = () => {
                             <p>{account ? <><strong>{account.name}</strong> is now part of the world’s largest open network.</> : <Skeleton className='w-full max-w-md' />}</p>
                         </div>
                     </div>
-                    <Button className={`min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white`} size='lg' onClick={() => navigate('/welcome/2')}>Next &rarr;</Button>
+                    <Button className={`min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white`} size='lg' onClick={() => navigate('/network/welcome/2')}>Next &rarr;</Button>
                 </div>
                 <div className='relative z-10 h-full'>
                     <img className='absolute left-1/2 top-[calc(-280px)] w-full min-w-[1240px] max-w-[1300px] -translate-x-1/2 dark:hidden' src={apNodes} />

--- a/apps/activitypub/src/components/layout/Onboarding/Step2.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step2.tsx
@@ -79,7 +79,7 @@ const Step2: React.FC = () => {
                         <p className='tracking-tight text-gray-700 dark:text-gray-600'>Best of all, you get realtime feedback and visibility when something you published is spreading fast across the social web.</p>
                     </div>
                 </div>
-                <Button className='min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white' size='lg' onClick={() => navigate('/welcome/3')}>Next &rarr;</Button>
+                <Button className='min-w-60 bg-gradient-to-r from-purple-500 to-[#6A1AD6] hover:opacity-90 dark:text-white' size='lg' onClick={() => navigate('/network/welcome/3')}>Next &rarr;</Button>
             </Header>
             <div className='mt-8 flex h-full max-h-[670px] flex-col items-stretch justify-end'>
                 <div className='relative -mx-14 mt-5 w-[calc(100%+112px)] overflow-y-hidden px-14 pt-8'>

--- a/apps/activitypub/src/components/layout/Onboarding/Step3.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step3.tsx
@@ -317,7 +317,7 @@ const Step3: React.FC = () => {
 
     const handleComplete = async () => {
         await setOnboarded(true);
-        navigate('/explore');
+        navigate('/network/explore');
     };
 
     return (

--- a/apps/activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
@@ -7,7 +7,7 @@ const FeedbackBox: React.FC = () => {
 
     function showFeedbackReply() {
         const targetPostId = 'https://activitypub.ghost.org/.ghost/activitypub/note/6d6d7f57-b656-4caa-ba9e-efa1d9a4b3fb';
-        navigate(`/notes/${encodeURIComponent(targetPostId)}`);
+        navigate(`/network/notes/${encodeURIComponent(targetPostId)}`);
     }
 
     return (

--- a/apps/activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -85,7 +85,7 @@ const Recommendations: React.FC = () => {
             </ul>
             <Button className='p-0 font-medium text-purple hover:text-black dark:hover:text-white' variant='link' onClick={() => {
                 resetStack();
-                navigate('/explore');
+                navigate('/network/explore');
             }}>Find more &rarr;</Button>
         </div>
     );

--- a/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -27,7 +27,8 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
 
     // Reset count when on notifications page
     React.useEffect(() => {
-        if (location.pathname === '/notifications' && notificationsCount && notificationsCount > 0) {
+        const notificationsPath = '/network/notifications';
+        if (location.pathname === notificationsPath && notificationsCount && notificationsCount > 0) {
             resetNotificationsCount.mutate();
         }
     }, [location.pathname, notificationsCount, resetNotificationsCount]);
@@ -55,31 +56,31 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
                         </Dialog>
                     </div>
                     <div className='flex w-full flex-col gap-px'>
-                        <SidebarMenuLink to='/reader'>
+                        <SidebarMenuLink to='/network/reader'>
                             <LucideIcon.BookOpen size={18} strokeWidth={1.5} />
                             Reader
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/notes'>
+                        <SidebarMenuLink to='/network/notes'>
                             <LucideIcon.MessageCircle size={18} strokeWidth={1.5} />
                             Notes
                         </SidebarMenuLink>
                         <SidebarMenuLink
-                            count={location.pathname !== '/notifications' ? notificationsCount : undefined}
-                            to='/notifications'
+                            count={location.pathname !== '/network/notifications' ? notificationsCount : undefined}
+                            to='/network/notifications'
                             onClick={handleNotificationsClick}
                         >
                             <LucideIcon.Bell size={18} strokeWidth={1.5} />
                             Notifications
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/explore'>
+                        <SidebarMenuLink to='/network/explore'>
                             <LucideIcon.Globe size={18} strokeWidth={1.5} />
                             Explore
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/profile'>
+                        <SidebarMenuLink to='/network/profile'>
                             <LucideIcon.User size={18} strokeWidth={1.5} />
                             Profile
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/preferences'>
+                        <SidebarMenuLink to='/network/preferences'>
                             <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
                             Preferences
                         </SidebarMenuLink>

--- a/apps/activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/activitypub/src/components/modals/NewNoteModal.tsx
@@ -85,7 +85,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                 onReply?.();
             } else {
                 await noteMutation.mutateAsync({content: trimmedContent, imageUrl: uploadedImageUrl || undefined, altText: altText || undefined});
-                navigate('/notes');
+                navigate('/network/notes');
             }
 
             setIsOpen(false);

--- a/apps/activitypub/src/hooks/use-keyboard-shortcuts.tsx
+++ b/apps/activitypub/src/hooks/use-keyboard-shortcuts.tsx
@@ -54,7 +54,9 @@ export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions = {}) => 
                 break;
             case 'r':
                 if (options.isReplyAvailable && options.onOpenReply) {
-                    const isReaderOrNote = location.pathname.includes('/notes/') || location.pathname.includes('/reader/');
+                    const notesPath = '/network/notes/';
+                    const readerPath = '/network/reader/';
+                    const isReaderOrNote = location.pathname.includes(notesPath) || location.pathname.includes(readerPath);
 
                     if (isReaderOrNote) {
                         e.preventDefault();

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -12,7 +12,7 @@ import OnboardingStep2 from '@components/layout/Onboarding/Step2';
 import OnboardingStep3 from '@components/layout/Onboarding/Step3';
 import Preferences from '@views/Preferences';
 import Profile from '@views/Profile';
-import {Navigate, RouteObject} from '@tryghost/admin-x-framework';
+import {Navigate, RouteObject, useLocation} from '@tryghost/admin-x-framework';
 
 export const APP_ROUTE_PREFIX = '/';
 
@@ -20,6 +20,12 @@ export type CustomRouteObject = RouteObject & {
     pageTitle?: string;
     children?: CustomRouteObject[];
     showBackButton?: boolean;
+};
+
+const ActivityPubToNetworkRedirect = () => {
+    const location = useLocation();
+    const newPath = location.pathname.replace(/^\/activitypub/, '/network');
+    return <Navigate to={`${newPath}${location.search}${location.hash}`} replace />;
 };
 
 export const routes: CustomRouteObject[] = [
@@ -143,5 +149,13 @@ export const routes: CustomRouteObject[] = [
                 element: <Error />
             }
         ]
+    },
+    {
+        path: 'activitypub',
+        element: <Navigate to="/network" replace />
+    },
+    {
+        path: 'activitypub/*',
+        element: <ActivityPubToNetworkRedirect />
     }
 ];

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -14,7 +14,7 @@ import Preferences from '@views/Preferences';
 import Profile from '@views/Profile';
 import {Navigate, RouteObject} from '@tryghost/admin-x-framework';
 
-export const APP_ROUTE_PREFIX = '/activitypub';
+export const APP_ROUTE_PREFIX = '/';
 
 export type CustomRouteObject = RouteObject & {
     pageTitle?: string;
@@ -25,7 +25,7 @@ export type CustomRouteObject = RouteObject & {
 export const routes: CustomRouteObject[] = [
     {
         // Root route configuration
-        path: '',
+        path: 'network',
         errorElement: <Error />, // This will catch all errors in child routes
         children: [
             {

--- a/apps/activitypub/src/utils/handle-profile-click.ts
+++ b/apps/activitypub/src/utils/handle-profile-click.ts
@@ -5,8 +5,8 @@ import {useNavigate} from '@tryghost/admin-x-framework';
 export const handleProfileClick = (actor: ActorProperties | string, navigate: ReturnType<typeof useNavigate>, e?: React.MouseEvent) => {
     e?.stopPropagation();
     if (typeof actor === 'string') {
-        navigate(`/profile/${actor}`);
+        navigate(`/network/profile/${actor}`);
     } else {
-        navigate(`/profile/${actor.handle || getUsername(actor)}`);
+        navigate(`/network/profile/${actor.handle || getUsername(actor)}`);
     }
 };

--- a/apps/activitypub/src/views/Explore/Explore.tsx
+++ b/apps/activitypub/src/views/Explore/Explore.tsx
@@ -43,7 +43,7 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
         <div
             className='flex w-full cursor-pointer items-start gap-3 pt-4 [&:last-of-type>:nth-child(2)]:border-none'
             onClick={() => {
-                navigate(`/profile/${profile.handle}`);
+                navigate(`/network/profile/${profile.handle}`);
             }}
         >
             <div className='flex w-full flex-col gap-1 border-b border-gray-200 pb-4 dark:border-gray-950'>

--- a/apps/activitypub/src/views/Feed/Note.tsx
+++ b/apps/activitypub/src/views/Feed/Note.tsx
@@ -228,7 +228,7 @@ const Note = () => {
                                             repostCount={item.object.repostCount ?? 0}
                                             type='Note'
                                             onClick={() => {
-                                                navigate(`/${item.object.type === 'Article' ? 'reader' : 'notes'}/${encodeURIComponent(item.object.id)}`);
+                                                navigate(`/network/${item.object.type === 'Article' ? 'reader' : 'notes'}/${encodeURIComponent(item.object.id)}`);
                                             }}
                                         />
                                     )
@@ -279,7 +279,7 @@ const Note = () => {
                                                             repostCount={replyGroup.mainReply.object.repostCount ?? 0}
                                                             type='Note'
                                                             onClick={() => {
-                                                                navigate(`/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
+                                                                navigate(`/network/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
                                                             }}
                                                             onDelete={handleDelete}
                                                         />
@@ -300,7 +300,7 @@ const Note = () => {
                                                                 repostCount={replyGroup.chain[0].object.repostCount ?? 0}
                                                                 type='Note'
                                                                 onClick={() => {
-                                                                    navigate(`/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
+                                                                    navigate(`/network/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
                                                                 }}
                                                                 onDelete={handleDelete}
                                                             />
@@ -327,7 +327,7 @@ const Note = () => {
                                                                     repostCount={chainItem.object.repostCount ?? 0}
                                                                     type='Note'
                                                                     onClick={() => {
-                                                                        navigate(`/notes/${encodeURIComponent(chainItem.id)}`);
+                                                                        navigate(`/network/notes/${encodeURIComponent(chainItem.id)}`);
                                                                     }}
                                                                     onDelete={handleDelete}
                                                                 />

--- a/apps/activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/activitypub/src/views/Feed/components/FeedList.tsx
@@ -92,7 +92,7 @@ const FeedList:React.FC<FeedListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            navigate(`/notes/${encodeURIComponent(activity.id)}`);
+                                                            navigate(`/network/notes/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (

--- a/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
+++ b/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
@@ -81,7 +81,7 @@ const SuggestedProfiles: React.FC = () => {
             <div className='pb-7 pt-4'>
                 <div className='mb-3 flex items-center justify-between'>
                     <H4 className='text-lg font-semibold text-black dark:text-white'>More people to follow</H4>
-                    <Button className='px-0 font-medium text-gray-700 hover:text-black dark:text-gray-600 dark:hover:text-white' variant='link' onClick={() => navigate('/explore')}>
+                    <Button className='px-0 font-medium text-gray-700 hover:text-black dark:text-gray-600 dark:hover:text-white' variant='link' onClick={() => navigate('/network/explore')}>
                     Find more &rarr;
                     </Button>
                 </div>
@@ -120,7 +120,7 @@ const SuggestedProfiles: React.FC = () => {
                             <div
                                 key={profile?.id || `loading-${index}`}
                                 className='relative w-40 shrink-0 snap-start rounded-lg bg-gray-75 p-4 dark:bg-gray-925/30'
-                                onClick={!isLoadingSuggestedProfiles && profile ? () => navigate(`/profile/${profile.handle}`) : undefined}
+                                onClick={!isLoadingSuggestedProfiles && profile ? () => navigate(`/network/profile/${profile.handle}`) : undefined}
                             >
                                 <Button
                                     className='absolute right-2 top-1 hidden p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'

--- a/apps/activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/activitypub/src/views/Inbox/components/InboxList.tsx
@@ -94,7 +94,7 @@ const InboxList:React.FC<InboxListProps> = ({
                                                         repostCount={activity.object.repostCount ?? 0}
                                                         type={activity.type}
                                                         onClick={() => {
-                                                            navigate(`/reader/${encodeURIComponent(activity.id)}`);
+                                                            navigate(`/network/reader/${encodeURIComponent(activity.id)}`);
                                                         }}
                                                     />
                                                     {index < activities.length - 1 && (
@@ -123,7 +123,7 @@ const InboxList:React.FC<InboxListProps> = ({
                                     <EmptyViewIcon><LucideIcon.Inbox /></EmptyViewIcon>
                                     <div>Your inbox is the home for <span className='text-black dark:text-white'>long-form posts</span>. It&apos;s empty for now, but posts will show up as soon as the people you follow share something.</div>
                                     <Button className='text-white dark:text-black' onClick={() => {
-                                        navigate('/explore');
+                                        navigate('/network/explore');
                                     }}>
                                     Find accounts to follow &rarr;
                                     </Button>
@@ -140,7 +140,7 @@ const InboxList:React.FC<InboxListProps> = ({
                         if (canGoBack) {
                             goBack();
                         } else {
-                            navigate('/reader');
+                            navigate('/network/reader');
                         }
                     }
                     setIsReaderOpen(open);
@@ -155,7 +155,7 @@ const InboxList:React.FC<InboxListProps> = ({
                         if (canGoBack) {
                             goBack();
                         } else {
-                            navigate('/reader');
+                            navigate('/network/reader');
                         }
                     }} />}
                 </DialogContent>

--- a/apps/activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/activitypub/src/views/Inbox/components/Reader.tsx
@@ -918,7 +918,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                                 if (container && postId) {
                                                                     scrollPositionCache.set(postId, container.scrollTop);
                                                                 }
-                                                                navigate(`/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
+                                                                navigate(`/network/notes/${encodeURIComponent(replyGroup.mainReply.id)}`);
                                                             }}
                                                             onDelete={handleDelete}
                                                         />
@@ -943,7 +943,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                                     if (container && postId) {
                                                                         scrollPositionCache.set(postId, container.scrollTop);
                                                                     }
-                                                                    navigate(`/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
+                                                                    navigate(`/network/notes/${encodeURIComponent(replyGroup.chain[0].id)}`);
                                                                 }}
                                                                 onDelete={handleDelete}
                                                             />
@@ -974,7 +974,7 @@ export const Reader: React.FC<ReaderProps> = ({
                                                                         if (container && postId) {
                                                                             scrollPositionCache.set(postId, container.scrollTop);
                                                                         }
-                                                                        navigate(`/notes/${encodeURIComponent(chainItem.id)}`);
+                                                                        navigate(`/network/notes/${encodeURIComponent(chainItem.id)}`);
                                                                     }}
                                                                     onDelete={handleDelete}
                                                                 />

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -233,17 +233,17 @@ const Notifications: React.FC = () => {
         switch (group.type) {
         case 'like':
             if (group.post) {
-                navigate(`/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
+                navigate(`/network/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'reply':
             if (group.post && group.inReplyTo) {
-                navigate(`/notes/${encodeURIComponent(group.post.id)}`);
+                navigate(`/network/notes/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'repost':
             if (group.post) {
-                navigate(`/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
+                navigate(`/network/${group.post.type === 'article' ? 'reader' : 'notes'}/${encodeURIComponent(group.post.id)}`);
             }
             break;
         case 'follow':
@@ -255,7 +255,7 @@ const Notifications: React.FC = () => {
             break;
         case 'mention':
             if (group.post) {
-                navigate(`/notes/${encodeURIComponent(group.post.id)}`);
+                navigate(`/network/notes/${encodeURIComponent(group.post.id)}`);
             }
             break;
         }

--- a/apps/activitypub/src/views/Preferences/components/Settings.tsx
+++ b/apps/activitypub/src/views/Preferences/components/Settings.tsx
@@ -35,7 +35,7 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                     </DialogContent>
                 </Dialog>
             </SettingItem>
-            <SettingItem withHover onClick={() => navigate('/preferences/moderation')}>
+            <SettingItem withHover onClick={() => navigate('/network/preferences/moderation')}>
                 <SettingHeader>
                     <SettingTitle>Moderation</SettingTitle>
                     <SettingDescription>Manage blocked users and domains</SettingDescription>
@@ -44,7 +44,7 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                     <LucideIcon.ChevronRight size={20} />
                 </SettingAction>
             </SettingItem>
-            <SettingItem withHover onClick={() => navigate('/preferences/bluesky-sharing')}>
+            <SettingItem withHover onClick={() => navigate('/network/preferences/bluesky-sharing')}>
                 <SettingHeader>
                     <SettingTitle>Bluesky sharing</SettingTitle>
                     <SettingDescription>Share content directly on Bluesky</SettingDescription>

--- a/apps/activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/activitypub/src/views/Profile/components/Likes.tsx
@@ -80,9 +80,9 @@ const Likes: React.FC<LikesProps> = ({
                             type={activity.type}
                             onClick={() => {
                                 if (activity.object.type === 'Note') {
-                                    navigate(`/notes/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/network/notes/${encodeURIComponent(activity.object.id)}`);
                                 } else if (activity.object.type === 'Article') {
-                                    navigate(`/reader/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/network/reader/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />

--- a/apps/activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/activitypub/src/views/Profile/components/Posts.tsx
@@ -82,9 +82,9 @@ const Posts: React.FC<PostsProps> = ({
                             type={activity.type}
                             onClick={() => {
                                 if (activity.object.type === 'Note') {
-                                    navigate(`/notes/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/network/notes/${encodeURIComponent(activity.object.id)}`);
                                 } else if (activity.object.type === 'Article') {
-                                    navigate(`/reader/${encodeURIComponent(activity.object.id)}`);
+                                    navigate(`/network/reader/${encodeURIComponent(activity.object.id)}`);
                                 }
                             }}
                         />

--- a/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -43,7 +43,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
     const navigate = useNavigate();
     const {canGoBack} = useNavigationStack();
 
-    const basePath = params.handle ? `/profile/${params.handle}` : '/profile';
+    const basePath = params.handle ? `/network/profile/${params.handle}` : '/network/profile';
     const likesEnabled = !params.handle;
 
     const tabSlug = params.handle

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,9 +1,9 @@
-import { Outlet, redirect, type RouteObject } from "@tryghost/admin-x-framework";
-import { routes as postRoutes } from "@tryghost/posts/src/routes";
+import {Outlet, type RouteObject} from "@tryghost/admin-x-framework";
+import {routes as postRoutes} from "@tryghost/posts/src/routes";
 import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
 import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
 import { routes as statsRoutes, APP_ROUTE_PREFIX as statsAppRoutePrefix } from "@tryghost/stats/src/routes";
-import { routes as activityPubRoutes, APP_ROUTE_PREFIX as activityPubAppRoutePrefix } from "@tryghost/activitypub/src/routes";
+import { routes as activityPubRoutes } from "@tryghost/activitypub/src/routes";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
@@ -23,18 +23,8 @@ export const routes: RouteObject[] = [
         ]
     },
     {
-        path: `network`,
-        loader: () => redirect(activityPubAppRoutePrefix)
-    },
-    {
-        path: `${activityPubAppRoutePrefix}`,
         element: <FeatureFlagsProvider><Outlet /></FeatureFlagsProvider>,
-        children: [
-            ...activityPubRoutes.map(route => ({
-                ...route,
-                path: `${activityPubAppRoutePrefix}${route.path ?? ''}`
-            }))
-        ]
+        children: activityPubRoutes
     },
     {
         path: "*",

--- a/ghost/admin/app/router.js
+++ b/ghost/admin/app/router.js
@@ -61,8 +61,12 @@ Router.map(function () {
         this.route('settings-x', {path: '/*sub'});
     });
 
-    this.route('activitypub-x',{path: '/activitypub'}, function () {
+    this.route('activitypub-x',{path: '/network'}, function () {
         this.route('activitypub-x', {path: '/*sub'});
+    });
+
+    this.route('activitypub-redirect', {path: '/activitypub'}, function () {
+        this.route('sub', {path: '/*sub'});
     });
 
     this.route('explore', function () {

--- a/ghost/admin/app/routes/activitypub-redirect.js
+++ b/ghost/admin/app/routes/activitypub-redirect.js
@@ -1,0 +1,5 @@
+import ActivitypubXRoute from './activitypub-x';
+
+export default class ActivitypubRedirectRoute extends ActivitypubXRoute {
+    templateName = 'activitypub-x';
+}

--- a/ghost/admin/app/routes/activitypub-redirect/sub.js
+++ b/ghost/admin/app/routes/activitypub-redirect/sub.js
@@ -1,0 +1,3 @@
+import ActivitypubRedirectRoute from '../activitypub-redirect';
+
+export default class ActivitypubRedirectSubRoute extends ActivitypubRedirectRoute {}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2916/remove-router-basepaths

Removing the base path and updating all links and urls within the app to include the network prefix directly makes links and URLs work the same regardless of if the app is mounted in Ember or as a sub-routes in the new React admin shell.

As part of changing the path that the activitypub app is mounted on we want to
ensure that the old URLs still work.