### PR TITLE
Remove activitypub router basepath

### DIFF
--- a/apps/activitypub/src/App.tsx
+++ b/apps/activitypub/src/App.tsx
@@ -1,7 +1,7 @@
-import {APP_ROUTE_PREFIX, routes} from '@src/routes';
 import {FeatureFlagsProvider} from './lib/feature-flags';
 import {FrameworkProvider, Outlet, RouterProvider, TopLevelFrameworkProps} from '@tryghost/admin-x-framework';
 import {ShadeApp} from '@tryghost/shade';
+import {routes} from '@src/routes';
 
 interface AppProps {
     framework: TopLevelFrameworkProps;
@@ -13,14 +13,9 @@ const App: React.FC<AppProps> = ({framework, activityPubEnabled}) => {
         return null;
     }
 
-    // In test mode, we use hash routing to avoid basename issues
-    const routerProps = import.meta.env.VITE_TEST
-        ? {prefix: '', hash: true, routes}
-        : {prefix: APP_ROUTE_PREFIX, routes};
-
     return (
         <FrameworkProvider {...framework}>
-            <RouterProvider {...routerProps}>
+            <RouterProvider prefix={'/'} routes={routes}>
                 <FeatureFlagsProvider>
                     <ShadeApp className="shade-activitypub" darkMode={false} fetchKoenigLexical={null}>
                         <Outlet />

--- a/apps/activitypub/src/components/feed/FeedItem.tsx
+++ b/apps/activitypub/src/components/feed/FeedItem.tsx
@@ -16,7 +16,7 @@ import {handleProfileClick} from '../../utils/handle-profile-click';
 import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {renderTimestamp} from '../../utils/render-timestamp';
 import {useDeleteMutationForUser, useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 export function getAttachment(object: ObjectProperties) {
     let attachment;
@@ -282,7 +282,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
     const [isTruncated, setIsTruncated] = useState(false);
 
     const deleteMutation = useDeleteMutationForUser('index');
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const followMutation = useFollowMutationForUser(
         'index',

--- a/apps/activitypub/src/components/global/APAvatar.tsx
+++ b/apps/activitypub/src/components/global/APAvatar.tsx
@@ -5,7 +5,7 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, LucideIcon, Skeleton} from '@tryghost/shade';
 import {toast} from 'sonner';
 import {useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 type AvatarSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'notification';
 
@@ -74,7 +74,7 @@ const APAvatar: React.FC<APAvatarProps> = ({author, size, isLoading = false, dis
     let containerClass = `shrink-0 items-center justify-center rounded-full relative z-10 flex bg-black/5 dark:bg-gray-900 ${size === 'lg' || disabled ? '' : 'cursor-pointer'} ${className}`;
     let imageClass = 'z-10 object-cover rounded-full outline outline-[0.5px] outline-offset-[-0.5px] outline-black/10';
     const [iconUrl, setIconUrl] = useState(author?.icon?.url);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const followMutation = useFollowMutationForUser(
         'index',

--- a/apps/activitypub/src/components/global/BackButton.tsx
+++ b/apps/activitypub/src/components/global/BackButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Button, LucideIcon, cn} from '@tryghost/shade';
-import {useNavigate, useNavigationStack} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
+import {useNavigationStack} from '@tryghost/admin-x-framework';
 
 interface BackButtonProps {
     className?: string;
@@ -8,7 +9,7 @@ interface BackButtonProps {
 }
 
 const BackButton: React.FC<BackButtonProps> = ({className, onClick}) => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const {previousPath} = useNavigationStack();
 
     return (

--- a/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
+++ b/apps/activitypub/src/components/global/ProfilePreviewHoverCard.tsx
@@ -6,7 +6,7 @@ import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Avatar, AvatarFallback, AvatarImage, Badge, H3, HoverCard, HoverCardContent, HoverCardTrigger, LucideIcon, Skeleton, abbreviateNumber} from '@tryghost/shade';
 import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
 import {useAccountForUser} from '../../hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 type ProfilePreviewHoverCardProps = {
     actor?: ActorProperties | Account | null;
@@ -30,7 +30,7 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
     isCurrentUser = false
 }) => {
     const [shouldFetch, setShouldFetch] = useState(false);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     let targetHandle = actor?.handle;
     if (!targetHandle && actor && isActorProperties(actor)) {

--- a/apps/activitypub/src/components/global/SuggestedProfiles.tsx
+++ b/apps/activitypub/src/components/global/SuggestedProfiles.tsx
@@ -5,7 +5,7 @@ import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard'
 import React from 'react';
 import {type Account} from '../../api/activitypub';
 import {Skeleton} from '@tryghost/shade';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useSuggestedProfilesForUser} from '@hooks/use-activity-pub-queries';
 
 interface SuggestedProfileProps {
@@ -31,7 +31,7 @@ export const SuggestedProfile: React.FC<SuggestedProfileProps & {
         });
     };
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <ProfilePreviewHoverCard actor={profile} align='center' isCurrentUser={false} side='left'>

--- a/apps/activitypub/src/components/layout/Error/Error.tsx
+++ b/apps/activitypub/src/components/layout/Error/Error.tsx
@@ -10,7 +10,7 @@ const Error = ({statusCode, errorCode}: {statusCode?: number, errorCode?: string
 
     const toAnalytics = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        navigate('/analytics', {crossApp: true});
+        navigate('/analytics/', {crossApp: true});
     };
 
     if (routeError) {

--- a/apps/activitypub/src/components/layout/Onboarding/Step1.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step1.tsx
@@ -5,12 +5,12 @@ import apNodesDark from '@assets/images/onboarding/ap-nodes-dark.png';
 import {Button, H3, LucideIcon, Skeleton} from '@tryghost/shade';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
 import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 const Step1: React.FC = () => {
     const {data: account} = useAccountForUser('index', 'me');
     const {data: {users, meta} = {users: []}, isLoading: usersLoading} = useBrowseUsers();
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const [copied, setCopied] = useState(false);
 
     const firstThreeUsers = users.slice(0, 3);

--- a/apps/activitypub/src/components/layout/Onboarding/Step2.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step2.tsx
@@ -5,7 +5,7 @@ import apDashedLinesDark from '@assets/images/onboarding/ap-dashed-lines-dark.pn
 import flipboardAvatar from '@assets/images/onboarding/avatar-flipboard.png';
 import vergeAvatar from '@assets/images/onboarding/avatar-verge.png';
 import {Avatar, AvatarFallback, AvatarImage, Button, LucideIcon, Separator} from '@tryghost/shade';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 const Reply: React.FC<{
     avatarNo: number,
@@ -65,7 +65,7 @@ const Reaction: React.FC<{
 };
 
 const Step2: React.FC = () => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <div className='relative flex size-full max-h-screen flex-col gap-4 overflow-hidden px-14'>

--- a/apps/activitypub/src/components/layout/Onboarding/Step3.tsx
+++ b/apps/activitypub/src/components/layout/Onboarding/Step3.tsx
@@ -17,7 +17,7 @@ import tangleAvatar from '@assets/images/onboarding/avatar-tangle.png';
 import tangleCover from '@assets/images/onboarding/cover-tangle.png';
 import {Avatar, AvatarFallback, AvatarImage, Button, H1, LucideIcon, Separator} from '@tryghost/shade';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useOnboardingStatus} from './Onboarding';
 
 const MenuItem: React.FC<{
@@ -301,7 +301,7 @@ const Step3: React.FC = () => {
     const [activeTab, setActiveTab] = useState(1);
     const [isHovering, setIsHovering] = useState(false);
     const {setOnboarded} = useOnboardingStatus();
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     useEffect(() => {
         if (isHovering) {

--- a/apps/activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/FeedbackBox.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {Button, H4, LucideIcon} from '@tryghost/shade';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 const FeedbackBox: React.FC = () => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     function showFeedbackReply() {
         const targetPostId = 'https://activitypub.ghost.org/.ghost/activitypub/note/6d6d7f57-b656-4caa-ba9e-efa1d9a4b3fb';

--- a/apps/activitypub/src/components/layout/Sidebar/Recommendations.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Recommendations.tsx
@@ -4,11 +4,12 @@ import ActivityItem from '@components/activities/ActivityItem';
 import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard';
 import {Button, H4, LucideIcon, Skeleton} from '@tryghost/shade';
 import {handleProfileClick} from '@utils/handle-profile-click';
-import {useNavigate, useNavigationStack} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
+import {useNavigationStack} from '@tryghost/admin-x-framework';
 import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
 
 const Recommendations: React.FC = () => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const {suggestedProfilesQuery} = useSuggestedProfilesForUser('index', 3);
     const {data: suggestedData, isLoading: isLoadingSuggested} = suggestedProfilesQuery;
     const suggested = isLoadingSuggested ? Array(3).fill(null) : (suggestedData || []);

--- a/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import Search from '@src/components/modals/Search';
 import SearchInput from '../Header/SearchInput';
 import SidebarMenuLink from './SidebarMenuLink';
 import {Button, Dialog, DialogContent, DialogTrigger, LucideIcon} from '@tryghost/shade';
+import {useAppBasePath} from '@src/hooks/use-app-base-path';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
 import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useLocation} from '@tryghost/admin-x-framework';
@@ -22,15 +23,16 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
     const [searchQuery, setSearchQuery] = React.useState('');
     const {data: currentUser} = useCurrentUser();
     const location = useLocation();
+    const basePath = useAppBasePath();
     const {data: notificationsCount} = useNotificationsCountForUser(currentUser?.slug || '');
     const resetNotificationsCount = useResetNotificationsCountForUser(currentUser?.slug || '');
 
     // Reset count when on notifications page
     React.useEffect(() => {
-        if (location.pathname === '/notifications' && notificationsCount && notificationsCount > 0) {
+        if (location.pathname === `${basePath}/notifications` && notificationsCount && notificationsCount > 0) {
             resetNotificationsCount.mutate();
         }
-    }, [location.pathname, notificationsCount, resetNotificationsCount]);
+    }, [location.pathname, basePath, notificationsCount, resetNotificationsCount]);
 
     const handleNotificationsClick = React.useCallback(() => {
         if (notificationsCount && notificationsCount > 0) {
@@ -55,31 +57,31 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
                         </Dialog>
                     </div>
                     <div className='flex w-full flex-col gap-px'>
-                        <SidebarMenuLink to='/reader'>
+                        <SidebarMenuLink to='../reader'>
                             <LucideIcon.BookOpen size={18} strokeWidth={1.5} />
                             Reader
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/notes'>
+                        <SidebarMenuLink to='../notes'>
                             <LucideIcon.MessageCircle size={18} strokeWidth={1.5} />
                             Notes
                         </SidebarMenuLink>
                         <SidebarMenuLink
-                            count={location.pathname !== '/notifications' ? notificationsCount : undefined}
-                            to='/notifications'
+                            count={location.pathname !== `${basePath}/notifications` ? notificationsCount : undefined}
+                            to='../notifications'
                             onClick={handleNotificationsClick}
                         >
                             <LucideIcon.Bell size={18} strokeWidth={1.5} />
                             Notifications
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/explore'>
+                        <SidebarMenuLink to='../explore'>
                             <LucideIcon.Globe size={18} strokeWidth={1.5} />
                             Explore
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/profile'>
+                        <SidebarMenuLink to='../profile'>
                             <LucideIcon.User size={18} strokeWidth={1.5} />
                             Profile
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='/preferences'>
+                        <SidebarMenuLink to='../preferences'>
                             <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
                             Preferences
                         </SidebarMenuLink>

--- a/apps/activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/activitypub/src/components/modals/NewNoteModal.tsx
@@ -9,7 +9,7 @@ import {ComponentPropsWithoutRef, ReactNode} from 'react';
 import {FILE_SIZE_ERROR_MESSAGE, MAX_FILE_SIZE} from '@utils/image';
 import {toast} from 'sonner';
 import {uploadFile, useAccountForUser, useNoteMutationForUser, useReplyMutationForUser, useUserDataForUser} from '@hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 interface NewNoteModalProps extends ComponentPropsWithoutRef<typeof Dialog> {
     children?: ReactNode;
@@ -40,7 +40,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
     const [showAltInput, setShowAltInput] = useState(false);
     const [isPosting, setIsPosting] = useState(false);
     const [isSticky, setIsSticky] = useState(false);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const MAX_CONTENT_LENGTH = 500;
 

--- a/apps/activitypub/src/components/modals/Search.tsx
+++ b/apps/activitypub/src/components/modals/Search.tsx
@@ -8,7 +8,7 @@ import {Button, H4, Input, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLa
 import {SuggestedProfiles} from '../global/SuggestedProfiles';
 import {useAccountForUser, useSearchForUser} from '@hooks/use-activity-pub-queries';
 import {useDebounce} from 'use-debounce';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 interface AccountSearchResult {
     id: string;
@@ -47,7 +47,7 @@ const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
         });
     };
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <ProfilePreviewHoverCard actor={account as unknown as ActorProperties} isCurrentUser={isCurrentUser}>

--- a/apps/activitypub/src/hooks/use-app-base-path.test.ts
+++ b/apps/activitypub/src/hooks/use-app-base-path.test.ts
@@ -1,0 +1,106 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+
+import * as framework from '@tryghost/admin-x-framework';
+
+import {useAppBasePath} from './use-app-base-path';
+
+vi.mock('@tryghost/admin-x-framework', () => ({
+    useMatches: vi.fn()
+}));
+
+describe('useAppBasePath', () => {
+    const useMatches = framework.useMatches as ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the base path when a matching route is found', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/activitypub',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            }
+        ]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('/activitypub');
+    });
+
+    it('returns empty string when no matching route exists', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+            {
+                id: 'some-route',
+                pathname: '/some-path',
+                params: {},
+                data: undefined,
+                handle: 'other-handle'
+            }
+        ]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('');
+    });
+
+    it('returns empty string when matches array is empty', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('');
+    });
+
+    it('strips trailing slash from pathname', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/activitypub/',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            }
+        ]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('/activitypub');
+    });
+
+    it('handles empty pathname', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+            {
+                id: 'root',
+                pathname: '',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            }
+        ]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('');
+    });
+
+    it('handles root pathname with trailing slash', () => {
+        (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            }
+        ]);
+
+        const {result} = renderHook(() => useAppBasePath());
+
+        expect(result.current).toBe('');
+    });
+});

--- a/apps/activitypub/src/hooks/use-app-base-path.ts
+++ b/apps/activitypub/src/hooks/use-app-base-path.ts
@@ -1,0 +1,17 @@
+import {useMatches} from '@tryghost/admin-x-framework';
+
+/**
+ * Hook that returns the app's base path by reading the first route match.
+ * This allows the app to be mounted at different paths (e.g., /activitypub or /network or /, like in the test environment)
+ * without hardcoding the path throughout the codebase.
+ *
+ * @returns The base path of the app (e.g., '/activitypub' or '/network' or '')
+ */
+export function useAppBasePath(): string {
+    const matches = useMatches();
+    // Find the first match with the handle 'activitypub-basepath'
+    const path = matches.find(match => match.handle === 'activitypub-basepath')?.pathname ?? '';
+
+    // Remove trailing slash if it exists
+    return path.endsWith('/') ? path.slice(0, -1) : path;
+}

--- a/apps/activitypub/src/hooks/use-navigate-with-base-path.test.ts
+++ b/apps/activitypub/src/hooks/use-navigate-with-base-path.test.ts
@@ -1,0 +1,117 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+
+import * as framework from '@tryghost/admin-x-framework';
+
+import {useNavigateWithBasePath} from './use-navigate-with-base-path';
+
+vi.mock('@tryghost/admin-x-framework', () => ({
+    useMatches: vi.fn(),
+    useNavigate: vi.fn()
+}));
+
+describe('useNavigateWithBasePath', () => {
+    const useMatches = framework.useMatches as ReturnType<typeof vi.fn>;
+    const useNavigate = framework.useNavigate as ReturnType<typeof vi.fn>;
+    const mockNavigate = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (useNavigate as ReturnType<typeof vi.fn>).mockReturnValue(mockNavigate);
+    });
+
+    describe('with base path /activitypub', () => {
+        beforeEach(() => {
+            (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+                {
+                    id: 'root',
+                    pathname: '/activitypub',
+                    params: {},
+                    data: undefined,
+                    handle: 'activitypub-basepath'
+                }
+            ]);
+        });
+
+        it('passes through numeric navigation unchanged', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+
+            result.current(-1);
+
+            expect(mockNavigate).toHaveBeenCalledWith(-1, undefined);
+        });
+
+        it('prepends base path to absolute paths', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+
+            result.current('/profile');
+
+            expect(mockNavigate).toHaveBeenCalledWith('/activitypub/profile', undefined);
+        });
+
+        it('prepends base path to root path', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+
+            result.current('/');
+
+            expect(mockNavigate).toHaveBeenCalledWith('/activitypub/', undefined);
+        });
+
+        it('passes through relative paths unchanged', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+
+            result.current('profile');
+
+            expect(mockNavigate).toHaveBeenCalledWith('profile', undefined);
+        });
+
+        it('preserves options with absolute path', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+            const options = {replace: true, state: {from: 'test'}};
+
+            result.current('/profile', options);
+
+            expect(mockNavigate).toHaveBeenCalledWith('/activitypub/profile', options);
+        });
+
+        it('preserves options with numeric navigation', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+            const options = {replace: true};
+
+            result.current(-1, options);
+
+            expect(mockNavigate).toHaveBeenCalledWith(-1, options);
+        });
+
+        it('preserves options with relative path', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+            const options = {state: {from: 'test'}};
+
+            result.current('profile', options);
+
+            expect(mockNavigate).toHaveBeenCalledWith('profile', options);
+        });
+    });
+
+    describe('with empty base path (test mode)', () => {
+        beforeEach(() => {
+            (useMatches as ReturnType<typeof vi.fn>).mockReturnValue([
+                {
+                    id: 'root',
+                    pathname: '',
+                    params: {},
+                    data: undefined,
+                    handle: 'activitypub-basepath'
+                }
+            ]);
+        });
+
+        it('does not prepend anything to absolute paths when base path is empty', () => {
+            const {result} = renderHook(() => useNavigateWithBasePath());
+
+            result.current('/profile');
+
+            expect(mockNavigate).toHaveBeenCalledWith('/profile', undefined);
+        });
+    });
+});

--- a/apps/activitypub/src/hooks/use-navigate-with-base-path.ts
+++ b/apps/activitypub/src/hooks/use-navigate-with-base-path.ts
@@ -1,6 +1,6 @@
+import {type NavigateOptions, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppBasePath} from './use-app-base-path';
 import {useCallback} from 'react';
-import {useNavigate} from '@tryghost/admin-x-framework';
 
 /**
  * Hook that wraps useNavigate and automatically prepends the app base path
@@ -18,7 +18,7 @@ export function useNavigateWithBasePath() {
 
     return useCallback((
         to: string | number,
-        options?: Parameters<typeof navigate>[1]
+        options?: NavigateOptions
     ) => {
         if (typeof to === 'number') {
             // Handle navigate(-1) etc

--- a/apps/activitypub/src/hooks/use-navigate-with-base-path.ts
+++ b/apps/activitypub/src/hooks/use-navigate-with-base-path.ts
@@ -1,0 +1,37 @@
+import {useAppBasePath} from './use-app-base-path';
+import {useCallback} from 'react';
+import {useNavigate} from '@tryghost/admin-x-framework';
+
+/**
+ * Hook that wraps useNavigate and automatically prepends the app base path
+ * for absolute paths (paths starting with '/').
+ *
+ * Usage:
+ * - Relative paths pass through unchanged: navigate('reader') → 'reader'
+ * - Absolute paths get base path prepended: navigate('/profile/handle') → '/activitypub/profile/handle'
+ * - Navigate back still works: navigate(-1)
+ * - Options are preserved: navigate('/reader', {replace: true})
+ */
+export function useNavigateWithBasePath() {
+    const navigate = useNavigate();
+    const basePath = useAppBasePath();
+
+    return useCallback((
+        to: string | number,
+        options?: Parameters<typeof navigate>[1]
+    ) => {
+        if (typeof to === 'number') {
+            // Handle navigate(-1) etc
+            navigate(to, options);
+            return;
+        }
+
+        if (to.startsWith('/')) {
+            // Absolute path - prepend base path
+            navigate(`${basePath}${to}`, options);
+        } else {
+            // Relative path - pass through unchanged
+            navigate(to, options);
+        }
+    }, [navigate, basePath]);
+}

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -12,9 +12,9 @@ import OnboardingStep2 from '@components/layout/Onboarding/Step2';
 import OnboardingStep3 from '@components/layout/Onboarding/Step3';
 import Preferences from '@views/Preferences';
 import Profile from '@views/Profile';
-import {Navigate, RouteObject} from '@tryghost/admin-x-framework';
+import {Navigate, Outlet, RouteObject} from '@tryghost/admin-x-framework';
 
-export const APP_ROUTE_PREFIX = '/activitypub';
+const basePath = import.meta.env.VITE_TEST ? '' : 'activitypub';
 
 export type CustomRouteObject = RouteObject & {
     pageTitle?: string;
@@ -24,9 +24,11 @@ export type CustomRouteObject = RouteObject & {
 
 export const routes: CustomRouteObject[] = [
     {
-        // Root route configuration
-        path: '',
+        // Root route that defines the app's base path
+        path: basePath,
+        element: <Outlet />,
         errorElement: <Error />, // This will catch all errors in child routes
+        handle: 'activitypub-basepath',
         children: [
             {
                 index: true,

--- a/apps/activitypub/src/views/Explore/Explore.tsx
+++ b/apps/activitypub/src/views/Explore/Explore.tsx
@@ -7,7 +7,7 @@ import {type Account} from '@src/api/activitypub';
 import {Button, H4, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 import {formatFollowNumber} from '@src/utils/content-formatters';
 import {useAccountForUser, useExploreProfilesForUser} from '@hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useOnboardingStatus} from '@src/components/layout/Onboarding';
 
 interface ExploreProfileProps {
@@ -37,7 +37,7 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
         });
     };
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <div

--- a/apps/activitypub/src/views/Feed/Note.tsx
+++ b/apps/activitypub/src/views/Feed/Note.tsx
@@ -13,7 +13,8 @@ import {LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {renderTimestamp} from '@src/utils/render-timestamp';
-import {useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
+import {useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 import {useReplyChainData} from '@hooks/use-reply-chain-data';
 
 const FeedItemDivider: React.FC = () => (
@@ -32,7 +33,7 @@ const Note = () => {
     const postRef = useRef<HTMLDivElement>(null);
     const observerRef = useRef<IntersectionObserver | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const {
         threadParents,

--- a/apps/activitypub/src/views/Feed/components/FeedList.tsx
+++ b/apps/activitypub/src/views/Feed/components/FeedList.tsx
@@ -9,7 +9,7 @@ import {Button, LoadingIndicator, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef} from 'react';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 export type FeedListProps = {
     isLoading: boolean,
@@ -28,7 +28,7 @@ const FeedList:React.FC<FeedListProps> = ({
     hasNextPage,
     isFetchingNextPage
 }) => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const observerRef = useRef<IntersectionObserver | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);

--- a/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
+++ b/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
@@ -4,12 +4,12 @@ import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard'
 import {Account} from '@src/api/activitypub';
 import {Button, H4, LucideIcon, Separator, Skeleton} from '@tryghost/shade';
 import {useEffect, useRef, useState} from 'react';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
 
 const SuggestedProfiles: React.FC = () => {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const [canScrollLeft, setCanScrollLeft] = useState(false);
     const [canScrollRight, setCanScrollRight] = useState(true);
 

--- a/apps/activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/activitypub/src/views/Inbox/components/InboxList.tsx
@@ -6,7 +6,8 @@ import {Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTi
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef, useState} from 'react';
-import {useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
+import {useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 
 export type InboxListProps = {
     isLoading: boolean,
@@ -23,7 +24,7 @@ const InboxList:React.FC<InboxListProps> = ({
     hasNextPage,
     isFetchingNextPage
 }) => {
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const {canGoBack, goBack} = useNavigationStack();
     const [isReaderOpen, setIsReaderOpen] = useState(false);
     const params = useParams();

--- a/apps/activitypub/src/views/Inbox/components/Reader.tsx
+++ b/apps/activitypub/src/views/Inbox/components/Reader.tsx
@@ -23,7 +23,7 @@ import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 interface IframeWindow extends Window {
     resizeIframe?: () => void;
@@ -683,7 +683,7 @@ export const Reader: React.FC<ReaderProps> = ({
         return () => clearTimeout(timeoutId);
     }, [iframeElement, tocItems, activeHeadingId]);
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     // Save scroll position when navigating away
     useEffect(() => {

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -5,12 +5,11 @@ import {Button, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 import APAvatar from '@components/global/APAvatar';
 import Error from '@components/layout/Error';
 import FeedItemStats from '@components/feed/FeedItemStats';
-import NotificationItem from './components/NotificationItem';
-import Separator from '@components/global/Separator';
-
 import Layout from '@components/layout';
 import NotificationIcon from './components/NotificationIcon';
+import NotificationItem from './components/NotificationItem';
 import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard';
+import Separator from '@components/global/Separator';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {Notification, isApiError} from '@src/api/activitypub';
 import {handleProfileClick} from '@utils/handle-profile-click';
@@ -18,7 +17,7 @@ import {renderFeedAttachment} from '@components/feed/FeedItem';
 import {renderTimestamp} from '@src/utils/render-timestamp';
 import {stripHtml} from '@src/utils/content-formatters';
 import {useFeatureFlags} from '@src/lib/feature-flags';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useNotificationsForUser} from '@hooks/use-activity-pub-queries';
 
 interface NotificationGroup {
@@ -108,7 +107,7 @@ const NotificationGroupDescription: React.FC<NotificationGroupDescriptionProps> 
 
     const actorClass = 'cursor-pointer font-semibold hover:underline text-black dark:text-white';
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const actorText = (
         <>
@@ -152,7 +151,7 @@ const ProfileLinkedContent: React.FC<{
     stripTags?: string[];
 }> = ({content, className, stripTags = []}) => {
     const contentRef = useRef<HTMLDivElement>(null);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     useEffect(() => {
         const element = contentRef.current;
@@ -193,7 +192,7 @@ const ProfileLinkedContent: React.FC<{
 
 const Notifications: React.FC = () => {
     const [openStates, setOpenStates] = React.useState<{[key: string]: boolean}>({});
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const {isEnabled} = useFeatureFlags();
 
     const toggleOpen = (groupId: string) => {

--- a/apps/activitypub/src/views/Preferences/components/Moderation.tsx
+++ b/apps/activitypub/src/views/Preferences/components/Moderation.tsx
@@ -8,7 +8,7 @@ import {Button, H2, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton, Tabs, 
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {toast} from 'sonner';
 import {useBlockDomainMutationForUser, useBlockMutationForUser, useBlockedAccountsForUser, useBlockedDomainsForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 const Moderation: React.FC = () => {
     const {data: blockedAccountsData, isLoading: blockedAccountsLoading} = useBlockedAccountsForUser('index');
@@ -30,7 +30,7 @@ const Moderation: React.FC = () => {
     const [unblockedDomainIds, setUnblockedDomainIds] = useState<Set<string>>(new Set());
 
     const [hoveredItemId, setHoveredItemId] = useState<string | null>(null);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     const handleUnblock = (account: Account) => {
         setUnblockedAccountIds((prev) => {

--- a/apps/activitypub/src/views/Preferences/components/Settings.tsx
+++ b/apps/activitypub/src/views/Preferences/components/Settings.tsx
@@ -2,7 +2,8 @@ import EditProfile from './EditProfile';
 import React, {useState} from 'react';
 import {Account} from '@src/api/activitypub';
 import {Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H4, LucideIcon, cn} from '@tryghost/shade';
-import {Link, useNavigate} from '@tryghost/admin-x-framework';
+import {Link} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 interface SettingsProps {
     account?: Account;
@@ -11,7 +12,7 @@ interface SettingsProps {
 
 const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
     const [isEditingProfile, setIsEditingProfile] = useState(false);
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <div className={`flex flex-col ${className}`}>

--- a/apps/activitypub/src/views/Profile/components/ActorList.tsx
+++ b/apps/activitypub/src/views/Profile/components/ActorList.tsx
@@ -9,7 +9,7 @@ import {Actor} from '@src/api/activitypub';
 import {Button, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon} from '@tryghost/shade';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 type ActorListProps = {
     noResultsMessage: string,
@@ -56,7 +56,7 @@ const ActorList: React.FC<ActorListProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <div className='pt-3' data-testid="actor-list">

--- a/apps/activitypub/src/views/Profile/components/Likes.tsx
+++ b/apps/activitypub/src/views/Profile/components/Likes.tsx
@@ -2,7 +2,7 @@ import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
 import {LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon, Separator} from '@tryghost/shade';
 import {useEffect, useRef} from 'react';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 export type LikesProps = {
     isLoading: boolean,
@@ -51,7 +51,7 @@ const Likes: React.FC<LikesProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <>

--- a/apps/activitypub/src/views/Profile/components/Posts.tsx
+++ b/apps/activitypub/src/views/Profile/components/Posts.tsx
@@ -2,7 +2,7 @@ import FeedItem from '@src/components/feed/FeedItem';
 import {Activity} from '@src/api/activitypub';
 import {LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon, Separator} from '@tryghost/shade';
 import {useEffect, useRef} from 'react';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
 export type PostsProps = {
     posts: Activity[],
@@ -53,7 +53,7 @@ const Posts: React.FC<PostsProps> = ({
         };
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
 
     return (
         <>

--- a/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -11,7 +11,8 @@ import {SettingAction} from '@src/views/Preferences/components/Settings';
 import {toast} from 'sonner';
 import {useAccountForUser, useBlockDomainMutationForUser, useBlockMutationForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useMemo, useRef, useState} from 'react';
-import {useLocation, useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
+import {useLocation, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
+import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import type {ProfileTab} from '../Profile';
 
 const noop = () => {};
@@ -40,10 +41,10 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
 }) => {
     const params = useParams<{handle?: string; tab?: string}>();
     const location = useLocation();
-    const navigate = useNavigate();
+    const navigate = useNavigateWithBasePath();
     const {canGoBack} = useNavigationStack();
 
-    const basePath = params.handle ? `/profile/${params.handle}` : '/profile';
+    const profilePath = params.handle ? `/profile/${params.handle}` : '/profile';
     const likesEnabled = !params.handle;
 
     const tabSlug = params.handle
@@ -137,16 +138,16 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
         }
 
         if (!allowedTabs.includes(tabSlug as ProfileTab)) {
-            navigate(basePath, {replace: true});
+            navigate(profilePath, {replace: true});
         }
-    }, [allowedTabs, basePath, navigate, tabSlug]);
+    }, [allowedTabs, profilePath, navigate, tabSlug]);
 
     const createTabPath = (tab: ProfileTab) => {
         if (tab === 'posts') {
-            return basePath;
+            return profilePath;
         }
 
-        return `${basePath}/${tab}`;
+        return `${profilePath}/${tab}`;
     };
 
     const handleTabChange = (tab: ProfileTab) => {

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -37,7 +37,7 @@ export type {RouteObject} from 'react-router';
 export type {RouterProviderProps} from './providers/RouterProvider';
 export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/RouterProvider';
 export {useNavigationStack} from './providers/NavigationStackProvider';
-export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes} from 'react-router';
+export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, useMatches} from 'react-router';
 
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -34,7 +34,7 @@ export type {BaseSourceData, ProcessedSourceData, ExtendSourcesOptions} from './
 
 // Routing
 export type {RouteObject} from 'react-router';
-export type {RouterProviderProps} from './providers/RouterProvider';
+export type {RouterProviderProps, NavigateOptions} from './providers/RouterProvider';
 export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/RouterProvider';
 export {useNavigationStack} from './providers/NavigationStackProvider';
 export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, useMatches} from 'react-router';

--- a/apps/admin-x-framework/src/providers/RouterProvider.tsx
+++ b/apps/admin-x-framework/src/providers/RouterProvider.tsx
@@ -138,7 +138,7 @@ export function RouterProvider({
  * used to determine if the navigate should be handled by the custom router, ie.
  * if we need to navigate outside of the current app in Ghost.
  */
-interface NavigateOptions extends ReactRouterNavigateOptions {
+export interface NavigateOptions extends ReactRouterNavigateOptions {
     crossApp?: boolean;
 }
 

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,8 +1,8 @@
-import { Outlet, type RouteObject } from "@tryghost/admin-x-framework";
+import { Outlet, type RouteObject, redirect } from "@tryghost/admin-x-framework";
 import { routes as postRoutes } from "@tryghost/posts/src/routes";
 import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
 import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
-import { routes as activityPubRoutes, APP_ROUTE_PREFIX as activityPubAppRoutePrefix } from "@tryghost/activitypub/src/routes";
+import { routes as activityPubRoutes } from "@tryghost/activitypub/src/routes";
 import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 import { EmberFallback } from "./ember-bridge";
 
@@ -17,13 +17,13 @@ export const routes: RouteObject[] = [
         children: statsRoutes
     },
     {
+        path: `network`,
+        loader: () => redirect('/activitypub')
+    },
+    {
+        path: '',
         element: <FeatureFlagsProvider><Outlet /></FeatureFlagsProvider>,
-        children: [
-            ...activityPubRoutes.map(route => ({
-                ...route,
-                path: `${activityPubAppRoutePrefix}${route.path ?? ''}`
-            }))
-        ]
+        children: activityPubRoutes
     },
     {
         path: "*",


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2916/remove-router-basepaths

Moving the base path to a wrapping route and updating all links and urls within the app to use either relative paths or a base-path aware navigation hook makes links and URLs work the same regardless of if the app is mounted by itself within Ember or as a sub-routes in the new React admin shell.

This also makes it easier for us to eventually update the base path from /activitypub to /network.