### PR TITLE
Remove router base path for stats app

### DIFF
--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,9 +1,9 @@
-import { Outlet, redirect, type RouteObject } from "@tryghost/admin-x-framework";
+import { Outlet, type RouteObject } from "@tryghost/admin-x-framework";
 import { routes as postRoutes } from "@tryghost/posts/src/routes";
 import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
 import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
-import { routes as statsRoutes, APP_ROUTE_PREFIX as statsAppRoutePrefix } from "@tryghost/stats/src/routes";
 import { routes as activityPubRoutes, APP_ROUTE_PREFIX as activityPubAppRoutePrefix } from "@tryghost/activitypub/src/routes";
+import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
@@ -13,21 +13,10 @@ export const routes: RouteObject[] = [
     },
     ...postRoutes[0].children!.filter(route => route.path !== "*"),
     {
-        path: `${statsAppRoutePrefix}`,
         element: <GlobalDataProvider><Outlet /></GlobalDataProvider>,
-        children: [
-            ...(statsRoutes).map(route => ({
-                ...route,
-                path: `${statsAppRoutePrefix}${route.path ?? ''}`
-            }))
-        ]
+        children: statsRoutes
     },
     {
-        path: `network`,
-        loader: () => redirect(activityPubAppRoutePrefix)
-    },
-    {
-        path: `${activityPubAppRoutePrefix}`,
         element: <FeatureFlagsProvider><Outlet /></FeatureFlagsProvider>,
         children: [
             ...activityPubRoutes.map(route => ({

--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -6,7 +6,7 @@ import Web from './views/Stats/Web';
 import {RouteObject} from '@tryghost/admin-x-framework';
 // import {withFeatureFlag} from './hooks/withFeatureFlag';
 
-export const APP_ROUTE_PREFIX = '/analytics';
+export const APP_ROUTE_PREFIX = '/';
 
 // Wrap all components with feature flag protection
 //  e.g.
@@ -14,24 +14,28 @@ export const APP_ROUTE_PREFIX = '/analytics';
 
 export const routes: RouteObject[] = [
     {
-        path: '/',
-        index: true,
-        element: <Overview />
-    },
-    {
-        path: '/web/',
-        element: <Web />
-    },
-    {
-        path: '/locations/',
-        element: <Locations />
-    },
-    {
-        path: '/growth/',
-        element: <Growth />
-    },
-    {
-        path: '/newsletters/',
-        element: <Newsletters />
+        path: 'analytics',
+        children: [
+            {
+                index: true,
+                element: <Overview />
+            },
+            {
+                path: 'web',
+                element: <Web />
+            },
+            {
+                path: 'locations',
+                element: <Locations />
+            },
+            {
+                path: 'growth',
+                element: <Growth />
+            },
+            {
+                path: 'newsletters',
+                element: <Newsletters />
+            }
+        ]
     }
 ];

--- a/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/OverviewKPIs.tsx
@@ -164,10 +164,10 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                     diffDirection='empty'
                     formattedValue={kpiValues.visits}
                     iconName='Globe'
-                    linkto='/web/'
+                    linkto='/analytics/web/'
                     title='Unique visitors'
                     onClick={() => {
-                        navigate('/web/');
+                        navigate('/analytics/web/');
                     }}
                 >
                     <GhAreaChart
@@ -214,11 +214,11 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                     diffValue={growthTotals.percentChanges.total}
                     formattedValue={formatNumber(growthTotals.totalMembers)}
                     iconName='User'
-                    linkto='/growth/'
+                    linkto='/analytics/growth/'
                     title='Members'
                     trendingFromValue={`${formatNumber(membersChartData[0].value)}`}
                     onClick={() => {
-                        navigate('/growth/?tab=total-members');
+                        navigate('/analytics/growth/?tab=total-members');
                     }}
                 >
                     <GhAreaChart
@@ -241,11 +241,11 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                     diffValue={growthTotals.percentChanges.mrr}
                     formattedValue={`${currencySymbol}${formatNumber(centsToDollars(growthTotals.mrr))}`}
                     iconName='Coins'
-                    linkto='/growth/'
+                    linkto='/analytics/growth/'
                     title='MRR'
                     trendingFromValue={`${currencySymbol}${formatNumber(mrrChartData[0].value)}`}
                     onClick={() => {
-                        navigate('/growth/?tab=mrr');
+                        navigate('/analytics/growth/?tab=mrr');
                     }}
                 >
                     <GhAreaChart

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -18,6 +18,7 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
         statsConfig,
         enabled: appSettings?.analytics?.webAnalytics ?? false
     });
+    const normalizedPath = location.pathname.endsWith('/') ? location.pathname : `${location.pathname}/`;
 
     return (
         <>
@@ -58,30 +59,30 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
                 </div>
             </header>
             <Navbar className='sticky top-0 z-40 flex-col items-start gap-y-5 border-none bg-white/70 py-8 backdrop-blur-md lg:flex-row lg:items-center dark:bg-black'>
-                <PageMenu defaultValue={location.pathname} responsive>
-                    <PageMenuItem value="/" onClick={() => {
-                        navigate('/');
+                <PageMenu defaultValue={normalizedPath} responsive>
+                    <PageMenuItem value="/analytics/" onClick={() => {
+                        navigate('/analytics/');
                     }}>Overview</PageMenuItem>
 
                     {appSettings?.analytics.webAnalytics &&
-                        <PageMenuItem value="/web/" onClick={() => {
-                            navigate('/web/');
+                        <PageMenuItem value="/analytics/web/" onClick={() => {
+                            navigate('/analytics/web/');
                         }}>Web traffic</PageMenuItem>
                     }
 
                     {appSettings?.newslettersEnabled &&
-                        <PageMenuItem value="/newsletters/" onClick={() => {
-                            navigate('/newsletters/');
+                        <PageMenuItem value="/analytics/newsletters/" onClick={() => {
+                            navigate('/analytics/newsletters/');
                         }}>Newsletters</PageMenuItem>
                     }
 
-                    <PageMenuItem value="/growth/" onClick={() => {
-                        navigate('/growth/');
+                    <PageMenuItem value="/analytics/growth/" onClick={() => {
+                        navigate('/analytics/growth/');
                     }}>Growth</PageMenuItem>
 
                     {appSettings?.analytics.webAnalytics && (
-                        <PageMenuItem value="/locations/" onClick={() => {
-                            navigate('/locations/');
+                        <PageMenuItem value="/analytics/locations/" onClick={() => {
+                            navigate('/analytics/locations/');
                         }}>Locations</PageMenuItem>
                     )}
                 </PageMenu>


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2916/remove-router-basepaths

Removing the base path and updating all links and urls within the app to include the base path directly makes links and URLs work the same regardless of if the app is mounted in Ember or as a sub-routes in the new React admin shell.