### PR TITLE
Implement externalNavigate

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@tryghost/activitypub": "*",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.37.0",
+    "@testing-library/react": "14.3.1",
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7",
     "@vitejs/plugin-react-swc": "4.1.0",
@@ -28,10 +30,12 @@
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.24",
     "globals": "16.4.0",
+    "jsdom": "24.1.0",
     "typescript": "5.8.3",
     "typescript-eslint": "8.46.1",
-    "vite": "7.1.10",
-    "vite-tsconfig-paths": "5.1.4"
+    "vite": "7.1.12",
+    "vite-tsconfig-paths": "5.1.4",
+    "vitest": "4.0.5"
   },
   "nx": {
     "targets": {

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -10,10 +10,13 @@ import {
 import { ShadeApp } from "@tryghost/shade";
 
 import { routes } from "./routes.tsx";
+import { navigateTo } from "./utils/navigation";
 
 const framework = {
     ghostVersion: "",
-    externalNavigate: () => {},
+    externalNavigate: (link: {route: string, isExternal: boolean}) => {
+        navigateTo(link.route);
+    },
     unsplashConfig: {
         Authorization: "",
         "Accept-Version": "",

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -7,10 +7,6 @@ import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
-    {
-        path: "/",
-        element: <div>Hello World</div>
-    },
     ...postRoutes[0].children!.filter(route => route.path !== "*"),
     {
         element: <GlobalDataProvider><Outlet /></GlobalDataProvider>,

--- a/apps/admin/src/utils/navigation.test.ts
+++ b/apps/admin/src/utils/navigation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { navigateTo } from "./navigation";
+
+describe("navigateTo", () => {
+    let locationMock: { href: string; hash: string };
+
+    beforeEach(() => {
+        locationMock = { href: "", hash: "" };
+        vi.stubGlobal("location", locationMock as unknown as Location);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe("safe external URLs", () => {
+        it("should navigate to https URLs", () => {
+            const result = navigateTo("https://example.com");
+            expect(result).toBe(true);
+            expect(locationMock.href).toBe("https://example.com");
+        });
+
+        it("should navigate to mailto URLs", () => {
+            const result = navigateTo("mailto:test@example.com");
+            expect(result).toBe(true);
+            expect(locationMock.href).toBe("mailto:test@example.com");
+        });
+    });
+
+    describe("dangerous URL schemes (XSS prevention)", () => {
+        it("should reject javascript: URLs", () => {
+            const result = navigateTo('javascript:alert("XSS")');
+            expect(result).toBe(false);
+            expect(locationMock.href).toBe("");
+        });
+
+        it("should reject data: URLs", () => {
+            const result = navigateTo(
+                'data:text/html,<script>alert("XSS")</script>'
+            );
+            expect(result).toBe(false);
+            expect(locationMock.href).toBe("");
+        });
+    });
+
+    describe("internal navigation", () => {
+        it("should use hash routing for paths starting with /", () => {
+            const result = navigateTo("/settings");
+            expect(result).toBe(true);
+            expect(locationMock.hash).toBe("/settings");
+        });
+
+        it("should add leading slash to paths without one", () => {
+            const result = navigateTo("settings");
+            expect(result).toBe(true);
+            expect(locationMock.hash).toBe("/settings");
+        });
+
+        it("should handle empty paths", () => {
+            const result = navigateTo("");
+            expect(result).toBe(true);
+            expect(locationMock.hash).toBe("/");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle case-insensitive URL schemes", () => {
+            const result = navigateTo("HTTPS://example.com");
+            expect(result).toBe(true);
+            expect(locationMock.href).toBe("HTTPS://example.com");
+        });
+
+        it("should handle complex internal routes with query params", () => {
+            const result = navigateTo("/settings/general?tab=advanced");
+            expect(result).toBe(true);
+            expect(locationMock.hash).toBe("/settings/general?tab=advanced");
+        });
+    });
+});

--- a/apps/admin/src/utils/navigation.ts
+++ b/apps/admin/src/utils/navigation.ts
@@ -1,0 +1,38 @@
+/**
+ * Allowed URL schemes for external navigation
+ */
+const ALLOWED_SCHEMES = ['http:', 'https:', 'mailto:', 'tel:'];
+
+/**
+ * Navigates to a URL, validating the protocol scheme for external URLs.
+ * Prevents XSS attacks by rejecting dangerous schemes like javascript: and data:
+ * Handles both external URLs (with protocol validation) and internal routes (via hash navigation).
+ *
+ * @param route - The route to navigate to
+ * @returns true if navigation was performed, false otherwise
+ */
+export function navigateTo(route: string): boolean {
+    // Check if URL has a protocol scheme
+    if (route.match(/^[a-z]+:/i)) {
+        try {
+            const url = new URL(route);
+            // Only allow explicitly safe schemes
+            if (ALLOWED_SCHEMES.includes(url.protocol)) {
+                window.location.href = route;
+                return true;
+            }
+            // Reject dangerous schemes (javascript:, data:, etc.)
+            return false;
+        } catch {
+            // Invalid URL, treat as internal route
+            const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+            window.location.hash = normalizedRoute;
+            return true;
+        }
+    } else {
+        // Internal cross-app navigation - use hash routing
+        const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+        window.location.hash = normalizedRoute;
+        return true;
+    }
+}

--- a/apps/admin/vite-backend-proxy.ts
+++ b/apps/admin/vite-backend-proxy.ts
@@ -98,8 +98,8 @@ export function ghostBackendProxyPlugin(): Plugin {
         name: "ghost-backend-proxy",
 
         async configResolved(config) {
-            // Only resolve backend URL for dev/preview, not for builds
-            if (config.command !== 'serve') return;
+            // Only resolve backend URL for dev/preview, not for builds or tests
+            if (config.command !== 'serve' || config.mode === 'test') return;
 
             try {
                 // We expect this to succeed immediately, but if the backend
@@ -126,6 +126,8 @@ Ensure the Ghost backend is running. If needed, set the GHOST_URL environment va
         },
 
         configureServer(server) {
+            if (!siteUrl) return;
+
             server.config.server.proxy = {
                 ...server.config.server.proxy,
                 ...createAdminApiProxy(siteUrl),
@@ -134,6 +136,8 @@ Ensure the Ghost backend is running. If needed, set the GHOST_URL environment va
         },
 
         configurePreviewServer(server) {
+            if (!siteUrl) return;
+
             server.config.preview.proxy = {
                 ...server.config.preview.proxy,
                 ...createAdminApiProxy(siteUrl),

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react-swc";
 
@@ -24,5 +24,10 @@ export default defineConfig({
         alias: {
             "@ghost-cards": GHOST_CARDS_PATH,
         },
+    },
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        include: ['src/**/*.test.ts', 'src/**/*.test.tsx']
     },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6494,6 +6494,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@standard-schema/spec@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
 "@standard-schema/utils@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
@@ -10200,6 +10205,18 @@
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
+"@vitest/expect@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.0.5.tgz#779dd235b0307abbcab9ebe97ee9befbf59d0224"
+  integrity sha512-DJctLVlKoddvP/G389oGmKWNG6GD9frm2FPXARziU80Rjo7SIYxQzb2YFzmQ4fVD3Q5utUYY8nUmWrqsuIlIXQ==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.0.5"
+    "@vitest/utils" "4.0.5"
+    chai "^6.0.1"
+    tinyrainbow "^3.0.3"
+
 "@vitest/mocker@3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
@@ -10208,6 +10225,15 @@
     "@vitest/spy" "3.2.4"
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
+
+"@vitest/mocker@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.0.5.tgz#45708620ac3f63e417e5b9baf8a923be992b97b1"
+  integrity sha512-iYHIy72LfbK+mL5W8zXROp6oOcJKXWeKcNjcPPsqoa18qIEDrhB6/Z08o0wRajTd6SSSDNw8NCSIHVNOMpz0mw==
+  dependencies:
+    "@vitest/spy" "4.0.5"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.19"
 
 "@vitest/pretty-format@2.0.5":
   version "2.0.5"
@@ -10230,6 +10256,13 @@
   dependencies:
     tinyrainbow "^2.0.0"
 
+"@vitest/pretty-format@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.0.5.tgz#b2abb93323867c569e3c950cb309a6e0793767c2"
+  integrity sha512-t1T/sSdsYyNc5AZl0EMeD0jW9cpJe2cODP0R++ZQe1kTkpgrwEfxGFR/yCG4w8ZybizbXRTHU7lE8sTDD/QsGw==
+  dependencies:
+    tinyrainbow "^3.0.3"
+
 "@vitest/runner@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.6.1.tgz#10f5857c3e376218d58c2bfacfea1161e27e117f"
@@ -10248,6 +10281,14 @@
     pathe "^2.0.3"
     strip-literal "^3.0.0"
 
+"@vitest/runner@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.0.5.tgz#12ea16d44f623d5a11c3fd9c7ce822bed6819d5c"
+  integrity sha512-CQVVe+YEeKSiFBD5gBAmRDQglm4PnMBYzeTmt06t5iWtsUN9StQeeKhYCea/oaqBYilf8sARG6fSctUcEL/UmQ==
+  dependencies:
+    "@vitest/utils" "4.0.5"
+    pathe "^2.0.3"
+
 "@vitest/snapshot@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.1.tgz#90414451a634bb36cd539ccb29ae0d048a8c0479"
@@ -10264,6 +10305,15 @@
   dependencies:
     "@vitest/pretty-format" "3.2.4"
     magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.0.5.tgz#b39276eab03c64d20fefe9a2268a4b846a2f4cdf"
+  integrity sha512-jfmSAeR6xYNEvcD+/RxFGA1bzpqHtkVhgxo2cxXia+Q3xX7m6GpZij07rz+WyQcA/xEGn4eIS1OItkMyWsGBmQ==
+  dependencies:
+    "@vitest/pretty-format" "4.0.5"
+    magic-string "^0.30.19"
     pathe "^2.0.3"
 
 "@vitest/spy@1.6.1":
@@ -10286,6 +10336,11 @@
   integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
   dependencies:
     tinyspy "^4.0.3"
+
+"@vitest/spy@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.0.5.tgz#ffe4f1a05c31cbed558d33e428957041df8a40af"
+  integrity sha512-TUmVQpAQign7r8+EnZsgTF3vY9BdGofTUge1rGNbnHn2IN3FChiQoT9lrPz7A7AVUZJU2LAZXl4v66HhsNMhoA==
 
 "@vitest/ui@3.2.4":
   version "3.2.4"
@@ -10328,6 +10383,14 @@
     "@vitest/pretty-format" "3.2.4"
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
+
+"@vitest/utils@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.0.5.tgz#9f787f0891c131e878aab52c745a15092fe88c62"
+  integrity sha512-V5RndUgCB5/AfNvK9zxGCrRs99IrPYtMTIdUzJMMFs9nrmE5JXExIEfjVtUteyTRiLfCm+dCRMHf/Uu7Mm8/dg==
+  dependencies:
+    "@vitest/pretty-format" "4.0.5"
+    tinyrainbow "^3.0.3"
 
 "@vitest/utils@^2.1.1":
   version "2.1.9"
@@ -10757,6 +10820,11 @@ agent-base@^7.0.2, agent-base@^7.1.0:
   integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
   dependencies:
     debug "^4.3.4"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 agentkeepalive@^4.1.3:
   version "4.2.1"
@@ -13825,6 +13893,11 @@ chai@^5.1.1, chai@^5.2.0:
     loupe "^3.1.0"
     pathval "^2.0.0"
 
+chai@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.0.tgz#181bca6a219cddb99c3eeefb82483800ffa550ce"
+  integrity sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==
+
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -15586,7 +15659,7 @@ debug@3.2.7, debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -18860,7 +18933,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect-type@^1.2.1:
+expect-type@^1.2.1, expect-type@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
   integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
@@ -21043,6 +21116,14 @@ https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.5:
     agent-base "^7.0.2"
     debug "4"
 
+https-proxy-agent@^7.0.4:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 https@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
@@ -22857,6 +22938,33 @@ jsdoc-type-pratt-parser@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz#ff6b4a3f339c34a6c188cbf50a16087858d22113"
   integrity sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==
 
+jsdom@24.1.0:
+  version "24.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-24.1.0.tgz#0cffdabd42c506788bfecd160e8ac22d4387f971"
+  integrity sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==
+  dependencies:
+    cssstyle "^4.0.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.4"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.10"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.7.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.4"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+    ws "^8.17.0"
+    xml-name-validator "^5.0.0"
+
 jsdom@24.1.3, jsdom@^24.1.1, jsdom@~24.1.0:
   version "24.1.3"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-24.1.3.tgz#88e4a07cb9dd21067514a619e9f17b090a394a9f"
@@ -24277,6 +24385,13 @@ magic-string@^0.30.0, magic-string@^0.30.1, magic-string@^0.30.17, magic-string@
   version "0.30.19"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.19.tgz#cebe9f104e565602e5d2098c5f2e79a77cc86da9"
   integrity sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magic-string@^0.30.19:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
@@ -25997,6 +26112,11 @@ nwsapi@^2.2.0, nwsapi@^2.2.12:
   version "2.2.12"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.12.tgz#fb6af5c0ec35b27b4581eb3bbad34ec9e5c696f8"
   integrity sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==
+
+nwsapi@^2.2.10:
+  version "2.2.22"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.22.tgz#109f9530cda6c156d6a713cdf5939e9f0de98b9d"
+  integrity sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==
 
 nx@20.8.0:
   version "20.8.0"
@@ -29794,7 +29914,7 @@ rrweb-cssom@^0.6.0:
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
   integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
 
-rrweb-cssom@^0.7.1:
+rrweb-cssom@^0.7.0, rrweb-cssom@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
   integrity sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==
@@ -32100,6 +32220,11 @@ tinyrainbow@^2.0.0:
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
   integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
 
+tinyrainbow@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.0.3.tgz#984a5b1c1b25854a9b6bccbe77964d0593d1ea42"
+  integrity sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==
+
 tinyspy@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
@@ -33407,7 +33532,21 @@ vite@5.4.20, vite@^5.0.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vite@7.1.10, "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
+vite@7.1.12, "vite@^6.0.0 || ^7.0.0":
+  version "7.1.12"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.12.tgz#8b29a3f61eba23bcb93fc9ec9af4a3a1e83eecdb"
+  integrity sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
   version "7.1.10"
   resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.10.tgz#47c9970f3b0fe9057bfbcfeff8cd370edd7bd41b"
   integrity sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==
@@ -33474,6 +33613,32 @@ vitest@3.2.4:
     tinyrainbow "^2.0.0"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
     vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
+
+vitest@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.0.5.tgz#6a84c31228ebc20cc18af4236463a46d655743af"
+  integrity sha512-4H+J28MI5oeYgGg3h5BFSkQ1g/2GKK1IR8oorH3a6EQQbb7CwjbnyBjH4PGxw9/6vpwAPNzaeUMp4Js4WJmdXQ==
+  dependencies:
+    "@vitest/expect" "4.0.5"
+    "@vitest/mocker" "4.0.5"
+    "@vitest/pretty-format" "4.0.5"
+    "@vitest/runner" "4.0.5"
+    "@vitest/snapshot" "4.0.5"
+    "@vitest/spy" "4.0.5"
+    "@vitest/utils" "4.0.5"
+    debug "^4.4.3"
+    es-module-lexer "^1.7.0"
+    expect-type "^1.2.2"
+    magic-string "^0.30.19"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+    vite "^6.0.0 || ^7.0.0"
     why-is-node-running "^2.3.0"
 
 vm-browserify@^1.0.1:
@@ -34019,6 +34184,11 @@ ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.17.0:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@^8.18.0, ws@^8.2.3:
   version "8.18.0"


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2916/remove-router-basepaths

This is needed so that links across what used to be different micro frontends work within the single router instance in the React admin shell.

Longer term, we probably want to get rid of this altogether, but for now this enables cross-step navigation. 
