### PR TITLE
Removed unnecessary events queries for sites that are already verified

### DIFF
--- a/ghost/core/core/server/services/VerificationTrigger.js
+++ b/ghost/core/core/server/services/VerificationTrigger.js
@@ -43,7 +43,10 @@ class VerificationTrigger {
         this._eventRepository = eventRepository;
 
         this._handleMemberCreatedEvent = this._handleMemberCreatedEvent.bind(this);
-        DomainEvents.subscribe(MemberCreatedEvent, this._handleMemberCreatedEvent);
+
+        if (!this._isVerified()) {
+            DomainEvents.subscribe(MemberCreatedEvent, this._handleMemberCreatedEvent);
+        }
     }
 
     get _apiTriggerThreshold() {

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -27,7 +27,8 @@ describe('Import threshold', function () {
                         }
                     }
                 })
-            }
+            },
+            isVerified: () => false
         });
 
         const result = await trigger.getImportThreshold();
@@ -45,7 +46,8 @@ describe('Import threshold', function () {
                         }
                     }
                 })
-            }
+            },
+            isVerified: () => false
         });
 
         const result = await trigger.getImportThreshold();
@@ -58,7 +60,8 @@ describe('Import threshold', function () {
             getImportTriggerThreshold: () => Infinity,
             eventRepository: {
                 getSignupEvents: membersStub
-            }
+            },
+            isVerified: () => false
         });
 
         const result = await trigger.getImportThreshold();
@@ -234,6 +237,34 @@ describe('Email verification flow', function () {
         eventStub.lastCall.lastArg.should.have.property('created_at');
         eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
         eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+    });
+
+    it('Does not trigger when site is already verified', async function () {
+        // We need to use the real event repository here to test event handling
+        domainEventsStub.restore();
+        const emailStub = sinon.stub().resolves(null);
+        const settingsStub = sinon.stub().resolves(null);
+        const eventStub = sinon.stub();
+
+        new VerificationTrigger({
+            getApiTriggerThreshold: () => 2,
+            Settings: {
+                edit: settingsStub
+            },
+            isVerified: () => true,
+            isVerificationRequired: () => false,
+            sendVerificationEmail: emailStub,
+            eventRepository: {
+                getSignupEvents: eventStub
+            }
+        });
+
+        DomainEvents.dispatch(MemberCreatedEvent.create({
+            memberId: 'hello!',
+            source: 'api'
+        }, new Date()));
+
+        eventStub.callCount.should.eql(0);
     });
 
     it('Triggers when a number of members are imported', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-712/improve-performance-of-verificationtrigger-queries

For sites that are already verified, the `VerificationTrigger` is still running the `getSignupEvents` queries for every `MemberCreatedEvent`. These queries are unnecessary and expensive for larger sites, so this change removes the event handler entirely for sites that are already verified.