### PR TITLE
Fixed Shade button regressions

### DIFF
--- a/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
@@ -40,7 +40,7 @@ function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <Button
                         variant='ghost'
                         size='icon'
-                        className="size-9 text-gray-800 rounded-full hover:bg-gray-200 -mr-1"
+                        className="size-9 text-gray-800 rounded-full hover:bg-gray-200 -mr-1 [&_svg]:size-auto"
                         title="Search site (Ctrl/⌘ + K)"
                     >
                         <LucideIcon.Search size={20} />
@@ -62,7 +62,7 @@ function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                         <Button
                             variant="ghost"
                             size="icon"
-                            className="size-9 hover:bg-gray-200 rounded-full p-0 text-gray-800"
+                            className="size-9 hover:bg-gray-200 rounded-full p-0 text-gray-800 [&_svg]:size-auto"
                             title="Settings (CTRL/⌘ + ,)"
                             asChild
                         >
@@ -73,7 +73,7 @@ function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                         <Button
                             variant="ghost"
                             size="icon"
-                            className="size-9 hover:bg-gray-200 rounded-full p-0 text-gray-800"
+                            className="size-9 hover:bg-gray-200 rounded-full p-0 text-gray-800 [&_svg]:size-auto"
                             title="Toggle theme"
                         >
                             <LucideIcon.Moon size={20} />

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -27,7 +27,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             <Button
                                 variant='ghost'
                                 size='icon'
-                                className={`absolute opacity-0 group-hover:opacity-100 transition-all left-3 top-0 p-0 h-9`}
+                                className='absolute opacity-0 group-hover:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto hover:bg-transparent'
                                 onClick={() =>
                                     setPostsExpanded(!postsExpanded)
                                 }
@@ -43,7 +43,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             <Button
                                 variant='ghost'
                                 size='icon'
-                                className="absolute hover:bg-gray-200 text-gray-800 transition-all rounded-full right-0 top-0 p-0 size-9"
+                                className="absolute hover:bg-gray-200 text-gray-800 transition-all rounded-full right-0 top-0 p-0 size-9 [&_svg]:size-auto"
                             >
                                 <LucideIcon.Plus size={24} className="!stroke-[1.2px]" />
                             </Button>

--- a/apps/shade/preflight.css
+++ b/apps/shade/preflight.css
@@ -211,7 +211,10 @@
         margin: 0; /* 2 */
         padding: 0; /* 3 */
         outline: none;
-        border: inherit;
+
+        /* Reset `border: none;` from global.css */
+        border-width: 0;
+        border-style: solid;
     }
 
     /*

--- a/apps/shade/preflight.css
+++ b/apps/shade/preflight.css
@@ -211,6 +211,7 @@
         margin: 0; /* 2 */
         padding: 0; /* 3 */
         outline: none;
+        border: inherit;
     }
 
     /*

--- a/apps/shade/src/components/ui/button.tsx
+++ b/apps/shade/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
                 default: 'h-[34px] px-3 py-2',
                 sm: 'h-7 rounded-md px-3 text-xs [&_svg]:size-3',
                 lg: 'h-11 rounded-md px-8 text-md font-semibold',
-                icon: 'size-auto [&_svg]:size-auto'
+                icon: 'size-9'
             }
         },
         defaultVariants: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2933/fix-button-regressions

- During to React port work we introduced a few regressions to buttons: `icon` buttons and icons sizing became off and borders got lost on outline buttons.