### PR TITLE
🐛 Scope PRESERVE_ENV to global teardown to prevent leaks

### DIFF
--- a/e2e/helpers/environment/EnvironmentManager.ts
+++ b/e2e/helpers/environment/EnvironmentManager.ts
@@ -177,9 +177,6 @@ export class EnvironmentManager {
      * Teardown a Ghost instance
      */
     public async teardownGhostInstance(ghostInstance: GhostInstance): Promise<void> {
-        if (this.shouldPreserveEnvironment()) {
-            return;
-        }
         try {
             debug('Tearing down Ghost instance:', ghostInstance.containerId);
             await this.ghost.remove(ghostInstance.containerId);


### PR DESCRIPTION
- Removed `PRESERVE_ENV` check from teardownGhostInstance()
- `PRESERVE_ENV` now only affects globalTeardown() to leave containers after all tests complete
- Prevents port conflicts when running tests multiple times with PRESERVE_ENV=true
- Containers are now always cleaned up between individual tests

Previously, `PRESERVE_ENV=true` would skip removing containers after each individual test, causing port allocation errors when running tests again. Now it only preserves the final state after all tests complete, which is the intended debugging behavior.