### PR TITLE
Added labs flag for welcome email features

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -39,6 +39,10 @@ const features: Feature[] = [{
     title: 'Email Unique ID',
     description: 'Enables {uniqueid} variable in emails for unique image URLs to bypass ESP image caching',
     flag: 'emailUniqueid'
+}, {
+    title: 'Welcome Emails',
+    description: 'Enables features related to sending welcome emails to new members',
+    flag: 'welcomeEmails'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -49,7 +49,8 @@ const PRIVATE_FEATURES = [
     'emailCustomization',
     'tagsX',
     'utmTracking',
-    'emailUniqueid'
+    'emailUniqueid',
+    'welcomeEmails'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,6 +30,7 @@ Object {
       "urlCache": true,
       "utmTracking": true,
       "webmentions": true,
+      "welcomeEmails": true,
     },
     "mail": "",
     "mailgunIsConfigured": false,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-707

- adds a labs flag to be used for features related to welcome emails

---
<img width="300" height="709" alt="Screenshot 2025-10-28 at 2 06 19 PM" src="https://github.com/user-attachments/assets/57eb7e06-09f7-4e38-8610-0cddc3849418" />
