### PR TITLE
Added outbox table

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -53,7 +53,8 @@ const BACKUP_TABLES = [
     'collections_posts',
     'recommendations',
     'recommendation_click_events',
-    'recommendation_subscribe_events'
+    'recommendation_subscribe_events',
+    'outbox'
 ];
 
 // NOTE: exposing only tables which are going to be included in a "default" export file

--- a/ghost/core/core/server/data/migrations/versions/6.6/2025-10-28-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.6/2025-10-28-18-29-37-add-outbox-table.js
@@ -1,0 +1,10 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('outbox', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    event_type: {type: 'string', maxlength: 50, nullable: false},
+    payload: {type: 'text', maxlength: 65535, nullable: false},
+    created_at: {type: 'dateTime', nullable: false},
+    retry_count: {type: 'integer', nullable: false, defaultTo: 0},
+    last_retry_at: {type: 'dateTime', nullable: true}
+});

--- a/ghost/core/core/server/data/migrations/versions/6.6/2025-10-28-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.6/2025-10-28-18-29-37-add-outbox-table.js
@@ -3,6 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('outbox', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     event_type: {type: 'string', maxlength: 50, nullable: false},
+    status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending'},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
     retry_count: {type: 'integer', nullable: false, defaultTo: 0},

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -7,5 +7,6 @@ module.exports = addTable('outbox', {
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
     retry_count: {type: 'integer', nullable: false, defaultTo: 0},
-    last_retry_at: {type: 'dateTime', nullable: true}
+    last_retry_at: {type: 'dateTime', nullable: true},
+    message: {type: 'string', maxlength: 2000, nullable: true}
 });

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -11,6 +11,6 @@ module.exports = addTable('outbox', {
     last_retry_at: {type: 'dateTime', nullable: true},
     message: {type: 'string', maxlength: 2000, nullable: true},
     '@@INDEXES@@': [
-        ['status', 'created_at']
+        ['event_type', 'status', 'created_at']
     ]
 });

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -6,7 +6,7 @@ module.exports = addTable('outbox', {
     status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
-    retry_count: {type: 'integer', nullable: false, defaultTo: 0},
+    retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
     last_retry_at: {type: 'dateTime', nullable: true},
     message: {type: 'string', maxlength: 2000, nullable: true},
     '@@INDEXES@@': [

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -6,6 +6,7 @@ module.exports = addTable('outbox', {
     status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true},
     retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
     last_retry_at: {type: 'dateTime', nullable: true},
     message: {type: 'string', maxlength: 2000, nullable: true},

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -8,5 +8,8 @@ module.exports = addTable('outbox', {
     created_at: {type: 'dateTime', nullable: false},
     retry_count: {type: 'integer', nullable: false, defaultTo: 0},
     last_retry_at: {type: 'dateTime', nullable: true},
-    message: {type: 'string', maxlength: 2000, nullable: true}
+    message: {type: 'string', maxlength: 2000, nullable: true},
+    '@@INDEXES@@': [
+        ['status', 'created_at']
+    ]
 });

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -3,7 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('outbox', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     event_type: {type: 'string', maxlength: 50, nullable: false},
-    status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
     updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -3,7 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('outbox', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     event_type: {type: 'string', maxlength: 50, nullable: false},
-    status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending'},
+    status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
     retry_count: {type: 'integer', nullable: false, defaultTo: 0},

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js
@@ -3,7 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('outbox', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     event_type: {type: 'string', maxlength: 50, nullable: false},
-    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending'},
     payload: {type: 'text', maxlength: 65535, nullable: false},
     created_at: {type: 'dateTime', nullable: false},
     updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1129,7 +1129,7 @@ module.exports = {
         last_retry_at: {type: 'dateTime', nullable: true},
         message: {type: 'string', maxlength: 2000, nullable: true},
         '@@INDEXES@@': [
-            ['status', 'created_at']
+            ['event_type', 'status', 'created_at']
         ]
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1121,7 +1121,7 @@ module.exports = {
     outbox: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         event_type: {type: 'string', maxlength: 50, nullable: false},
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending'},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1121,11 +1121,14 @@ module.exports = {
     outbox: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         event_type: {type: 'string', maxlength: 50, nullable: false},
-        status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending'},
+        status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         retry_count: {type: 'integer', nullable: false, defaultTo: 0},
         last_retry_at: {type: 'dateTime', nullable: true},
-        message: {type: 'string', maxlength: 2000, nullable: true}
+        message: {type: 'string', maxlength: 2000, nullable: true},
+        '@@INDEXES@@': [
+            ['status', 'created_at']
+        ]
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1124,6 +1124,7 @@ module.exports = {
         status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true},
         retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         last_retry_at: {type: 'dateTime', nullable: true},
         message: {type: 'string', maxlength: 2000, nullable: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1117,5 +1117,13 @@ module.exports = {
         recommendation_id: {type: 'string', maxlength: 24, nullable: false, references: 'recommendations.id', unique: false, cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', unique: false, setNullDelete: true},
         created_at: {type: 'dateTime', nullable: false}
+    },
+    outbox: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        event_type: {type: 'string', maxlength: 50, nullable: false},
+        payload: {type: 'text', maxlength: 65535, nullable: false},
+        created_at: {type: 'dateTime', nullable: false},
+        retry_count: {type: 'integer', nullable: false, defaultTo: 0},
+        last_retry_at: {type: 'dateTime', nullable: true}
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1125,6 +1125,7 @@ module.exports = {
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         retry_count: {type: 'integer', nullable: false, defaultTo: 0},
-        last_retry_at: {type: 'dateTime', nullable: true}
+        last_retry_at: {type: 'dateTime', nullable: true},
+        message: {type: 'string', maxlength: 2000, nullable: true}
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1121,6 +1121,7 @@ module.exports = {
     outbox: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         event_type: {type: 'string', maxlength: 50, nullable: false},
+        status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending'},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         retry_count: {type: 'integer', nullable: false, defaultTo: 0},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1121,7 +1121,7 @@ module.exports = {
     outbox: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         event_type: {type: 'string', maxlength: 50, nullable: false},
-        status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1124,7 +1124,7 @@ module.exports = {
         status: {type: 'string', maxlength: 20, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'processing', 'failed']]}},
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
-        retry_count: {type: 'integer', nullable: false, defaultTo: 0},
+        retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         last_retry_at: {type: 'dateTime', nullable: true},
         message: {type: 'string', maxlength: 2000, nullable: true},
         '@@INDEXES@@': [

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -68,6 +68,7 @@ describe('Exporter', function () {
                 'newsletters',
                 'offers',
                 'offer_redemptions',
+                'outbox',
                 'permissions',
                 'permissions_roles',
                 'permissions_users',

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -124,7 +124,8 @@ describe('Exporter', function () {
                 'members_email_change_events',
                 'members_status_events',
                 'members_paid_subscription_events',
-                'members_subscribe_events'
+                'members_subscribe_events',
+                'outbox'
             ];
 
             excludedTables.forEach((tableName) => {

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '4e68fd06f63aab5fef99dddd8dc866bb';
+    const currentSchemaHash = '34938745eb81427846ddba92c31d1b16';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-708

- adds an `outbox` table
- this table is used to provide durability and atomicity in an event-driven system - for events that we might want to take some action on, such as creation of a member, we can create a transaction that writes to both the members table and outbox table (among others)
- The outbox table is then processed by some system(s) that take an action based on the event type. Where the outbox table differs from tables like `members_created_events` is that the outbox table is meant to be cleaned up over time, whereas `members_created_events` is a historical record

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an `outbox` table (schema + migration), adds it to backup export lists, updates tests, and bumps the schema hash.
> 
> - **Database**
>   - Add `outbox` table to `core/server/data/schema/schema.js` with indexes and fields (`event_type`, `status`, `payload`, retries, timestamps).
>   - New migration `data/migrations/versions/6.7/2025-11-02-18-29-37-add-outbox-table.js` to create `outbox`.
> - **Exporter**
>   - Include `outbox` in `BACKUP_TABLES` (`core/server/data/exporter/table-lists.js`).
>   - Integration test updates (`test/integration/exporter/exporter.test.js`): expect `outbox` key in export set but with no data (excluded tables).
> - **Tests/Integrity**
>   - Update schema hash in `test/unit/server/data/schema/integrity.test.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e62650e9b9fb8daed57ec94e59c2adda4ba37c93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->