### PR TITLE
Improved notification grouping with short time window in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/lib/feature-flags.tsx
+++ b/apps/activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['global-feed'] as const;
+export const FEATURE_FLAGS = ['global-feed', 'notification-group'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -74,7 +74,7 @@ function groupNotifications(notifications: Notification[], useTimeGrouping: bool
             break;
         case 'follow':
             // Group follows by time window
-            groupKey = `follow_${notification.type}${timeBucket}`;
+            groupKey = `follow_${timeBucket}`;
             break;
         case 'mention':
             // Don't group mentions

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -19,6 +19,7 @@ import {renderTimestamp} from '@src/utils/render-timestamp';
 import {stripHtml} from '@src/utils/content-formatters';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useNotificationsForUser} from '@hooks/use-activity-pub-queries';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 
 interface NotificationGroup {
     id: string;
@@ -33,19 +34,32 @@ interface NotificationGroupDescriptionProps {
     group: NotificationGroup;
 }
 
-function groupNotifications(notifications: Notification[]): NotificationGroup[] {
+/**
+ * Calculate a time bucket for grouping notifications
+ * Groups notifications into time windows
+ */
+function getTimeBucket(timestamp: string): string {
+    const TIME_WINDOW_MS = 6 * 60 * 60 * 1000; // 6 hours
+    const date = new Date(timestamp);
+    const timeMs = date.getTime();
+    const bucketStart = Math.floor(timeMs / TIME_WINDOW_MS) * TIME_WINDOW_MS;
+    return bucketStart.toString();
+}
+
+function groupNotifications(notifications: Notification[], useTimeGrouping: boolean = false): NotificationGroup[] {
     const groups: {
         [key: string]: NotificationGroup
     } = {};
 
     notifications.forEach((notification) => {
         let groupKey = '';
+        const timeBucket = useTimeGrouping ? `_${getTimeBucket(notification.createdAt)}` : '';
 
         switch (notification.type) {
         case 'like':
             if (notification.post?.id) {
-                // Group likes by the target object
-                groupKey = `like_${notification.post.id}`;
+                // Group likes by the target object and time window
+                groupKey = `like_${notification.post.id}${timeBucket}`;
             }
             break;
         case 'reply':
@@ -54,13 +68,13 @@ function groupNotifications(notifications: Notification[]): NotificationGroup[] 
             break;
         case 'repost':
             if (notification.post?.id) {
-                // Group reposts by the target object
-                groupKey = `repost_${notification.post.id}`;
+                // Group reposts by the target object and time window
+                groupKey = `repost_${notification.post.id}${timeBucket}`;
             }
             break;
         case 'follow':
-            // Group follows that are next to each other in the array
-            groupKey = `follow_${notification.type}`;
+            // Group follows by time window
+            groupKey = `follow_${notification.type}${timeBucket}`;
             break;
         case 'mention':
             // Don't group mentions
@@ -180,6 +194,7 @@ const ProfileLinkedContent: React.FC<{
 const Notifications: React.FC = () => {
     const [openStates, setOpenStates] = React.useState<{[key: string]: boolean}>({});
     const navigate = useNavigate();
+    const {isEnabled} = useFeatureFlags();
 
     const toggleOpen = (groupId: string) => {
         setOpenStates(prev => ({
@@ -199,7 +214,7 @@ const Notifications: React.FC = () => {
 
     const notificationGroups = (
         data?.pages.flatMap((page) => {
-            return groupNotifications(page.notifications);
+            return groupNotifications(page.notifications, isEnabled('notification-group'));
         })
         // If no notifications, return 10 empty groups for the loading state
         ?? Array(10).fill({actors: [{}]}));

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -17,9 +17,9 @@ import {handleProfileClick} from '@utils/handle-profile-click';
 import {renderFeedAttachment} from '@components/feed/FeedItem';
 import {renderTimestamp} from '@src/utils/render-timestamp';
 import {stripHtml} from '@src/utils/content-formatters';
+import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigate} from '@tryghost/admin-x-framework';
 import {useNotificationsForUser} from '@hooks/use-activity-pub-queries';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 
 interface NotificationGroup {
     id: string;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2937/improve-notification-grouping-by-adding-date-criteria

-   Grouped same-type notifications only when they occur within a short timeframe
-   Prevented unrelated notifications from being merged hours apart
-   Made grouped notifications feel timely and relevant