### PR TITLE
Reorganize runtime service managers for clearer ownership

### DIFF
--- a/e2e/helpers/environment/EnvironmentManager.ts
+++ b/e2e/helpers/environment/EnvironmentManager.ts
@@ -61,21 +61,7 @@ export class EnvironmentManager {
         logging.info('Starting global environment setup...');
 
         await this.cleanupResources();
-
-        // Start required docker compose services
-        this.dockerCompose.up([
-            'mysql',
-            'ghost-migrations',
-            'caddy',
-            'analytics',
-            'tinybird-local',
-            'tb-cli',
-            'mailpit',
-            'portal'
-        ]);
-
-        await this.dockerCompose.waitForAll();
-
+        await this.dockerCompose.up();
         await this.mysql.createSnapshot();
         this.tinybird.fetchAndSaveConfig();
 

--- a/e2e/helpers/environment/EnvironmentManager.ts
+++ b/e2e/helpers/environment/EnvironmentManager.ts
@@ -3,22 +3,10 @@ import baseDebug from '@tryghost/debug';
 import logging from '@tryghost/logging';
 import {DOCKER_COMPOSE_CONFIG, PORTAL, TINYBIRD} from './constants';
 import {DockerCompose} from './DockerCompose';
-import {GhostManager} from './GhostManager';
-import {MySQLManager} from './MySQLManager';
-import {PortalManager} from './PortalManager';
-import {TinybirdManager} from './TinybirdManager';
+import {GhostInstance, GhostManager, MySQLManager, PortalManager, TinybirdManager} from './service-managers';
 import {randomUUID} from 'crypto';
 
 const debug = baseDebug('e2e:EnvironmentManager');
-
-export interface GhostInstance {
-    containerId: string; // docker container ID
-    instanceId: string; // unique instance name (e.g. ghost_<siteUuid>)
-    database: string;
-    port: number;
-    baseUrl: string;
-    siteUuid: string;
-}
 
 /**
  * Manages the lifecycle of Docker containers and shared services for end-to-end tests

--- a/e2e/helpers/environment/index.ts
+++ b/e2e/helpers/environment/index.ts
@@ -1,1 +1,3 @@
+export * from './service-managers';
 export * from './EnvironmentManager';
+

--- a/e2e/helpers/environment/service-managers/GhostManager.ts
+++ b/e2e/helpers/environment/service-managers/GhostManager.ts
@@ -1,13 +1,21 @@
 import Docker from 'dockerode';
 import baseDebug from '@tryghost/debug';
 import logging from '@tryghost/logging';
-import {DOCKER_COMPOSE_CONFIG, GHOST_DEFAULTS, MAILPIT, MYSQL, PORTAL, TINYBIRD} from './constants';
-import {DockerCompose} from './DockerCompose';
+import {DOCKER_COMPOSE_CONFIG, GHOST_DEFAULTS, MAILPIT, MYSQL, PORTAL, TINYBIRD} from '../constants';
+import {DockerCompose} from '../DockerCompose';
 import {TinybirdManager} from './TinybirdManager';
 import type {Container, ContainerCreateOptions} from 'dockerode';
-import type {GhostInstance} from './EnvironmentManager';
 
 const debug = baseDebug('e2e:GhostManager');
+
+export interface GhostInstance {
+    containerId: string; // docker container ID
+    instanceId: string; // unique instance name (e.g. ghost_<siteUuid>)
+    database: string;
+    port: number;
+    baseUrl: string;
+    siteUuid: string;
+}
 
 export interface GhostStartConfig {
     instanceId: string;

--- a/e2e/helpers/environment/service-managers/MySQLManager.ts
+++ b/e2e/helpers/environment/service-managers/MySQLManager.ts
@@ -1,6 +1,6 @@
 import baseDebug from '@tryghost/debug';
 import logging from '@tryghost/logging';
-import {DockerCompose} from './DockerCompose';
+import {DockerCompose} from '../DockerCompose';
 import {PassThrough} from 'stream';
 import type {Container} from 'dockerode';
 

--- a/e2e/helpers/environment/service-managers/PortalManager.ts
+++ b/e2e/helpers/environment/service-managers/PortalManager.ts
@@ -1,6 +1,6 @@
 import baseDebug from '@tryghost/debug';
 import logging from '@tryghost/logging';
-import {DockerCompose} from './DockerCompose';
+import {DockerCompose} from '../DockerCompose';
 
 const debug = baseDebug('e2e:PortalManager');
 

--- a/e2e/helpers/environment/service-managers/TinybirdManager.ts
+++ b/e2e/helpers/environment/service-managers/TinybirdManager.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import baseDebug from '@tryghost/debug';
 import logging from '@tryghost/logging';
 import path from 'path';
-import {DockerCompose} from './DockerCompose';
-import {ensureDir} from '../utils';
+import {DockerCompose} from '../DockerCompose';
+import {ensureDir} from '../../utils';
 
 const debug = baseDebug('e2e:TinybirdManager');
 
@@ -14,6 +14,7 @@ export interface TinybirdConfig {
 }
 
 /**
+ * Manages TinyBird and Tinybird CLI operations within these docker containers.
  * Encapsulates TinyBird and Tinybird CLI operations within the docker-compose environment.
  * Handles Tinybird token fetching and local config persistence.
  */

--- a/e2e/helpers/environment/service-managers/index.ts
+++ b/e2e/helpers/environment/service-managers/index.ts
@@ -1,0 +1,4 @@
+export * from './GhostManager';
+export * from './MySQLManager';
+export * from './PortalManager';
+export * from './TinybirdManager';

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,7 +1,7 @@
 import baseDebug from '@tryghost/debug';
 import {AnalyticsOverviewPage, LoginPage} from '../pages/admin';
 import {Browser, BrowserContext, Page, TestInfo, test as base} from '@playwright/test';
-import {EnvironmentManager, GhostInstance} from '../environment/EnvironmentManager';
+import {EnvironmentManager, GhostInstance} from '../environment';
 import {SettingsService} from '../services/settings/SettingsService';
 import {faker} from '@faker-js/faker';
 import {setupUser} from '../utils';


### PR DESCRIPTION
- Moved managers (Ghost, MySQL, Portal, Tinybird) into service-managers/ subfolder for better code organization
- It aligns better with Docker Compose terminology, and separates cleaner environment manager, compose from service managers
