### PR TITLE
Updated logging for email analytics job(s)

### DIFF
--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsService.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsService.js
@@ -24,8 +24,31 @@ const errors = require('@tryghost/errors');
  * @typedef {'delivered' | 'opened' | 'failed' | 'unsubscribed' | 'complained'} EmailAnalyticsEvent
  */
 
+/**
+ * @typedef {object} EmailAnalyticsFetchResult
+ * @property {number} eventCount - The number of events fetched
+ * @property {number} apiPollingTime - Time spent polling the API in milliseconds
+ * @property {number} processingTime - Time spent processing events in milliseconds
+ * @property {number} aggregationTime - Time spent aggregating stats in milliseconds
+ * @property {EventProcessingResult} result - The processing result with event breakdown
+ */
+
 const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 const FETCH_LATEST_END_MARGIN_MS = 1 * 60 * 1000; // Do not fetch events newer than 1 minute (yet). Reduces the chance of having missed events in fetchLatest.
+
+/**
+ * Helper function to create an empty fetch result
+ * @returns {EmailAnalyticsFetchResult}
+ */
+function createEmptyResult() {
+    return {
+        eventCount: 0,
+        apiPollingTime: 0,
+        processingTime: 0,
+        aggregationTime: 0,
+        result: new EventProcessingResult()
+    };
+}
 
 module.exports = class EmailAnalyticsService {
     config;
@@ -125,7 +148,7 @@ module.exports = class EmailAnalyticsService {
      * Fetches the latest opened events.
      * @param {Object} options - The options for fetching events.
      * @param {number} [options.maxEvents=Infinity] - The maximum number of events to fetch.
-     * @returns {Promise<number>} The total number of events fetched.
+     * @returns {Promise<EmailAnalyticsFetchResult>} Fetch results with timing metrics
      */
     async fetchLatestOpenedEvents({maxEvents = Infinity} = {}) {
         const begin = await this.getLastOpenedEventTimestamp();
@@ -134,7 +157,7 @@ module.exports = class EmailAnalyticsService {
         if (end <= begin) {
             // Skip for now
             logging.info('[EmailAnalytics] Skipping fetchLatestOpenedEvents because end (' + end + ') is before begin (' + begin + ')');
-            return 0;
+            return createEmptyResult();
         }
 
         return await this.#fetchEvents(this.#fetchLatestOpenedData, {begin, end, maxEvents, eventTypes: ['opened']});
@@ -144,7 +167,7 @@ module.exports = class EmailAnalyticsService {
      * Fetches the latest non-opened events.
      * @param {Object} options - The options for fetching events.
      * @param {number} [options.maxEvents=Infinity] - The maximum number of events to fetch.
-     * @returns {Promise<number>} The total number of events fetched.
+     * @returns {Promise<EmailAnalyticsFetchResult>} Fetch results with timing metrics
      */
     async fetchLatestNonOpenedEvents({maxEvents = Infinity} = {}) {
         const begin = await this.getLastNonOpenedEventTimestamp();
@@ -153,7 +176,7 @@ module.exports = class EmailAnalyticsService {
         if (end <= begin) {
             // Skip for now
             logging.info('[EmailAnalytics] Skipping fetchLatestNonOpenedEvents because end (' + end + ') is before begin (' + begin + ')');
-            return 0;
+            return createEmptyResult();
         }
 
         return await this.#fetchEvents(this.#fetchLatestNonOpenedData, {begin, end, maxEvents, eventTypes: ['delivered', 'failed', 'unsubscribed', 'complained']});
@@ -163,6 +186,7 @@ module.exports = class EmailAnalyticsService {
      * Fetches events that are older than 30 minutes, because then the 'storage' of the Mailgun API is stable. And we are sure we don't miss any events.
      * @param {object} options
      * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     * @returns {Promise<EmailAnalyticsFetchResult>} Fetch results with timing metrics
      */
     async fetchMissing({maxEvents = Infinity} = {}) {
         const begin = await this.getLastMissingEventTimestamp();
@@ -178,7 +202,7 @@ module.exports = class EmailAnalyticsService {
         if (end <= begin) {
             // Skip for now
             logging.info('[EmailAnalytics] Skipping fetchMissing because end (' + end + ') is before begin (' + begin + ')');
-            return 0;
+            return createEmptyResult();
         }
 
         return await this.#fetchEvents(this.#fetchMissingData, {begin, end, maxEvents});
@@ -233,18 +257,18 @@ module.exports = class EmailAnalyticsService {
      * @method fetchScheduled
      * @param {Object} [options] - The options for fetching scheduled events.
      * @param {number} [options.maxEvents=Infinity] - The maximum number of events to fetch.
-     * @returns {Promise<number>} The number of events fetched.
+     * @returns {Promise<EmailAnalyticsFetchResult>} Fetch results with timing metrics
      */
     async fetchScheduled({maxEvents = Infinity} = {}) {
         if (!this.#fetchScheduledData || !this.#fetchScheduledData.schedule) {
             // Nothing scheduled
-            return 0;
+            return createEmptyResult();
         }
 
         if (this.#fetchScheduledData.canceled) {
             // Skip for now
             this.#fetchScheduledData = null;
-            return 0;
+            return createEmptyResult();
         }
 
         let begin = this.#fetchScheduledData.schedule.begin;
@@ -262,11 +286,11 @@ module.exports = class EmailAnalyticsService {
                 running: false,
                 jobName: 'email-analytics-scheduled'
             };
-            return 0;
+            return createEmptyResult();
         }
 
-        const count = await this.#fetchEvents(this.#fetchScheduledData, {begin, end, maxEvents});
-        if (count === 0 || this.#fetchScheduledData.canceled) {
+        const fetchResult = await this.#fetchEvents(this.#fetchScheduledData, {begin, end, maxEvents});
+        if (fetchResult.eventCount === 0 || this.#fetchScheduledData.canceled) {
             // Reset the scheduled fetch
             this.#fetchScheduledData = {
                 running: false,
@@ -275,7 +299,7 @@ module.exports = class EmailAnalyticsService {
         }
 
         this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp);
-        return count;
+        return fetchResult;
     }
     /**
      * Start fetching analytics and store the data of the progress inside fetchData
@@ -285,7 +309,7 @@ module.exports = class EmailAnalyticsService {
      * @param {Date} options.end - End date for fetching events
      * @param {number} [options.maxEvents=Infinity] - Maximum number of events to fetch. Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      * @param {EmailAnalyticsEvent[]} [options.eventTypes] - Array of event types to fetch. If not provided, Mailgun will return all event types.
-     * @returns {Promise<number>} The number of events fetched
+     * @returns {Promise<EmailAnalyticsFetchResult>} Fetch results with timing metrics
      */
     async #fetchEvents(fetchData, {begin, end, maxEvents = Infinity, eventTypes = null}) {
         // Start where we left of, or the last stored event in the database, or start 30 minutes ago if we have nothing available
@@ -296,6 +320,11 @@ module.exports = class EmailAnalyticsService {
         fetchData.lastStarted = new Date();
         fetchData.lastBegin = begin;
         this.queries.setJobTimestamp(fetchData.jobName, 'started', begin);
+
+        // Timing metrics
+        let apiPollingTime = 0;
+        let processingTime = 0;
+        let aggregationTime = 0;
 
         let lastAggregation = Date.now();
         let eventCount = 0;
@@ -314,7 +343,9 @@ module.exports = class EmailAnalyticsService {
          */
         const processBatch = async (events) => {
             // Even if the fetching is interrupted because of an error, we still store the last event timestamp
+            const processingStart = Date.now();
             await this.processEventBatch(events, processingResult, fetchData);
+            processingTime += (Date.now() - processingStart);
             eventCount += events.length;
 
             // Every 5 minutes or 5000 members we do an aggregation and clear the processingResult
@@ -323,7 +354,9 @@ module.exports = class EmailAnalyticsService {
                 // Aggregate and clear the processingResult
                 // We do this here because otherwise it could take a long time before the new events are visible in the stats
                 try {
+                    const aggregationStart = Date.now();
                     await this.aggregateStats(processingResult, includeOpenedEvents);
+                    aggregationTime += (Date.now() - aggregationStart);
                     lastAggregation = Date.now();
                     processingResult = new EventProcessingResult();
                 } catch (err) {
@@ -341,7 +374,9 @@ module.exports = class EmailAnalyticsService {
 
         try {
             for (const provider of this.providers) {
+                const apiStart = Date.now();
                 await provider.fetchLatest(processBatch, {begin, end, maxEvents, events: eventTypes});
+                apiPollingTime += (Date.now() - apiStart);
             }
 
             logging.info('[EmailAnalytics] Fetching finished');
@@ -357,7 +392,9 @@ module.exports = class EmailAnalyticsService {
 
         if (processingResult.memberIds.length > 0 || processingResult.emailIds.length > 0) {
             try {
+                const aggregationStart = Date.now();
                 await this.aggregateStats(processingResult, includeOpenedEvents);
+                aggregationTime += (Date.now() - aggregationStart);
             } catch (err) {
                 logging.error('[EmailAnalytics] Error while aggregating stats');
                 logging.error(err);
@@ -388,7 +425,14 @@ module.exports = class EmailAnalyticsService {
         if (error) {
             throw error;
         }
-        return eventCount;
+
+        return {
+            eventCount,
+            apiPollingTime,
+            processingTime,
+            aggregationTime,
+            result: processingResult
+        };
     }
 
     /**

--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
@@ -67,24 +67,24 @@ class EmailAnalyticsServiceWrapper {
      * Log comprehensive job completion with timing metrics
      * @param {string} jobType - Type of job (e.g., 'latest-opened', 'latest', 'missing', 'scheduled')
      * @param {object} fetchResult - The fetch result from EmailAnalyticsService
-     * @param {number} totalDuration - Total duration in milliseconds
+     * @param {number} totalDurationMs - Total duration in milliseconds
      */
-    _logJobCompletion(jobType, fetchResult, totalDuration) {
-        const {eventCount, apiPollingTime, processingTime, aggregationTime, result} = fetchResult;
+    _logJobCompletion(jobType, fetchResult, totalDurationMs) {
+        const {eventCount, apiPollingTimeMs, processingTimeMs, aggregationTimeMs, result} = fetchResult;
 
         if (eventCount === 0) {
             return;
         }
 
-        const throughput = totalDuration > 0 ? eventCount / (totalDuration / 1000) : 0;
-        const apiPercent = totalDuration > 0 ? Math.round((apiPollingTime / totalDuration) * 100) : 0;
-        const processingPercent = totalDuration > 0 ? Math.round((processingTime / totalDuration) * 100) : 0;
-        const aggregationPercent = totalDuration > 0 ? Math.round((aggregationTime / totalDuration) * 100) : 0;
+        const throughput = totalDurationMs > 0 ? eventCount / (totalDurationMs / 1000) : 0;
+        const apiPercent = totalDurationMs > 0 ? Math.round((apiPollingTimeMs / totalDurationMs) * 100) : 0;
+        const processingPercent = totalDurationMs > 0 ? Math.round((processingTimeMs / totalDurationMs) * 100) : 0;
+        const aggregationPercent = totalDurationMs > 0 ? Math.round((aggregationTimeMs / totalDurationMs) * 100) : 0;
 
         const logMessage = [
             `[EmailAnalytics] Job complete: ${jobType}`,
-            `${eventCount} events in ${(totalDuration / 1000).toFixed(1)}s (${throughput.toFixed(2)} events/s)`,
-            `Timings: API ${(apiPollingTime / 1000).toFixed(1)}s (${apiPercent}%) / Processing ${(processingTime / 1000).toFixed(1)}s (${processingPercent}%) / Aggregation ${(aggregationTime / 1000).toFixed(1)}s (${aggregationPercent}%)`,
+            `${eventCount} events in ${(totalDurationMs / 1000).toFixed(1)}s (${throughput.toFixed(2)} events/s)`,
+            `Timings: API ${(apiPollingTimeMs / 1000).toFixed(1)}s (${apiPercent}%) / Processing ${(processingTimeMs / 1000).toFixed(1)}s (${processingPercent}%) / Aggregation ${(aggregationTimeMs / 1000).toFixed(1)}s (${aggregationPercent}%)`,
             `Events: opened=${result.opened} delivered=${result.delivered} failed=${result.permanentFailed + result.temporaryFailed} unprocessable=${result.unprocessable}`
         ].join(' | ');
 
@@ -98,7 +98,7 @@ class EmailAnalyticsServiceWrapper {
                 metrics.metric('email-analytics-open-throughput', {
                     value: throughput,
                     events: eventCount,
-                    duration: totalDuration
+                    duration: totalDurationMs
                 });
             }
         }

--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
@@ -94,18 +94,18 @@ class EmailAnalyticsServiceWrapper {
         ].join(' | ');
 
         logging.info(logMessage);
-
-        // Emit open throughput metric if enabled and above threshold
-        const openThroughputEnabled = config.get('emailAnalytics:metrics:openThroughput:enabled');
-        const openThroughputThreshold = config.get('emailAnalytics:metrics:openThroughput:threshold') || 0;
-
-        if (openThroughputEnabled && eventCount >= openThroughputThreshold) {
-            metrics.metric('email-analytics-open-throughput', {
-                value: eventCount / (totalDuration / 1000),
-                jobType,
-                events: eventCount,
-                duration: totalDuration
-            });
+        
+        // We're only concerned with open throughput as this is displayed to users and is most sensitive to being up to date
+        if (jobType === 'latest-opened') {
+            const openThroughputEnabled = config.get('emailAnalytics:metrics:openThroughput:enabled');
+            const openThroughputThreshold = config.get('emailAnalytics:metrics:openThroughput:threshold') || 0;
+            if (openThroughputEnabled && eventCount >= openThroughputThreshold) {
+                metrics.metric('email-analytics-open-throughput', {
+                    value: eventCount / (totalDuration / 1000),
+                    events: eventCount,
+                    duration: totalDuration
+                });
+            }
         }
     }
 

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -10,7 +10,7 @@ module.exports = {
     async scheduleRecurringJobs(skipEmailCheck = false) {
         if (
             !hasScheduled &&
-            config.get('emailAnalytics') &&
+            config.get('emailAnalytics:enabled') &&
             config.get('backgroundJobs:emailAnalytics') &&
             !process.env.NODE_ENV.startsWith('test')
         ) {

--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -213,7 +213,10 @@ module.exports = class MailgunClient {
             const totalDuration = overallEndTime - overallStartTime;
             const averageBatchTime = batchCount > 0 ? totalBatchTime / batchCount : 0;
 
-            logging.info(`[MailgunClient fetchEvents]: Processed ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s`);
+            // Only log if we actually processed batches
+            if (batchCount > 0) {
+                logging.info(`[MailgunClient fetchEvents]: Processed ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s`);
+            }
         } catch (error) {
             logging.error(error);
             throw error;

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -17,7 +17,7 @@ module.exports = function getConfigProperties() {
         enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
         stripeDirect: config.get('stripeDirect'),
         mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
-        emailAnalytics: config.get('emailAnalytics'),
+        emailAnalytics: config.get('emailAnalytics:enabled'),
         hostSettings: config.get('hostSettings'),
         tenor: config.get('tenor'),
         pintura: config.get('pintura'),

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -216,7 +216,13 @@
     "stripeDirect": false,
     "enableStripePromoCodes": false,
     "enableTipsAndDonations": true,
-    "emailAnalytics": true,
+    "emailAnalytics": {
+        "enabled": true,
+        "metrics": {
+            "enabled": false
+        },
+        "openedJobLagWarningMinutes": 30
+    },
     "linkClickTrackingCacheMemberUuid": false,
     "backgroundJobs": {
         "emailAnalytics": true,

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -219,7 +219,10 @@
     "emailAnalytics": {
         "enabled": true,
         "metrics": {
-            "enabled": false
+            "openThroughput": {
+                "enabled": false,
+                "threshold": 500
+            }
         },
         "openedJobLagWarningMinutes": 30
     },

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -195,7 +195,7 @@ describe('EmailAnalyticsService', function () {
 
             it('returns 0 when nothing is scheduled', async function () {
                 const result = await service.fetchScheduled();
-                result.should.equal(0);
+                result.eventCount.should.equal(0);
                 processEventBatchStub.called.should.be.false();
                 aggregateStatsStub.called.should.be.false();
             });
@@ -207,7 +207,7 @@ describe('EmailAnalyticsService', function () {
                 });
                 service.cancelScheduled();
                 const result = await service.fetchScheduled();
-                result.should.equal(0);
+                result.eventCount.should.equal(0);
                 processEventBatchStub.called.should.be.false();
                 aggregateStatsStub.called.should.be.false();
             });
@@ -220,7 +220,7 @@ describe('EmailAnalyticsService', function () {
 
                 const result = await service.fetchScheduled({maxEvents: 100});
 
-                result.should.equal(10);
+                result.eventCount.should.equal(10);
                 setJobStatusStub.calledOnce.should.be.true();
                 processEventBatchStub.calledOnce.should.be.true();
             });
@@ -231,7 +231,7 @@ describe('EmailAnalyticsService', function () {
                     end: new Date(2023, 0, 1)
                 });
                 const result = await service.fetchScheduled({maxEvents: 100});
-                result.should.equal(0);
+                result.eventCount.should.equal(0);
             });
 
             it('resets fetchScheduledData when no events are fetched', async function () {
@@ -252,7 +252,7 @@ describe('EmailAnalyticsService', function () {
                     end: new Date(2023, 0, 2)
                 });
                 const result = await service.fetchScheduled({maxEvents: 100});
-                result.should.equal(0);
+                result.eventCount.should.equal(0);
             });
         });
 

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -116,5 +116,21 @@ describe('Public-config Service', function () {
 
             assert.equal(configProperties.stats, undefined);
         });
+
+        it('should return emailAnalytics as boolean from nested config structure', function () {
+            // Default config has emailAnalytics.enabled = true
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.emailAnalytics, true);
+            assert.equal(typeof configProperties.emailAnalytics, 'boolean');
+        });
+
+        it('should return false for emailAnalytics when disabled', function () {
+            configUtils.set('emailAnalytics:enabled', false);
+
+            let configProperties = getConfigProperties();
+
+            assert.equal(configProperties.emailAnalytics, false);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-721/
- updated `emailAnalytics` config and defaults to have more tunability around alerts/logs
- added new metric for tracking email analytics throughput (behind config)
- added new console warning for delays in the open job (behind config)
- updated logging to be more concise and specific

This is laying the groundwork for better observability in our logs for monitoring the email analytics job. The new metric allows us to monitor the events/s throughput for sites in question - namely, for very large sites where they need to ingest 10ks of events, possibly within a few minutes. Previously we couldn't do this without a lot of manual math and searching in Elastic.

NOTE: The lagging warning for email opens is a flawed measure. We currently only update the job timestamp _if we process events_ so if there was a legitimate period where there were no Mailgun events, this would be a false positive. As such, this is going to issue a warning for sites that have 1) low activity or 2) experience any kind of outage in the site/Mailgun. As such, it may be worth removing and skipping this, though we can try it out.