### PR TITLE
Increased notification grouping window to 24 hours in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Notifications/Notifications.tsx
+++ b/apps/activitypub/src/views/Notifications/Notifications.tsx
@@ -39,7 +39,7 @@ interface NotificationGroupDescriptionProps {
  * Groups notifications into time windows
  */
 function getTimeBucket(timestamp: string): string {
-    const TIME_WINDOW_MS = 6 * 60 * 60 * 1000; // 6 hours
+    const TIME_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
     const date = new Date(timestamp);
     const timeMs = date.getTime();
     const bucketStart = Math.floor(timeMs / TIME_WINDOW_MS) * TIME_WINDOW_MS;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2937/improve-notification-grouping-by-adding-date-criteria

-   Extended grouping timeframe from 6h to 24h as it felt a bit too short for grouping