### PR TITLE
Added topics to Discover mode in Reader

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -450,7 +450,7 @@ export class ActivityPubAPI {
         return this.getPaginatedPosts('.ghost/activitypub/v1/feed/reader', next);
     }
 
-    async getGlobalFeed(next?: string, topic?: string): Promise<PaginatedPostsResponse> {
+    async getDiscoveryFeed(next?: string, topic?: string): Promise<PaginatedPostsResponse> {
         const topicPath = topic && topic !== 'all' ? topic : 'top';
         const endpoint = `.ghost/activitypub/v1/feed/discover/${topicPath}`;
         return this.getPaginatedPosts(endpoint, next);

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -450,9 +450,8 @@ export class ActivityPubAPI {
         return this.getPaginatedPosts('.ghost/activitypub/v1/feed/reader', next);
     }
 
-    async getDiscoveryFeed(next?: string, topic?: string): Promise<PaginatedPostsResponse> {
-        const topicPath = topic && topic !== 'all' ? topic : 'top';
-        const endpoint = `.ghost/activitypub/v1/feed/discover/${topicPath}`;
+    async getDiscoveryFeed(next?: string, topic: string = 'top'): Promise<PaginatedPostsResponse> {
+        const endpoint = `.ghost/activitypub/v1/feed/discover/${topic}`;
         return this.getPaginatedPosts(endpoint, next);
     }
 

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -450,8 +450,10 @@ export class ActivityPubAPI {
         return this.getPaginatedPosts('.ghost/activitypub/v1/feed/reader', next);
     }
 
-    async getGlobalFeed(next?: string): Promise<PaginatedPostsResponse> {
-        return this.getPaginatedPosts('.ghost/activitypub/v1/feed/global', next);
+    async getGlobalFeed(next?: string, topic?: string): Promise<PaginatedPostsResponse> {
+        const topicPath = topic && topic !== 'all' ? topic : 'top';
+        const endpoint = `.ghost/activitypub/v1/feed/discover/${topicPath}`;
+        return this.getPaginatedPosts(endpoint, next);
     }
 
     async getPostsByAccount(handle: string, next?: string): Promise<PaginatedPostsResponse> {

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Button} from '@tryghost/shade';
+
+export type Topic = 'all' | 'news' | 'technology' | 'business' | 'culture' | 'politics' | 'finance' | 'design';
+
+const TOPICS: {value: Topic; label: string}[] = [
+    {value: 'all', label: 'Top'},
+    {value: 'news', label: 'News'},
+    {value: 'technology', label: 'Technology'},
+    {value: 'business', label: 'Business'},
+    {value: 'culture', label: 'Culture'},
+    {value: 'politics', label: 'Politics'},
+    {value: 'finance', label: 'Finance'},
+    {value: 'design', label: 'Design'},
+];
+
+interface TopicFilterProps {
+    currentTopic: Topic;
+    onTopicChange: (topic: Topic) => void;
+}
+
+const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange}) => {
+    return (
+        <div className="flex gap-3 overflow-x-auto mt-4">
+            {TOPICS.map(({value, label}) => (
+                <Button
+                    key={value}
+                    variant={currentTopic === value ? 'default' : 'secondary'}
+                    onClick={() => onTopicChange(value)}
+                >
+                    {label}
+                </Button>
+            ))}
+        </div>
+    );
+};
+
+export default TopicFilter;

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {Button} from '@tryghost/shade';
 
-export type Topic = 'all' | 'news' | 'technology' | 'business' | 'culture' | 'politics' | 'finance' | 'design';
+export type Topic = 'top' | 'news' | 'technology' | 'business' | 'culture' | 'politics' | 'finance' | 'design';
 
 const TOPICS: {value: Topic; label: string}[] = [
-    {value: 'all', label: 'Top'},
+    {value: 'top', label: 'Top'},
     {value: 'news', label: 'News'},
     {value: 'technology', label: 'Technology'},
     {value: 'business', label: 'Business'},

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -11,7 +11,7 @@ const TOPICS: {value: Topic; label: string}[] = [
     {value: 'culture', label: 'Culture'},
     {value: 'politics', label: 'Politics'},
     {value: 'finance', label: 'Finance'},
-    {value: 'design', label: 'Design'},
+    {value: 'design', label: 'Design'}
 ];
 
 interface TopicFilterProps {
@@ -21,7 +21,7 @@ interface TopicFilterProps {
 
 const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange}) => {
     return (
-        <div className="flex gap-3 overflow-x-auto mt-4">
+        <div className="mt-4 flex gap-3 overflow-x-auto">
             {TOPICS.map(({value, label}) => (
                 <Button
                     key={value}

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -85,7 +85,7 @@ const QUERY_KEYS = {
     },
     feed: ['feed'],
     inbox: ['inbox'],
-    globalFeed: ['global_feed'],
+    discoveryFeed: ['discovery_feed'],
     postsByAccount: ['account_posts'],
     postsLikedByAccount: ['account_liked_posts'],
     notifications: (handle: string) => ['notifications', handle],
@@ -98,7 +98,7 @@ function updateLikeCache(queryClient: QueryClient, id: string, liked: boolean) {
     const queryKeys = [
         QUERY_KEYS.feed,
         QUERY_KEYS.inbox,
-        QUERY_KEYS.globalFeed,
+        QUERY_KEYS.discoveryFeed,
         QUERY_KEYS.postsLikedByAccount,
         QUERY_KEYS.profilePosts(null)
     ];
@@ -168,7 +168,7 @@ function updateFollowCache(queryClient: QueryClient, handle: string, authorHandl
     const queryKeys = [
         QUERY_KEYS.feed,
         QUERY_KEYS.inbox,
-        QUERY_KEYS.globalFeed,
+        QUERY_KEYS.discoveryFeed,
         QUERY_KEYS.profilePosts('index')
     ];
 
@@ -496,7 +496,7 @@ function updateReplyCache(queryClient: QueryClient, id: string, delta: number) {
     const queryKeys = [
         QUERY_KEYS.feed,
         QUERY_KEYS.inbox,
-        QUERY_KEYS.globalFeed,
+        QUERY_KEYS.discoveryFeed,
         QUERY_KEYS.profilePosts('index'),
         QUERY_KEYS.postsLikedByAccount
     ];
@@ -748,7 +748,7 @@ export function useBlockMutationForUser(handle: string) {
             );
             queryClient.invalidateQueries({queryKey: QUERY_KEYS.feed});
             queryClient.invalidateQueries({queryKey: QUERY_KEYS.inbox});
-            queryClient.invalidateQueries({queryKey: QUERY_KEYS.globalFeed});
+            queryClient.invalidateQueries({queryKey: QUERY_KEYS.discoveryFeed});
         },
         onError(error: {message: string, statusCode: number}) {
             if (error.statusCode === 429) {
@@ -794,7 +794,7 @@ function updateRepostCache(queryClient: QueryClient, id: string, reposted: boole
     const queryKeys = [
         QUERY_KEYS.feed,
         QUERY_KEYS.inbox,
-        QUERY_KEYS.globalFeed,
+        QUERY_KEYS.discoveryFeed,
         QUERY_KEYS.profilePosts(null)
     ];
 
@@ -1724,18 +1724,18 @@ export function useInboxForUser(options: {enabled: boolean}) {
     return {inboxQuery, updateInboxActivity};
 }
 
-export function useGlobalFeedForUser(options: {enabled: boolean; topic?: string}) {
-    const queryKey = [...QUERY_KEYS.globalFeed, options.topic || 'all'];
+export function useDiscoveryFeedForUser(options: {enabled: boolean; topic?: string}) {
+    const queryKey = [...QUERY_KEYS.discoveryFeed, options.topic || 'all'];
     const queryClient = useQueryClient();
 
-    const globalFeedQuery = useInfiniteQuery({
+    const discoveryFeedQuery = useInfiniteQuery({
         queryKey,
         enabled: options.enabled,
         staleTime: 20 * 1000, // 20s
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI('index', siteUrl);
-            return api.getGlobalFeed(pageParam, options.topic).then((response) => {
+            return api.getDiscoveryFeed(pageParam, options.topic).then((response) => {
                 return {
                     posts: response.posts.map(mapPostToActivity),
                     next: response.next
@@ -1747,7 +1747,7 @@ export function useGlobalFeedForUser(options: {enabled: boolean; topic?: string}
         }
     });
 
-    const updateGlobalFeedActivity = (id: string, updated: Partial<Activity>) => {
+    const updateDiscoveryFeedActivity = (id: string, updated: Partial<Activity>) => {
         updateActivityInPaginatedCollection(
             queryClient,
             queryKey,
@@ -1757,7 +1757,7 @@ export function useGlobalFeedForUser(options: {enabled: boolean; topic?: string}
         );
     };
 
-    return {globalFeedQuery, updateGlobalFeedActivity};
+    return {discoveryFeedQuery, updateDiscoveryFeedActivity};
 }
 
 export function usePostsByAccount(profileHandle: string, options: {enabled: boolean}) {
@@ -1968,6 +1968,7 @@ export function useDeleteMutationForUser(handle: string) {
             const wasLiked = [
                 QUERY_KEYS.feed,
                 QUERY_KEYS.inbox,
+                QUERY_KEYS.discoveryFeed,
                 QUERY_KEYS.profilePosts('index'),
                 QUERY_KEYS.postsLikedByAccount
             ].some((key) => {

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -1724,8 +1724,8 @@ export function useInboxForUser(options: {enabled: boolean}) {
     return {inboxQuery, updateInboxActivity};
 }
 
-export function useDiscoveryFeedForUser(options: {enabled: boolean; topic?: string}) {
-    const queryKey = [...QUERY_KEYS.discoveryFeed, options.topic || 'all'];
+export function useDiscoveryFeedForUser(options: {enabled: boolean; topic: string}) {
+    const queryKey = [...QUERY_KEYS.discoveryFeed, options.topic];
     const queryClient = useQueryClient();
 
     const discoveryFeedQuery = useInfiniteQuery({

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -1724,8 +1724,8 @@ export function useInboxForUser(options: {enabled: boolean}) {
     return {inboxQuery, updateInboxActivity};
 }
 
-export function useGlobalFeedForUser(options: {enabled: boolean}) {
-    const queryKey = QUERY_KEYS.globalFeed;
+export function useGlobalFeedForUser(options: {enabled: boolean; topic?: string}) {
+    const queryKey = [...QUERY_KEYS.globalFeed, options.topic || 'all'];
     const queryClient = useQueryClient();
 
     const globalFeedQuery = useInfiniteQuery({
@@ -1735,7 +1735,7 @@ export function useGlobalFeedForUser(options: {enabled: boolean}) {
         async queryFn({pageParam}: {pageParam?: string}) {
             const siteUrl = await getSiteUrl();
             const api = createActivityPubAPI('index', siteUrl);
-            return api.getGlobalFeed(pageParam).then((response) => {
+            return api.getGlobalFeed(pageParam, options.topic).then((response) => {
                 return {
                     posts: response.posts.map(mapPostToActivity),
                     next: response.next

--- a/apps/activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/activitypub/src/views/Inbox/Inbox.tsx
@@ -3,9 +3,9 @@ import InboxList from './components/InboxList';
 import React, {useState} from 'react';
 import {Topic} from '@src/components/TopicFilter';
 import {isApiError} from '@src/api/activitypub';
+import {useDiscoveryFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-queries';
 import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useFeedMode} from '@src/hooks/use-feed-mode';
-import {useDiscoveryFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-queries';
 
 const Inbox: React.FC = () => {
     const {isEnabled} = useFeatureFlags();

--- a/apps/activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/activitypub/src/views/Inbox/Inbox.tsx
@@ -10,7 +10,7 @@ import {useDiscoveryFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-
 const Inbox: React.FC = () => {
     const {isEnabled} = useFeatureFlags();
     const {feedMode} = useFeedMode(isEnabled('global-feed'));
-    const [topic, setTopic] = useState<Topic>('all');
+    const [topic, setTopic] = useState<Topic>('top');
 
     const {inboxQuery: followingQuery} = useInboxForUser({enabled: feedMode === 'following'});
     const {discoveryFeedQuery: discoverQuery} = useDiscoveryFeedForUser({enabled: feedMode === 'discover', topic});

--- a/apps/activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/activitypub/src/views/Inbox/Inbox.tsx
@@ -1,6 +1,7 @@
 import Error from '@components/layout/Error';
 import InboxList from './components/InboxList';
-import React from 'react';
+import React, {useState} from 'react';
+import {Topic} from '@src/components/TopicFilter';
 import {isApiError} from '@src/api/activitypub';
 import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useFeedMode} from '@src/hooks/use-feed-mode';
@@ -9,9 +10,10 @@ import {useGlobalFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-que
 const Inbox: React.FC = () => {
     const {isEnabled} = useFeatureFlags();
     const {feedMode} = useFeedMode(isEnabled('global-feed'));
+    const [topic, setTopic] = useState<Topic>('all');
 
     const {inboxQuery: followingQuery} = useInboxForUser({enabled: feedMode === 'following'});
-    const {globalFeedQuery: discoverQuery} = useGlobalFeedForUser({enabled: feedMode === 'discover'});
+    const {globalFeedQuery: discoverQuery} = useGlobalFeedForUser({enabled: feedMode === 'discover', topic});
 
     const feedQueryData = feedMode === 'discover' ? discoverQuery : followingQuery;
     const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQueryData;
@@ -24,10 +26,13 @@ const Inbox: React.FC = () => {
 
     return <InboxList
         activities={activities}
+        currentTopic={topic}
+        feedMode={feedMode}
         fetchNextPage={fetchNextPage}
         hasNextPage={hasNextPage!}
         isFetchingNextPage={isFetchingNextPage}
         isLoading={isLoading}
+        onTopicChange={setTopic}
     />;
 };
 

--- a/apps/activitypub/src/views/Inbox/Inbox.tsx
+++ b/apps/activitypub/src/views/Inbox/Inbox.tsx
@@ -5,7 +5,7 @@ import {Topic} from '@src/components/TopicFilter';
 import {isApiError} from '@src/api/activitypub';
 import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useFeedMode} from '@src/hooks/use-feed-mode';
-import {useGlobalFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-queries';
+import {useDiscoveryFeedForUser, useInboxForUser} from '@hooks/use-activity-pub-queries';
 
 const Inbox: React.FC = () => {
     const {isEnabled} = useFeatureFlags();
@@ -13,7 +13,7 @@ const Inbox: React.FC = () => {
     const [topic, setTopic] = useState<Topic>('all');
 
     const {inboxQuery: followingQuery} = useInboxForUser({enabled: feedMode === 'following'});
-    const {globalFeedQuery: discoverQuery} = useGlobalFeedForUser({enabled: feedMode === 'discover', topic});
+    const {discoveryFeedQuery: discoverQuery} = useDiscoveryFeedForUser({enabled: feedMode === 'discover', topic});
 
     const feedQueryData = feedMode === 'discover' ? discoverQuery : followingQuery;
     const {data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = feedQueryData;

--- a/apps/activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/activitypub/src/views/Inbox/components/InboxList.tsx
@@ -1,9 +1,11 @@
 import FeedItem from '@src/components/feed/FeedItem';
 import Layout from '@src/components/layout';
 import Reader from './Reader';
+import TopicFilter, {Topic} from '@src/components/TopicFilter';
 import {Activity} from '@src/api/activitypub';
 import {Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, LoadingIndicator, LucideIcon, Separator} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
+import {FeedMode} from '@src/hooks/use-feed-mode';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef, useState} from 'react';
 import {useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-framework';
@@ -11,17 +13,23 @@ import {useNavigate, useNavigationStack, useParams} from '@tryghost/admin-x-fram
 export type InboxListProps = {
     isLoading: boolean,
     activities: Activity[],
+    currentTopic: Topic,
+    feedMode: FeedMode,
     fetchNextPage: () => void,
     hasNextPage: boolean,
-    isFetchingNextPage: boolean
+    isFetchingNextPage: boolean,
+    onTopicChange: (topic: Topic) => void
 }
 
 const InboxList:React.FC<InboxListProps> = ({
     isLoading,
     activities,
+    currentTopic,
+    feedMode,
     fetchNextPage,
     hasNextPage,
-    isFetchingNextPage
+    isFetchingNextPage,
+    onTopicChange
 }) => {
     const navigate = useNavigate();
     const {canGoBack, goBack} = useNavigationStack();
@@ -67,6 +75,7 @@ const InboxList:React.FC<InboxListProps> = ({
 
     return (
         <Layout>
+            {feedMode === 'discover' && <TopicFilter currentTopic={currentTopic} onTopicChange={onTopicChange} />}
             <div className='flex w-full flex-col'>
                 <div className='w-full'>
                     {activities.length > 0 ? (

--- a/apps/activitypub/test/acceptance/inbox.test.ts
+++ b/apps/activitypub/test/acceptance/inbox.test.ts
@@ -16,9 +16,9 @@ test.describe('Inbox', async () => {
                 path: '/v1/feed/reader',
                 response: inboxFixture
             },
-            getGlobalFeed: {
+            getDiscoveryFeed: {
                 method: 'GET',
-                path: '/v1/feed/global',
+                path: '/v1/feed/discover/top',
                 response: inboxFixture
             }
         }, options: {useActivityPub: true}});
@@ -53,9 +53,9 @@ test.describe('Inbox', async () => {
                 path: '/v1/feed/reader',
                 response: inboxFixture
             },
-            getGlobalFeed: {
+            getDiscoveryFeed: {
                 method: 'GET',
-                path: '/v1/feed/global',
+                path: '/v1/feed/discover/top',
                 response: inboxFixture
             },
             getPost: {
@@ -123,9 +123,9 @@ test.describe('Inbox', async () => {
                 path: '/v1/feed/reader',
                 response: inboxFixture
             },
-            getGlobalFeed: {
+            getDiscoveryFeed: {
                 method: 'GET',
-                path: '/v1/feed/global',
+                path: '/v1/feed/discover/top',
                 response: inboxFixture
             },
             likePost: {
@@ -174,9 +174,9 @@ test.describe('Inbox', async () => {
                 path: '/v1/feed/reader',
                 response: inboxFixture
             },
-            getGlobalFeed: {
+            getDiscoveryFeed: {
                 method: 'GET',
-                path: '/v1/feed/global',
+                path: '/v1/feed/discover/top',
                 response: inboxFixture
             },
             getPost: {
@@ -268,9 +268,9 @@ test.describe('Inbox', async () => {
                 path: '/v1/feed/reader',
                 response: inboxFixture
             },
-            getGlobalFeed: {
+            getDiscoveryFeed: {
                 method: 'GET',
-                path: '/v1/feed/global',
+                path: '/v1/feed/discover/top',
                 response: inboxFixture
             },
             repostPost: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2943/topical-feed

-    Updated Discover to show "Top" plus selectable topic feeds
-    Kept global feed as "Top" and added topic tabs for exploration
-    Updated endpoints from `/feed/global` to `/feed/discover/top` and `/feed/discover/[topic]`