### PR TITLE
Fixed Ember modals not being visible on React routes

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -18,6 +18,7 @@
     <div id="root"></div>
     <div id="ember-app"></div>
     <div id="ember-basic-dropdown-wormhole"></div>
+    <div id="ember-modal-wormhole"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ghost/admin/app/controllers/application.js
+++ b/ghost/admin/app/controllers/application.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import {action} from '@ember/object';
+import {getOwner} from '@ember/application';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
@@ -16,6 +17,18 @@ export default class ApplicationController extends Controller {
     @service store;
 
     @inject config;
+
+    get modalDestinationElement() {
+        const owner = getOwner(this);
+        const app = owner.lookup('application:main');
+        let rootElement = app.rootElement || 'body';
+
+        if (typeof rootElement === 'string') {
+            rootElement = document.querySelector(rootElement);
+        }
+
+        return document.getElementById('ember-modal-wormhole') || rootElement;
+    }
 
     get showBilling() {
         return this.config.hostSettings?.billing?.enabled;

--- a/ghost/admin/app/templates/application.hbs
+++ b/ghost/admin/app/templates/application.hbs
@@ -87,5 +87,8 @@
 
 <div id="unsplash-selector-wormhole"></div>
 
-<EpmModalContainer />
+{{#in-element this.modalDestinationElement insertBefore=null}}
+    <EpmModalContainer />
+{{/in-element}}
+
 <EmberLoadRemover />


### PR DESCRIPTION
no issue

- added `#ember-modal-wormhole` element outside of the `#ember-app` element so it doesn't get hidden when on React routes
- updated Ember application template to render modals into the new `#ember-modal-wormhole` when it exists
