### PR TITLE
🐛 Fix activitypub sidebar navigation active state

### DIFF
--- a/apps/activitypub/src/components/layout/Header/Header.tsx
+++ b/apps/activitypub/src/components/layout/Header/Header.tsx
@@ -1,10 +1,13 @@
-import BackButton from '@src/components/global/BackButton';
-import FeedModeDropdown from './FeedModeDropdown';
 import React from 'react';
-import useActiveRoute from '@src/hooks/use-active-route';
 import {Button, H1, LucideIcon} from '@tryghost/shade';
-import {useBaseRoute, useNavigationStack, useRouteHasParams} from '@tryghost/admin-x-framework';
+import {useNavigationStack, useRouteHasParams} from '@tryghost/admin-x-framework';
+
+import BackButton from '@src/components/global/BackButton';
+import useActiveRoute from '@src/hooks/use-active-route';
+import {useCurrentPage} from '@src/hooks/use-current-page';
 import {useFeatureFlags} from '@src/lib/feature-flags';
+
+import FeedModeDropdown from './FeedModeDropdown';
 
 interface HeaderTitleProps {
     title: string;
@@ -53,18 +56,18 @@ const MobileMenuButton: React.FC<MobileMenuButtonProps> = ({onToggleMobileSideba
 
 const Header: React.FC<HeaderProps> = ({onToggleMobileSidebar}) => {
     const {canGoBack} = useNavigationStack();
-    const baseRoute = useBaseRoute();
+    const currentPage = useCurrentPage();
     const routeHasParams = useRouteHasParams();
     const activeRoute = useActiveRoute();
     const {isEnabled} = useFeatureFlags();
 
     // Logic for special pages
     let onlyBackButton = false;
-    if (baseRoute === 'profile') {
+    if (currentPage === 'profile') {
         onlyBackButton = true;
     }
 
-    if (baseRoute === 'notes' && canGoBack) {
+    if (currentPage === 'notes' && canGoBack) {
         onlyBackButton = true;
     }
 
@@ -72,7 +75,7 @@ const Header: React.FC<HeaderProps> = ({onToggleMobileSidebar}) => {
     const backActive = (canGoBack && routeHasParams) || activeRoute?.showBackButton === true;
 
     // Show feed mode dropdown on reader route with global-feed flag enabled
-    const showFeedModeDropdown = baseRoute === 'reader' && isEnabled('global-feed');
+    const showFeedModeDropdown = currentPage === 'reader' && isEnabled('global-feed');
 
     return (
         <>

--- a/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -57,31 +57,31 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
                         </Dialog>
                     </div>
                     <div className='flex w-full flex-col gap-px'>
-                        <SidebarMenuLink to='../reader'>
+                        <SidebarMenuLink to='/reader'>
                             <LucideIcon.BookOpen size={18} strokeWidth={1.5} />
                             Reader
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='../notes'>
+                        <SidebarMenuLink to='/notes'>
                             <LucideIcon.MessageCircle size={18} strokeWidth={1.5} />
                             Notes
                         </SidebarMenuLink>
                         <SidebarMenuLink
                             count={location.pathname !== `${basePath}/notifications` ? notificationsCount : undefined}
-                            to='../notifications'
+                            to='/notifications'
                             onClick={handleNotificationsClick}
                         >
                             <LucideIcon.Bell size={18} strokeWidth={1.5} />
                             Notifications
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='../explore'>
+                        <SidebarMenuLink to='/explore'>
                             <LucideIcon.Globe size={18} strokeWidth={1.5} />
                             Explore
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='../profile'>
+                        <SidebarMenuLink to='/profile'>
                             <LucideIcon.User size={18} strokeWidth={1.5} />
                             Profile
                         </SidebarMenuLink>
-                        <SidebarMenuLink to='../preferences'>
+                        <SidebarMenuLink to='/preferences'>
                             <LucideIcon.Settings2 size={18} strokeWidth={1.5} />
                             Preferences
                         </SidebarMenuLink>

--- a/apps/activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/SidebarMenuLink.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {Button, ButtonProps, cn, formatNumber} from '@tryghost/shade';
 import {Link, resetScrollPosition, useLocation, useNavigationStack} from '@tryghost/admin-x-framework';
 
+import {useAppBasePath} from '@src/hooks/use-app-base-path';
+
 interface SidebarButtonProps extends ButtonProps {
     to?: string;
     children: React.ReactNode;
@@ -12,10 +14,19 @@ const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
     ({to, children, count, ...props}, ref) => {
         const location = useLocation();
         const {resetStack} = useNavigationStack();
+        const basePath = useAppBasePath();
+
+        // Build full path by prepending base path to absolute paths
+        // Following the same pattern as useNavigateWithBasePath
+        const fullPath = to && to.startsWith('/') ? `${basePath}${to}` : to;
+        const isActive = fullPath && (
+            location.pathname === fullPath ||
+            location.pathname.startsWith(`${fullPath}/`)
+        );
 
         const linkClass = cn(
             'justify-start text-md font-medium text-gray-800 dark:hover:bg-gray-925/70 dark:text-gray-500 h-9 [&_svg]:size-[18px]',
-            (to && (location.pathname === to || location.pathname.startsWith(`${to}/`))) && 'bg-gray-100 dark:bg-gray-925/70 dark:text-white text-black font-semibold'
+            isActive && 'bg-gray-100 dark:bg-gray-925/70 dark:text-white text-black font-semibold'
         );
 
         const badge = count && count > 0 ? (
@@ -26,12 +37,12 @@ const SidebarMenuLink = React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
             </span>
         ) : null;
 
-        if (to) {
+        if (fullPath) {
             return (
                 <Button className={linkClass} variant='ghost' asChild>
-                    <Link to={to} onClick={() => {
+                    <Link to={fullPath} onClick={() => {
                         resetStack();
-                        resetScrollPosition(to);
+                        resetScrollPosition(fullPath);
                     }}>
                         {children}
                         {badge}

--- a/apps/activitypub/src/hooks/use-current-page.test.ts
+++ b/apps/activitypub/src/hooks/use-current-page.test.ts
@@ -1,0 +1,156 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+
+import * as framework from '@tryghost/admin-x-framework';
+
+import {useCurrentPage} from './use-current-page';
+
+vi.mock('@tryghost/admin-x-framework', () => ({
+    useMatches: vi.fn()
+}));
+
+describe('useCurrentPage', () => {
+    const useMatches = framework.useMatches as ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the child route segment when base path is /activitypub', () => {
+        useMatches.mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'activitypub-base',
+                pathname: '/activitypub',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            },
+            {
+                id: 'activitypub-profile',
+                pathname: '/activitypub/profile',
+                params: {},
+                data: undefined,
+                handle: undefined
+            }
+        ]);
+
+        const {result} = renderHook(() => useCurrentPage());
+        expect(result.current).toBe('profile');
+    });
+
+    it('returns the child route segment in test mode (empty base path)', () => {
+        useMatches.mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'activitypub-base',
+                pathname: '',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            },
+            {
+                id: 'activitypub-reader',
+                pathname: '/reader',
+                params: {},
+                data: undefined,
+                handle: undefined
+            }
+        ]);
+
+        const {result} = renderHook(() => useCurrentPage());
+        expect(result.current).toBe('reader');
+    });
+
+    it('returns the child route segment even with nested routes', () => {
+        useMatches.mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'activitypub-base',
+                pathname: '/activitypub',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            },
+            {
+                id: 'activitypub-profile',
+                pathname: '/activitypub/profile',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'activitypub-profile-handle',
+                pathname: '/activitypub/profile/somehandle',
+                params: {handle: 'somehandle'},
+                data: undefined,
+                handle: undefined
+            }
+        ]);
+
+        const {result} = renderHook(() => useCurrentPage());
+        expect(result.current).toBe('profile');
+    });
+
+    it('returns empty string when base path route is not found', () => {
+        useMatches.mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'some-route',
+                pathname: '/some-route',
+                params: {},
+                data: undefined,
+                handle: undefined
+            }
+        ]);
+
+        const {result} = renderHook(() => useCurrentPage());
+        expect(result.current).toBe('');
+    });
+
+    it('returns empty string when no child route exists after base path', () => {
+        useMatches.mockReturnValue([
+            {
+                id: 'root',
+                pathname: '/',
+                params: {},
+                data: undefined,
+                handle: undefined
+            },
+            {
+                id: 'activitypub-base',
+                pathname: '/activitypub',
+                params: {},
+                data: undefined,
+                handle: 'activitypub-basepath'
+            }
+        ]);
+
+        const {result} = renderHook(() => useCurrentPage());
+        expect(result.current).toBe('');
+    });
+});

--- a/apps/activitypub/src/hooks/use-current-page.ts
+++ b/apps/activitypub/src/hooks/use-current-page.ts
@@ -1,0 +1,37 @@
+import {useMatches} from '@tryghost/admin-x-framework';
+
+export function useCurrentPage(): string {
+    const matches = useMatches();
+
+    // Find the index of the activitypub base path route
+    const basePathIndex = matches.findIndex(match => match.handle === 'activitypub-basepath');
+
+    if (basePathIndex === -1) {
+        return '';
+    }
+
+    // Get the next route after the base path (the child route)
+    const childRoute = matches[basePathIndex + 1];
+
+    if (!childRoute) {
+        return '';
+    }
+
+    // Get the base path route to extract its pathname
+    const basePathRoute = matches[basePathIndex];
+
+    // Remove the base path from the child route's pathname to get the relative segment
+    const basePath = basePathRoute.pathname;
+    const childPath = childRoute.pathname;
+
+    // Remove base path prefix
+    let relativePath = childPath.startsWith(basePath)
+        ? childPath.slice(basePath.length)
+        : childPath;
+
+    // Remove leading slash and get first segment
+    relativePath = relativePath.replace(/^\//, '');
+    const segment = relativePath.split('/')[0];
+
+    return segment;
+}


### PR DESCRIPTION
The recent basepath changes broke Header's page detection logic. 

This PR adds a `useCurrentPage` hook that uses `useMatches` to extract the current page segment from the route hierarchy, handling both `/activitypub` and empty basepaths.

Similarly, the sidebar active states were broken because links used relative paths that didn't match the value of `location.pathname`. This was addressed by changing the `to` prop to absolute paths and updating `SidebarMenuLink` to prepend the correct base path.
