### PR TITLE
Added toggle switch to Dark mode button

### DIFF
--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -89,7 +89,13 @@ function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
                 >
                     <LucideIcon.Moon />
                     <span className="flex-1">Dark mode</span>
-                    <Switch size='sm' checked={dummyDarkMode}/>
+                    <Switch
+                        size='sm'
+                        checked={dummyDarkMode}
+                        onCheckedChange={setDummyDarkMode}
+                        onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
+                        tabIndex={-1}
+                    />
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="cursor-pointer text-base" onClick={() => {

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 
 import {
     Avatar,
@@ -10,12 +10,14 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
     LucideIcon,
-    SidebarMenuButton
+    SidebarMenuButton,
+    Switch
 } from "@tryghost/shade"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 
 function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
     const currentUser = useCurrentUser();
+    const [dummyDarkMode, setDummyDarkMode] = useState(false);
 
     return (
         <DropdownMenu {...props}>
@@ -78,9 +80,16 @@ function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
                         Resources & guides
                     </a>
                 </DropdownMenuItem>
-                <DropdownMenuItem className="cursor-pointer text-base">
+                <DropdownMenuItem
+                    className="cursor-pointer text-base"
+                    onSelect={(e) => {
+                        e.preventDefault();
+                        setDummyDarkMode(!dummyDarkMode);
+                    }}
+                >
                     <LucideIcon.Moon />
-                    <span>Dark mode</span>
+                    <span className="flex-1">Dark mode</span>
+                    <Switch size='sm' checked={dummyDarkMode}/>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="cursor-pointer text-base" onClick={() => {

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -83,7 +83,7 @@
         "@radix-ui/react-separator": "1.1.7",
         "@radix-ui/react-slider": "1.3.6",
         "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-switch": "1.2.5",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "1.1.12",
         "@radix-ui/react-toggle": "1.1.9",
         "@radix-ui/react-toggle-group": "1.1.10",

--- a/apps/shade/src/components/ui/switch.stories.tsx
+++ b/apps/shade/src/components/ui/switch.stories.tsx
@@ -1,0 +1,315 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import * as React from 'react';
+import {useForm} from 'react-hook-form';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {z} from 'zod';
+import {Switch} from './switch';
+import {Label} from './label';
+import {Form, FormControl, FormDescription, FormField, FormItem, FormLabel} from './form';
+import {Button} from './button';
+
+const meta = {
+    title: 'Components / Switch',
+    component: Switch,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'A control that allows users to toggle between checked and unchecked states. Built on Radix UI Switch primitive.'
+            }
+        }
+    },
+    decorators: [
+        Story => (
+            <div style={{padding: '24px'}}>
+                <Story />
+            </div>
+        )
+    ]
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof Switch>;
+
+export const Default: Story = {
+    args: {},
+    parameters: {
+        docs: {
+            description: {
+                story: 'Basic switch component without a label in default size.'
+            }
+        }
+    }
+};
+
+export const Small: Story = {
+    render: () => (
+        <div className="flex items-center space-x-2">
+            <Switch id="small-switch" size="sm" />
+            <Label htmlFor="small-switch">Small Switch</Label>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Smaller variant of the switch component (h-4 w-7 with h-3 w-3 thumb).'
+            }
+        }
+    }
+};
+
+export const WithLabel: Story = {
+    render: () => (
+        <div className="flex items-center space-x-2">
+            <Switch id="airplane-mode" />
+            <Label htmlFor="airplane-mode">Airplane Mode</Label>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Switch with an associated label for better accessibility and UX.'
+            }
+        }
+    }
+};
+
+export const Checked: Story = {
+    render: () => (
+        <div className="flex items-center space-x-2">
+            <Switch id="notifications" defaultChecked />
+            <Label htmlFor="notifications">Enable Notifications</Label>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Switch in the checked/on state by default.'
+            }
+        }
+    }
+};
+
+export const Disabled: Story = {
+    render: () => (
+        <div className="flex items-center space-x-2">
+            <Switch id="disabled-switch" disabled />
+            <Label htmlFor="disabled-switch">Disabled Switch</Label>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Disabled switch that cannot be interacted with.'
+            }
+        }
+    }
+};
+
+export const DisabledChecked: Story = {
+    render: () => (
+        <div className="flex items-center space-x-2">
+            <Switch id="disabled-checked" defaultChecked disabled />
+            <Label htmlFor="disabled-checked">Disabled (Checked)</Label>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Disabled switch in the checked state.'
+            }
+        }
+    }
+};
+
+export const Controlled: Story = {
+    render: () => {
+        const [checked, setChecked] = React.useState(false);
+
+        return (
+            <div className="space-y-4">
+                <div className="flex items-center space-x-2">
+                    <Switch
+                        checked={checked}
+                        id="controlled-switch"
+                        onCheckedChange={setChecked}
+                    />
+                    <Label htmlFor="controlled-switch">
+                        {checked ? 'Enabled' : 'Disabled'}
+                    </Label>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                    Current state: {checked ? 'On' : 'Off'}
+                </div>
+            </div>
+        );
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Controlled switch with state managed in React. The label text updates based on the switch state.'
+            }
+        }
+    }
+};
+
+const formSchema = z.object({
+    marketingEmails: z.boolean(),
+    securityEmails: z.boolean(),
+    productUpdates: z.boolean()
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+const FormExample = () => {
+    const form = useForm<FormData>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            marketingEmails: false,
+            securityEmails: true,
+            productUpdates: true
+        }
+    });
+
+    const onSubmit = (data: FormData) => {
+        alert(`Form submitted:\n${JSON.stringify(data, null, 2)}`);
+    };
+
+    return (
+        <div style={{maxWidth: '400px'}}>
+            <Form {...form}>
+                <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+                    <div>
+                        <h3 className="mb-4 text-lg font-medium">Email Notifications</h3>
+                        <div className="space-y-4">
+                            <FormField
+                                control={form.control}
+                                name="marketingEmails"
+                                render={({field}) => (
+                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                                        <div className="space-y-0.5">
+                                            <FormLabel>Marketing emails</FormLabel>
+                                            <FormDescription>
+                                                Receive emails about new products, features, and more.
+                                            </FormDescription>
+                                        </div>
+                                        <FormControl>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </FormControl>
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="securityEmails"
+                                render={({field}) => (
+                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                                        <div className="space-y-0.5">
+                                            <FormLabel>Security emails</FormLabel>
+                                            <FormDescription>
+                                                Receive emails about your account security.
+                                            </FormDescription>
+                                        </div>
+                                        <FormControl>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </FormControl>
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="productUpdates"
+                                render={({field}) => (
+                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                                        <div className="space-y-0.5">
+                                            <FormLabel>Product updates</FormLabel>
+                                            <FormDescription>
+                                                Receive emails about product updates and improvements.
+                                            </FormDescription>
+                                        </div>
+                                        <FormControl>
+                                            <Switch
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                            />
+                                        </FormControl>
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                    </div>
+                    <Button type="submit">Save preferences</Button>
+                </form>
+            </Form>
+        </div>
+    );
+};
+
+export const FormIntegration: Story = {
+    render: () => <FormExample />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'Switch components integrated with react-hook-form for managing notification preferences. This example demonstrates a common use case for switches in settings forms.'
+            }
+        }
+    }
+};
+
+export const MultipleSettings: Story = {
+    render: () => (
+        <div className="space-y-4" style={{maxWidth: '400px'}}>
+            <div className="flex items-center justify-between">
+                <Label htmlFor="wifi">Wi-Fi</Label>
+                <Switch id="wifi" defaultChecked />
+            </div>
+            <div className="flex items-center justify-between">
+                <Label htmlFor="bluetooth">Bluetooth</Label>
+                <Switch id="bluetooth" defaultChecked />
+            </div>
+            <div className="flex items-center justify-between">
+                <Label htmlFor="airplane">Airplane Mode</Label>
+                <Switch id="airplane" />
+            </div>
+            <div className="flex items-center justify-between">
+                <Label htmlFor="location">Location Services</Label>
+                <Switch id="location" defaultChecked />
+            </div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Multiple switches arranged in a settings list layout with labels aligned to the left and switches to the right.'
+            }
+        }
+    }
+};
+
+export const SizeComparison: Story = {
+    render: () => (
+        <div className="space-y-4">
+            <div className="flex items-center space-x-2">
+                <Switch id="size-default" />
+                <Label htmlFor="size-default">Default size</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+                <Switch id="size-small" size="sm" />
+                <Label htmlFor="size-small">Small size</Label>
+            </div>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Comparison of available switch sizes: default (h-5 w-9) and small (h-4 w-7).'
+            }
+        }
+    }
+};

--- a/apps/shade/src/components/ui/switch.tsx
+++ b/apps/shade/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/apps/shade/src/components/ui/switch.tsx
+++ b/apps/shade/src/components/ui/switch.tsx
@@ -1,27 +1,57 @@
-import * as React from "react"
-import * as SwitchPrimitives from "@radix-ui/react-switch"
+import * as React from 'react';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import {cva, type VariantProps} from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import {cn} from '@/lib/utils';
+
+const switchVariants = cva(
+    'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+    {
+        variants: {
+            size: {
+                default: 'h-5 w-9',
+                sm: 'h-4 w-7'
+            }
+        },
+        defaultVariants: {
+            size: 'default'
+        }
+    }
+);
+
+const switchThumbVariants = cva(
+    'pointer-events-none block rounded-full bg-background ring-0 transition-transform [filter:drop-shadow(0_1px_2px_rgba(0,0,0,0.07))] data-[state=unchecked]:translate-x-0',
+    {
+        variants: {
+            size: {
+                default: 'size-4 data-[state=checked]:translate-x-4',
+                sm: 'size-3 data-[state=checked]:translate-x-3'
+            }
+        },
+        defaultVariants: {
+            size: 'default'
+        }
+    }
+);
+
+export interface SwitchProps
+    extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
+    VariantProps<typeof switchVariants> {}
 
 const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
-      className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-      )}
-    />
-  </SwitchPrimitives.Root>
-))
-Switch.displayName = SwitchPrimitives.Root.displayName
+    React.ElementRef<typeof SwitchPrimitives.Root>,
+    SwitchProps
+>(({className, size, ...props}, ref) => (
+    <SwitchPrimitives.Root
+        className={cn(switchVariants({size, className}))}
+        {...props}
+        ref={ref}
+    >
+        <SwitchPrimitives.Thumb
+            className={cn(switchThumbVariants({size}))}
+        />
+    </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
 
-export { Switch }
+export {Switch};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -34,6 +34,7 @@ export * from './components/ui/sheet';
 export * from './components/ui/sidebar';
 export * from './components/ui/skeleton';
 export * from './components/ui/sonner';
+export * from './components/ui/switch';
 export * from './components/ui/table';
 export * from './components/ui/tabs';
 export * from './components/ui/textarea';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5238,6 +5238,19 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
+"@radix-ui/react-switch@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.2.6.tgz#ff79acb831f0d5ea9216cfcc5b939912571358e3"
+  integrity sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-tabs@1.1.12":
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz#99b3522c73db9263f429a6d0f5a9acb88df3b129"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- We didn't have an indication of the appearance mode in the current implementation. This PR adds a switch component to Shade and uses it in the new user menu for the dark mode button.