### PR TITLE
Added EmberBridge global to sync state from React shell to Ember

### DIFF
--- a/apps/admin/src/ember-bridge/EmberBridge.tsx
+++ b/apps/admin/src/ember-bridge/EmberBridge.tsx
@@ -1,0 +1,15 @@
+export interface EmberBridge {
+    state: StateBridge;
+}
+
+export interface StateBridge {
+    onUpdate: (dataType: string, response: unknown) => void;
+    onInvalidate: (dataType: string) => void;
+    onDelete: (dataType: string, id: string) => void;
+}
+
+declare global {
+    interface Window {
+        EmberBridge?: EmberBridge;
+    }
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -22,9 +22,15 @@ const framework = {
         "X-Unsplash-Cache": true,
     },
     sentryDSN: null,
-    onUpdate: () => {},
-    onInvalidate: () => {},
-    onDelete: () => {},
+    onUpdate: (dataType: string, response: unknown) => {
+        window.EmberBridge?.state.onUpdate(dataType, response);
+    },
+    onInvalidate: (dataType: string) => {
+        window.EmberBridge?.state.onInvalidate(dataType);
+    },
+    onDelete: (dataType: string, id: string) => {
+        window.EmberBridge?.state.onDelete(dataType, id);
+    },
 };
 
 createRoot(document.getElementById("root")!).render(

--- a/ghost/admin/app/instance-initializers/ember-bridge-global.js
+++ b/ghost/admin/app/instance-initializers/ember-bridge-global.js
@@ -1,0 +1,12 @@
+export function initialize(appInstance) {
+    const stateBridge = appInstance.lookup('service:state-bridge');
+
+    window.EmberBridge = {
+        state: stateBridge
+    };
+}
+
+export default {
+    name: 'ember-bridge-global',
+    initialize
+};

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -40,7 +40,7 @@ export default class StateBridgeService extends Service {
     @action
     onUpdate(dataType, response) {
         if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation updating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+            throw new Error(`A mutation updating ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
         }
 
         // Skip processing if mapping is explicitly set to null
@@ -92,7 +92,7 @@ export default class StateBridgeService extends Service {
     @action
     onInvalidate(dataType) {
         if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation invalidating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+            throw new Error(`A mutation invalidating ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
         }
 
         // Skip processing if mapping is explicitly set to null
@@ -104,7 +104,7 @@ export default class StateBridgeService extends Service {
 
         if (singleton) {
             // eslint-disable-next-line no-console
-            console.warn(`An AdminX mutation invalidated ${dataType}, but this is is marked as a singleton and cannot be reloaded in Ember. You probably wanted to use updateQueries instead of invalidateQueries`);
+            console.warn(`An React Admin mutation invalidated ${dataType}, but this is is marked as a singleton and cannot be reloaded in Ember. You probably wanted to use updateQueries instead of invalidateQueries`);
             return;
         }
 
@@ -119,7 +119,7 @@ export default class StateBridgeService extends Service {
     @action
     onDelete(dataType, id) {
         if (!(dataType in emberDataTypeMapping)) {
-            throw new Error(`A mutation deleting ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+            throw new Error(`A mutation deleting ${dataType} succeeded in React Admin but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
         }
 
         // Skip processing if mapping is explicitly set to null

--- a/ghost/admin/tests/integration/instance-initializers/ember-bridge-global-test.js
+++ b/ghost/admin/tests/integration/instance-initializers/ember-bridge-global-test.js
@@ -1,0 +1,31 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Integration: Instance initializer: ember-bridge-global', function () {
+    setupTest();
+
+    it('creates window.EmberBridge global', function () {
+        expect(window.EmberBridge).to.exist;
+    });
+
+    it('has state bridge service instance', function () {
+        expect(window.EmberBridge.state).to.equal(this.owner.lookup('service:state-bridge'));
+    });
+
+    it('allows state bridge service instance methods to be called', function () {
+        const stateBridge = this.owner.lookup('service:state-bridge');
+        Object.defineProperty(stateBridge, 'onUpdate', {value: sinon.stub()});
+        Object.defineProperty(stateBridge, 'onInvalidate', {value: sinon.stub()});
+        Object.defineProperty(stateBridge, 'onDelete', {value: sinon.stub()});
+
+        window.EmberBridge.state.onUpdate('SettingsResponseType', {settings: [{key: 'title', value: 'Test Title'}]});
+        expect(stateBridge.onUpdate).to.have.been.calledWith('SettingsResponseType', {settings: [{key: 'title', value: 'Test Title'}]});
+
+        window.EmberBridge.state.onInvalidate('SettingsResponseType');
+        expect(stateBridge.onInvalidate).to.have.been.calledWith('SettingsResponseType');
+
+        window.EmberBridge.state.onDelete('SettingsResponseType', '1');
+        expect(stateBridge.onDelete).to.have.been.calledWith('SettingsResponseType', '1');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2929/

- added Ember instance initializer that makes our `state-bridge` service instance available on `window.EmberBridge.state`
- updated the react shell's framework setup to use `window.EmberBridge.state.{onUpdate,onInvalidate,onDelete}` in the same way as apps mounted inside Ember via `AdminXComponent`
