### PR TITLE
Added Ember to React data syncing

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -2,10 +2,12 @@ import { Outlet } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { EmberProvider, EmberFallback, EmberRoot, useEmberAuthSync } from "./ember-bridge";
 import { AdminLayout } from "./layout/AdminLayout";
+import { useEmberDataSync } from "./ember-bridge";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
     useEmberAuthSync();
+    useEmberDataSync();
 
     return (
         <EmberProvider>

--- a/apps/admin/src/ember-bridge/EmberBridge.tsx
+++ b/apps/admin/src/ember-bridge/EmberBridge.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
 export interface EmberBridge {
     state: StateBridge;
 }
@@ -6,10 +9,91 @@ export interface StateBridge {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    on: (event: string, callback: (event: EmberDataChangeEvent) => void) => void;
+    off: (event: string, callback: (event: EmberDataChangeEvent) => void) => void;
 }
 
 declare global {
     interface Window {
         EmberBridge?: EmberBridge;
     }
+}
+
+export interface EmberDataChangeEvent {
+    operation: 'update' | 'create' | 'delete';
+    modelName: string;
+    id: string;
+    data: Record<string, unknown> | null;
+}
+
+/**
+ * Maps Ember Data model names to React ResponseType strings.
+ * This is the inverse of emberDataTypeMapping in state-bridge.js
+ */
+const EMBER_TO_REACT_TYPE_MAPPING: Record<string, string> = {
+    'integration': 'IntegrationsResponseType',
+    'invite': 'InvitesResponseType',
+    'offer': 'OffersResponseType',
+    'newsletter': 'NewslettersResponseType',
+    'recommendation': 'RecommendationResponseType',
+    'setting': 'SettingsResponseType',
+    'theme': 'ThemesResponseType',
+    'tier': 'TiersResponseType',
+    'user': 'UsersResponseType',
+    'post': 'PostsResponseType',
+    'member': 'MembersResponseType',
+    'tag': 'TagsResponseType',
+    'label': 'LabelsResponseType',
+    'webhook': 'WebhooksResponseType'
+};
+
+/**
+ * Hook to sync Ember Data store changes with React Query cache.
+ *
+ * This hook listens to Ember Data store events (update, create, delete) and
+ * automatically invalidates the corresponding React Query cache entries.
+ *
+ * This is a temporary bridge during the Ember -> React migration and should be
+ * called once at the app level. It will be removed once the migration is complete.
+ */
+export function useEmberDataSync() {
+    const queryClient = useQueryClient();
+
+    useEffect(() => {
+        let isSubscribed = false;
+
+        const handler = (event: EmberDataChangeEvent) => {
+            const { modelName } = event;
+            const reactDataType = EMBER_TO_REACT_TYPE_MAPPING[modelName];
+
+            if (!reactDataType) {
+                // Model not configured for syncing, ignore
+                return;
+            }
+
+            // Invalidate all queries matching this data type
+            void queryClient.invalidateQueries({
+                predicate: (query) => {
+                    // Query keys are structured as [dataType, url]
+                    return query.queryKey[0] === reactDataType;
+                }
+            });
+        };
+
+        // Poll for EmberBridge availability since it's created after React shell renders
+        const pollInterval = setInterval(() => {
+            if (window.EmberBridge?.state) {
+                clearInterval(pollInterval);
+                window.EmberBridge.state.on('emberDataChange', handler);
+                isSubscribed = true;
+            }
+        }, 100);
+
+        return () => {
+            clearInterval(pollInterval);
+            if (isSubscribed && window.EmberBridge?.state) {
+                window.EmberBridge.state.off('emberDataChange', handler);
+            }
+        };
+    }, [queryClient]);
 }

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -3,3 +3,5 @@ export { EmberProvider } from "./EmberProvider";
 export { useEmberContext } from "./EmberContext";
 export { EmberFallback } from "./EmberFallback";
 export { useEmberAuthSync } from "./EmberAuthSync";
+export { useEmberDataSync } from "./EmberBridge";
+export type { EmberDataChangeEvent } from "./EmberBridge";

--- a/ghost/admin/app/adapters/base.js
+++ b/ghost/admin/app/adapters/base.js
@@ -9,6 +9,7 @@ export default RESTAdapter.extend(AjaxServiceSupport, {
     namespace: ghostPaths().apiRoot.slice(1),
 
     session: service(),
+    stateBridge: service(),
 
     shouldBackgroundReloadRecord() {
         return false;

--- a/ghost/admin/app/adapters/embedded-relation-adapter.js
+++ b/ghost/admin/app/adapters/embedded-relation-adapter.js
@@ -130,7 +130,10 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
     }
 
     createRecord(store, type, snapshot) {
-        return this.saveRecord(store, type, snapshot, {method: 'POST'}, 'createRecord');
+        return this.saveRecord(store, type, snapshot, {method: 'POST'}, 'createRecord').then((response) => {
+            this.stateBridge.triggerEmberDataChange('create', type.modelName, snapshot.id, response);
+            return response;
+        });
     }
 
     updateRecord(store, type, snapshot) {
@@ -139,7 +142,10 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
             id: get(snapshot, 'id')
         };
 
-        return this.saveRecord(store, type, snapshot, options, 'updateRecord');
+        return this.saveRecord(store, type, snapshot, options, 'updateRecord').then((response) => {
+            this.stateBridge.triggerEmberDataChange('update', type.modelName, snapshot.id, response);
+            return response;
+        });
     }
 
     saveRecord(store, type, snapshot, options, requestType) {
@@ -148,6 +154,13 @@ export default class EmbeddedRelationAdapter extends BaseAdapter {
         let payload = this.preparePayload(store, type, snapshot);
 
         return this.ajax(url, _options.method, payload);
+    }
+
+    deleteRecord(store, type, snapshot) {
+        return super.deleteRecord(...arguments).then((response) => {
+            this.stateBridge.triggerEmberDataChange('delete', type.modelName, snapshot.id, null);
+            return response;
+        });
     }
 
     preparePayload(store, type, snapshot) {

--- a/ghost/admin/tests/unit/services/state-bridge-test.js
+++ b/ghost/admin/tests/unit/services/state-bridge-test.js
@@ -324,4 +324,112 @@ describe('Unit: Service: state-bridge', function () {
             // Should not throw error
         });
     });
+
+    describe('#triggerEmberDataChange', function () {
+        it('triggers emberDataChange event with correct parameters', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler);
+
+            const mockResponse = {
+                posts: [{id: '123', title: 'Test Post'}]
+            };
+
+            stateBridge.triggerEmberDataChange('create', 'post', '123', mockResponse);
+
+            expect(handler.calledOnce).to.be.true;
+            expect(handler.firstCall.args[0]).to.deep.equal({
+                operation: 'create',
+                modelName: 'post',
+                id: '123',
+                data: mockResponse
+            });
+        });
+
+        it('triggers event for update operation', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler);
+
+            const mockResponse = {
+                users: [{id: '456', name: 'John Doe'}]
+            };
+
+            stateBridge.triggerEmberDataChange('update', 'user', '456', mockResponse);
+
+            expect(handler.calledOnce).to.be.true;
+            expect(handler.firstCall.args[0]).to.deep.equal({
+                operation: 'update',
+                modelName: 'user',
+                id: '456',
+                data: mockResponse
+            });
+        });
+
+        it('triggers event for delete operation with null data', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler);
+
+            stateBridge.triggerEmberDataChange('delete', 'tag', '789', null);
+
+            expect(handler.calledOnce).to.be.true;
+            expect(handler.firstCall.args[0]).to.deep.equal({
+                operation: 'delete',
+                modelName: 'tag',
+                id: '789',
+                data: null
+            });
+        });
+
+        it('allows multiple handlers to be registered', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler1 = sinon.spy();
+            const handler2 = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler1);
+            stateBridge.on('emberDataChange', handler2);
+
+            const mockResponse = {
+                newsletters: [{id: '111', name: 'Weekly Update'}]
+            };
+
+            stateBridge.triggerEmberDataChange('create', 'newsletter', '111', mockResponse);
+
+            expect(handler1.calledOnce).to.be.true;
+            expect(handler2.calledOnce).to.be.true;
+            expect(handler1.firstCall.args[0]).to.deep.equal(handler2.firstCall.args[0]);
+        });
+
+        it('handlers can be removed with off', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler);
+            stateBridge.off('emberDataChange', handler);
+
+            stateBridge.triggerEmberDataChange('update', 'setting', '999', {});
+
+            expect(handler.called).to.be.false;
+        });
+
+        it('handles multiple triggers correctly', function () {
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const handler = sinon.spy();
+
+            stateBridge.on('emberDataChange', handler);
+
+            stateBridge.triggerEmberDataChange('create', 'post', '1', {});
+            stateBridge.triggerEmberDataChange('update', 'post', '1', {});
+            stateBridge.triggerEmberDataChange('delete', 'post', '1', null);
+
+            expect(handler.calledThrice).to.be.true;
+            expect(handler.firstCall.args[0].operation).to.equal('create');
+            expect(handler.secondCall.args[0].operation).to.equal('update');
+            expect(handler.thirdCall.args[0].operation).to.equal('delete');
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2929/

- updated Ember's `state-bridge` service
  - extended from `Evented` to add `.{on,off,trigger}` methods to manage event subscription and triggering
  - added `triggerEmberDataChange` method that fires a `'emberDataChange'` event, containing the operation type, model, id, and response data that will allow React to invalidate or update its query cache
- updated `EmbeddedRelationAdapter` to call `stateBridge.triggerEmberDataChange` on any create/update/delete calls made on the Ember Data store
  - our `ApplicationAdapter` extends from `EmbeddedRelationAdapter` so this catches all store activity
- added `useEmberDataSync` hook on the React side
  - polls for `window.EmberBridge` to exist because it will only be available once Ember boots and that's now hosted inside of the React shell
  - once `window.EmberBridge` is available, subscribes to `'emberDataChange'` events
  - when an event occurs, looks up our React Query data type key based on the Ember Data model name and invalidates all queries using that key
  - only does query invalidation for now rather than optimistic query cache updates to keep things simpler, we can add optimistic updates if/when we find a use-case for it
