### PR TITLE
Wired up search button in React sidebar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/NavHeader.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavHeader.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-
 import {
     Button,
     Kbd,
@@ -7,6 +6,21 @@ import {
     SidebarHeader
 } from "@tryghost/shade"
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
+
+const ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
+const searchShortcut = ctrlOrCmd === 'command' ? '⌘K' : 'Ctrl+K';
+
+// Search is currently handled by the Ember app, firing a keyboard event avoids needing to sync state
+const openSearchModal = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    const searchShortcutEvent = new KeyboardEvent('keydown', {
+        key: 'k',
+        keyCode: 75, // Ember uses keymaster.js which still uses keyCode
+        metaKey: ctrlOrCmd === 'command',
+        ctrlKey: ctrlOrCmd === 'ctrl'
+    });
+    document.dispatchEvent(searchShortcutEvent);
+}
 
 function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
     const site = useBrowseSite();
@@ -33,12 +47,13 @@ function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
                 <Button
                     variant="outline"
                     className="flex items-center justify-between text-gray-500 hover:text-gray-700 hover:bg-background text-base [&_svg]:stroke-2 pr-2 shadow-xs hover:shadow-sm hover:border-gray-200 h-[38px]"
+                    onClick={openSearchModal}
                 >
                     <div className="flex items-center gap-2">
                         <LucideIcon.Search className="text-muted-foreground" />
                         Search site
                     </div>
-                    <Kbd className="text-gray-500 bg-transparent">⌘K</Kbd>
+                    <Kbd className="text-gray-500 bg-transparent">{searchShortcut}</Kbd>
                 </Button>
             </div>
         </SidebarHeader>


### PR DESCRIPTION
no issue

- we're not planning on migrating search to React yet but we still want the search button in the sidebar to function
- firing the keyboard event that the Ember app listens to is the simplest way to have Ember enter the right state without needing any additional state syncing behaviour
