### PR TITLE
Add feature flag to enable admin forward opt-in

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -43,6 +43,10 @@ const features: Feature[] = [{
     title: 'Welcome Emails',
     description: 'Enables features related to sending welcome emails to new members',
     flag: 'welcomeEmails'
+}, {
+    title: 'New Admin Experience',
+    description: 'Try the new React-based admin interface. Only available on ghost.io',
+    flag: 'adminForward'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -38,6 +38,27 @@ export function feature(name, options = {}) {
     }));
 }
 
+// Cookie utilities for admin forward functionality
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+        return parts.pop().split(';').shift();
+    }
+    return null;
+}
+
+function setCookie(name, value, days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    const expires = `expires=${date.toUTCString()}`;
+    document.cookie = `${name}=${value};${expires};path=/ghost/`;
+}
+
+function deleteCookie(name) {
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/ghost/`;
+}
+
 @classic
 export default class FeatureService extends Service {
     @service lazyLoader;
@@ -59,6 +80,7 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
+    @feature('adminForward') adminForward;
     @feature('audienceFeedback') audienceFeedback;
     @feature('webmentions') webmentions;
     @feature('stripeAutomaticTax') stripeAutomaticTax;
@@ -97,9 +119,41 @@ export default class FeatureService extends Service {
         }
     }
 
+    get inAdminForward() {
+        // Detect if Ember is running inside the React admin shell
+        // In React shell: Ember renders to #ember-app
+        // Standalone: Ember renders to body (no #ember-app element)
+        return document.querySelector('#ember-app') !== null;
+    }
+
+    _reconcileAdminForwardState() {
+        // Only proceed if we're on a *.ghost.io or *.ghost.is domain
+        const hostname = window.location.hostname;
+        if (!hostname.endsWith('.ghost.io') && !hostname.endsWith('.ghost.is')) {
+            return;
+        }
+
+        const cookieName = 'ghost-admin-forward';
+        const hasAdminForwardCookie = !!getCookie(cookieName);
+
+        // Update cookie based on feature flag
+        if (hasAdminForwardCookie && !this.adminForward) {
+            deleteCookie(cookieName);
+        } else if (!hasAdminForwardCookie && this.adminForward) {
+            setCookie(cookieName, '1', 365);
+        }
+
+        // Reload if flag state doesn't match current wrapper
+        // (flag enabled but in Ember standalone, or flag disabled but in React shell)
+        if (this.adminForward !== this.inAdminForward) {
+            window.location.reload();
+        }
+    }
+
     fetch() {
         return this.settings.fetch().then(() => {
             this.set('_user', this.session.user);
+            this._reconcileAdminForwardState();
             return this._setAdminTheme().then(() => true);
         });
     }

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -67,7 +67,11 @@ export default class StateBridgeService extends Service {
             // Blog title is based on settings, but the one stored in config is used instead in various places
             this.config.blogTitle = response.settings.find(setting => setting.key === 'title').value;
 
-            this.settings.reload();
+            // TODO: Reloading settings does not trigger a re-fetch of the
+            // feature flags. We should maybe find a better way to do this.
+            this.settings.reload().then(() => {
+                this.feature.fetch();
+            });
         }
 
         if (dataType === 'TiersResponseType') {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -50,7 +50,8 @@ const PRIVATE_FEATURES = [
     'tagsX',
     'utmTracking',
     'emailUniqueid',
-    'welcomeEmails'
+    'welcomeEmails',
+    'adminForward'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -10,6 +10,7 @@ Object {
     "environment": StringMatching /\\^testing/,
     "labs": Object {
       "additionalPaymentMethods": true,
+      "adminForward": true,
       "announcementBar": true,
       "audienceFeedback": true,
       "contentVisibility": true,


### PR DESCRIPTION
Allows users on ghost.io to opt into the new React-based admin interface via a private feature flag. The flag manages a cookie that controls which admin shell (Ember vs React) is served and reloading of the page when the flag is updated.

Also updates the state bridge to re-fetch features after settings reload. This ensures adminForward reconciliation runs when settings are updated from React. Previously, the feature service wasn't re-evaluating when settings changed via the state bridge, so the cookie/reload logic wouldn't trigger on toggle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `adminForward` private flag to opt into the React admin on ghost.io, managing a cookie and re-fetching features after settings reload to keep state in sync.
> 
> - **Private Labs/UI**
>   - Add "New Admin Experience" toggle in `apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx` (`adminForward`).
> - **Ember Admin**
>   - `ghost/admin/app/services/feature.js`:
>     - Add `adminForward` flag.
>     - Add cookie utilities and `inAdminForward` detection.
>     - Implement `_reconcileAdminForwardState` to set/remove `ghost-admin-forward` cookie and reload when flag/shell mismatch; invoke during `fetch()`.
>   - `ghost/admin/app/services/state-bridge.js`:
>     - After settings reload, call `feature.fetch()` to refresh flags.
> - **Core**
>   - Add `adminForward` to `PRIVATE_FEATURES` in `ghost/core/core/shared/labs.js`.
>   - Update config API snapshot to include `labs.adminForward`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee05ba1fb7c7af7315a8e1fb6a62c49002f1c1dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->