### PR TITLE
Updated header spaces and font-size in React app

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -6,17 +6,17 @@ body:not(.ember-application) .gh-canvas-header {
     padding-bottom: 24px;
 }
 
-body:not(.ember-application) .gh-canvas-title,
-body:not(.ember-application) [data-header="header-title"] {
-    font-size: 25px;
-}
-
 body:not(.ember-application) .gh-canvas-breadcrumb+.gh-canvas-title {
     padding-top: 0px;
     margin-top: -4px;
 }
 
-body:not(.ember-application) [data-header="header-container"] {
+body:not(.ember-application) .gh-canvas-title,
+body:not(.ember-application) [data-header="header-title"] {
+    font-size: 25px;
+}
+
+body:not(.ember-application) [data-header="header"] {
     padding-top: 24px;
 }
 

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,1 +1,26 @@
 @import "@tryghost/shade/styles.css";
+
+/* Temporary overrides until Ember transition is finished */
+body:not(.ember-application) .gh-canvas-header {
+    padding-top: 24px;
+    padding-bottom: 24px;
+}
+
+body:not(.ember-application) .gh-canvas-title,
+body:not(.ember-application) [data-header="header-title"] {
+    font-size: 25px;
+}
+
+body:not(.ember-application) .gh-canvas-breadcrumb+.gh-canvas-title {
+    padding-top: 0px;
+    margin-top: -4px;
+}
+
+body:not(.ember-application) [data-header="header-container"] {
+    padding-top: 24px;
+}
+
+body:not(.ember-application) [data-navbar="navbar"] {
+    padding-top: 24px;
+    padding-bottom: 24px;
+}

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -80,7 +80,10 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     return (
         <>
             <header className='z-50 -mx-8 bg-white/70 backdrop-blur-md dark:bg-black'>
-                <div className='relative flex min-h-[102px] w-full items-start justify-between gap-5 px-8 pb-0 pt-8'>
+                <div
+                    className='relative flex min-h-[102px] w-full items-start justify-between gap-5 px-8 pb-0 pt-8'
+                    data-header='header'
+                >
                     <div className='flex w-full flex-col gap-5'>
                         <div className='flex w-full flex-col justify-between md:flex-row md:items-center'>
                             <Breadcrumb>

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -30,18 +30,18 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
         statsConfig,
         enabled: appSettings?.analytics?.webAnalytics ?? false
     });
-    
+
     // Determine which tabs to show based on post type and settings
     const availableTabs = useMemo(() => {
         if (!post) {
             return [];
         }
         const tabs = [];
-        
+
         // Only show Overview and Web tabs if it's NOT a published-only post with web analytics disabled
         const isPublishedOnlyWithoutWebAnalytics = isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics;
         if (!isPublishedOnlyWithoutWebAnalytics) {
-            tabs.push('Overview');   
+            tabs.push('Overview');
             if (!post.email_only && appSettings?.analytics.webAnalytics) {
                 tabs.push('Web');
             }
@@ -50,7 +50,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
             tabs.push('Newsletter');
         }
         tabs.push('Growth');
-        
+
         return tabs;
     }, [post, appSettings?.analytics.webAnalytics]);
 
@@ -179,7 +179,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 }}></div>
                             }
                             <div>
-                                <H1 className='-ml-px max-w-[920px] indent-0 text-xl md:min-h-[35px] md:text-3xl md:leading-[1.2em]'>
+                                <H1 className='-ml-px max-w-[920px] indent-0 text-xl md:min-h-[35px] md:text-3xl md:leading-[1.2em]' data-header='header-title'>
                                     {post?.title}
                                 </H1>
                                 {post?.published_at && (

--- a/apps/shade/src/components/layout/header.tsx
+++ b/apps/shade/src/components/layout/header.tsx
@@ -22,7 +22,7 @@ function HeaderTitle({className, children}: HeaderTitleProps) {
     return (
         <H1
             className={cn(
-                'text-2xl leading-[1.2em] lg:text-3xl [grid-area:title]',
+                'text-2xl leading-[1.2em] lg:text-[25px] [grid-area:title]',
                 className
             )}
         >
@@ -67,7 +67,7 @@ function HeaderNav({className, children}: HeaderNavProps) {
     );
 }
 
-const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md [grid-template-areas:'above''title''meta''actions''nav'] sm:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav'] lg:-mb-8 lg:p-8 dark:bg-black`, {
+const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md [grid-template-areas:'above''title''meta''actions''nav'] sm:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav'] lg:-mb-8 lg:px-8 lg:py-6 dark:bg-black`, {
     variants: {
         variant: {
             default: `lg:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav']`,
@@ -81,7 +81,7 @@ const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-
 interface HeaderProps extends PropsWithChildrenAndClassName, VariantProps<typeof headerVariants> {}
 function Header({className, children, variant}: HeaderProps) {
     return (
-        <header className={cn(headerVariants({variant, className}))}>
+        <header className={cn(headerVariants({variant, className}))} data-header="header-container">
             {children}
         </header>
     );

--- a/apps/shade/src/components/layout/header.tsx
+++ b/apps/shade/src/components/layout/header.tsx
@@ -11,7 +11,10 @@ type PropsWithChildrenAndClassName = React.PropsWithChildren & {
 interface HeaderAboveProps extends PropsWithChildrenAndClassName {}
 function HeaderAbove({className, children}: HeaderAboveProps) {
     return (
-        <div className={cn('flex items-center gap-2 [grid-area:above]', className)}>
+        <div
+            className={cn('flex items-center gap-2 [grid-area:above]', className)}
+            data-header='header-above'
+        >
             {children}
         </div>
     );
@@ -22,9 +25,10 @@ function HeaderTitle({className, children}: HeaderTitleProps) {
     return (
         <H1
             className={cn(
-                'text-2xl leading-[1.2em] lg:text-[25px] [grid-area:title]',
+                'text-2xl leading-[1.2em] lg:text-3xl [grid-area:title]',
                 className
             )}
+            data-header='header-title'
         >
             {children}
         </H1>
@@ -34,7 +38,10 @@ function HeaderTitle({className, children}: HeaderTitleProps) {
 interface HeaderMetaProps extends PropsWithChildrenAndClassName {}
 function HeaderMeta({className, children}: HeaderMetaProps) {
     return (
-        <div className={cn('flex items-center justify-start text-muted-foreground [grid-area:meta] pb-4 pt-1', className)}>
+        <div
+            className={cn('flex items-center justify-start text-muted-foreground [grid-area:meta] pb-4 pt-1', className)}
+            data-header='header-meta'
+        >
             {children}
         </div>
     );
@@ -43,7 +50,10 @@ function HeaderMeta({className, children}: HeaderMetaProps) {
 interface HeaderActionGroupProps extends PropsWithChildrenAndClassName {}
 function HeaderActionGroup({className, children}: HeaderActionGroupProps) {
     return (
-        <div className={cn('flex items-center gap-2', className)}>
+        <div
+            className={cn('flex items-center gap-2', className)}
+            data-header='header-action-group'
+        >
             {children}
         </div>
     );
@@ -52,7 +62,10 @@ function HeaderActionGroup({className, children}: HeaderActionGroupProps) {
 interface HeaderActionsProps extends PropsWithChildrenAndClassName {}
 function HeaderActions({className, children}: HeaderActionsProps) {
     return (
-        <div className={cn('flex items-center gap-4 [grid-area:actions] sm:justify-self-end self-start', className)}>
+        <div
+            className={cn('flex items-center gap-4 [grid-area:actions] sm:justify-self-end self-start', className)}
+            data-header='header-actions'
+        >
             {children}
         </div>
     );
@@ -61,13 +74,16 @@ function HeaderActions({className, children}: HeaderActionsProps) {
 interface HeaderNavProps extends PropsWithChildrenAndClassName {}
 function HeaderNav({className, children}: HeaderNavProps) {
     return (
-        <div className={cn('flex items-center gap-2 [grid-area:nav] self-start mt-2 lg:mt-0.5', className)}>
+        <div
+            className={cn('flex items-center gap-2 [grid-area:nav] self-start mt-2 lg:mt-0.5', className)}
+            data-header='header-nav'
+        >
             {children}
         </div>
     );
 }
 
-const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md [grid-template-areas:'above''title''meta''actions''nav'] sm:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav'] lg:-mb-8 lg:px-8 lg:py-6 dark:bg-black`, {
+const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-b from-background via-background/70 to-background/70 p-4 backdrop-blur-md [grid-template-areas:'above''title''meta''actions''nav'] sm:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav'] lg:-mb-8 lg:p-8 dark:bg-black`, {
     variants: {
         variant: {
             default: `lg:[grid-template-areas:'above_above''title_actions''meta_actions''nav_nav']`,
@@ -81,7 +97,10 @@ const headerVariants = cva(`sticky top-0 z-50 -mb-4 grid gap-x-4 bg-gradient-to-
 interface HeaderProps extends PropsWithChildrenAndClassName, VariantProps<typeof headerVariants> {}
 function Header({className, children, variant}: HeaderProps) {
     return (
-        <header className={cn(headerVariants({variant, className}))} data-header="header-container">
+        <header
+            className={cn(headerVariants({variant, className}))}
+            data-header='header'
+        >
             {children}
         </header>
     );

--- a/apps/shade/src/components/ui/navbar.tsx
+++ b/apps/shade/src/components/ui/navbar.tsx
@@ -11,6 +11,7 @@ const NavbarActions = React.forwardRef<HTMLDivElement, NavbarActionsProps>(({chi
         <div
             ref={ref}
             className={cn('flex items-center gap-2', className)}
+            data-navbar='navbar-actions'
             {...props}
         >
             {children}
@@ -30,6 +31,7 @@ const Navbar = React.forwardRef<HTMLDivElement, NavbarProps>(({children, classNa
         <div
             ref={ref}
             className={cn('flex items-center border-b justify-between gap-x-5 gap-y-2', className)}
+            data-navbar='navbar'
             {...props}
         >
             {children}

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -23,8 +23,8 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
     return (
         <>
             <header className='z-40 -mx-8 bg-white/70 backdrop-blur-md dark:bg-black'>
-                <div className='relative flex w-full items-center justify-between gap-5 px-8 pb-0 pt-8'>
-                    <H1 className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]'>
+                <div className='relative flex w-full items-center justify-between gap-5 px-8 pb-0 pt-8' data-header='header-container'>
+                    <H1 className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]' data-header='header-title'>
                         Analytics
                     </H1>
                     {appSettings?.analytics.webAnalytics && (

--- a/apps/stats/src/views/Stats/layout/StatsHeader.tsx
+++ b/apps/stats/src/views/Stats/layout/StatsHeader.tsx
@@ -23,8 +23,14 @@ const StatsHeader:React.FC<StatsHeaderProps> = ({
     return (
         <>
             <header className='z-40 -mx-8 bg-white/70 backdrop-blur-md dark:bg-black'>
-                <div className='relative flex w-full items-center justify-between gap-5 px-8 pb-0 pt-8' data-header='header-container'>
-                    <H1 className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]' data-header='header-title'>
+                <div
+                    className='relative flex w-full items-center justify-between gap-5 px-8 pb-0 pt-8'
+                    data-header='header'
+                >
+                    <H1
+                        className='-ml-px min-h-[35px] max-w-[920px] indent-0 leading-[1.2em]'
+                        data-header='header-title'
+                    >
                         Analytics
                     </H1>
                     {appSettings?.analytics.webAnalytics && (


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- The updated React sidebar spacing is different than the Ember one which means page headers got a bit misaligned.
- The React sidebar is a little bit smaller which goes better with a page header smaller font size

In this transitional period I'm targeting specific components via data attributes. This provides stable, semantic hooks for cross-app styling without compromising the TailwindCSS-first component architecture (vs. e.g. using custom classnames like `gh-header-title` outside the Ember app).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds data-header/data-navbar hooks and temporary CSS overrides to align header/navbar spacing and title size across React and Ember, updating Post and Stats analytics headers.
> 
> - **UI/Header & Navbar**:
>   - Add `data-header="header"` and `data-header="header-title"` to `PostAnalyticsHeader` and `StatsHeader` containers/titles.
>   - Add `data-header` attributes to `Header` subcomponents (`Above`, `Title`, `Meta`, `ActionGroup`, `Actions`, `Nav`).
>   - Add `data-navbar="navbar"` and `data-navbar="navbar-actions"` to `Navbar` components.
> - **Styles (admin index.css)**:
>   - Temporary cross-app overrides for non-Ember pages to adjust header/navbar padding and title font-size via `[data-header]`/`[data-navbar]` selectors.
>   - Tweak legacy `.gh-canvas-*` spacing to match updated layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b199a6ff2c266091971cc578abed3c42cf8e441e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->