### PR TITLE
Fix blank screen when viewing tag details

### DIFF
--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -7,6 +7,14 @@ import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
+    {
+        // Override the blank tag detail route in the post app to ensure we
+        // display the Ember screen. Without this the posts app renders a blank
+        // screen. This is needed when running the posts app within Ember as it
+        // prevents the error fallback route screen from showing.
+        path: "/tags/:tagSlug",
+        Component: EmberFallback
+    },
     ...postRoutes[0].children!.filter(route => route.path !== "*"),
     {
         element: <GlobalDataProvider><Outlet /></GlobalDataProvider>,


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-2963/fixed-blank-screen-when-viewing-tag-details

Override blank tag detail route to display Ember screen instead of empty fallback, allowing us to correctly fall back to Ember in the React admin shell without also displaying the error screen when running React within Ember.
