### PR TITLE
Add support for uppercase `GHOST_` environment variables

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -490,6 +490,13 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
 
         // At this point logging is required, so we can handle errors better
 
+        // Surface config loader warnings now that logging is available
+        if (config.unmatchedGhostEnvVars && config.unmatchedGhostEnvVars.length > 0) {
+            config.unmatchedGhostEnvVars.forEach(({envVar, configKey}) => {
+                logging.warn(`Environment variable ${envVar} does not match any known config key and was applied as "${configKey}". Custom config keys with camelCase parts must be set with exact casing, e.g. GHOST_storage__s3__accessKeyId or storage__s3__accessKeyId.`);
+            });
+        }
+
         // Add a process handler to capture and log unhandled rejections
         debug('Begin: Add unhandled rejection handler');
         process.on('unhandledRejection', (error) => {

--- a/ghost/core/core/shared/config/env-keys.js
+++ b/ghost/core/core/shared/config/env-keys.js
@@ -1,0 +1,118 @@
+const PREFIX = 'GHOST_';
+
+// Documented config keys that have no entry in defaults.json
+const SUPPLEMENTARY_KEYS = [
+    'database__client',
+    'database__connection__host',
+    'database__connection__port',
+    'database__connection__user',
+    'database__connection__password',
+    'database__connection__database',
+    'database__connection__filename',
+    'mail__transport',
+    'mail__from',
+    'mail__options__service',
+    'mail__options__host',
+    'mail__options__port',
+    'mail__options__secure',
+    'mail__options__auth__user',
+    'mail__options__auth__pass'
+];
+
+// Environment variables Ghost reads directly from process.env - these are not config keys
+const INTERNAL_ENV_VARS = new Set([
+    'GHOST_DEV_IS_DOCKER',
+    'GHOST_CI_SHUTDOWN_AFTER_BOOT',
+    'GHOST_BUILD_VERSION',
+    'GHOST_NODE_VERSION_CHECK'
+]);
+
+/**
+ * Builds an index from uppercased nested key paths to their canonical casing,
+ * e.g. 'PATHS__CONTENTPATH' -> 'paths__contentPath'
+ *
+ * @param {object} defaults - parsed defaults.json
+ * @returns {Object.<string, string>}
+ */
+function buildCanonicalKeyIndex(defaults) {
+    const index = {};
+
+    const walk = (obj, prefix) => {
+        Object.entries(obj).forEach(([key, value]) => {
+            const keyPath = prefix ? `${prefix}__${key}` : key;
+            index[keyPath.toUpperCase()] = keyPath;
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                walk(value, keyPath);
+            }
+        });
+    };
+
+    walk(defaults, '');
+
+    SUPPLEMENTARY_KEYS.forEach((key) => {
+        index[key.toUpperCase()] = key;
+    });
+
+    return index;
+}
+
+/**
+ * Creates an nconf env transform that maps GHOST_-prefixed environment variables
+ * to config keys. Uppercase variables are mapped back to their canonical casing via
+ * the key index, mixed-case variables are used as given (minus the prefix), and
+ * remaining all-uppercase variables are lowercased and recorded in `unmatchedKeys`.
+ *
+ * When both a GHOST_-prefixed variable and its plain equivalent are set, the
+ * prefixed variable wins.
+ *
+ * @param {object} defaults - parsed defaults.json
+ * @returns {{transform: function({key: string, value: string}): ({key: string, value: string}|undefined), unmatchedKeys: Map<string, string>}}
+ */
+function createEnvTransform(defaults) {
+    const index = buildCanonicalKeyIndex(defaults);
+    const unmatchedKeys = new Map();
+
+    const mapPrefixedKey = (key) => {
+        const remainder = key.slice(PREFIX.length);
+        const canonical = index[remainder.toUpperCase()];
+
+        if (canonical) {
+            return canonical;
+        }
+
+        if (/[a-z]/.test(remainder)) {
+            return remainder;
+        }
+
+        unmatchedKeys.set(key, remainder.toLowerCase());
+        return remainder.toLowerCase();
+    };
+
+    const prefixedTargets = new Set(
+        Object.keys(process.env)
+            .filter(key => key.startsWith(PREFIX) && !INTERNAL_ENV_VARS.has(key))
+            .map(mapPrefixedKey)
+    );
+
+    const transform = (obj) => {
+        if (INTERNAL_ENV_VARS.has(obj.key)) {
+            return obj;
+        }
+
+        if (obj.key.startsWith(PREFIX)) {
+            return {key: mapPrefixedKey(obj.key), value: obj.value};
+        }
+
+        if (prefixedTargets.has(obj.key)) {
+            return undefined;
+        }
+
+        return obj;
+    };
+
+    return {transform, unmatchedKeys};
+}
+
+module.exports = {
+    createEnvTransform
+};

--- a/ghost/core/core/shared/config/loader.js
+++ b/ghost/core/core/shared/config/loader.js
@@ -26,6 +26,18 @@ function loadNconf(options) {
 
     // command line arguments take precedence, then environment variables
     nconf.argv();
+    nconf.env({
+        // handle uppercase GHOST_ environment variables, like GHOST_MAIL_OPTIONS_HOST
+        separator: '_',
+        transform(obj) {
+            const prefix = /^GHOST_/;
+            if (!prefix.test(obj.key)) return false;
+            
+            // strip prefix and convert to lower case
+            obj.key = obj.key.replace(prefix, '').toLowerCase();
+            return obj;
+        }
+    });
     nconf.env({separator: '__', parseValues: true});
 
     // Now load various config json files

--- a/ghost/core/core/shared/config/loader.js
+++ b/ghost/core/core/shared/config/loader.js
@@ -29,9 +29,12 @@ function loadNconf(options) {
     nconf.env({
         // handle uppercase GHOST_ environment variables, like GHOST_MAIL_OPTIONS_HOST
         separator: '_',
+        parseValues: true,
         transform(obj) {
             const prefix = /^GHOST_/;
-            if (!prefix.test(obj.key)) return false;
+            if (!prefix.test(obj.key)) {
+                return false;
+            }
             
             // strip prefix and convert to lower case
             obj.key = obj.key.replace(prefix, '').toLowerCase();

--- a/ghost/core/core/shared/config/loader.js
+++ b/ghost/core/core/shared/config/loader.js
@@ -1,9 +1,11 @@
 const Nconf = require('nconf');
+const fs = require('fs');
 const path = require('path');
 const _debug = require('@tryghost/debug')._base;
 const debug = _debug('ghost:config');
 const localUtils = require('./utils');
 const helpers = require('./helpers');
+const envKeys = require('./env-keys');
 const urlHelpers = require('@tryghost/config-url-helpers');
 
 /**
@@ -26,22 +28,17 @@ function loadNconf(options) {
 
     // command line arguments take precedence, then environment variables
     nconf.argv();
-    nconf.env({
-        // handle uppercase GHOST_ environment variables, like GHOST_MAIL_OPTIONS_HOST
-        separator: '_',
-        parseValues: true,
-        transform(obj) {
-            const prefix = /^GHOST_/;
-            if (!prefix.test(obj.key)) {
-                return false;
-            }
-            
-            // strip prefix and convert to lower case
-            obj.key = obj.key.replace(prefix, '').toLowerCase();
-            return obj;
-        }
-    });
-    nconf.env({separator: '__', parseValues: true});
+
+    // GHOST_-prefixed environment variables are mapped to config keys via the
+    // canonical key index built from defaults.json
+    let defaults = {};
+    try {
+        defaults = JSON.parse(fs.readFileSync(path.join(baseConfigPath, 'defaults.json'), 'utf8'));
+    } catch (err) {
+        debug('could not read defaults.json for the env key index', err);
+    }
+    const envTransform = envKeys.createEnvTransform(defaults);
+    nconf.env({separator: '__', parseValues: true, transform: envTransform.transform});
 
     // Now load various config json files
     nconf.file('custom-env', path.join(customConfigPath, 'config.' + env + '.json'));
@@ -84,6 +81,10 @@ function loadNconf(options) {
 
     // Manually set values
     nconf.set('env', env);
+
+    // GHOST_-prefixed all-uppercase variables that didn't match any known config key,
+    // exposed so the boot logger can warn about them once logging is available
+    nconf.unmatchedGhostEnvVars = Array.from(envTransform.unmatchedKeys, ([envVar, configKey]) => ({envVar, configKey}));
 
     // Wrap this in a check, because else nconf.get() is executed unnecessarily
     // To output this, use DEBUG=ghost:*,ghost-config

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -103,6 +103,114 @@ describe('Config Loader', function () {
         });
     });
 
+    describe('GHOST_ prefixed environment variables', function () {
+        let originalEnv;
+        let originalArgv;
+        let customConfig;
+        let loader;
+
+        function loadConfig() {
+            return loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            });
+        }
+
+        beforeEach(function () {
+            originalEnv = _.clone(process.env);
+            originalArgv = _.clone(process.argv);
+            loader = rewire('../../../../core/shared/config/loader');
+            sinon.stub(localUtils, 'getNodeEnv').returns('testing');
+            process.env.paths__contentPath = 'content/';
+            delete process.env.logging__level;
+        });
+
+        afterEach(function () {
+            process.env = originalEnv;
+            process.argv = originalArgv;
+            sinon.restore();
+        });
+
+        it('maps uppercase variables to canonical camelCase config keys', function () {
+            process.env.GHOST_SPAM__USER_LOGIN__MINWAIT = '123';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('spam:user_login:minWait'), 123);
+        });
+
+        it('recovers canonical casing regardless of the given casing', function () {
+            process.env.GHOST_spam__user_login__minwait = '456';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('spam:user_login:minWait'), 456);
+        });
+
+        it('maps uppercase variables for documented keys without defaults', function () {
+            process.env.GHOST_MAIL__OPTIONS__AUTH__USER = 'mailuser';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('mail:options:auth:user'), 'mailuser');
+        });
+
+        it('lowercases unknown all-uppercase variables', function () {
+            process.env.GHOST_CUSTOMSECTION__VALUE = 'custom';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('customsection:value'), 'custom');
+        });
+
+        it('passes exact-case variables through without the prefix', function () {
+            process.env.GHOST_storage__s3__accessKeyId = 'abc123';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('storage:s3:accessKeyId'), 'abc123');
+            assert.equal(customConfig.unmatchedGhostEnvVars.find(entry => entry.envVar === 'GHOST_storage__s3__accessKeyId'), undefined);
+        });
+
+        it('leaves non-prefixed variables untouched', function () {
+            process.env.storage__s3__secretAccessKey = 'shh';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('storage:s3:secretAccessKey'), 'shh');
+        });
+
+        it('prefers the GHOST_ prefixed form when both forms are set', function () {
+            process.env.spam__user_login__minWait = '1';
+            process.env.GHOST_SPAM__USER_LOGIN__MINWAIT = '2';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('spam:user_login:minWait'), 2);
+        });
+
+        it('collects unmatched all-uppercase variables for warning', function () {
+            process.env.GHOST_STORAGE__S3__ACCESSKEYID = 'abc';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('storage:s3:accesskeyid'), 'abc');
+            assert.deepEqual(customConfig.unmatchedGhostEnvVars.find(entry => entry.envVar === 'GHOST_STORAGE__S3__ACCESSKEYID'), {
+                envVar: 'GHOST_STORAGE__S3__ACCESSKEYID',
+                configKey: 'storage__s3__accesskeyid'
+            });
+        });
+
+        it('does not transform internal GHOST_ environment variables', function () {
+            process.env.GHOST_DEV_IS_DOCKER = 'false';
+
+            customConfig = loadConfig();
+
+            assert.equal(customConfig.get('dev_is_docker'), undefined);
+            assert.equal(customConfig.unmatchedGhostEnvVars.find(entry => entry.envVar === 'GHOST_DEV_IS_DOCKER'), undefined);
+        });
+    });
+
     describe('Index', function () {
         it('should have exactly the right keys', function () {
             const pathConfig = configUtils.config.get('paths');


### PR DESCRIPTION
**Motivation:** Ensure best practices for environment variables by using uppercase naming and the `GHOST_` prefix (to avoid collisions with generic variables like `url`), such as `GHOST_MAIL_OPTIONS_HOST`.

**What:** Add `nconf` configuration to load environmental variables prefixed with `GHOST_`. The prefix is stripped and the variable is converted to lower case. These environment variables take higher precedence than the previous lowercase ones like `mail__options__host`.

**Why:** This change was requested by the community (#21021) and aligns with recommended environment variable practices.

# Testing

I haven't added an automated test. Two possible approaches:

1. Modify some environment variables in the current E2E testing: https://github.com/TryGhost/Ghost/blob/d3ee99c2a3c5d8b7450c65a615fde0d0fc0df7ba/e2e/compose.yml#L27-L31
2. Create a dedicated automated test. I don't think there is much benefit of going this route just to test env vars configuration.

Please tell me which approach (or alternatives) you recommend to test this. Thanks!

# PR checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `nconf` handling for `GHOST_`-prefixed env vars (e.g., GHOST_MAIL_OPTIONS_HOST), stripping the prefix, lowercasing keys, and loading them before existing `__`-based vars.
> 
> - **Config loading (`core/shared/config/loader.js`)**:
>   - Add `nconf.env` handler for `GHOST_`-prefixed environment variables.
>     - Uses `_` separator, strips `GHOST_` prefix, lowercases keys, and parses values.
>     - Loaded before existing `nconf.env` with `__` separator to take precedence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44b86945d6f4a6bf26587b72a7fabcdf9aa01f88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->