### PR TITLE
React sidebar visual refinements

### DIFF
--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -9,6 +9,7 @@ import {
     SidebarMenuBadge
 } from "@tryghost/shade"
 import { NavMenuItem } from "./NavMenuItem";
+import NavSubMenu from "./NavSubMenu";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const [postsExpanded, setPostsExpanded] = useState(false);
@@ -50,29 +51,25 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     </NavMenuItem>
 
                     {/* Posts submenu */}
-                    <div
-                        className={`grid transition-all duration-200 ease-out ${postsExpanded ? 'grid-rows-[1fr] mb-5' : 'grid-rows-[0fr] mb-0'}`}
-                    >
-                        <div className="overflow-hidden">
-                            <NavMenuItem>
-                                <NavMenuItem.Link className="pl-9" href="#/posts?type=draft">
-                                    <NavMenuItem.Label>Drafts</NavMenuItem.Label>
-                                </NavMenuItem.Link>
-                            </NavMenuItem>
+                    <NavSubMenu isExpanded={postsExpanded}>
+                        <NavMenuItem>
+                            <NavMenuItem.Link className="pl-9" href="#/posts?type=draft">
+                                <NavMenuItem.Label>Drafts</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
 
-                            <NavMenuItem>
-                                <NavMenuItem.Link className="pl-9" href="#/posts?type=scheduled">
-                                    <NavMenuItem.Label>Scheduled</NavMenuItem.Label>
-                                </NavMenuItem.Link>
-                            </NavMenuItem>
+                        <NavMenuItem>
+                            <NavMenuItem.Link className="pl-9" href="#/posts?type=scheduled">
+                                <NavMenuItem.Label>Scheduled</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
 
-                            <NavMenuItem>
-                                <NavMenuItem.Link className="pl-9" href="#/posts?type=published">
-                                    <NavMenuItem.Label>Published</NavMenuItem.Label>
-                                </NavMenuItem.Link>
-                            </NavMenuItem>
-                        </div>
-                    </div>
+                        <NavMenuItem>
+                            <NavMenuItem.Link className="pl-9" href="#/posts?type=published">
+                                <NavMenuItem.Label>Published</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
+                    </NavSubMenu>
 
                     <NavMenuItem>
                         <NavMenuItem.Link href="#/pages">

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -50,8 +50,10 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     </NavMenuItem>
 
                     {/* Posts submenu */}
-                    {postsExpanded && (
-                        <div className="mb-5">
+                    <div
+                        className={`grid transition-all duration-200 ease-out ${postsExpanded ? 'grid-rows-[1fr] mb-5' : 'grid-rows-[0fr] mb-0'}`}
+                    >
+                        <div className="overflow-hidden">
                             <NavMenuItem>
                                 <NavMenuItem.Link className="pl-9" href="#/posts?type=draft">
                                     <NavMenuItem.Label>Drafts</NavMenuItem.Label>
@@ -70,7 +72,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 </NavMenuItem.Link>
                             </NavMenuItem>
                         </div>
-                    )}
+                    </div>
 
                     <NavMenuItem>
                         <NavMenuItem.Link href="#/pages">

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -51,7 +51,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     </NavMenuItem>
 
                     {/* Posts submenu */}
-                    <NavSubMenu isExpanded={postsExpanded}>
+                    <NavSubMenu isExpanded={postsExpanded} id="posts-submenu">
                         <NavMenuItem>
                             <NavMenuItem.Link className="pl-9" href="#/posts?type=draft">
                                 <NavMenuItem.Label>Drafts</NavMenuItem.Label>

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -23,9 +23,9 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             aria-controls="posts-submenu"
                             aria-expanded={postsExpanded}
                             aria-label="Toggle post views"
-                            variant='ghost'
-                            size='icon'
-                            className='!h-[34px] absolute opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent'
+                            variant="ghost"
+                            size="icon"
+                            className="!h-[34px] absolute opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
                             onClick={() =>
                                 setPostsExpanded(!postsExpanded)
                             }

--- a/apps/admin/src/layout/app-sidebar/NavHeader.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavHeader.tsx
@@ -25,7 +25,7 @@ const openSearchModal = (event: React.MouseEvent<HTMLButtonElement>) => {
 function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
     const site = useBrowseSite();
     const title = site.data?.site.title ?? "";
-    const logo = site.data?.site.logo ?? "https://static.ghost.org/v4.0.0/images/ghost-orb-1.png";
+    const siteIcon = site.data?.site.icon ?? "https://static.ghost.org/v4.0.0/images/ghost-orb-1.png";
 
     return (
         <SidebarHeader {...props}>
@@ -34,7 +34,7 @@ function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
                     <div className="flex items-center gap-3">
                         <div className="w-8 h-8 rounded-md bg-transparent border-0 flex-shrink-0">
                             <img
-                                src={logo}
+                                src={siteIcon}
                                 alt="Site icon"
                                 className="w-full h-full rounded-md object-cover"
                                 />

--- a/apps/admin/src/layout/app-sidebar/NavMain.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMain.tsx
@@ -19,7 +19,7 @@ function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
             <SidebarGroupContent>
                 <SidebarMenu>
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/analytics">
+                        <NavMenuItem.Link href="#/analytics" activeOnSubpath>
                             <LucideIcon.TrendingUp />
                             <NavMenuItem.Label>Analytics</NavMenuItem.Label>
                         </NavMenuItem.Link>

--- a/apps/admin/src/layout/app-sidebar/NavSubMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSubMenu.tsx
@@ -3,11 +3,13 @@ import React from "react";
 interface NavSubMenuProps {
     isExpanded: boolean;
     children: React.ReactNode;
+    id?: string;
 }
 
-function NavSubMenu({ isExpanded, children }: NavSubMenuProps) {
+function NavSubMenu({ isExpanded, children, id }: NavSubMenuProps) {
     return (
         <div
+            id={id}
             className={`grid transition-all duration-200 ease-out ${isExpanded ? 'grid-rows-[1fr] mb-5' : 'grid-rows-[0fr] mb-0'}`}
         >
             <div className="overflow-hidden">

--- a/apps/admin/src/layout/app-sidebar/NavSubMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSubMenu.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface NavSubMenuProps {
+    isExpanded: boolean;
+    children: React.ReactNode;
+}
+
+function NavSubMenu({ isExpanded, children }: NavSubMenuProps) {
+    return (
+        <div
+            className={`grid transition-all duration-200 ease-out ${isExpanded ? 'grid-rows-[1fr] mb-5' : 'grid-rows-[0fr] mb-0'}`}
+        >
+            <div className="overflow-hidden">
+                {children}
+            </div>
+        </div>
+    );
+}
+
+export default NavSubMenu;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- Analytics menu became inactive on submenus, so I've set the `activeOnSubpath` flag on it
- The post view submenus weren't animated. Also, I factored it out to a new component for future reusability
- There were `'` and `"` mixups & inconsistencies in the code
- The site logo was used instead of site icon in the sidebar header


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an animated `NavSubMenu` for Posts, keeps Analytics active on subroutes, and switches the header image to the site icon.
> 
> - **Admin Sidebar**:
>   - **Submenu UX**: Introduces `NavSubMenu` for animated expand/collapse and applies it to the Posts submenu in `NavContent.tsx`.
>   - **Navigation State**: Sets `activeOnSubpath` on `#/analytics` in `NavMain.tsx`.
>   - **Header Icon**: Uses `site.icon` for the header image in `NavHeader.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abb8fa9d8082894dbac1e51ddefe0a2421781176. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->