### PR TITLE
Added labs flag for domain warming

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/PrivateFeatures.tsx
@@ -47,6 +47,10 @@ const features: Feature[] = [{
     title: 'New Admin Experience',
     description: 'Try the new React-based admin interface. Only available on ghost.io',
     flag: 'adminForward'
+}, {
+    title: 'Domain Warmup',
+    description: 'Enable custom sending domain warmup for gradual email volume increases',
+    flag: 'domainWarmup'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -51,7 +51,8 @@ const PRIVATE_FEATURES = [
     'utmTracking',
     'emailUniqueid',
     'welcomeEmails',
-    'adminForward'
+    'adminForward',
+    'domainWarmup'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -16,6 +16,7 @@ Object {
       "contentVisibility": true,
       "contentVisibilityAlpha": true,
       "customFonts": true,
+      "domainWarmup": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,


### PR DESCRIPTION
ref [GVA-581](https://linear.app/ghost/issue/GVA-581/create-labs-flag-for-domain-warming)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a new private labs flag and UI toggle for Domain Warmup email sending.
> 
> - **Settings UI (Admin)**:
>   - Add `Domain Warmup` toggle in `apps/admin-x-settings/.../PrivateFeatures.tsx` with description and `flag: 'domainWarmup'`.
> - **Core Labs Flags**:
>   - Include `domainWarmup` in `PRIVATE_FEATURES` in `ghost/core/core/shared/labs.js` (propagates to `WRITABLE_KEYS_ALLOWLIST`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571a51e0da1bfce40e1d2a136e9e9f9261e707b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->