### PR TITLE
Migrations for domain warmup feature

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-03-15-17-05-add-csd-email-count.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-03-15-17-05-add-csd-email-count.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('emails', 'csd_email_count', {
+    type: 'integer',
+    nullable: true,
+    unsigned: true
+});

--- a/ghost/core/core/server/data/migrations/versions/6.7/2025-11-03-15-18-04-add-email-batch-fallback-domain.js
+++ b/ghost/core/core/server/data/migrations/versions/6.7/2025-11-03-15-18-04-add-email-batch-fallback-domain.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('email_batches', 'fallback_sending_domain', {
+    type: 'boolean',
+    nullable: false,
+    defaultTo: false
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -838,6 +838,7 @@ module.exports = {
         error: {type: 'string', maxlength: 2000, nullable: true},
         error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         email_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        csd_email_count: {type: 'integer', nullable: true, unsigned: true},
         delivered_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         opened_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         failed_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -867,6 +867,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         email_id: {type: 'string', maxlength: 24, nullable: false, references: 'emails.id'},
         provider_id: {type: 'string', maxlength: 255, nullable: true},
+        fallback_sending_domain: {type: 'boolean', nullable: false, defaultTo: false},
         status: {
             type: 'string',
             maxlength: 50,

--- a/ghost/core/core/server/models/email-batch.js
+++ b/ghost/core/core/server/models/email-batch.js
@@ -5,7 +5,8 @@ const EmailBatch = ghostBookshelf.Model.extend({
 
     defaults() {
         return {
-            status: 'pending'
+            status: 'pending',
+            fallback_sending_domain: false
         };
     },
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -22699,7 +22699,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "17979",
+  "content-length": "18117",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -23948,7 +23948,7 @@ exports[`Activity Feed API Returns email delivered events in activity feed 2: [h
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1051",
+  "content-length": "1074",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -23982,7 +23982,7 @@ exports[`Activity Feed API Returns email opened events in activity feed 2: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1048",
+  "content-length": "1071",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -24040,7 +24040,7 @@ exports[`Activity Feed API Returns email sent events in activity feed 2: [header
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3860",
+  "content-length": "3952",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/emails.test.js.snap
@@ -490,6 +490,7 @@ Object {
   "emails": Array [
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "csd_email_count": null,
       "delivered_count": 1,
       "email_count": 0,
       "error": null,
@@ -517,6 +518,7 @@ Object {
     },
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "csd_email_count": null,
       "delivered_count": 0,
       "email_count": 3,
       "error": "Everything went south",
@@ -560,7 +562,7 @@ exports[`Emails API Can browse emails 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1405",
+  "content-length": "1451",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -689,6 +691,7 @@ Object {
   "emails": Array [
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "csd_email_count": null,
       "delivered_count": 1,
       "email_count": 0,
       "error": null,
@@ -722,7 +725,7 @@ exports[`Emails API Can read an email 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "642",
+  "content-length": "665",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -736,6 +739,7 @@ Object {
   "emails": Array [
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "csd_email_count": null,
       "delivered_count": 0,
       "email_count": 3,
       "error": "Everything went south",
@@ -769,7 +773,7 @@ exports[`Emails API Can retry a failed email 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "688",
+  "content-length": "711",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -783,6 +787,7 @@ Object {
   "emails": Array [
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "csd_email_count": null,
       "delivered_count": 0,
       "email_count": 1,
       "error": null,
@@ -817,7 +822,7 @@ exports[`Emails API Does default replacements on the HTML body of an old email 2
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1061",
+  "content-length": "1084",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-server/click-tracking.test.js
+++ b/ghost/core/test/e2e-server/click-tracking.test.js
@@ -39,7 +39,7 @@ describe('Click Tracking', function () {
             body: {
                 posts: [{
                     title: 'My Newsletter',
-                    html: `<p>External link <a href="https://example.com/a">https://example.com/a</a>; Internal link <a href=${siteUrl.href}/about">${siteUrl.href}/about</a>;Ghost homepage <a href="https://ghost.org">https://ghost.org</a></p>`
+                    html: `<p>External link <a href="https://example.com/a">https://example.com/a</a>; Internal link <a href="${siteUrl.href}/about">${siteUrl.href}/about</a>;Ghost homepage <a href="https://ghost.org">https://ghost.org</a></p>`
                 }]
             }
         });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'aa00ea8206673b21837fbcc24897f779';
+    const currentSchemaHash = '5d90909b1b8232b45f0174dfa720a051';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '5d90909b1b8232b45f0174dfa720a051';
+    const currentSchemaHash = '4e68fd06f63aab5fef99dddd8dc866bb';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
     const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -783,7 +783,8 @@ DataGenerator.Content = {
             id: ObjectId().toHexString(),
             email_id: null, // emails[0] relation added later
             provider_id: 'email1@testing.mailgun.net',
-            status: 'submitted'
+            status: 'submitted',
+            fallback_sending_domain: false
         }
     ],
 


### PR DESCRIPTION
closes [GVA-583](https://linear.app/ghost/issue/GVA-583/create-migration-in-ghost-to-add-csd-member-count-to-emails)
closes [GVA-587](https://linear.app/ghost/issue/GVA-587/create-a-migration-for-the-email-batches-table-to-say-whether-its-sent)

These migrations are both required for the feature. I ran an experimental spike to see what data we'd need to get domain warmup working, and these two came out:

* A count of the messages that were sent by the CSD for each email => this lets us ramp up the number of emails that we send from the CSD on each subsequent send
* A boolean flag that says whether an email batch was sent by the fallback domain (a back-up domain configured for if we're going to exceed the CSD's budget)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DB migrations and schema/model/test updates for `emails.csd_email_count` and `email_batches.fallback_sending_domain`.
> 
> - **Database/Migrations**
>   - Add `emails.csd_email_count` (nullable integer, unsigned) via `versions/6.7/2025-11-03-15-17-05-add-csd-email-count.js`.
>   - Add `email_batches.fallback_sending_domain` (boolean, default `false`) via `versions/6.7/2025-11-03-15-18-04-add-email-batch-fallback-domain.js`.
>   - Update `core/server/data/schema/schema.js` to include both columns.
> - **Models**
>   - Update `core/server/models/email-batch.js` defaults to include `fallback_sending_domain: false`.
> - **Tests/Fixtures**
>   - Update fixtures in `test/utils/fixtures/data-generator.js` to populate `fallback_sending_domain` and reflect new schema.
>   - Refresh schema hash in `test/unit/server/data/schema/integrity.test.js`.
>   - Adjust E2E/API snapshots to include `csd_email_count` and changed `content-length`s.
>   - Fix link HTML in `test/e2e-server/click-tracking.test.js` (adds missing quotes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecb9bec83b0e6452a12f777a2481462700a62939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->