### PR TITLE
Add missing post analytics context provider

### DIFF
--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,36 +1,61 @@
-import { Outlet, type RouteObject, redirect } from "@tryghost/admin-x-framework";
-import { routes as postRoutes } from "@tryghost/posts/src/routes";
-import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
-import {FeatureFlagsProvider} from "@tryghost/activitypub/src/lib/feature-flags";
+import { type RouteObject, Outlet, redirect } from "@tryghost/admin-x-framework";
+
+// ActivityPub
+import { FeatureFlagsProvider } from "@tryghost/activitypub/src/lib/feature-flags";
 import { routes as activityPubRoutes } from "@tryghost/activitypub/src/routes";
+
+// Posts (aka tags and post analytics)
+import PostsAppContextProvider from "@tryghost/posts/src/providers/PostsAppContext";
+import { routes as postRoutes } from "@tryghost/posts/src/routes";
+
+// Stats (aka analytics)
+import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
 import { routes as statsRoutes } from "@tryghost/stats/src/routes";
+
+import { navigateTo as externalNavigate } from "./utils/navigation";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
     {
-        // Override the blank tag detail route in the post app to ensure we
-        // display the Ember screen. Without this the posts app renders a blank
-        // screen. This is needed when running the posts app within Ember as it
-        // prevents the error fallback route screen from showing.
+        // Override the tag detail route from the posts app to ensure we
+        // correctly delegate to Ember since we can't remove the blank screen in
+        // the posts app. The blank screen needs to be there to prevent the
+        // router error fallback from triggering when navigating from the tag
+        // list to a tag detail page.
         path: "/tags/:tagSlug",
-        Component: EmberFallback
+        Component: EmberFallback,
     },
-    ...postRoutes[0].children!.filter(route => route.path !== "*"),
     {
-        element: <GlobalDataProvider><Outlet /></GlobalDataProvider>,
-        children: statsRoutes
+        element: (
+            <PostsAppContextProvider value={{ fromAnalytics: true, externalNavigate }}>
+                <Outlet />
+            </PostsAppContextProvider>
+        ),
+        children: postRoutes[0].children!.filter((route) => route.path !== "*"),
+    },
+    {
+        element: (
+            <GlobalDataProvider>
+                <Outlet />
+            </GlobalDataProvider>
+        ),
+        children: statsRoutes,
     },
     {
         path: `network`,
-        loader: () => redirect('/activitypub')
+        loader: () => redirect("/activitypub"),
     },
     {
-        path: '',
-        element: <FeatureFlagsProvider><Outlet /></FeatureFlagsProvider>,
-        children: activityPubRoutes
+        path: "",
+        element: (
+            <FeatureFlagsProvider>
+                <Outlet />
+            </FeatureFlagsProvider>
+        ),
+        children: activityPubRoutes,
     },
     {
         path: "*",
-        Component: EmberFallback
-    }
+        Component: EmberFallback,
+    },
 ];

--- a/apps/posts/src/App.tsx
+++ b/apps/posts/src/App.tsx
@@ -1,22 +1,9 @@
+import PostsAppContextProvider, {PostsAppContextType} from './providers/PostsAppContext';
 import PostsErrorBoundary from './components/errors/PostsErrorBoundary';
-import React, {createContext, useContext} from 'react';
+import React from 'react';
 import {APP_ROUTE_PREFIX, routes} from '@src/routes';
-import {AppContextType, BaseAppProps, FrameworkProvider, Outlet, RouterProvider} from '@tryghost/admin-x-framework';
+import {BaseAppProps, FrameworkProvider, Outlet, RouterProvider} from '@tryghost/admin-x-framework';
 import {ShadeApp} from '@tryghost/shade';
-
-interface PostsAppContextType extends AppContextType {
-    fromAnalytics: boolean;
-}
-
-const PostsAppContext = createContext<PostsAppContextType | undefined>(undefined);
-
-export const useAppContext = () => {
-    const context = useContext(PostsAppContext);
-    if (context === undefined) {
-        throw new Error('useAppContext must be used within an AppProvider');
-    }
-    return context;
-};
 
 interface AppProps extends BaseAppProps {
     fromAnalytics?: boolean;
@@ -40,7 +27,7 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
                 refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
             }}
         >
-            <PostsAppContext.Provider value={appContextValue}>
+            <PostsAppContextProvider value={appContextValue}>
                 <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                     <PostsErrorBoundary>
                         <ShadeApp className="shade-posts" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
@@ -48,7 +35,7 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
                         </ShadeApp>
                     </PostsErrorBoundary>
                 </RouterProvider>
-            </PostsAppContext.Provider>
+            </PostsAppContextProvider>
         </FrameworkProvider>
     );
 };

--- a/apps/posts/src/providers/PostsAppContext.tsx
+++ b/apps/posts/src/providers/PostsAppContext.tsx
@@ -1,0 +1,29 @@
+import {AppContextType} from '@tryghost/admin-x-framework';
+import {ReactNode, createContext, useContext} from 'react';
+
+export interface PostsAppContextType extends AppContextType {
+    fromAnalytics: boolean;
+}
+
+const PostsAppContext = createContext<PostsAppContextType | undefined>(undefined);
+
+export const useAppContext = () => {
+    const context = useContext(PostsAppContext);
+    if (context === undefined) {
+        throw new Error('useAppContext must be used within an AppProvider');
+    }
+    return context;
+};
+
+interface PostsAppContextProviderProps {
+    children: ReactNode;
+    value: PostsAppContextType;
+}
+
+export const PostsAppContextProvider = ({children, value}: PostsAppContextProviderProps) => {
+    return <PostsAppContext.Provider value={value}>
+        {children}
+    </PostsAppContext.Provider>;
+};
+
+export default PostsAppContextProvider;

--- a/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/Growth.tsx
@@ -4,7 +4,7 @@ import PostAnalyticsContent from '../components/PostAnalyticsContent';
 import PostAnalyticsHeader from '../components/PostAnalyticsHeader';
 import React from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
-import {useAppContext} from '@src/App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';

--- a/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/GrowthSources.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SourceIcon from '../../components/SourceIcon';
 import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate} from '@tryghost/admin-x-framework';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber} from '@tryghost/shade';
-import {useAppContext} from '@src/App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 
 // Default source icon URL - apps can override this
 const DEFAULT_SOURCE_ICON_URL = 'https://www.google.com/s2/favicons?domain=ghost.org&sz=64';

--- a/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/Newsletter.tsx
@@ -8,7 +8,7 @@ import {NewsletterRadialChart, NewsletterRadialChartData} from './components/New
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {getLinkById} from '@src/utils/link-helpers';
 import {hasBeenEmailed, useNavigate} from '@tryghost/admin-x-framework';
-import {useAppContext} from '@src/App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 import {useEditLinks} from '@src/hooks/useEditLinks';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {usePostNewsletterStats} from '@src/hooks/usePostNewsletterStats';

--- a/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/Overview.tsx
@@ -10,7 +10,7 @@ import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {STATS_RANGES} from '@src/utils/constants';
 import {centsToDollars} from '../Growth/Growth';
 import {hasBeenEmailed, isPublishedOnly, useNavigate, useTinybirdQuery} from '@tryghost/admin-x-framework';
-import {useAppContext} from '@src/App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 import {useEffect, useMemo} from 'react';
 import {usePostReferrers} from '@src/hooks/usePostReferrers';
 

--- a/apps/posts/src/views/PostAnalytics/components/AudienceSelect.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/AudienceSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Button, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger, LucideIcon} from '@tryghost/shade';
-import {useAppContext} from '@src/App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 import {useGlobalData} from '@src/providers/PostAnalyticsContext';
 
 const AUDIENCE_BITS = {

--- a/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/PostAnalyticsHeader.tsx
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, H1, LucideIcon, Navbar, NavbarActions, PageMenu, PageMenuItem, PostShareModal, formatNumber} from '@tryghost/shade';
 import {Post, useGlobalData} from '@src/providers/PostAnalyticsContext';
 import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
-import {useAppContext} from '../../../App';
+import {useAppContext} from '@src/providers/PostsAppContext';
 import {useDeletePost} from '@tryghost/admin-x-framework/api/posts';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 


### PR DESCRIPTION
### Changes 
- Moved PostsAppContext to dedicated provider file 
- Wire up the PostsAppContext in the admin routes definition

### Note
We need to figure out a different way to track the fromAnalytics value, as the current implementation really only makes sense in the Ember context. For now, this change will ensure that the app at least runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts PostsAppContext into a dedicated provider, wraps Posts routes in Admin with it, and updates analytics views to use the new context.
> 
> - **Posts app**:
>   - **New provider**: Adds `providers/PostsAppContext` (context, hook, provider, types).
>   - **App wiring**: `App.tsx` wraps app in `PostsAppContextProvider` and builds context value.
>   - **Consumers updated**: Post analytics views (`Overview`, `Newsletter`, `Growth`, `GrowthSources`, `AudienceSelect`, `PostAnalyticsHeader`) now import `useAppContext` from `providers/PostsAppContext`.
> - **Admin app**:
>   - **Routes integration**: Wraps Posts routes with `PostsAppContextProvider` passing `{fromAnalytics: true, externalNavigate}`.
>   - **Routing tweaks**: Clarifies `/tags/:tagSlug` Ember fallback override and keeps ActivityPub/Stats providers structured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3ce0db350f5dbc9b97bee1cae44db52816725c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->