### PR TITLE
🐛 Add missing basepath to onboarding redirect

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/layout/Layout.tsx
+++ b/apps/activitypub/src/components/layout/Layout.tsx
@@ -4,11 +4,13 @@ import Onboarding, {useOnboardingStatus} from './Onboarding';
 import React, {useRef, useState} from 'react';
 import Sidebar from './Sidebar';
 import {Navigate, ScrollRestoration} from '@tryghost/admin-x-framework';
+import {useAppBasePath} from '@src/hooks/use-app-base-path';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
 import {useKeyboardShortcuts} from '@hooks/use-keyboard-shortcuts';
 
 const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     const {isOnboarded} = useOnboardingStatus();
+    const basePath = useAppBasePath();
     const {data: currentUser, isLoading} = useCurrentUser();
     const containerRef = useRef<HTMLDivElement>(null);
     const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
@@ -28,7 +30,7 @@ const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...pr
     }
 
     if (!isOnboarded) {
-        return <Navigate to={`/welcome`} replace />;
+        return <Navigate to={`${basePath}/welcome`} replace />;
     }
 
     return (


### PR DESCRIPTION
Fixes https://linear.app/ghost/issue/BER-2971/strange-error-when-accessing-the-ap-in-ghost-admin

The onboarding redirect needs to include the app basepath. Without it new users ends up on a 404 page. I've tested this locally. 

We might want to add an E2E test for the onboarding flow as a followup?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefixes the onboarding redirect with the app base path in `Layout.tsx` to route correctly; bumps package version.
> 
> - **ActivityPub UI**:
>   - Update `Layout.tsx` to use `useAppBasePath` and change onboarding redirect to `Navigate` to `${basePath}/welcome`.
> - **Versioning**:
>   - Bump `@tryghost/activitypub` package version to `1.0.24` in `apps/activitypub/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d753d97c0ef29cd0781608b918ca5cafc57bd698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->