### PR TITLE
Fixed version mismatch error in React admin shell

### DIFF
--- a/apps/admin-x-framework/src/utils/api/fetchApi.ts
+++ b/apps/admin-x-framework/src/utils/api/fetchApi.ts
@@ -22,9 +22,15 @@ export const useFetchApi = () => {
     return async <ResponseData = any>(endpoint: string | URL, {headers = {}, retry, ...options}: RequestOptions = {}): Promise<ResponseData> => {
         // By default, we set the Content-Type header to application/json
         const defaultHeaders: Record<string, string> = {
-            'app-pragma': 'no-cache',
-            'x-ghost-version': ghostVersion
+            'app-pragma': 'no-cache'
         };
+        
+        // Only include version header if ghostVersion is provided
+        // This allows forward admin deployments to skip version checks
+        if (ghostVersion) {
+            defaultHeaders['x-ghost-version'] = ghostVersion;
+        }
+        
         if (typeof options.body === 'string') {
             defaultHeaders['content-type'] = 'application/json';
         }

--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -192,7 +192,7 @@ export default class AdminXComponent extends Component {
                     <Suspense fallback={fallback}>
                         <this.AdminXApp
                             framework={{
-                                ghostVersion: config.APP.version,
+                                ghostVersion: this.feature.inAdminForward ? '' : config.APP.version,
                                 externalNavigate: this.externalNavigate,
                                 unsplashConfig: defaultUnsplashHeaders,
                                 sentryDSN: this.config.sentry_dsn ?? null,

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -227,6 +227,7 @@ export function isAcceptedResponse(errorOrStatus) {
 class ajaxService extends AjaxService {
     @service session;
     @service upgradeStatus;
+    @service feature;
 
     @inject config;
 
@@ -237,10 +238,19 @@ class ajaxService extends AjaxService {
     skipSessionDeletion = false;
 
     get headers() {
-        return {
-            'X-Ghost-Version': config.APP.version,
+        const headers = {
             'App-Pragma': 'no-cache'
         };
+
+        // Omit the version header when running in forward admin to avoid issues
+        // with the server triggering a version mismatch error. We can expect
+        // the admin and backend will be on different versions from time to time
+        // due to different release cadences.
+        if (!this.feature.inAdminForward) {
+            headers['X-Ghost-Version'] = config.APP.version;
+        }
+
+        return headers;
     }
 
     init() {


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-2969/version-mismatch-error-in-production

Omitting the `X-Ghost-Version` header when running in the React admin shell avoids version mismatch errors when the continuously delivered version of the admin is ahead of the backend releases. When the header is not set the backend skips the version check.

This is needed since the continuously delivered admin can be on a newer version than production backends during e.g. the window between a minor release being cut and rolled out. 

Note that removing this check on the backend does not prevent us from implementing our own check in the frontend to handle clients that are lagging behind due e.g. to not reloading their browser for a very long time. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally skip sending the X-Ghost-Version header when running the forward admin, updating both React fetch and Ember ajax paths to avoid version mismatch errors.
> 
> - **Header handling**:
>   - In `apps/admin-x-framework/src/utils/api/fetchApi.ts`, only add `x-ghost-version` when `ghostVersion` is provided; keep `app-pragma` default.
> - **Ember Admin**:
>   - `ghost/admin/app/components/admin-x/admin-x-component.js`: pass `framework.ghostVersion` as `''` when `feature.inAdminForward` is true.
>   - `ghost/admin/app/services/ajax.js`:
>     - Inject `feature` service.
>     - Return headers with `App-Pragma` always; include `X-Ghost-Version` only when not in forward admin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7cbba08444be49ca4fc405fef4c78d9ab6a009a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->