### PR TITLE
Added app settings context to React admin shell

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -4,7 +4,7 @@ export {FrameworkProvider, useFramework} from './providers/FrameworkProvider';
 
 // App Context
 export type {AppSettings, BaseAppProps, AppContextType, AppProviderProps} from './providers/AppProvider';
-export {AppProvider, useAppContext} from './providers/AppProvider';
+export {AppContext, AppProvider, useAppContext} from './providers/AppProvider';
 
 // Hooks
 export {useActiveVisitors} from './hooks/useActiveVisitors';

--- a/apps/admin-x-framework/src/providers/AppProvider.tsx
+++ b/apps/admin-x-framework/src/providers/AppProvider.tsx
@@ -34,7 +34,7 @@ export interface AppProviderProps {
     children: ReactNode;
 }
 
-const AppContext = createContext<AppContextType | undefined>(undefined);
+export const AppContext = createContext<AppContextType | undefined>(undefined);
 
 export const AppProvider: React.FC<AppProviderProps> = ({
     appSettings,

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,19 +2,16 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
-import {
-    FrameworkProvider,
-    RouterProvider,
-    AppProvider,
-} from "@tryghost/admin-x-framework";
+import { FrameworkProvider, RouterProvider } from "@tryghost/admin-x-framework";
 import { ShadeApp } from "@tryghost/shade";
 
 import { routes } from "./routes.tsx";
 import { navigateTo } from "./utils/navigation";
+import { AppProvider } from "./providers/AppProvider";
 
 const framework = {
     ghostVersion: "",
-    externalNavigate: (link: {route: string, isExternal: boolean}) => {
+    externalNavigate: (link: { route: string; isExternal: boolean }) => {
         navigateTo(link.route);
     },
     unsplashConfig: {
@@ -38,9 +35,9 @@ const framework = {
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
-        <AppProvider>
-            <FrameworkProvider {...framework}>
-                <RouterProvider prefix={"/"} routes={routes}>
+        <FrameworkProvider {...framework}>
+            <RouterProvider prefix={"/"} routes={routes}>
+                <AppProvider>
                     <ShadeApp
                         className="shade-admin"
                         darkMode={false}
@@ -48,8 +45,8 @@ createRoot(document.getElementById("root")!).render(
                     >
                         <App />
                     </ShadeApp>
-                </RouterProvider>
-            </FrameworkProvider>
-        </AppProvider>
+                </AppProvider>
+            </RouterProvider>
+        </FrameworkProvider>
     </StrictMode>
 );

--- a/apps/admin/src/providers/AppProvider.tsx
+++ b/apps/admin/src/providers/AppProvider.tsx
@@ -1,0 +1,43 @@
+import { AppProvider as FrameworkAppProvider, type AppSettings } from "@tryghost/admin-x-framework";
+import { useBrowseSettings, getSettingValue } from "@tryghost/admin-x-framework/api/settings";
+import { type ReactNode, useMemo } from "react";
+
+interface AppProviderProps {
+    children: ReactNode;
+}
+
+/**
+ * Wrapper around AppProvider that fetches Ghost settings and constructs
+ * the appSettings object expected by admin-x apps
+ */
+export function AppProvider({ children }: AppProviderProps) {
+    const { data: settingsData } = useBrowseSettings();
+
+    // Construct appSettings from Ghost settings
+    const appSettings: AppSettings | undefined = useMemo(() => {
+        if (!settingsData?.settings) {
+            return undefined;
+        }
+
+        const settings = settingsData.settings;
+
+        return {
+            paidMembersEnabled: getSettingValue<boolean>(settings, 'paid_members_enabled') ?? false,
+            newslettersEnabled: getSettingValue(settings, 'editor_default_email_recipients') !== 'disabled',
+            analytics: {
+                emailTrackOpens: getSettingValue<boolean>(settings, 'email_track_opens') ?? false,
+                emailTrackClicks: getSettingValue<boolean>(settings, 'email_track_clicks') ?? false,
+                membersTrackSources: getSettingValue<boolean>(settings, 'members_track_sources') ?? false,
+                outboundLinkTagging: getSettingValue<boolean>(settings, 'outbound_link_tagging') ?? false,
+                webAnalytics: getSettingValue<boolean>(settings, 'web_analytics_enabled') ?? false,
+            }
+        };
+    }, [settingsData]);
+
+    return (
+        <FrameworkAppProvider appSettings={appSettings}>
+            {children}
+        </FrameworkAppProvider>
+    );
+}
+

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -12,7 +12,6 @@ import { routes as postRoutes } from "@tryghost/posts/src/routes";
 import GlobalDataProvider from "@tryghost/stats/src/providers/GlobalDataProvider";
 import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 
-import { navigateTo as externalNavigate } from "./utils/navigation";
 import { EmberFallback } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
@@ -27,7 +26,7 @@ export const routes: RouteObject[] = [
     },
     {
         element: (
-            <PostsAppContextProvider value={{ fromAnalytics: true, externalNavigate }}>
+            <PostsAppContextProvider value={{ fromAnalytics: true }}>
                 <Outlet />
             </PostsAppContextProvider>
         ),

--- a/apps/posts/src/providers/PostsAppContext.tsx
+++ b/apps/posts/src/providers/PostsAppContext.tsx
@@ -1,4 +1,4 @@
-import {AppContextType} from '@tryghost/admin-x-framework';
+import {AppContext, AppContextType} from '@tryghost/admin-x-framework';
 import {ReactNode, createContext, useContext} from 'react';
 
 export interface PostsAppContextType extends AppContextType {
@@ -17,11 +17,29 @@ export const useAppContext = () => {
 
 interface PostsAppContextProviderProps {
     children: ReactNode;
-    value: PostsAppContextType;
+    value: Partial<PostsAppContextType>;
 }
 
 export const PostsAppContextProvider = ({children, value}: PostsAppContextProviderProps) => {
-    return <PostsAppContext.Provider value={value}>
+    // Try to get parent AppContext - will be undefined in standalone mode (e.g. within Ember)
+    const parentContext = useContext(AppContext);
+
+    // Determine externalNavigate - prefer local value, fallback to parent
+    const externalNavigate = value.externalNavigate ?? parentContext?.externalNavigate;
+
+    if (!externalNavigate) {
+        throw new Error('External navigate function is required');
+    }
+
+    // Merge parent context with local value, with local value taking precedence
+    const mergedValue: PostsAppContextType = {
+        externalNavigate,
+        fromAnalytics: false,
+        ...parentContext,
+        ...value
+    };
+
+    return <PostsAppContext.Provider value={mergedValue}>
         {children}
     </PostsAppContext.Provider>;
 };


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-2970/fetch-and-inject-config

React apps were missing configuration data from Ember. Added AppProvider to fetch Ghost settings and provide appSettings to admin-x apps, enabling  additional analytics tabs and other features based on site configuration.
