### PR TITLE
React sidebar mobile version

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -37,7 +37,7 @@ export type {RouteObject} from 'react-router';
 export type {RouterProviderProps, NavigateOptions} from './providers/RouterProvider';
 export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/RouterProvider';
 export {useNavigationStack} from './providers/NavigationStackProvider';
-export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, useMatches} from 'react-router';
+export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, matchPath, useMatches} from 'react-router';
 
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -37,7 +37,7 @@ export type {RouteObject} from 'react-router';
 export type {RouterProviderProps, NavigateOptions} from './providers/RouterProvider';
 export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrollPosition, ScrollRestoration, Navigate} from './providers/RouterProvider';
 export {useNavigationStack} from './providers/NavigationStackProvider';
-export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, matchPath, useMatches} from 'react-router';
+export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, matchPath, useMatch, useMatches} from 'react-router';
 
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';

--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import {
+    Button,
+    LucideIcon,
     SidebarInset,
     SidebarProvider,
     SidebarTrigger,
@@ -20,8 +22,22 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             <SidebarInset className="bg-white">
                 <main className="flex-1 min-h-screen">{children}</main>
             </SidebarInset>
-            <div className="absolute bottom-0 w-full h-[55px]">
-                <SidebarTrigger className="-ml-1" />
+            <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border">
+                <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[330px]">
+                    <Button variant="ghost" size="icon">
+                        <LucideIcon.TrendingUp strokeWidth={1.5} />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                        <LucideIcon.PenLine />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                        <LucideIcon.Users />
+                    </Button>
+                    <SidebarTrigger className="-ml-1">
+                        <LucideIcon.Ellipsis />
+                        <span className="sr-only">Toggle Sidebar</span>
+                    </SidebarTrigger>
+                </div>
             </div>
         </SidebarProvider>
     );

--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
     SidebarInset,
     SidebarProvider,
+    SidebarTrigger,
 } from "@tryghost/shade";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import AppSidebar from "./app-sidebar";
@@ -19,6 +20,9 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             <SidebarInset className="bg-white">
                 <main className="flex-1 min-h-screen">{children}</main>
             </SidebarInset>
+            <div className="absolute bottom-0 w-full h-[55px]">
+                <SidebarTrigger className="-ml-1" />
+            </div>
         </SidebarProvider>
     );
 }

--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -19,8 +19,8 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             <AppSidebar />
             <SidebarInset className="bg-white">
                 <main className="flex-1 min-h-screen">{children}</main>
+                <MobileNavBar />
             </SidebarInset>
-            <MobileNavBar />
         </SidebarProvider>
     );
 }

--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import {
-    Button,
-    LucideIcon,
     SidebarInset,
     SidebarProvider,
-    SidebarTrigger,
 } from "@tryghost/shade";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import AppSidebar from "./app-sidebar";
+import { MobileNavBar } from "./app-sidebar/MobileNavBar";
 
 interface AdminLayoutProps {
     children: React.ReactNode;
@@ -22,23 +20,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             <SidebarInset className="bg-white">
                 <main className="flex-1 min-h-screen">{children}</main>
             </SidebarInset>
-            <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border">
-                <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[330px]">
-                    <Button variant="ghost" size="icon">
-                        <LucideIcon.TrendingUp strokeWidth={1.5} />
-                    </Button>
-                    <Button variant="ghost" size="icon">
-                        <LucideIcon.PenLine />
-                    </Button>
-                    <Button variant="ghost" size="icon">
-                        <LucideIcon.Users />
-                    </Button>
-                    <SidebarTrigger className="-ml-1">
-                        <LucideIcon.Ellipsis />
-                        <span className="sr-only">Toggle Sidebar</span>
-                    </SidebarTrigger>
-                </div>
-            </div>
+            <MobileNavBar />
         </SidebarProvider>
     );
 }

--- a/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
@@ -2,29 +2,18 @@ import React from "react"
 
 import {
     Sidebar,
-    SidebarContent,
 } from "@tryghost/shade"
 
-import NavMain from "./NavMain";
-import NavContent from "./NavContent";
-import NavGhostPro from "./NavGhostPro";
-import NavHeader from "./NavHeader";
-import NavFooter from "./NavFooter";
-import NavSettings from "./NavSettings";
+import AppSidebarHeader from "./AppSidebarHeader";
+import AppSidebarFooter from "./AppSidebarFooter";
+import AppSidebarContent from "./AppSidebarContent";
 
 function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     return (
         <Sidebar {...props}>
-            <NavHeader className="px-5 pt-6 pb-0" />
-            <SidebarContent className="px-3 pt-4 justify-between">
-                <div className="flex flex-col gap-2 sidebar:gap-4">
-                    <NavMain />
-                    <NavContent />
-                    <NavGhostPro />
-                </div>
-                <NavSettings className="pb-0" />
-            </SidebarContent>
-            <NavFooter className="p-3 gap-0" />
+            <AppSidebarHeader className="px-5 pt-6 pb-0" />
+            <AppSidebarContent />
+            <AppSidebarFooter className="p-3 gap-0" />
         </Sidebar>
     )
 }

--- a/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebar.tsx
@@ -10,15 +10,19 @@ import NavContent from "./NavContent";
 import NavGhostPro from "./NavGhostPro";
 import NavHeader from "./NavHeader";
 import NavFooter from "./NavFooter";
+import NavSettings from "./NavSettings";
 
 function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     return (
         <Sidebar {...props}>
             <NavHeader className="px-5 pt-6 pb-0" />
-            <SidebarContent className="px-3 pt-4">
-                <NavMain />
-                <NavContent />
-                <NavGhostPro />
+            <SidebarContent className="px-3 pt-4 justify-between">
+                <div className="flex flex-col gap-2 sidebar:gap-4">
+                    <NavMain />
+                    <NavContent />
+                    <NavGhostPro />
+                </div>
+                <NavSettings className="pb-0" />
             </SidebarContent>
             <NavFooter className="p-3 gap-0" />
         </Sidebar>

--- a/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+
+import {
+    SidebarContent,
+} from "@tryghost/shade"
+
+import NavMain from "./NavMain";
+import NavContent from "./NavContent";
+import NavGhostPro from "./NavGhostPro";
+import NavSettings from "./NavSettings";
+
+function AppSidebarContent() {
+    return (
+        <SidebarContent className="px-3 pt-4 justify-between">
+            <div className="flex flex-col gap-2 sidebar:gap-4">
+                <NavMain />
+                <NavContent />
+                <NavGhostPro />
+            </div>
+            <NavSettings className="pb-0" />
+        </SidebarContent>
+    )
+}
+
+export default AppSidebarContent;

--- a/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 import {
     SidebarContent,
 } from "@tryghost/shade"

--- a/apps/admin/src/layout/app-sidebar/AppSidebarFooter.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarFooter.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tryghost/shade"
 import UserMenu from "./UserMenu";
 
-function NavFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
+function AppSidebarFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
     return (
         <SidebarFooter {...props}>
             <SidebarGroup>
@@ -22,4 +22,4 @@ function NavFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
     );
 }
 
-export default NavFooter;
+export default AppSidebarFooter;

--- a/apps/admin/src/layout/app-sidebar/AppSidebarHeader.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarHeader.tsx
@@ -22,7 +22,7 @@ const openSearchModal = (event: React.MouseEvent<HTMLButtonElement>) => {
     document.dispatchEvent(searchShortcutEvent);
 }
 
-function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
+function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
     const site = useBrowseSite();
     const title = site.data?.site.title ?? "";
     const siteIcon = site.data?.site.icon ?? "https://static.ghost.org/v4.0.0/images/ghost-orb-1.png";
@@ -60,4 +60,4 @@ function NavHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
     );
 }
 
-export default NavHeader;
+export default AppSidebarHeader;

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -40,7 +40,7 @@ export function MobileNavBar() {
     }
 
     return (
-        <div className="fixed flex justify-center bottom-0 w-full h-[var(--mobile-navbar-height)] bg-sidebar/80 backdrop-blur-md border-t border-sidebar-border px-5 z-50">
+        <div className="sticky flex justify-center bottom-0 w-full h-[var(--mobile-navbar-height)] bg-sidebar/80 backdrop-blur-md border-t border-sidebar-border px-5 z-50">
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -40,7 +40,7 @@ export function MobileNavBar() {
     }
 
     return (
-        <div className="absolute flex justify-center bottom-0 w-full h-16 bg-sidebar border-t border-sidebar-border px-5">
+        <div className="fixed flex justify-center bottom-0 w-full h-16 bg-sidebar border-t border-sidebar-border px-5">
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -19,7 +19,7 @@ function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props 
     return (
         <Button
             asChild
-            className={`rounded-full px-8 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
+            className={`rounded-full w-full max-w-16 min-w-9 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
             variant="ghost"
             size="icon"
             data-active={isActive}
@@ -33,15 +33,24 @@ function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props 
 
 export function MobileNavBar() {
     return (
-        <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border">
-            <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[330px]">
-                <MobileNavBarButton href="#/analytics" activeOnSubpath>
+        <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border px-5">
+            <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
+                <MobileNavBarButton
+                    activeOnSubpath
+                    href="#/analytics"
+                >
                     <LucideIcon.TrendingUp strokeWidth={ICON_STROKE_WIDTH} />
                 </MobileNavBarButton>
-                <MobileNavBarButton href="#/posts" activeOnSubpath>
+                <MobileNavBarButton
+                    activeOnSubpath
+                    href="#/posts"
+                >
                     <LucideIcon.PenLine strokeWidth={ICON_STROKE_WIDTH} />
                 </MobileNavBarButton>
-                <MobileNavBarButton href="#/members" activeOnSubpath>
+                <MobileNavBarButton
+                    activeOnSubpath
+                    href="#/members"
+                >
                     <LucideIcon.Users strokeWidth={ICON_STROKE_WIDTH} />
                 </MobileNavBarButton>
                 <SidebarTrigger className="rounded-full px-8">

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     LucideIcon,
     SidebarTrigger,
+    useSidebar,
 } from "@tryghost/shade";
 import { useIsActiveLink } from "./useIsActiveLink";
 
@@ -32,8 +33,14 @@ function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props 
 }
 
 export function MobileNavBar() {
+    const { isMobile } = useSidebar();
+
+    if (!isMobile) {
+        return <></>
+    }
+
     return (
-        <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border px-5">
+        <div className="absolute flex justify-center bottom-0 w-full h-16 bg-sidebar bg-sidebar border-t border-sidebar-border px-5">
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -10,12 +10,12 @@ import { useIsActiveLink } from "./useIsActiveLink";
 const ICON_STROKE_WIDTH = 1.5;
 
 interface MobileNavBarButtonProps extends Omit<React.ComponentProps<typeof Button>, 'asChild'> {
-    href?: string;
+    to?: string;
     activeOnSubpath?: boolean;
 }
 
-function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props }: MobileNavBarButtonProps) {
-    const isActive = useIsActiveLink({ href, activeOnSubpath });
+function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }: MobileNavBarButtonProps) {
+    const isActive = useIsActiveLink({ path: to, activeOnSubpath });
 
     return (
         <Button
@@ -25,7 +25,7 @@ function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props 
             size="icon"
             data-active={isActive}
         >
-            <a href={href}>
+            <a href={to}>
                 {children}
             </a>
         </Button>
@@ -44,21 +44,21 @@ export function MobileNavBar() {
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath
-                    href="#/analytics"
+                    to="analytics"
                 >
                     <LucideIcon.TrendingUp strokeWidth={ICON_STROKE_WIDTH} />
                     <span className="sr-only">Analytics</span>
                 </MobileNavBarButton>
                 <MobileNavBarButton
                     activeOnSubpath
-                    href="#/posts"
+                    to="posts"
                 >
                     <LucideIcon.PenLine strokeWidth={ICON_STROKE_WIDTH} />
                     <span className="sr-only">Posts</span>
                 </MobileNavBarButton>
                 <MobileNavBarButton
                     activeOnSubpath
-                    href="#/members"
+                    to="members"
                 >
                     <LucideIcon.Users strokeWidth={ICON_STROKE_WIDTH} />
                     <span className="sr-only">Members</span>

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -40,7 +40,7 @@ export function MobileNavBar() {
     }
 
     return (
-        <div className="absolute flex justify-center bottom-0 w-full h-16 bg-sidebar bg-sidebar border-t border-sidebar-border px-5">
+        <div className="absolute flex justify-center bottom-0 w-full h-16 bg-sidebar border-t border-sidebar-border px-5">
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import {
+    Button,
+    LucideIcon,
+    SidebarTrigger,
+} from "@tryghost/shade";
+import { useIsActiveLink } from "./useIsActiveLink";
+
+const ICON_STROKE_WIDTH = 1.5;
+
+interface MobileNavBarButtonProps extends Omit<React.ComponentProps<typeof Button>, 'asChild'> {
+    href?: string;
+    activeOnSubpath?: boolean;
+}
+
+function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props }: MobileNavBarButtonProps) {
+    const isActive = useIsActiveLink({ href, activeOnSubpath });
+
+    return (
+        <Button
+            asChild
+            className={`rounded-full px-8 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
+            variant="ghost"
+            size="icon"
+            data-active={isActive}
+        >
+            <a href={href}>
+                {children}
+            </a>
+        </Button>
+    );
+}
+
+export function MobileNavBar() {
+    return (
+        <div className="absolute flex justify-center bottom-0 w-full h-[55px] bg-sidebar bg-sidebar border-t border-sidebar-border">
+            <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[330px]">
+                <MobileNavBarButton href="#/analytics" activeOnSubpath>
+                    <LucideIcon.TrendingUp strokeWidth={ICON_STROKE_WIDTH} />
+                </MobileNavBarButton>
+                <MobileNavBarButton href="#/posts" activeOnSubpath>
+                    <LucideIcon.PenLine strokeWidth={ICON_STROKE_WIDTH} />
+                </MobileNavBarButton>
+                <MobileNavBarButton href="#/members" activeOnSubpath>
+                    <LucideIcon.Users strokeWidth={ICON_STROKE_WIDTH} />
+                </MobileNavBarButton>
+                <SidebarTrigger className="rounded-full px-8">
+                    <LucideIcon.Ellipsis strokeWidth={ICON_STROKE_WIDTH} />
+                    <span className="sr-only">Toggle Sidebar</span>
+                </SidebarTrigger>
+            </div>
+        </div>
+    );
+}

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -40,7 +40,7 @@ export function MobileNavBar() {
     }
 
     return (
-        <div className="fixed flex justify-center bottom-0 w-full h-16 bg-sidebar border-t border-sidebar-border px-5">
+        <div className="fixed flex justify-center bottom-0 w-full h-[var(--mobile-navbar-height)] bg-sidebar/80 backdrop-blur-md border-t border-sidebar-border px-5 z-50">
             <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
                 <MobileNavBarButton
                     activeOnSubpath

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -20,7 +20,7 @@ function MobileNavBarButton({ href, activeOnSubpath = false, children, ...props 
     return (
         <Button
             asChild
-            className={`rounded-full w-full max-w-16 min-w-9 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
+            className={`rounded-full w-full max-w-16 min-w-9 hover:bg-gray-200 ${isActive ? 'bg-gray-200' : 'bg-transparent'}`} {...props}
             variant="ghost"
             size="icon"
             data-active={isActive}
@@ -60,7 +60,7 @@ export function MobileNavBar() {
                 >
                     <LucideIcon.Users strokeWidth={ICON_STROKE_WIDTH} />
                 </MobileNavBarButton>
-                <SidebarTrigger className="rounded-full px-8">
+                <SidebarTrigger className="rounded-full px-8 h-9 hover:bg-transparent">
                     <LucideIcon.Ellipsis strokeWidth={ICON_STROKE_WIDTH} />
                     <span className="sr-only">Toggle Sidebar</span>
                 </SidebarTrigger>

--- a/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
+++ b/apps/admin/src/layout/app-sidebar/MobileNavBar.tsx
@@ -47,18 +47,21 @@ export function MobileNavBar() {
                     href="#/analytics"
                 >
                     <LucideIcon.TrendingUp strokeWidth={ICON_STROKE_WIDTH} />
+                    <span className="sr-only">Analytics</span>
                 </MobileNavBarButton>
                 <MobileNavBarButton
                     activeOnSubpath
                     href="#/posts"
                 >
                     <LucideIcon.PenLine strokeWidth={ICON_STROKE_WIDTH} />
+                    <span className="sr-only">Posts</span>
                 </MobileNavBarButton>
                 <MobileNavBarButton
                     activeOnSubpath
                     href="#/members"
                 >
                     <LucideIcon.Users strokeWidth={ICON_STROKE_WIDTH} />
+                    <span className="sr-only">Members</span>
                 </MobileNavBarButton>
                 <SidebarTrigger className="rounded-full px-8 h-9 hover:bg-transparent">
                     <LucideIcon.Ellipsis strokeWidth={ICON_STROKE_WIDTH} />

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -37,7 +37,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 className={`transition-all ${postsExpanded && 'rotate-[90deg]'}`}
                             />
                         </Button>
-                        <NavMenuItem.Link href="#/posts">
+                        <NavMenuItem.Link to="posts">
                             <LucideIcon.PenLine className="opacity-0 sidebar:opacity-100 sidebar:group-hover/menu-item:opacity-0 pointer-events-none transition-all" />
                             <NavMenuItem.Label>Posts</NavMenuItem.Label>
                         </NavMenuItem.Link>
@@ -55,40 +55,40 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     {/* Posts submenu */}
                     <NavSubMenu isExpanded={postsExpanded} id="posts-submenu">
                         <NavMenuItem>
-                            <NavMenuItem.Link className="pl-9" href="#/posts?type=draft">
+                            <NavMenuItem.Link className="pl-9" to="posts?type=draft">
                                 <NavMenuItem.Label>Drafts</NavMenuItem.Label>
                             </NavMenuItem.Link>
                         </NavMenuItem>
 
                         <NavMenuItem>
-                            <NavMenuItem.Link className="pl-9" href="#/posts?type=scheduled">
+                            <NavMenuItem.Link className="pl-9" to="posts?type=scheduled">
                                 <NavMenuItem.Label>Scheduled</NavMenuItem.Label>
                             </NavMenuItem.Link>
                         </NavMenuItem>
 
                         <NavMenuItem>
-                            <NavMenuItem.Link className="pl-9" href="#/posts?type=published">
+                            <NavMenuItem.Link className="pl-9" to="posts?type=published">
                                 <NavMenuItem.Label>Published</NavMenuItem.Label>
                             </NavMenuItem.Link>
                         </NavMenuItem>
                     </NavSubMenu>
 
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/pages">
+                        <NavMenuItem.Link to="pages">
                             <LucideIcon.File />
                             <NavMenuItem.Label>Pages</NavMenuItem.Label>
                         </NavMenuItem.Link>
                     </NavMenuItem>
 
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/tags">
+                        <NavMenuItem.Link to="tags">
                             <LucideIcon.Tag />
                             <NavMenuItem.Label>Tags</NavMenuItem.Label>
                         </NavMenuItem.Link>
                     </NavMenuItem>
 
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/members" activeOnSubpath>
+                        <NavMenuItem.Link to="members" activeOnSubpath>
                             <LucideIcon.Users />
                             <NavMenuItem.Label>Members</NavMenuItem.Label>
                         </NavMenuItem.Link>

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -27,7 +27,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             aria-label="Toggle post views"
                             variant="ghost"
                             size="icon"
-                            className="!h-[34px] absolute opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
+                            className="!h-[34px] absolute sidebar:opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
                             onClick={() =>
                                 setPostsExpanded(!postsExpanded)
                             }
@@ -38,7 +38,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             />
                         </Button>
                         <NavMenuItem.Link href="#/posts">
-                            <LucideIcon.PenLine className="group-hover/menu-item:opacity-0 pointer-events-none transition-all" />
+                            <LucideIcon.PenLine className="opacity-0 sidebar:opacity-100 sidebar:group-hover/menu-item:opacity-0 pointer-events-none transition-all" />
                             <NavMenuItem.Label>Posts</NavMenuItem.Label>
                         </NavMenuItem.Link>
                         <a href="#/editor/post"

--- a/apps/admin/src/layout/app-sidebar/NavFooter.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavFooter.tsx
@@ -1,41 +1,16 @@
 import React from "react"
 
 import {
-    LucideIcon,
     SidebarFooter,
     SidebarGroup,
-    SidebarGroupContent,
     SidebarMenu,
     SidebarMenuItem
 } from "@tryghost/shade"
 import UserMenu from "./UserMenu";
-import { NavMenuItem } from "./NavMenuItem";
 
 function NavFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
     return (
         <SidebarFooter {...props}>
-            <SidebarGroup>
-                <SidebarGroupContent>
-                    <SidebarMenu>
-                        <NavMenuItem>
-                            <NavMenuItem.Link href="#/settings">
-                                <LucideIcon.Settings />
-                                <NavMenuItem.Label>Settings</NavMenuItem.Label>
-                            </NavMenuItem.Link>
-                        </NavMenuItem>
-
-                        <NavMenuItem>
-                            <NavMenuItem.Link
-                                href="https://ghost.org/help?utm_source=admin&utm_campaign=help"
-                                target="_blank"
-                            >
-                                <LucideIcon.HelpCircle />
-                                <NavMenuItem.Label>Help</NavMenuItem.Label>
-                            </NavMenuItem.Link>
-                        </NavMenuItem>
-                    </SidebarMenu>
-                </SidebarGroupContent>
-            </SidebarGroup>
             <SidebarGroup>
                 <SidebarMenu>
                     <SidebarMenuItem>

--- a/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
@@ -14,7 +14,7 @@ function NavGhostPro({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
             <SidebarGroupContent>
                 <SidebarMenu>
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/billing">
+                        <NavMenuItem.Link to="billing">
                             <LucideIcon.CreditCard />
                             <NavMenuItem.Label>Ghost(Pro)</NavMenuItem.Label>
                         </NavMenuItem.Link>

--- a/apps/admin/src/layout/app-sidebar/NavMain.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMain.tsx
@@ -19,19 +19,19 @@ function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
             <SidebarGroupContent>
                 <SidebarMenu>
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/analytics" activeOnSubpath>
+                        <NavMenuItem.Link to="analytics" activeOnSubpath>
                             <LucideIcon.TrendingUp />
                             <NavMenuItem.Label>Analytics</NavMenuItem.Label>
                         </NavMenuItem.Link>
                     </NavMenuItem>
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/network">
+                        <NavMenuItem.Link to="network">
                             <NetworkIcon />
                             <NavMenuItem.Label>Network</NavMenuItem.Label>
                         </NavMenuItem.Link>
                     </NavMenuItem>
                     <NavMenuItem className="relative group/viewsite">
-                        <NavMenuItem.Link href="#/site">
+                        <NavMenuItem.Link to="site">
                             <LucideIcon.AppWindow />
                             <NavMenuItem.Label>View site</NavMenuItem.Label>
                         </NavMenuItem.Link>

--- a/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {
     SidebarMenuButton,
-    SidebarMenuItem
+    SidebarMenuItem,
+    useSidebar
 } from '@tryghost/shade';
 import { useIsActiveLink } from './useIsActiveLink';
 
@@ -28,6 +29,13 @@ function NavMenuLink({
     ...props
 }: NavMenuLinkProps) {
     const isActive = useIsActiveLink({ href, activeOnSubpath });
+    const { isMobile, setOpenMobile } = useSidebar();
+
+    const handleClick = () => {
+        if (isMobile) {
+            setOpenMobile(false);
+        }
+    };
 
     return (
         <SidebarMenuButton
@@ -39,6 +47,7 @@ function NavMenuLink({
                 rel={target === '_blank' ? rel ?? 'noopener noreferrer' : rel}
                 target={target}
                 aria-current={isActive ? 'page' : undefined}
+                onClick={handleClick}
             >
                 {children}
             </a>

--- a/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
@@ -3,8 +3,7 @@ import {
     SidebarMenuButton,
     SidebarMenuItem
 } from '@tryghost/shade';
-import {useLocation} from 'react-router';
-import { useBaseRoute } from '@tryghost/admin-x-framework';
+import { useIsActiveLink } from './useIsActiveLink';
 
 function NavMenuItem({ children, ...props }: React.ComponentProps<typeof SidebarMenuItem>) {
     return (
@@ -28,27 +27,7 @@ function NavMenuLink({
     children,
     ...props
 }: NavMenuLinkProps) {
-    const location = useLocation();
-    const currentBaseRoute = useBaseRoute();
-
-    // Normalize href: strip leading hash and any trailing fragment
-    const normalizedHref = href?.startsWith('#') ? href.slice(1) : href;
-    const hrefNoHash = normalizedHref?.split('#')[0];
-
-    // Extract path (keep optional query for exact match mode)
-    const [linkPath = ''] = (hrefNoHash ?? '').split('?');
-    const linkBaseRoute = linkPath.split('/')[1] ?? '';
-
-    let isActive = false;
-
-    if (activeOnSubpath) {
-        // Match by first segment only; ignore query and deeper segments
-        isActive = !!linkBaseRoute && currentBaseRoute === linkBaseRoute;
-    } else if (hrefNoHash) {
-        // Exact path + query match
-        const currentFull = `${location.pathname}${location.search}`;
-        isActive = currentFull === hrefNoHash;
-    }
+    const isActive = useIsActiveLink({ href, activeOnSubpath });
 
     return (
         <SidebarMenuButton

--- a/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
@@ -15,20 +15,21 @@ function NavMenuItem({ children, ...props }: React.ComponentProps<typeof Sidebar
 }
 
 type NavMenuLinkProps = React.ComponentProps<typeof SidebarMenuButton> & {
-    href?: string
+    to?: string
     target?: string
     rel?: string
     activeOnSubpath?: boolean
 };
 function NavMenuLink({
-    href,
+    to,
     target,
     rel,
     activeOnSubpath = false,
     children,
     ...props
 }: NavMenuLinkProps) {
-    const isActive = useIsActiveLink({ href, activeOnSubpath });
+    const href = `#/${to}`;
+    const isActive = useIsActiveLink({ path: to, activeOnSubpath });
     const { isMobile, setOpenMobile } = useSidebar();
 
     const handleClick = () => {

--- a/apps/admin/src/layout/app-sidebar/NavSettings.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSettings.tsx
@@ -14,7 +14,7 @@ function NavSettings({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
             <SidebarGroupContent>
                 <SidebarMenu>
                     <NavMenuItem>
-                        <NavMenuItem.Link href="#/settings">
+                        <NavMenuItem.Link to="settings">
                             <LucideIcon.Settings />
                             <NavMenuItem.Label>Settings</NavMenuItem.Label>
                         </NavMenuItem.Link>
@@ -22,7 +22,7 @@ function NavSettings({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
 
                     <NavMenuItem>
                         <NavMenuItem.Link
-                            href="https://ghost.org/help?utm_source=admin&utm_campaign=help"
+                            to="https://ghost.org/help?utm_source=admin&utm_campaign=help"
                             target="_blank"
                             rel="noopener noreferrer"
                         >

--- a/apps/admin/src/layout/app-sidebar/NavSettings.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSettings.tsx
@@ -24,6 +24,7 @@ function NavSettings({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                         <NavMenuItem.Link
                             href="https://ghost.org/help?utm_source=admin&utm_campaign=help"
                             target="_blank"
+                            rel="noopener noreferrer"
                         >
                             <LucideIcon.HelpCircle />
                             <NavMenuItem.Label>Help</NavMenuItem.Label>

--- a/apps/admin/src/layout/app-sidebar/NavSettings.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSettings.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+
+import {
+    LucideIcon,
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarMenu
+} from "@tryghost/shade"
+import { NavMenuItem } from "./NavMenuItem";
+
+function NavSettings({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
+    return (
+        <SidebarGroup {...props}>
+            <SidebarGroupContent>
+                <SidebarMenu>
+                    <NavMenuItem>
+                        <NavMenuItem.Link href="#/settings">
+                            <LucideIcon.Settings />
+                            <NavMenuItem.Label>Settings</NavMenuItem.Label>
+                        </NavMenuItem.Link>
+                    </NavMenuItem>
+
+                    <NavMenuItem>
+                        <NavMenuItem.Link
+                            href="https://ghost.org/help?utm_source=admin&utm_campaign=help"
+                            target="_blank"
+                        >
+                            <LucideIcon.HelpCircle />
+                            <NavMenuItem.Label>Help</NavMenuItem.Label>
+                        </NavMenuItem.Link>
+                    </NavMenuItem>
+                </SidebarMenu>
+            </SidebarGroupContent>
+        </SidebarGroup>
+    );
+}
+
+export default NavSettings;

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -44,7 +44,7 @@ function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
             <DropdownMenuContent
                 align="end"
                 sideOffset={10}
-                className="min-w-[260px]"
+                className="w-full min-w-[240px] sidebar:min-w-[260px]"
             >
                 <div className="p-3">
                     <div className="flex items-center gap-3">

--- a/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
+++ b/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
@@ -1,5 +1,4 @@
-import { useLocation } from 'react-router';
-import { useBaseRoute } from '@tryghost/admin-x-framework';
+import { matchPath, useLocation } from "@tryghost/admin-x-framework";
 
 interface UseIsActiveLinkOptions {
     href?: string;
@@ -8,26 +7,30 @@ interface UseIsActiveLinkOptions {
 
 export function useIsActiveLink({ href, activeOnSubpath = false }: UseIsActiveLinkOptions): boolean {
     const location = useLocation();
-    const currentBaseRoute = useBaseRoute();
+
+    if (!href) {
+        return false;
+    }
 
     // Normalize href: strip leading hash and any trailing fragment
-    const normalizedHref = href?.startsWith('#') ? href.slice(1) : href;
-    const hrefNoHash = normalizedHref?.split('#')[0];
-
-    // Extract path (keep optional query for exact match mode)
-    const [linkPath = ''] = (hrefNoHash ?? '').split('?');
-    const linkBaseRoute = linkPath.split('/')[1] ?? '';
-
-    let isActive = false;
+    const normalizedHref = href.startsWith('#') ? href.slice(1) : href;
+    const [pathWithQuery] = normalizedHref.split('#');
 
     if (activeOnSubpath) {
         // Match by first segment only; ignore query and deeper segments
-        isActive = !!linkBaseRoute && currentBaseRoute === linkBaseRoute;
-    } else if (hrefNoHash) {
+        const [linkPath] = pathWithQuery.split('?');
+        const linkBaseRoute = linkPath.split('/')[1];
+
+        if (!linkBaseRoute) {
+            return false;
+        }
+
+        // Use matchPath to check if current location starts with this base route
+        const pattern = `/${linkBaseRoute}/*`;
+        return matchPath(pattern, location.pathname) !== null;
+    } else {
         // Exact path + query match
         const currentFull = `${location.pathname}${location.search}`;
-        isActive = currentFull === hrefNoHash;
+        return currentFull === pathWithQuery;
     }
-
-    return isActive;
 }

--- a/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
+++ b/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
@@ -1,0 +1,33 @@
+import { useLocation } from 'react-router';
+import { useBaseRoute } from '@tryghost/admin-x-framework';
+
+interface UseIsActiveLinkOptions {
+    href?: string;
+    activeOnSubpath?: boolean;
+}
+
+export function useIsActiveLink({ href, activeOnSubpath = false }: UseIsActiveLinkOptions): boolean {
+    const location = useLocation();
+    const currentBaseRoute = useBaseRoute();
+
+    // Normalize href: strip leading hash and any trailing fragment
+    const normalizedHref = href?.startsWith('#') ? href.slice(1) : href;
+    const hrefNoHash = normalizedHref?.split('#')[0];
+
+    // Extract path (keep optional query for exact match mode)
+    const [linkPath = ''] = (hrefNoHash ?? '').split('?');
+    const linkBaseRoute = linkPath.split('/')[1] ?? '';
+
+    let isActive = false;
+
+    if (activeOnSubpath) {
+        // Match by first segment only; ignore query and deeper segments
+        isActive = !!linkBaseRoute && currentBaseRoute === linkBaseRoute;
+    } else if (hrefNoHash) {
+        // Exact path + query match
+        const currentFull = `${location.pathname}${location.search}`;
+        isActive = currentFull === hrefNoHash;
+    }
+
+    return isActive;
+}

--- a/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
+++ b/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
@@ -15,18 +15,11 @@ export function useIsActiveLink({ href, activeOnSubpath = false }: UseIsActiveLi
     // Normalize href: strip leading hash and any trailing fragment
     const normalizedHref = href.startsWith('#') ? href.slice(1) : href;
     const [pathWithQuery] = normalizedHref.split('#');
+    const [linkPath] = pathWithQuery.split('?');
 
     if (activeOnSubpath) {
-        // Match by first segment only; ignore query and deeper segments
-        const [linkPath] = pathWithQuery.split('?');
-        const linkBaseRoute = linkPath.split('/')[1];
-
-        if (!linkBaseRoute) {
-            return false;
-        }
-
-        // Use matchPath to check if current location starts with this base route
-        const pattern = `/${linkBaseRoute}/*`;
+        // Match any subpath under this route using wildcard pattern
+        const pattern = `${linkPath}/*`;
         return matchPath(pattern, location.pathname) !== null;
     } else {
         // Exact path + query match

--- a/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
+++ b/apps/admin/src/layout/app-sidebar/useIsActiveLink.ts
@@ -1,29 +1,13 @@
-import { matchPath, useLocation } from "@tryghost/admin-x-framework";
+import { useMatch } from "@tryghost/admin-x-framework";
 
 interface UseIsActiveLinkOptions {
-    href?: string;
+    path?: string;
     activeOnSubpath?: boolean;
 }
 
-export function useIsActiveLink({ href, activeOnSubpath = false }: UseIsActiveLinkOptions): boolean {
-    const location = useLocation();
+export function useIsActiveLink({ path, activeOnSubpath = false }: UseIsActiveLinkOptions): boolean {
+    const pattern = activeOnSubpath && path ? `${path}/*` : path;
+    const match = useMatch(pattern || '');
 
-    if (!href) {
-        return false;
-    }
-
-    // Normalize href: strip leading hash and any trailing fragment
-    const normalizedHref = href.startsWith('#') ? href.slice(1) : href;
-    const [pathWithQuery] = normalizedHref.split('#');
-    const [linkPath] = pathWithQuery.split('?');
-
-    if (activeOnSubpath) {
-        // Match any subpath under this route using wildcard pattern
-        const pattern = `${linkPath}/*`;
-        return matchPath(pattern, location.pathname) !== null;
-    } else {
-        // Exact path + query match
-        const currentFull = `${location.pathname}${location.search}`;
-        return currentFull === pathWithQuery;
-    }
+    return match !== null;
 }

--- a/apps/posts/src/App.tsx
+++ b/apps/posts/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
             <PostsAppContextProvider value={appContextValue}>
                 <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                     <PostsErrorBoundary>
-                        <ShadeApp className="shade-posts" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
+                        <ShadeApp className="shade-posts app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
                             <Outlet />
                         </ShadeApp>
                     </PostsErrorBoundary>

--- a/apps/posts/src/components/layout/MainLayout.tsx
+++ b/apps/posts/src/components/layout/MainLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
-        <div className='h-screen w-full overflow-y-scroll'>
+        <div className='h-[calc(100svh-var(--mobile-navbar-height))] w-full overflow-y-scroll sidebar:h-screen'>
             <div className='relative mx-auto flex h-screen max-w-page flex-col' {...props}>
                 {children}
             </div>

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -20,7 +20,7 @@ import {
 const SIDEBAR_COOKIE_NAME = 'sidebar:state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '30rem';
-const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH_MOBILE = '28rem';
 const SIDEBAR_WIDTH_ICON = '4rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 const SIDEBAR_MENU_HEIGHT = '[34px]';

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -261,7 +261,7 @@ Sidebar.displayName = 'Sidebar';
 const SidebarTrigger = React.forwardRef<
     React.ElementRef<typeof Button>,
     React.ComponentProps<typeof Button>
->(({className, onClick, ...props}, ref) => {
+>(({children, className, onClick, ...props}, ref) => {
     const {toggleSidebar} = useSidebar();
 
     return (
@@ -277,8 +277,13 @@ const SidebarTrigger = React.forwardRef<
             }}
             {...props}
         >
-            <PanelLeft />
-            <span className="sr-only">Toggle Sidebar</span>
+            {
+                children ||
+                <>
+                    <PanelLeft />
+                    <span className="sr-only">Toggle Sidebar</span>
+                </>
+            }
         </Button>
     );
 });

--- a/apps/shade/src/hooks/use-mobile.tsx
+++ b/apps/shade/src/hooks/use-mobile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT = 801;
 
 export function useIsMobile() {
     const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);

--- a/apps/shade/src/hooks/use-mobile.tsx
+++ b/apps/shade/src/hooks/use-mobile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 800;
+const MOBILE_BREAKPOINT = 801;
 
 export function useIsMobile() {
     const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);

--- a/apps/shade/src/hooks/use-mobile.tsx
+++ b/apps/shade/src/hooks/use-mobile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 801;
+const MOBILE_BREAKPOINT = 800;
 
 export function useIsMobile() {
     const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -156,10 +156,6 @@
     body.ember-application .shade {
         height: calc(100vh - var(--mobile-navbar-height));
     }
-
-    body:not(.ember-application) .shade {
-        padding-bottom: var(--mobile-navbar-height);
-    }
 }
 
 .dark .shade {

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -145,7 +145,9 @@
     -moz-osx-font-smoothing: grayscale;
     -webkit-text-size-adjust: 100%;
     letter-spacing: unset;
+}
 
+.shade.app-container {
     height: 100vh;
     width: 100%;
     overflow-x: hidden;

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -151,9 +151,9 @@
     overflow-y: auto;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 768px) {
     .shade {
-        height: calc(100vh - 55px);
+        height: calc(100vh - 64px);
     }
 }
 

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -151,7 +151,7 @@
     overflow-y: auto;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 800px) {
     .shade {
         height: calc(100vh - 64px);
     }

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -73,6 +73,7 @@
         --sidebar-accent-foreground: 216 11% 9%;
         --sidebar-border: 200 12% 96%;
         --sidebar-ring: 215 13% 63%;
+        --mobile-navbar-height: 64px;
     }
 
     .dark {
@@ -152,8 +153,12 @@
 }
 
 @media (max-width: 800px) {
-    .shade {
-        height: calc(100vh - 64px);
+    body.ember-application .shade {
+        height: calc(100vh - var(--mobile-navbar-height));
+    }
+
+    body:not(.ember-application) .shade {
+        padding-bottom: var(--mobile-navbar-height);
     }
 }
 

--- a/apps/shade/tailwind.config.cjs
+++ b/apps/shade/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         screens: {
             sm: '480px',
             md: '640px',
-            sidebar: '800px',
+            sidebar: '768px',
             lg: '1024px',
             sidebarlg: '1240px',
             xl: '1320px',

--- a/apps/shade/tailwind.config.cjs
+++ b/apps/shade/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         screens: {
             sm: '480px',
             md: '640px',
-            sidebar: '768px',
+            sidebar: '800px',
             lg: '1024px',
             sidebarlg: '1240px',
             xl: '1320px',

--- a/apps/stats/src/App.tsx
+++ b/apps/stats/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC<BaseAppProps> = ({framework, designSystem, appSettings}) => 
                 <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
                     <StatsErrorBoundary>
                         <GlobalDataProvider>
-                            <ShadeApp className="shade-stats" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
+                            <ShadeApp className="shade-stats app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
                                 <Outlet />
                             </ShadeApp>
                         </GlobalDataProvider>

--- a/apps/stats/src/components/layout/MainLayout.tsx
+++ b/apps/stats/src/components/layout/MainLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
-        <div className='h-screen w-full overflow-y-scroll'>
+        <div className='h-[calc(100svh-var(--mobile-navbar-height))] w-full overflow-y-scroll sidebar:h-screen'>
             <div className='relative h-screen w-full' {...props}>
                 <div className='mx-auto flex size-full max-w-page flex-col'>
                     {children}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- Mobile bottom navigation bar and handling responsive sizes for the new React sidebar was completely missing. This PR introduces standard ShadCN sidebar for mobile and a custom mobile navigation bar, similar to the one in Ember.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a mobile bottom navigation and responsive sidebar for Admin, refactors nav links to use route-aware matching, and adjusts Shade mobile behavior and container heights.
> 
> - **Admin UI (Sidebar & Layout)**
>   - Add `MobileNavBar` and include it in `AdminLayout` footer.
>   - Refactor sidebar into `AppSidebarHeader`, `AppSidebarContent`, `AppSidebarFooter`; move settings/help into new `NavSettings`.
>   - Update nav items to use `to` props and route-aware active state via `useIsActiveLink` (uses `useMatch`).
>   - Improve mobile UX: auto-close sidebar on link click; tweak icon visibility and user menu sizing.
> - **Routing/Framework**
>   - Export `matchPath` and `useMatch` from `react-router` via `admin-x-framework` index for consumers.
> - **Shade (design system)**
>   - Increase mobile sidebar width to `28rem`; make `SidebarTrigger` accept custom children.
>   - Raise mobile breakpoint to 801px via `useIsMobile`.
>   - Add `--mobile-navbar-height` and `.shade.app-container`; adjust mobile heights for Ember host.
> - **Apps (Posts/Stats)**
>   - Apply `.app-container` to `ShadeApp` and adjust `MainLayout` heights to `calc(100svh - var(--mobile-navbar-height))` with desktop override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2d9ba39c0d598ba178d7fca6ba2461f866235b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->