### PR TITLE
Added eslint-plugin-playwright linting to e2e package

### DIFF
--- a/e2e/.eslintrc.js
+++ b/e2e/.eslintrc.js
@@ -2,10 +2,10 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: [
         'ghost',
-        'eslint-plugin-playwright'
+        'playwright'
     ],
     extends: [
-        'plugin:ghost/ts',
+        'plugin:ghost/ts'
     ],
     ignorePatterns: ['build/'],
     rules: {

--- a/e2e/.eslintrc.js
+++ b/e2e/.eslintrc.js
@@ -1,8 +1,11 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    plugins: ['ghost'],
+    plugins: [
+        'ghost',
+        'eslint-plugin-playwright'
+    ],
     extends: [
-        'plugin:ghost/ts'
+        'plugin:ghost/ts',
     ],
     ignorePatterns: ['build/'],
     rules: {
@@ -10,5 +13,11 @@ module.exports = {
         'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
             memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
         }]
-    }
+    },
+    overrides: [
+        {
+            files: ['tests/**', 'helpers/playwright/**', 'helpers/pages/**'],
+            extends: ['plugin:playwright/recommended']
+        }
+    ]
 };

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -24,16 +24,17 @@
   "devDependencies": {
     "@faker-js/faker": "8.4.1",
     "@playwright/test": "1.55.1",
+    "@tryghost/debug": "0.1.35",
+    "@tryghost/logging": "2.4.23",
+    "@types/dockerode": "3.3.44",
     "c8": "10.1.3",
     "dockerode": "4.0.9",
     "dotenv": "16.6.1",
+    "eslint-plugin-playwright": "2.3.0",
     "knex": "3.1.0",
     "mysql2": "3.15.2",
     "ts-node": "10.9.2",
-    "typescript": "5.8.3",
-    "@tryghost/logging": "2.4.23",
-    "@tryghost/debug": "0.1.35",
-    "@types/dockerode": "3.3.44"
+    "typescript": "5.8.3"
   },
   "dependencies": {}
 }

--- a/e2e/tests/.eslintrc.js
+++ b/e2e/tests/.eslintrc.js
@@ -5,7 +5,28 @@ module.exports = {
         'plugin:ghost/ts-test'
     ],
     rules: {
-        'no-console': 'off'
+        // Disable all mocha rules from ghost plugin since this package uses playwright instead
+        'ghost/mocha/no-exclusive-tests': 'off',
+        'ghost/mocha/no-pending-tests': 'off',
+        'ghost/mocha/no-skipped-tests': 'off',
+        'ghost/mocha/handle-done-callback': 'off',
+        'ghost/mocha/no-synchronous-tests': 'off',
+        'ghost/mocha/no-global-tests': 'off',
+        'ghost/mocha/no-return-and-callback': 'off',
+        'ghost/mocha/no-return-from-async': 'off',
+        'ghost/mocha/valid-test-description': 'off',
+        'ghost/mocha/valid-suite-description': 'off',
+        'ghost/mocha/no-mocha-arrows': 'off',
+        'ghost/mocha/no-hooks': 'off',
+        'ghost/mocha/no-hooks-for-single-case': 'off',
+        'ghost/mocha/no-sibling-hooks': 'off',
+        'ghost/mocha/no-top-level-hooks': 'off',
+        'ghost/mocha/no-identical-title': 'off',
+        'ghost/mocha/max-top-level-suites': 'off',
+        'ghost/mocha/no-nested-tests': 'off',
+        'ghost/mocha/no-setup-in-describe': 'off',
+        'ghost/mocha/prefer-arrow-callback': 'off',
+        'ghost/mocha/no-async-describe': 'off'
     },
     overrides: [
         {
@@ -18,4 +39,3 @@ module.exports = {
         }
     ]
 };
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -18447,6 +18447,13 @@ eslint-plugin-n@16.2.0:
     resolve "^1.22.2"
     semver "^7.5.3"
 
+eslint-plugin-playwright@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-2.3.0.tgz#e14dfe981455254bbf5a7299802f5c01bb93d148"
+  integrity sha512-7UeUuIb5SZrNkrUGb2F+iwHM97kn33/huajcVtAaQFCSMUYGNFvjzRPil5C0OIppslPfuOV68M/zsisXx+/ZvQ==
+  dependencies:
+    globals "^16.4.0"
+
 eslint-plugin-react-hooks@4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
@@ -20383,6 +20390,11 @@ globals@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
+
+globals@^16.4.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-16.5.0.tgz#ccf1594a437b97653b2be13ed4d8f5c9f850cac1"
+  integrity sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==
 
 globals@^9.18.0:
   version "9.18.0"


### PR DESCRIPTION
no issue

This PR does two things in the e2e package:
- Installs and enables `eslint-plugin-playwright` for our e2e test suite using the recommended configuration
- Disables mocha rules from the main ghost eslint plugin in the e2e package, which just create noise currently

Note: If you run `yarn lint` in the e2e package in this PR, you'll see a bunch of warnings. I'd like to tackle some of these in follow up PRs, and potentially change a few rules from "warn" to "error" for the more impactful ones.