### PR TITLE
Bumped ActivityPub version

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump @tryghost/activitypub package version from 1.0.24 to 1.0.25.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 202134d97706f1c4416338242ada91e838427cc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->