### PR TITLE
Add prettier config and root level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "nx": "20.8.0",
     "patch-package": "8.0.1",
     "postinstall-postinstall": "2.1.0",
+    "prettier": "3.6.2",
     "rimraf": "5.0.10",
     "typescript": "5.8.3"
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,17 @@
+/**
+ * This Prettier config has been adapted to match the formatting imposed by
+ * ESLint. There might still be some minor formatting differences, so ensure
+ * you're running Prettier first and then ESLint after. 
+ *
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+module.exports = {
+    trailingComma: 'none',
+    tabWidth: 4,
+    semi: true,
+    singleQuote: true,
+    printWidth: 120,
+    bracketSpacing: false,
+    arrowParens: 'avoid'
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -28170,6 +28170,11 @@ pretender@3.4.7, pretender@^3.4.7:
     fake-xml-http-request "^2.1.2"
     route-recognizer "^0.3.3"
 
+prettier@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
+
 prettier@^2.8.0:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
Adding a prettier config and a pinned dependency will allow use of editor formatting features that rely on prettier without offending ESLint as badly.

I've tried to adapt the Prettier config to the formatting imposed by ESLint. There might still be some subtle differences. Running Prettier first and ESLint second helps with resolving those. 