### PR TITLE
Hide Ember sidebar and disable React apps that have been migrated

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -14,11 +14,14 @@ function App() {
             {currentUser ?
                 <AdminLayout>
                     <Outlet />
+                    <EmberRoot />
                 </AdminLayout>
                 :
-                <EmberFallback />
+                <>
+                    <EmberFallback />
+                    <EmberRoot />
+                </>
             }
-            <EmberRoot />
         </EmberProvider>
     );
 }

--- a/apps/admin/src/ember-bridge/EmberRoot.tsx
+++ b/apps/admin/src/ember-bridge/EmberRoot.tsx
@@ -24,5 +24,5 @@ export const EmberRoot = React.memo(function EmberRoot() {
         };
     }, []);
 
-    return <div ref={ref} hidden={!isFallbackPresent}></div>;
+    return <div ref={ref} hidden={!isFallbackPresent} className="w-full h-screen overflow-auto"></div>;
 });

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,5 +1,12 @@
 @import "@tryghost/shade/styles.css";
 
+/* Hide the nav menu and tab bar on mobile when running in React admin shell */
+body:not(.ember-application) #ember-app .gh-nav,
+body:not(.ember-application) #ember-app .gh-mobile-nav-bar {
+    display: none;
+}
+
+
 /* Temporary overrides until Ember transition is finished */
 body:not(.ember-application) .gh-canvas-header {
     padding-top: 24px;

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,11 +1,21 @@
 @import "@tryghost/shade/styles.css";
 
+/* Ensure the Ember app renders in the correct position */
+body:not(.ember-application) #ember-app {
+    width: 100%;
+    height: 100%;
+}
+
+body:not(.ember-application) #ember-app .gh-app {
+    position: static;
+}
+
+
 /* Hide the nav menu and tab bar on mobile when running in React admin shell */
 body:not(.ember-application) #ember-app .gh-nav,
 body:not(.ember-application) #ember-app .gh-mobile-nav-bar {
     display: none;
 }
-
 
 /* Temporary overrides until Ember transition is finished */
 body:not(.ember-application) .gh-canvas-header {

--- a/apps/shade/src/providers/ShadeProvider.tsx
+++ b/apps/shade/src/providers/ShadeProvider.tsx
@@ -40,7 +40,7 @@ const ToasterPortal = () => {
 
     return mounted
         ? createPortal(
-            <div className={SHADE_APP_NAMESPACES}>
+            <div className={SHADE_APP_NAMESPACES} style={{width: 'unset', height: 'unset'}}>
                 <Toaster
                     icons={{
                         error: <Icon.ErrorFill className='text-red' />,

--- a/ghost/admin/app/templates/activitypub-x.hbs
+++ b/ghost/admin/app/templates/activitypub-x.hbs
@@ -1,1 +1,4 @@
-<AdminX::Activitypub />
+{{! ActivityPub has been migrated to the new React admin shell }}
+{{#unless (feature "inAdminForward")}}
+    <AdminX::Activitypub />
+{{/unless}}

--- a/ghost/admin/app/templates/posts-x.hbs
+++ b/ghost/admin/app/templates/posts-x.hbs
@@ -1,1 +1,4 @@
-<AdminX::Posts />
+{{! Posts has been migrated to the new React admin shell }}
+{{#unless (feature "inAdminForward")}}
+    <AdminX::Posts />
+{{/unless}}

--- a/ghost/admin/app/templates/stats-x.hbs
+++ b/ghost/admin/app/templates/stats-x.hbs
@@ -1,1 +1,4 @@
-<AdminX::Stats />
+{{! Stats has been migrated to the new React admin shell }}
+{{#unless (feature "inAdminForward")}}
+    <AdminX::Stats />
+{{/unless}}

--- a/ghost/admin/app/templates/tags.hbs
+++ b/ghost/admin/app/templates/tags.hbs
@@ -1,2 +1,5 @@
 {{! Tags screens lives inside the Posts React app }}
-<AdminX::Posts />
+{{! Posts has been migrated to the new React admin shell }}
+{{#unless (feature "inAdminForward")}}
+    <AdminX::Posts />
+{{/unless}}


### PR DESCRIPTION
**Do not load migrated React apps within Ember** 
Prevents stats, activitypub and posts apps from mounting in Ember when running inside the React admin shell using the `feature.inAdminForward` flag.

**Hide Ember sidebar and bottom nav bar** 
Initially, I used the `inAdminForward` feature flag to completely prevent these views from rendering, but we are reliant on the sidebar being mounted to e.g. handle admin search.

**Render Ember app within sidebar container**
The Ember root was rendered outside of the sidebar container. Some additional CSS overrides are also needed to ensure the layout is respected.