### PR TITLE
Made the topics buttons a bit larger in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -49,7 +49,7 @@ const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange}) 
                 {TOPICS.map(({value, label}) => (
                     <Button
                         key={value}
-                        className="h-6 snap-start rounded-full px-2.5 text-xs"
+                        className="h-8 snap-start rounded-full px-3.5 text-sm"
                         variant={currentTopic === value ? 'default' : 'secondary'}
                         onClick={() => onTopicChange(value)}
                     >

--- a/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx
@@ -56,7 +56,7 @@ const Sidebar: React.FC<SidebarProps> = ({isMobileSidebarOpen}) => {
                             </DialogContent>
                         </Dialog>
                     </div>
-                    <div className='-mt-1 flex w-full flex-col gap-px'>
+                    <div className='flex w-full flex-col gap-px'>
                         <SidebarMenuLink to='/reader'>
                             <LucideIcon.BookOpen size={18} strokeWidth={1.5} />
                             Reader


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2962/finalise-design-for-topic-based-feeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase TopicFilter button size, remove negative margin on the Sidebar menu container, and bump the package version.
> 
> - **UI**:
>   - **TopicFilter**: Increase button size (`h-8 px-3.5 text-sm` from `h-6 px-2.5 text-xs`) in `apps/activitypub/src/components/TopicFilter.tsx`.
>   - **Sidebar**: Remove negative top margin (`-mt-1`) from the menu container in `apps/activitypub/src/components/layout/Sidebar/Sidebar.tsx`.
> - **Package**:
>   - Bump `@tryghost/activitypub` version to `1.0.26` in `apps/activitypub/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17238180257d4b4fb7fffb2b46b86a4c5dde1b43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->