### PR TITLE
Added typecheck script and TypeScript configuration improvements

### DIFF
--- a/apps/activitypub/.gitignore
+++ b/apps/activitypub/.gitignore
@@ -1,3 +1,4 @@
 dist
+types
 playwright-report
 test-results

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "typecheck": "tsc -b"
   },
   "dependencies": {
     "@tryghost/activitypub": "*",

--- a/apps/admin/tsconfig.app.json
+++ b/apps/admin/tsconfig.app.json
@@ -15,6 +15,13 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@test-utils/*": ["./test-utils/*"],
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -23,7 +30,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
+  "include": ["src", "test-utils"],
   "references": [
     { "path": "../posts/tsconfig.declaration.json" },
     { "path": "../stats/tsconfig.declaration.json" },

--- a/apps/posts/.gitignore
+++ b/apps/posts/.gitignore
@@ -1,3 +1,4 @@
 dist
+types
 playwright-report
 test-results

--- a/apps/stats/.gitignore
+++ b/apps/stats/.gitignore
@@ -1,3 +1,4 @@
 dist
+types
 playwright-report
 test-results


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2610

## Why are we making this change?

We wanted to add an independent `typecheck` script to validate TypeScript types in the `apps/admin` package and all new React code being added as part of the Ember → React migration.

### The Problem
Initially, we attempted to use `tsc --noEmit` for type checking, but this doesn't work with TypeScript project references. The `apps/admin` package uses project references (composite TypeScript configuration) to depend on other packages:
- `apps/admin-x-framework`
- `apps/posts`
- `apps/stats`
- `apps/activitypub`

With project references, TypeScript needs to emit `.d.ts` declaration files from referenced projects so the consuming project can type-check against them. This means we must use `tsc -b` (build mode) instead of `tsc --noEmit`.

### The Side Effect
When running `tsc -b`, TypeScript builds all the referenced dependencies and generates their declaration files into `types/` directories (as configured in each package's `tsconfig.declaration.json`). These generated files were appearing as untracked in git.

We found an established pattern in the codebase where packages like `admin-x-framework`, `admin-x-design-system`, and `shade` already have `types/` in their `.gitignore`. This PR extends that pattern to the remaining dependencies.

## What does this PR do?

1. **Adds `.gitignore` entries** for generated `types/` directories in:
   - `apps/activitypub`
   - `apps/posts`
   - `apps/stats`

2. **Adds `typecheck` npm script** to `apps/admin/package.json`:
   ```json
   "typecheck": "tsc -b"
   ```

3. **Configures TypeScript path aliases** in `apps/admin/tsconfig.app.json`:
   - `@/*` → `./src/*`
   - `@test-utils/*` → `./test-utils/*`
   
4. **Updates TypeScript includes** to include the `test-utils` directory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `typecheck` script, configures TS path aliases and includes in admin, and ignores generated `types/` in related apps.
> 
> - **TypeScript & Build**:
>   - Add `typecheck` script (`tsc -b`) in `apps/admin/package.json`.
>   - Configure TS path aliases in `apps/admin/tsconfig.app.json` (`@/*`, `@test-utils/*`), include `test-utils`, and add reference to `../admin-x-framework/tsconfig.declaration.json`.
> - **Repo hygiene**:
>   - Ignore generated `types/` in `.gitignore` for `apps/activitypub`, `apps/posts`, and `apps/stats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d498b15cb20da259e0161712748f720e5570f5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->