### PR TITLE
Added ESLint rule to enforce path aliases over relative imports

### DIFF
--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
+import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths'
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -15,6 +16,9 @@ export default tseslint.config([
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
+    plugins: {
+      'no-relative-import-paths': noRelativeImportPaths,
+    },
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -22,6 +26,28 @@ export default tseslint.config([
       },
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  // Apply no-relative-import-paths rule for src files (auto-fix supported)
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'error',
+        { allowSameFolder: true, rootDir: 'src', prefix: '@' },
+      ],
+    },
+  },
+  // Apply no-relative-import-paths rule for test-utils files
+  // Note: auto-fix may produce incorrect paths for cross-directory imports
+  // Use the correct alias manually: @/* for src/, @test-utils/* for test-utils/
+  {
+    files: ['test-utils/**/*.{ts,tsx}'],
+    rules: {
+      'no-relative-import-paths/no-relative-import-paths': [
+        'error',
+        { allowSameFolder: true },
+      ],
     },
   },
 ])

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "18.3.7",
     "@vitejs/plugin-react-swc": "4.1.0",
     "eslint": "9.37.0",
+    "eslint-plugin-no-relative-import-paths": "^1.6.1",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.24",
     "globals": "16.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18447,6 +18447,11 @@ eslint-plugin-n@16.2.0:
     resolve "^1.22.2"
     semver "^7.5.3"
 
+eslint-plugin-no-relative-import-paths@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.6.1.tgz#7d1e8f34694016d6d390c28063bedfa7203e7771"
+  integrity sha512-YZNeOnsOrJcwhFw0X29MXjIzu2P/f5X2BZDPWw1R3VUYBRFxNIh77lyoL/XrMU9ewZNQPcEvAgL/cBOT1P330A==
+
 eslint-plugin-playwright@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-2.3.0.tgz#e14dfe981455254bbf5a7299802f5c01bb93d148"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2610

## Why are we making this change?

As part of the Ember → React migration, we're adding new React code to `apps/admin`. We've configured TypeScript path aliases (`@/*` for src, `@test-utils/*` for test-utils) to improve code readability and maintainability.

However, developers can still write relative imports (`../../utils/foo`) even when path aliases are available. This PR enforces the use of path aliases through ESLint to ensure consistency across the codebase.

## What does this PR do?

1. **Adds `eslint-plugin-no-relative-import-paths`** to `apps/admin/package.json`

2. **Configures ESLint rules** in `apps/admin/eslint.config.js`:
   - For `src/**/*.{ts,tsx}`: Enforces `@/*` aliases, allows same-folder relative imports
   - For `test-utils/**/*.{ts,tsx}`: Enforces use of aliases, allows same-folder relative imports
   
3. **Updates `yarn.lock`** with the new dependency

## Why is this needed?

- **Consistency**: Ensures all developers use path aliases consistently
- **Refactoring safety**: Moving files doesn't break imports when using absolute aliases
- **Readability**: `@/utils/foo` is clearer than `../../../utils/foo`
- **Auto-fixable**: The ESLint rule can automatically fix violations

## Example

```typescript
// ❌ Before (relative imports)
import { foo } from '../../utils/foo';
import { mockUser } from '../../../test-utils/factories/user';

// ✅ After (path aliases)
import { foo } from '@/utils/foo';
import { mockUser } from '@test-utils/factories/user';
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces path alias imports in `apps/admin` by adding and configuring `eslint-plugin-no-relative-import-paths`.
> 
> - **ESLint (apps/admin)**:
>   - **Plugin**: Add `eslint-plugin-no-relative-import-paths` and register it in `eslint.config.js`.
>   - **Rules**:
>     - For `src/**/*.{ts,tsx}`: Enforce alias imports with `{ rootDir: 'src', prefix: '@', allowSameFolder: true }`.
>     - For `test-utils/**/*.{ts,tsx}`: Enforce no relative imports (allow same-folder).
> - **Dependencies**:
>   - Add `eslint-plugin-no-relative-import-paths` to `devDependencies` and update `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0879916c3ff54a03c636e430baecb9264f91d978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->