### PR TITLE
Added What's New orchestration hook

### DIFF
--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -193,25 +193,28 @@ describe("useUserPreferences", () => {
             expect(result.current.data).toEqual(fixtures.existingPreferences);
         });
 
-        [
-            {
-                scenario: "invalid JSON",
-                accessibility: "{invalid json",
-            },
-            {
-                scenario: "invalid schema",
+        queryTest("errors when invalid JSON", async ({ setup }) => {
+            const result = await setup({ accessibility: "{invalid json" });
+
+            expect(result.current.isError).toBe(true);
+            expect(result.current.error).toBeInstanceOf(Error);
+        });
+
+        queryTest("gracefully handles invalid schema values", async ({ setup }) => {
+            const result = await setup({
                 accessibility: JSON.stringify({
                     whatsNew: {
                         lastSeenDate: "not-a-valid-datetime",
                     },
                 }),
-            },
-        ].forEach(({ scenario, accessibility }) => {
-            queryTest(`errors when ${scenario}`, async ({ setup }) => {
-                const result = await setup({ accessibility });
+            });
 
-                expect(result.current.isError).toBe(true);
-                expect(result.current.error).toBeInstanceOf(Error);
+            // Should not error - catches and returns undefined for invalid fields
+            expect(result.current.isError).toBe(false);
+            expect(result.current.data).toEqual({
+                whatsNew: {
+                    lastSeenDate: undefined,
+                },
             });
         });
 

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -5,16 +5,22 @@ import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { useEditUser, type User } from "@tryghost/admin-x-framework/api/users";
 
-const WhatsNewPreferencesSchema = z.object({
-    lastSeenDate: z.iso.datetime(),
+const isoDatetimeToDate = z.codec(z.iso.datetime(), z.date(), {
+    decode: (isoString) => new Date(isoString),
+    encode: (date) => date.toISOString(),
+});
+
+const WhatsNewPreferencesSchema = z.looseObject({
+    lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
 const PreferencesSchema = z.looseObject({
-    whatsNew: WhatsNewPreferencesSchema.optional(),
+    whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
+export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 
 const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
@@ -57,14 +63,16 @@ export const useEditUserPreferences = (): UseMutationResult<void, Error, Prefere
 
             const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? {};
 
-            const newPreferences = {
+            const newPreferences: Preferences = {
                 ...currentPreferences,
                 ...updatedPreferences,
             };
 
+            const encodedForStorage = PreferencesSchema.encode(newPreferences);
+
             await editUser({
                 ...user,
-                accessibility: JSON.stringify(newPreferences),
+                accessibility: JSON.stringify(encodedForStorage),
             });
         },
     });

--- a/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
@@ -1,0 +1,426 @@
+import { test as baseTest, describe, expect } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { QueryClient } from "@tanstack/react-query";
+import { useWhatsNew, useDismissWhatsNew } from "./use-whats-new";
+import { HttpResponse, http } from "msw";
+import { mockUser, createRawChangelogEntry } from "@test-utils/factories";
+import { waitForQuerySettled } from "@test-utils/test-helpers";
+import type { UpdateUserRequestBody, UsersResponseType } from "@tryghost/admin-x-framework/api/users";
+import type { RawChangelogResponse, RawChangelogEntry } from "./use-changelog";
+import { serverFixture } from "@test-utils/fixtures/msw";
+import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
+import type { SetupServer } from "msw/node";
+
+// Constants
+const USERS_API_URL = "/ghost/api/admin/users/me/";
+const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+const CHANGELOG_API_URL = "https://ghost.org/changelog.json";
+
+// Types
+interface SetupQueryOptions {
+    accessibility?: string | null;
+    changelog?: Partial<RawChangelogResponse>;
+}
+
+interface SetupMutationOptions {
+    lastSeenDate?: string;
+    posts?: RawChangelogEntry[];
+}
+
+type SetupQueryTest = (options?: SetupQueryOptions) => ReturnType<typeof setupQuery>;
+type SetupMutationTest = (options?: SetupMutationOptions) => ReturnType<typeof setupMutation>;
+
+// Test fixtures
+const dates = {
+    past: "2025-01-01T00:00:00Z",
+    recent: "2025-01-10T00:00:00Z",
+    current: "2025-01-15T10:00:00Z",
+    future: "2025-01-20T10:00:00Z",
+};
+
+const fixtures = {
+    entries: {
+        newEntry: () =>
+            createRawChangelogEntry({
+                published_at: dates.current,
+            }),
+        oldEntry: () =>
+            createRawChangelogEntry({
+                published_at: dates.past,
+            }),
+        featuredEntry: () =>
+            createRawChangelogEntry({
+                published_at: dates.current,
+                featured: "true",
+            }),
+    },
+    preferences: {
+        empty: {},
+        withOtherSetting: { otherSetting: "value" },
+        withLastSeen: (date: string) => ({
+            whatsNew: { lastSeenDate: date },
+        }),
+    },
+};
+
+// Setup functions
+/**
+ * Setup function for testing `useWhatsNew`.
+ *
+ * This fixture handles the boilerplate of:
+ * 1. Mocking the user API endpoint with customizable accessibility preferences
+ * 2. Mocking the user mutation endpoint (for initializing preferences)
+ * 3. Mocking the changelog API endpoint with customizable changelog data
+ * 4. Rendering the hook with the necessary React Query wrapper
+ * 5. Waiting for the query to settle (success or error state)
+ *
+ * Note: The query is disabled until preferences exist (hasWhatsNewPreferences = true).
+ * This means the query naturally stays in loading state during initialization, then
+ * enables and settles once the mutation completes. Tests only need to wait once.
+ *
+ * This allows tests to focus on asserting behavior rather than setup logic,
+ * making test code more ergonomic and readable.
+ *
+ * @param server - MSW server instance for mocking API endpoints
+ * @param wrapper - React Query wrapper component for hook testing
+ * @param options - Test configuration options (accessibility, changelog data)
+ * @returns The renderHook result with the query in a settled state
+ */
+async function setupQuery(server: SetupServer, wrapper: TestWrapperComponent, options: SetupQueryOptions = {}) {
+    const { accessibility = null, changelog = {} } = options;
+
+    server.use(
+        // Mock the user preferences endpoint
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        accessibility: accessibility ?? mockUser.accessibility,
+                    },
+                ],
+            });
+        }),
+        // Mock the user mutation endpoint (for initializing preferences)
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(USER_UPDATE_API_URL, async ({ request }) => {
+            const body = await request.json();
+            const newAccessibility = body.users[0]?.accessibility;
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        accessibility: newAccessibility,
+                    },
+                ],
+            });
+        }),
+        // Mock the changelog endpoint
+        http.get(CHANGELOG_API_URL, () => {
+            return HttpResponse.json({
+                posts: changelog.posts ?? [],
+                changelogUrl: changelog.changelogUrl ?? "https://ghost.org/changelog",
+            });
+        })
+    );
+
+    const { result } = renderHook(() => useWhatsNew(), {
+        wrapper,
+    });
+
+    // Wait for query to settle. The query is disabled until preferences are initialized,
+    // so it stays in loading state during the mutation, then enables and settles naturally.
+    await waitForQuerySettled(result);
+
+    return result;
+}
+
+/**
+ * Setup function for testing `useDismissWhatsNew`.
+ *
+ * This fixture handles the boilerplate of:
+ * 1. Mocking the user API endpoint with customizable lastSeenDate
+ * 2. Mocking the user mutation endpoint (for updating preferences)
+ * 3. Mocking the changelog API endpoint with customizable posts
+ * 4. Rendering both the query hook (to read state) and mutation hook (to update state)
+ * 5. Waiting for the initial query to settle before tests run
+ *
+ * This allows mutation tests to immediately call `mutation.mutateAsync()` without worrying
+ * about setup, making test code more ergonomic and focused on the mutation behavior.
+ *
+ * @param server - MSW server instance for mocking API endpoints
+ * @param wrapper - React Query wrapper component for hook testing
+ * @param options - Test configuration options (lastSeenDate, posts)
+ * @returns Both query and mutation hook results, ready for testing mutations
+ */
+async function setupMutation(server: SetupServer, wrapper: TestWrapperComponent, options: SetupMutationOptions = {}) {
+    const { lastSeenDate = dates.past, posts = [fixtures.entries.newEntry()] } = options;
+
+    server.use(
+        // Mock the user preferences endpoint
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        accessibility: JSON.stringify({
+                            whatsNew: { lastSeenDate },
+                        }),
+                    },
+                ],
+            });
+        }),
+        // Mock the user mutation endpoint
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(USER_UPDATE_API_URL, async ({ request }) => {
+            const body = await request.json();
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        accessibility: body.users[0].accessibility,
+                    },
+                ],
+            });
+        }),
+        // Mock the changelog endpoint
+        http.get(CHANGELOG_API_URL, () => {
+            return HttpResponse.json({
+                posts,
+                changelogUrl: "https://ghost.org/changelog",
+            });
+        })
+    );
+
+    const query = renderHook(() => useWhatsNew(), { wrapper });
+    const mutation = renderHook(() => useDismissWhatsNew(), {
+        wrapper,
+    });
+
+    await waitForQuerySettled(query.result);
+
+    return {
+        query: query.result,
+        mutation: mutation.result,
+    };
+}
+
+// Test extensions
+const queryTest = baseTest.extend<{
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    setup: SetupQueryTest;
+}>({
+    ...serverFixture,
+    ...queryClientFixtures,
+    setup: async ({ server, wrapper }, provide) => {
+        await provide((options) => setupQuery(server, wrapper, options));
+    },
+});
+
+const mutationTest = baseTest.extend<{
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    setup: SetupMutationTest;
+}>({
+    ...serverFixture,
+    ...queryClientFixtures,
+    setup: async ({ server, wrapper }, provide) => {
+        await provide((options) => setupMutation(server, wrapper, options));
+    },
+});
+
+describe("useWhatsNew", () => {
+    describe("hasNew", () => {
+        describe("returns true", () => {
+            queryTest("when lastSeenDate is before entry", async ({ setup }) => {
+                const result = await setup({
+                    changelog: {
+                        posts: [fixtures.entries.newEntry()],
+                    },
+                    accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
+                });
+
+                expect(result.current.data?.hasNew).toBe(true);
+            });
+        });
+
+        describe("returns false", () => {
+            [
+                {
+                    scenario: "when preferences are missing",
+                    input: {
+                        changelog: { posts: [fixtures.entries.newEntry()] },
+                    },
+                },
+                {
+                    scenario: "when whatsNew key is missing",
+                    input: {
+                        changelog: { posts: [fixtures.entries.newEntry()] },
+                        accessibility: JSON.stringify(fixtures.preferences.withOtherSetting),
+                    },
+                },
+                {
+                    scenario: "when whatsNew exists but lastSeenDate is missing",
+                    input: {
+                        changelog: { posts: [fixtures.entries.newEntry()] },
+                        accessibility: JSON.stringify({ whatsNew: { foo: "bar" } }),
+                    },
+                },
+                {
+                    scenario: "when lastSeenDate is undefined",
+                    input: {
+                        changelog: { posts: [fixtures.entries.newEntry()] },
+                        accessibility: JSON.stringify({ whatsNew: { lastSeenDate: undefined } }),
+                    },
+                },
+                {
+                    scenario: "when no entries exist",
+                    input: {
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
+                        changelog: { posts: [] },
+                    },
+                },
+                {
+                    scenario: "when lastSeenDate is after entry",
+                    input: {
+                        changelog: {
+                            posts: [fixtures.entries.oldEntry()],
+                        },
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.current)),
+                    },
+                },
+                {
+                    scenario: "when lastSeenDate equals entry",
+                    input: {
+                        changelog: {
+                            posts: [fixtures.entries.newEntry()],
+                        },
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.current)),
+                    },
+                },
+                {
+                    scenario: "when first entry is old despite newer entries existing",
+                    input: {
+                        changelog: {
+                            posts: [fixtures.entries.oldEntry(), fixtures.entries.newEntry()],
+                        },
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.recent)),
+                    },
+                },
+            ].forEach(({ scenario, input }) => {
+                queryTest(scenario, async ({ setup }) => {
+                    const result = await setup(input);
+                    expect(result.current.data?.hasNew).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe("hasNewFeatured", () => {
+        describe("returns true", () => {
+            queryTest("when entry is newer than lastSeenDate and featured", async ({ setup }) => {
+                const result = await setup({
+                    changelog: {
+                        posts: [fixtures.entries.featuredEntry()],
+                    },
+                    accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
+                });
+
+                expect(result.current.data?.hasNewFeatured).toBe(true);
+            });
+        });
+
+        describe("returns false", () => {
+            [
+                {
+                    scenario: "when entry is older than lastSeenDate",
+                    input: {
+                        changelog: {
+                            posts: [fixtures.entries.featuredEntry()],
+                        },
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.future)),
+                    },
+                },
+                {
+                    scenario: "when entry is newer but not featured",
+                    input: {
+                        changelog: {
+                            posts: [fixtures.entries.newEntry()],
+                        },
+                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
+                    },
+                },
+                {
+                    scenario: "when no entries exist",
+                    input: {
+                        changelog: { posts: [] },
+                    },
+                },
+            ].forEach(({ scenario, input }) => {
+                queryTest(scenario, async ({ setup }) => {
+                    const result = await setup(input);
+                    expect(result.current.data?.hasNewFeatured).toBe(false);
+                });
+            });
+        });
+    });
+});
+
+describe("useDismissWhatsNew", () => {
+    mutationTest("changes hasNew from true to false", async ({ setup }) => {
+        const { query, mutation } = await setup();
+
+        expect(query.current.data?.hasNew).toBe(true);
+
+        await act(async () => {
+            await mutation.current.mutateAsync();
+        });
+
+        await waitFor(() => {
+            expect(query.current.data?.hasNew).toBe(false);
+        });
+    });
+
+    mutationTest("works with multiple entries", async ({ setup }) => {
+        const { query, mutation } = await setup({
+            posts: [
+                createRawChangelogEntry({
+                    published_at: dates.future,
+                }),
+                createRawChangelogEntry({
+                    published_at: dates.current,
+                }),
+                createRawChangelogEntry({
+                    published_at: dates.recent,
+                }),
+            ],
+        });
+
+        expect(query.current.data?.hasNew).toBe(true);
+
+        await act(async () => {
+            await mutation.current.mutateAsync();
+        });
+
+        await waitFor(() => {
+            expect(query.current.data?.hasNew).toBe(false);
+        });
+    });
+
+    mutationTest("handles empty entries gracefully", async ({ setup }) => {
+        const { query, mutation } = await setup({
+            posts: [],
+        });
+
+        expect(query.current.data?.hasNew).toBe(false);
+
+        await act(async () => {
+            await mutation.current.mutateAsync();
+        });
+
+        await waitFor(() => {
+            expect(query.current.data?.hasNew).toBe(false);
+        });
+    });
+});

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -1,0 +1,87 @@
+import { useEffect } from "react";
+import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from "@tanstack/react-query";
+
+import {
+    useUserPreferences,
+    useEditUserPreferences,
+    type Preferences,
+    type WhatsNewPreferences,
+} from "@/hooks/user-preferences";
+import { useChangelog, type ChangelogEntry } from "./use-changelog";
+
+function getDefaultWhatsNewPreferences(): WhatsNewPreferences {
+    return {
+        lastSeenDate: new Date(),
+    };
+}
+
+interface WhatsNewData {
+    hasNew: boolean;
+    hasNewFeatured: boolean;
+}
+
+const whatsNewQueryKey = (preferences: Preferences | undefined, latestEntry: ChangelogEntry | undefined) =>
+    ["whatsNew", preferences?.whatsNew?.lastSeenDate?.toISOString(), latestEntry?.publishedAt.toISOString()] as const;
+
+export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
+    const { data: preferences, isSuccess: isPreferencesLoaded } = useUserPreferences();
+    const { data: changelog, isSuccess: isChangelogLoaded } = useChangelog();
+    const { mutateAsync: updatePreferences } = useEditUserPreferences();
+
+    const hasWhatsNewPreferences = !!preferences?.whatsNew?.lastSeenDate;
+
+    // Initialize default whatsNewPreferences if missing or invalid
+    useEffect(() => {
+        if (!hasWhatsNewPreferences && isPreferencesLoaded) {
+            void updatePreferences({
+                whatsNew: getDefaultWhatsNewPreferences(),
+            });
+        }
+    }, [hasWhatsNewPreferences, isPreferencesLoaded, updatePreferences]);
+
+    const latestEntry = changelog?.entries[0];
+
+    return useQuery({
+        queryKey: whatsNewQueryKey(preferences, latestEntry),
+        queryFn: () => {
+            if (!latestEntry) {
+                return { hasNew: false, hasNewFeatured: false };
+            }
+
+            // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
+            // and useEffect ensures whatsNew is initialized with a valid lastSeenDate
+            const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
+
+            const hasNew = latestEntry.publishedAt > lastSeenDate;
+            const hasNewFeatured = hasNew && latestEntry.featured === true;
+
+            return { hasNew, hasNewFeatured };
+        },
+        enabled: isChangelogLoaded && hasWhatsNewPreferences,
+        staleTime: Infinity,
+        cacheTime: 0,
+    });
+};
+
+export const useDismissWhatsNew = (): UseMutationResult<void, Error, void, unknown> => {
+    const { data: changelog } = useChangelog();
+    const { mutateAsync: updatePreferences } = useEditUserPreferences();
+
+    return useMutation({
+        mutationFn: async () => {
+            const latestEntry = changelog?.entries[0];
+
+            if (!latestEntry) {
+                return;
+            }
+
+            const newPreferences: WhatsNewPreferences = {
+                lastSeenDate: latestEntry.publishedAt,
+            };
+
+            await updatePreferences({
+                whatsNew: newPreferences,
+            });
+        },
+    });
+};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2610

## Why are we making this change?

This PR completes the React implementation of the What's New feature by orchestrating the changelog data and user preferences to provide notification state. The core challenge is determining whether the current user has seen the latest changelog entry, and providing a simple API for UI components to display notifications and mark entries as seen.

This is the final piece in the What's New feature port from Ember to React.

## What does this PR do?

This PR introduces two hooks: `useWhatsNew` and `useDismissWhatsNew`.

The query hook combines the changelog data with the user's stored `lastSeenDate` preference to compute whether there are new entries. Rather than checking every changelog entry, we only need to compare the latest entry's publication date with when the user last viewed the changelog. This keeps the logic simple and efficient.

The hook also distinguishes between regular new entries and featured entries, since featured entries deserve special UI treatment (like more prominent badges or notifications). This distinction is computed by checking both the "new" status and the entry's featured flag.

For first-time users who have never opened What's New before, the hook automatically initializes their preferences with the current date. This prevents existing changelog entries from appearing as "new" when someone opens the feature for the first time.

The mutation hook provides a simple way to dismiss What's New notifications. When called, it updates the user's `lastSeenDate` to match the latest changelog entry's publication date, which automatically causes the query hook to return `hasNew: false` on subsequent renders.

This PR also refactors the user preferences system to use Zod codecs with explicit encode/decode functions. This allows the internal representation to use native `Date` objects for type safety, while automatically converting to/from ISO datetime strings for storage. This makes working with dates in the preferences system more ergonomic and less error-prone.

## Why is this needed?

The What's New feature needs a centralized source of truth for notification state. UI components shouldn't need to understand the relationship between changelog data and user preferences, or how to compute "new" status. By encapsulating this logic in hooks, we make it easy for multiple components to consistently show or hide notification badges, and we ensure the feature behaves correctly for both new and returning users.

The separate `hasNewFeatured` flag lets us create better UX by highlighting particularly important updates differently from routine changelog entries.

## Testing

```bash
yarn workspace @tryghost/admin test:unit src/whats-new/hooks/use-whats-new.test.tsx
```

Tests cover new user initialization, computing new entry status, the dismiss mutation, and handling edge cases like empty changelogs.

## Dependencies

Depends on:
- #25356 (test infrastructure + user preferences)
- #25357 (changelog hook)