### PR TITLE
✨ Added discovery feeds to the Network tab

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/layout/Layout.tsx
+++ b/apps/activitypub/src/components/layout/Layout.tsx
@@ -7,7 +7,6 @@ import {Navigate, ScrollRestoration} from '@tryghost/admin-x-framework';
 import {useAppBasePath} from '@src/hooks/use-app-base-path';
 import {useCurrentPage} from '@src/hooks/use-current-page';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useKeyboardShortcuts} from '@hooks/use-keyboard-shortcuts';
 
 const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
@@ -17,7 +16,6 @@ const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...pr
     const containerRef = useRef<HTMLDivElement>(null);
     const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
     const currentPage = useCurrentPage();
-    const {isEnabled} = useFeatureFlags();
 
     const {isNewNoteModalOpen, setIsNewNoteModalOpen} = useKeyboardShortcuts();
 
@@ -46,7 +44,7 @@ const Layout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...pr
                         <div className='block grid-cols-[auto_320px] items-start lg:grid'>
                             <div className='z-0 min-w-0'>
                                 <Header
-                                    showBorder={!(currentPage === 'reader' && isEnabled('global-feed'))}
+                                    showBorder={!(currentPage === 'reader')}
                                     onToggleMobileSidebar={toggleMobileSidebar}
                                 />
                                 <div className='px-[min(4vw,32px)]'>

--- a/apps/activitypub/src/lib/feature-flags.tsx
+++ b/apps/activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['global-feed', 'notification-group'] as const;
+export const FEATURE_FLAGS = ['notification-group'] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;

--- a/apps/activitypub/src/views/Inbox/components/InboxList.tsx
+++ b/apps/activitypub/src/views/Inbox/components/InboxList.tsx
@@ -6,7 +6,6 @@ import {Activity} from '@src/api/activitypub';
 import {Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, EmptyIndicator, LoadingIndicator, LucideIcon, Separator} from '@tryghost/shade';
 import {isPendingActivity} from '@src/utils/pending-activity';
 import {useEffect, useRef, useState} from 'react';
-import {useFeatureFlags} from '@src/lib/feature-flags';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useNavigationStack, useParams} from '@tryghost/admin-x-framework';
 
@@ -29,7 +28,6 @@ const InboxList:React.FC<InboxListProps> = ({
     isFetchingNextPage,
     onTopicChange
 }) => {
-    const {isEnabled} = useFeatureFlags();
     const navigate = useNavigateWithBasePath();
     const {canGoBack, goBack} = useNavigationStack();
     const [isReaderOpen, setIsReaderOpen] = useState(false);
@@ -74,7 +72,7 @@ const InboxList:React.FC<InboxListProps> = ({
 
     return (
         <Layout>
-            {isEnabled('global-feed') && <TopicFilter currentTopic={currentTopic} onTopicChange={onTopicChange} />}
+            <TopicFilter currentTopic={currentTopic} onTopicChange={onTopicChange} />
             <div className='flex w-full flex-col'>
                 <div className='w-full'>
                     {activities.length > 0 ? (


### PR DESCRIPTION
ref https://linear.app/ghost/project/activitypub-discovery-feeds-ed06ad7be6b7

Added topic-based discovery feeds (Technology, News, Culture, etc.) alongside the default “Following” feed in Reader -- so that there are more ways for users to discover content / publications they might be interested in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c7e7aeecb7391383504fdf11c5ddacae99e11627. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->