### PR TITLE
🐛 Fixed magic links only being valid for 10 minutes

### DIFF
--- a/ghost/core/core/server/services/members/SingleUseTokenProvider.js
+++ b/ghost/core/core/server/services/members/SingleUseTokenProvider.js
@@ -397,6 +397,10 @@ class SingleUseTokenProvider {
      * @returns {void}
      */
     _validateTimeSinceFirstUsage(model) {
+        if (model.get('used_count') === 0 && !model.get('first_used_at')) {
+            return;
+        }
+
         const createdAtEpoch = model.get('created_at').getTime();
         const firstUsedAtEpoch = model.get('first_used_at')?.getTime() ?? createdAtEpoch;
         const timeSinceFirstUsage = Date.now() - firstUsedAtEpoch;

--- a/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
+++ b/ghost/core/test/unit/server/services/members/SingleUseTokenProvider.test.js
@@ -385,6 +385,14 @@ describe('SingleUseTokenProvider', function () {
                     {code: 'TOKEN_EXPIRED'}
                 );
             });
+
+            it('should not throw ValidationError when token is past validityPeriodAfterUsage but has not been used', async function () {
+                const oldCreatedAt = new Date(Date.now() - (HOUR_MS + 1));
+                buildModel({usedCount: 0, firstUsedAt: null, createdAt: oldCreatedAt});
+                await assert.doesNotReject(
+                    tokenProvider.validate(testToken)
+                );
+            });
         });
 
         it('should increment usage count for previously used token', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2977/

- during a refactor of `SingleUseTokenProvider` the time-since-first-usage check was extracted to a method but in doing so the pre-condition check for the token having been used was lost meaning all magic links had an effective lifetime of `validityAfterFirstUsage` (10 minutes)
- restored pre-condition check and added missing test that would have caught this during the refactor
