### PR TITLE
Improved order of OTC validation checks

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/RouterController.js
@@ -705,19 +705,19 @@ module.exports = class RouterController {
             });
         }
 
-        const isValidOTC = await tokenProvider.verifyOTC(otcRef, otc);
-        if (!isValidOTC) {
-            throw new errors.BadRequestError({
-                message: tpl(messages.invalidCode),
-                code: 'INVALID_OTC'
-            });
-        }
-
         const tokenValue = await tokenProvider.getTokenByRef(otcRef);
         if (!tokenValue) {
             throw new errors.BadRequestError({
                 message: tpl(messages.invalidCode),
                 code: 'INVALID_OTC_REF'
+            });
+        }
+
+        const isValidOTC = await tokenProvider.verifyOTC(otcRef, otc);
+        if (!isValidOTC) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.invalidCode),
+                code: 'INVALID_OTC'
             });
         }
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/RouterController.test.js
@@ -1176,6 +1176,7 @@ describe('RouterController', function () {
 
                 for (const invalid of invalidOtcs) {
                     req.body.otc = invalid;
+                    mockMagicLinkService.tokenProvider.getTokenByRef.resolves(OTC_TEST_CONSTANTS.TOKEN_VALUE);
                     mockMagicLinkService.tokenProvider.verifyOTC.resolves(false);
 
                     await assert.rejects(
@@ -1224,6 +1225,7 @@ describe('RouterController', function () {
             });
 
             it('should throw BadRequestError when verifyOTC returns false', async function () {
+                mockMagicLinkService.tokenProvider.getTokenByRef.resolves(OTC_TEST_CONSTANTS.TOKEN_VALUE);
                 mockMagicLinkService.tokenProvider.verifyOTC.resolves(false);
 
                 await assert.rejects(


### PR DESCRIPTION
no issue

- `tokenProvider.verifyOTC` has an internal dependency on the `otcRef` being correct meaning we'd never reach the `INVALID_OTC_REF` condition
- nothing changes for user-visible behaviour but this re-order does mean that logging can be more explicit about the type of error that has occurred

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders `verifyOTC` to validate `otcRef` via `getTokenByRef` before `verifyOTC`, updating error codes and unit tests accordingly.
> 
> - **Members API (RouterController `verifyOTC`)**:
>   - Reorder validation: call `tokenProvider.getTokenByRef(otcRef)` first, then `verifyOTC(otcRef, otc)`.
>   - Adjust error codes: `INVALID_OTC_REF` when no token for `otcRef`; `INVALID_OTC` when code verification fails.
> - **Tests**:
>   - Update unit tests to reflect new validation order and stubbing sequence.
>   - Ensure invalid OTC format and verification failure scenarios resolve token first, then assert `INVALID_OTC`.
>   - Keep success and integration flows intact with updated expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3a5682f7875bfe221757826c951043c8c542531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->