### PR TITLE
Removed notification-group feature flag and fixed chronological grouping

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/lib/feature-flags.tsx
+++ b/apps/activitypub/src/lib/feature-flags.tsx
@@ -2,7 +2,7 @@ import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useLocation} from '@tryghost/admin-x-framework';
 
 // Define all available feature flags as string here, e.g. ['flag-1', 'flag-2']
-export const FEATURE_FLAGS = ['notification-group'] as const;
+export const FEATURE_FLAGS = [] as const;
 
 // ---
 export type FeatureFlag = typeof FEATURE_FLAGS[number] | string;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2937/improve-notification-grouping-by-adding-date-criteria

- removed the feature flag, and enabled the time grouping by default
- fixed notifications grouping out of order when changing time windows
- notifications now only group with consecutive ones of the same type

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the notification-group flag and enforce 24h, sequential same‑type notification grouping to preserve chronological order.
> 
> - **Notifications (ActivityPub)**:
>   - Remove `notification-group` feature flag and related checks; time-based grouping is now always on.
>   - Revise `groupNotifications`:
>     - Always group by 24h time buckets.
>     - Add sequence key to prevent grouping across type changes, preserving chronological order and grouping only consecutive same-type notifications.
>     - Keep replies/mentions ungrouped; update group keys for likes/reposts/follows.
> - **Feature Flags**:
>   - Clear `FEATURE_FLAGS` list; remove flag usage from `Notifications.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af47e2245ad294f35f3f982ee450480714d8ee55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->