### PR TITLE
Added support for uploading GIFs to Notes

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/modals/NewNoteModal.tsx
+++ b/apps/activitypub/src/components/modals/NewNoteModal.tsx
@@ -349,7 +349,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({children, replyTo, onReply, 
                                 <FormPrimitive.Control asChild>
                                     <input
                                         ref={imageInputRef}
-                                        accept="image/jpeg,image/png,image/webp"
+                                        accept="image/jpeg,image/png,image/webp,image/gif"
                                         className='hidden'
                                         type="file"
                                         onChange={handleImageChange}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows uploading GIF images in the New Note modal and bumps package version to 1.0.30.
> 
> - **Frontend**:
>   - **New Note modal** (`apps/activitypub/src/components/modals/NewNoteModal.tsx`): extend file input `accept` to include `image/gif`, enabling GIF uploads.
> - **Package**:
>   - Bump `@tryghost/activitypub` version from `1.0.29` to `1.0.30` in `apps/activitypub/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6656ab774f992aef48b9444d98b4d20078eb00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->