### PR TITLE
Removed inactive topics in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Button} from '@tryghost/shade';
 
-export type Topic = 'following' | 'technology' | 'business' | 'news' | 'culture' | 'art' | 'travel' | 'education' | 'finance' | 'entertainment' | 'productivity' | 'literature' | 'personal' | 'programming' | 'design' | 'sport' | 'faith-spirituality' | 'science' | 'crypto' | 'food-drink' | 'music' | 'nature-outdoors' | 'fashion-beauty' | 'climate' | 'fiction' | 'history' | 'parenting' | 'gear-gadgets' | 'house-home';
+export type Topic = 'following' | 'technology' | 'business' | 'news' | 'culture' | 'art' | 'travel' | 'education' | 'finance' | 'entertainment' | 'productivity' | 'literature' | 'personal' | 'programming' | 'design' | 'sport' | 'faith-spirituality' | 'science' | 'crypto' | 'food-drink' | 'music' | 'nature-outdoors' | 'climate' | 'history' | 'gear-gadgets';
 
 const TOPICS: {value: Topic; label: string}[] = [
     {value: 'following', label: 'Following'},
@@ -26,13 +26,9 @@ const TOPICS: {value: Topic; label: string}[] = [
     {value: 'food-drink', label: 'Food & drink'},
     {value: 'music', label: 'Music'},
     {value: 'nature-outdoors', label: 'Nature & outdoors'},
-    {value: 'fashion-beauty', label: 'Fashion & beauty'},
     {value: 'climate', label: 'Climate'},
-    {value: 'fiction', label: 'Fiction'},
     {value: 'history', label: 'History'},
-    {value: 'parenting', label: 'Parenting'},
-    {value: 'gear-gadgets', label: 'Gear & gadgets'},
-    {value: 'house-home', label: 'House & home'}
+    {value: 'gear-gadgets', label: 'Gear & gadgets'}
 ];
 
 interface TopicFilterProps {


### PR DESCRIPTION
no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes several inactive topics from `TopicFilter` and bumps `@tryghost/activitypub` to 1.0.29.
> 
> - **ActivityPub**
>   - **TopicFilter (`src/components/TopicFilter.tsx`)**:
>     - Prunes topics: removes `fashion-beauty`, `fiction`, `parenting`, `house-home` from `Topic` type and `TOPICS` list.
>   - **Package**:
>     - Bumps `version` in `apps/activitypub/package.json` from `1.0.28` to `1.0.29`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73a77711c0fe539d1a593cbe76a51e6bc57710c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->