### PR TITLE
Improved export button copy in Settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/migrationtools/MigrationToolsExport.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migrationtools/MigrationToolsExport.tsx
@@ -34,7 +34,7 @@ const MigrationToolsExport: React.FC = () => {
     };
 
     return (
-        <div className='grid grid-cols-3 items-center gap-4 pt-4'>
+        <div className='grid grid-cols-1 gap-4 pt-4 md:grid-cols-2 lg:grid-cols-3'>
             <Button className='!h-9 !font-semibold' color='grey' icon='export' iconColorClass='!h-4 !w-auto' label='Content & settings' onClick={() => downloadAllContent()} />
             <Button className='!h-9 !font-semibold' color='grey' icon='baseline-chart' iconColorClass='!h-4 !w-auto' label='Post analytics' onClick={exportPosts} />
         </div>

--- a/apps/admin-x-settings/src/components/settings/advanced/migrationtools/MigrationToolsExport.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migrationtools/MigrationToolsExport.tsx
@@ -34,9 +34,9 @@ const MigrationToolsExport: React.FC = () => {
     };
 
     return (
-        <div className='flex flex-wrap items-center gap-4 pt-4'>
-            <Button className='!h-9 !font-semibold' color='grey' icon='export' iconColorClass='!h-4 !w-auto' label='Export content & settings' onClick={() => downloadAllContent()} />
-            <Button className='!h-9 !font-semibold' color='grey' icon='baseline-chart' iconColorClass='!h-4 !w-auto' label='Export post analytics' onClick={exportPosts} />
+        <div className='grid grid-cols-3 items-center gap-4 pt-4'>
+            <Button className='!h-9 !font-semibold' color='grey' icon='export' iconColorClass='!h-4 !w-auto' label='Content & settings' onClick={() => downloadAllContent()} />
+            <Button className='!h-9 !font-semibold' color='grey' icon='baseline-chart' iconColorClass='!h-4 !w-auto' label='Post analytics' onClick={exportPosts} />
         </div>
     );
 };

--- a/apps/admin-x-settings/test/acceptance/advanced/migrationTools.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/migrationTools.test.ts
@@ -75,7 +75,7 @@ test.describe('Migration tools', async () => {
 
         await migrationSection.getByRole('tab', {name: 'Export'}).click();
 
-        await migrationSection.getByRole('button', {name: 'Export content'}).click();
+        await migrationSection.getByRole('button', {name: 'Content & settings'}).click();
 
         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/db\/$/);
 

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -127,7 +127,7 @@ test.describe('Analytics settings', async () => {
 
         await section.getByRole('tab', {name: 'Export'}).click();
 
-        await section.getByRole('button', {name: 'Export post analytics'}).click();
+        await section.getByRole('button', {name: 'Post analytics'}).click();
 
         const hasDownloadUrl = lastApiRequests.postsExport?.url?.includes('/posts/export/?limit=1000');
         expect(hasDownloadUrl).toBe(true);


### PR DESCRIPTION
no ref.

- The word "Export" was redundant in the Labs/Migration export buttons. Also it wasn't following the same layout pattern as the import ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies export button labels and switches the export actions to a responsive grid, updating tests accordingly.
> 
> - **Frontend (Migration tools export UI)**:
>   - Switch layout in `MigrationToolsExport.tsx` from flex to a responsive grid (`grid-cols-1` → `md:grid-cols-2` → `lg:grid-cols-3`).
>   - Shorten button labels: `Export content & settings` → `Content & settings`, `Export post analytics` → `Post analytics`.
> - **Tests**:
>   - Update acceptance tests to use new button labels in `advanced/migrationTools.test.ts` and `membership/analytics.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10756c2563e172dc246fd1f87eb78f8ccb27b911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->