### PR TITLE
Fixed member count display in React admin sidebar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -10,9 +10,11 @@ import {
 } from "@tryghost/shade"
 import { NavMenuItem } from "./NavMenuItem";
 import NavSubMenu from "./NavSubMenu";
+import { useMemberCount } from "./hooks/useMemberCount";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const [postsExpanded, setPostsExpanded] = useState(false);
+    const memberCount = useMemberCount();
 
     return (
         <SidebarGroup {...props}>
@@ -90,7 +92,9 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             <LucideIcon.Users />
                             <NavMenuItem.Label>Members</NavMenuItem.Label>
                         </NavMenuItem.Link>
-                        <SidebarMenuBadge>24</SidebarMenuBadge>
+                        {memberCount != null && (
+                            <SidebarMenuBadge>{memberCount}</SidebarMenuBadge>
+                        )}
                     </NavMenuItem>
                 </SidebarMenu>
             </SidebarGroupContent>

--- a/apps/admin/src/layout/app-sidebar/hooks/useMemberCount.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/useMemberCount.ts
@@ -1,0 +1,15 @@
+import { useBrowseMembers } from "@tryghost/admin-x-framework/api/members";
+
+/**
+ * Hook to fetch the total member count efficiently.
+ * Only fetches pagination metadata (limit=1) to minimize API overhead.
+ * Automatically invalidates when members are created/updated/deleted in Ember.
+ */
+export function useMemberCount() {
+    const { data: membersData } = useBrowseMembers({
+        searchParams: { limit: '1' }
+    });
+    
+    return membersData?.meta?.pagination.total;
+}
+


### PR DESCRIPTION
Replaced hardcoded count with live data. The count syncs automatically with Ember changes through the existing bridge.

Note: When testing this locally, I noticed that it's not possible to delete members within the new admin shell. I'll take a look at that and try to resolve it. 

Closes https://linear.app/ghost/issue/BER-2983/display-correct-member-count-in-sidebar