### PR TITLE
Added cache clear of site data when settings are edited

### DIFF
--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -46,7 +46,8 @@ export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({
             ...newData,
             settings: newData.settings
         })
-    }
+    },
+    invalidateQueries: {dataType: 'SiteResponseType'}
 });
 
 export const useDeleteStripeSettings = createMutation<unknown, null>({

--- a/apps/admin/src/ember-bridge/EmberBridge.tsx
+++ b/apps/admin/src/ember-bridge/EmberBridge.tsx
@@ -75,7 +75,15 @@ export function useEmberDataSync() {
             void queryClient.invalidateQueries({
                 predicate: (query) => {
                     // Query keys are structured as [dataType, url]
-                    return query.queryKey[0] === reactDataType;
+                    const queryKeyType = query.queryKey[0];
+
+                    // Settings updates also need to clear `SiteResponseType` queries
+                    // because the site API includes settings data
+                    if (modelName === 'setting' && queryKeyType === 'SiteResponseType') {
+                        return true;
+                    }
+
+                    return queryKeyType === reactDataType;
                 }
             });
         };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2984/

- the `/site/` API includes data from settings such as the site title that is used across our React apps. It's unauthenticated meaning it gets fetched by the React shell when Ember is going through the site setup flow which ends up changing data exposed on the site API
- with the auth-route based cache invalidation removed it meant we could end up with stale site data in the React query cache after site setup
- adding explicit clearing of `SiteReponseType` cache entries any time Ember updates settings solves the immediate stale data issue
  - longer-term we shouldn't be relying on site data in our React apps, it's only useful for unauthenticated states and has the danger of becoming stale
- on the React side we also want to invalidate `/site/` query caches in `useEditSettings` so that the changes to site title, accent color, etc within our settings app get reflected correctly