### PR TITLE
Added domains to blocked outbound refs

### DIFF
--- a/ghost/core/core/server/services/member-attribution/OutboundLinkTagger.js
+++ b/ghost/core/core/server/services/member-attribution/OutboundLinkTagger.js
@@ -8,7 +8,9 @@ const blockedReferrerDomains = [
     'web.archive.org',
     'archive.org',
     'www.federalreserve.gov',
-    'www.chicagomag.com'
+    'www.chicagomag.com',
+    'bailii.org',
+    'www.bailii.org'
 ];
 
 /**


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1248/

Adding query params to 'old' site urls (particularly .html) tends to break a link when outbound link tagging is enabled. Occasionally we need to add a new domain to the list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `bailii.org` and `www.bailii.org` to the blocked outbound referrer domains list.
> 
> - **Member Attribution (backend)**:
>   - Update `blockedReferrerDomains` in `core/server/services/member-attribution/OutboundLinkTagger.js` to include `bailii.org` and `www.bailii.org`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77058cb3575c18e3c937cce7fdee03033a5588b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->