### PR TITLE
fix broken test caused by split fix.

### DIFF
--- a/ghost/core/test/unit/frontend/helpers/concat.test.js
+++ b/ghost/core/test/unit/frontend/helpers/concat.test.js
@@ -141,7 +141,7 @@ describe('{{concat}} helper', function () {
     });
     it('can concatenate an array produced by the split helper', function () {
         const templateString = '{{concat (split "hello,world,") separator="|"}}';
-        const expected = 'hello|world|';
+        const expected = 'hello|world';
         shouldCompileToExpected(templateString, {}, expected);
     });
     it('can concatenate an array produced by the split helper with a custom separator', function () {


### PR DESCRIPTION

no ref

Accidentally merged overlapping incompatible PRs (#25282 and #25283).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts concat+split test expectation to exclude trailing separator from a trailing delimiter in input.
> 
> - **Tests**:
>   - Update `concat` helper test to expect no trailing separator when concatenating an array from `split "hello,world,"` (`ghost/core/test/unit/frontend/helpers/concat.test.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b61050dc8ba492e6881f358de85040f2da69728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->