### PR TITLE
Added fallback sending domain for domain warming

### DIFF
--- a/ghost/core/core/server/services/email-address/EmailAddressService.ts
+++ b/ghost/core/core/server/services/email-address/EmailAddressService.ts
@@ -19,24 +19,40 @@ type LabsService = {
     isSet: (flag: string) => boolean
 }
 
+type GetAddressOptions = {
+    useFallbackAddress: boolean
+}
+
 export class EmailAddressService {
     #getManagedEmailEnabled: () => boolean;
     #getSendingDomain: () => string | null;
     #getDefaultEmail: () => EmailAddress;
+    #getFallbackDomain: () => string | null;
+    #getFallbackEmail: () => EmailAddress | null;
     #isValidEmailAddress: (email: string) => boolean;
     #labs: LabsService;
 
     constructor(dependencies: {
         getManagedEmailEnabled: () => boolean,
         getSendingDomain: () => string | null,
+        getFallbackDomain: () => string | null,
         getDefaultEmail: () => EmailAddress,
+        getFallbackEmail: () => string | null,
         isValidEmailAddress: (email: string) => boolean,
         labs: LabsService
 
     }) {
         this.#getManagedEmailEnabled = dependencies.getManagedEmailEnabled;
         this.#getSendingDomain = dependencies.getSendingDomain;
+        this.#getFallbackDomain = dependencies.getFallbackDomain;
         this.#getDefaultEmail = dependencies.getDefaultEmail;
+        this.#getFallbackEmail = () => {
+            const fallbackAddress = dependencies.getFallbackEmail();
+            if (!fallbackAddress) {
+                return null;
+            }
+            return EmailAddressParser.parse(fallbackAddress);
+        };
         this.#isValidEmailAddress = dependencies.isValidEmailAddress;
         this.#labs = dependencies.labs;
     }
@@ -45,12 +61,20 @@ export class EmailAddressService {
         return this.#getSendingDomain();
     }
 
+    get fallbackDomain(): string | null {
+        return this.#getFallbackDomain();
+    }
+
     get managedEmailEnabled(): boolean {
         return this.#getManagedEmailEnabled();
     }
 
     get defaultFromEmail(): EmailAddress {
         return this.#getDefaultEmail();
+    }
+
+    get fallbackEmail(): EmailAddress | null {
+        return this.#getFallbackEmail();
     }
 
     getAddressFromString(from: string, replyTo?: string): EmailAddresses {
@@ -71,7 +95,7 @@ export class EmailAddressService {
      * If we send an email from an email address that doesn't pass, we'll just default to the default email address,
      * and instead add a replyTo email address from the requested from address.
      */
-    getAddress(preferred: EmailAddresses): EmailAddresses {
+    getAddress(preferred: EmailAddresses, options: GetAddressOptions = {useFallbackAddress: false}): EmailAddresses {
         if (preferred.replyTo && !this.#isValidEmailAddress(preferred.replyTo.address)) {
             // Remove invalid replyTo addresses
             logging.error(`[EmailAddresses] Invalid replyTo address: ${preferred.replyTo.address}`);
@@ -90,6 +114,19 @@ export class EmailAddressService {
         if (!this.managedEmailEnabled) {
             // Self hoster or legacy Ghost Pro
             return preferred;
+        }
+
+        // Case: use fallback address when warming up custom domain
+        if (this.#labs.isSet('domainWarmup') && options.useFallbackAddress) {
+            const fallbackEmail = this.fallbackEmail;
+            if (fallbackEmail) {
+                return {
+                    from: fallbackEmail,
+                    replyTo: preferred.replyTo || preferred.from
+                };
+            } else {
+                logging.error('[EmailAddresses] Fallback email address is not configured, cannot use fallback address for sending email.');
+            }
         }
 
         // Case: always allow the default from address

--- a/ghost/core/core/server/services/email-address/EmailAddressServiceWrapper.js
+++ b/ghost/core/core/server/services/email-address/EmailAddressServiceWrapper.js
@@ -24,8 +24,14 @@ class EmailAddressServiceWrapper {
             getSendingDomain: () => {
                 return config.get('hostSettings:managedEmail:sendingDomain') || null;
             },
+            getFallbackDomain: () => {
+                return config.get('hostSettings:managedEmail:fallbackDomain') || null;
+            },
             getDefaultEmail: () => {
                 return settingsHelpers.getDefaultEmail();
+            },
+            getFallbackEmail: () => {
+                return config.get('hostSettings:managedEmail:fallbackAddress') || null;
             },
             isValidEmailAddress: (emailAddress) => {
                 return validator.isEmail(emailAddress);

--- a/ghost/core/core/server/services/email-service/BatchSendingService.js
+++ b/ghost/core/core/server/services/email-service/BatchSendingService.js
@@ -357,7 +357,7 @@ class BatchSendingService {
     async sendBatches({email, batches, post, newsletter}) {
         logging.info(`Sending ${batches.length} batches for email ${email.id}`);
         const deadline = this.getDeliveryDeadline(email);
-        
+
         if (deadline) {
             logging.info(`Delivery deadline for email ${email.id} is ${deadline}`);
         }
@@ -457,6 +457,7 @@ class BatchSendingService {
                 }, {
                     openTrackingEnabled: !!email.get('track_opens'),
                     clickTrackingEnabled: !!email.get('track_clicks'),
+                    useFallbackAddress: batch.get('fallback_sending_domain'),
                     deliveryTime,
                     emailBodyCache
                 });
@@ -657,7 +658,7 @@ class BatchSendingService {
     /**
      * Returns the sending deadline for an email
      * Based on the email.created_at timestamp and the configured target delivery window
-     * @param {*} email 
+     * @param {*} email
      * @returns Date | undefined
      */
     getDeliveryDeadline(email) {

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -247,11 +247,11 @@ class EmailRenderer {
         return locale;
     }
 
-    getFromAddress(post, newsletter) {
+    getFromAddress(post, newsletter, useFallbackAddress = false) {
         // Clean from address to ensure DMARC alignment
         const addresses = this.#emailAddressService.getAddress({
             from: this.#getRawFromAddress(post, newsletter)
-        });
+        }, {useFallbackAddress});
 
         return EmailAddressParser.stringify(addresses.from);
     }

--- a/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
+++ b/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
@@ -107,7 +107,8 @@ class EmailServiceWrapper {
 
         const sendingService = new SendingService({
             emailProvider: mailgunEmailProvider,
-            emailRenderer
+            emailRenderer,
+            emailAddressService: emailAddressService.service
         });
 
         const emailSegmenter = new EmailSegmenter({

--- a/ghost/core/core/server/services/email-service/MailgunEmailProvider.js
+++ b/ghost/core/core/server/services/email-service/MailgunEmailProvider.js
@@ -90,6 +90,7 @@ class MailgunEmailProvider {
             html,
             plaintext,
             from,
+            domainOverride,
             replyTo,
             emailId,
             recipients,
@@ -107,6 +108,7 @@ class MailgunEmailProvider {
                 plaintext,
                 from,
                 replyTo,
+                domainOverride,
                 id: emailId,
                 track_opens: !!options.openTrackingEnabled,
                 track_clicks: !!options.clickTrackingEnabled
@@ -180,7 +182,7 @@ class MailgunEmailProvider {
 
     /**
      * Returns the configured delay between batches in milliseconds
-     * 
+     *
      * @returns {number}
      */
     getTargetDeliveryWindow() {

--- a/ghost/core/core/server/services/email-service/SendingService.js
+++ b/ghost/core/core/server/services/email-service/SendingService.js
@@ -9,6 +9,7 @@ const logging = require('@tryghost/logging');
  * @prop {string} from
  * @prop {string} emailId
  * @prop {string} [replyTo]
+ * @prop {string} [domainOverride]
  * @prop {Recipient[]} recipients
  * @prop {import("./EmailRenderer").ReplacementDefinition[]} replacementDefinitions
  *
@@ -27,9 +28,14 @@ const logging = require('@tryghost/logging');
  */
 
 /**
+ * @typedef {import("../email-address/EmailAddressService").EmailAddressService} EmailAddressService
+ */
+
+/**
  * @typedef {object} EmailSendingOptions
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
+ * @prop {boolean} useFallbackAddress
  * @prop {Date} deliveryTime
  * @prop {{get(id: string): EmailBody | null, set(id: string, body: EmailBody): void}} [emailBodyCache]
  */
@@ -59,18 +65,22 @@ const logging = require('@tryghost/logging');
 class SendingService {
     #emailProvider;
     #emailRenderer;
+    #emailAddressService;
 
     /**
      * @param {object} dependencies
      * @param {IEmailProviderService} dependencies.emailProvider
      * @param {EmailRenderer} dependencies.emailRenderer
+     * @param {EmailAddressService} dependencies.emailAddressService
      */
     constructor({
         emailProvider,
-        emailRenderer
+        emailRenderer,
+        emailAddressService
     }) {
         this.#emailProvider = emailProvider;
         this.#emailRenderer = emailRenderer;
+        this.#emailAddressService = emailAddressService;
     }
 
     getMaximumRecipients() {
@@ -79,7 +89,7 @@ class SendingService {
 
     /**
      * Returns the configured target delivery window in seconds
-     * 
+     *
      * @returns {number}
      */
     getTargetDeliveryWindow() {
@@ -127,16 +137,18 @@ class SendingService {
         const recipients = this.buildRecipients(members, emailBody.replacements);
         return await this.#emailProvider.send({
             subject: this.#emailRenderer.getSubject(post, isTestEmail),
-            from: this.#emailRenderer.getFromAddress(post, newsletter),
+            from: this.#emailRenderer.getFromAddress(post, newsletter, !!options.useFallbackAddress),
             replyTo: this.#emailRenderer.getReplyToAddress(post, newsletter) ?? undefined,
             html: emailBody.html,
             plaintext: emailBody.plaintext,
             recipients,
             emailId: emailId,
-            replacementDefinitions: emailBody.replacements
+            replacementDefinitions: emailBody.replacements,
+            domainOverride: options.useFallbackAddress ? this.#emailAddressService.fallbackDomain : undefined
         }, {
             clickTrackingEnabled: !!options.clickTrackingEnabled,
             openTrackingEnabled: !!options.openTrackingEnabled,
+            useFallbackAddress: !!options.useFallbackAddress,
             ...(options.deliveryTime && {deliveryTime: options.deliveryTime})
         });
     }

--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -106,7 +106,11 @@ module.exports = class MailgunClient {
 
             const mailgunConfig = this.#getConfig();
             startTime = Date.now();
-            const response = await mailgunInstance.messages.create(mailgunConfig.domain, messageData);
+
+            // Use overriden domain if specified in message
+            const mailDomain = message.domainOverride ? message.domainOverride : mailgunConfig.domain;
+
+            const response = await mailgunInstance.messages.create(mailDomain, messageData);
             metrics.metric('mailgun-send-mail', {
                 value: Date.now() - startTime,
                 statusCode: 200

--- a/ghost/core/test/unit/server/services/email-address/EmailAddressService.test.ts
+++ b/ghost/core/test/unit/server/services/email-address/EmailAddressService.test.ts
@@ -1,0 +1,215 @@
+import assert from 'assert/strict';
+import sinon from 'sinon';
+import {EmailAddressService} from '../../../../../core/server/services/email-address/EmailAddressService.js';
+
+describe('EmailAddressService', function () {
+    let labsStub: any;
+
+    beforeEach(function () {
+        labsStub = {
+            isSet: sinon.stub()
+        };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('getAddress with fallback domain', function () {
+        it('uses fallback address when domainWarmup flag is enabled and useFallbackAddress is true', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: true});
+
+            assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.replyTo?.address, 'custom@custom.example.com');
+            assert.equal(result.replyTo?.name, 'Custom Sender');
+        });
+
+        it('does not use fallback address when useFallbackAddress is false', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: false});
+
+            assert.equal(result.from.address, 'custom@custom.example.com');
+            assert.equal(result.from.name, 'Custom Sender');
+            assert.equal(result.replyTo, undefined);
+        });
+
+        it('does not use fallback address when domainWarmup flag is disabled', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(false);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: true});
+
+            // Should use the original address when flag is disabled
+            assert.equal(result.from.address, 'custom@custom.example.com');
+            assert.equal(result.from.name, 'Custom Sender');
+            assert.equal(result.replyTo, undefined);
+        });
+
+        it('does not use fallback address when fallback email is not configured', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => null,
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: true});
+
+            // Should fall back to normal behavior when fallback not configured
+            assert.equal(result.from.address, 'custom@custom.example.com');
+            assert.equal(result.from.name, 'Custom Sender');
+            assert.equal(result.replyTo, undefined);
+        });
+
+        it('preserves existing replyTo when using fallback address', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'},
+                replyTo: {address: 'support@custom.example.com', name: 'Support'}
+            }, {useFallbackAddress: true});
+
+            assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.replyTo?.address, 'support@custom.example.com');
+            assert.equal(result.replyTo?.name, 'Support');
+        });
+
+        it('uses fallback address before defaulting to managed email', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'managed.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: true});
+
+            // Should use fallback instead of managed email
+            assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.replyTo?.address, 'custom@custom.example.com');
+        });
+    });
+
+    describe('fallbackDomain getter', function () {
+        it('returns the fallback domain', function () {
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => 'fallback@fallback.example.com',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            assert.equal(service.fallbackDomain, 'fallback.example.com');
+        });
+
+        it('returns null when not configured', function () {
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => null,
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => null,
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            assert.equal(service.fallbackDomain, null);
+        });
+    });
+
+    describe('fallbackEmail getter', function () {
+        it('returns the parsed fallback email', function () {
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => '"Fallback" <fallback@fallback.example.com>',
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            assert.equal(service.fallbackEmail?.address, 'fallback@fallback.example.com');
+            assert.equal(service.fallbackEmail?.name, 'Fallback');
+        });
+
+        it('returns null when not configured', function () {
+            const service = new EmailAddressService({
+                getManagedEmailEnabled: () => true,
+                getSendingDomain: () => 'custom.example.com',
+                getFallbackDomain: () => 'fallback.example.com',
+                getDefaultEmail: () => ({address: 'noreply@ghost.org', name: 'Ghost'}),
+                getFallbackEmail: () => null,
+                isValidEmailAddress: () => true,
+                labs: labsStub
+            });
+
+            assert.equal(service.fallbackEmail, null);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
+++ b/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
@@ -37,6 +37,7 @@ describe('Mailgun Email Provider', function () {
                 from: 'ghost@example.com',
                 replyTo: 'ghost@example.com',
                 emailId: '123',
+                domainOverride: undefined,
                 recipients: [
                     {
                         email: 'member@example.com',
@@ -71,6 +72,7 @@ describe('Mailgun Email Provider', function () {
                     from: 'ghost@example.com',
                     replyTo: 'ghost@example.com',
                     id: '123',
+                    domainOverride: undefined,
                     deliveryTime,
                     track_opens: true,
                     track_clicks: true

--- a/ghost/core/test/unit/server/services/email-service/sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/sending-service.test.js
@@ -8,6 +8,7 @@ describe('Sending service', function () {
     describe('send', function () {
         let emailProvider;
         let emailRenderer;
+        let emailAddressService;
         let sendStub;
         let replyTo;
 
@@ -42,6 +43,10 @@ describe('Sending service', function () {
             emailProvider = {
                 send: sendStub
             };
+
+            emailAddressService = {
+                fallbackDomain: undefined
+            };
         });
 
         afterEach(function () {
@@ -51,7 +56,8 @@ describe('Sending service', function () {
         it('calls mailgun client with correct data', async function () {
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             const deliveryTime = new Date();
@@ -74,21 +80,13 @@ describe('Sending service', function () {
             });
             assert.equal(response.id, 'provider-123');
             sinon.assert.calledOnce(sendStub);
-            assert(sendStub.calledWith(
+            sinon.assert.calledWithMatch(sendStub,
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -98,6 +96,14 @@ describe('Sending service', function () {
                                 value: 'John'
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
@@ -105,13 +111,16 @@ describe('Sending service', function () {
                     openTrackingEnabled: true,
                     deliveryTime
                 }
-            ));
+            );
+            // Verify domain is not included when useFallbackAddress is not set
+            assert.equal(sendStub.getCall(0).args[0].domain, undefined);
         });
 
         it('calls mailgun client without the deliverytime if it is not defined', async function () {
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             const deliveryTime = undefined;
@@ -134,21 +143,13 @@ describe('Sending service', function () {
             });
             assert.equal(response.id, 'provider-123');
             sinon.assert.calledOnce(sendStub);
-            assert(sendStub.calledWith(
+            sinon.assert.calledWithMatch(sendStub,
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -158,19 +159,28 @@ describe('Sending service', function () {
                                 value: 'John'
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
                     clickTrackingEnabled: true,
                     openTrackingEnabled: true
                 }
-            ));
+            );
         });
 
         it('defaults to empty string if replacement returns undefined', async function () {
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             const response = await sendingService.send({
@@ -190,21 +200,13 @@ describe('Sending service', function () {
             });
             assert.equal(response.id, 'provider-123');
             sinon.assert.calledOnce(sendStub);
-            assert(sendStub.calledWith(
+            sinon.assert.calledWithMatch(sendStub,
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -214,20 +216,29 @@ describe('Sending service', function () {
                                 value: ''
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
                     clickTrackingEnabled: true,
                     openTrackingEnabled: true
                 }
-            ));
+            );
         });
 
         it('supports cache', async function () {
             const emailBodyCache = new EmailBodyCache();
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             const response = await sendingService.send({
@@ -249,21 +260,13 @@ describe('Sending service', function () {
             assert.equal(response.id, 'provider-123');
             sinon.assert.calledOnce(sendStub);
             sinon.assert.calledOnce(emailRenderer.renderBody);
-            assert(sendStub.calledWith(
+            sinon.assert.calledWithMatch(sendStub,
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -273,13 +276,21 @@ describe('Sending service', function () {
                                 value: 'John'
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
                     clickTrackingEnabled: true,
                     openTrackingEnabled: true
                 }
-            ));
+            );
 
             // Do again and see if cache is used
             const response2 = await sendingService.send({
@@ -300,21 +311,13 @@ describe('Sending service', function () {
             });
             assert.equal(response2.id, 'provider-123');
             sinon.assert.calledTwice(sendStub);
-            assert(sendStub.getCall(1).calledWith(
+            sinon.assert.calledWithMatch(sendStub.getCall(1),
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -324,13 +327,21 @@ describe('Sending service', function () {
                                 value: 'John'
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
                     clickTrackingEnabled: true,
                     openTrackingEnabled: true
                 }
-            ));
+            );
 
             // Didn't call renderBody again
             sinon.assert.calledOnce(emailRenderer.renderBody);
@@ -339,7 +350,8 @@ describe('Sending service', function () {
         it('removes invalid recipients before sending', async function () {
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             const response = await sendingService.send({
@@ -363,21 +375,13 @@ describe('Sending service', function () {
             });
             assert.equal(response.id, 'provider-123');
             sinon.assert.calledOnce(sendStub);
-            assert(sendStub.calledWith(
+            sinon.assert.calledWithMatch(sendStub,
                 {
                     subject: 'Hi',
                     from: 'ghost@example.com',
                     replyTo: 'ghost+reply@example.com',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
-                    emailId: '123',
-                    replacementDefinitions: [
-                        {
-                            id: 'name',
-                            token: '{{name}}',
-                            getValue: sinon.match.func
-                        }
-                    ],
                     recipients: [
                         {
                             email: 'member@example.com',
@@ -387,19 +391,28 @@ describe('Sending service', function () {
                                 value: 'John'
                             }]
                         }
+                    ],
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
                     ]
                 },
                 {
                     clickTrackingEnabled: true,
                     openTrackingEnabled: true
                 }
-            ));
+            );
         });
 
         it('maps null replyTo to undefined', async function () {
             const sendingService = new SendingService({
                 emailRenderer,
-                emailProvider
+                emailProvider,
+                emailAddressService
             });
 
             replyTo = null;
@@ -422,6 +435,188 @@ describe('Sending service', function () {
             sinon.assert.calledOnce(sendStub);
             const firstCall = sendStub.getCall(0);
             assert.equal(firstCall.args[0].replyTo, undefined);
+        });
+
+        describe('fallback sending domain', function () {
+            it('uses fallback domain when useFallbackAddress is true and fallback is configured', async function () {
+                emailAddressService.fallbackDomain = 'fallback.example.com';
+
+                const sendingService = new SendingService({
+                    emailRenderer,
+                    emailProvider,
+                    emailAddressService
+                });
+
+                const response = await sendingService.send({
+                    post: {},
+                    newsletter: {},
+                    segment: null,
+                    emailId: '123',
+                    members: [
+                        {
+                            email: 'member@example.com',
+                            name: 'John'
+                        }
+                    ]
+                }, {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true,
+                    useFallbackAddress: true
+                });
+
+                assert.equal(response.id, 'provider-123');
+                sinon.assert.calledOnce(sendStub);
+
+                // Verify getFromAddress was called with useFallbackAddress: true
+                sinon.assert.calledWith(
+                    emailRenderer.getFromAddress,
+                    sinon.match.object,
+                    sinon.match.object,
+                    true
+                );
+
+                // Verify domain was passed to email provider
+                sinon.assert.calledWithMatch(sendStub,
+                    {
+                        domainOverride: 'fallback.example.com'
+                    },
+                    {
+                        clickTrackingEnabled: true,
+                        openTrackingEnabled: true,
+                        useFallbackAddress: true
+                    }
+                );
+            });
+
+            it('does not include domain when useFallbackAddress is false', async function () {
+                emailAddressService.fallbackDomain = 'fallback.example.com';
+
+                const sendingService = new SendingService({
+                    emailRenderer,
+                    emailProvider,
+                    emailAddressService
+                });
+
+                const response = await sendingService.send({
+                    post: {},
+                    newsletter: {},
+                    segment: null,
+                    emailId: '123',
+                    members: [
+                        {
+                            email: 'member@example.com',
+                            name: 'John'
+                        }
+                    ]
+                }, {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true,
+                    useFallbackAddress: false
+                });
+
+                assert.equal(response.id, 'provider-123');
+                sinon.assert.calledOnce(sendStub);
+
+                // Verify getFromAddress was called with useFallbackAddress: false
+                sinon.assert.calledWith(
+                    emailRenderer.getFromAddress,
+                    sinon.match.object,
+                    sinon.match.object,
+                    false
+                );
+
+                // Verify domain was not included in the message
+                assert.equal(sendStub.getCall(0).args[0].domain, undefined);
+            });
+
+            it('does not include domain when useFallbackAddress is true but fallback domain is not configured', async function () {
+                emailAddressService.fallbackDomain = null;
+
+                const sendingService = new SendingService({
+                    emailRenderer,
+                    emailProvider,
+                    emailAddressService
+                });
+
+                const response = await sendingService.send({
+                    post: {},
+                    newsletter: {},
+                    segment: null,
+                    emailId: '123',
+                    members: [
+                        {
+                            email: 'member@example.com',
+                            name: 'John'
+                        }
+                    ]
+                }, {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true,
+                    useFallbackAddress: true
+                });
+
+                assert.equal(response.id, 'provider-123');
+                sinon.assert.calledOnce(sendStub);
+
+                // Verify getFromAddress was still called with useFallbackAddress: true
+                sinon.assert.calledWith(
+                    emailRenderer.getFromAddress,
+                    sinon.match.object,
+                    sinon.match.object,
+                    true
+                );
+
+                // Verify domain was not included (fallback not configured)
+                assert.equal(sendStub.getCall(0).args[0].domainOverride, null);
+            });
+
+            it('defaults useFallbackAddress to false when not specified', async function () {
+                emailAddressService.fallbackDomain = 'fallback.example.com';
+
+                const sendingService = new SendingService({
+                    emailRenderer,
+                    emailProvider,
+                    emailAddressService
+                });
+
+                const response = await sendingService.send({
+                    post: {},
+                    newsletter: {},
+                    segment: null,
+                    emailId: '123',
+                    members: [
+                        {
+                            email: 'member@example.com',
+                            name: 'John'
+                        }
+                    ]
+                }, {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true
+                    // useFallbackAddress not specified
+                });
+
+                assert.equal(response.id, 'provider-123');
+                sinon.assert.calledOnce(sendStub);
+
+                // Verify getFromAddress was called with false (default)
+                sinon.assert.calledWith(
+                    emailRenderer.getFromAddress,
+                    sinon.match.object,
+                    sinon.match.object,
+                    false
+                );
+
+                // Verify useFallbackAddress defaults to false in options
+                sinon.assert.calledWithMatch(sendStub,
+                    sinon.match.object,
+                    {
+                        clickTrackingEnabled: true,
+                        openTrackingEnabled: true,
+                        useFallbackAddress: false
+                    }
+                );
+            });
         });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/sending-service.test.js
@@ -438,6 +438,25 @@ describe('Sending service', function () {
         });
 
         describe('fallback sending domain', function () {
+            // Shared test data to reduce boilerplate
+            const baseEmailData = {
+                post: {},
+                newsletter: {},
+                segment: null,
+                emailId: '123',
+                members: [
+                    {
+                        email: 'member@example.com',
+                        name: 'John'
+                    }
+                ]
+            };
+
+            const baseOptions = {
+                clickTrackingEnabled: true,
+                openTrackingEnabled: true
+            };
+
             it('uses fallback domain when useFallbackAddress is true and fallback is configured', async function () {
                 emailAddressService.fallbackDomain = 'fallback.example.com';
 
@@ -447,22 +466,10 @@ describe('Sending service', function () {
                     emailAddressService
                 });
 
-                const response = await sendingService.send({
-                    post: {},
-                    newsletter: {},
-                    segment: null,
-                    emailId: '123',
-                    members: [
-                        {
-                            email: 'member@example.com',
-                            name: 'John'
-                        }
-                    ]
-                }, {
-                    clickTrackingEnabled: true,
-                    openTrackingEnabled: true,
-                    useFallbackAddress: true
-                });
+                const response = await sendingService.send(
+                    baseEmailData,
+                    {...baseOptions, useFallbackAddress: true}
+                );
 
                 assert.equal(response.id, 'provider-123');
                 sinon.assert.calledOnce(sendStub);
@@ -497,22 +504,10 @@ describe('Sending service', function () {
                     emailAddressService
                 });
 
-                const response = await sendingService.send({
-                    post: {},
-                    newsletter: {},
-                    segment: null,
-                    emailId: '123',
-                    members: [
-                        {
-                            email: 'member@example.com',
-                            name: 'John'
-                        }
-                    ]
-                }, {
-                    clickTrackingEnabled: true,
-                    openTrackingEnabled: true,
-                    useFallbackAddress: false
-                });
+                const response = await sendingService.send(
+                    baseEmailData,
+                    {...baseOptions, useFallbackAddress: false}
+                );
 
                 assert.equal(response.id, 'provider-123');
                 sinon.assert.calledOnce(sendStub);
@@ -538,22 +533,10 @@ describe('Sending service', function () {
                     emailAddressService
                 });
 
-                const response = await sendingService.send({
-                    post: {},
-                    newsletter: {},
-                    segment: null,
-                    emailId: '123',
-                    members: [
-                        {
-                            email: 'member@example.com',
-                            name: 'John'
-                        }
-                    ]
-                }, {
-                    clickTrackingEnabled: true,
-                    openTrackingEnabled: true,
-                    useFallbackAddress: true
-                });
+                const response = await sendingService.send(
+                    baseEmailData,
+                    {...baseOptions, useFallbackAddress: true}
+                );
 
                 assert.equal(response.id, 'provider-123');
                 sinon.assert.calledOnce(sendStub);
@@ -579,22 +562,10 @@ describe('Sending service', function () {
                     emailAddressService
                 });
 
-                const response = await sendingService.send({
-                    post: {},
-                    newsletter: {},
-                    segment: null,
-                    emailId: '123',
-                    members: [
-                        {
-                            email: 'member@example.com',
-                            name: 'John'
-                        }
-                    ]
-                }, {
-                    clickTrackingEnabled: true,
-                    openTrackingEnabled: true
-                    // useFallbackAddress not specified
-                });
+                const response = await sendingService.send(
+                    baseEmailData,
+                    baseOptions // useFallbackAddress not specified
+                );
 
                 assert.equal(response.id, 'provider-123');
                 sinon.assert.calledOnce(sendStub);


### PR DESCRIPTION
ref [GVA-588](https://linear.app/ghost/issue/GVA-588/add-the-ability-to-send-from-a-fallback-domain)

The changes here:

* If the boolean is set at the batch level (which we currently never do) -- then we send from the fallback domain in the SendingService (see BatchSendingService)
* In the sending service, we use the bool passed in to determine the from address we pass to the mail provider, and if it's set we also pass in the fallback domain.
* The address service pulls the fallback address + domain from config (injected in the wrapper file)
* The MailgunEmailProvider was just modified to pass the domain through to the MailgunClient, which can now take a domain to override the default one from config

That's all the logic changes, 87 lines of code changes + tests.