### PR TITLE
Wired up dark mode toggle

### DIFF
--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -11,6 +11,7 @@ const WhatsNewPreferencesSchema = z.object({
 
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional(),
+    nightShift: z.boolean().optional(),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react"
-
+import React from "react"
 import {
     Avatar,
     AvatarFallback,
@@ -14,10 +13,16 @@ import {
     Switch
 } from "@tryghost/shade"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { useUserPreferences, useEditUserPreferences } from "@/hooks/user-preferences";
 
 function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
     const currentUser = useCurrentUser();
-    const [dummyDarkMode, setDummyDarkMode] = useState(false);
+    const {data: preferences} = useUserPreferences();
+    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
+
+    const setNightShift = (nightShift: boolean) => {
+        void editPreferences({nightShift});
+    }
 
     return (
         <DropdownMenu {...props}>
@@ -84,15 +89,16 @@ function UserMenu({ ...props }: React.ComponentProps<typeof DropdownMenu>) {
                     className="cursor-pointer text-base"
                     onSelect={(e) => {
                         e.preventDefault();
-                        setDummyDarkMode(!dummyDarkMode);
+                        setNightShift(!preferences?.nightShift);
                     }}
                 >
                     <LucideIcon.Moon />
                     <span className="flex-1">Dark mode</span>
                     <Switch
                         size='sm'
-                        checked={dummyDarkMode}
-                        onCheckedChange={setDummyDarkMode}
+                        checked={preferences?.nightShift ?? false}
+                        disabled={isEditingPreferences}
+                        onCheckedChange={setNightShift}
                         onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
                         tabIndex={-1}
                     />

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -64,6 +64,16 @@ export default class StateBridgeService extends Service.extend(Evented) {
             this.store.pushPayload(type, response);
         }
 
+        if (dataType === 'UsersResponseType' && response.users[0]?.id === this.session.user?.id) {
+            // nightShift preference is managed by the feature service and won't auto-update when store data changes
+            try {
+                this.feature._setAdminTheme();
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('Failed to set admin theme', error);
+            }
+        }
+
         if (dataType === 'SettingsResponseType') {
             // Blog title is based on settings, but the one stored in config is used instead in various places
             this.config.blogTitle = response.settings.find(setting => setting.key === 'title').value;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2952/

- used the new user preferences hooks to wire up the `nightShift` preference to the dark mode toggle UI
- on the Ember side we need to explicitly make the theme change call because we're no longer making the data change via the feature service
