### PR TITLE
Fixed modal event handling in React shell

### DIFF
--- a/ghost/admin/app/components/gh-dropdown-button.hbs
+++ b/ghost/admin/app/components/gh-dropdown-button.hbs
@@ -1,0 +1,10 @@
+<button
+    type={{this.type}}
+    role={{this.role}}
+    class="{{@classNames}} {{this.openClosedClass}}"
+    {{on "click" this.handleClick}}
+    ...attributes
+>
+    {{yield}}
+</button>
+

--- a/ghost/admin/app/components/gh-dropdown-button.js
+++ b/ghost/admin/app/components/gh-dropdown-button.js
@@ -1,34 +1,31 @@
 import Component from '@ember/component';
-import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
 import classic from 'ember-classic-decorator';
-import {attributeBindings, tagName} from '@ember-decorators/component';
-import {computed} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 @classic
-@tagName('button')
-@attributeBindings('href', 'role', 'type')
-export default class GhDropdownButton extends Component.extend(DropdownMixin) {
+export default class GhDropdownButton extends Component {
+    tagName = '';
+
     @service dropdown;
 
     role = 'button';
+    type = 'button';
+    isOpen = false;
 
     // matches with the dropdown this button toggles
     dropdownName = null;
 
-    @computed
-    get type() {
-        return this.tagName === 'button' ? 'button' : null;
+    @computed('isOpen')
+    get openClosedClass() {
+        return this.isOpen ? 'open' : 'closed';
     }
 
     // Notify dropdown service this dropdown should be toggled
-    click() {
-        super.click(...arguments);
-
+    @action
+    handleClick(event) {
         this.dropdown.toggleDropdown(this.dropdownName, this);
-
-        if (this.tagName === 'a') {
-            return false;
-        }
+        event.stopPropagation();
+        event.preventDefault();
     }
 }

--- a/ghost/admin/app/components/gh-task-button.hbs
+++ b/ghost/admin/app/components/gh-task-button.hbs
@@ -1,46 +1,55 @@
-{{#if (has-block)}}
-    {{yield (hash
-        isIdle=this.isIdle
-        isRunning=this.isRunning
-        isSuccess=this.isSuccess
-        isFailure=this.isFailure
-    )}}
-{{else}}
-    {{#if this.isRunning}}
-        <span data-test-task-button-state="running">
-            {{#if this.showIcon}}
-                {{svg-jar "spinner" class="gh-icon-spinner"}}
-            {{/if}}
-            {{this.runningText}}
-        </span>
-    {{/if}}
-
-    {{#if (and this.isIdle (not (or this.isRunning this.isSuccess this.isFailure)))}}
-        <span data-test-task-button-state="idle">
-            {{#if this.showIcon}}
-                {{#if this.idleIcon}}
-                    {{svg-jar this.idleIcon}}
+<button
+    type={{or @type "button"}}
+    style={{this.style}}
+    class="{{@class}} {{if this.isRunning "appear-disabled"}} {{this.isIdleClass}} {{this.isRunningClass}} {{this.isSuccessClass}} {{this.isFailureClass}}"
+    {{on "click" this.handleClick}}
+    {{on "mousedown" this.handleMouseDown}}
+    ...attributes
+>
+    {{#if (has-block)}}
+        {{yield (hash
+            isIdle=this.isIdle
+            isRunning=this.isRunning
+            isSuccess=this.isSuccess
+            isFailure=this.isFailure
+        )}}
+    {{else}}
+        {{#if this.isRunning}}
+            <span data-test-task-button-state="running">
+                {{#if this.showIcon}}
+                    {{svg-jar "spinner" class="gh-icon-spinner"}}
                 {{/if}}
-            {{/if}}
-            {{this.buttonText}}
-        </span>
-    {{/if}}
+                {{this.runningText}}
+            </span>
+        {{/if}}
+
+        {{#if this.isIdle}}
+            <span data-test-task-button-state="idle">
+                {{#if this.showIcon}}
+                    {{#if this.idleIcon}}
+                        {{svg-jar this.idleIcon}}
+                    {{/if}}
+                {{/if}}
+                {{this.buttonText}}
+            </span>
+        {{/if}}
 
 
-    {{#if this.isSuccess}}
-        <span {{did-insert this.handleReset}} data-test-task-button-state="success">
-            {{#if this.showIcon}}
-                {{svg-jar "check-circle"}}
-            {{/if}}
-            {{this.successText}}
-        </span>
+        {{#if this.isSuccess}}
+            <span {{did-insert this.handleReset}} data-test-task-button-state="success">
+                {{#if this.showIcon}}
+                    {{svg-jar "check-circle"}}
+                {{/if}}
+                {{this.successText}}
+            </span>
+        {{/if}}
+        {{#if this.isFailure}}
+            <span data-test-task-button-state="failure">
+                {{#if this.showIcon}}
+                    {{svg-jar "retry"}}
+                {{/if}}
+                {{this.failureText}}
+            </span>
+        {{/if}}
     {{/if}}
-    {{#if this.isFailure}}
-        <span data-test-task-button-state="failure">
-            {{#if this.showIcon}}
-                {{svg-jar "retry"}}
-            {{/if}}
-            {{this.failureText}}
-        </span>
-    {{/if}}
-{{/if}}
+</button>


### PR DESCRIPTION
## Problem
Modal buttons (delete, save, etc.) weren't working when Ember runs inside the React shell because modals render to `#ember-modal-wormhole` outside the `#ember-app` container where EventDispatcher listens.

## Solution
Converted `GhTaskButton` and `GhDropdownButton` to tagless components using `{{on}}` modifiers, which attach native event listeners directly to DOM elements instead of relying on EventDispatcher delegation.

## Changes
- `gh-task-button` → tagless with explicit `<button {{on "click"}}>` 
- `gh-dropdown-button` → tagless with explicit `<button {{on "click"}}>` 

This fixes all modal button interactions in React shell while maintaining backward compatibility with standalone Ember.

---

fixes https://linear.app/ghost/issue/BER-2986/event-delegation-does-not-work-in-modals