### PR TITLE
Fixed event delegation from modals and dropdowns

### DIFF
--- a/ghost/admin/app/instance-initializers/patch-event-dispatcher.js
+++ b/ghost/admin/app/instance-initializers/patch-event-dispatcher.js
@@ -1,0 +1,23 @@
+// In the React shell we use {{in-element}} to render modals outside of the Ember root
+// so we need the EventDispatcher to listen to events on the body element instead of
+// the root element in order to capture events that bubble up from modals.
+
+export function initialize(appInstance) {
+    const inAdminForward = document.querySelector('#ember-app') !== null;
+
+    if (!inAdminForward) {
+        return;
+    }
+
+    const dispatcher = appInstance.lookup('event_dispatcher:main');
+    const originalSetup = dispatcher.setup;
+
+    dispatcher.setup = function (addedEvents) {
+        return originalSetup.call(this, addedEvents, 'body');
+    };
+}
+
+export default {
+    name: 'patch-event-dispatcher',
+    initialize
+};


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-2986/

Ember sets up its EventDispatcher to listen to events on the configured `rootElement` but in the React shell we set `rootElement` to `#ember-app` but also render elements like modals _outside_ of `rootElement` in `#ember-modal-wormhole` or `#ember-basic-dropdown-wormhole`. Any events that bubble up from those wormholes are then never caught by Ember's EventDispatcher meaning we end up with buttons and other UI elements that do nothing when clicked

- added an instance initializer that patches the `setup` method on `EventDispatcher` so event listeners get added to the document body instead of the configured root element
  - ensures Ember can handle events from it's main app element as well as the wormhole elements that live elsewhere in the DOM tree
