### PR TITLE
Added role-based permission checks to React admin sidebar

### DIFF
--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -170,6 +170,10 @@ export function isEditorUser(user: User) {
     return isAnyEditor;
 }
 
+export function isSuperEditorUser(user: User) {
+    return user.roles.some(role => role.name === 'Super Editor');
+}
+
 export function isAuthorUser(user: User) {
     return user.roles.some(role => role.name === 'Author');
 }
@@ -184,6 +188,16 @@ export function isAuthorOrContributor(user: User) {
 
 export function canAccessSettings(user: User) {
     return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+}
+
+export function canManageMembers(user: User) {
+    // Owner, Admin, or Super Editor can manage members
+    return isOwnerUser(user) || isAdminUser(user) || isSuperEditorUser(user);
+}
+
+export function canManageTags(user: User) {
+    // Admin or Editor can manage tags
+    return isAdminUser(user) || isEditorUser(user);
 }
 
 export function hasAdminAccess(user: User) {

--- a/apps/admin/src/layout/app-sidebar/AppSidebarHeader.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarHeader.tsx
@@ -6,6 +6,8 @@ import {
     SidebarHeader
 } from "@tryghost/shade"
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { isContributorUser } from "@tryghost/admin-x-framework/api/users";
 
 const ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
 const searchShortcut = ctrlOrCmd === 'command' ? '⌘K' : 'Ctrl+K';
@@ -23,9 +25,11 @@ const openSearchModal = (event: React.MouseEvent<HTMLButtonElement>) => {
 }
 
 function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeader>) {
+    const { data: currentUser } = useCurrentUser();
     const site = useBrowseSite();
     const title = site.data?.site.title ?? "";
     const siteIcon = site.data?.site.icon ?? "https://static.ghost.org/v4.0.0/images/ghost-orb-1.png";
+    const showSearch = currentUser && !isContributorUser(currentUser);
 
     return (
         <SidebarHeader {...props}>
@@ -44,17 +48,19 @@ function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeade
                         </div>
                     </div>
                 </div>
-                <Button
-                    variant="outline"
-                    className="flex items-center justify-between text-gray-500 hover:text-gray-700 hover:bg-background text-base [&_svg]:stroke-2 pr-2 shadow-xs hover:shadow-sm hover:border-gray-200 h-[38px]"
-                    onClick={openSearchModal}
-                >
-                    <div className="flex items-center gap-2">
-                        <LucideIcon.Search className="text-muted-foreground" />
-                        Search site
-                    </div>
-                    <Kbd className="text-gray-500 bg-transparent">{searchShortcut}</Kbd>
-                </Button>
+                {showSearch && (
+                    <Button
+                        variant="outline"
+                        className="flex items-center justify-between text-gray-500 hover:text-gray-700 hover:bg-background text-base [&_svg]:stroke-2 pr-2 shadow-xs hover:shadow-sm hover:border-gray-200 h-[38px]"
+                        onClick={openSearchModal}
+                    >
+                        <div className="flex items-center gap-2">
+                            <LucideIcon.Search className="text-muted-foreground" />
+                            Search site
+                        </div>
+                        <Kbd className="text-gray-500 bg-transparent">{searchShortcut}</Kbd>
+                    </Button>
+                )}
             </div>
         </SidebarHeader>
     );

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -8,13 +8,19 @@ import {
     SidebarMenu,
     SidebarMenuBadge
 } from "@tryghost/shade"
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api/users";
 import { NavMenuItem } from "./NavMenuItem";
 import NavSubMenu from "./NavSubMenu";
 import { useMemberCount } from "./hooks/useMemberCount";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
+    const { data: currentUser } = useCurrentUser();
     const [postsExpanded, setPostsExpanded] = useState(false);
     const memberCount = useMemberCount();
+
+    const showTags = currentUser && canManageTags(currentUser);
+    const showMembers = currentUser && canManageMembers(currentUser);
 
     return (
         <SidebarGroup {...props}>
@@ -80,22 +86,26 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                         </NavMenuItem.Link>
                     </NavMenuItem>
 
-                    <NavMenuItem>
-                        <NavMenuItem.Link to="tags">
-                            <LucideIcon.Tag />
-                            <NavMenuItem.Label>Tags</NavMenuItem.Label>
-                        </NavMenuItem.Link>
-                    </NavMenuItem>
+                    {showTags && (
+                        <NavMenuItem>
+                            <NavMenuItem.Link to="tags">
+                                <LucideIcon.Tag />
+                                <NavMenuItem.Label>Tags</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
+                    )}
 
-                    <NavMenuItem>
-                        <NavMenuItem.Link to="members" activeOnSubpath>
-                            <LucideIcon.Users />
-                            <NavMenuItem.Label>Members</NavMenuItem.Label>
-                        </NavMenuItem.Link>
-                        {memberCount != null && (
-                            <SidebarMenuBadge>{memberCount}</SidebarMenuBadge>
-                        )}
-                    </NavMenuItem>
+                    {showMembers && (
+                        <NavMenuItem>
+                            <NavMenuItem.Link to="members" activeOnSubpath>
+                                <LucideIcon.Users />
+                                <NavMenuItem.Label>Members</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                            {memberCount != null && (
+                                <SidebarMenuBadge>{memberCount}</SidebarMenuBadge>
+                            )}
+                        </NavMenuItem>
+                    )}
                 </SidebarMenu>
             </SidebarGroupContent>
         </SidebarGroup>

--- a/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
@@ -6,9 +6,20 @@ import {
     SidebarGroupContent,
     SidebarMenu
 } from "@tryghost/shade"
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
+import { isOwnerUser } from "@tryghost/admin-x-framework/api/users";
 import { NavMenuItem } from "./NavMenuItem";
 
 function NavGhostPro({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
+    const { data: currentUser } = useCurrentUser();
+    const { data: config } = useBrowseConfig();
+
+    // Only show Ghost(Pro) for owner users when billing is enabled
+    if (!currentUser || !isOwnerUser(currentUser) || !config?.config.hostSettings?.billing?.enabled) {
+        return null;
+    }
+
     return (
         <SidebarGroup {...props}>
             <SidebarGroupContent>

--- a/apps/admin/src/layout/app-sidebar/NavMain.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMain.tsx
@@ -7,12 +7,25 @@ import {
     SidebarMenu
 } from "@tryghost/shade"
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { useBrowseSettings } from "@tryghost/admin-x-framework/api/settings";
+import { getSettingValue } from "@tryghost/admin-x-framework/api/settings";
+import { hasAdminAccess } from "@tryghost/admin-x-framework/api/users";
 import NetworkIcon from "./icons/NetworkIcon";
 import { NavMenuItem } from "./NavMenuItem";
 
 function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
+    const { data: currentUser } = useCurrentUser();
+    const { data: settings } = useBrowseSettings();
     const site = useBrowseSite();
     const url = site.data?.site.url;
+
+    // Only show NavMain for admin users
+    if (!currentUser || !hasAdminAccess(currentUser)) {
+        return null;
+    }
+
+    const socialWebEnabled = getSettingValue<boolean>(settings?.settings, 'social_web_enabled');
 
     return (
         <SidebarGroup {...props}>
@@ -24,12 +37,14 @@ function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             <NavMenuItem.Label>Analytics</NavMenuItem.Label>
                         </NavMenuItem.Link>
                     </NavMenuItem>
-                    <NavMenuItem>
-                        <NavMenuItem.Link to="network">
-                            <NetworkIcon />
-                            <NavMenuItem.Label>Network</NavMenuItem.Label>
-                        </NavMenuItem.Link>
-                    </NavMenuItem>
+                    {socialWebEnabled && (
+                        <NavMenuItem>
+                            <NavMenuItem.Link to="network">
+                                <NetworkIcon />
+                                <NavMenuItem.Label>Network</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
+                    )}
                     <NavMenuItem className="relative group/viewsite">
                         <NavMenuItem.Link to="site">
                             <LucideIcon.AppWindow />

--- a/apps/admin/src/layout/app-sidebar/NavSettings.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavSettings.tsx
@@ -6,19 +6,26 @@ import {
     SidebarGroupContent,
     SidebarMenu
 } from "@tryghost/shade"
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { canAccessSettings } from "@tryghost/admin-x-framework/api/users";
 import { NavMenuItem } from "./NavMenuItem";
 
 function NavSettings({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
+    const { data: currentUser } = useCurrentUser();
+    const showSettings = currentUser && canAccessSettings(currentUser);
+
     return (
         <SidebarGroup {...props}>
             <SidebarGroupContent>
                 <SidebarMenu>
-                    <NavMenuItem>
-                        <NavMenuItem.Link to="settings">
-                            <LucideIcon.Settings />
-                            <NavMenuItem.Label>Settings</NavMenuItem.Label>
-                        </NavMenuItem.Link>
-                    </NavMenuItem>
+                    {showSettings && (
+                        <NavMenuItem>
+                            <NavMenuItem.Link to="settings">
+                                <LucideIcon.Settings />
+                                <NavMenuItem.Label>Settings</NavMenuItem.Label>
+                            </NavMenuItem.Link>
+                        </NavMenuItem>
+                    )}
 
                     <NavMenuItem>
                         <NavMenuItem.Link


### PR DESCRIPTION
Implemented granular permission checks matching Ember sidebar behavior:
- Owner: Ghost(Pro) billing section (when enabled)
- Admin: Analytics, View site, Network (when social_web_enabled)
- Admin/Super Editor: Members management                                        
- Admin/Editor: Tags, Settings access
- Contributors: Search hidden, basic content only (the sidebar design still need tweaking)

I think the implementation, as it stands, is about as clean as you can make it without taking on the work of redoing the permissions. I'd very much like to do that, though. 

---

Fixes https://linear.app/ghost/issue/BER-2988/add-missing-permission-checks
