### PR TITLE
Fixed sidebar not showing on React routes

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -14,7 +14,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   </head>
-  <body>
+  <body class="react-admin">
     <div id="root"></div>
     <div id="ember-app"></div>
     <div id="ember-basic-dropdown-wormhole"></div>

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,43 +1,43 @@
 @import "@tryghost/shade/styles.css";
 
 /* Ensure the Ember app renders in the correct position */
-body:not(.ember-application) #ember-app {
+body.react-admin #ember-app {
     width: 100%;
     height: 100%;
 }
 
-body:not(.ember-application) #ember-app .gh-app {
+body.react-admin #ember-app .gh-app {
     position: static;
 }
 
 
 /* Hide the nav menu and tab bar on mobile when running in React admin shell */
-body:not(.ember-application) #ember-app .gh-nav,
-body:not(.ember-application) #ember-app .gh-mobile-nav-bar {
+body.react-admin #ember-app .gh-nav,
+body.react-admin #ember-app .gh-mobile-nav-bar {
     display: none;
 }
 
 /* Temporary overrides until Ember transition is finished */
-body:not(.ember-application) .gh-canvas-header {
+body.react-admin .gh-canvas-header {
     padding-top: 24px;
     padding-bottom: 24px;
 }
 
-body:not(.ember-application) .gh-canvas-breadcrumb+.gh-canvas-title {
+body.react-admin .gh-canvas-breadcrumb+.gh-canvas-title {
     padding-top: 0px;
     margin-top: -4px;
 }
 
-body:not(.ember-application) .gh-canvas-title,
-body:not(.ember-application) [data-header="header-title"] {
+body.react-admin .gh-canvas-title,
+body.react-admin [data-header="header-title"] {
     font-size: 25px;
 }
 
-body:not(.ember-application) [data-header="header"] {
+body.react-admin [data-header="header"] {
     padding-top: 24px;
 }
 
-body:not(.ember-application) [data-navbar="navbar"] {
+body.react-admin [data-navbar="navbar"] {
     padding-top: 24px;
     padding-bottom: 24px;
 }

--- a/ghost/admin/app/styles/patterns/global.css
+++ b/ghost/admin/app/styles/patterns/global.css
@@ -633,14 +633,14 @@ input[type="image"] {
 .show {
     display: block;
 }
-.ember-application .show {
+.gh-app .show {
     display: block !important;
 }
 
 .hidden {
     display: none;
 }
-.ember-application .hidden {
+.gh-app .hidden {
     visibility: hidden !important;
     display: none !important;
 }


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/11b56ab9f44219e148f3269ae485c56a91e4455a

- changing `EventDispatcher` to register listeners on `document.body` meant Ember started adding the `.ember-application` class to the body element rather than the nested `#ember-app` element
- updated our React shell override styles for parts of the Ember app by adding `.react-admin` class to the body element and using it in place of `:not(.ember-application)`
- fixed the Ember `.show/.hidden !important` styles to be specific to `.gh-app` rather than `.ember-application` so they don't collide with the Shade classes of the same name
