### PR TITLE
Refined screen heights for React app

### DIFF
--- a/apps/admin/src/ember-bridge/EmberRoot.tsx
+++ b/apps/admin/src/ember-bridge/EmberRoot.tsx
@@ -24,5 +24,5 @@ export const EmberRoot = React.memo(function EmberRoot() {
         };
     }, []);
 
-    return <div ref={ref} hidden={!isFallbackPresent} className="w-full h-screen overflow-auto"></div>;
+    return <div ref={ref} hidden={!isFallbackPresent} className="h-[calc(100svh-var(--mobile-navbar-height))] w-full sidebar:h-screen overflow-auto"></div>;
 });

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -41,3 +41,7 @@ body.react-admin [data-navbar="navbar"] {
     padding-top: 24px;
     padding-bottom: 24px;
 }
+
+body.react-admin #ember-app .gh-viewport {
+    padding-bottom: 0px;
+}

--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -18,7 +18,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
         <SidebarProvider open={!!currentUser}>
             <AppSidebar />
             <SidebarInset className="bg-white">
-                <main className="flex-1 min-h-screen">{children}</main>
+                <main className="flex-1">{children}</main>
                 <MobileNavBar />
             </SidebarInset>
         </SidebarProvider>

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -155,7 +155,7 @@
 }
 
 @media (max-width: 800px) {
-    body.ember-application .shade {
+    body:not(.react-admin) .shade {
         height: calc(100vh - var(--mobile-navbar-height));
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- In a couple of places in the React app there were unexpected double scrollbars showing up. The main reason for this is because we treat the mobile nav bar differently in React than in Ember.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts container heights and CSS so React-admin and Ember views handle mobile navbar space and scrolling correctly.
> 
> - **Layout/Heights**
>   - Update `apps/admin/src/ember-bridge/EmberRoot.tsx` container to `h-[calc(100svh-var(--mobile-navbar-height))] w-full sidebar:h-screen` for correct mobile viewport and sidebar behavior.
>   - Remove `min-h-screen` from `apps/admin/src/layout/AdminLayout.tsx` `<main>` to avoid forced full-height.
> - **CSS Adjustments**
>   - Add `body.react-admin #ember-app .gh-viewport { padding-bottom: 0px; }` in `apps/admin/src/index.css` to prevent extra space.
>   - Change mobile height rule in `apps/shade/styles.css` to `body:not(.react-admin) .shade { height: calc(100vh - var(--mobile-navbar-height)); }` so only non-React-admin views apply the offset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8dc3845e15c1bea9634a8086d379ae7f5ec8cf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->