### PR TITLE
Ensured authenticated routes redirect rather than transition

### DIFF
--- a/ghost/admin/app/routes/authenticated.js
+++ b/ghost/admin/app/routes/authenticated.js
@@ -1,10 +1,19 @@
+import AuthConfiguration from 'ember-simple-auth/configuration';
 import Route from '@ember/routing/route';
+import windowProxy from 'ghost-admin/utils/window-proxy';
 import {inject as service} from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
+    @service feature;
     @service session;
 
     async beforeModel(transition) {
-        this.session.requireAuthentication(transition, 'signin');
+        if (this.feature.inAdminForward) {
+            this.session.requireAuthentication(transition, () => {
+                windowProxy.replaceLocation(AuthConfiguration.rootURL);
+            });
+        } else {
+            this.session.requireAuthentication(transition, 'signin');
+        }
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2984/

- ensured Ember matches our expectations with auth, performing a full reload and clearing all client-side data when a session becomes invalidated
  - fixed misleading authentication tests for transition to /signin during unauthenticated app load
  - added test to ensure window.location.replace() is called when an authenticated session becomes unauthenticated
  - modified our AuthenticatedRoute class to pass a callback to ember-simple-auth's requireAuthentication() method to ensure it performs a location replacement rather than internal transition when hosted in the React shell
